### PR TITLE
fix: inject sandbox workdir into agent system prompt

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -99,6 +99,7 @@ default:
     #   that have been inactive (no commands) for this duration and terminates them.
     ttl: 600 # 10 minutes in seconds
     cleanup_interval: 60 # Cleanup task interval in seconds
+    workdir: "/workspace" # Default working directory for command execution
     volume:
       enabled: false # Temporarily disabled — backend not yet ready
       mount_path: "/workspace"

--- a/backend/cubebox/middleware/sandbox.py
+++ b/backend/cubebox/middleware/sandbox.py
@@ -13,7 +13,7 @@ from langchain_core.tools import BaseTool, StructuredTool
 from pydantic import BaseModel
 
 from cubebox.middleware._utils import append_to_system_message
-from cubebox.prompts.sandbox import SANDBOX_PROMPT
+from cubebox.prompts.sandbox import SANDBOX_PROMPT_TEMPLATE
 from cubebox.sandbox.base import Sandbox
 
 
@@ -51,5 +51,6 @@ class SandboxMiddleware(AgentMiddleware[Any, Any, Any]):
         request: ModelRequest[Any],
         handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any] | AIMessage]],
     ) -> ModelResponse[Any] | AIMessage:
-        new_system = append_to_system_message(request.system_message, SANDBOX_PROMPT)
+        prompt = SANDBOX_PROMPT_TEMPLATE.format(workdir=self.sandbox.workdir)
+        new_system = append_to_system_message(request.system_message, prompt)
         return await handler(request.override(system_message=new_system))

--- a/backend/cubebox/prompts/sandbox.py
+++ b/backend/cubebox/prompts/sandbox.py
@@ -6,8 +6,9 @@ You have access to the `execute` tool to run shell commands in a sandbox environ
 
 **Working directory:** `{workdir}`
 All commands execute in this directory by default. Always use this path (or relative paths \
-from it) when reading, writing, or referencing files. Do NOT use other paths like `/home/user`, \
-`/workspace`, or `~` unless you have explicitly confirmed they exist.
+from it) when reading, writing, or referencing files. Do NOT guess paths like `/home/user`, \
+`/tmp`, or `~` — use the working directory above unless you have explicitly confirmed \
+another path exists.
 
 **Use shell commands for all file operations:**
 - Read files: `cat`, `head`, `tail`, `less`

--- a/backend/cubebox/prompts/sandbox.py
+++ b/backend/cubebox/prompts/sandbox.py
@@ -1,8 +1,13 @@
 """Sandbox execution prompt — injected when a sandbox is available."""
 
-SANDBOX_PROMPT = """## Shell Execution
+SANDBOX_PROMPT_TEMPLATE = """## Shell Execution
 
 You have access to the `execute` tool to run shell commands in a sandbox environment.
+
+**Working directory:** `{workdir}`
+All commands execute in this directory by default. Always use this path (or relative paths \
+from it) when reading, writing, or referencing files. Do NOT use other paths like `/home/user`, \
+`/workspace`, or `~` unless you have explicitly confirmed they exist.
 
 **Use shell commands for all file operations:**
 - Read files: `cat`, `head`, `tail`, `less`

--- a/backend/cubebox/sandbox/base.py
+++ b/backend/cubebox/sandbox/base.py
@@ -26,6 +26,12 @@ class Sandbox(ABC):
         """Unique identifier for this sandbox instance."""
         ...
 
+    @property
+    @abstractmethod
+    def workdir(self) -> str:
+        """Working directory for command execution."""
+        ...
+
     @abstractmethod
     async def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResult:
         """Execute a shell command. Returns combined stdout+stderr and exit code."""

--- a/backend/cubebox/sandbox/local.py
+++ b/backend/cubebox/sandbox/local.py
@@ -22,6 +22,10 @@ class LocalSandbox(Sandbox):
     def id(self) -> str:
         return self._id
 
+    @property
+    def workdir(self) -> str:
+        return self._workdir
+
     async def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResult:
         proc = await asyncio.create_subprocess_shell(
             command,

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -37,6 +37,9 @@ class SandboxManager:
         self._ttl: int = config.get("sandbox.ttl", 600)
         self._ready_timeout: int = config.get("sandbox.ready_timeout", 60)
 
+        # Sandbox workdir
+        self._workdir: str = config.get("sandbox.workdir", "/workspace")
+
         # Volume config
         self._volume_enabled: bool = config.get("sandbox.volume.enabled", False)
         self._volume_mount_path: str = config.get("sandbox.volume.mount_path", "/workspace")
@@ -96,7 +99,7 @@ class SandboxManager:
                     if await raw_sandbox.is_healthy():
                         await repo.update_activity(record.id)
                         logger.info("Reusing healthy sandbox {}", record.sandbox_id)
-                        return OpenSandbox(sandbox=raw_sandbox)
+                        return OpenSandbox(sandbox=raw_sandbox, workdir=self._workdir)
                     else:
                         logger.warning(
                             "Sandbox {} is not healthy, will recreate",

--- a/backend/cubebox/sandbox/opensandbox.py
+++ b/backend/cubebox/sandbox/opensandbox.py
@@ -9,10 +9,9 @@ from cubebox.sandbox.base import ExecuteResult, Sandbox
 class OpenSandbox(Sandbox):
     """Sandbox backed by a remote OpenSandbox container."""
 
-    def __init__(self, *, sandbox: opensandbox.Sandbox) -> None:
+    def __init__(self, *, sandbox: opensandbox.Sandbox, workdir: str = "/workspace") -> None:
         self._sandbox = sandbox
-
-    _DEFAULT_WORKDIR = "/workspace"
+        self._workdir = workdir
 
     @property
     def id(self) -> str:
@@ -20,7 +19,7 @@ class OpenSandbox(Sandbox):
 
     @property
     def workdir(self) -> str:
-        return self._DEFAULT_WORKDIR
+        return self._workdir
 
     async def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResult:
         execution = await self._sandbox.commands.run(command)

--- a/backend/cubebox/sandbox/opensandbox.py
+++ b/backend/cubebox/sandbox/opensandbox.py
@@ -12,7 +12,7 @@ class OpenSandbox(Sandbox):
     def __init__(self, *, sandbox: opensandbox.Sandbox) -> None:
         self._sandbox = sandbox
 
-    _DEFAULT_WORKDIR = "/root"
+    _DEFAULT_WORKDIR = "/workspace"
 
     @property
     def id(self) -> str:

--- a/backend/cubebox/sandbox/opensandbox.py
+++ b/backend/cubebox/sandbox/opensandbox.py
@@ -12,9 +12,15 @@ class OpenSandbox(Sandbox):
     def __init__(self, *, sandbox: opensandbox.Sandbox) -> None:
         self._sandbox = sandbox
 
+    _DEFAULT_WORKDIR = "/root"
+
     @property
     def id(self) -> str:
         return self._sandbox.id
+
+    @property
+    def workdir(self) -> str:
+        return self._DEFAULT_WORKDIR
 
     async def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResult:
         execution = await self._sandbox.commands.run(command)

--- a/backend/tests/unit/test_prompts.py
+++ b/backend/tests/unit/test_prompts.py
@@ -1,20 +1,30 @@
-from cubebox.prompts.sandbox import SANDBOX_PROMPT
+from cubebox.prompts.sandbox import SANDBOX_PROMPT_TEMPLATE
 from cubebox.prompts.skills import SKILLS_PROMPT_TEMPLATE
 from cubebox.prompts.subagents import SUBAGENT_PROMPT
 from cubebox.prompts.system import BASE_SYSTEM_PROMPT
 
 
 def test_all_prompts_are_non_empty_strings():
-    for prompt in [BASE_SYSTEM_PROMPT, SANDBOX_PROMPT, SUBAGENT_PROMPT, SKILLS_PROMPT_TEMPLATE]:
+    for prompt in [
+        BASE_SYSTEM_PROMPT,
+        SANDBOX_PROMPT_TEMPLATE,
+        SUBAGENT_PROMPT,
+        SKILLS_PROMPT_TEMPLATE,
+    ]:
         assert isinstance(prompt, str)
         assert len(prompt.strip()) > 50
 
 
-def test_prompts_have_no_format_placeholders():
+def test_template_prompts_have_expected_placeholders():
+    """Template prompts must contain their expected placeholders."""
+    assert "{workdir}" in SANDBOX_PROMPT_TEMPLATE
+    assert "{skills_list}" in SKILLS_PROMPT_TEMPLATE
+
+
+def test_non_template_prompts_have_no_placeholders():
     """Prompts used directly (not as templates) must have no unformatted {} placeholders."""
-    for prompt in [BASE_SYSTEM_PROMPT, SANDBOX_PROMPT, SUBAGENT_PROMPT]:
-        # Skills prompt is a template — skip it
-        assert "{" not in prompt or prompt.count("{") == prompt.count("}")
+    for prompt in [BASE_SYSTEM_PROMPT, SUBAGENT_PROMPT]:
+        assert "{" not in prompt
 
 
 def test_system_prompt_mentions_tools():
@@ -22,4 +32,10 @@ def test_system_prompt_mentions_tools():
 
 
 def test_sandbox_prompt_mentions_execute():
-    assert "execute" in SANDBOX_PROMPT.lower()
+    rendered = SANDBOX_PROMPT_TEMPLATE.format(workdir="/root")
+    assert "execute" in rendered.lower()
+
+
+def test_sandbox_prompt_includes_workdir():
+    rendered = SANDBOX_PROMPT_TEMPLATE.format(workdir="/my/workdir")
+    assert "/my/workdir" in rendered


### PR DESCRIPTION
## Summary
- Agent was using wrong directories (`/home/user`, `/workspace`) when executing commands because the system prompt didn't specify the actual working directory
- Added `workdir` abstract property to `Sandbox` base class, implemented in `LocalSandbox` and `OpenSandbox`
- Sandbox prompt now includes the concrete working directory and explicitly tells the agent not to guess paths

## Test plan
- [x] Unit tests pass (`test_prompts.py` updated with workdir injection tests)
- [x] mypy, ruff all pass
- [ ] Manual test: ask agent to create a file and verify it uses the correct directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)