### PR TITLE
Improve streamed tool-call timing and write_file preview

### DIFF
--- a/backend/cubebox/agents/convert.py
+++ b/backend/cubebox/agents/convert.py
@@ -58,6 +58,26 @@ def _consolidate_subagent_events(
     }
 
 
+def _get_tool_call_started_at(
+    response_metadata: dict[str, Any] | None,
+    *,
+    index: int,
+    tool_call_id: str | None,
+) -> str | None:
+    timestamps = (response_metadata or {}).get("tool_call_started_at_by_index")
+    if isinstance(timestamps, dict):
+        raw = timestamps.get(str(index), timestamps.get(index))
+        if isinstance(raw, str):
+            return raw
+    if tool_call_id:
+        timestamps_by_id = (response_metadata or {}).get("tool_call_started_at_by_id")
+        if isinstance(timestamps_by_id, dict):
+            raw = timestamps_by_id.get(tool_call_id)
+            if isinstance(raw, str):
+                return raw
+    return None
+
+
 def convert_to_api_messages(lc_messages: list[BaseMessage]) -> list[dict[str, Any]]:
     """Convert a list of LangChain messages to the API response format.
 
@@ -105,8 +125,13 @@ def convert_to_api_messages(lc_messages: list[BaseMessage]) -> list[dict[str, An
                         "name": tc["name"],
                         "arguments": tc["args"],
                         "tool_call_id": tc.get("id", ""),
+                        "started_at": _get_tool_call_started_at(
+                            msg.response_metadata,
+                            index=i,
+                            tool_call_id=tc.get("id"),
+                        ),
                     }
-                    for tc in msg.tool_calls
+                    for i, tc in enumerate(msg.tool_calls)
                 ] or None
 
             reasoning = (msg.additional_kwargs or {}).get("reasoning_content")
@@ -159,6 +184,7 @@ def convert_to_api_messages(lc_messages: list[BaseMessage]) -> list[dict[str, An
                     "reasoning": None,
                     "name": msg.name,
                     "tool_call_id": getattr(msg, "tool_call_id", None),
+                    "started_at": (msg.response_metadata or {}).get("tool_started_at"),
                     "subagent_events": subagent_events,
                     "created_at": ts,
                 }

--- a/backend/cubebox/agents/schemas.py
+++ b/backend/cubebox/agents/schemas.py
@@ -69,6 +69,18 @@ class ToolCallEvent(AgentEvent):
     )
 
 
+class ToolCallDeltaEvent(AgentEvent):
+    """Streaming tool call argument delta.
+
+    Emitted as the LLM generates tool call arguments token-by-token.
+    """
+
+    type: Literal["tool_call_delta"] = "tool_call_delta"
+    data: dict[str, Any] = Field(
+        description="Event data with tool_call_id, name, args_delta, and index"
+    )
+
+
 class ToolResultEvent(AgentEvent):
     """Tool execution result event.
 

--- a/backend/cubebox/agents/stream.py
+++ b/backend/cubebox/agents/stream.py
@@ -87,6 +87,32 @@ def convert_messages_chunk(
             }
         )
 
+    # Tool call argument deltas (streaming tool input)
+    tool_call_chunks = getattr(msg, "tool_call_chunks", []) or []
+    for tc_chunk in tool_call_chunks:
+        chunk_name = tc_chunk.get("name") if isinstance(tc_chunk, dict) else None
+        chunk_args = tc_chunk.get("args") if isinstance(tc_chunk, dict) else None
+        chunk_id = tc_chunk.get("id") if isinstance(tc_chunk, dict) else None
+        chunk_index = tc_chunk.get("index") if isinstance(tc_chunk, dict) else None
+
+        # Skip chunks with no useful data
+        if not chunk_name and not chunk_args:
+            continue
+
+        events.append(
+            {
+                "type": "tool_call_delta",
+                "timestamp": timestamp,
+                "data": {
+                    "tool_call_id": chunk_id,
+                    "name": chunk_name,
+                    "args_delta": chunk_args or "",
+                    "index": chunk_index,
+                },
+                "agent_id": agent_id,
+            }
+        )
+
     return events
 
 

--- a/backend/cubebox/agents/stream.py
+++ b/backend/cubebox/agents/stream.py
@@ -25,6 +25,26 @@ def _unwrap_mcp_content(content: Any) -> str:
     return "\n".join(texts) if texts else str(content)
 
 
+def _get_tool_call_started_at(
+    response_metadata: dict[str, Any] | None,
+    *,
+    index: int,
+    tool_call_id: str | None,
+) -> str | None:
+    timestamps = (response_metadata or {}).get("tool_call_started_at_by_index")
+    if isinstance(timestamps, dict):
+        raw = timestamps.get(str(index), timestamps.get(index))
+        if isinstance(raw, str):
+            return raw
+    if tool_call_id:
+        timestamps_by_id = (response_metadata or {}).get("tool_call_started_at_by_id")
+        if isinstance(timestamps_by_id, dict):
+            raw = timestamps_by_id.get(tool_call_id)
+            if isinstance(raw, str):
+                return raw
+    return None
+
+
 def convert_messages_chunk(
     chunk: Any,
     agent_id: str | None = None,
@@ -152,24 +172,34 @@ def _extract_tool_events(
         content = msg.get("content", "")
         tool_name = msg.get("name")
         tool_call_id = msg.get("tool_call_id", "")
+        response_metadata = msg.get("response_metadata", {})
     else:
         tool_calls = getattr(msg, "tool_calls", []) or []
         content = getattr(msg, "content", "") or ""
         tool_name = getattr(msg, "name", None)
         tool_call_id = getattr(msg, "tool_call_id", "")
+        response_metadata = getattr(msg, "response_metadata", {}) or {}
 
     # Tool calls (from AIMessage)
-    for tc in tool_calls:
+    for index, tc in enumerate(tool_calls):
         tc_name = tc.get("name") if isinstance(tc, dict) else getattr(tc, "name", "")
         tc_id = tc.get("id", "") if isinstance(tc, dict) else getattr(tc, "id", "")
         tc_args = tc.get("args", {}) if isinstance(tc, dict) else getattr(tc, "args", {})
         if not tc_name:
             continue
+        data: dict[str, Any] = {"tool_call_id": tc_id, "name": tc_name, "arguments": tc_args}
+        started_at = _get_tool_call_started_at(
+            response_metadata,
+            index=index,
+            tool_call_id=tc_id or None,
+        )
+        if started_at:
+            data["started_at"] = started_at
         events.append(
             {
                 "type": "tool_call",
                 "timestamp": timestamp,
-                "data": {"tool_call_id": tc_id, "name": tc_name, "arguments": tc_args},
+                "data": data,
                 "agent_id": agent_id,
             }
         )
@@ -189,19 +219,22 @@ def _extract_tool_events(
         else:
             result_str = str(content)
 
-        data: dict[str, Any] = {
+        tool_result_data: dict[str, Any] = {
             "tool_name": tool_name,
             "tool_call_id": tool_call_id,
             "content": result_str,
         }
+        tool_started_at = (response_metadata or {}).get("tool_started_at")
+        if isinstance(tool_started_at, str):
+            tool_result_data["started_at"] = tool_started_at
         if content_type:
-            data["content_type"] = content_type
+            tool_result_data["content_type"] = content_type
 
         events.append(
             {
                 "type": "tool_result",
                 "timestamp": timestamp,
-                "data": data,
+                "data": tool_result_data,
                 "agent_id": agent_id,
             }
         )

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -151,7 +151,42 @@ def _ns_to_agent_id(ns: tuple[Any, ...]) -> str | None:
     return ":".join(str(part) for part in ns)
 
 
-def _dicts_to_sse_events(event_dicts: list[dict[str, Any]]) -> list[AgentEvent]:
+def _backfill_tool_call_delta_identity(
+    evt_dict: dict[str, Any],
+    delta_context: dict[tuple[str | None, int], dict[str, Any]],
+) -> dict[str, Any]:
+    """Fill missing tool_call_delta identity fields from prior chunks in the same stream."""
+    if evt_dict.get("type") != "tool_call_delta":
+        return evt_dict
+
+    data = evt_dict.get("data")
+    if not isinstance(data, dict):
+        return evt_dict
+
+    index = data.get("index")
+    if not isinstance(index, int):
+        return evt_dict
+
+    key = (evt_dict.get("agent_id"), index)
+    cached = delta_context.get(key, {})
+    normalized_data = dict(data)
+
+    if normalized_data.get("tool_call_id") is None and cached.get("tool_call_id") is not None:
+        normalized_data["tool_call_id"] = cached["tool_call_id"]
+    if normalized_data.get("name") is None and cached.get("name") is not None:
+        normalized_data["name"] = cached["name"]
+
+    delta_context[key] = {
+        "tool_call_id": normalized_data.get("tool_call_id"),
+        "name": normalized_data.get("name"),
+    }
+    return {**evt_dict, "data": normalized_data}
+
+
+def _dicts_to_sse_events(
+    event_dicts: list[dict[str, Any]],
+    delta_context: dict[tuple[str | None, int], dict[str, Any]] | None = None,
+) -> list[AgentEvent]:
     """Wrap raw event dicts from stream helpers into typed AgentEvent objects."""
     from cubebox.agents.schemas import (
         ArtifactEvent,
@@ -164,6 +199,8 @@ def _dicts_to_sse_events(event_dicts: list[dict[str, Any]]) -> list[AgentEvent]:
 
     events: list[AgentEvent] = []
     for evt_dict in event_dicts:
+        if delta_context is not None:
+            evt_dict = _backfill_tool_call_delta_identity(evt_dict, delta_context)
         evt_type = evt_dict.get("type")
         if evt_type == "reasoning":
             events.append(
@@ -171,6 +208,7 @@ def _dicts_to_sse_events(event_dicts: list[dict[str, Any]]) -> list[AgentEvent]:
                     timestamp=evt_dict["timestamp"],
                     data=evt_dict["data"],
                     agent_id=evt_dict.get("agent_id"),
+                    agent_name=evt_dict.get("agent_name"),
                 )
             )
         elif evt_type == "tool_call":
@@ -179,6 +217,7 @@ def _dicts_to_sse_events(event_dicts: list[dict[str, Any]]) -> list[AgentEvent]:
                     timestamp=evt_dict["timestamp"],
                     data=evt_dict["data"],
                     agent_id=evt_dict.get("agent_id"),
+                    agent_name=evt_dict.get("agent_name"),
                 )
             )
         elif evt_type == "tool_result":
@@ -187,6 +226,7 @@ def _dicts_to_sse_events(event_dicts: list[dict[str, Any]]) -> list[AgentEvent]:
                     timestamp=evt_dict["timestamp"],
                     data=evt_dict["data"],
                     agent_id=evt_dict.get("agent_id"),
+                    agent_name=evt_dict.get("agent_name"),
                 )
             )
         elif evt_type == "text_delta":
@@ -195,6 +235,7 @@ def _dicts_to_sse_events(event_dicts: list[dict[str, Any]]) -> list[AgentEvent]:
                     timestamp=evt_dict["timestamp"],
                     data=evt_dict["data"],
                     agent_id=evt_dict.get("agent_id"),
+                    agent_name=evt_dict.get("agent_name"),
                 )
             )
         elif evt_type == "tool_call_delta":
@@ -203,6 +244,7 @@ def _dicts_to_sse_events(event_dicts: list[dict[str, Any]]) -> list[AgentEvent]:
                     timestamp=evt_dict["timestamp"],
                     data=evt_dict["data"],
                     agent_id=evt_dict.get("agent_id"),
+                    agent_name=evt_dict.get("agent_name"),
                 )
             )
         elif evt_type == "artifact":
@@ -211,6 +253,7 @@ def _dicts_to_sse_events(event_dicts: list[dict[str, Any]]) -> list[AgentEvent]:
                     timestamp=evt_dict["timestamp"],
                     data=evt_dict["data"],
                     agent_id=evt_dict.get("agent_id"),
+                    agent_name=evt_dict.get("agent_name"),
                 )
             )
 
@@ -381,6 +424,7 @@ async def send_message(
             )
 
             stream_task = asyncio.create_task(_drain_main_stream())
+            tool_delta_context: dict[tuple[str | None, int], dict[str, Any]] = {}
 
             while True:
                 try:
@@ -407,7 +451,7 @@ async def send_message(
                             evts = convert_updates_chunk(data, agent_id=agent_id)
                         else:
                             evts = []
-                        for sse_event in _dicts_to_sse_events(evts):
+                        for sse_event in _dicts_to_sse_events(evts, tool_delta_context):
                             yield f"data: {sse_event.model_dump_json()}\n\n"
 
                 elif kind == "subagent":
@@ -421,7 +465,7 @@ async def send_message(
                             evts = convert_updates_chunk(data, agent_id=sa_agent_id)
                         else:
                             evts = []
-                        for sse_event in _dicts_to_sse_events(evts):
+                        for sse_event in _dicts_to_sse_events(evts, tool_delta_context):
                             yield f"data: {sse_event.model_dump_json()}\n\n"
 
                 elif kind == "error":

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -157,6 +157,7 @@ def _dicts_to_sse_events(event_dicts: list[dict[str, Any]]) -> list[AgentEvent]:
         ArtifactEvent,
         ReasoningEvent,
         TextDeltaEvent,
+        ToolCallDeltaEvent,
         ToolCallEvent,
         ToolResultEvent,
     )
@@ -191,6 +192,14 @@ def _dicts_to_sse_events(event_dicts: list[dict[str, Any]]) -> list[AgentEvent]:
         elif evt_type == "text_delta":
             events.append(
                 TextDeltaEvent(
+                    timestamp=evt_dict["timestamp"],
+                    data=evt_dict["data"],
+                    agent_id=evt_dict.get("agent_id"),
+                )
+            )
+        elif evt_type == "tool_call_delta":
+            events.append(
+                ToolCallDeltaEvent(
                     timestamp=evt_dict["timestamp"],
                     data=evt_dict["data"],
                     agent_id=evt_dict.get("agent_id"),

--- a/backend/cubebox/llm/openai_compatible.py
+++ b/backend/cubebox/llm/openai_compatible.py
@@ -6,6 +6,7 @@ This is useful for OpenAI-compatible endpoints that return reasoning in the resp
 
 import time
 from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
 from typing import Any
 
 from langchain_core.callbacks import (
@@ -52,11 +53,13 @@ class ChatOpenAICompatible(ChatOpenAI):
     _stream_metadata_emitted: bool = False
     _reasoning_start: float | None = None  # monotonic
     _reasoning_end: float | None = None  # monotonic
+    _tool_call_started_at_by_index: dict[int, str] | None = None
 
     def _reset_stream_state(self) -> None:
         self._stream_metadata_emitted = False
         self._reasoning_start = None
         self._reasoning_end = None
+        self._tool_call_started_at_by_index = {}
 
     def _create_chat_result(
         self,
@@ -157,17 +160,37 @@ class ChatOpenAICompatible(ChatOpenAI):
         if has_reasoning and isinstance(generation_chunk.message, AIMessageChunk):
             generation_chunk.message.additional_kwargs["reasoning_content"] = reasoning_delta
 
+        tool_call_chunks = getattr(generation_chunk.message, "tool_call_chunks", []) or []
+        if tool_call_chunks:
+            for tool_call_chunk in tool_call_chunks:
+                if not isinstance(tool_call_chunk, dict):
+                    continue
+                index = tool_call_chunk.get("index")
+                if not isinstance(index, int):
+                    continue
+                if self._tool_call_started_at_by_index is None:
+                    self._tool_call_started_at_by_index = {}
+                self._tool_call_started_at_by_index.setdefault(
+                    index,
+                    datetime.now(UTC).isoformat(),
+                )
+
         # --- On finish: stamp reasoning_duration_ms ---
         # Only on the last chunk to avoid LangChain merge_dicts garbling.
         # created_at is handled by TimestampMiddleware at the agent level.
         if finish_reason is not None and not self._stream_metadata_emitted:
-            if self._reasoning_start is not None:
-                if isinstance(generation_chunk.message, AIMessageChunk):
+            if isinstance(generation_chunk.message, AIMessageChunk):
+                if self._reasoning_start is not None:
                     end = self._reasoning_end or time.monotonic()
                     duration_ms = int((end - self._reasoning_start) * 1000)
                     generation_chunk.message.response_metadata["reasoning_duration_ms"] = (
                         duration_ms
                     )
+                if self._tool_call_started_at_by_index:
+                    generation_chunk.message.response_metadata["tool_call_started_at_by_index"] = {
+                        str(index): started_at
+                        for index, started_at in self._tool_call_started_at_by_index.items()
+                    }
             self._stream_metadata_emitted = True
 
         return generation_chunk

--- a/backend/cubebox/middleware/sandbox.py
+++ b/backend/cubebox/middleware/sandbox.py
@@ -71,7 +71,12 @@ def _create_edit_file_tool(sandbox: Sandbox) -> BaseTool:
     async def _edit_file(file_path: str, old_string: str, new_string: str) -> str:
         if old_string == new_string:
             return "Error: old_string and new_string must differ."
-        files = await sandbox.download([file_path])
+        try:
+            files = await sandbox.download([file_path])
+        except FileNotFoundError:
+            return f"Error: file not found — {file_path}"
+        except Exception as exc:
+            return f"Error reading {file_path}: {exc}"
         current = files[0][1].decode()
         count = current.count(old_string)
         if count == 0:

--- a/backend/cubebox/middleware/sandbox.py
+++ b/backend/cubebox/middleware/sandbox.py
@@ -10,7 +10,7 @@ from langchain.agents.middleware.types import (
 )
 from langchain_core.messages import AIMessage
 from langchain_core.tools import BaseTool, StructuredTool
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from cubebox.middleware._utils import append_to_system_message
 from cubebox.prompts.sandbox import SANDBOX_PROMPT_TEMPLATE
@@ -39,12 +39,70 @@ def _create_execute_tool(sandbox: Sandbox) -> BaseTool:
     )
 
 
+class _WriteFileArgs(BaseModel):
+    file_path: str = Field(description="Absolute path where the file should be created.")
+    content: str = Field(description="The text content to write to the file.")
+
+
+class _EditFileArgs(BaseModel):
+    file_path: str = Field(description="Absolute path to the file to edit.")
+    old_string: str = Field(description="The exact text to find and replace. Must be unique.")
+    new_string: str = Field(description="The replacement text. Must differ from old_string.")
+
+
+def _create_write_file_tool(sandbox: Sandbox) -> BaseTool:
+    """Build the write_file tool backed by a sandbox instance."""
+
+    async def _write_file(file_path: str, content: str) -> str:
+        await sandbox.upload([(file_path, content.encode())])
+        return f"Successfully wrote {file_path}"
+
+    return StructuredTool.from_function(
+        coroutine=_write_file,
+        name="write_file",
+        description="Create or overwrite a file with the given content.",
+        args_schema=_WriteFileArgs,
+    )
+
+
+def _create_edit_file_tool(sandbox: Sandbox) -> BaseTool:
+    """Build the edit_file tool backed by a sandbox instance."""
+
+    async def _edit_file(file_path: str, old_string: str, new_string: str) -> str:
+        if old_string == new_string:
+            return "Error: old_string and new_string must differ."
+        files = await sandbox.download([file_path])
+        current = files[0][1].decode()
+        count = current.count(old_string)
+        if count == 0:
+            return f"Error: old_string not found in {file_path}"
+        if count > 1:
+            return (
+                f"Error: old_string appears {count} times in {file_path}. "
+                "It must be unique — provide more context."
+            )
+        updated = current.replace(old_string, new_string, 1)
+        await sandbox.upload([(file_path, updated.encode())])
+        return f"Successfully edited {file_path}"
+
+    return StructuredTool.from_function(
+        coroutine=_edit_file,
+        name="edit_file",
+        description="Find and replace a unique string in an existing file.",
+        args_schema=_EditFileArgs,
+    )
+
+
 class SandboxMiddleware(AgentMiddleware[Any, Any, Any]):
     """Registers the execute tool and injects sandbox context into system prompt."""
 
     def __init__(self, *, sandbox: Sandbox) -> None:
         self.sandbox = sandbox
-        self.tools: Sequence[BaseTool] = [_create_execute_tool(sandbox)]
+        self.tools: Sequence[BaseTool] = [
+            _create_execute_tool(sandbox),
+            _create_write_file_tool(sandbox),
+            _create_edit_file_tool(sandbox),
+        ]
 
     async def awrap_model_call(
         self,

--- a/backend/cubebox/middleware/timestamps.py
+++ b/backend/cubebox/middleware/timestamps.py
@@ -51,9 +51,11 @@ class TimestampMiddleware(AgentMiddleware[Any, Any, Any]):
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
     ) -> ToolMessage | Command[Any]:
+        started_at = datetime.now(UTC).isoformat()
         result = await handler(request)
         if isinstance(result, ToolMessage):
             if not result.response_metadata:
                 result.response_metadata = {}
+            result.response_metadata.setdefault("tool_started_at", started_at)
             result.response_metadata.setdefault("created_at", datetime.now(UTC).isoformat())
         return result

--- a/backend/cubebox/prompts/sandbox.py
+++ b/backend/cubebox/prompts/sandbox.py
@@ -10,12 +10,21 @@ from it) when reading, writing, or referencing files. Do NOT guess paths like `/
 `/tmp`, or `~` — use the working directory above unless you have explicitly confirmed \
 another path exists.
 
-**Use shell commands for all file operations:**
-- Read files: `cat`, `head`, `tail`, `less`
-- List files: `ls -la`, `find`, `tree`
-- Search: `grep -r`, `rg`, `awk`
-- Write/edit: `echo`, `tee`, `sed`, `patch`
-- Run code: `python`, `node`, `bash`
+## File Tools
+
+You have dedicated tools for file operations:
+
+- `write_file(file_path, content)` — Create a new file with the given content. \
+Creates parent directories automatically. Prefer this over `echo`/`cat` heredocs.
+- `edit_file(file_path, old_string, new_string)` — Replace an exact string in an existing file. \
+old_string must appear exactly once. Prefer this over `sed`/`awk`.
+
+**When to use which:**
+- Creating new files → `write_file`
+- Modifying existing files → `edit_file`
+- Running code, installing packages, listing files → `execute`
+
+## Shell Commands (`execute` tool)
 
 **Shell features available:**
 - Pipes: `cat file.txt | grep pattern | wc -l`

--- a/backend/tests/e2e/test_sandbox_tools.py
+++ b/backend/tests/e2e/test_sandbox_tools.py
@@ -43,3 +43,18 @@ async def test_edit_file_replaces_content(tmp_path) -> None:
     )
     assert "greet.txt" in result
     assert target.read_text() == "goodbye world"
+
+
+@pytest.mark.asyncio
+async def test_edit_file_returns_error_for_missing_file(tmp_path) -> None:
+    sandbox = LocalSandbox(workdir=str(tmp_path))
+    mw = SandboxMiddleware(sandbox=sandbox)
+    edit_tool = next(t for t in mw.tools if t.name == "edit_file")
+    result = await edit_tool.ainvoke(
+        {
+            "file_path": str(tmp_path / "nonexistent.txt"),
+            "old_string": "hello",
+            "new_string": "goodbye",
+        }
+    )
+    assert "Error" in result or "error" in result.lower()

--- a/backend/tests/e2e/test_sandbox_tools.py
+++ b/backend/tests/e2e/test_sandbox_tools.py
@@ -1,0 +1,45 @@
+"""E2E test: sandbox middleware tool registration."""
+
+import pytest
+
+from cubebox.middleware.sandbox import SandboxMiddleware
+from cubebox.sandbox.local import LocalSandbox
+
+
+def test_sandbox_middleware_registers_file_tools() -> None:
+    sandbox = LocalSandbox(workdir="/tmp")
+    mw = SandboxMiddleware(sandbox=sandbox)
+    names = [t.name for t in mw.tools]
+    assert "execute" in names
+    assert "write_file" in names
+    assert "edit_file" in names
+
+
+@pytest.mark.asyncio
+async def test_write_file_creates_file(tmp_path) -> None:
+    sandbox = LocalSandbox(workdir=str(tmp_path))
+    mw = SandboxMiddleware(sandbox=sandbox)
+    write_tool = next(t for t in mw.tools if t.name == "write_file")
+    result = await write_tool.ainvoke(
+        {"file_path": str(tmp_path / "hello.txt"), "content": "hello world"}
+    )
+    assert "hello.txt" in result
+    assert (tmp_path / "hello.txt").read_text() == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_edit_file_replaces_content(tmp_path) -> None:
+    target = tmp_path / "greet.txt"
+    target.write_text("hello world")
+    sandbox = LocalSandbox(workdir=str(tmp_path))
+    mw = SandboxMiddleware(sandbox=sandbox)
+    edit_tool = next(t for t in mw.tools if t.name == "edit_file")
+    result = await edit_tool.ainvoke(
+        {
+            "file_path": str(target),
+            "old_string": "hello",
+            "new_string": "goodbye",
+        }
+    )
+    assert "greet.txt" in result
+    assert target.read_text() == "goodbye world"

--- a/backend/tests/e2e/test_stream_converter.py
+++ b/backend/tests/e2e/test_stream_converter.py
@@ -1,7 +1,6 @@
 """Tests for stream converter tool_call_delta extraction."""
 
-from langchain_core.messages import AIMessage
-from langchain_core.messages import AIMessageChunk
+from langchain_core.messages import AIMessage, AIMessageChunk
 
 from cubebox.agents.stream import convert_messages_chunk, convert_updates_chunk
 

--- a/backend/tests/e2e/test_stream_converter.py
+++ b/backend/tests/e2e/test_stream_converter.py
@@ -1,0 +1,78 @@
+"""Tests for stream converter tool_call_delta extraction."""
+
+from langchain_core.messages import AIMessageChunk
+
+from cubebox.agents.stream import convert_messages_chunk
+
+
+def test_tool_call_chunk_emits_delta_event() -> None:
+    """tool_call_chunks in AIMessageChunk should produce tool_call_delta events."""
+    msg = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {"name": "write_file", "args": '{"file_path": "/app/', "id": "tc_1", "index": 0}
+        ],
+    )
+    events = convert_messages_chunk((msg, {}))
+    deltas = [e for e in events if e["type"] == "tool_call_delta"]
+    assert len(deltas) == 1
+    assert deltas[0]["data"]["name"] == "write_file"
+    assert deltas[0]["data"]["args_delta"] == '{"file_path": "/app/'
+    assert deltas[0]["data"]["tool_call_id"] == "tc_1"
+    assert deltas[0]["data"]["index"] == 0
+
+
+def test_tool_call_chunk_continuation_no_name() -> None:
+    """Continuation chunks have name=None and id=None."""
+    msg = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {"name": None, "args": "hello world", "id": None, "index": 0}
+        ],
+    )
+    events = convert_messages_chunk((msg, {}))
+    deltas = [e for e in events if e["type"] == "tool_call_delta"]
+    assert len(deltas) == 1
+    assert deltas[0]["data"]["name"] is None
+    assert deltas[0]["data"]["args_delta"] == "hello world"
+
+
+def test_text_and_tool_call_chunk_coexist() -> None:
+    """Text content and tool_call_chunks can appear in the same chunk."""
+    msg = AIMessageChunk(
+        content="Let me write that file.",
+        tool_call_chunks=[],
+    )
+    events = convert_messages_chunk((msg, {}))
+    text_events = [e for e in events if e["type"] == "text_delta"]
+    delta_events = [e for e in events if e["type"] == "tool_call_delta"]
+    assert len(text_events) == 1
+    assert len(delta_events) == 0
+
+
+def test_empty_args_delta_skipped() -> None:
+    """Chunks with empty or None args and no name should not produce events."""
+    msg = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {"name": None, "args": "", "id": None, "index": 0},
+            {"name": None, "args": None, "id": None, "index": 1},
+        ],
+    )
+    events = convert_messages_chunk((msg, {}))
+    deltas = [e for e in events if e["type"] == "tool_call_delta"]
+    assert len(deltas) == 0
+
+
+def test_name_only_chunk_emits_event() -> None:
+    """A chunk with name but empty args should emit (signals tool start)."""
+    msg = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {"name": "write_file", "args": "", "id": "tc_1", "index": 0},
+        ],
+    )
+    events = convert_messages_chunk((msg, {}))
+    deltas = [e for e in events if e["type"] == "tool_call_delta"]
+    assert len(deltas) == 1
+    assert deltas[0]["data"]["name"] == "write_file"

--- a/backend/tests/e2e/test_stream_converter.py
+++ b/backend/tests/e2e/test_stream_converter.py
@@ -1,8 +1,9 @@
 """Tests for stream converter tool_call_delta extraction."""
 
+from langchain_core.messages import AIMessage
 from langchain_core.messages import AIMessageChunk
 
-from cubebox.agents.stream import convert_messages_chunk
+from cubebox.agents.stream import convert_messages_chunk, convert_updates_chunk
 
 
 def test_tool_call_chunk_emits_delta_event() -> None:
@@ -26,9 +27,7 @@ def test_tool_call_chunk_continuation_no_name() -> None:
     """Continuation chunks have name=None and id=None."""
     msg = AIMessageChunk(
         content="",
-        tool_call_chunks=[
-            {"name": None, "args": "hello world", "id": None, "index": 0}
-        ],
+        tool_call_chunks=[{"name": None, "args": "hello world", "id": None, "index": 0}],
     )
     events = convert_messages_chunk((msg, {}))
     deltas = [e for e in events if e["type"] == "tool_call_delta"]
@@ -76,3 +75,22 @@ def test_name_only_chunk_emits_event() -> None:
     deltas = [e for e in events if e["type"] == "tool_call_delta"]
     assert len(deltas) == 1
     assert deltas[0]["data"]["name"] == "write_file"
+
+
+def test_convert_updates_chunk_includes_tool_call_started_at() -> None:
+    msg = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "id": "tc_1",
+                "name": "write_file",
+                "args": {"file_path": "/app/main.py", "content": "print('hi')"},
+                "type": "tool_call",
+            }
+        ],
+        response_metadata={"tool_call_started_at_by_index": {"0": "2026-04-10T10:00:00+00:00"}},
+    )
+    events = convert_updates_chunk({"model": {"messages": [msg]}})
+    tool_calls = [e for e in events if e["type"] == "tool_call"]
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["data"]["started_at"] == "2026-04-10T10:00:00+00:00"

--- a/backend/tests/e2e/test_streaming.py
+++ b/backend/tests/e2e/test_streaming.py
@@ -57,6 +57,64 @@ async def test_stream_always_ends_with_done(memory_client: httpx.AsyncClient) ->
     assert events[-1]["type"] == "done"
 
 
+def test_tool_call_delta_identity_is_backfilled_per_agent() -> None:
+    context: dict[tuple[str | None, int], dict[str, object]] = {}
+    events = conversations_route._dicts_to_sse_events(
+        [
+            {
+                "type": "tool_call_delta",
+                "timestamp": "",
+                "data": {
+                    "tool_call_id": "tc-a",
+                    "name": "write_file",
+                    "args_delta": '{"file_path":"a.py"',
+                    "index": 0,
+                },
+                "agent_id": "subagent:a",
+            },
+            {
+                "type": "tool_call_delta",
+                "timestamp": "",
+                "data": {
+                    "tool_call_id": "tc-b",
+                    "name": "write_file",
+                    "args_delta": '{"file_path":"b.py"',
+                    "index": 0,
+                },
+                "agent_id": "subagent:b",
+            },
+            {
+                "type": "tool_call_delta",
+                "timestamp": "",
+                "data": {
+                    "tool_call_id": None,
+                    "name": None,
+                    "args_delta": ',"content":"print(1)"}',
+                    "index": 0,
+                },
+                "agent_id": "subagent:a",
+            },
+            {
+                "type": "tool_call_delta",
+                "timestamp": "",
+                "data": {
+                    "tool_call_id": None,
+                    "name": None,
+                    "args_delta": ',"content":"print(2)"}',
+                    "index": 0,
+                },
+                "agent_id": "subagent:b",
+            },
+        ],
+        context,
+    )
+
+    assert events[2].data["tool_call_id"] == "tc-a"
+    assert events[2].data["name"] == "write_file"
+    assert events[3].data["tool_call_id"] == "tc-b"
+    assert events[3].data["name"] == "write_file"
+
+
 @pytest.mark.asyncio
 async def test_agent_id_is_null_for_main_agent(memory_client: httpx.AsyncClient) -> None:
     resp = await memory_client.post("/api/v1/conversations", params={"title": "test"})
@@ -252,9 +310,7 @@ async def test_tool_call_delta_events_in_sse_stream(
     monkeypatch.setattr(
         conversations_route, "_update_conversation_timestamp", _noop_update_timestamp
     )
-    monkeypatch.setattr(
-        conversations_route.ConversationRepository, "get_by_id", _fake_get_by_id
-    )
+    monkeypatch.setattr(conversations_route.ConversationRepository, "get_by_id", _fake_get_by_id)
     monkeypatch.setattr(
         "cubebox.agents.graph.create_cubebox_agent",
         lambda **_kwargs: _FakeToolCallAgent(),
@@ -287,4 +343,6 @@ async def test_tool_call_delta_events_in_sse_stream(
     assert len(delta_events) == 2, f"Expected 2 tool_call_delta events, got {len(delta_events)}"
     assert delta_events[0]["data"]["name"] == "write_file"
     assert delta_events[0]["data"]["tool_call_id"] == "tc_1"
+    assert delta_events[1]["data"]["name"] == "write_file"
+    assert delta_events[1]["data"]["tool_call_id"] == "tc_1"
     assert delta_events[1]["data"]["args_delta"] == 'os\\nimport sys"}'

--- a/backend/tests/e2e/test_streaming.py
+++ b/backend/tests/e2e/test_streaming.py
@@ -190,3 +190,101 @@ async def test_client_disconnect_cancels_stream_before_closing_checkpointer(
             events.append(json.loads(payload))
 
     assert events[-1]["type"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_delta_events_in_sse_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """tool_call_delta events should appear in SSE stream for tool_call_chunks."""
+    from langchain_core.messages import AIMessageChunk
+
+    class _DummySessionContext:
+        async def __aenter__(self) -> object:
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    class _FakeConn:
+        def close(self) -> None:
+            pass
+
+    class _FakeCheckpointer:
+        def __init__(self) -> None:
+            self.conn = _FakeConn()
+
+    class _FakeToolCallAgent:
+        async def astream(self, *_args, **_kwargs):
+            # First chunk: tool name + start of args
+            chunk1 = AIMessageChunk(
+                content="",
+                tool_call_chunks=[
+                    {
+                        "name": "write_file",
+                        "args": '{"file_path": "/app/main.py", "content": "import ',
+                        "id": "tc_1",
+                        "index": 0,
+                    }
+                ],
+            )
+            yield ("messages", (chunk1, {}))
+
+            # Second chunk: continuation
+            chunk2 = AIMessageChunk(
+                content="",
+                tool_call_chunks=[
+                    {"name": None, "args": 'os\\nimport sys"}', "id": None, "index": 0}
+                ],
+            )
+            yield ("messages", (chunk2, {}))
+
+    def _fake_session_maker() -> _DummySessionContext:
+        return _DummySessionContext()
+
+    async def _fake_get_by_id(self, conversation_id: str):
+        return SimpleNamespace(id=conversation_id, title=conversation_id)
+
+    async def _noop_update_timestamp(_conversation_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(conversations_route, "async_session_maker", _fake_session_maker)
+    monkeypatch.setattr(
+        conversations_route, "_update_conversation_timestamp", _noop_update_timestamp
+    )
+    monkeypatch.setattr(
+        conversations_route.ConversationRepository, "get_by_id", _fake_get_by_id
+    )
+    monkeypatch.setattr(
+        "cubebox.agents.graph.create_cubebox_agent",
+        lambda **_kwargs: _FakeToolCallAgent(),
+    )
+
+    raw_request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                checkpointer_factory=_FakeCheckpointer,
+                sandbox_factory=lambda: None,
+                skills=[],
+            )
+        ),
+        state=SimpleNamespace(user_id="test-user"),
+    )
+
+    response = await conversations_route.send_message(
+        "test-conv",
+        conversations_route.SendMessageRequest(content="write a file"),
+        raw_request,
+    )
+
+    events = []
+    async for chunk in response.body_iterator:
+        payload = chunk.removeprefix("data: ").strip()
+        if payload:
+            events.append(json.loads(payload))
+
+    delta_events = [e for e in events if e["type"] == "tool_call_delta"]
+    assert len(delta_events) == 2, f"Expected 2 tool_call_delta events, got {len(delta_events)}"
+    assert delta_events[0]["data"]["name"] == "write_file"
+    assert delta_events[0]["data"]["tool_call_id"] == "tc_1"
+    assert delta_events[1]["data"]["args_delta"] == 'os\\nimport sys"}'

--- a/backend/tests/unit/test_convert_messages.py
+++ b/backend/tests/unit/test_convert_messages.py
@@ -22,21 +22,35 @@ def test_convert_ai_message_with_tool_calls():
     msg = AIMessage(
         content="",
         tool_calls=[{"id": "1", "name": "execute", "args": {"command": "ls"}, "type": "tool_call"}],
+        response_metadata={"tool_call_started_at_by_index": {"0": "2026-04-10T10:00:00+00:00"}},
     )
     result = convert_to_api_messages([msg])
     assert result[0]["role"] == "assistant"
     assert result[0]["content"] is None
     assert result[0]["tool_calls"] == [
-        {"name": "execute", "arguments": {"command": "ls"}, "tool_call_id": "1"}
+        {
+            "name": "execute",
+            "arguments": {"command": "ls"},
+            "tool_call_id": "1",
+            "started_at": "2026-04-10T10:00:00+00:00",
+        }
     ]
 
 
 def test_convert_tool_message():
-    msgs = [ToolMessage(content="file.txt\nother.txt", name="execute", tool_call_id="1")]
+    msgs = [
+        ToolMessage(
+            content="file.txt\nother.txt",
+            name="execute",
+            tool_call_id="1",
+            response_metadata={"tool_started_at": "2026-04-10T10:00:01+00:00"},
+        )
+    ]
     result = convert_to_api_messages(msgs)
     assert result[0]["role"] == "tool"
     assert result[0]["name"] == "execute"
     assert result[0]["content"] == "file.txt\nother.txt"
+    assert result[0]["started_at"] == "2026-04-10T10:00:01+00:00"
 
 
 def test_convert_ai_message_with_reasoning():

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -77,7 +77,23 @@ function appendToolCallBlock(
   toolCallId: string,
 ): ContentBlock[] {
   const finalized = finalizeLastReasoning(blocks)
-  return [...finalized, { type: 'tool_call', name, arguments: args, tool_call_id: toolCallId }]
+  const exactMatchIndex = finalized.findIndex(
+    (block) => block.type === 'tool_call_streaming' && block.tool_call_id === toolCallId,
+  )
+  let fallbackMatchIndex = -1
+  for (let i = finalized.length - 1; i >= 0; i--) {
+    const block = finalized[i]
+    if (block.type === 'tool_call_streaming' && block.tool_call_id === null && block.name === name) {
+      fallbackMatchIndex = i
+      break
+    }
+  }
+  const matchIndex = exactMatchIndex >= 0 ? exactMatchIndex : fallbackMatchIndex
+  const nextBlocks = matchIndex >= 0
+    ? finalized.filter((_, index) => index !== matchIndex)
+    : finalized
+
+  return [...nextBlocks, { type: 'tool_call', name, arguments: args, tool_call_id: toolCallId }]
 }
 
 function normalizeTodoStatus(status: unknown): TodoItem['status'] {
@@ -247,6 +263,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
             const prev =
               s.streamAgents[agentKey]
               ?? emptyStream(event.agent_name)
+            const existingStartedAt = s.toolStartedMap[e.data.tool_call_id]
 
             let nextTodos = s.todos
             if (e.data.name === 'write_todos') {
@@ -257,7 +274,8 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
               todos: nextTodos,
               toolStartedMap: {
                 ...s.toolStartedMap,
-                [e.data.tool_call_id]: Date.now(),
+                [e.data.tool_call_id]: existingStartedAt
+                  ?? (e.data.started_at ? new Date(e.data.started_at).getTime() : Date.now()),
               },
               streamAgents: {
                 ...s.streamAgents,
@@ -280,6 +298,13 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
             const prev = s.streamAgents[agentKey] ?? emptyStream(event.agent_name)
             const idx = e.data.index ?? 0
             const blocks = [...prev.blocks]
+            const startedAt = e.timestamp ? new Date(e.timestamp).getTime() : Date.now()
+            const nextToolStartedMap = e.data.tool_call_id && !s.toolStartedMap[e.data.tool_call_id]
+              ? {
+                  ...s.toolStartedMap,
+                  [e.data.tool_call_id]: startedAt,
+                }
+              : s.toolStartedMap
 
             // Find existing streaming block for this index
             const existingIdx = blocks.findIndex(
@@ -296,6 +321,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
                 tool_call_id: e.data.tool_call_id ?? existing.tool_call_id,
               }
               return {
+                toolStartedMap: nextToolStartedMap,
                 streamAgents: {
                   ...s.streamAgents,
                   [agentKey]: { ...prev, blocks },
@@ -313,6 +339,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
               index: idx,
             })
             return {
+              toolStartedMap: nextToolStartedMap,
               streamAgents: {
                 ...s.streamAgents,
                 [agentKey]: { ...prev, blocks: finalized },
@@ -328,7 +355,8 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
               newMap[tcId] = {
                 content: e.data.content,
                 receivedAt: Date.now(),
-                startedAt: s.toolStartedMap[tcId],
+                startedAt: s.toolStartedMap[tcId]
+                  ?? (e.data.started_at ? new Date(e.data.started_at).getTime() : undefined),
                 contentType: e.data.content_type,
               }
             }
@@ -379,7 +407,9 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       const mainStream = agents[MAIN_AGENT_KEY]
       if (mainStream) {
         // Finalize any pending reasoning block and strip internal started_at field
-        const finalBlocks = finalizeLastReasoning(mainStream.blocks).map((b) => {
+        const finalBlocks = finalizeLastReasoning(mainStream.blocks)
+          .filter((b) => b.type !== 'tool_call_streaming')
+          .map((b) => {
           if (b.type === 'reasoning') {
             const { started_at: _, ...rest } = b
             return rest
@@ -395,6 +425,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
                 name: tc.data.name,
                 arguments: tc.data.arguments,
                 tool_call_id: tc.data.tool_call_id,
+                started_at: tc.data.started_at ?? null,
               }))
             : null,
           reasoning: mainStream.reasoning || null,

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -2,7 +2,7 @@
 import { create } from 'zustand'
 import type {
   ContentBlock, TodoItem,
-  Message, TextDeltaEvent, ToolCallEvent,
+  Message, TextDeltaEvent, ToolCallEvent, ToolCallDeltaEvent,
   ToolResultEvent, ReasoningEvent, ArtifactEventData,
 } from '../types'
 import type { ApiClient } from '../api'
@@ -271,6 +271,51 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
                     e.data.tool_call_id,
                   ),
                 },
+              },
+            }
+          })
+        } else if (event.type === 'tool_call_delta') {
+          const e = event as ToolCallDeltaEvent
+          batchedSet((s) => {
+            const prev = s.streamAgents[agentKey] ?? emptyStream(event.agent_name)
+            const idx = e.data.index ?? 0
+            const blocks = [...prev.blocks]
+
+            // Find existing streaming block for this index
+            const existingIdx = blocks.findIndex(
+              (b) => b.type === 'tool_call_streaming' && b.index === idx,
+            )
+
+            if (existingIdx >= 0) {
+              const existing = blocks[existingIdx] as Extract<
+                ContentBlock, { type: 'tool_call_streaming' }
+              >
+              blocks[existingIdx] = {
+                ...existing,
+                args_text: existing.args_text + (e.data.args_delta || ''),
+                tool_call_id: e.data.tool_call_id ?? existing.tool_call_id,
+              }
+              return {
+                streamAgents: {
+                  ...s.streamAgents,
+                  [agentKey]: { ...prev, blocks },
+                },
+              }
+            }
+
+            // Create new streaming block
+            const finalized = finalizeLastReasoning(blocks)
+            finalized.push({
+              type: 'tool_call_streaming',
+              name: e.data.name ?? '',
+              args_text: e.data.args_delta || '',
+              tool_call_id: e.data.tool_call_id ?? null,
+              index: idx,
+            })
+            return {
+              streamAgents: {
+                ...s.streamAgents,
+                [agentKey]: { ...prev, blocks: finalized },
               },
             }
           })

--- a/frontend/packages/core/src/stores/panelStore.ts
+++ b/frontend/packages/core/src/stores/panelStore.ts
@@ -1,6 +1,6 @@
 // frontend/packages/core/src/stores/panelStore.ts
 import { create } from 'zustand'
-import type { PanelContentType } from '../types'
+import type { PanelContentType, ToolCallRef } from '../types'
 
 /** Map tool name + optional backend content_type to a PanelContentType. */
 function mapContentType(
@@ -9,6 +9,7 @@ function mapContentType(
 ): PanelContentType {
   if (toolName === 'load_skill') return 'skill'
   if (toolName === 'execute') return 'terminal'
+  if (toolName === 'write_file') return 'write_file'
   if (toolName === 'code_execute' || toolName === 'python') return 'code_execute'
 
   if (backendContentType === 'json') {
@@ -33,6 +34,7 @@ export type PanelView =
       toolArgs: Record<string, unknown>
       toolResult: string | null
       contentType: PanelContentType
+      toolRef: ToolCallRef | null
     }
   | {
       type: 'artifact'
@@ -48,6 +50,7 @@ export interface PanelStore {
     toolArgs: Record<string, unknown>,
     toolResult: string | null,
     contentType?: string,
+    toolRef?: ToolCallRef,
   ) => void
 
   openArtifact: (conversationId: string, artifactId: string) => void
@@ -58,7 +61,7 @@ export interface PanelStore {
 export const usePanelStore = create<PanelStore>((set) => ({
   view: { type: 'closed' },
 
-  openTool: (toolName, toolArgs, toolResult, contentType) =>
+  openTool: (toolName, toolArgs, toolResult, contentType, toolRef) =>
     set({
       view: {
         type: 'tool',
@@ -66,6 +69,7 @@ export const usePanelStore = create<PanelStore>((set) => ({
         toolArgs,
         toolResult,
         contentType: mapContentType(toolName, contentType),
+        toolRef: toolRef ?? null,
       },
     }),
 

--- a/frontend/packages/core/src/stores/toolDetailStore.ts
+++ b/frontend/packages/core/src/stores/toolDetailStore.ts
@@ -1,7 +1,7 @@
 // frontend/packages/core/src/stores/toolDetailStore.ts
 // Thin compatibility layer — delegates to the unified panelStore.
 import { usePanelStore } from './panelStore'
-import type { PanelContentType } from '../types'
+import type { PanelContentType, ToolCallRef } from '../types'
 
 export interface ToolDetailStore {
   isOpen: boolean
@@ -9,12 +9,14 @@ export interface ToolDetailStore {
   toolArgs: Record<string, unknown>
   toolResult: string | null
   contentType: PanelContentType
+  toolRef: ToolCallRef | null
 
   open: (
     toolName: string,
     toolArgs: Record<string, unknown>,
     toolResult: string | null,
     contentType?: string,
+    toolRef?: ToolCallRef,
   ) => void
   close: () => void
 }
@@ -31,6 +33,7 @@ export const useToolDetailStore = Object.assign(
               toolArgs: v.toolArgs,
               toolResult: v.toolResult,
               contentType: v.contentType,
+              toolRef: v.toolRef,
               open: panel.openTool,
               close: panel.close,
             }
@@ -40,6 +43,7 @@ export const useToolDetailStore = Object.assign(
               toolArgs: {},
               toolResult: null,
               contentType: 'generic',
+              toolRef: null,
               open: panel.openTool,
               close: panel.close,
             }
@@ -57,6 +61,7 @@ export const useToolDetailStore = Object.assign(
           toolArgs: v.toolArgs,
           toolResult: v.toolResult,
           contentType: v.contentType,
+          toolRef: v.toolRef,
           open: panel.openTool,
           close: panel.close,
         }
@@ -67,6 +72,7 @@ export const useToolDetailStore = Object.assign(
         toolArgs: {},
         toolResult: null,
         contentType: 'generic',
+        toolRef: null,
         open: panel.openTool,
         close: panel.close,
       }

--- a/frontend/packages/core/src/types/events.ts
+++ b/frontend/packages/core/src/types/events.ts
@@ -27,11 +27,18 @@ export interface TodoItem {
   status: 'pending' | 'in_progress' | 'completed'
 }
 
+export interface ToolCallRef {
+  agent_id: string | null
+  tool_call_id: string | null
+  index: number | null
+}
+
 export type PanelContentType =
   | 'search'
   | 'code_execute'
   | 'web_fetch'
   | 'terminal'
+  | 'write_file'
   | 'generic'
   | 'artifact'
   | 'skill'
@@ -77,6 +84,7 @@ export interface ToolCallEvent extends AgentEvent {
     tool_call_id: string
     name: string
     arguments: Record<string, unknown>
+    started_at?: string
   }
 }
 
@@ -96,6 +104,7 @@ export interface ToolResultEvent extends AgentEvent {
     tool_name: string
     tool_call_id: string
     content: string
+    started_at?: string
     content_type?: string
   }
 }

--- a/frontend/packages/core/src/types/events.ts
+++ b/frontend/packages/core/src/types/events.ts
@@ -13,6 +13,13 @@ export type ContentBlock =
       arguments: Record<string, unknown>
       tool_call_id: string
     }
+  | {
+      type: 'tool_call_streaming'
+      name: string
+      args_text: string
+      tool_call_id: string | null
+      index: number
+    }
 
 export interface TodoItem {
   id: string | null
@@ -33,6 +40,7 @@ export type AgentEventType =
   | 'text_delta'
   | 'reasoning'
   | 'tool_call'
+  | 'tool_call_delta'
   | 'tool_result'
   | 'artifact'
   | 'error'
@@ -69,6 +77,16 @@ export interface ToolCallEvent extends AgentEvent {
     tool_call_id: string
     name: string
     arguments: Record<string, unknown>
+  }
+}
+
+export interface ToolCallDeltaEvent extends AgentEvent {
+  type: 'tool_call_delta'
+  data: {
+    tool_call_id: string | null
+    name: string | null
+    args_delta: string
+    index: number | null
   }
 }
 

--- a/frontend/packages/core/src/types/message.ts
+++ b/frontend/packages/core/src/types/message.ts
@@ -14,13 +14,14 @@ export interface Message {
   role: 'user' | 'assistant' | 'tool'
   content: string | null
   tool_calls?: {
-    name: string; arguments: Record<string, unknown>; tool_call_id?: string
+    name: string; arguments: Record<string, unknown>; tool_call_id?: string; started_at?: string | null
   }[] | null
   reasoning?: string | null
   reasoning_duration_ms?: number | null  // from backend: estimated reasoning duration
   blocks?: ContentBlock[] | null  // ordered content blocks preserving temporal order
   name?: string | null  // for tool messages
   tool_call_id?: string | null  // for tool messages: which tool_call this responds to
+  started_at?: string | null
   subagent_events?: SubagentSummary | null  // consolidated subagent data for tool messages
   created_at?: string
 }

--- a/frontend/packages/web/__tests__/hooks/useMessages.test.ts
+++ b/frontend/packages/web/__tests__/hooks/useMessages.test.ts
@@ -20,6 +20,7 @@ function mockSSEResponse(events: object[]) {
 const mockClient = { baseUrl: '', get: vi.fn(), post: vi.fn() }
 
 beforeEach(() => {
+  vi.useRealTimers()
   useMessageStore.setState({
     messages: {},
     streamAgents: {},
@@ -193,5 +194,136 @@ describe('messageStore.send', () => {
         status: 'in_progress',
       },
     ])
+  })
+
+  it('replaces streamed tool-call placeholders with the finalized tool call', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => mockSSEResponse([
+      {
+        type: 'tool_call_delta',
+        data: {
+          tool_call_id: 'call-1',
+          name: 'execute',
+          args_delta: '{"cmd":"echo',
+          index: 0,
+        },
+        agent_id: null,
+        agent_name: null,
+        timestamp: '',
+      },
+      {
+        type: 'tool_call',
+        data: {
+          tool_call_id: 'call-1',
+          name: 'execute',
+          arguments: { cmd: 'echo hello' },
+        },
+        agent_id: null,
+        agent_name: null,
+        timestamp: '',
+      },
+      { type: 'done', data: {}, agent_id: null, agent_name: null, timestamp: '' },
+    ])))
+
+    await act(async () => {
+      await useMessageStore.getState().send(mockClient as any, CONV_ID, 'run it')
+    })
+
+    const msgs = useMessageStore.getState().messages[CONV_ID] ?? []
+    const assistantMsg = msgs.find((m) => m.role === 'assistant')
+    expect(assistantMsg?.blocks).toEqual([
+      {
+        type: 'tool_call',
+        name: 'execute',
+        arguments: { cmd: 'echo hello' },
+        tool_call_id: 'call-1',
+      },
+    ])
+  })
+
+  it('does not persist unfinished streaming tool-call placeholders', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => mockSSEResponse([
+      {
+        type: 'tool_call_delta',
+        data: {
+          tool_call_id: null,
+          name: 'search',
+          args_delta: '{"query":"partial',
+          index: 0,
+        },
+        agent_id: null,
+        agent_name: null,
+        timestamp: '',
+      },
+      { type: 'done', data: {}, agent_id: null, agent_name: null, timestamp: '' },
+    ])))
+
+    await act(async () => {
+      await useMessageStore.getState().send(mockClient as any, CONV_ID, 'search')
+    })
+
+    const msgs = useMessageStore.getState().messages[CONV_ID] ?? []
+    const assistantMsg = msgs.find((m) => m.role === 'assistant')
+    expect(assistantMsg?.blocks).toBeNull()
+  })
+
+  it('preserves tool timing from the first tool_call_delta through completion', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => mockSSEResponse([
+      {
+        type: 'tool_call_delta',
+        data: {
+          tool_call_id: 'write-1',
+          name: 'write_file',
+          args_delta: '{"file_path":"/tmp/demo.txt","content":"hello"}',
+          index: 0,
+        },
+        agent_id: null,
+        agent_name: null,
+        timestamp: '',
+      },
+      {
+        type: 'tool_call',
+        data: {
+          tool_call_id: 'write-1',
+          name: 'write_file',
+          arguments: {
+            file_path: '/tmp/demo.txt',
+            content: 'hello',
+          },
+        },
+        agent_id: null,
+        agent_name: null,
+        timestamp: '',
+      },
+      {
+        type: 'tool_result',
+        data: {
+          tool_name: 'write_file',
+          tool_call_id: 'write-1',
+          content: 'Successfully wrote /tmp/demo.txt',
+        },
+        agent_id: null,
+        agent_name: null,
+        timestamp: '',
+      },
+      { type: 'done', data: {}, agent_id: null, agent_name: null, timestamp: '' },
+    ])))
+
+    const nowSpy = vi.spyOn(Date, 'now')
+    nowSpy
+      .mockImplementationOnce(() => 100)
+      .mockImplementationOnce(() => 1_000)
+      .mockImplementationOnce(() => 4_000)
+      .mockImplementationOnce(() => 5_000)
+
+    await act(async () => {
+      await useMessageStore.getState().send(mockClient as any, CONV_ID, 'write file')
+    })
+
+    expect(useMessageStore.getState().toolResultMap['write-1']).toMatchObject({
+      startedAt: 1_000,
+      receivedAt: 4_000,
+    })
+
+    nowSpy.mockRestore()
   })
 })

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -11,6 +11,8 @@ import { ArtifactCard } from './ArtifactCard'
 import { SubAgentCard } from './SubAgentCard'
 import { SubAgentCluster } from './SubAgentCluster'
 import { ToolCallGroup } from './ToolCallGroup'
+import { ToolCallItem } from './ToolCallItem'
+import { getWriteFileSummary } from '@/lib/writeFilePreview'
 
 interface ReasoningBlockProps {
   reasoning: string
@@ -196,13 +198,14 @@ function subagentSummaryToStream(summary: SubagentSummary): AgentStream {
 
 function ContentBlockRenderer(
   { block, index, isLast, isStreaming, subAgentStreams, subagentDataMap, toolResultMap,
-    messageCreatedAt, subagentIndex }: {
+    messageCreatedAt, subagentIndex, agentId }: {
     block: ContentBlock; index: number; isLast: boolean; isStreaming: boolean
     subAgentStreams?: Record<string, AgentStream>
     subagentDataMap?: Record<string, SubagentSummary>
     toolResultMap: Record<string, { content: string; receivedAt: number }>
     messageCreatedAt?: string
     subagentIndex?: number
+    agentId?: string | null
   },
 ) {
   if (block.type === 'reasoning') {
@@ -232,6 +235,7 @@ function ContentBlockRenderer(
         role={args.role ?? ''}
         task={args.task ?? ''}
         index={subagentIndex ?? 1}
+        agentId={agentKey}
         stream={stream ?? historicalStream}
         isRunning={isStreaming && !!stream && !toolResultMap[block.tool_call_id]}
         toolResultMap={toolResultMap}
@@ -266,6 +270,9 @@ function ContentBlockRenderer(
     if (artifact) {
       return <ArtifactCard artifact={artifact} />
     }
+    if (isStreaming || !toolResult) {
+      return null
+    }
     // Fallback to regular tool call rendering
     return (
       <ToolCallGroup
@@ -273,6 +280,7 @@ function ContentBlockRenderer(
         toolResultMap={toolResultMap}
         isStreaming={isStreaming}
         messageCreatedAt={messageCreatedAt}
+        agentId={agentId}
       />
     )
   }
@@ -283,15 +291,50 @@ function ContentBlockRenderer(
         toolResultMap={toolResultMap}
         isStreaming={isStreaming}
         messageCreatedAt={messageCreatedAt}
+        agentId={agentId}
       />
     )
   }
-  // text block
-  return (
-    <div className={proseClasses}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{block.content}</ReactMarkdown>
-    </div>
-  )
+  if (block.type === 'tool_call_streaming') {
+    const supportsPreview = block.name === 'write_file'
+    return (
+      <div
+        className="bg-card border border-border rounded-xl
+          overflow-hidden border-l-2
+          border-l-muted-foreground/20"
+      >
+        <ToolCallItem
+          name={block.name || 'tool'}
+          arguments={{}}
+          toolCallId={block.tool_call_id ?? `streaming-${index}`}
+          summaryOverride={supportsPreview
+            ? getWriteFileSummary({}, block.args_text)
+            : (block.args_text.trim() || undefined)}
+          contentTypeOverride={supportsPreview ? 'write_file' : undefined}
+          toolRef={supportsPreview
+            ? {
+                agent_id: agentId ?? null,
+                tool_call_id: block.tool_call_id,
+                index: block.index,
+              }
+            : undefined}
+          timestamp={messageCreatedAt}
+          isPending={true}
+          allowOpenWhenPending={supportsPreview}
+        />
+      </div>
+    )
+  }
+  if (block.type === 'text') {
+    return (
+      <div className={proseClasses}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{block.content}</ReactMarkdown>
+      </div>
+    )
+  }
+
+  const _exhaustive: never = block
+  return _exhaustive
 }
 
 /** Group consecutive tool_call blocks for compact rendering (subagent calls render individually) */
@@ -327,6 +370,7 @@ export function AssistantMessage(
   { message, stream, isStreaming, statusPhase, subAgentStreams, subagentDataMap, toolResultMap }:
   AssistantMessageProps,
 ) {
+  const streamAgentId = stream ? 'main' : undefined
   const blocks: ContentBlock[] = stream
     ? stream.blocks
     : (message!.blocks ?? blocksFromMessage(message!))
@@ -377,6 +421,7 @@ export function AssistantMessage(
                 toolResultMap={toolResultMap}
                 isStreaming={isStreaming === true}
                 messageCreatedAt={msgCreatedAt}
+                agentId={streamAgentId}
               />
             )
           }
@@ -392,6 +437,7 @@ export function AssistantMessage(
               toolResultMap={toolResultMap}
               messageCreatedAt={msgCreatedAt}
               subagentIndex={subagentIndexMap.get(i)}
+              agentId={streamAgentId}
             />
           )
         })}

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -41,22 +41,27 @@ function buildHistoricalToolResultMap(
   const map: Record<string, {
     content: string; receivedAt: number; startedAt?: number; contentType?: string
   }> = {}
-  // Build a map of tool_call_id → assistant message created_at (= tool call start time)
+  // Build a map of tool_call_id → authoritative tool start time from history.
   const toolCallStartMap: Record<string, number> = {}
   for (const msg of messages) {
-    if (msg.role === 'assistant' && msg.tool_calls && msg.created_at) {
-      const ts = new Date(msg.created_at).getTime()
+    if (msg.role === 'assistant' && msg.tool_calls) {
       for (const tc of msg.tool_calls) {
-        if (tc.tool_call_id) toolCallStartMap[tc.tool_call_id] = ts
+        if (!tc.tool_call_id) continue
+        const rawStart = tc.started_at ?? msg.created_at
+        if (!rawStart) continue
+        toolCallStartMap[tc.tool_call_id] = new Date(rawStart).getTime()
       }
     }
   }
   for (const msg of messages) {
     if (msg.role === 'tool' && msg.tool_call_id) {
+      const fallbackStartedAt = msg.started_at
+        ? new Date(msg.started_at).getTime()
+        : undefined
       map[msg.tool_call_id] = {
         content: msg.content ?? '',
         receivedAt: new Date(msg.created_at ?? 0).getTime(),
-        startedAt: toolCallStartMap[msg.tool_call_id],
+        startedAt: toolCallStartMap[msg.tool_call_id] ?? fallbackStartedAt,
       }
     }
   }

--- a/frontend/packages/web/components/chat/SubAgentCard.tsx
+++ b/frontend/packages/web/components/chat/SubAgentCard.tsx
@@ -4,20 +4,27 @@ import { useState, useEffect, useRef, memo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { CheckCircle2, ChevronDown, ChevronRight } from 'lucide-react'
-import type { AgentStream } from '@cubebox/core'
+import type { AgentStream, ContentBlock, ToolCallRef } from '@cubebox/core'
 import { ToolCallItem } from './ToolCallItem'
 import { AgentAvatar } from './AgentAvatar'
 import { proseClasses } from '@/lib/utils'
+import { getWriteFileSummary } from '@/lib/writeFilePreview'
 
 interface Props {
   name: string
   role: string
   task: string
   index: number
+  agentId?: string
   stream?: AgentStream
   isRunning: boolean
   toolResultMap: Record<string, { content: string; receivedAt: number }>
 }
+
+type ToolDisplayBlock = Extract<
+  ContentBlock,
+  { type: 'tool_call' | 'tool_call_streaming' }
+>
 
 function formatDuration(ms: number): string {
   if (ms < 0) return '0s'
@@ -33,6 +40,7 @@ export const SubAgentCard = memo(function SubAgentCard({
   role,
   task,
   index,
+  agentId,
   stream,
   isRunning,
   toolResultMap,
@@ -67,14 +75,76 @@ export const SubAgentCard = memo(function SubAgentCard({
   }, [toolCallCount, toolResultCount, streamText, isRunning])
 
   const toolCalls = stream?.toolCalls ?? []
+  const toolBlocks = (stream?.blocks ?? []).filter(
+    (block): block is ToolDisplayBlock =>
+      block.type === 'tool_call' || block.type === 'tool_call_streaming',
+  )
+  const visibleToolBlocks: ToolDisplayBlock[] = toolBlocks.length > 0
+    ? toolBlocks
+    : toolCalls.map((tc) => ({
+        type: 'tool_call' as const,
+        name: tc.data.name,
+        arguments: tc.data.arguments,
+        tool_call_id: tc.data.tool_call_id,
+      }))
   const completedCount = toolCalls.filter(
     (tc) => toolResultMap[tc.data.tool_call_id],
   ).length
   const pendingTc = toolCalls.find(
     (tc) => !toolResultMap[tc.data.tool_call_id],
   )
-  const hasContent = stream && (toolCalls.length > 0 || stream.text)
+  const hasContent = stream && (toolBlocks.length > 0 || toolCalls.length > 0 || stream.text)
   const displayTime = isRunning ? elapsed : (hasContent ? elapsed : 0)
+
+  const renderToolBlock = (block: ToolDisplayBlock, i: number, showDivider = false) => {
+    if (block.type === 'tool_call_streaming') {
+      const supportsPreview = block.name === 'write_file'
+      return (
+        <ToolCallItem
+          key={block.tool_call_id ?? `streaming-${i}`}
+          name={block.name || 'tool'}
+          arguments={{}}
+          toolCallId={block.tool_call_id ?? `streaming-${i}`}
+          summaryOverride={supportsPreview
+            ? getWriteFileSummary({}, block.args_text)
+            : (block.args_text.trim() || undefined)}
+          contentTypeOverride={supportsPreview ? 'write_file' : undefined}
+          toolRef={supportsPreview
+            ? {
+                agent_id: agentId ?? null,
+                tool_call_id: block.tool_call_id,
+                index: block.index,
+              } satisfies ToolCallRef
+            : undefined}
+          isPending={true}
+          allowOpenWhenPending={supportsPreview}
+          showDivider={showDivider}
+        />
+      )
+    }
+
+    const result = toolResultMap[block.tool_call_id] ?? null
+    return (
+      <ToolCallItem
+        key={block.tool_call_id || i}
+        name={block.name}
+        arguments={block.arguments}
+        toolCallId={block.tool_call_id}
+        contentTypeOverride={block.name === 'write_file' ? 'write_file' : undefined}
+        toolRef={block.name === 'write_file'
+          ? {
+              agent_id: agentId ?? null,
+              tool_call_id: block.tool_call_id,
+              index: null,
+            } satisfies ToolCallRef
+          : undefined}
+        toolResult={result}
+        isPending={isRunning && !result}
+        allowOpenWhenPending={block.name === 'write_file'}
+        showDivider={showDivider}
+      />
+    )
+  }
 
   return (
     <div className="border border-border rounded-xl overflow-hidden bg-muted/10 border-l-2
@@ -111,20 +181,7 @@ export const SubAgentCard = memo(function SubAgentCard({
                   'linear-gradient(to bottom, transparent 0%, black 15%, black 80%, transparent 100%)',
               }}
             >
-              {toolCalls.map((tc, i) => {
-                const result = toolResultMap[tc.data.tool_call_id] ?? null
-                return (
-                  <ToolCallItem
-                    key={tc.data.tool_call_id || i}
-                    name={tc.data.name}
-                    arguments={tc.data.arguments}
-                    toolCallId={tc.data.tool_call_id}
-                    toolResult={result}
-                    timestamp={tc.timestamp}
-                    isPending={isRunning && !result}
-                  />
-                )
-              })}
+              {visibleToolBlocks.map((block, i) => renderToolBlock(block, i))}
               {!isRunning && stream?.text && (
                 <div className={`px-3 py-2 text-xs text-muted-foreground line-clamp-3`}>
                   {stream.text.slice(-200)}
@@ -136,21 +193,7 @@ export const SubAgentCard = memo(function SubAgentCard({
           {/* Expanded full content */}
           {expanded && (
             <div className="max-h-80 overflow-y-auto">
-              {toolCalls.map((tc, i) => {
-                const result = toolResultMap[tc.data.tool_call_id] ?? null
-                return (
-                  <ToolCallItem
-                    key={tc.data.tool_call_id || i}
-                    name={tc.data.name}
-                    arguments={tc.data.arguments}
-                    toolCallId={tc.data.tool_call_id}
-                    toolResult={result}
-                    timestamp={tc.timestamp}
-                    isPending={isRunning && !result}
-                    showDivider={i > 0}
-                  />
-                )
-              })}
+              {visibleToolBlocks.map((block, i) => renderToolBlock(block, i, i > 0))}
               {stream?.text && (
                 <div className={`px-3 py-2 border-t border-border ${proseClasses}`}>
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{stream.text}</ReactMarkdown>

--- a/frontend/packages/web/components/chat/ToolCallGroup.tsx
+++ b/frontend/packages/web/components/chat/ToolCallGroup.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ContentBlock } from '@cubebox/core'
+import type { ContentBlock, ToolCallRef } from '@cubebox/core'
 import { ToolCallItem } from './ToolCallItem'
 
 interface ToolCallGroupProps {
@@ -12,6 +12,7 @@ interface ToolCallGroupProps {
   isStreaming: boolean
   /** ISO timestamp of the parent assistant message (used to compute tool call duration) */
   messageCreatedAt?: string
+  agentId?: string | null
 }
 
 export function ToolCallGroup({
@@ -19,6 +20,7 @@ export function ToolCallGroup({
   toolResultMap,
   isStreaming,
   messageCreatedAt,
+  agentId,
 }: ToolCallGroupProps) {
   return (
     <div
@@ -36,9 +38,18 @@ export function ToolCallGroup({
             name={block.name}
             arguments={block.arguments}
             toolCallId={block.tool_call_id}
+            contentTypeOverride={block.name === 'write_file' ? 'write_file' : undefined}
+            toolRef={block.name === 'write_file'
+              ? {
+                  agent_id: agentId ?? null,
+                  tool_call_id: block.tool_call_id,
+                  index: null,
+                } satisfies ToolCallRef
+              : undefined}
             toolResult={result}
             timestamp={messageCreatedAt}
             isPending={isPending}
+            allowOpenWhenPending={block.name === 'write_file'}
             showDivider={i > 0}
           />
         )

--- a/frontend/packages/web/components/chat/ToolCallItem.tsx
+++ b/frontend/packages/web/components/chat/ToolCallItem.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef, memo } from 'react'
+import type { ToolCallRef } from '@cubebox/core'
 import {
   CheckCircle2,
   Circle,
@@ -13,6 +14,9 @@ interface ToolCallItemProps {
   name: string
   arguments: Record<string, unknown>
   toolCallId: string
+  summaryOverride?: string
+  contentTypeOverride?: string
+  toolRef?: ToolCallRef
   toolResult?: {
     content: string
     receivedAt: number
@@ -22,6 +26,7 @@ interface ToolCallItemProps {
   timestamp?: string
   /** True while this tool is still executing */
   isPending: boolean
+  allowOpenWhenPending?: boolean
   /** Show border-top separator (not first in group) */
   showDivider?: boolean
 }
@@ -39,9 +44,13 @@ export const ToolCallItem = memo(function ToolCallItem({
   name,
   arguments: args,
   toolCallId,
+  summaryOverride,
+  contentTypeOverride,
+  toolRef,
   toolResult,
   timestamp,
   isPending,
+  allowOpenWhenPending,
   showDivider,
 }: ToolCallItemProps) {
   const [elapsed, setElapsed] = useState(0)
@@ -69,10 +78,17 @@ export const ToolCallItem = memo(function ToolCallItem({
     : elapsed
 
   const Icon = getToolIcon(name)
-  const summary = getParamSummary(name, args)
+  const summary = summaryOverride ?? getParamSummary(name, args)
+  const canOpen = Boolean(toolResult) || allowOpenWhenPending
 
   const handleViewInPanel = () => {
-    openPanel(name, args, toolResult?.content ?? null, toolResult?.contentType)
+    openPanel(
+      name,
+      args,
+      toolResult?.content ?? null,
+      contentTypeOverride ?? toolResult?.contentType,
+      toolRef,
+    )
   }
 
   return (
@@ -83,10 +99,10 @@ export const ToolCallItem = memo(function ToolCallItem({
     >
       <button
         type="button"
-        onClick={toolResult ? handleViewInPanel : undefined}
+        onClick={canOpen ? handleViewInPanel : undefined}
         className={`flex w-full items-center gap-2 px-3
           py-2 text-sm transition-colors
-          ${toolResult ? 'hover:bg-muted/50 cursor-pointer' : ''}`}
+          ${canOpen ? 'hover:bg-muted/50 cursor-pointer' : ''}`}
       >
         <Icon
           className="size-3.5 text-muted-foreground
@@ -146,6 +162,10 @@ export const ToolCallItem = memo(function ToolCallItem({
                 className="size-3 text-muted-foreground"
               />
             </>
+          ) : canOpen ? (
+            <PanelRight
+              className="size-3 text-muted-foreground"
+            />
           ) : null}
         </span>
       </button>

--- a/frontend/packages/web/components/panel/ToolDetailPanel.tsx
+++ b/frontend/packages/web/components/panel/ToolDetailPanel.tsx
@@ -8,6 +8,7 @@ import { SearchResultView } from './SearchResultView'
 import { WebFetchView } from './WebFetchView'
 import { GenericToolView } from './GenericToolView'
 import { SkillView } from './SkillView'
+import { WriteFilePreviewView } from './WriteFilePreviewView'
 
 export function ToolDetailPanel() {
   const {
@@ -15,6 +16,7 @@ export function ToolDetailPanel() {
     toolArgs,
     toolResult,
     contentType,
+    toolRef,
     close,
   } = useToolDetail()
 
@@ -49,6 +51,13 @@ export function ToolDetailPanel() {
           <SkillView
             args={toolArgs}
             result={toolResult}
+          />
+        )}
+        {contentType === 'write_file' && (
+          <WriteFilePreviewView
+            args={toolArgs}
+            result={toolResult}
+            toolRef={toolRef}
           />
         )}
         {(contentType === 'generic' ||

--- a/frontend/packages/web/components/panel/WriteFilePreviewView.tsx
+++ b/frontend/packages/web/components/panel/WriteFilePreviewView.tsx
@@ -1,0 +1,270 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { useMessageStore } from '@cubebox/core'
+import type { ToolCallRef } from '@cubebox/core'
+import { proseClasses } from '@/lib/utils'
+import {
+  parseWriteFileArgs,
+  resolveLiveWriteFile,
+} from '@/lib/writeFilePreview'
+
+interface WriteFilePreviewViewProps {
+  args: Record<string, unknown>
+  result: string | null
+  toolRef: ToolCallRef | null
+}
+
+type PreviewMode = 'markdown' | 'code' | 'text'
+
+interface Token {
+  type: 'plain' | 'comment' | 'string' | 'keyword' | 'number' | 'tag' | 'property'
+  value: string
+}
+
+function detectLanguage(filePath: string): string | null {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? ''
+  const map: Record<string, string> = {
+    js: 'javascript',
+    jsx: 'javascript',
+    ts: 'typescript',
+    tsx: 'typescript',
+    py: 'python',
+    rb: 'ruby',
+    go: 'go',
+    rs: 'rust',
+    java: 'java',
+    kt: 'kotlin',
+    swift: 'swift',
+    php: 'php',
+    c: 'c',
+    h: 'c',
+    cpp: 'cpp',
+    cc: 'cpp',
+    cxx: 'cpp',
+    hpp: 'cpp',
+    cs: 'csharp',
+    sh: 'bash',
+    bash: 'bash',
+    zsh: 'bash',
+    json: 'json',
+    html: 'html',
+    xml: 'html',
+    css: 'css',
+    scss: 'css',
+    sql: 'sql',
+    yaml: 'yaml',
+    yml: 'yaml',
+  }
+  return map[ext] ?? null
+}
+
+function detectMode(filePath: string): PreviewMode {
+  const normalized = filePath.toLowerCase()
+  if (/\.(md|markdown|mdx)$/.test(normalized)) return 'markdown'
+  if (detectLanguage(filePath)) return 'code'
+  return 'text'
+}
+
+function getTokenPatterns(language: string | null): Array<{ type: Token['type']; regex: RegExp }> {
+  if (language === 'python') {
+    return [
+      { type: 'comment', regex: /#[^\n]*/ },
+      { type: 'string', regex: /"""[\s\S]*?"""|'''[\s\S]*?'''|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'/ },
+      {
+        type: 'keyword',
+        regex: /\b(?:def|class|return|if|elif|else|for|while|import|from|as|try|except|finally|with|yield|lambda|pass|raise|True|False|None|async|await)\b/,
+      },
+      { type: 'number', regex: /\b\d+(?:\.\d+)?\b/ },
+    ]
+  }
+  if (language === 'json' || language === 'yaml') {
+    return [
+      { type: 'string', regex: /"(?:\\.|[^"\\])*"/ },
+      { type: 'keyword', regex: /\b(?:true|false|null)\b/ },
+      { type: 'number', regex: /\b\d+(?:\.\d+)?\b/ },
+      { type: 'property', regex: /\b[a-zA-Z_][\w-]*(?=\s*:)/ },
+    ]
+  }
+  if (language === 'html') {
+    return [
+      { type: 'comment', regex: /<!--[\s\S]*?-->/ },
+      { type: 'tag', regex: /<\/?[A-Za-z][^>]*?>/ },
+      { type: 'string', regex: /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'/ },
+    ]
+  }
+  if (language === 'css') {
+    return [
+      { type: 'comment', regex: /\/\*[\s\S]*?\*\// },
+      { type: 'string', regex: /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'/ },
+      { type: 'property', regex: /\b[a-z-]+(?=\s*:)/i },
+      { type: 'number', regex: /#[0-9a-fA-F]{3,8}\b|\b\d+(?:\.\d+)?(?:px|rem|em|vh|vw|%)?\b/ },
+    ]
+  }
+
+  return [
+    { type: 'comment', regex: /\/\/[^\n]*|\/\*[\s\S]*?\*\// },
+    { type: 'string', regex: /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`/ },
+    {
+      type: 'keyword',
+      regex: /\b(?:const|let|var|function|return|if|else|for|while|import|from|export|default|class|extends|new|async|await|try|catch|throw|switch|case|break|continue|type|interface|implements|public|private|protected|readonly|true|false|null|undefined)\b/,
+    },
+    { type: 'number', regex: /\b\d+(?:\.\d+)?\b/ },
+  ]
+}
+
+function tokenizeCode(code: string, language: string | null): Token[] {
+  const patterns = getTokenPatterns(language)
+  const tokens: Token[] = []
+  let cursor = 0
+
+  while (cursor < code.length) {
+    let bestMatch:
+      | { start: number; end: number; type: Token['type']; value: string }
+      | null = null
+
+    for (const pattern of patterns) {
+      const match = pattern.regex.exec(code.slice(cursor))
+      if (!match || match.index == null) continue
+      const start = cursor + match.index
+      const end = start + match[0].length
+      if (!bestMatch || start < bestMatch.start) {
+        bestMatch = { start, end, type: pattern.type, value: match[0] }
+      }
+    }
+
+    if (!bestMatch) {
+      tokens.push({ type: 'plain', value: code.slice(cursor) })
+      break
+    }
+
+    if (bestMatch.start > cursor) {
+      tokens.push({ type: 'plain', value: code.slice(cursor, bestMatch.start) })
+    }
+    tokens.push({ type: bestMatch.type, value: bestMatch.value })
+    cursor = bestMatch.end
+  }
+
+  return tokens
+}
+
+function tokenClassName(type: Token['type']): string {
+  switch (type) {
+    case 'comment':
+      return 'text-emerald-700 dark:text-emerald-400'
+    case 'string':
+      return 'text-amber-700 dark:text-amber-300'
+    case 'keyword':
+      return 'text-sky-700 dark:text-sky-300'
+    case 'number':
+      return 'text-fuchsia-700 dark:text-fuchsia-300'
+    case 'tag':
+      return 'text-rose-700 dark:text-rose-300'
+    case 'property':
+      return 'text-cyan-700 dark:text-cyan-300'
+    default:
+      return 'text-foreground'
+  }
+}
+
+function CodePreview({ code, language }: { code: string; language: string | null }) {
+  const tokens = useMemo(() => tokenizeCode(code, language), [code, language])
+
+  return (
+    <pre
+      className="p-4 text-xs leading-relaxed font-mono whitespace-pre-wrap break-words
+        bg-muted/40"
+    >
+      {tokens.map((token, index) => (
+        <span key={index} className={tokenClassName(token.type)}>
+          {token.value}
+        </span>
+      ))}
+    </pre>
+  )
+}
+
+export function WriteFilePreviewView({ args, result, toolRef }: WriteFilePreviewViewProps) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const stickToBottom = useRef(true)
+  const prevStreamingRef = useRef(false)
+  const liveBlocks = useMessageStore((s) => {
+    const agentId = toolRef?.agent_id
+    return agentId ? (s.streamAgents[agentId]?.blocks ?? []) : []
+  })
+
+  const parsed = useMemo(() => {
+    const live = resolveLiveWriteFile(liveBlocks, toolRef)
+    if (live) {
+      return result
+        ? { ...live, status: 'completed' as const }
+        : live
+    }
+    const fallback = parseWriteFileArgs(args)
+    return result
+      ? { ...fallback, status: 'completed' as const }
+      : fallback
+  }, [args, liveBlocks, result, toolRef])
+
+  const filePath = parsed.filePath || 'Untitled file'
+  const content = parsed.content
+  const mode = detectMode(filePath)
+  const language = detectLanguage(filePath)
+  const isStreaming = parsed.status === 'streaming_args'
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const threshold = 80
+    stickToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < threshold
+  }, [])
+
+  useEffect(() => {
+    const contentEl = contentRef.current
+    const scrollEl = scrollRef.current
+    if (!contentEl || !scrollEl) return
+
+    const ro = new ResizeObserver(() => {
+      if (stickToBottom.current) {
+        scrollEl.scrollTop = scrollEl.scrollHeight
+      }
+    })
+    ro.observe(contentEl)
+    return () => ro.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (isStreaming && !prevStreamingRef.current) {
+      stickToBottom.current = true
+      if (scrollRef.current) {
+        scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+      }
+    }
+    prevStreamingRef.current = isStreaming
+  }, [isStreaming])
+
+  return (
+    <div ref={scrollRef} className="h-full overflow-auto" onScroll={handleScroll}>
+      <div ref={contentRef}>
+        <div className="px-4 py-3 border-b border-border bg-card">
+          <div className="text-sm font-medium text-foreground truncate">{filePath}</div>
+        </div>
+
+        {mode === 'markdown' ? (
+          <div className={`p-4 ${proseClasses}`}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+          </div>
+        ) : mode === 'code' ? (
+          <CodePreview code={content} language={language} />
+        ) : (
+          <pre className="p-4 text-sm leading-relaxed whitespace-pre-wrap break-words text-foreground">
+            {content}
+          </pre>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/packages/web/hooks/useToolDetail.ts
+++ b/frontend/packages/web/hooks/useToolDetail.ts
@@ -12,6 +12,8 @@ export function useToolDetail() {
     useToolDetailStore((s) => s.toolResult)
   const contentType =
     useToolDetailStore((s) => s.contentType)
+  const toolRef =
+    useToolDetailStore((s) => s.toolRef)
   const open = useToolDetailStore((s) => s.open)
   const close = useToolDetailStore((s) => s.close)
 
@@ -21,6 +23,7 @@ export function useToolDetail() {
     toolArgs,
     toolResult,
     contentType,
+    toolRef,
     open,
     close,
   }

--- a/frontend/packages/web/lib/toolIcons.ts
+++ b/frontend/packages/web/lib/toolIcons.ts
@@ -12,6 +12,8 @@ import {
 
 const iconMap: Record<string, LucideIcon> = {
   execute: Terminal,
+  write_file: Code,
+  edit_file: Code,
   web_search: Search,
   search: Search,
   web_fetch: Globe,
@@ -41,6 +43,10 @@ export function getParamSummary(
   let value = ''
   if (toolName === 'execute') {
     value = String(args.command ?? args.cmd ?? '')
+  } else if (
+    toolName === 'write_file' || toolName === 'edit_file'
+  ) {
+    value = String(args.file_path ?? args.file_name ?? '')
   } else if (
     toolName === 'web_search' || toolName === 'search'
   ) {

--- a/frontend/packages/web/lib/writeFilePreview.ts
+++ b/frontend/packages/web/lib/writeFilePreview.ts
@@ -1,0 +1,139 @@
+import type { ContentBlock, ToolCallRef } from '@cubebox/core'
+
+export type WriteFileStatus = 'streaming_args' | 'pending_execution' | 'completed'
+
+export interface ParsedWriteFile {
+  filePath: string
+  content: string
+  status: WriteFileStatus
+}
+
+function readStringArg(args: Record<string, unknown>, key: string): string {
+  return typeof args[key] === 'string' ? args[key] : ''
+}
+
+function decodeEscapeSequence(char: string): string {
+  switch (char) {
+    case 'n':
+      return '\n'
+    case 'r':
+      return '\r'
+    case 't':
+      return '\t'
+    case 'b':
+      return '\b'
+    case 'f':
+      return '\f'
+    case '"':
+      return '"'
+    case '\\':
+      return '\\'
+    case '/':
+      return '/'
+    default:
+      return char
+  }
+}
+
+function extractJsonStringPrefix(raw: string, key: string): string {
+  const keyMatch = new RegExp(`"${key}"\\s*:\\s*"`, 'm').exec(raw)
+  if (!keyMatch) return ''
+
+  let i = keyMatch.index + keyMatch[0].length
+  let value = ''
+
+  while (i < raw.length) {
+    const char = raw[i]
+    if (char === '"') break
+    if (char === '\\') {
+      const next = raw[i + 1]
+      if (!next) break
+      if (next === 'u') {
+        const hex = raw.slice(i + 2, i + 6)
+        if (hex.length < 4 || /[^0-9a-fA-F]/.test(hex)) break
+        value += String.fromCharCode(parseInt(hex, 16))
+        i += 6
+        continue
+      }
+      value += decodeEscapeSequence(next)
+      i += 2
+      continue
+    }
+    value += char
+    i++
+  }
+
+  return value
+}
+
+function readFilePath(args: Record<string, unknown>): string {
+  return readStringArg(args, 'file_path') || readStringArg(args, 'file_name')
+}
+
+export function parseWriteFileArgs(
+  args: Record<string, unknown>,
+  rawArgsText?: string | null,
+): ParsedWriteFile {
+  const filePathFromArgs = readFilePath(args)
+  const contentFromArgs = readStringArg(args, 'content')
+
+  if (filePathFromArgs || contentFromArgs) {
+    return {
+      filePath: filePathFromArgs,
+      content: contentFromArgs,
+      status: 'pending_execution',
+    }
+  }
+
+  const raw = rawArgsText ?? ''
+  return {
+    filePath: extractJsonStringPrefix(raw, 'file_path')
+      || extractJsonStringPrefix(raw, 'file_name'),
+    content: extractJsonStringPrefix(raw, 'content'),
+    status: 'streaming_args',
+  }
+}
+
+export function resolveLiveWriteFile(
+  blocks: ContentBlock[],
+  toolRef: ToolCallRef | null,
+): ParsedWriteFile | null {
+  if (!toolRef) return null
+
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const block = blocks[i]
+    if (block.type === 'tool_call' && block.name === 'write_file') {
+      if (toolRef.tool_call_id && block.tool_call_id === toolRef.tool_call_id) {
+        return {
+          filePath: readFilePath(block.arguments),
+          content: readStringArg(block.arguments, 'content'),
+          status: 'pending_execution',
+        }
+      }
+    }
+    if (block.type === 'tool_call_streaming' && block.name === 'write_file') {
+      const sameId = toolRef.tool_call_id && block.tool_call_id === toolRef.tool_call_id
+      const sameIndex = toolRef.index != null && block.index === toolRef.index
+      if (sameId || sameIndex) {
+        return parseWriteFileArgs({}, block.args_text)
+      }
+    }
+  }
+
+  return null
+}
+
+export function getWriteFileSummary(
+  args: Record<string, unknown>,
+  rawArgsText?: string | null,
+): string {
+  const parsed = parseWriteFileArgs(args, rawArgsText)
+  if (parsed.filePath) return parsed.filePath
+
+  const firstLine = parsed.content.split('\n')[0]?.trim() ?? ''
+  if (firstLine) {
+    return firstLine.length > 60 ? `${firstLine.slice(0, 60)}...` : firstLine
+  }
+
+  return 'Preparing file...'
+}

--- a/frontend/packages/web/next.config.ts
+++ b/frontend/packages/web/next.config.ts
@@ -4,13 +4,6 @@ const nextConfig: NextConfig = {
   allowedDevOrigins: ['localhost', '127.0.0.1', '[::1]', '192.168.1.111'],
   compress: false,
   turbopack: {},
-  experimental: {
-    // Default is 30s which kills long-running SSE streams through rewrites proxy.
-    // Runtime: `proxyTimeout === null ? undefined : proxyTimeout || 30000`
-    // null disables timeout, but type only allows number | undefined.
-    // @ts-expect-error -- null is intentional; see next/dist/.../proxy-request.js
-    proxyTimeout: null,
-  },
   async rewrites() {
     return {
       beforeFiles: [],


### PR DESCRIPTION
## Summary
- backfill streamed tool-call identity and persist per-tool start timestamps through the backend streaming pipeline
- fix frontend streamed tool-call rendering so partial blocks are resolved cleanly and completed messages persist only finalized tool calls
- add live write_file preview UX with parsed arguments, auto-scroll, cleaner preview panel, and deferred artifact card rendering

## Test Plan
- uv run pytest tests/unit/test_convert_messages.py tests/e2e/test_stream_converter.py tests/e2e/test_streaming.py
- pnpm --dir frontend/packages/web test __tests__/hooks/useMessages.test.ts
- pnpm --dir frontend/packages/core build
- pnpm --dir frontend/packages/web build