### PR TITLE
debug: enable verbose logging for Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,6 +34,9 @@ jobs:
       ANTHROPIC_DEFAULT_SONNET_MODEL: MiniMax-M2.7
       ANTHROPIC_DEFAULT_OPUS_MODEL: MiniMax-M2.7
       ANTHROPIC_DEFAULT_HAIKU_MODEL: MiniMax-M2.7
+      # Enable debug logging
+      ACTIONS_STEP_DEBUG: true
+      CLAUDE_CODE_DEBUG: 1
 
     steps:
       - name: Checkout repository
@@ -49,6 +52,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: '--verbose'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Add `--verbose` to `claude_args` for detailed Claude Code CLI output
- Enable `ACTIONS_STEP_DEBUG` and `CLAUDE_CODE_DEBUG` env vars for GitHub Actions and Claude Code debug logging
- Goal: diagnose why code review produces "No buffered inline comments"

## Note
Remember to remove these debug settings after the issue is identified.

https://claude.ai/code/session_01Eu6tgFRfhxLyyCK7XygBy5