### PR TITLE
feat(conv): scope conversations to their creator

### DIFF
--- a/backend/alembic/versions/1a8d521ac153_add_creator_user_id_to_conversations.py
+++ b/backend/alembic/versions/1a8d521ac153_add_creator_user_id_to_conversations.py
@@ -1,0 +1,95 @@
+"""add creator_user_id to conversations
+
+Revision ID: 1a8d521ac153
+Revises: 1d1dab71f0fa
+Create Date: 2026-04-20 17:51:31.505436
+
+Backfills existing rows from the workspace's admin membership (option 1
+from the design discussion). Fails the migration if any workspace has
+conversations but no admin — the operator must intervene.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1a8d521ac153"
+down_revision: str | Sequence[str] | None = "1d1dab71f0fa"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # 1. Add column as nullable so backfill can populate it.
+    op.add_column(
+        "conversations",
+        sa.Column(
+            "creator_user_id",
+            sqlmodel.sql.sqltypes.AutoString(length=36),
+            nullable=True,
+        ),
+    )
+
+    # 2. Backfill from workspace admin membership. Picks one admin
+    # arbitrarily when a workspace has multiple — correct for the common
+    # "Personal" workspace (single admin = creator), best-effort for
+    # multi-admin workspaces.
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            """
+            UPDATE conversations c
+            JOIN (
+                SELECT workspace_id, MIN(user_id) AS user_id
+                FROM memberships
+                WHERE role = 'admin'
+                GROUP BY workspace_id
+            ) m ON m.workspace_id = c.workspace_id
+            SET c.creator_user_id = m.user_id
+            WHERE c.creator_user_id IS NULL
+            """
+        )
+    )
+
+    # 3. Verify no rows were left unbackfilled.
+    remaining = bind.execute(
+        sa.text("SELECT COUNT(*) FROM conversations WHERE creator_user_id IS NULL")
+    ).scalar_one()
+    if remaining:
+        raise RuntimeError(
+            f"{remaining} conversation row(s) could not be backfilled "
+            "(workspace has no admin). Resolve manually before re-running."
+        )
+
+    # 4. Enforce NOT NULL now that every row is populated.
+    op.alter_column(
+        "conversations",
+        "creator_user_id",
+        existing_type=sqlmodel.sql.sqltypes.AutoString(length=36),
+        nullable=False,
+    )
+
+    # 5. Swap indexes.
+    op.drop_index(op.f("ix_conversations_org_ws"), table_name="conversations")
+    op.create_index(
+        "ix_conversations_user_ws",
+        "conversations",
+        ["creator_user_id", "workspace_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_conversations_user_ws", table_name="conversations")
+    op.create_index(
+        op.f("ix_conversations_org_ws"),
+        "conversations",
+        ["org_id", "workspace_id"],
+        unique=False,
+    )
+    op.drop_column("conversations", "creator_user_id")

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -31,6 +31,7 @@ async def _update_conversation_timestamp(
     *,
     org_id: str,
     workspace_id: str,
+    user_id: str,
 ) -> None:
     """Update conversation timestamp using an isolated NullPool engine.
 
@@ -41,7 +42,10 @@ async def _update_conversation_timestamp(
     try:
         async with AsyncSession(save_engine, expire_on_commit=False) as save_session:
             save_conv_repo = ConversationRepository(
-                save_session, org_id=org_id, workspace_id=workspace_id
+                save_session,
+                org_id=org_id,
+                workspace_id=workspace_id,
+                user_id=user_id,
             )
             await save_conv_repo.update_timestamp(conversation_id)
     finally:
@@ -55,7 +59,12 @@ async def create_conversation(
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> dict[str, object]:
     """Create a new conversation."""
-    repo = ConversationRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
+    repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
     conversation = await repo.create(title=title)
     return {
         "id": conversation.id,
@@ -72,7 +81,12 @@ async def get_conversation(
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> dict[str, object]:
     """Get a conversation by ID."""
-    repo = ConversationRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
+    repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
     conversation = await repo.get_by_id(conversation_id)
     if not conversation:
         raise HTTPException(
@@ -95,7 +109,12 @@ async def list_conversations(
     offset: int = 0,
 ) -> dict[str, object]:
     """List conversations with pagination."""
-    repo = ConversationRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
+    repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
     conversations, total = await repo.list_all(limit=limit, offset=offset)
     return {
         "conversations": [
@@ -121,7 +140,12 @@ async def update_conversation(
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> dict[str, object]:
     """Update conversation title."""
-    repo = ConversationRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
+    repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
     conversation = await repo.update_title(conversation_id, title)
     if not conversation:
         raise HTTPException(
@@ -143,7 +167,12 @@ async def delete_conversation(
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> None:
     """Delete a conversation."""
-    repo = ConversationRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
+    repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
     deleted = await repo.delete(conversation_id)
     if not deleted:
         raise HTTPException(
@@ -287,7 +316,10 @@ async def send_message(
     # for the entire SSE stream duration, causing connection leaks on cancellation.
     async with async_session_maker() as session:
         conv_repo = ConversationRepository(
-            session, org_id=ctx.org_id, workspace_id=ctx.workspace_id
+            session,
+            org_id=ctx.org_id,
+            workspace_id=ctx.workspace_id,
+            user_id=ctx.user.id,
         )
         conversation = await conv_repo.get_by_id(conversation_id)
     if not conversation:
@@ -695,7 +727,10 @@ async def send_message(
             if not request_cancelled:
                 try:
                     await _update_conversation_timestamp(
-                        conversation_id, org_id=org_id, workspace_id=workspace_id
+                        conversation_id,
+                        org_id=org_id,
+                        workspace_id=workspace_id,
+                        user_id=user_id,
                     )
                 except Exception as e:
                     logger.warning("Error updating conversation timestamp: {}", e)
@@ -718,7 +753,12 @@ async def list_messages(
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> dict[str, object]:
     """List messages in a conversation, read from LangGraph thread state."""
-    conv_repo = ConversationRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
+    conv_repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
     conversation = await conv_repo.get_by_id(conversation_id)
     if not conversation:
         raise HTTPException(

--- a/backend/cubebox/models/conversation.py
+++ b/backend/cubebox/models/conversation.py
@@ -13,9 +13,10 @@ class Conversation(SQLModel, OrgScopedMixin, table=True):
     """Conversation model for storing chat sessions."""
 
     __tablename__ = "conversations"
-    __table_args__ = (Index("ix_conversations_org_ws", "org_id", "workspace_id"),)
+    __table_args__ = (Index("ix_conversations_user_ws", "creator_user_id", "workspace_id"),)
 
     id: str = Field(default_factory=lambda: str(uuid7()), primary_key=True)
+    creator_user_id: str = Field(max_length=36)
     title: str = Field(max_length=255)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/backend/cubebox/repositories/conversation.py
+++ b/backend/cubebox/repositories/conversation.py
@@ -1,8 +1,15 @@
-"""Conversation repository — scoped by (org_id, workspace_id)."""
+"""Conversation repository — scoped by (workspace_id, creator_user_id).
+
+Conversations are per-user: only the creator can see/mutate their rows.
+Org + workspace columns are still persisted via ``OrgScopedMixin`` but
+the primary access check is ``creator_user_id``.
+"""
 
 from datetime import UTC, datetime
+from typing import Any
 
 from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.models import Conversation
 from cubebox.repositories.base import ScopedRepository
@@ -11,11 +18,32 @@ from cubebox.repositories.base import ScopedRepository
 class ConversationRepository(ScopedRepository[Conversation]):
     model = Conversation
 
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        org_id: str,
+        workspace_id: str,
+        user_id: str,
+    ) -> None:
+        super().__init__(session, org_id=org_id, workspace_id=workspace_id)
+        self.user_id = user_id
+
+    def _scoped_select(self) -> Any:
+        return (
+            super()
+            ._scoped_select()
+            .where(
+                Conversation.creator_user_id == self.user_id,
+            )
+        )
+
     async def create(self, title: str) -> Conversation:
         conv = Conversation(
             title=title,
             org_id=self.org_id,
             workspace_id=self.workspace_id,
+            creator_user_id=self.user_id,
         )
         return await self.add(conv)
 
@@ -36,8 +64,8 @@ class ConversationRepository(ScopedRepository[Conversation]):
             select(func.count())
             .select_from(Conversation)
             .where(
-                Conversation.org_id == self.org_id,  # type: ignore[arg-type]
                 Conversation.workspace_id == self.workspace_id,  # type: ignore[arg-type]
+                Conversation.creator_user_id == self.user_id,  # type: ignore[arg-type]
             )
         )
         total = (await self.session.execute(count_stmt)).scalar_one()

--- a/backend/cubebox/repositories/invite_token.py
+++ b/backend/cubebox/repositories/invite_token.py
@@ -26,7 +26,11 @@ class InviteTokenRepository:
         if tok is None:
             return None
         now = datetime.now(UTC)
-        if tok.used_at is not None or tok.expires_at < now:
+        # MySQL DATETIME drops tz on round-trip — coerce to UTC-aware before comparing.
+        expires_at = tok.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        if tok.used_at is not None or expires_at < now:
             return None
         tok.used_at = now
         await self.session.commit()

--- a/backend/tests/e2e/test_conversation_privacy.py
+++ b/backend/tests/e2e/test_conversation_privacy.py
@@ -1,0 +1,134 @@
+"""E2E test: conversations are private to their creator even inside a shared workspace.
+
+Product rule (2026-04): a conversation is only visible to the user who
+created it. Two members of the same workspace must not be able to see
+each other's conversations via list/get/update/delete/messages.
+"""
+
+import secrets
+
+import pytest
+
+from cubebox.api.middleware.rate_limit import limiter
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+async def _seed_csrf(client) -> str:
+    await client.get("/api/v1/auth/me")
+    csrf = client.cookies.get("cubebox_csrf")
+    assert csrf, "cubebox_csrf cookie not set after GET /api/v1/auth/me"
+    return csrf
+
+
+async def _login(client, email: str, password: str) -> str:
+    client.cookies.clear()
+    r = await client.post("/api/v1/auth/login", data={"username": email, "password": password})
+    assert r.status_code in (200, 204), r.text
+    return await _seed_csrf(client)
+
+
+@pytest.mark.asyncio
+async def test_conversation_invisible_to_other_member_same_workspace(
+    unauthenticated_memory_client,
+):
+    """B (a member of the same workspace) cannot see A's conversation."""
+    client = unauthenticated_memory_client
+
+    a_email = f"a-{secrets.token_hex(4)}@example.com"
+    b_email = f"b-{secrets.token_hex(4)}@example.com"
+    pw = "passwordpassword"
+
+    for email in (a_email, b_email):
+        r = await client.post("/api/v1/auth/register", json={"email": email, "password": pw})
+        assert r.status_code == 201, r.text
+
+    # --- A: create shared workspace, invite B, create a conversation --------
+    csrf_a = await _login(client, a_email, pw)
+    r = await client.post(
+        "/api/v1/workspaces",
+        json={"name": "Shared", "org_id": "default-org"},
+        headers={"X-CSRF-Token": csrf_a},
+    )
+    assert r.status_code == 201, r.text
+    ws_id = r.json()["id"]
+
+    r = await client.post(
+        f"/api/v1/workspaces/{ws_id}/invites",
+        json={"role": "member"},
+        headers={"X-CSRF-Token": csrf_a},
+    )
+    assert r.status_code == 201, r.text
+    invite_token = r.json()["token"]
+
+    r = await client.post(
+        f"/api/v1/ws/{ws_id}/conversations",
+        params={"title": "A's private chat"},
+        headers={"X-CSRF-Token": csrf_a},
+    )
+    assert r.status_code == 201, r.text
+    conv_id = r.json()["id"]
+
+    # --- B: accept invite (legit workspace member via the HTTP flow) --------
+    csrf_b = await _login(client, b_email, pw)
+    r = await client.post(
+        "/api/v1/workspaces/invites/accept",
+        json={"token": invite_token},
+        headers={"X-CSRF-Token": csrf_b},
+    )
+    assert r.status_code == 200, r.text
+
+    # B's list must be empty — A's conversation is filtered out by creator_user_id.
+    r = await client.get(f"/api/v1/ws/{ws_id}/conversations")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["total"] == 0
+    assert body["conversations"] == []
+
+    # Direct read: 404 (structurally invisible, not 403).
+    r = await client.get(f"/api/v1/ws/{ws_id}/conversations/{conv_id}")
+    assert r.status_code == 404, r.text
+
+    # Update: 404.
+    r = await client.patch(
+        f"/api/v1/ws/{ws_id}/conversations/{conv_id}",
+        params={"title": "Hijacked"},
+        headers={"X-CSRF-Token": csrf_b},
+    )
+    assert r.status_code == 404, r.text
+
+    # Delete: 404.
+    r = await client.delete(
+        f"/api/v1/ws/{ws_id}/conversations/{conv_id}",
+        headers={"X-CSRF-Token": csrf_b},
+    )
+    assert r.status_code == 404, r.text
+
+    # Messages list: 404 (the conversation-existence pre-check fires first).
+    r = await client.get(f"/api/v1/ws/{ws_id}/conversations/{conv_id}/messages")
+    assert r.status_code == 404, r.text
+
+    # Send message: 404 (same pre-check gate).
+    r = await client.post(
+        f"/api/v1/ws/{ws_id}/conversations/{conv_id}/messages",
+        json={"content": "sneaky"},
+        headers={"X-CSRF-Token": csrf_b},
+    )
+    assert r.status_code == 404, r.text
+
+    # --- A positive control: A still sees their own conversation ------------
+    csrf_a = await _login(client, a_email, pw)
+    r = await client.get(f"/api/v1/ws/{ws_id}/conversations/{conv_id}")
+    assert r.status_code == 200, r.text
+    assert r.json()["title"] == "A's private chat"
+
+    r = await client.get(f"/api/v1/ws/{ws_id}/conversations")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["total"] == 1
+    assert body["conversations"][0]["id"] == conv_id


### PR DESCRIPTION
## Summary

- Conversations are now private to their creator, not shared across a workspace. A member of the same workspace no longer sees another member's chats via any CRUD or message endpoint.
- New column `conversations.creator_user_id` (NOT NULL) + composite index `(creator_user_id, workspace_id)` replacing the old `(org_id, workspace_id)` index. `creator_user_id` is placed first so future "all my conversations across workspaces" queries can reuse the same index.
- `ConversationRepository` now takes `user_id` in its constructor and adds a `creator_user_id = :user_id` predicate to every query. All 7 callsites in the conversations route were updated to pass `ctx.user.id`.
- Migration `1a8d521ac153` backfills existing rows by picking the workspace's admin membership (`MIN(user_id) WHERE role='admin' GROUP BY workspace_id`), then enforces NOT NULL. If any workspace has conversations but no admin, the migration aborts with a clear error — operator must intervene.
- **Drive-by fix** (same PR because the new test exercises it): `InviteTokenRepository.consume` compared `tok.expires_at` (naive on MySQL DATETIME round-trip) against `datetime.now(UTC)` (aware) and 500'd every invite accept. Now coerces the DB value to UTC-aware before comparing.
- Out of scope (tracked for follow-up): artifact routes are still workspace-scoped — a malicious same-workspace member who guesses an artifact id can still read it. Leaving that for a separate PR.

## Test plan

- [x] `make format lint type-check` — clean
- [x] `pytest tests/e2e/test_conversation_privacy.py` — new: B (member of A's workspace) gets 404/empty on list/get/patch/delete/messages/send, A retains access
- [x] `pytest tests/e2e/test_conversations.py tests/e2e/test_scoping.py tests/e2e/test_rbac.py` — existing tests still green
- [x] 39-test e2e fast-path suite passes locally
- [x] `alembic upgrade head` runs clean on the existing dev DB (backfill + index swap verified via `SHOW CREATE TABLE conversations`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)