### PR TITLE
feat: configure GitHub Actions to use Minimax API

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,6 +25,15 @@ jobs:
       issues: read
       id-token: write
 
+    env:
+      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.MINIMAX_API_TOKEN }}
+      ANTHROPIC_MODEL: MiniMax-M2.7
+      ANTHROPIC_SMALL_FAST_MODEL: MiniMax-M2.7
+      ANTHROPIC_DEFAULT_SONNET_MODEL: MiniMax-M2.7
+      ANTHROPIC_DEFAULT_OPUS_MODEL: MiniMax-M2.7
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: MiniMax-M2.7
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -35,7 +44,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.MINIMAX_API_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,6 +24,14 @@ jobs:
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+    env:
+      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.MINIMAX_API_TOKEN }}
+      ANTHROPIC_MODEL: MiniMax-M2.7
+      ANTHROPIC_SMALL_FAST_MODEL: MiniMax-M2.7
+      ANTHROPIC_DEFAULT_SONNET_MODEL: MiniMax-M2.7
+      ANTHROPIC_DEFAULT_OPUS_MODEL: MiniMax-M2.7
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: MiniMax-M2.7
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,7 +42,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.MINIMAX_API_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- Replace Anthropic OAuth token with Minimax API configuration
- Use Minimax-M2.7 model for Claude Code and code review workflows
- Move API endpoint and credentials to GitHub Secrets for security

## Changes
- Updated `.github/workflows/claude.yml` to use Minimax API
- Updated `.github/workflows/claude-code-review.yml` to use Minimax API
- Configured environment variables for ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN, and model settings

## Next Steps
Add the following GitHub Secrets:
- `MINIMAX_API_TOKEN`: Your Minimax API token
- `ANTHROPIC_BASE_URL`: https://api.minimaxi.com/anthropic