### PR TITLE
fix: todo frontend display and refresh persistence

### DIFF
--- a/backend/cubebox/middleware/todo.py
+++ b/backend/cubebox/middleware/todo.py
@@ -4,10 +4,6 @@ import json
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Any, Literal, NotRequired, cast, override
 
-from langchain.agents.middleware.todo import (
-    WRITE_TODOS_SYSTEM_PROMPT,
-    WRITE_TODOS_TOOL_DESCRIPTION,
-)
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
@@ -24,6 +20,80 @@ from langgraph.runtime import Runtime
 from langgraph.types import Command
 from pydantic import BaseModel
 from typing_extensions import TypedDict
+
+WRITE_TODOS_TOOL_DESCRIPTION = """Use this tool to create and manage a structured task list for your current work session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
+
+Only use this tool if you think it will be helpful in staying organized. If the user's request is trivial and takes less than 3 steps, it is better to NOT use this tool and just do the task directly.
+
+## When to Use This Tool
+Use this tool in these scenarios:
+
+1. Complex multi-step tasks - When a task requires 3 or more distinct steps or actions
+2. Non-trivial and complex tasks - Tasks that require careful planning or multiple operations
+3. User explicitly requests todo list - When the user directly asks you to use the todo list
+4. User provides multiple tasks - When users provide a list of things to be done (numbered or comma-separated)
+5. The plan may need future revisions or updates based on results from the first few steps
+
+## How to Use This Tool
+1. When you start working on a task - Mark it as in_progress BEFORE beginning work.
+2. After completing a task - Mark it as completed and add any new follow-up tasks discovered during implementation.
+3. You can also update future tasks, such as deleting them if they are no longer necessary, or adding new tasks that are necessary. Don't change previously completed tasks.
+4. You can make several updates to the todo list at once. For example, when you complete a task, you can mark the next task you need to start as in_progress.
+
+## When NOT to Use This Tool
+It is important to skip using this tool when:
+1. There is only a single, straightforward task
+2. The task is trivial and tracking it provides no benefit
+3. The task can be completed in less than 3 trivial steps
+4. The task is purely conversational or informational
+
+## Task States and Management
+
+1. **Task States**: Use these states to track progress:
+   - pending: Task not yet started
+   - in_progress: Currently working on (you can have multiple tasks in_progress at a time if they are not related to each other and can be run in parallel)
+   - completed: Task finished successfully
+
+2. **Task Management**:
+   - Update task status in real-time as you work
+   - Mark tasks complete IMMEDIATELY after finishing (don't batch completions)
+   - Complete current tasks before starting new ones
+   - Remove tasks that are no longer relevant from the list entirely
+   - IMPORTANT: When you write this todo list, you should mark your first task (or tasks) as in_progress immediately!.
+   - IMPORTANT: Unless all tasks are completed, you should always have at least one task in_progress to show the user that you are working on something.
+
+3. **Task Completion Requirements**:
+   - ONLY mark a task as completed when you have FULLY accomplished it
+   - If you encounter errors, blockers, or cannot finish, keep the task as in_progress
+   - When blocked, create a new task describing what needs to be resolved
+   - Never mark a task as completed if:
+     - There are unresolved issues or errors
+     - Work is partial or incomplete
+     - You encountered blockers that prevent completion
+     - You couldn't find necessary resources or dependencies
+     - Quality standards haven't been met
+
+4. **Task Breakdown**:
+   - Create specific, actionable items
+   - Break complex tasks into smaller, manageable steps
+   - Use clear, descriptive task names
+
+Being proactive with task management demonstrates attentiveness and ensures you complete all requirements successfully
+Remember: If you only need to make a few tool calls to complete a task, and it is clear what you need to do, it is better to just do the task directly and NOT call this tool at all."""  # noqa: E501
+
+WRITE_TODOS_SYSTEM_PROMPT = """## `write_todos`
+
+You have access to the `write_todos` tool to help you manage and plan complex objectives.
+Use this tool for complex objectives to ensure that you are tracking each necessary step and giving the user visibility into your progress.
+This tool is very helpful for planning complex objectives, and for breaking down these larger complex objectives into smaller steps.
+
+It is critical that you mark todos as completed as soon as you are done with a step. Do not batch up multiple steps before marking them as completed.
+For simple objectives that only require a few steps, it is better to just complete the objective directly and NOT use this tool.
+Writing todos takes time and tokens, use it when it is helpful for managing complex many-step problems! But not for simple few-step requests.
+
+## Important To-Do List Usage Notes to Remember
+- The `write_todos` tool should never be called multiple times in parallel.
+- Don't be afraid to revise the To-Do list as you go. New information may reveal new tasks that need to be done, or old tasks that are irrelevant."""  # noqa: E501
 
 
 class Todo(TypedDict):
@@ -46,7 +116,7 @@ class WriteTodosInput(BaseModel):
 
 
 def _build_todo_tool_message(
-    tool_call_id: str,
+    tool_call_id: str | None,
     todos: list[Todo],
 ) -> ToolMessage:
     return ToolMessage(

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -156,8 +156,22 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       // Re-check after await: if streaming started while we were fetching,
       // discard the API response to preserve the optimistic user message.
       if (get().isStreaming) return
+
+      // Restore todos from the last write_todos tool call in history
+      let restoredTodos: TodoItem[] = []
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const msg = messages[i]
+        if (msg.role !== 'assistant' || !msg.tool_calls) continue
+        const tc = msg.tool_calls.find((t) => t.name === 'write_todos')
+        if (tc) {
+          restoredTodos = parseTodosFromToolCall(tc.arguments)
+          break
+        }
+      }
+
       set((s) => ({
         messages: { ...s.messages, [conversationId]: messages },
+        todos: restoredTodos,
         error: null,
         // Clear completed stream state — history messages are now source of truth
         streamAgents: {},

--- a/frontend/packages/web/components/chat/TaskProgressBar.tsx
+++ b/frontend/packages/web/components/chat/TaskProgressBar.tsx
@@ -17,10 +17,10 @@ interface TaskProgressBarProps {
 export function TaskProgressBar({
   todos,
 }: TaskProgressBarProps) {
-  const [isExpanded, setIsExpanded] = useState(false)
-  const prevCount = useRef(0)
+  const [isExpanded, setIsExpanded] = useState(todos.length > 0)
 
-  // Auto-expand on first todo arrival
+  // Auto-expand when todos first become non-empty
+  const prevCount = useRef(todos.length)
   useEffect(() => {
     if (prevCount.current === 0 && todos.length > 0) {
       setIsExpanded(true)

--- a/frontend/packages/web/next.config.ts
+++ b/frontend/packages/web/next.config.ts
@@ -4,6 +4,13 @@ const nextConfig: NextConfig = {
   allowedDevOrigins: ['localhost', '127.0.0.1', '[::1]', '192.168.1.111'],
   compress: false,
   turbopack: {},
+  experimental: {
+    // Default is 30s which kills long-running SSE streams through rewrites proxy.
+    // Runtime: `proxyTimeout === null ? undefined : proxyTimeout || 30000`
+    // null disables timeout, but type only allows number | undefined.
+    // @ts-expect-error -- null is intentional; see next/dist/.../proxy-request.js
+    proxyTimeout: null,
+  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## Summary
- Fix todo progress bar showing empty content after streaming by correctly parsing `write_todos` tool call arguments
- Restore todos from message history on page refresh so the TaskProgressBar persists across reloads
- Fix TaskProgressBar defaulting to collapsed state after refresh by initializing expand state from current todos
- Inline `WRITE_TODOS_TOOL_DESCRIPTION` and `WRITE_TODOS_SYSTEM_PROMPT` into local `todo.py` middleware for future prompt customization
- Disable Next.js proxy timeout (`proxyTimeout: null`) to prevent long-running SSE streams from being killed

## Test plan
- [ ] Send a message that triggers `write_todos` (e.g. a multi-step coding task) and verify the TaskProgressBar shows task content
- [ ] Refresh the page and verify todos persist and the progress bar is expanded
- [ ] Verify SSE streams are not cut off after 30s on long-running agent tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)