### PR TITLE
fix: render todo middleware content from batch payload

### DIFF
--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -80,6 +80,31 @@ function appendToolCallBlock(
   return [...finalized, { type: 'tool_call', name, arguments: args, tool_call_id: toolCallId }]
 }
 
+function normalizeTodoStatus(status: unknown): TodoItem['status'] {
+  return status === 'in_progress' || status === 'completed' ? status : 'pending'
+}
+
+function parseTodosFromToolCall(
+  args: Record<string, unknown>,
+): TodoItem[] {
+  const rawTodos = Array.isArray(args.todos) ? args.todos : []
+  const todos: TodoItem[] = []
+
+  for (const todo of rawTodos) {
+    if (!todo || typeof todo !== 'object') continue
+    const raw = todo as { content?: unknown; status?: unknown }
+    const description = typeof raw.content === 'string' ? raw.content.trim() : ''
+    if (!description) continue
+    todos.push({
+      id: null,
+      description,
+      status: normalizeTodoStatus(raw.status),
+    })
+  }
+
+  return todos
+}
+
 /**
  * Batched state updater: collects multiple set() calls within a single microtask
  * and flushes them as one Zustand update. This prevents N SSE events arriving in
@@ -209,31 +234,9 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
               s.streamAgents[agentKey]
               ?? emptyStream(event.agent_name)
 
-            // Upsert write_todos into todos list
             let nextTodos = s.todos
             if (e.data.name === 'write_todos') {
-              const args = e.data.arguments as {
-                description?: string
-                status?: string
-              }
-              const desc = String(args.description ?? '')
-              const status = (args.status ?? 'pending') as
-                TodoItem['status']
-              const idx = s.todos.findIndex(
-                (t) => t.description === desc,
-              )
-              if (idx >= 0) {
-                nextTodos = [...s.todos]
-                nextTodos[idx] = {
-                  ...nextTodos[idx],
-                  status,
-                }
-              } else {
-                nextTodos = [
-                  ...s.todos,
-                  { id: null, description: desc, status },
-                ]
-              }
+              nextTodos = parseTodosFromToolCall(e.data.arguments)
             }
 
             return {
@@ -271,34 +274,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
               }
             }
 
-            // Update todo id from write_todos result
-            let nextTodos = s.todos
-            if (
-              e.data.tool_name === 'write_todos' && tcId
-            ) {
-              try {
-                const parsed = JSON.parse(e.data.content)
-                const taskId =
-                  parsed.task_id as string | undefined
-                if (taskId) {
-                  const idx = s.todos.findIndex(
-                    (t) => t.id === null,
-                  )
-                  if (idx >= 0) {
-                    nextTodos = [...s.todos]
-                    nextTodos[idx] = {
-                      ...nextTodos[idx],
-                      id: taskId,
-                    }
-                  }
-                }
-              } catch {
-                // Ignore parse errors
-              }
-            }
-
             return {
-              todos: nextTodos,
               toolResultMap: newMap,
               streamAgents: {
                 ...s.streamAgents,

--- a/frontend/packages/web/__tests__/hooks/useMessages.test.ts
+++ b/frontend/packages/web/__tests__/hooks/useMessages.test.ts
@@ -26,6 +26,9 @@ beforeEach(() => {
     isStreaming: false,
     statusPhase: null,
     error: null,
+    todos: [],
+    toolStartedMap: {},
+    toolResultMap: {},
   })
 })
 
@@ -96,5 +99,99 @@ describe('messageStore.send', () => {
     })
 
     expect(useMessageStore.getState().isStreaming).toBe(false)
+  })
+
+  it('renders todos from write_todos batch payload', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => mockSSEResponse([
+      {
+        type: 'tool_call',
+        data: {
+          tool_call_id: 'todo-1',
+          name: 'write_todos',
+          arguments: {
+            todos: [
+              { content: 'Inspect frontend todo parsing', status: 'in_progress' },
+              { content: 'Verify backend payload shape', status: 'pending' },
+            ],
+          },
+        },
+        agent_id: null,
+        agent_name: null,
+        timestamp: '',
+      },
+      { type: 'done', data: {}, agent_id: null, agent_name: null, timestamp: '' },
+    ])))
+
+    await act(async () => {
+      await useMessageStore.getState().send(mockClient as any, CONV_ID, 'fix todos')
+    })
+
+    expect(useMessageStore.getState().todos).toEqual([
+      {
+        id: null,
+        description: 'Inspect frontend todo parsing',
+        status: 'in_progress',
+      },
+      {
+        id: null,
+        description: 'Verify backend payload shape',
+        status: 'pending',
+      },
+    ])
+  })
+
+  it('replaces todos on subsequent write_todos updates', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => mockSSEResponse([
+      {
+        type: 'tool_call',
+        data: {
+          tool_call_id: 'todo-1',
+          name: 'write_todos',
+          arguments: {
+            todos: [
+              { content: 'Inspect frontend todo parsing', status: 'in_progress' },
+              { content: 'Verify backend payload shape', status: 'pending' },
+            ],
+          },
+        },
+        agent_id: null,
+        agent_name: null,
+        timestamp: '',
+      },
+      {
+        type: 'tool_call',
+        data: {
+          tool_call_id: 'todo-2',
+          name: 'write_todos',
+          arguments: {
+            todos: [
+              { content: 'Inspect frontend todo parsing', status: 'completed' },
+              { content: 'Patch store parsing', status: 'in_progress' },
+            ],
+          },
+        },
+        agent_id: null,
+        agent_name: null,
+        timestamp: '',
+      },
+      { type: 'done', data: {}, agent_id: null, agent_name: null, timestamp: '' },
+    ])))
+
+    await act(async () => {
+      await useMessageStore.getState().send(mockClient as any, CONV_ID, 'fix todos')
+    })
+
+    expect(useMessageStore.getState().todos).toEqual([
+      {
+        id: null,
+        description: 'Inspect frontend todo parsing',
+        status: 'completed',
+      },
+      {
+        id: null,
+        description: 'Patch store parsing',
+        status: 'in_progress',
+      },
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- update frontend todo parsing to consume TodoListMiddleware's current `write_todos({ todos: [...] })` payload
- replace the old single-item upsert logic with full-list replacement
- remove obsolete `task_id` handling and add regression tests for initial and subsequent todo updates

## Testing
- `pnpm --dir frontend --filter @cubebox/core exec tsc --noEmit`
- `pnpm --dir frontend --filter web test -- --run __tests__/hooks/useMessages.test.ts`