### PR TITLE
refactor: move workspace scope from X-Workspace-Id header to URL path

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -65,7 +65,7 @@ Single test file: `uv run pytest tests/e2e/test_agents.py`
 
 ## Architecture
 
-**Request flow:** `POST /api/v1/conversations/{id}/messages` → `create_cubebox_agent()` → LangGraph `astream(stream_mode="messages", stream_subgraphs=True)` → SSE stream of typed events (`text_delta`, `reasoning`, `tool_call`, `tool_result`, `error`, `done`)
+**Request flow:** `POST /api/v1/ws/{workspace_id}/conversations/{id}/messages` → `create_cubebox_agent()` → LangGraph `astream(stream_mode="messages", stream_subgraphs=True)` → SSE stream of typed events (`text_delta`, `reasoning`, `tool_call`, `tool_result`, `error`, `done`)
 
 **Key components:**
 - `create_cubebox_agent` (`cubebox/agents/graph.py`) — factory that wires LLM, tools, and middleware (sandbox, subagents, skills) into a LangGraph CompiledStateGraph via `langchain.agents.create_agent()`
@@ -85,7 +85,7 @@ Identity model: `Organization` → `Workspace` → `Membership` → `User`. One 
 
 **CSRF:** double-submit cookie pattern. A `cubebox_csrf` cookie is set on login; mutating requests (POST/PUT/PATCH/DELETE) must echo it in the `X-CSRF-Token` header whenever the `cubebox_auth` cookie is present.
 
-**Workspace scoping:** every business request requires an `X-Workspace-Id` header. The `request_context` dependency resolves it into a `RequestContext` (user + org_id + workspace_id + role). Missing header → 400; workspace not found → 404; not a member → 403.
+**Workspace scoping:** every business route lives under `/api/v1/ws/{workspace_id}/...` — the workspace id is a path parameter, not a header. The `request_context` dependency extracts it via FastAPI `Path`, validates membership, and produces a `RequestContext` (user + org_id + workspace_id + role). Workspace not found → 404; not a member → 403. Path-based scoping lets browser-direct loads (`<img>`, `<iframe>`, `<a href>`) work without custom headers.
 
 **Repository layer:** `OrgScopedMixin` + `ScopedRepository[T]` (`cubebox/repositories/base.py`) automatically filter every query by `(org_id, workspace_id)` — structural isolation, not an ACL check bolted on top. New business repositories should subclass `ScopedRepository`.
 
@@ -93,6 +93,7 @@ Identity model: `Organization` → `Workspace` → `Membership` → `User`. One 
 - `POST /api/v1/auth/register`, `POST /api/v1/auth/login`, `POST /api/v1/auth/logout`, `GET /api/v1/auth/me`
 - `GET/POST /api/v1/workspaces`
 - `POST /api/v1/workspaces/{ws}/invites` (admin only), `POST /api/v1/workspaces/invites/accept`
+- `/api/v1/ws/{workspace_id}/conversations/...` and `/api/v1/ws/{workspace_id}/conversations/{cid}/artifacts/...` — all scoped business endpoints
 
 **Register bootstrap:** `UserManager.on_after_register` auto-creates a personal Organization (`"<email-local-part>'s Org"`), a Workspace (`"Personal"`), and an Admin Membership for the new user in the same session. If any of these fails, the User row is best-effort deleted before the exception propagates so registration appears atomic to the client. The register response returns `{id, email, default_workspace_id}`.
 

--- a/backend/cubebox/api/routes/v1/artifacts.py
+++ b/backend/cubebox/api/routes/v1/artifacts.py
@@ -17,7 +17,10 @@ from cubebox.db import get_session
 from cubebox.objectstore import get_objectstore_client
 from cubebox.repositories import ArtifactRepository, ArtifactVersionRepository
 
-router = APIRouter(prefix="/conversations/{conversation_id}/artifacts", tags=["artifacts"])
+router = APIRouter(
+    prefix="/ws/{workspace_id}/conversations/{conversation_id}/artifacts",
+    tags=["artifacts"],
+)
 
 
 @router.get("")

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -23,7 +23,7 @@ from cubebox.db.engine import _build_database_url, async_session_maker
 from cubebox.repositories import ConversationRepository
 from cubebox.utils.time import utc_isoformat
 
-router = APIRouter(prefix="/conversations", tags=["conversations"])
+router = APIRouter(prefix="/ws/{workspace_id}/conversations", tags=["conversations"])
 
 
 async def _update_conversation_timestamp(

--- a/backend/cubebox/api/routes/v1/workspaces.py
+++ b/backend/cubebox/api/routes/v1/workspaces.py
@@ -73,11 +73,6 @@ async def create_invite(
     ctx: Annotated[RequestContext, Depends(require_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> dict[str, str]:
-    if ctx.workspace_id != workspace_id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="X-Workspace-Id header must match workspace_id in path",
-        )
     if body.role not in ("admin", "member"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="role must be admin or member"

--- a/backend/cubebox/auth/dependencies.py
+++ b/backend/cubebox/auth/dependencies.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from typing import Annotated
 
-from fastapi import Depends, Header, HTTPException, status
+from fastapi import Depends, HTTPException, Path, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.auth.context import RequestContext
@@ -16,27 +16,27 @@ current_active_user = fastapi_users.current_user(active=True)
 
 
 async def request_context(
+    workspace_id: Annotated[str, Path()],
     user: Annotated[User, Depends(current_active_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
-    x_workspace_id: Annotated[str | None, Header(alias="X-Workspace-Id")] = None,
 ) -> RequestContext:
-    """Resolve the active workspace + role from header + membership lookup."""
-    if not x_workspace_id:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="X-Workspace-Id header is required",
-        )
+    """Resolve the active workspace + role from URL path + membership lookup.
 
+    Workspace scoping is encoded in the URL (`/api/v1/ws/{workspace_id}/...`);
+    every business endpoint declares `workspace_id` as a path parameter and
+    depends on this function. There is no header fallback — the path is the
+    single source of truth.
+    """
     ws_repo = WorkspaceRepository(session)
-    workspace = await ws_repo.get(x_workspace_id)
+    workspace = await ws_repo.get(workspace_id)
     if workspace is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Workspace '{x_workspace_id}' not found",
+            detail=f"Workspace '{workspace_id}' not found",
         )
 
     mem_repo = MembershipRepository(session)
-    role = await mem_repo.get_role(user_id=user.id, workspace_id=x_workspace_id)
+    role = await mem_repo.get_role(user_id=user.id, workspace_id=workspace_id)
     if role is None:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -44,7 +44,7 @@ async def request_context(
         )
 
     return RequestContext(
-        user=user, org_id=workspace.org_id, workspace_id=x_workspace_id, role=role
+        user=user, org_id=workspace.org_id, workspace_id=workspace_id, role=role
     )
 
 

--- a/backend/cubebox/auth/dependencies.py
+++ b/backend/cubebox/auth/dependencies.py
@@ -43,9 +43,7 @@ async def request_context(
             detail="You are not a member of this workspace",
         )
 
-    return RequestContext(
-        user=user, org_id=workspace.org_id, workspace_id=workspace_id, role=role
-    )
+    return RequestContext(user=user, org_id=workspace.org_id, workspace_id=workspace_id, role=role)
 
 
 def require_role(

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -120,9 +120,7 @@ async def _ensure_default_user_and_membership() -> None:
         await test_engine.dispose()
 
 
-async def _login_and_attach(
-    client: httpx.AsyncClient, email: str, password: str
-) -> None:
+async def _login_and_attach(client: httpx.AsyncClient, email: str, password: str) -> None:
     """Log in and set the CSRF header on the client."""
     await client.get("/api/v1/auth/me")  # obtain CSRF cookie (401 but sets cookie)
     csrf = client.cookies.get("cubebox_csrf") or ""

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -121,9 +121,9 @@ async def _ensure_default_user_and_membership() -> None:
 
 
 async def _login_and_attach(
-    client: httpx.AsyncClient, email: str, password: str, workspace_id: str
+    client: httpx.AsyncClient, email: str, password: str
 ) -> None:
-    """Log in and set default X-Workspace-Id on the client."""
+    """Log in and set the CSRF header on the client."""
     await client.get("/api/v1/auth/me")  # obtain CSRF cookie (401 but sets cookie)
     csrf = client.cookies.get("cubebox_csrf") or ""
     r = await client.post(
@@ -132,13 +132,15 @@ async def _login_and_attach(
         headers={"X-CSRF-Token": csrf},
     )
     assert r.status_code in (200, 204), f"login failed: {r.status_code} {r.text}"
-    client.headers["X-Workspace-Id"] = workspace_id
     client.headers["X-CSRF-Token"] = client.cookies.get("cubebox_csrf") or csrf
 
 
 @pytest_asyncio.fixture
 async def client() -> AsyncIterator[TestClient]:
-    """Sync test client, auto-logged-in as default user in default-ws."""
+    """Sync test client, auto-logged-in as default user in default-ws.
+
+    Business-scoped calls should be prefixed with `/api/v1/ws/{DEFAULT_WS_ID}/...`.
+    """
     await _ensure_default_user_and_membership()
     app = _make_test_app()
     sync_client = TestClient(app)
@@ -150,20 +152,22 @@ async def client() -> AsyncIterator[TestClient]:
         headers={"X-CSRF-Token": csrf},
     )
     assert r.status_code in (200, 204), f"login failed: {r.status_code} {r.text}"
-    sync_client.headers["X-Workspace-Id"] = DEFAULT_WS_ID
     sync_client.headers["X-CSRF-Token"] = sync_client.cookies.get("cubebox_csrf") or csrf
     yield sync_client
 
 
 @pytest_asyncio.fixture
 async def async_client() -> AsyncIterator[httpx.AsyncClient]:
-    """Async HTTP client, auto-logged-in as default user in default-ws."""
+    """Async HTTP client, auto-logged-in as default user in default-ws.
+
+    Business-scoped calls should be prefixed with `/api/v1/ws/{DEFAULT_WS_ID}/...`.
+    """
     await _ensure_default_user_and_membership()
     app = _make_test_app()
     async with _lifespan_context(app):
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
-            await _login_and_attach(c, DEFAULT_TEST_EMAIL, DEFAULT_TEST_PASSWORD, DEFAULT_WS_ID)
+            await _login_and_attach(c, DEFAULT_TEST_EMAIL, DEFAULT_TEST_PASSWORD)
             yield c
     await engine.dispose()
 
@@ -176,7 +180,7 @@ async def memory_client() -> AsyncIterator[httpx.AsyncClient]:
     async with _lifespan_context(app):
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
-            await _login_and_attach(c, DEFAULT_TEST_EMAIL, DEFAULT_TEST_PASSWORD, DEFAULT_WS_ID)
+            await _login_and_attach(c, DEFAULT_TEST_EMAIL, DEFAULT_TEST_PASSWORD)
             yield c
     await engine.dispose()
 
@@ -235,33 +239,37 @@ async def _make_isolated_user(role: Role) -> tuple[FastAPI, str, str, str]:
 
 
 @pytest_asyncio.fixture
-async def authenticated_client() -> AsyncIterator[tuple[httpx.AsyncClient, dict[str, str]]]:
-    """Fresh client logged in as a brand-new admin of a brand-new workspace."""
+async def authenticated_client() -> AsyncIterator[tuple[httpx.AsyncClient, str]]:
+    """Fresh client logged in as a brand-new admin of a brand-new workspace.
+
+    Yields ``(client, workspace_id)``. Callers prepend ``/api/v1/ws/{workspace_id}``
+    to business-scoped paths.
+    """
     app, email, password, workspace_id = await _make_isolated_user(Role.ADMIN)
     async with _lifespan_context(app):
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
-            await _login_and_attach(c, email, password, workspace_id)
-            yield c, {"X-Workspace-Id": workspace_id}
+            await _login_and_attach(c, email, password)
+            yield c, workspace_id
 
 
 @pytest_asyncio.fixture
 async def admin_client(
-    authenticated_client: tuple[httpx.AsyncClient, dict[str, str]],
-) -> tuple[httpx.AsyncClient, dict[str, str]]:
+    authenticated_client: tuple[httpx.AsyncClient, str],
+) -> tuple[httpx.AsyncClient, str]:
     """Alias — authenticated_client is already admin."""
     return authenticated_client
 
 
 @pytest_asyncio.fixture
-async def member_client() -> AsyncIterator[tuple[httpx.AsyncClient, dict[str, str]]]:
+async def member_client() -> AsyncIterator[tuple[httpx.AsyncClient, str]]:
     """Fresh client logged in as a brand-new member (not admin) of a brand-new workspace."""
     app, email, password, workspace_id = await _make_isolated_user(Role.MEMBER)
     async with _lifespan_context(app):
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
-            await _login_and_attach(c, email, password, workspace_id)
-            yield c, {"X-Workspace-Id": workspace_id}
+            await _login_and_attach(c, email, password)
+            yield c, workspace_id
 
 
 async def collect_sse_events(

--- a/backend/tests/e2e/test_conversation_flow.py
+++ b/backend/tests/e2e/test_conversation_flow.py
@@ -9,13 +9,13 @@ from tests.e2e.conftest import collect_sse_events
 @pytest.mark.asyncio
 async def test_send_message_returns_sse_stream(memory_client: httpx.AsyncClient) -> None:
     # Create conversation first
-    resp = await memory_client.post("/api/v1/conversations", params={"title": "test"})
+    resp = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "test"})
     assert resp.status_code == 201
     conv_id = resp.json()["id"]
 
     events = await collect_sse_events(
         memory_client,
-        f"/api/v1/conversations/{conv_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
         json_data={"content": "Say the word 'hello' and nothing else."},
     )
     assert len(events) > 0
@@ -24,12 +24,12 @@ async def test_send_message_returns_sse_stream(memory_client: httpx.AsyncClient)
 
 @pytest.mark.asyncio
 async def test_stream_contains_text_delta(memory_client: httpx.AsyncClient) -> None:
-    resp = await memory_client.post("/api/v1/conversations", params={"title": "test"})
+    resp = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "test"})
     conv_id = resp.json()["id"]
 
     events = await collect_sse_events(
         memory_client,
-        f"/api/v1/conversations/{conv_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
         json_data={"content": "Say the word 'hello' and nothing else."},
     )
     text_events = [e for e in events if e["type"] == "text_delta"]
@@ -40,16 +40,16 @@ async def test_stream_contains_text_delta(memory_client: httpx.AsyncClient) -> N
 
 @pytest.mark.asyncio
 async def test_list_messages_returns_history_after_send(memory_client: httpx.AsyncClient) -> None:
-    resp = await memory_client.post("/api/v1/conversations", params={"title": "test"})
+    resp = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "test"})
     conv_id = resp.json()["id"]
 
     await collect_sse_events(
         memory_client,
-        f"/api/v1/conversations/{conv_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
         json_data={"content": "Say the word 'hello' and nothing else."},
     )
 
-    resp = await memory_client.get(f"/api/v1/conversations/{conv_id}/messages")
+    resp = await memory_client.get(f"/api/v1/ws/default-ws/conversations/{conv_id}/messages")
     assert resp.status_code == 200
     messages = resp.json()["messages"]
     assert len(messages) >= 2
@@ -62,7 +62,7 @@ async def test_send_to_nonexistent_conversation_returns_404(
     memory_client: httpx.AsyncClient,
 ) -> None:
     resp = await memory_client.post(
-        "/api/v1/conversations/nonexistent-id/messages",
+        "/api/v1/ws/default-ws/conversations/nonexistent-id/messages",
         json={"content": "hello"},
     )
     assert resp.status_code == 404
@@ -70,11 +70,11 @@ async def test_send_to_nonexistent_conversation_returns_404(
 
 @pytest.mark.asyncio
 async def test_send_empty_content_returns_400(memory_client: httpx.AsyncClient) -> None:
-    resp = await memory_client.post("/api/v1/conversations", params={"title": "test"})
+    resp = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "test"})
     conv_id = resp.json()["id"]
 
     resp = await memory_client.post(
-        f"/api/v1/conversations/{conv_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
         json={"content": ""},
     )
     assert resp.status_code == 400

--- a/backend/tests/e2e/test_conversations.py
+++ b/backend/tests/e2e/test_conversations.py
@@ -16,7 +16,7 @@ class TestConversationsCRUD:
 
     def test_create_conversation(self, client: TestClient) -> None:
         """Create a conversation and verify the response."""
-        response = client.post("/api/v1/conversations", params={"title": "Test Conversation"})
+        response = client.post("/api/v1/ws/default-ws/conversations", params={"title": "Test Conversation"})
         assert response.status_code == 201
         data = response.json()
         assert data["title"] == "Test Conversation"
@@ -26,10 +26,10 @@ class TestConversationsCRUD:
 
     def test_get_conversation(self, client: TestClient) -> None:
         """Create then retrieve a conversation."""
-        create_resp = client.post("/api/v1/conversations", params={"title": "Get Test"})
+        create_resp = client.post("/api/v1/ws/default-ws/conversations", params={"title": "Get Test"})
         conversation_id = create_resp.json()["id"]
 
-        get_resp = client.get(f"/api/v1/conversations/{conversation_id}")
+        get_resp = client.get(f"/api/v1/ws/default-ws/conversations/{conversation_id}")
         assert get_resp.status_code == 200
         data = get_resp.json()
         assert data["id"] == conversation_id
@@ -37,16 +37,16 @@ class TestConversationsCRUD:
 
     def test_get_conversation_not_found(self, client: TestClient) -> None:
         """Get a non-existent conversation returns 404."""
-        response = client.get("/api/v1/conversations/nonexistent-id")
+        response = client.get("/api/v1/ws/default-ws/conversations/nonexistent-id")
         assert response.status_code == 404
 
     def test_list_conversations(self, client: TestClient) -> None:
         """List conversations returns paginated results."""
         # Create two conversations
-        client.post("/api/v1/conversations", params={"title": "List Test 1"})
-        client.post("/api/v1/conversations", params={"title": "List Test 2"})
+        client.post("/api/v1/ws/default-ws/conversations", params={"title": "List Test 1"})
+        client.post("/api/v1/ws/default-ws/conversations", params={"title": "List Test 2"})
 
-        response = client.get("/api/v1/conversations", params={"limit": 10, "offset": 0})
+        response = client.get("/api/v1/ws/default-ws/conversations", params={"limit": 10, "offset": 0})
         assert response.status_code == 200
         data = response.json()
         assert "conversations" in data
@@ -56,11 +56,11 @@ class TestConversationsCRUD:
 
     def test_update_conversation_title(self, client: TestClient) -> None:
         """Update conversation title."""
-        create_resp = client.post("/api/v1/conversations", params={"title": "Original Title"})
+        create_resp = client.post("/api/v1/ws/default-ws/conversations", params={"title": "Original Title"})
         conversation_id = create_resp.json()["id"]
 
         update_resp = client.patch(
-            f"/api/v1/conversations/{conversation_id}",
+            f"/api/v1/ws/default-ws/conversations/{conversation_id}",
             params={"title": "Updated Title"},
         )
         assert update_resp.status_code == 200
@@ -69,25 +69,25 @@ class TestConversationsCRUD:
     def test_update_conversation_not_found(self, client: TestClient) -> None:
         """Update a non-existent conversation returns 404."""
         response = client.patch(
-            "/api/v1/conversations/nonexistent-id",
+            "/api/v1/ws/default-ws/conversations/nonexistent-id",
             params={"title": "New Title"},
         )
         assert response.status_code == 404
 
     def test_delete_conversation(self, client: TestClient) -> None:
         """Delete a conversation and verify it's gone."""
-        create_resp = client.post("/api/v1/conversations", params={"title": "To Delete"})
+        create_resp = client.post("/api/v1/ws/default-ws/conversations", params={"title": "To Delete"})
         conversation_id = create_resp.json()["id"]
 
-        delete_resp = client.delete(f"/api/v1/conversations/{conversation_id}")
+        delete_resp = client.delete(f"/api/v1/ws/default-ws/conversations/{conversation_id}")
         assert delete_resp.status_code == 204
 
-        get_resp = client.get(f"/api/v1/conversations/{conversation_id}")
+        get_resp = client.get(f"/api/v1/ws/default-ws/conversations/{conversation_id}")
         assert get_resp.status_code == 404
 
     def test_delete_conversation_not_found(self, client: TestClient) -> None:
         """Delete a non-existent conversation returns 404."""
-        response = client.delete("/api/v1/conversations/nonexistent-id")
+        response = client.delete("/api/v1/ws/default-ws/conversations/nonexistent-id")
         assert response.status_code == 404
 
 
@@ -97,10 +97,10 @@ class TestConversationsMessages:
 
     def test_list_messages_empty(self, client: TestClient) -> None:
         """List messages for a new conversation returns empty list."""
-        create_resp = client.post("/api/v1/conversations", params={"title": "Messages Test"})
+        create_resp = client.post("/api/v1/ws/default-ws/conversations", params={"title": "Messages Test"})
         conversation_id = create_resp.json()["id"]
 
-        response = client.get(f"/api/v1/conversations/{conversation_id}/messages")
+        response = client.get(f"/api/v1/ws/default-ws/conversations/{conversation_id}/messages")
         assert response.status_code == 200
         data = response.json()
         assert data["messages"] == []
@@ -108,7 +108,7 @@ class TestConversationsMessages:
 
     def test_list_messages_not_found(self, client: TestClient) -> None:
         """List messages for non-existent conversation returns 404."""
-        response = client.get("/api/v1/conversations/nonexistent-id/messages")
+        response = client.get("/api/v1/ws/default-ws/conversations/nonexistent-id/messages")
         assert response.status_code == 404
 
 
@@ -121,14 +121,14 @@ class TestSendMessage:
     async def test_send_message_streams_events(self, async_client: httpx.AsyncClient) -> None:
         """Send a message and verify SSE event stream structure."""
         create_resp = await async_client.post(
-            "/api/v1/conversations", params={"title": "Stream Test"}
+            "/api/v1/ws/default-ws/conversations", params={"title": "Stream Test"}
         )
         assert create_resp.status_code == 201
         conversation_id = create_resp.json()["id"]
 
         async with async_client.stream(
             "POST",
-            f"/api/v1/conversations/{conversation_id}/messages",
+            f"/api/v1/ws/default-ws/conversations/{conversation_id}/messages",
             json={"content": "Say 'hello' in one word."},
         ) as response:
             assert response.status_code == 200
@@ -144,21 +144,21 @@ class TestSendMessage:
     async def test_send_message_saves_to_db(self, async_client: httpx.AsyncClient) -> None:
         """After streaming, messages are persisted in the DB."""
         create_resp = await async_client.post(
-            "/api/v1/conversations", params={"title": "Persist Test"}
+            "/api/v1/ws/default-ws/conversations", params={"title": "Persist Test"}
         )
         assert create_resp.status_code == 201
         conversation_id = create_resp.json()["id"]
 
         async with async_client.stream(
             "POST",
-            f"/api/v1/conversations/{conversation_id}/messages",
+            f"/api/v1/ws/default-ws/conversations/{conversation_id}/messages",
             json={"content": "What is 1+1?"},
         ) as response:
             assert response.status_code == 200
             # Consume the stream
             await parse_sse_stream(response.aiter_bytes())
 
-        msgs_resp = await async_client.get(f"/api/v1/conversations/{conversation_id}/messages")
+        msgs_resp = await async_client.get(f"/api/v1/ws/default-ws/conversations/{conversation_id}/messages")
         assert msgs_resp.status_code == 200
         data = msgs_resp.json()
         assert data["total"] >= 2  # user + assistant
@@ -171,13 +171,13 @@ class TestSendMessage:
     async def test_send_message_empty_content(self, async_client: httpx.AsyncClient) -> None:
         """Empty message content returns 400."""
         create_resp = await async_client.post(
-            "/api/v1/conversations", params={"title": "Empty Content Test"}
+            "/api/v1/ws/default-ws/conversations", params={"title": "Empty Content Test"}
         )
         assert create_resp.status_code == 201
         conversation_id = create_resp.json()["id"]
 
         response = await async_client.post(
-            f"/api/v1/conversations/{conversation_id}/messages",
+            f"/api/v1/ws/default-ws/conversations/{conversation_id}/messages",
             json={"content": ""},
         )
         assert response.status_code == 400
@@ -188,7 +188,7 @@ class TestSendMessage:
     ) -> None:
         """Sending to non-existent conversation returns 404."""
         response = await async_client.post(
-            "/api/v1/conversations/nonexistent-id/messages",
+            "/api/v1/ws/default-ws/conversations/nonexistent-id/messages",
             json={"content": "Hello"},
         )
         assert response.status_code == 404

--- a/backend/tests/e2e/test_conversations.py
+++ b/backend/tests/e2e/test_conversations.py
@@ -16,7 +16,9 @@ class TestConversationsCRUD:
 
     def test_create_conversation(self, client: TestClient) -> None:
         """Create a conversation and verify the response."""
-        response = client.post("/api/v1/ws/default-ws/conversations", params={"title": "Test Conversation"})
+        response = client.post(
+            "/api/v1/ws/default-ws/conversations", params={"title": "Test Conversation"}
+        )
         assert response.status_code == 201
         data = response.json()
         assert data["title"] == "Test Conversation"
@@ -26,7 +28,9 @@ class TestConversationsCRUD:
 
     def test_get_conversation(self, client: TestClient) -> None:
         """Create then retrieve a conversation."""
-        create_resp = client.post("/api/v1/ws/default-ws/conversations", params={"title": "Get Test"})
+        create_resp = client.post(
+            "/api/v1/ws/default-ws/conversations", params={"title": "Get Test"}
+        )
         conversation_id = create_resp.json()["id"]
 
         get_resp = client.get(f"/api/v1/ws/default-ws/conversations/{conversation_id}")
@@ -46,7 +50,9 @@ class TestConversationsCRUD:
         client.post("/api/v1/ws/default-ws/conversations", params={"title": "List Test 1"})
         client.post("/api/v1/ws/default-ws/conversations", params={"title": "List Test 2"})
 
-        response = client.get("/api/v1/ws/default-ws/conversations", params={"limit": 10, "offset": 0})
+        response = client.get(
+            "/api/v1/ws/default-ws/conversations", params={"limit": 10, "offset": 0}
+        )
         assert response.status_code == 200
         data = response.json()
         assert "conversations" in data
@@ -56,7 +62,9 @@ class TestConversationsCRUD:
 
     def test_update_conversation_title(self, client: TestClient) -> None:
         """Update conversation title."""
-        create_resp = client.post("/api/v1/ws/default-ws/conversations", params={"title": "Original Title"})
+        create_resp = client.post(
+            "/api/v1/ws/default-ws/conversations", params={"title": "Original Title"}
+        )
         conversation_id = create_resp.json()["id"]
 
         update_resp = client.patch(
@@ -76,7 +84,9 @@ class TestConversationsCRUD:
 
     def test_delete_conversation(self, client: TestClient) -> None:
         """Delete a conversation and verify it's gone."""
-        create_resp = client.post("/api/v1/ws/default-ws/conversations", params={"title": "To Delete"})
+        create_resp = client.post(
+            "/api/v1/ws/default-ws/conversations", params={"title": "To Delete"}
+        )
         conversation_id = create_resp.json()["id"]
 
         delete_resp = client.delete(f"/api/v1/ws/default-ws/conversations/{conversation_id}")
@@ -97,7 +107,9 @@ class TestConversationsMessages:
 
     def test_list_messages_empty(self, client: TestClient) -> None:
         """List messages for a new conversation returns empty list."""
-        create_resp = client.post("/api/v1/ws/default-ws/conversations", params={"title": "Messages Test"})
+        create_resp = client.post(
+            "/api/v1/ws/default-ws/conversations", params={"title": "Messages Test"}
+        )
         conversation_id = create_resp.json()["id"]
 
         response = client.get(f"/api/v1/ws/default-ws/conversations/{conversation_id}/messages")
@@ -158,7 +170,9 @@ class TestSendMessage:
             # Consume the stream
             await parse_sse_stream(response.aiter_bytes())
 
-        msgs_resp = await async_client.get(f"/api/v1/ws/default-ws/conversations/{conversation_id}/messages")
+        msgs_resp = await async_client.get(
+            f"/api/v1/ws/default-ws/conversations/{conversation_id}/messages"
+        )
         assert msgs_resp.status_code == 200
         data = msgs_resp.json()
         assert data["total"] >= 2  # user + assistant

--- a/backend/tests/e2e/test_rbac.py
+++ b/backend/tests/e2e/test_rbac.py
@@ -1,12 +1,11 @@
-"""E2E RBAC tests: admin mutation, member denial, workspace header requirements."""
+"""E2E RBAC tests: admin mutation, member denial, path-based workspace scoping."""
 
 import pytest
 
 
 @pytest.mark.asyncio
 async def test_admin_can_create_invite(admin_client):
-    client, headers = admin_client
-    workspace_id = headers["X-Workspace-Id"]
+    client, workspace_id = admin_client
     r = await client.post(
         f"/api/v1/workspaces/{workspace_id}/invites",
         json={"role": "member"},
@@ -18,8 +17,7 @@ async def test_admin_can_create_invite(admin_client):
 
 @pytest.mark.asyncio
 async def test_member_cannot_create_invite(member_client):
-    client, headers = member_client
-    workspace_id = headers["X-Workspace-Id"]
+    client, workspace_id = member_client
     r = await client.post(
         f"/api/v1/workspaces/{workspace_id}/invites",
         json={"role": "member"},
@@ -28,21 +26,9 @@ async def test_member_cannot_create_invite(member_client):
 
 
 @pytest.mark.asyncio
-async def test_no_workspace_header_returns_400(admin_client):
+async def test_unaffiliated_workspace_returns_404(admin_client):
     client, _ = admin_client
-    if "X-Workspace-Id" in client.headers:
-        del client.headers["X-Workspace-Id"]
-    r = await client.get("/api/v1/conversations")
-    assert r.status_code == 400, r.text
-
-
-@pytest.mark.asyncio
-async def test_unaffiliated_workspace_returns_404_or_403(admin_client):
-    client, _ = admin_client
-    # Clear default then send a bogus workspace id
-    if "X-Workspace-Id" in client.headers:
-        del client.headers["X-Workspace-Id"]
-    r = await client.get("/api/v1/conversations", headers={"X-Workspace-Id": "ws-does-not-exist"})
-    # Per request_context dependency, workspace-not-found yields 404 before
-    # role/membership check (which would yield 403).
+    r = await client.get("/api/v1/ws/ws-does-not-exist/conversations")
+    # Workspace-not-found yields 404 before the role/membership check (which
+    # would yield 403). Intentional — avoids workspace id enumeration.
     assert r.status_code == 404, r.text

--- a/backend/tests/e2e/test_scoping.py
+++ b/backend/tests/e2e/test_scoping.py
@@ -68,9 +68,9 @@ async def test_conversation_invisible_to_other_workspace(unauthenticated_memory_
     ws_a = r.json()["id"]
 
     r = await client.post(
-        "/api/v1/conversations",
+        f"/api/v1/ws/{ws_a}/conversations",
         params={"title": "Secret"},
-        headers={"X-CSRF-Token": csrf_a, "X-Workspace-Id": ws_a},
+        headers={"X-CSRF-Token": csrf_a},
     )
     assert r.status_code == 201, r.text
     conv_id = r.json()["id"]
@@ -79,10 +79,7 @@ async def test_conversation_invisible_to_other_workspace(unauthenticated_memory_
     # Without this, a silent bug (e.g. creation landing in the wrong workspace,
     # or the endpoint returning a stub id without persisting) would make B's
     # 404 pass for the wrong reason.
-    r = await client.get(
-        f"/api/v1/conversations/{conv_id}",
-        headers={"X-Workspace-Id": ws_a},
-    )
+    r = await client.get(f"/api/v1/ws/{ws_a}/conversations/{conv_id}")
     assert r.status_code == 200, f"A must see their own conversation: {r.text}"
 
     # A logs out.
@@ -107,16 +104,15 @@ async def test_conversation_invisible_to_other_workspace(unauthenticated_memory_
     )
     assert r.status_code == 201, r.text
     ws_b = r.json()["id"]
-    headers_b = {"X-CSRF-Token": csrf_b, "X-Workspace-Id": ws_b}
 
     # Direct read must 404 — structurally invisible, not a 403 auth error.
     # 404 because ScopedRepository filters by (org_id, workspace_id) at the
     # query layer — the row is invisible, not merely forbidden.
-    r = await client.get(f"/api/v1/conversations/{conv_id}", headers=headers_b)
+    r = await client.get(f"/api/v1/ws/{ws_b}/conversations/{conv_id}")
     assert r.status_code == 404, r.text
 
     # List must be empty — the scoped WHERE clause hides A's row entirely.
-    r = await client.get("/api/v1/conversations", headers=headers_b)
+    r = await client.get(f"/api/v1/ws/{ws_b}/conversations")
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["total"] == 0

--- a/backend/tests/e2e/test_streaming.py
+++ b/backend/tests/e2e/test_streaming.py
@@ -25,12 +25,12 @@ def _make_fake_ctx() -> RequestContext:
 
 @pytest.mark.asyncio
 async def test_sse_response_content_type(memory_client: httpx.AsyncClient) -> None:
-    resp = await memory_client.post("/api/v1/conversations", params={"title": "test"})
+    resp = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "test"})
     conv_id = resp.json()["id"]
 
     async with memory_client.stream(
         "POST",
-        f"/api/v1/conversations/{conv_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
         json={"content": "Say hi."},
     ) as response:
         assert "text/event-stream" in response.headers["content-type"]
@@ -38,12 +38,12 @@ async def test_sse_response_content_type(memory_client: httpx.AsyncClient) -> No
 
 @pytest.mark.asyncio
 async def test_every_event_is_valid_json(memory_client: httpx.AsyncClient) -> None:
-    resp = await memory_client.post("/api/v1/conversations", params={"title": "test"})
+    resp = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "test"})
     conv_id = resp.json()["id"]
 
     async with memory_client.stream(
         "POST",
-        f"/api/v1/conversations/{conv_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
         json={"content": "Say hi."},
     ) as response:
         async for line in response.aiter_lines():
@@ -55,13 +55,13 @@ async def test_every_event_is_valid_json(memory_client: httpx.AsyncClient) -> No
 
 @pytest.mark.asyncio
 async def test_stream_always_ends_with_done(memory_client: httpx.AsyncClient) -> None:
-    resp = await memory_client.post("/api/v1/conversations", params={"title": "test"})
+    resp = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "test"})
     conv_id = resp.json()["id"]
 
     events = []
     async with memory_client.stream(
         "POST",
-        f"/api/v1/conversations/{conv_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
         json={"content": "Say hi."},
     ) as response:
         async for line in response.aiter_lines():
@@ -130,13 +130,13 @@ def test_tool_call_delta_identity_is_backfilled_per_agent() -> None:
 
 @pytest.mark.asyncio
 async def test_agent_id_is_null_for_main_agent(memory_client: httpx.AsyncClient) -> None:
-    resp = await memory_client.post("/api/v1/conversations", params={"title": "test"})
+    resp = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "test"})
     conv_id = resp.json()["id"]
 
     events = []
     async with memory_client.stream(
         "POST",
-        f"/api/v1/conversations/{conv_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
         json={"content": "Say hi."},
     ) as response:
         async for line in response.aiter_lines():

--- a/backend/tests/e2e/test_thread_state.py
+++ b/backend/tests/e2e/test_thread_state.py
@@ -9,18 +9,18 @@ from tests.e2e.conftest import collect_sse_events
 @pytest.mark.asyncio
 async def test_multi_turn_context_is_retained(memory_client: httpx.AsyncClient) -> None:
     """Agent should remember context from previous turns."""
-    resp = await memory_client.post("/api/v1/conversations", params={"title": "test"})
+    resp = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "test"})
     conv_id = resp.json()["id"]
 
     await collect_sse_events(
         memory_client,
-        f"/api/v1/conversations/{conv_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
         json_data={"content": "My name is TestUser. Just acknowledge this."},
     )
 
     events = await collect_sse_events(
         memory_client,
-        f"/api/v1/conversations/{conv_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
         json_data={"content": "What is my name? Reply with just the name."},
     )
 
@@ -31,21 +31,21 @@ async def test_multi_turn_context_is_retained(memory_client: httpx.AsyncClient) 
 
 @pytest.mark.asyncio
 async def test_message_count_after_two_turns(memory_client: httpx.AsyncClient) -> None:
-    resp = await memory_client.post("/api/v1/conversations", params={"title": "test"})
+    resp = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "test"})
     conv_id = resp.json()["id"]
 
     await collect_sse_events(
         memory_client,
-        f"/api/v1/conversations/{conv_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
         json_data={"content": "First message."},
     )
     await collect_sse_events(
         memory_client,
-        f"/api/v1/conversations/{conv_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
         json_data={"content": "Second message."},
     )
 
-    resp = await memory_client.get(f"/api/v1/conversations/{conv_id}/messages")
+    resp = await memory_client.get(f"/api/v1/ws/default-ws/conversations/{conv_id}/messages")
     messages = resp.json()["messages"]
     assert len(messages) >= 4
     user_msgs = [m for m in messages if m["role"] == "user"]
@@ -56,20 +56,20 @@ async def test_message_count_after_two_turns(memory_client: httpx.AsyncClient) -
 async def test_separate_conversations_have_independent_state(
     memory_client: httpx.AsyncClient,
 ) -> None:
-    resp1 = await memory_client.post("/api/v1/conversations", params={"title": "conv1"})
-    resp2 = await memory_client.post("/api/v1/conversations", params={"title": "conv2"})
+    resp1 = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "conv1"})
+    resp2 = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "conv2"})
     conv1_id = resp1.json()["id"]
     conv2_id = resp2.json()["id"]
 
     await collect_sse_events(
         memory_client,
-        f"/api/v1/conversations/{conv1_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv1_id}/messages",
         json_data={"content": "My secret word is ALPHA."},
     )
 
     events = await collect_sse_events(
         memory_client,
-        f"/api/v1/conversations/{conv2_id}/messages",
+        f"/api/v1/ws/default-ws/conversations/{conv2_id}/messages",
         json_data={"content": "Do you know my secret word? Just say no if you don't."},
     )
 

--- a/backend/tests/e2e/test_thread_state.py
+++ b/backend/tests/e2e/test_thread_state.py
@@ -56,8 +56,12 @@ async def test_message_count_after_two_turns(memory_client: httpx.AsyncClient) -
 async def test_separate_conversations_have_independent_state(
     memory_client: httpx.AsyncClient,
 ) -> None:
-    resp1 = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "conv1"})
-    resp2 = await memory_client.post("/api/v1/ws/default-ws/conversations", params={"title": "conv2"})
+    resp1 = await memory_client.post(
+        "/api/v1/ws/default-ws/conversations", params={"title": "conv1"}
+    )
+    resp2 = await memory_client.post(
+        "/api/v1/ws/default-ws/conversations", params={"title": "conv2"}
+    )
     conv1_id = resp1.json()["id"]
     conv2_id = resp2.json()["id"]
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -102,7 +102,7 @@ pnpm --filter @cubebox/core type-check
 
 **Proxy (`proxy.ts`):** checks for the `cubebox_auth` cookie. Unauthenticated hits to `/w/*` or `/workspaces` redirect to `/login?next=<path>`. Logged-in hits to `/login` or `/register` redirect to `/`.
 
-**Active workspace:** the URL segment `[wsId]` is the single source of truth. `useWorkspaceContext()` (in `(app)` tree) reads it. The `ApiClient` instance each page creates via `createApiClient('')` calls `client.setWorkspaceId(wsId)`, which triggers automatic `X-Workspace-Id` injection on workspace-scoped calls.
+**Active workspace:** the URL segment `[wsId]` is the single source of truth. `useWorkspaceContext()` (in `(app)` tree) reads it. The `ApiClient` instance each page creates via `createApiClient('')` calls `client.setWorkspaceId(wsId)`, which automatically rewrites scoped paths — `/api/v1/conversations/...` becomes `/api/v1/ws/{wsId}/conversations/...`. Paths under `/api/v1/auth/` and `/api/v1/workspaces` are workspace-neutral and not rewritten. For browser-direct loads (`<img>`, `<iframe>`, `<a href>`, pdf.js) use the URL builders in `components/panel/artifact/previewUtils.ts` (`buildPreviewUrl`, `buildDownloadUrl`) or call `client.resolvePath(...)`.
 
 **CSRF:** double-submit pattern. `ApiClient` reads `cubebox_csrf` from `document.cookie` and adds `X-CSRF-Token` on every non-GET. The backend seeds the cookie on login.
 
@@ -110,7 +110,7 @@ pnpm --filter @cubebox/core type-check
 - `authStore` — `{id, email}` of the current user, or `null`. Populated by `loadMe` on `(app)` mount.
 - `workspaceStore` — list of the user's workspaces + `create(client, name)` (reuses the first workspace's `org_id`, M1 assumption: one user = one org).
 
-**SSE proxy:** the Next.js route handler at `app/api/v1/conversations/[id]/messages/route.ts` forwards `cookie`, `X-Workspace-Id`, `X-CSRF-Token`, and `x-user-id` to the backend so streaming requests carry auth + scoping.
+**SSE proxy:** the Next.js route handler at `app/api/v1/ws/[wsId]/conversations/[id]/messages/route.ts` forwards `cookie`, `X-CSRF-Token`, and `x-user-id` to the backend. Workspace scoping rides in the URL path, not a header.
 
 **Known one-user-one-org assumption:** `workspaceStore.create` reads `workspaces[0].org_id`. When multi-org-per-user ships (P2), this must take an explicit org id.
 

--- a/frontend/packages/core/__tests__/api/client.test.ts
+++ b/frontend/packages/core/__tests__/api/client.test.ts
@@ -7,7 +7,6 @@ describe('ApiClient', () => {
   beforeEach(() => {
     fetchMock = vi.fn(async () => new Response('{}', { status: 200 }))
     globalThis.fetch = fetchMock as unknown as typeof fetch
-    // jsdom: fake cookie
     Object.defineProperty(document, 'cookie', {
       writable: true,
       value: 'cubebox_csrf=csrf-abc; other=x',
@@ -25,26 +24,49 @@ describe('ApiClient', () => {
     )
   })
 
-  it('injects X-Workspace-Id on scoped paths when workspaceId is set', async () => {
+  it('injects /ws/<id>/ into scoped paths when workspaceId is set', async () => {
     const client = createApiClient('')
     client.setWorkspaceId('ws-123')
     await client.get('/api/v1/conversations')
-    const [, init] = fetchMock.mock.calls[0]
-    expect((init as RequestInit).headers).toMatchObject({ 'X-Workspace-Id': 'ws-123' })
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/v1/ws/ws-123/conversations')
   })
 
-  it('does NOT inject X-Workspace-Id on /api/v1/auth/* paths', async () => {
+  it('does NOT rewrite /api/v1/auth/* paths', async () => {
     const client = createApiClient('')
     client.setWorkspaceId('ws-123')
     await client.post('/api/v1/auth/login', { a: 1 })
-    const [, init] = fetchMock.mock.calls[0]
-    expect((init as RequestInit).headers).not.toHaveProperty('X-Workspace-Id')
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/v1/auth/login')
   })
 
-  it('does NOT inject X-Workspace-Id on /api/v1/workspaces paths', async () => {
+  it('does NOT rewrite /api/v1/workspaces paths', async () => {
     const client = createApiClient('')
     client.setWorkspaceId('ws-123')
     await client.get('/api/v1/workspaces')
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/v1/workspaces')
+  })
+
+  it('does NOT double-inject /ws/ if path already scoped', async () => {
+    const client = createApiClient('')
+    client.setWorkspaceId('ws-123')
+    await client.get('/api/v1/ws/ws-123/conversations')
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/v1/ws/ws-123/conversations')
+  })
+
+  it('resolvePath mirrors the rewrite (for direct fetch callers)', () => {
+    const client = createApiClient('')
+    client.setWorkspaceId('ws-123')
+    expect(client.resolvePath('/api/v1/conversations/abc/messages'))
+      .toBe('/api/v1/ws/ws-123/conversations/abc/messages')
+  })
+
+  it('never sends X-Workspace-Id header (legacy behavior removed)', async () => {
+    const client = createApiClient('')
+    client.setWorkspaceId('ws-123')
+    await client.get('/api/v1/conversations')
     const [, init] = fetchMock.mock.calls[0]
     expect((init as RequestInit).headers).not.toHaveProperty('X-Workspace-Id')
   })

--- a/frontend/packages/core/src/api/client.ts
+++ b/frontend/packages/core/src/api/client.ts
@@ -1,11 +1,13 @@
 /**
- * ApiClient — wraps fetch with credentials, workspace/CSRF header injection,
- * and a 401 observable.
+ * ApiClient — wraps fetch with credentials, workspace-path prefixing,
+ * CSRF header injection, and a 401 observable.
  *
  * Path-based rules:
  *   - credentials: 'include' on every call (so cookies flow).
- *   - X-Workspace-Id is injected on paths NOT starting with /api/v1/auth/ or
- *     /api/v1/workspaces (those are workspace-neutral).
+ *   - When workspaceId is set, paths are rewritten:
+ *       /api/v1/<scoped>...  ->  /api/v1/ws/<wsId>/<scoped>...
+ *     Paths starting with /api/v1/auth/ or /api/v1/workspaces are left alone
+ *     (workspace-neutral).
  *   - X-CSRF-Token is injected on non-GET methods, read from document.cookie
  *     (cubebox_csrf).
  *
@@ -17,6 +19,8 @@ export interface ApiClient {
   baseUrl: string
   workspaceId: string | null
   setWorkspaceId(id: string | null): void
+  /** Rewrite a path by injecting the workspace segment when applicable. */
+  resolvePath(path: string): string
   get(path: string): Promise<Response>
   post(path: string, body: unknown): Promise<Response>
   postForm(path: string, form: Record<string, string>): Promise<Response>
@@ -26,11 +30,18 @@ export interface ApiClient {
 }
 
 const WS_NEUTRAL_PREFIXES = ['/api/v1/auth/', '/api/v1/workspaces']
+const SCOPED_ROOT = '/api/v1/'
 
-function needsWorkspaceHeader(path: string): boolean {
-  return !WS_NEUTRAL_PREFIXES.some(
+function isWorkspaceNeutral(path: string): boolean {
+  return WS_NEUTRAL_PREFIXES.some(
     (p) => path === p || path.startsWith(p + '/') || path.startsWith(p + '?') || path.startsWith(p)
   )
+}
+
+function injectWorkspace(path: string, wsId: string): string {
+  if (!path.startsWith(SCOPED_ROOT) || isWorkspaceNeutral(path)) return path
+  if (path.startsWith(`${SCOPED_ROOT}ws/`)) return path
+  return `${SCOPED_ROOT}ws/${wsId}/${path.slice(SCOPED_ROOT.length)}`
 }
 
 function readCookie(name: string): string {
@@ -43,11 +54,11 @@ export function createApiClient(baseUrl: string): ApiClient {
   let workspaceId: string | null = null
   const unauthorizedHandlers = new Set<() => void>()
 
-  const buildHeaders = (path: string, method: string, base: Record<string, string>) => {
+  const resolvePath = (path: string): string =>
+    workspaceId ? injectWorkspace(path, workspaceId) : path
+
+  const buildHeaders = (method: string, base: Record<string, string>) => {
     const headers: Record<string, string> = { ...base }
-    if (workspaceId && needsWorkspaceHeader(path)) {
-      headers['X-Workspace-Id'] = workspaceId
-    }
     if (method !== 'GET') {
       const csrf = readCookie('cubebox_csrf')
       if (csrf) headers['X-CSRF-Token'] = csrf
@@ -56,7 +67,7 @@ export function createApiClient(baseUrl: string): ApiClient {
   }
 
   const doFetch = async (path: string, init: RequestInit): Promise<Response> => {
-    const res = await fetch(`${baseUrl}${path}`, {
+    const res = await fetch(`${baseUrl}${resolvePath(path)}`, {
       ...init,
       credentials: 'include',
     })
@@ -76,16 +87,17 @@ export function createApiClient(baseUrl: string): ApiClient {
     setWorkspaceId(id) {
       workspaceId = id
     },
+    resolvePath,
     get(path) {
       return doFetch(path, {
         method: 'GET',
-        headers: buildHeaders(path, 'GET', {}),
+        headers: buildHeaders('GET', {}),
       })
     },
     post(path, body) {
       return doFetch(path, {
         method: 'POST',
-        headers: buildHeaders(path, 'POST', { 'Content-Type': 'application/json' }),
+        headers: buildHeaders('POST', { 'Content-Type': 'application/json' }),
         body: JSON.stringify(body),
       })
     },
@@ -93,7 +105,7 @@ export function createApiClient(baseUrl: string): ApiClient {
       const body = new URLSearchParams(form).toString()
       return doFetch(path, {
         method: 'POST',
-        headers: buildHeaders(path, 'POST', {
+        headers: buildHeaders('POST', {
           'Content-Type': 'application/x-www-form-urlencoded',
         }),
         body,
@@ -102,14 +114,14 @@ export function createApiClient(baseUrl: string): ApiClient {
     patch(path, body) {
       return doFetch(path, {
         method: 'PATCH',
-        headers: buildHeaders(path, 'PATCH', { 'Content-Type': 'application/json' }),
+        headers: buildHeaders('PATCH', { 'Content-Type': 'application/json' }),
         body: JSON.stringify(body),
       })
     },
     del(path) {
       return doFetch(path, {
         method: 'DELETE',
-        headers: buildHeaders(path, 'DELETE', {}),
+        headers: buildHeaders('DELETE', {}),
       })
     },
     onUnauthorized(handler) {

--- a/frontend/packages/core/src/api/stream.ts
+++ b/frontend/packages/core/src/api/stream.ts
@@ -35,12 +35,12 @@ export async function* streamMessages(
     Accept: 'text/event-stream',
     'Cache-Control': 'no-cache',
   }
-  if (client.workspaceId) headers['X-Workspace-Id'] = client.workspaceId
   const csrf = readCookie('cubebox_csrf')
   if (csrf) headers['X-CSRF-Token'] = csrf
 
+  const path = client.resolvePath(`/api/v1/conversations/${conversationId}/messages`)
   const res = await fetch(
-    `${client.baseUrl}/api/v1/conversations/${conversationId}/messages`,
+    `${client.baseUrl}${path}`,
     {
       method: 'POST',
       credentials: 'include',

--- a/frontend/packages/web/__tests__/api/messages-route.test.ts
+++ b/frontend/packages/web/__tests__/api/messages-route.test.ts
@@ -1,11 +1,11 @@
-import { GET, POST } from '../../app/api/v1/conversations/[id]/messages/route'
+import { GET, POST } from '../../app/api/v1/ws/[wsId]/conversations/[id]/messages/route'
 
 describe('conversation messages route proxy', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
   })
 
-  it('forwards identity headers to the backend for streaming POST requests', async () => {
+  it('forwards identity headers and wsId in the URL for streaming POST requests', async () => {
     const backendFetch = vi.fn(async () => new Response('ok', { status: 200 }))
     vi.stubGlobal('fetch', backendFetch)
 
@@ -17,17 +17,20 @@ describe('conversation messages route proxy', () => {
       text: async () => JSON.stringify({ content: 'hello' }),
     } as any
 
-    await POST(request, { params: Promise.resolve({ id: 'conv-1' }) })
+    await POST(request, {
+      params: Promise.resolve({ wsId: 'ws-42', id: 'conv-1' }),
+    })
 
     expect(backendFetch).toHaveBeenCalledTimes(1)
     const [url, init] = backendFetch.mock.calls[0] as [string, RequestInit]
-    expect(url).toContain('/api/v1/conversations/conv-1/messages')
+    expect(url).toContain('/api/v1/ws/ws-42/conversations/conv-1/messages')
     expect(init.headers).toMatchObject({
       'Content-Type': 'application/json',
       'Accept': 'text/event-stream',
       'cookie': 'cubebox_user_id=user-cookie',
       'x-user-id': 'header-user',
     })
+    expect(init.headers).not.toHaveProperty('X-Workspace-Id')
   })
 
   it('passes backend set-cookie through the streaming response', async () => {
@@ -51,28 +54,32 @@ describe('conversation messages route proxy', () => {
       text: async () => JSON.stringify({ content: 'hello' }),
     } as any
 
-    const response = await POST(request, { params: Promise.resolve({ id: 'conv-1' }) })
+    const response = await POST(request, {
+      params: Promise.resolve({ wsId: 'ws-42', id: 'conv-1' }),
+    })
 
     expect(response.headers.get('set-cookie')).toContain('cubebox_user_id=user-cookie')
   })
 
-  it('forwards identity headers on GET requests too', async () => {
+  it('forwards identity headers and wsId in the URL on GET requests too', async () => {
     const backendFetch = vi.fn(async () => Response.json({ messages: [] }))
     vi.stubGlobal('fetch', backendFetch)
 
     const request = {
-      url: 'http://localhost/api/v1/conversations/conv-1/messages?limit=10',
+      url: 'http://localhost/api/v1/ws/ws-42/conversations/conv-1/messages?limit=10',
       headers: new Headers([
         ['cookie', 'cubebox_user_id=user-cookie'],
         ['x-user-id', 'header-user'],
       ]),
     } as any
 
-    await GET(request, { params: Promise.resolve({ id: 'conv-1' }) })
+    await GET(request, {
+      params: Promise.resolve({ wsId: 'ws-42', id: 'conv-1' }),
+    })
 
     expect(backendFetch).toHaveBeenCalledTimes(1)
     const [url, init] = backendFetch.mock.calls[0] as [string, RequestInit]
-    expect(url).toContain('/api/v1/conversations/conv-1/messages?limit=10')
+    expect(url).toContain('/api/v1/ws/ws-42/conversations/conv-1/messages?limit=10')
     expect(init?.headers).toMatchObject({
       'cookie': 'cubebox_user_id=user-cookie',
       'x-user-id': 'header-user',

--- a/frontend/packages/web/__tests__/hooks/useMessages.test.ts
+++ b/frontend/packages/web/__tests__/hooks/useMessages.test.ts
@@ -17,7 +17,12 @@ function mockSSEResponse(events: object[]) {
   })
 }
 
-const mockClient = { baseUrl: '', get: vi.fn(), post: vi.fn() }
+const mockClient = {
+  baseUrl: '',
+  get: vi.fn(),
+  post: vi.fn(),
+  resolvePath: (p: string) => p,
+}
 
 beforeEach(() => {
   vi.useRealTimers()

--- a/frontend/packages/web/app/api/v1/ws/[wsId]/conversations/[id]/messages/route.ts
+++ b/frontend/packages/web/app/api/v1/ws/[wsId]/conversations/[id]/messages/route.ts
@@ -15,7 +15,6 @@ function buildProxyHeaders(request: NextRequest, accept: string): HeadersInit {
   const headers: Record<string, string> = { Accept: accept }
   const cookie = request.headers.get('cookie')
   const userId = request.headers.get('x-user-id')
-  const wsId = request.headers.get('x-workspace-id')
   const csrf = request.headers.get('x-csrf-token')
 
   if (cookie) {
@@ -23,9 +22,6 @@ function buildProxyHeaders(request: NextRequest, accept: string): HeadersInit {
   }
   if (userId) {
     headers['x-user-id'] = userId
-  }
-  if (wsId) {
-    headers['X-Workspace-Id'] = wsId
   }
   if (csrf) {
     headers['X-CSRF-Token'] = csrf
@@ -51,13 +47,13 @@ function appendSetCookie(target: Headers, source: Headers): void {
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
+  { params }: { params: Promise<{ wsId: string; id: string }> },
 ) {
-  const { id } = await params
+  const { wsId, id } = await params
   const body = await request.text()
 
   const backendRes = await fetch(
-    `${BACKEND_URL}/api/v1/conversations/${id}/messages`,
+    `${BACKEND_URL}/api/v1/ws/${wsId}/conversations/${id}/messages`,
     {
       method: 'POST',
       headers: {
@@ -93,14 +89,14 @@ export async function POST(
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
+  { params }: { params: Promise<{ wsId: string; id: string }> },
 ) {
-  const { id } = await params
+  const { wsId, id } = await params
   const url = new URL(request.url)
   const qs = url.search
 
   const backendRes = await fetch(
-    `${BACKEND_URL}/api/v1/conversations/${id}/messages${qs}`,
+    `${BACKEND_URL}/api/v1/ws/${wsId}/conversations/${id}/messages${qs}`,
     {
       headers: buildProxyHeaders(request, 'application/json'),
     },

--- a/frontend/packages/web/components/chat/ArtifactCard.tsx
+++ b/frontend/packages/web/components/chat/ArtifactCard.tsx
@@ -5,22 +5,22 @@ import { Download, Package, Eye } from 'lucide-react'
 import type { Artifact } from '@cubebox/core'
 import { usePanelStore } from '@cubebox/core'
 import { getArtifactIcon, getArtifactLabel } from '@/components/panel/artifact/artifactIcons'
+import { buildDownloadUrl } from '@/components/panel/artifact/previewUtils'
+import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
 
 interface ArtifactCardProps {
   artifact: Artifact
-  baseUrl?: string
 }
 
 export const ArtifactCard = memo(function ArtifactCard({
   artifact,
-  baseUrl = '',
 }: ArtifactCardProps) {
   const Icon = getArtifactIcon(artifact)
   const label = getArtifactLabel(artifact)
   const openPreview = usePanelStore(s => s.openArtifact)
+  const { workspaceId } = useWorkspaceContext()
 
-  const downloadUrl =
-    `${baseUrl}/api/v1/conversations/${artifact.conversation_id}/artifacts/${artifact.id}/download`
+  const downloadUrl = workspaceId ? buildDownloadUrl(artifact, workspaceId) : '#'
 
   const handlePreview = useCallback(() => {
     openPreview(artifact.conversation_id, artifact.id)

--- a/frontend/packages/web/components/chat/ArtifactGallery.tsx
+++ b/frontend/packages/web/components/chat/ArtifactGallery.tsx
@@ -7,6 +7,8 @@ import {
 import { useArtifactStore, usePanelStore } from '@cubebox/core'
 import type { Artifact } from '@cubebox/core'
 import { getArtifactIcon } from '@/components/panel/artifact/artifactIcons'
+import { buildDownloadUrl } from '@/components/panel/artifact/previewUtils'
+import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
 
 interface ArtifactGalleryProps {
   conversationId: string
@@ -76,8 +78,8 @@ function ArtifactGalleryItem(
   { artifact, onPreview }: { artifact: Artifact; onPreview: () => void },
 ) {
   const Icon = getArtifactIcon(artifact)
-  const downloadUrl =
-    `/api/v1/conversations/${artifact.conversation_id}/artifacts/${artifact.id}/download`
+  const { workspaceId } = useWorkspaceContext()
+  const downloadUrl = workspaceId ? buildDownloadUrl(artifact, workspaceId) : '#'
 
   return (
     <div

--- a/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
+++ b/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
@@ -15,6 +15,7 @@ import { CodePreview } from './CodePreview'
 import { DocumentPreview } from './DocumentPreview'
 import { DataPreview } from './DataPreview'
 import { FallbackPreview } from './FallbackPreview'
+import { buildDownloadUrl } from './previewUtils'
 
 const PdfPreview = dynamic(
   () => import('./PdfPreview').then(m => m.PdfPreview),
@@ -108,19 +109,17 @@ function ArtifactPanelHeader({
   selectedVersion,
   onSelectVersion,
   onClose,
+  workspaceId,
 }: {
   artifact: Artifact
   versions: ArtifactVersion[]
   selectedVersion: number | null
   onSelectVersion: (version: number | null) => void
   onClose: () => void
+  workspaceId: string
 }) {
   const Icon = getArtifactIcon(artifact)
-  const baseDownloadUrl =
-    `/api/v1/conversations/${artifact.conversation_id}/artifacts/${artifact.id}/download`
-  const downloadUrl = selectedVersion != null
-    ? `${baseDownloadUrl}?version=${selectedVersion}`
-    : baseDownloadUrl
+  const downloadUrl = buildDownloadUrl(artifact, workspaceId, selectedVersion)
 
   return (
     <header className="h-11 border-b border-border flex items-center gap-2 px-4 shrink-0 bg-card">
@@ -157,28 +156,29 @@ function ArtifactPanelHeader({
 function PreviewContent({
   artifact,
   version,
+  workspaceId,
 }: {
   artifact: Artifact
   version: number | null
+  workspaceId: string
 }) {
-  // Route PDFs to PdfPreview regardless of artifact_type
   if (isPdf(artifact)) {
-    return <PdfPreview artifact={artifact} version={version} />
+    return <PdfPreview artifact={artifact} version={version} workspaceId={workspaceId} />
   }
 
   switch (artifact.artifact_type) {
     case 'website':
-      return <HtmlPreview artifact={artifact} version={version} />
+      return <HtmlPreview artifact={artifact} version={version} workspaceId={workspaceId} />
     case 'image':
-      return <ImagePreview artifact={artifact} version={version} />
+      return <ImagePreview artifact={artifact} version={version} workspaceId={workspaceId} />
     case 'code':
-      return <CodePreview artifact={artifact} version={version} />
+      return <CodePreview artifact={artifact} version={version} workspaceId={workspaceId} />
     case 'document':
-      return <DocumentPreview artifact={artifact} version={version} />
+      return <DocumentPreview artifact={artifact} version={version} workspaceId={workspaceId} />
     case 'data':
-      return <DataPreview artifact={artifact} version={version} />
+      return <DataPreview artifact={artifact} version={version} workspaceId={workspaceId} />
     default:
-      return <FallbackPreview artifact={artifact} version={version} />
+      return <FallbackPreview artifact={artifact} version={version} workspaceId={workspaceId} />
   }
 }
 
@@ -206,7 +206,7 @@ export function ArtifactPanel() {
     loadVersions(client, conversationId, artifactId)
   }, [artifact, conversationId, artifactId, loadVersions, workspaceId])
 
-  if (view.type !== 'artifact' || !artifact) return null
+  if (view.type !== 'artifact' || !artifact || !workspaceId) return null
 
   const artifactVersions = versions[artifact.id] ?? []
   const currentSelectedVersion = selectedVersion[artifact.id] ?? null
@@ -219,9 +219,14 @@ export function ArtifactPanel() {
         selectedVersion={currentSelectedVersion}
         onSelectVersion={(v) => selectVersion(artifact.id, v)}
         onClose={close}
+        workspaceId={workspaceId}
       />
       <div className="flex-1 overflow-hidden">
-        <PreviewContent artifact={artifact} version={currentSelectedVersion} />
+        <PreviewContent
+          artifact={artifact}
+          version={currentSelectedVersion}
+          workspaceId={workspaceId}
+        />
       </div>
     </div>
   )

--- a/frontend/packages/web/components/panel/artifact/CodePreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/CodePreview.tsx
@@ -8,14 +8,15 @@ import { buildPreviewUrl } from './previewUtils'
 interface CodePreviewProps {
   artifact: Artifact
   version: number | null
+  workspaceId: string
 }
 
-export function CodePreview({ artifact, version }: CodePreviewProps) {
+export function CodePreview({ artifact, version, workspaceId }: CodePreviewProps) {
   const [code, setCode] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const filename = artifact.entry_file || artifact.path.split('/').pop() || 'file'
-  const previewUrl = buildPreviewUrl(artifact, filename, version)
+  const previewUrl = buildPreviewUrl(artifact, filename, version, workspaceId)
 
   useEffect(() => {
     fetch(previewUrl)

--- a/frontend/packages/web/components/panel/artifact/DataPreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/DataPreview.tsx
@@ -8,6 +8,7 @@ import { buildPreviewUrl } from './previewUtils'
 interface DataPreviewProps {
   artifact: Artifact
   version: number | null
+  workspaceId: string
 }
 
 function parseCsv(text: string): { headers: string[]; rows: string[][] } {
@@ -54,12 +55,12 @@ function JsonTable({ data }: { data: unknown }) {
   )
 }
 
-export function DataPreview({ artifact, version }: DataPreviewProps) {
+export function DataPreview({ artifact, version, workspaceId }: DataPreviewProps) {
   const [content, setContent] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const filename = artifact.entry_file || artifact.path.split('/').pop() || 'file'
-  const previewUrl = buildPreviewUrl(artifact, filename, version)
+  const previewUrl = buildPreviewUrl(artifact, filename, version, workspaceId)
 
   useEffect(() => {
     fetch(previewUrl)

--- a/frontend/packages/web/components/panel/artifact/DocumentPreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/DocumentPreview.tsx
@@ -10,14 +10,15 @@ import { buildPreviewUrl } from './previewUtils'
 interface DocumentPreviewProps {
   artifact: Artifact
   version: number | null
+  workspaceId: string
 }
 
-export function DocumentPreview({ artifact, version }: DocumentPreviewProps) {
+export function DocumentPreview({ artifact, version, workspaceId }: DocumentPreviewProps) {
   const [content, setContent] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const filename = artifact.entry_file || artifact.path.split('/').pop() || 'file'
-  const previewUrl = buildPreviewUrl(artifact, filename, version)
+  const previewUrl = buildPreviewUrl(artifact, filename, version, workspaceId)
 
   useEffect(() => {
     fetch(previewUrl)

--- a/frontend/packages/web/components/panel/artifact/FallbackPreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/FallbackPreview.tsx
@@ -2,16 +2,16 @@
 
 import { File, Download } from 'lucide-react'
 import type { Artifact } from '@cubebox/core'
+import { buildDownloadUrl } from './previewUtils'
 
 interface FallbackPreviewProps {
   artifact: Artifact
   version: number | null
+  workspaceId: string
 }
 
-export function FallbackPreview({ artifact, version }: FallbackPreviewProps) {
-  const versionParam = version != null ? `?version=${version}` : ''
-  const downloadUrl =
-    `/api/v1/conversations/${artifact.conversation_id}/artifacts/${artifact.id}/download${versionParam}`
+export function FallbackPreview({ artifact, version, workspaceId }: FallbackPreviewProps) {
+  const downloadUrl = buildDownloadUrl(artifact, workspaceId, version)
 
   return (
     <div className="flex flex-col items-center justify-center h-full gap-4 p-8 text-center">

--- a/frontend/packages/web/components/panel/artifact/HtmlPreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/HtmlPreview.tsx
@@ -8,12 +8,13 @@ import { buildPreviewUrl } from './previewUtils'
 interface HtmlPreviewProps {
   artifact: Artifact
   version: number | null
+  workspaceId: string
 }
 
-export function HtmlPreview({ artifact, version }: HtmlPreviewProps) {
+export function HtmlPreview({ artifact, version, workspaceId }: HtmlPreviewProps) {
   const [loading, setLoading] = useState(true)
   const entryFile = artifact.entry_file || artifact.path.split('/').pop() || 'index.html'
-  const previewUrl = buildPreviewUrl(artifact, entryFile, version)
+  const previewUrl = buildPreviewUrl(artifact, entryFile, version, workspaceId)
 
   return (
     <div className="relative w-full h-full">

--- a/frontend/packages/web/components/panel/artifact/ImagePreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/ImagePreview.tsx
@@ -8,12 +8,13 @@ import { buildPreviewUrl } from './previewUtils'
 interface ImagePreviewProps {
   artifact: Artifact
   version: number | null
+  workspaceId: string
 }
 
-export function ImagePreview({ artifact, version }: ImagePreviewProps) {
+export function ImagePreview({ artifact, version, workspaceId }: ImagePreviewProps) {
   const [loading, setLoading] = useState(true)
   const filename = artifact.path.split('/').pop() || 'image'
-  const previewUrl = buildPreviewUrl(artifact, filename, version)
+  const previewUrl = buildPreviewUrl(artifact, filename, version, workspaceId)
 
   return (
     <div className="flex items-center justify-center h-full p-4 bg-muted/20">

--- a/frontend/packages/web/components/panel/artifact/PdfPreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/PdfPreview.tsx
@@ -148,9 +148,10 @@ function TocItem({
 interface PdfPreviewProps {
   artifact: Artifact
   version: number | null
+  workspaceId: string
 }
 
-export function PdfPreview({ artifact, version }: PdfPreviewProps) {
+export function PdfPreview({ artifact, version, workspaceId }: PdfPreviewProps) {
   const [loading, setLoading] = useState(true)
   const [numPages, setNumPages] = useState(0)
   const [currentPage, setCurrentPage] = useState(1)
@@ -163,7 +164,7 @@ export function PdfPreview({ artifact, version }: PdfPreviewProps) {
   const pageRefs = useRef<Map<number, HTMLDivElement>>(new Map())
 
   const filename = artifact.entry_file || artifact.path.split('/').pop() || 'file.pdf'
-  const fileUrl = buildPreviewUrl(artifact, filename, version)
+  const fileUrl = buildPreviewUrl(artifact, filename, version, workspaceId)
 
   // Track container width for responsive page sizing
   useEffect(() => {

--- a/frontend/packages/web/components/panel/artifact/previewUtils.ts
+++ b/frontend/packages/web/components/panel/artifact/previewUtils.ts
@@ -4,8 +4,21 @@ export function buildPreviewUrl(
   artifact: Artifact,
   filePath: string,
   version: number | null,
+  workspaceId: string,
 ): string {
   const base =
-    `/api/v1/conversations/${artifact.conversation_id}/artifacts/${artifact.id}/preview/${filePath}`
+    `/api/v1/ws/${workspaceId}/conversations/${artifact.conversation_id}` +
+    `/artifacts/${artifact.id}/preview/${filePath}`
+  return version != null ? `${base}?version=${version}` : base
+}
+
+export function buildDownloadUrl(
+  artifact: Artifact,
+  workspaceId: string,
+  version?: number | null,
+): string {
+  const base =
+    `/api/v1/ws/${workspaceId}/conversations/${artifact.conversation_id}` +
+    `/artifacts/${artifact.id}/download`
   return version != null ? `${base}?version=${version}` : base
 }


### PR DESCRIPTION
All business endpoints now live under /api/v1/ws/{workspace_id}/... instead of relying on an X-Workspace-Id header. This lets browser-direct loads (<img>, <iframe>, <a href>, pdf.js) carry workspace scope naturally, fixing the "X-Workspace-Id header is required" error when viewing artifacts.

Backend
- request_context dependency now extracts workspace_id via Path()
- conversations + artifacts routers prefixed with /ws/{workspace_id}
- Removed the header requirement; workspace not-found → 404, non-member → 403
- E2E fixtures yield (client, workspace_id) tuples and build URLs accordingly

Frontend
- ApiClient.setWorkspaceId now rewrites scoped paths to include /ws/<id>/ (auth + workspaces routes stay neutral)
- Exposed client.resolvePath for browser-direct consumers
- previewUtils builds absolute /ws/-scoped URLs for artifact preview/download
- All preview + artifact card components thread workspaceId explicitly
- Moved SSE proxy route to app/api/v1/ws/[wsId]/conversations/[id]/messages and dropped X-Workspace-Id forwarding