### PR TITLE
docs(v1): batch 1 foundations — M0 plugin arch, M6 file_read, M2 admin shell

### DIFF
--- a/docs/superpowers/plans/2026-04-23-m0-ce-ee-plugin-architecture.md
+++ b/docs/superpowers/plans/2026-04-23-m0-ce-ee-plugin-architecture.md
@@ -2843,7 +2843,96 @@ git commit -m "ci(plugins): add test-ee-compat job for Layer 1 contract tests + 
 
 ---
 
-### Task 24: Final integration smoke test
+### Task 24: E2E — end-to-end plugin architecture path
+
+Per CLAUDE.md project rule "Focus on E2E tests". Contract tests (Task 22) verify the registry surface in isolation; this task verifies real integration: discovery via entry_points, auth/permission delegation on a live FastAPI app, and the admin extensions manifest served through a real HTTP request.
+
+**Files:**
+- Create: `backend/tests/e2e/test_plugin_architecture_e2e.py`
+
+- [ ] **Step 1: Write failing e2e**
+
+```python
+# backend/tests/e2e/test_plugin_architecture_e2e.py
+"""E2E: plugin discovery + CE defaults + admin manifest via real HTTP."""
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.e2e
+def test_ce_defaults_load_and_serve(client: TestClient) -> None:
+    """CE-only deployment: all Protocols resolve to builtin; app starts cleanly."""
+    from cubebox.plugins import get_registry
+
+    reg = get_registry()
+    assert reg.auth_provider is not None
+    assert reg.permission_checker is not None
+    assert reg.audit_sink is not None
+    assert reg.user_directory_syncer is None  # no default CE directory syncer
+    # get_admin_panel_extensions returns a list in the current contract.
+    assert isinstance(reg.get_admin_panel_extensions(), list)
+
+
+@pytest.mark.e2e
+def test_admin_extensions_manifest_requires_admin(client: TestClient, admin_cookie: str, member_cookie: str) -> None:
+    """Manifest endpoint enforces admin gating end-to-end through real middleware."""
+    r = client.get("/api/v1/admin/_extensions/manifest")
+    assert r.status_code == 401  # unauthenticated
+
+    r = client.get("/api/v1/admin/_extensions/manifest", cookies={"access_token": member_cookie})
+    assert r.status_code == 403  # non-admin
+
+    r = client.get("/api/v1/admin/_extensions/manifest", cookies={"access_token": admin_cookie})
+    assert r.status_code == 200
+    assert r.json() == []  # CE-only: no external AdminPanelExtension installed
+
+
+@pytest.mark.e2e
+def test_login_emits_audit_event(client: TestClient, member_credentials: tuple[str, str], caplog) -> None:
+    """AuditSink receives `auth.login` via the real login flow."""
+    email, password = member_credentials
+    with caplog.at_level("INFO", logger="cubebox.audit"):
+        r = client.post("/auth/jwt/login", data={"username": email, "password": password})
+        assert r.status_code == 200
+    assert any("auth.login" in rec.message for rec in caplog.records), (
+        "audit sink did not record auth.login"
+    )
+
+
+@pytest.mark.e2e
+def test_permission_check_denies_non_admin_on_workspace_admin_route(
+    client: TestClient, member_cookie: str, workspace_id: str
+) -> None:
+    """require_admin → PermissionChecker.check → denies non-admin on admin-only route."""
+    r = client.get(f"/api/v1/workspaces/{workspace_id}/admin", cookies={"access_token": member_cookie})
+    assert r.status_code == 403
+```
+
+- [ ] **Step 2: Add fixtures if missing**
+
+In `backend/tests/e2e/conftest.py` ensure the following fixtures exist and are reused (don't duplicate if already present in other e2e modules): `client`, `admin_cookie`, `member_cookie`, `member_credentials`, `workspace_id`.
+
+- [ ] **Step 3: Run e2e**
+
+```bash
+cd backend && uv run pytest tests/e2e/test_plugin_architecture_e2e.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/e2e/test_plugin_architecture_e2e.py backend/tests/e2e/conftest.py
+git commit -m "test(plugins): e2e plugin architecture (CE defaults + admin manifest + audit + authz)"
+```
+
+---
+
+### Task 25: Final integration smoke test
 
 **Files:**
 - Run all tests + start server

--- a/docs/superpowers/plans/2026-04-23-m0-ce-ee-plugin-architecture.md
+++ b/docs/superpowers/plans/2026-04-23-m0-ce-ee-plugin-architecture.md
@@ -1,0 +1,2909 @@
+# M0 · CE/EE 插件架构 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Freeze 5 `Protocol` extension interfaces (AuthProvider / PermissionChecker / AuditSink / UserDirectorySyncer / AdminPanelExtension), wire `pip entry_points` discovery + CE default fallback, integrate AuthProvider + PermissionChecker into existing CE flows, hook 3 audit call sites, and stand up the AdminPanelExtension startup scan — all without breaking any existing auth / RBAC test.
+
+**Architecture:** New package `backend/cubebox/plugins/` holds Protocols + registry + CE defaults. CE default implementations are instantiated directly by the registry (no entry_points). External plugins declare entry_points under per-Protocol groups (`cubebox.auth_provider` etc.) plus a mandatory `cubebox.plugin_manifest` for API version checking. `Sandbox.execute / upload / download` are unchanged; only auth + admin plumbing touched.
+
+**Tech Stack:** Python 3.12, FastAPI, fastapi-users, pytest, pytest-asyncio, importlib.metadata (entry_points), structlog, Pydantic, SQLModel, dynaconf.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-ce-ee-plugin-architecture-design.md`
+
+---
+
+## File Structure
+
+### Create
+
+```
+backend/cubebox/plugins/
+├─ __init__.py                      # Re-export PluginManifest, registry getters, CUBEBOX_PLUGIN_API_VERSION
+├─ protocols.py                     # 5 Protocols + dataclasses + PluginManifest
+├─ registry.py                      # PluginRegistry (discover, resolve, getters)
+├─ audit.py                         # audit_log() helper
+└─ defaults/
+   ├─ __init__.py
+   ├─ auth.py                       # DefaultAuthProvider wraps fastapi-users
+   ├─ permissions.py                # DefaultPermissionChecker wraps Role lookup
+   ├─ audit.py                      # DefaultAuditSink: structlog INFO no-op
+   └─ admin_panel.py                # DefaultAdminPanelExtension: empty
+
+backend/tests/plugins/
+├─ __init__.py
+├─ conftest.py                      # registry fixtures + helpers
+└─ test_contracts.py                # 11 contract assertions
+
+backend/tests/fixtures/fake_plugin/
+├─ pyproject.toml                   # tomled in tmp install for tests
+├─ fake_plugin/
+│  ├─ __init__.py                   # exports MANIFEST + 5 plugin classes
+│  ├─ auth.py                       # FakeAuthProvider
+│  ├─ permissions.py                # FakePermissionChecker
+│  ├─ audit.py                      # FakeAuditSink
+│  ├─ directory.py                  # FakeUserDirectorySyncer
+│  └─ admin_panel.py                # FakeAdminPanelExtension
+```
+
+### Modify
+
+```
+backend/cubebox/auth/dependencies.py        # require_role rewritten to call PermissionChecker
+backend/cubebox/auth/users.py               # on_after_login hook + audit_log calls
+backend/cubebox/api/app.py                  # Plugin discovery startup; mount auth routers + admin extension routers + manifest endpoint
+backend/cubebox/api/routes/v1/workspaces.py # invite create → audit_log
+backend/cubebox/config.py                   # plugins.* pydantic schema
+backend/config.yaml                         # plugins: section default
+backend/config.development.yaml             # plugins: section default
+backend/config.test.yaml                    # plugins: section default
+.github/workflows/ci.yml                    # test-ee-compat placeholder job
+```
+
+---
+
+## Tasks
+
+### Task 1: Create `cubebox.plugins` package skeleton
+
+**Files:**
+- Create: `backend/cubebox/plugins/__init__.py`
+- Create: `backend/cubebox/plugins/defaults/__init__.py`
+- Create: `backend/tests/plugins/__init__.py`
+
+- [ ] **Step 1: Create directory + empty __init__.py files**
+
+```bash
+mkdir -p backend/cubebox/plugins/defaults
+mkdir -p backend/tests/plugins
+touch backend/cubebox/plugins/defaults/__init__.py
+touch backend/tests/plugins/__init__.py
+```
+
+- [ ] **Step 2: Add placeholder `cubebox/plugins/__init__.py` with module docstring**
+
+```python
+"""CE/EE plugin protocols + entry_points-based discovery.
+
+This package defines the contracts that external plugins (e.g. cubebox-ee)
+implement to extend cubebox CE. See docs/superpowers/specs/2026-04-22-ce-ee-plugin-architecture-design.md.
+"""
+```
+
+- [ ] **Step 3: Verify import works**
+
+Run: `cd backend && uv run python -c "import cubebox.plugins"`
+Expected: no error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/cubebox/plugins/ backend/tests/plugins/
+git commit -m "chore(plugins): create package skeleton for M0 plugin architecture"
+```
+
+---
+
+### Task 2: Define `PluginManifest` + `CUBEBOX_PLUGIN_API_VERSION` constant
+
+**Files:**
+- Create: `backend/cubebox/plugins/protocols.py`
+- Create: `backend/tests/plugins/test_protocols.py`
+
+- [ ] **Step 1: Write failing test for PluginManifest dataclass**
+
+```python
+# backend/tests/plugins/test_protocols.py
+from cubebox.plugins.protocols import CUBEBOX_PLUGIN_API_VERSION, PluginManifest
+
+
+def test_plugin_manifest_constructs_with_required_fields() -> None:
+    m = PluginManifest(api_version=1, name="test-plugin", version="0.1.0")
+    assert m.api_version == 1
+    assert m.name == "test-plugin"
+    assert m.version == "0.1.0"
+    assert m.description == ""
+
+
+def test_plugin_manifest_accepts_description() -> None:
+    m = PluginManifest(api_version=1, name="x", version="0.1.0", description="Hello")
+    assert m.description == "Hello"
+
+
+def test_api_version_constant_is_int_one() -> None:
+    assert CUBEBOX_PLUGIN_API_VERSION == 1
+    assert isinstance(CUBEBOX_PLUGIN_API_VERSION, int)
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `cd backend && uv run pytest tests/plugins/test_protocols.py -v`
+Expected: FAIL with `ImportError: cannot import name 'PluginManifest' from 'cubebox.plugins.protocols'`
+
+- [ ] **Step 3: Implement protocols.py with manifest + version**
+
+```python
+# backend/cubebox/plugins/protocols.py
+"""Plugin Protocols + supporting dataclasses + version constant.
+
+CUBEBOX_PLUGIN_API_VERSION is the single integer plugins must declare via
+their PluginManifest. Mismatch → registry refuses to load the plugin.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Final, Protocol, runtime_checkable
+from uuid import UUID
+
+from fastapi import APIRouter, Request
+
+CUBEBOX_PLUGIN_API_VERSION: Final[int] = 1
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    """Plugin self-describing metadata. Required entry_point per wheel."""
+
+    api_version: int
+    name: str
+    version: str
+    description: str = ""
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `cd backend && uv run pytest tests/plugins/test_protocols.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/plugins/protocols.py backend/tests/plugins/test_protocols.py
+git commit -m "feat(plugins): add PluginManifest dataclass and CUBEBOX_PLUGIN_API_VERSION constant"
+```
+
+---
+
+### Task 3: Define `PermissionResource`, `AuditEvent`, `AdminNavItem`, `SyncResult`, `SyncSchedule` dataclasses
+
+**Files:**
+- Modify: `backend/cubebox/plugins/protocols.py`
+- Modify: `backend/tests/plugins/test_protocols.py`
+
+- [ ] **Step 1: Add failing tests for new dataclasses**
+
+Append to `backend/tests/plugins/test_protocols.py`:
+
+```python
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from cubebox.plugins.protocols import (
+    AdminNavItem,
+    AuditEvent,
+    PermissionResource,
+    SyncResult,
+    SyncSchedule,
+)
+
+
+def test_permission_resource_minimal() -> None:
+    r = PermissionResource(type="workspace", id=None)
+    assert r.type == "workspace"
+    assert r.id is None
+    assert r.org_id is None
+    assert r.workspace_id is None
+
+
+def test_permission_resource_full() -> None:
+    ws_id = uuid4()
+    org_id = uuid4()
+    r = PermissionResource(type="workspace", id=ws_id, org_id=org_id, workspace_id=ws_id)
+    assert r.workspace_id == ws_id
+    assert r.org_id == org_id
+
+
+def test_audit_event_constructs() -> None:
+    ev = AuditEvent(
+        timestamp=datetime.now(UTC),
+        user_id=uuid4(),
+        org_id=uuid4(),
+        workspace_id=None,
+        action="auth.login",
+        target_type=None,
+        target_id=None,
+        ip="127.0.0.1",
+        user_agent="pytest",
+        metadata={"foo": "bar"},
+    )
+    assert ev.action == "auth.login"
+    assert ev.metadata == {"foo": "bar"}
+
+
+def test_admin_nav_item_constructs() -> None:
+    item = AdminNavItem(
+        id="billing",
+        label="Billing",
+        icon="dollar",
+        section="settings",
+        order=10,
+        url_path="billing/usage",
+    )
+    assert item.id == "billing"
+    assert item.section == "settings"
+
+
+def test_sync_result_defaults_to_zero_counts() -> None:
+    r = SyncResult(added=0, updated=0, removed=0, errors=[])
+    assert r.added == 0
+    assert r.errors == []
+
+
+def test_sync_schedule_allows_none_for_on_demand() -> None:
+    s = SyncSchedule(interval_seconds=None)
+    assert s.interval_seconds is None
+```
+
+- [ ] **Step 2: Run tests, verify failures**
+
+Run: `cd backend && uv run pytest tests/plugins/test_protocols.py -v`
+Expected: FAIL with import errors for PermissionResource, AuditEvent, AdminNavItem, SyncResult, SyncSchedule.
+
+- [ ] **Step 3: Add dataclasses to protocols.py**
+
+Append to `backend/cubebox/plugins/protocols.py`:
+
+```python
+@dataclass(frozen=True)
+class PermissionResource:
+    """Identifies the target of a permission check."""
+
+    type: str  # "workspace" | "organization" | "conversation" | ...
+    id: UUID | None  # None = type-level policy
+    org_id: UUID | None = None
+    workspace_id: UUID | None = None
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    timestamp: datetime
+    user_id: UUID | None
+    org_id: UUID | None
+    workspace_id: UUID | None
+    action: str
+    target_type: str | None
+    target_id: str | None
+    ip: str | None
+    user_agent: str | None
+    metadata: dict[str, Any]
+
+
+@dataclass
+class SyncResult:
+    added: int
+    updated: int
+    removed: int
+    errors: list[str]
+
+
+@dataclass
+class SyncSchedule:
+    interval_seconds: int | None  # None = on-demand only
+
+
+@dataclass(frozen=True)
+class AdminNavItem:
+    id: str
+    label: str
+    icon: str | None
+    section: str  # "identity" | "integrations" | "settings" | "custom"
+    order: int
+    url_path: str
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/plugins/test_protocols.py -v`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/plugins/protocols.py backend/tests/plugins/test_protocols.py
+git commit -m "feat(plugins): add PermissionResource, AuditEvent, AdminNavItem, SyncResult, SyncSchedule"
+```
+
+---
+
+### Task 4: Define 5 Protocols (`AuthProvider`, `PermissionChecker`, `AuditSink`, `UserDirectorySyncer`, `AdminPanelExtension`)
+
+**Files:**
+- Modify: `backend/cubebox/plugins/protocols.py`
+- Modify: `backend/tests/plugins/test_protocols.py`
+
+- [ ] **Step 1: Add failing tests asserting Protocol satisfaction**
+
+Append to `backend/tests/plugins/test_protocols.py`:
+
+```python
+from cubebox.plugins.protocols import (
+    AdminPanelExtension,
+    AuditSink,
+    AuthProvider,
+    PermissionChecker,
+    UserDirectorySyncer,
+)
+
+
+class _SatisfiesAuthProvider:
+    async def authenticate(self, request):  # type: ignore[no-untyped-def]
+        return None
+    def get_auth_routers(self):  # type: ignore[no-untyped-def]
+        return []
+
+
+class _SatisfiesPermissionChecker:
+    async def check(self, user, action, resource):  # type: ignore[no-untyped-def]
+        return False
+
+
+class _SatisfiesAuditSink:
+    async def record(self, event):  # type: ignore[no-untyped-def]
+        return None
+
+
+class _SatisfiesUserDirectorySyncer:
+    async def sync(self):  # type: ignore[no-untyped-def]
+        return SyncResult(added=0, updated=0, removed=0, errors=[])
+    def get_schedule(self):  # type: ignore[no-untyped-def]
+        return SyncSchedule(interval_seconds=None)
+
+
+class _SatisfiesAdminPanelExtension:
+    def get_router(self):  # type: ignore[no-untyped-def]
+        return None
+    def get_nav_items(self):  # type: ignore[no-untyped-def]
+        return []
+    def get_static_path(self):  # type: ignore[no-untyped-def]
+        return None
+
+
+def test_protocols_are_runtime_checkable() -> None:
+    assert isinstance(_SatisfiesAuthProvider(), AuthProvider)
+    assert isinstance(_SatisfiesPermissionChecker(), PermissionChecker)
+    assert isinstance(_SatisfiesAuditSink(), AuditSink)
+    assert isinstance(_SatisfiesUserDirectorySyncer(), UserDirectorySyncer)
+    assert isinstance(_SatisfiesAdminPanelExtension(), AdminPanelExtension)
+
+
+class _MissingMethod:
+    """Doesn't satisfy AuthProvider — only has authenticate, no get_auth_routers."""
+
+    async def authenticate(self, request):  # type: ignore[no-untyped-def]
+        return None
+
+
+def test_protocol_rejects_incomplete_impl() -> None:
+    assert not isinstance(_MissingMethod(), AuthProvider)
+```
+
+- [ ] **Step 2: Run tests, verify failures**
+
+Run: `cd backend && uv run pytest tests/plugins/test_protocols.py -v`
+Expected: FAIL — Protocols don't exist yet.
+
+- [ ] **Step 3: Add Protocol definitions to protocols.py**
+
+Append to `backend/cubebox/plugins/protocols.py`:
+
+```python
+# Forward-declare User type; imported only for type checking to avoid cycles
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cubebox.models import User
+
+
+@runtime_checkable
+class AuthProvider(Protocol):
+    """Authenticate requests and yield a User principal."""
+
+    async def authenticate(self, request: Request) -> "User | None": ...
+
+    def get_auth_routers(self) -> list[APIRouter]: ...
+
+
+@runtime_checkable
+class PermissionChecker(Protocol):
+    async def check(
+        self,
+        user: "User",
+        action: str,
+        resource: PermissionResource,
+    ) -> bool: ...
+
+
+@runtime_checkable
+class AuditSink(Protocol):
+    async def record(self, event: AuditEvent) -> None: ...
+
+
+@runtime_checkable
+class UserDirectorySyncer(Protocol):
+    async def sync(self) -> SyncResult: ...
+
+    def get_schedule(self) -> SyncSchedule: ...
+
+
+@runtime_checkable
+class AdminPanelExtension(Protocol):
+    def get_router(self) -> APIRouter | None: ...
+
+    def get_nav_items(self) -> list[AdminNavItem]: ...
+
+    def get_static_path(self) -> Path | None: ...
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/plugins/test_protocols.py -v`
+Expected: PASS (11 tests total)
+
+- [ ] **Step 5: Re-export from `cubebox/plugins/__init__.py`**
+
+Replace `backend/cubebox/plugins/__init__.py`:
+
+```python
+"""CE/EE plugin protocols + entry_points-based discovery."""
+
+from cubebox.plugins.protocols import (
+    CUBEBOX_PLUGIN_API_VERSION,
+    AdminNavItem,
+    AdminPanelExtension,
+    AuditEvent,
+    AuditSink,
+    AuthProvider,
+    PermissionChecker,
+    PermissionResource,
+    PluginManifest,
+    SyncResult,
+    SyncSchedule,
+    UserDirectorySyncer,
+)
+
+__all__ = [
+    "CUBEBOX_PLUGIN_API_VERSION",
+    "AdminNavItem",
+    "AdminPanelExtension",
+    "AuditEvent",
+    "AuditSink",
+    "AuthProvider",
+    "PermissionChecker",
+    "PermissionResource",
+    "PluginManifest",
+    "SyncResult",
+    "SyncSchedule",
+    "UserDirectorySyncer",
+]
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/plugins/protocols.py backend/cubebox/plugins/__init__.py backend/tests/plugins/test_protocols.py
+git commit -m "feat(plugins): define 5 runtime_checkable Protocols (auth/permissions/audit/sync/admin)"
+```
+
+---
+
+### Task 5: `PluginRegistry` skeleton + manifest discovery + version validation
+
+**Files:**
+- Create: `backend/cubebox/plugins/registry.py`
+- Create: `backend/tests/plugins/test_registry_manifest.py`
+
+- [ ] **Step 1: Write failing test for manifest discovery + version mismatch**
+
+```python
+# backend/tests/plugins/test_registry_manifest.py
+"""PluginRegistry manifest discovery + version validation."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cubebox.plugins.protocols import CUBEBOX_PLUGIN_API_VERSION, PluginManifest
+from cubebox.plugins.registry import PluginRegistry
+
+
+def _ep(name: str, value, group: str = "cubebox.plugin_manifest"):
+    """Build a fake importlib.metadata.EntryPoint mock that load() returns `value`."""
+    m = MagicMock()
+    m.name = name
+    m.group = group
+    m.value = f"<fake>:{name}"
+    m.load.return_value = value
+    return m
+
+
+@pytest.mark.asyncio
+async def test_no_external_manifests_uses_defaults_only() -> None:
+    reg = PluginRegistry()
+    with patch("cubebox.plugins.registry.importlib.metadata.entry_points") as mock_eps:
+        mock_eps.return_value = []
+        await reg.discover()
+    # No external manifests → registry has no plugins beyond defaults.
+    assert reg._manifests == {}
+
+
+@pytest.mark.asyncio
+async def test_valid_manifest_is_registered() -> None:
+    manifest = PluginManifest(
+        api_version=CUBEBOX_PLUGIN_API_VERSION, name="ee", version="0.1.0"
+    )
+    reg = PluginRegistry()
+    with patch("cubebox.plugins.registry.importlib.metadata.entry_points") as mock_eps:
+        mock_eps.side_effect = lambda group: (
+            [_ep("main", manifest)] if group == "cubebox.plugin_manifest" else []
+        )
+        await reg.discover()
+    assert "ee" in reg._manifests
+    assert reg._manifests["ee"].version == "0.1.0"
+
+
+@pytest.mark.asyncio
+async def test_version_mismatch_raises() -> None:
+    bad_manifest = PluginManifest(api_version=999, name="ee", version="0.1.0")
+    reg = PluginRegistry()
+    with patch("cubebox.plugins.registry.importlib.metadata.entry_points") as mock_eps:
+        mock_eps.side_effect = lambda group: (
+            [_ep("main", bad_manifest)] if group == "cubebox.plugin_manifest" else []
+        )
+        with pytest.raises(RuntimeError, match="api_version"):
+            await reg.discover()
+
+
+@pytest.mark.asyncio
+async def test_missing_manifest_for_plugin_with_entry_point_raises() -> None:
+    """A wheel registers an AuthProvider but no plugin_manifest → reject."""
+    fake_provider_cls = MagicMock()
+    reg = PluginRegistry()
+    with patch("cubebox.plugins.registry.importlib.metadata.entry_points") as mock_eps:
+        def by_group(group):
+            if group == "cubebox.auth_provider":
+                ep = _ep("rogue", fake_provider_cls, group)
+                ep.dist = MagicMock(name="rogue-pkg")
+                return [ep]
+            return []
+        mock_eps.side_effect = by_group
+        with pytest.raises(RuntimeError, match="missing.*manifest"):
+            await reg.discover()
+```
+
+- [ ] **Step 2: Run tests, verify fail**
+
+Run: `cd backend && uv run pytest tests/plugins/test_registry_manifest.py -v`
+Expected: FAIL — `cubebox.plugins.registry` doesn't exist.
+
+- [ ] **Step 3: Implement registry.py with manifest discovery**
+
+```python
+# backend/cubebox/plugins/registry.py
+"""Plugin discovery + resolution."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+from typing import TYPE_CHECKING
+
+from cubebox.plugins.protocols import (
+    CUBEBOX_PLUGIN_API_VERSION,
+    AdminPanelExtension,
+    AuditSink,
+    AuthProvider,
+    PermissionChecker,
+    PluginManifest,
+    UserDirectorySyncer,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Per-Protocol entry_points group names. External wheels publish here.
+GROUP_MANIFEST = "cubebox.plugin_manifest"
+GROUP_AUTH = "cubebox.auth_provider"
+GROUP_PERMISSIONS = "cubebox.permission_checker"
+GROUP_AUDIT = "cubebox.audit_sink"
+GROUP_DIRECTORY = "cubebox.user_directory_syncer"
+GROUP_ADMIN_PANEL = "cubebox.admin_panel_extension"
+
+PROTOCOL_GROUPS: dict[str, type] = {
+    GROUP_AUTH: AuthProvider,
+    GROUP_PERMISSIONS: PermissionChecker,
+    GROUP_AUDIT: AuditSink,
+    GROUP_DIRECTORY: UserDirectorySyncer,
+    GROUP_ADMIN_PANEL: AdminPanelExtension,
+}
+
+# Reserved entry_point name for CE built-in implementations. External plugins
+# may not use this name.
+RESERVED_NAME = "builtin"
+
+
+class PluginRegistry:
+    """Singleton-style holder of discovered plugin classes + CE defaults."""
+
+    def __init__(self) -> None:
+        self._manifests: dict[str, PluginManifest] = {}  # plugin_name → manifest
+        self._candidates: dict[str, dict[str, type]] = {
+            group: {} for group in PROTOCOL_GROUPS
+        }  # group → {entry_point_name → impl class}
+
+    async def discover(self) -> None:
+        """Scan all entry_points + validate manifests + collect candidates."""
+        manifest_eps = list(importlib.metadata.entry_points(group=GROUP_MANIFEST))
+        # Each plugin_manifest entry_point loads to a PluginManifest instance.
+        plugin_dist_to_manifest: dict[str, PluginManifest] = {}
+        for ep in manifest_eps:
+            manifest = ep.load()
+            if not isinstance(manifest, PluginManifest):
+                raise RuntimeError(
+                    f"entry_point {ep.value} did not return a PluginManifest"
+                )
+            if manifest.api_version != CUBEBOX_PLUGIN_API_VERSION:
+                raise RuntimeError(
+                    f"plugin {manifest.name!r}: api_version={manifest.api_version} "
+                    f"but cubebox CE requires api_version={CUBEBOX_PLUGIN_API_VERSION}"
+                )
+            self._manifests[manifest.name] = manifest
+            # Map dist name to manifest for cross-group lookup
+            dist_name = self._dist_name(ep)
+            if dist_name:
+                plugin_dist_to_manifest[dist_name] = manifest
+            logger.info(
+                "registered plugin manifest: %s v%s (api=%d)",
+                manifest.name,
+                manifest.version,
+                manifest.api_version,
+            )
+
+        # Walk per-Protocol groups; reject unknown plugins (no manifest)
+        for group, _ in PROTOCOL_GROUPS.items():
+            for ep in importlib.metadata.entry_points(group=group):
+                if ep.name == RESERVED_NAME:
+                    raise RuntimeError(
+                        f"entry_point name {RESERVED_NAME!r} is reserved for CE; "
+                        f"plugin {ep.value} cannot use it"
+                    )
+                dist_name = self._dist_name(ep)
+                if dist_name and dist_name not in plugin_dist_to_manifest:
+                    raise RuntimeError(
+                        f"plugin {ep.value} (dist={dist_name}) is missing a "
+                        f"{GROUP_MANIFEST} entry_point"
+                    )
+                self._candidates[group][ep.name] = ep.load()
+                logger.info("registered candidate %s.%s = %s", group, ep.name, ep.value)
+
+    @staticmethod
+    def _dist_name(ep) -> str | None:  # type: ignore[no-untyped-def]
+        try:
+            return ep.dist.name if ep.dist else None
+        except AttributeError:
+            return None
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/plugins/test_registry_manifest.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/plugins/registry.py backend/tests/plugins/test_registry_manifest.py
+git commit -m "feat(plugins): PluginRegistry discovery + manifest version validation"
+```
+
+---
+
+### Task 6: Singular Protocol resolution (selected sentinel + 0/1/multiple external)
+
+**Files:**
+- Modify: `backend/cubebox/plugins/registry.py`
+- Create: `backend/tests/plugins/test_registry_singular.py`
+
+- [ ] **Step 1: Write failing tests for singular resolution scenarios**
+
+```python
+# backend/tests/plugins/test_registry_singular.py
+from unittest.mock import MagicMock
+
+import pytest
+
+from cubebox.plugins.protocols import CUBEBOX_PLUGIN_API_VERSION, PluginManifest
+from cubebox.plugins.registry import GROUP_AUTH, PluginRegistry
+
+
+class _StubAuthProvider:
+    name: str
+
+    def __init__(self, name="external"):
+        self.name = name
+
+    async def authenticate(self, request):  # type: ignore[no-untyped-def]
+        return None
+
+    def get_auth_routers(self):  # type: ignore[no-untyped-def]
+        return []
+
+
+def _seed_registry(reg: PluginRegistry, candidates: dict[str, type]) -> None:
+    reg._candidates[GROUP_AUTH] = dict(candidates)
+    reg._manifests = {
+        "ee": PluginManifest(api_version=CUBEBOX_PLUGIN_API_VERSION, name="ee", version="0.1.0")
+    }
+
+
+def test_zero_external_uses_default() -> None:
+    reg = PluginRegistry()
+    default = _StubAuthProvider("default")
+    chosen = reg.resolve_singular(GROUP_AUTH, default=default, selected=None)
+    assert chosen is default
+
+
+def test_one_external_replaces_default() -> None:
+    reg = PluginRegistry()
+    default = _StubAuthProvider("default")
+    _seed_registry(reg, {"saml": _StubAuthProvider})
+    chosen = reg.resolve_singular(GROUP_AUTH, default=default, selected=None)
+    assert isinstance(chosen, _StubAuthProvider)
+    assert chosen is not default
+
+
+def test_multiple_external_with_no_selected_raises() -> None:
+    reg = PluginRegistry()
+    default = _StubAuthProvider("default")
+    _seed_registry(reg, {"saml": _StubAuthProvider, "oidc": _StubAuthProvider})
+    with pytest.raises(RuntimeError, match="multiple"):
+        reg.resolve_singular(GROUP_AUTH, default=default, selected=None)
+
+
+def test_selected_builtin_forces_default() -> None:
+    reg = PluginRegistry()
+    default = _StubAuthProvider("default")
+    _seed_registry(reg, {"saml": _StubAuthProvider})
+    chosen = reg.resolve_singular(GROUP_AUTH, default=default, selected="builtin")
+    assert chosen is default
+
+
+def test_selected_by_name_picks_specific() -> None:
+    reg = PluginRegistry()
+    default = _StubAuthProvider("default")
+    _seed_registry(
+        reg, {"saml": _StubAuthProvider, "oidc": _StubAuthProvider}
+    )
+    chosen = reg.resolve_singular(GROUP_AUTH, default=default, selected="saml")
+    assert isinstance(chosen, _StubAuthProvider)
+
+
+def test_selected_unknown_name_raises() -> None:
+    reg = PluginRegistry()
+    default = _StubAuthProvider("default")
+    _seed_registry(reg, {"saml": _StubAuthProvider})
+    with pytest.raises(RuntimeError, match="not registered"):
+        reg.resolve_singular(GROUP_AUTH, default=default, selected="nonexistent")
+```
+
+- [ ] **Step 2: Run, verify fail (resolve_singular missing)**
+
+Run: `cd backend && uv run pytest tests/plugins/test_registry_singular.py -v`
+Expected: FAIL with `AttributeError: ... has no attribute 'resolve_singular'`
+
+- [ ] **Step 3: Implement `resolve_singular` on PluginRegistry**
+
+Append to `PluginRegistry` class in `backend/cubebox/plugins/registry.py`:
+
+```python
+    def resolve_singular(
+        self,
+        group: str,
+        *,
+        default: object,
+        selected: str | None,
+    ) -> object:
+        """Resolve a singular Protocol candidate; instantiate or pass through default.
+
+        Resolution rules:
+        - selected="builtin" → CE default (forces fallback even if externals present)
+        - selected="<name>"  → look up that entry_point name; raise if missing
+        - selected=None      → 0 ext: default; 1 ext: that one; ≥2 ext: RuntimeError
+        """
+        candidates = self._candidates[group]
+
+        if selected == RESERVED_NAME:
+            return default
+        if selected is not None:
+            if selected not in candidates:
+                raise RuntimeError(
+                    f"{group}: 'selected' is {selected!r} but no such entry_point is "
+                    f"registered (available: {sorted(candidates)})"
+                )
+            return candidates[selected]()
+
+        # selected is None — implicit rules
+        if len(candidates) == 0:
+            return default
+        if len(candidates) == 1:
+            (cls,) = candidates.values()
+            return cls()
+        raise RuntimeError(
+            f"{group}: multiple entry_points registered ({sorted(candidates)}); "
+            f"set plugins.{group.split('.')[1]}.selected = '<name>' to pick one"
+        )
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/plugins/test_registry_singular.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/plugins/registry.py backend/tests/plugins/test_registry_singular.py
+git commit -m "feat(plugins): registry.resolve_singular with selected sentinel + conflict rules"
+```
+
+---
+
+### Task 7: Multi-instance Protocol resolution + `disabled` config
+
+**Files:**
+- Modify: `backend/cubebox/plugins/registry.py`
+- Create: `backend/tests/plugins/test_registry_plural.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/plugins/test_registry_plural.py
+from cubebox.plugins.registry import GROUP_AUDIT, PluginRegistry
+
+
+class _StubSink:
+    name = "stub"
+
+    async def record(self, event):  # type: ignore[no-untyped-def]
+        return None
+
+
+class _StubSink2:
+    name = "stub2"
+
+    async def record(self, event):  # type: ignore[no-untyped-def]
+        return None
+
+
+def _seed(reg: PluginRegistry, candidates: dict[str, type]) -> None:
+    reg._candidates[GROUP_AUDIT] = dict(candidates)
+
+
+def test_plural_with_no_external_returns_only_default() -> None:
+    reg = PluginRegistry()
+    default = _StubSink()
+    out = reg.resolve_plural(GROUP_AUDIT, default=default, disabled=[])
+    assert out == [default]
+
+
+def test_plural_with_one_external_returns_default_plus_external() -> None:
+    reg = PluginRegistry()
+    default = _StubSink()
+    _seed(reg, {"siem": _StubSink2})
+    out = reg.resolve_plural(GROUP_AUDIT, default=default, disabled=[])
+    assert default in out
+    assert any(isinstance(o, _StubSink2) for o in out)
+    assert len(out) == 2
+
+
+def test_plural_disabled_builtin_excludes_default() -> None:
+    reg = PluginRegistry()
+    default = _StubSink()
+    _seed(reg, {"siem": _StubSink2})
+    out = reg.resolve_plural(GROUP_AUDIT, default=default, disabled=["builtin"])
+    assert default not in out
+    assert any(isinstance(o, _StubSink2) for o in out)
+    assert len(out) == 1
+
+
+def test_plural_disabled_external_excludes_it() -> None:
+    reg = PluginRegistry()
+    default = _StubSink()
+    _seed(reg, {"siem": _StubSink2, "other": _StubSink})
+    out = reg.resolve_plural(GROUP_AUDIT, default=default, disabled=["siem"])
+    assert default in out
+    assert not any(isinstance(o, _StubSink2) for o in out)
+
+
+def test_plural_default_can_be_none() -> None:
+    """For multi-instance protocols without a CE default (e.g. UserDirectorySyncer)."""
+    reg = PluginRegistry()
+    out = reg.resolve_plural(GROUP_AUDIT, default=None, disabled=[])
+    assert out == []
+```
+
+- [ ] **Step 2: Run tests, verify fail**
+
+Run: `cd backend && uv run pytest tests/plugins/test_registry_plural.py -v`
+Expected: FAIL — `resolve_plural` missing.
+
+- [ ] **Step 3: Implement `resolve_plural`**
+
+Append to `PluginRegistry` class in `backend/cubebox/plugins/registry.py`:
+
+```python
+    def resolve_plural(
+        self,
+        group: str,
+        *,
+        default: object | None,
+        disabled: list[str],
+    ) -> list[object]:
+        """Resolve all candidates for a plural Protocol; honor `disabled` filter.
+
+        - default: optional CE built-in instance (registered as RESERVED_NAME)
+        - disabled: list of entry_point names to exclude (incl. RESERVED_NAME for default)
+        """
+        disabled_set = set(disabled)
+        out: list[object] = []
+        if default is not None and RESERVED_NAME not in disabled_set:
+            out.append(default)
+        for name, cls in self._candidates[group].items():
+            if name in disabled_set:
+                continue
+            out.append(cls())
+        return out
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/plugins/test_registry_plural.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/plugins/registry.py backend/tests/plugins/test_registry_plural.py
+git commit -m "feat(plugins): registry.resolve_plural with disabled filter"
+```
+
+---
+
+### Task 8: CE default `AuthProvider` (wraps fastapi-users)
+
+**Files:**
+- Create: `backend/cubebox/plugins/defaults/auth.py`
+- Create: `backend/tests/plugins/test_default_auth.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/plugins/test_default_auth.py
+import pytest
+from cubebox.plugins import AuthProvider
+from cubebox.plugins.defaults.auth import DefaultAuthProvider
+
+
+def test_default_auth_provider_satisfies_protocol() -> None:
+    p = DefaultAuthProvider()
+    assert isinstance(p, AuthProvider)
+
+
+def test_default_auth_provider_returns_routers() -> None:
+    p = DefaultAuthProvider()
+    routers = p.get_auth_routers()
+    assert isinstance(routers, list)
+    # fastapi-users gives at least login/register routers; expect ≥2
+    assert len(routers) >= 2
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/plugins/test_default_auth.py -v`
+Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Implement DefaultAuthProvider**
+
+```python
+# backend/cubebox/plugins/defaults/auth.py
+"""CE default AuthProvider: wraps fastapi-users for cookie/JWT auth."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from cubebox.auth.jwt import auth_backend
+from cubebox.auth.users import fastapi_users
+from cubebox.models import User
+
+
+class DefaultAuthProvider:
+    """CE default: cookie-based JWT via fastapi-users."""
+
+    async def authenticate(self, request: Request) -> User | None:
+        # Delegate to fastapi-users' current_user dependency machinery.
+        # We instantiate it lazily; calling it directly is async.
+        get_user = fastapi_users.current_user(active=True, optional=True)
+        return await get_user(request)  # type: ignore[no-any-return,operator]
+
+    def get_auth_routers(self) -> list[APIRouter]:
+        return [
+            fastapi_users.get_auth_router(auth_backend),
+            fastapi_users.get_register_router(
+                # Schema imports stay lazy to avoid circular imports at module load
+                __import__("cubebox.api.schemas.auth", fromlist=["UserRead"]).UserRead,
+                __import__("cubebox.api.schemas.auth", fromlist=["UserCreate"]).UserCreate,
+            ),
+            fastapi_users.get_users_router(
+                __import__("cubebox.api.schemas.auth", fromlist=["UserRead"]).UserRead,
+                __import__("cubebox.api.schemas.auth", fromlist=["UserUpdate"]).UserUpdate,
+            ),
+        ]
+```
+
+NOTE: actual imports for UserRead/UserCreate/UserUpdate may need adjustment based on real `cubebox/api/schemas/auth.py` shape. If the `__import__` indirection feels brittle, refactor to direct imports once the file structure is verified.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/plugins/test_default_auth.py -v`
+Expected: PASS (2 tests). If schema imports fail, fix them per actual `api/schemas/` paths.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/plugins/defaults/auth.py backend/tests/plugins/test_default_auth.py
+git commit -m "feat(plugins): DefaultAuthProvider wraps fastapi-users"
+```
+
+---
+
+### Task 9: CE default `PermissionChecker` (wraps Role lookup)
+
+**Files:**
+- Create: `backend/cubebox/plugins/defaults/permissions.py`
+- Create: `backend/tests/plugins/test_default_permissions.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/plugins/test_default_permissions.py
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from cubebox.models import Role
+from cubebox.plugins import PermissionChecker, PermissionResource
+from cubebox.plugins.defaults.permissions import DefaultPermissionChecker
+
+
+def test_default_permission_checker_satisfies_protocol() -> None:
+    assert isinstance(DefaultPermissionChecker(), PermissionChecker)
+
+
+@pytest.mark.asyncio
+async def test_admin_access_grants_admin_role() -> None:
+    repo = AsyncMock()
+    repo.get_role = AsyncMock(return_value=Role.ADMIN)
+    checker = DefaultPermissionChecker(membership_repo_factory=lambda _s: repo)
+    user = MagicMock(id=str(uuid4()))
+    ws_id = uuid4()
+    res = PermissionResource(type="workspace", id=ws_id, workspace_id=ws_id)
+    assert await checker.check(user, "admin_access", res) is True
+
+
+@pytest.mark.asyncio
+async def test_admin_access_denies_member_role() -> None:
+    repo = AsyncMock()
+    repo.get_role = AsyncMock(return_value=Role.MEMBER)
+    checker = DefaultPermissionChecker(membership_repo_factory=lambda _s: repo)
+    user = MagicMock(id=str(uuid4()))
+    ws_id = uuid4()
+    res = PermissionResource(type="workspace", id=ws_id, workspace_id=ws_id)
+    assert await checker.check(user, "admin_access", res) is False
+
+
+@pytest.mark.asyncio
+async def test_member_access_grants_admin_or_member() -> None:
+    repo = AsyncMock()
+    repo.get_role = AsyncMock(return_value=Role.MEMBER)
+    checker = DefaultPermissionChecker(membership_repo_factory=lambda _s: repo)
+    user = MagicMock(id=str(uuid4()))
+    ws_id = uuid4()
+    res = PermissionResource(type="workspace", id=ws_id, workspace_id=ws_id)
+    assert await checker.check(user, "member_access", res) is True
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_denies() -> None:
+    repo = AsyncMock()
+    repo.get_role = AsyncMock(return_value=Role.ADMIN)
+    checker = DefaultPermissionChecker(membership_repo_factory=lambda _s: repo)
+    user = MagicMock(id=str(uuid4()))
+    ws_id = uuid4()
+    res = PermissionResource(type="workspace", id=ws_id, workspace_id=ws_id)
+    assert await checker.check(user, "delete_workspace", res) is False
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/plugins/test_default_permissions.py -v`
+Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Implement DefaultPermissionChecker**
+
+```python
+# backend/cubebox/plugins/defaults/permissions.py
+"""CE default PermissionChecker: wraps existing Membership.get_role lookup."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from cubebox.models import Role
+from cubebox.plugins.protocols import PermissionResource
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from cubebox.repositories import MembershipRepository
+
+
+class DefaultPermissionChecker:
+    """Maps known actions to Role checks; unknown actions deny."""
+
+    def __init__(
+        self,
+        membership_repo_factory: Callable[[Any], "MembershipRepository"] | None = None,
+    ) -> None:
+        # Allow injection for tests; default obtains a fresh repo from current session.
+        self._repo_factory = membership_repo_factory
+
+    async def check(
+        self,
+        user: Any,
+        action: str,
+        resource: PermissionResource,
+    ) -> bool:
+        if resource.workspace_id is None:
+            return False
+        repo = self._get_repo()
+        role = await repo.get_role(user_id=user.id, workspace_id=str(resource.workspace_id))
+        if role is None:
+            return False
+        if action == "admin_access":
+            return role == Role.ADMIN
+        if action == "member_access":
+            return role in (Role.ADMIN, Role.MEMBER)
+        return False
+
+    def _get_repo(self) -> "MembershipRepository":
+        if self._repo_factory is None:
+            raise RuntimeError(
+                "DefaultPermissionChecker requires a membership_repo_factory "
+                "in production (FastAPI dependency injection)"
+            )
+        # In production this will be wired via FastAPI Depends; for tests it's injected.
+        return self._repo_factory(None)
+```
+
+NOTE: The production wiring for `_repo_factory` happens in Task 14 when we replace `require_role` to inject a session-bound checker via FastAPI dependency.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/plugins/test_default_permissions.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/plugins/defaults/permissions.py backend/tests/plugins/test_default_permissions.py
+git commit -m "feat(plugins): DefaultPermissionChecker wraps Role lookup"
+```
+
+---
+
+### Task 10: CE default `AuditSink` (no-op + structlog)
+
+**Files:**
+- Create: `backend/cubebox/plugins/defaults/audit.py`
+- Create: `backend/tests/plugins/test_default_audit.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/plugins/test_default_audit.py
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from cubebox.plugins import AuditEvent, AuditSink
+from cubebox.plugins.defaults.audit import DefaultAuditSink
+
+
+def test_default_audit_sink_satisfies_protocol() -> None:
+    assert isinstance(DefaultAuditSink(), AuditSink)
+
+
+@pytest.mark.asyncio
+async def test_default_audit_sink_logs_via_structlog(caplog: pytest.LogCaptureFixture) -> None:
+    sink = DefaultAuditSink()
+    event = AuditEvent(
+        timestamp=datetime.now(UTC),
+        user_id=uuid4(),
+        org_id=uuid4(),
+        workspace_id=None,
+        action="auth.login",
+        target_type=None,
+        target_id=None,
+        ip="127.0.0.1",
+        user_agent="pytest",
+        metadata={},
+    )
+    with caplog.at_level("INFO"):
+        await sink.record(event)
+    assert any("auth.login" in r.getMessage() for r in caplog.records)
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/plugins/test_default_audit.py -v`
+Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Implement DefaultAuditSink**
+
+```python
+# backend/cubebox/plugins/defaults/audit.py
+"""CE default AuditSink: structlog INFO no-op (no DB write)."""
+
+from __future__ import annotations
+
+import logging
+
+from cubebox.plugins.protocols import AuditEvent
+
+logger = logging.getLogger("cubebox.audit")
+
+
+class DefaultAuditSink:
+    async def record(self, event: AuditEvent) -> None:
+        logger.info(
+            "audit.%s user=%s org=%s ws=%s target=%s/%s ip=%s",
+            event.action,
+            event.user_id,
+            event.org_id,
+            event.workspace_id,
+            event.target_type,
+            event.target_id,
+            event.ip,
+            extra={"audit_event": event},
+        )
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/plugins/test_default_audit.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/plugins/defaults/audit.py backend/tests/plugins/test_default_audit.py
+git commit -m "feat(plugins): DefaultAuditSink logs via structlog (no DB write)"
+```
+
+---
+
+### Task 11: CE default `AdminPanelExtension` (empty)
+
+**Files:**
+- Create: `backend/cubebox/plugins/defaults/admin_panel.py`
+- Create: `backend/tests/plugins/test_default_admin_panel.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/plugins/test_default_admin_panel.py
+from cubebox.plugins import AdminPanelExtension
+from cubebox.plugins.defaults.admin_panel import DefaultAdminPanelExtension
+
+
+def test_default_admin_panel_satisfies_protocol() -> None:
+    assert isinstance(DefaultAdminPanelExtension(), AdminPanelExtension)
+
+
+def test_default_admin_panel_returns_empty() -> None:
+    e = DefaultAdminPanelExtension()
+    assert e.get_router() is None
+    assert e.get_nav_items() == []
+    assert e.get_static_path() is None
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/plugins/test_default_admin_panel.py -v`
+Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Implement DefaultAdminPanelExtension**
+
+```python
+# backend/cubebox/plugins/defaults/admin_panel.py
+"""CE default AdminPanelExtension: empty (CE itself contributes nothing)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter
+
+from cubebox.plugins.protocols import AdminNavItem
+
+
+class DefaultAdminPanelExtension:
+    def get_router(self) -> APIRouter | None:
+        return None
+
+    def get_nav_items(self) -> list[AdminNavItem]:
+        return []
+
+    def get_static_path(self) -> Path | None:
+        return None
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/plugins/test_default_admin_panel.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/plugins/defaults/admin_panel.py backend/tests/plugins/test_default_admin_panel.py
+git commit -m "feat(plugins): DefaultAdminPanelExtension returns empty (CE contributes no extensions)"
+```
+
+---
+
+### Task 12: Wire `PluginRegistry` getters + module-level singleton
+
+**Files:**
+- Modify: `backend/cubebox/plugins/registry.py`
+- Modify: `backend/cubebox/plugins/__init__.py`
+- Create: `backend/tests/plugins/test_registry_getters.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/plugins/test_registry_getters.py
+import pytest
+
+from cubebox.plugins import (
+    AdminPanelExtension,
+    AuditSink,
+    AuthProvider,
+    PermissionChecker,
+)
+from cubebox.plugins.registry import PluginRegistry
+
+
+@pytest.mark.asyncio
+async def test_get_auth_provider_falls_back_to_default() -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    assert isinstance(reg.get_auth_provider(), AuthProvider)
+
+
+@pytest.mark.asyncio
+async def test_get_permission_checker_falls_back_to_default() -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    assert isinstance(reg.get_permission_checker(), PermissionChecker)
+
+
+@pytest.mark.asyncio
+async def test_get_audit_sinks_returns_at_least_default() -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    sinks = reg.get_audit_sinks()
+    assert len(sinks) >= 1
+    assert all(isinstance(s, AuditSink) for s in sinks)
+
+
+@pytest.mark.asyncio
+async def test_get_admin_panel_extensions_empty_in_ce() -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    exts = reg.get_admin_panel_extensions()
+    # CE-only: only the default returning empty everything
+    assert all(isinstance(e, AdminPanelExtension) for e in exts)
+
+
+@pytest.mark.asyncio
+async def test_get_user_directory_syncers_empty_in_ce() -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    syncers = reg.get_user_directory_syncers()
+    assert syncers == []  # No CE default for syncer
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/plugins/test_registry_getters.py -v`
+Expected: FAIL — getters not implemented.
+
+- [ ] **Step 3: Implement getters + bind_defaults + module singleton**
+
+Append to `PluginRegistry` class in `backend/cubebox/plugins/registry.py`:
+
+```python
+    # Resolved instances (set by bind_defaults after discover).
+    _auth_provider: object | None = None
+    _permission_checker: object | None = None
+    _audit_sinks: list[object] | None = None
+    _user_directory_syncers: list[object] | None = None
+    _admin_panel_extensions: list[object] | None = None
+
+    def bind_defaults(
+        self,
+        *,
+        auth_default: object | None = None,
+        permissions_default: object | None = None,
+        audit_default: object | None = None,
+        admin_panel_default: object | None = None,
+        config: object | None = None,
+    ) -> None:
+        """Resolve every Protocol with the supplied defaults + applied config.
+
+        Defaults default to lazy imports if None, so tests can call without args.
+        `config` should be a config object exposing `plugins.<group>.selected`
+        and `plugins.<group>.disabled` (None = empty list / None).
+        """
+        from cubebox.plugins.defaults.admin_panel import DefaultAdminPanelExtension
+        from cubebox.plugins.defaults.audit import DefaultAuditSink
+        from cubebox.plugins.defaults.auth import DefaultAuthProvider
+        from cubebox.plugins.defaults.permissions import DefaultPermissionChecker
+
+        auth_default = auth_default or DefaultAuthProvider()
+        permissions_default = permissions_default or DefaultPermissionChecker()
+        audit_default = audit_default or DefaultAuditSink()
+        admin_panel_default = admin_panel_default or DefaultAdminPanelExtension()
+
+        sel_auth = self._cfg(config, "auth_provider", "selected")
+        sel_perm = self._cfg(config, "permission_checker", "selected")
+        dis_audit = self._cfg(config, "audit_sink", "disabled") or []
+        dis_dir = self._cfg(config, "user_directory_syncer", "disabled") or []
+        dis_admin = self._cfg(config, "admin_panel_extension", "disabled") or []
+
+        self._auth_provider = self.resolve_singular(
+            GROUP_AUTH, default=auth_default, selected=sel_auth
+        )
+        self._permission_checker = self.resolve_singular(
+            GROUP_PERMISSIONS, default=permissions_default, selected=sel_perm
+        )
+        self._audit_sinks = self.resolve_plural(
+            GROUP_AUDIT, default=audit_default, disabled=dis_audit
+        )
+        self._user_directory_syncers = self.resolve_plural(
+            GROUP_DIRECTORY, default=None, disabled=dis_dir
+        )
+        self._admin_panel_extensions = self.resolve_plural(
+            GROUP_ADMIN_PANEL, default=admin_panel_default, disabled=dis_admin
+        )
+
+    @staticmethod
+    def _cfg(config: object | None, group_name: str, key: str):  # type: ignore[no-untyped-def]
+        if config is None:
+            return None
+        return getattr(getattr(getattr(config, "plugins", None), group_name, None), key, None)
+
+    def get_auth_provider(self):  # type: ignore[no-untyped-def]
+        if self._auth_provider is None:
+            raise RuntimeError("call bind_defaults() first")
+        return self._auth_provider
+
+    def get_permission_checker(self):  # type: ignore[no-untyped-def]
+        if self._permission_checker is None:
+            raise RuntimeError("call bind_defaults() first")
+        return self._permission_checker
+
+    def get_audit_sinks(self):  # type: ignore[no-untyped-def]
+        return self._audit_sinks or []
+
+    def get_user_directory_syncers(self):  # type: ignore[no-untyped-def]
+        return self._user_directory_syncers or []
+
+    def get_admin_panel_extensions(self):  # type: ignore[no-untyped-def]
+        return self._admin_panel_extensions or []
+
+
+# Module-level singleton, populated by app startup.
+_registry: PluginRegistry | None = None
+
+
+def get_registry() -> PluginRegistry:
+    global _registry
+    if _registry is None:
+        _registry = PluginRegistry()
+    return _registry
+
+
+def reset_registry_for_tests() -> None:
+    global _registry
+    _registry = None
+```
+
+- [ ] **Step 4: Re-export getters from `cubebox/plugins/__init__.py`**
+
+Append to `backend/cubebox/plugins/__init__.py` (inside __all__ + new imports):
+
+```python
+from cubebox.plugins.registry import (
+    PluginRegistry,
+    get_registry,
+    reset_registry_for_tests,
+)
+```
+
+Add to `__all__`: `"PluginRegistry"`, `"get_registry"`, `"reset_registry_for_tests"`.
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/plugins/ -v`
+Expected: All plugin tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/plugins/registry.py backend/cubebox/plugins/__init__.py backend/tests/plugins/test_registry_getters.py
+git commit -m "feat(plugins): registry getters + bind_defaults + module-level singleton"
+```
+
+---
+
+### Task 13: Add `plugins.*` config schema (pydantic + YAML)
+
+**Files:**
+- Modify: `backend/cubebox/config.py`
+- Modify: `backend/config.yaml`
+- Modify: `backend/config.development.yaml`
+- Modify: `backend/config.test.yaml`
+
+- [ ] **Step 1: Read current `cubebox/config.py` to find pydantic model location**
+
+Run: `cd backend && head -80 cubebox/config.py`
+
+Identify the pydantic settings class (commonly `Settings` or similar).
+
+- [ ] **Step 2: Add plugins schema**
+
+If `config.py` uses pydantic Settings, append a nested model:
+
+```python
+# Append in backend/cubebox/config.py near other section schemas
+
+from pydantic import BaseModel
+
+
+class _SingularPluginConfig(BaseModel):
+    selected: str | None = None  # null / "builtin" / "<plugin_name>"
+
+
+class _PluralPluginConfig(BaseModel):
+    disabled: list[str] = []
+
+
+class PluginsConfig(BaseModel):
+    auth_provider: _SingularPluginConfig = _SingularPluginConfig()
+    permission_checker: _SingularPluginConfig = _SingularPluginConfig()
+    audit_sink: _PluralPluginConfig = _PluralPluginConfig()
+    user_directory_syncer: _PluralPluginConfig = _PluralPluginConfig()
+    admin_panel_extension: _PluralPluginConfig = _PluralPluginConfig()
+
+
+# Then add `plugins: PluginsConfig = PluginsConfig()` to the top-level Settings model.
+```
+
+If `config.py` uses dynaconf, expose `config.plugins` accessors via `config.get("plugins.auth_provider.selected")` style — and add the section to YAML files for default values.
+
+- [ ] **Step 3: Append `plugins:` section to YAML configs**
+
+To `backend/config.yaml`, `backend/config.development.yaml`, `backend/config.test.yaml`:
+
+```yaml
+plugins:
+  auth_provider:
+    selected: null           # null / "builtin" / "<plugin_name>"
+  permission_checker:
+    selected: null
+  audit_sink:
+    disabled: []
+  user_directory_syncer:
+    disabled: []
+  admin_panel_extension:
+    disabled: []
+```
+
+- [ ] **Step 4: Verify config loads without error**
+
+Run: `cd backend && uv run python -c "from cubebox.config import config; print(config.get('plugins.auth_provider.selected'))"`
+Expected: prints `None`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/config.py backend/config.yaml backend/config.development.yaml backend/config.test.yaml
+git commit -m "feat(plugins): add plugins.* config section with sensible defaults"
+```
+
+---
+
+### Task 14: Rewrite `require_role` to call `PermissionChecker`
+
+**Files:**
+- Modify: `backend/cubebox/auth/dependencies.py`
+- Run regression: `backend/tests/test_rbac.py`
+
+- [ ] **Step 1: Write a focused regression test that asserts behavior unchanged**
+
+Run existing test FIRST to ensure baseline green:
+
+```bash
+cd backend && uv run pytest tests/test_rbac.py -v
+```
+
+Expected: PASS (baseline confirmed before refactor).
+
+- [ ] **Step 2: Modify `require_role` to delegate to PermissionChecker**
+
+Replace the body of `require_role` factory in `backend/cubebox/auth/dependencies.py`:
+
+```python
+from cubebox.plugins import PermissionResource, get_registry
+from cubebox.plugins.defaults.permissions import DefaultPermissionChecker
+
+
+def _action_for_roles(allowed: tuple[Role, ...]) -> str:
+    """Map allowed-role set → action name for PermissionChecker.
+
+    {ADMIN}            → "admin_access"
+    {ADMIN, MEMBER}    → "member_access"
+    other combinations not yet supported (would be M1-E3 territory).
+    """
+    s = set(allowed)
+    if s == {Role.ADMIN}:
+        return "admin_access"
+    if s == {Role.ADMIN, Role.MEMBER}:
+        return "member_access"
+    raise NotImplementedError(f"role set {s} has no mapped action")
+
+
+def require_role(
+    *allowed: Role,
+) -> Callable[..., Awaitable[RequestContext]]:
+    """Dependency factory: enforce permission via PermissionChecker."""
+
+    action = _action_for_roles(allowed)
+
+    async def _check(
+        ctx: Annotated[RequestContext, Depends(request_context)],
+        session: Annotated[AsyncSession, Depends(get_session)],
+    ) -> RequestContext:
+        # Construct a session-bound checker. CE default reads MembershipRepository.
+        checker = get_registry().get_permission_checker()
+        # CE default needs a repo factory bound at call time
+        if isinstance(checker, DefaultPermissionChecker):
+            from cubebox.repositories import MembershipRepository
+            checker._repo_factory = lambda _s: MembershipRepository(session)
+        resource = PermissionResource(
+            type="workspace", id=ctx.workspace_id, workspace_id=ctx.workspace_id  # type: ignore[arg-type]
+        )
+        if not await checker.check(ctx.user, action, resource):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Permission denied: action={action}",
+            )
+        return ctx
+
+    return _check
+```
+
+NOTE: `ctx.workspace_id` is a `str` in `RequestContext`; `PermissionResource.id` is `UUID | None`. If passing str works in your DB layer use it; otherwise wrap with `UUID(ctx.workspace_id)`.
+
+- [ ] **Step 3: Bootstrap the registry once at module import (or app startup)**
+
+If running tests, the registry singleton needs `bind_defaults()` to have been called at least once. Add to `backend/cubebox/plugins/__init__.py`:
+
+```python
+def ensure_registry_bound() -> None:
+    """Idempotent: call from app startup or test fixtures to seed defaults."""
+    reg = get_registry()
+    if reg._auth_provider is None:  # not yet bound
+        reg.bind_defaults()
+```
+
+Add to `__all__`.
+
+In `backend/tests/conftest.py` (or create one if absent), add an autouse fixture:
+
+```python
+import pytest
+
+from cubebox.plugins import ensure_registry_bound, reset_registry_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _bind_plugin_registry():
+    reset_registry_for_tests()
+    ensure_registry_bound()
+```
+
+- [ ] **Step 4: Run rbac tests and full auth tests to confirm regression-free**
+
+```bash
+cd backend && uv run pytest tests/test_rbac.py -v
+cd backend && uv run pytest tests/test_auth.py -v 2>/dev/null || echo "no test_auth.py"
+cd backend && uv run pytest tests/ -v -k "rbac or auth"
+```
+
+Expected: PASS for all rbac + auth tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/auth/dependencies.py backend/cubebox/plugins/__init__.py backend/tests/conftest.py
+git commit -m "refactor(auth): rewrite require_role to call PermissionChecker (CE default = current Role lookup)"
+```
+
+---
+
+### Task 15: Wire `current_active_user` to `AuthProvider.authenticate`
+
+**Files:**
+- Modify: `backend/cubebox/auth/dependencies.py`
+- Run regression: any auth e2e tests
+
+- [ ] **Step 1: Confirm baseline auth tests pass**
+
+```bash
+cd backend && uv run pytest tests/ -v -k "auth"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Replace `current_active_user` with delegate to AuthProvider**
+
+In `backend/cubebox/auth/dependencies.py`, replace the line:
+
+```python
+current_active_user = fastapi_users.current_user(active=True)
+```
+
+With:
+
+```python
+from fastapi import Request
+
+
+async def current_active_user(request: Request) -> User:
+    """Resolve the active user via the configured AuthProvider.
+
+    CE default = fastapi-users JWT cookie. EE plugins (e.g. SAML) override.
+    """
+    user = await get_registry().get_auth_provider().authenticate(request)
+    if user is None or not getattr(user, "is_active", True):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+    return user
+```
+
+- [ ] **Step 3: Run auth tests; verify no regression**
+
+```bash
+cd backend && uv run pytest tests/ -v -k "auth or rbac"
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/cubebox/auth/dependencies.py
+git commit -m "refactor(auth): current_active_user delegates to AuthProvider.authenticate"
+```
+
+---
+
+### Task 16: Mount `AuthProvider.get_auth_routers()` at app startup
+
+**Files:**
+- Modify: `backend/cubebox/api/app.py`
+
+- [ ] **Step 1: Read current `app.py` to find where auth routers are mounted today**
+
+```bash
+cd backend && grep -n "auth" cubebox/api/app.py | head -30
+```
+
+Identify lines like `app.include_router(fastapi_users.get_auth_router(...))`.
+
+- [ ] **Step 2: Replace direct `fastapi_users.get_*_router` calls with registry-driven mount**
+
+In `backend/cubebox/api/app.py`, find the `lifespan` async context manager (or app startup section). Add at startup:
+
+```python
+from cubebox.plugins import ensure_registry_bound, get_registry
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # ... existing lifespan setup (DB, MCP, etc.) ...
+    reg = get_registry()
+    await reg.discover()
+    reg.bind_defaults(config=config)
+
+    # Mount AuthProvider routers dynamically
+    for router in reg.get_auth_provider().get_auth_routers():
+        app.include_router(router, prefix="/api/v1/auth", tags=["auth"])
+
+    yield
+    # ... shutdown ...
+```
+
+REMOVE the static `app.include_router(fastapi_users.get_auth_router(...))` calls.
+
+- [ ] **Step 3: Run e2e auth tests + manually start server**
+
+```bash
+cd backend && uv run pytest tests/ -v -k "auth"
+cd backend && uv run python main.py &
+sleep 3
+curl -s http://localhost:8000/api/v1/auth/me  # should 401 without cookie
+kill %1
+```
+
+Expected: tests PASS; server returns 401 on `/me` without cookie.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/cubebox/api/app.py
+git commit -m "feat(api): mount AuthProvider.get_auth_routers() at startup via registry"
+```
+
+---
+
+### Task 17: Add `audit_log()` helper
+
+**Files:**
+- Create: `backend/cubebox/plugins/audit.py`
+- Create: `backend/tests/plugins/test_audit_helper.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/plugins/test_audit_helper.py
+from datetime import datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from cubebox.plugins import get_registry
+from cubebox.plugins.audit import audit_log
+
+
+@pytest.mark.asyncio
+async def test_audit_log_dispatches_to_all_sinks() -> None:
+    sink_a = AsyncMock()
+    sink_b = AsyncMock()
+    reg = get_registry()
+    reg._audit_sinks = [sink_a, sink_b]
+
+    await audit_log(
+        action="auth.login",
+        user_id=uuid4(),
+        org_id=uuid4(),
+        workspace_id=None,
+        ip="127.0.0.1",
+    )
+    sink_a.record.assert_awaited_once()
+    sink_b.record.assert_awaited_once()
+    event = sink_a.record.call_args.args[0]
+    assert event.action == "auth.login"
+    assert isinstance(event.timestamp, datetime)
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/plugins/test_audit_helper.py -v`
+Expected: FAIL — `cubebox.plugins.audit` doesn't exist.
+
+- [ ] **Step 3: Implement audit helper**
+
+```python
+# backend/cubebox/plugins/audit.py
+"""Helper for emitting AuditEvents to all registered AuditSinks."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from cubebox.plugins.protocols import AuditEvent
+from cubebox.plugins.registry import get_registry
+
+
+async def audit_log(
+    action: str,
+    *,
+    user_id: UUID | None = None,
+    org_id: UUID | None = None,
+    workspace_id: UUID | None = None,
+    target_type: str | None = None,
+    target_id: str | None = None,
+    ip: str | None = None,
+    user_agent: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Construct AuditEvent + dispatch to every registered AuditSink."""
+    event = AuditEvent(
+        timestamp=datetime.now(UTC),
+        user_id=user_id,
+        org_id=org_id,
+        workspace_id=workspace_id,
+        action=action,
+        target_type=target_type,
+        target_id=target_id,
+        ip=ip,
+        user_agent=user_agent,
+        metadata=metadata or {},
+    )
+    for sink in get_registry().get_audit_sinks():
+        await sink.record(event)
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/plugins/test_audit_helper.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/plugins/audit.py backend/tests/plugins/test_audit_helper.py
+git commit -m "feat(plugins): add audit_log helper that fans out to all AuditSinks"
+```
+
+---
+
+### Task 18: Hook `audit_log("auth.login")` in `UserManager.on_after_login`
+
+**Files:**
+- Modify: `backend/cubebox/auth/users.py`
+- Create: `backend/tests/test_audit_login.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/test_audit_login.py
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from cubebox.auth.users import UserManager
+from cubebox.plugins import get_registry
+
+
+@pytest.mark.asyncio
+async def test_on_after_login_emits_audit_event() -> None:
+    sink = AsyncMock()
+    reg = get_registry()
+    reg._audit_sinks = [sink]
+
+    user = MagicMock(id=str(uuid4()), email="a@b.com")
+    request = MagicMock(client=MagicMock(host="1.2.3.4"), headers={"user-agent": "test"})
+    user_db = MagicMock()
+    mgr = UserManager(user_db)
+
+    await mgr.on_after_login(user, request)
+    sink.record.assert_awaited_once()
+    ev = sink.record.call_args.args[0]
+    assert ev.action == "auth.login"
+    assert ev.ip == "1.2.3.4"
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/test_audit_login.py -v`
+Expected: FAIL — `on_after_login` doesn't exist on UserManager.
+
+- [ ] **Step 3: Add `on_after_login` to UserManager**
+
+In `backend/cubebox/auth/users.py`, add method to `UserManager` class:
+
+```python
+    async def on_after_login(
+        self,
+        user: User,
+        request: Request | None = None,
+    ) -> None:
+        from cubebox.plugins.audit import audit_log
+        await audit_log(
+            action="auth.login",
+            user_id=user.id,
+            ip=request.client.host if request and request.client else None,
+            user_agent=request.headers.get("user-agent") if request else None,
+        )
+```
+
+- [ ] **Step 4: Modify existing `on_after_register` to also emit audit event**
+
+In the same `UserManager.on_after_register`, add at end (after the bootstrap try/except block, before setting `_default_workspace_id`):
+
+```python
+        from cubebox.plugins.audit import audit_log
+        await audit_log(
+            action="auth.register",
+            user_id=user.id,
+            ip=request.client.host if request and request.client else None,
+            user_agent=request.headers.get("user-agent") if request else None,
+        )
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/test_audit_login.py tests/test_rbac.py -v`
+Expected: PASS for new test + no regression in rbac.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/auth/users.py backend/tests/test_audit_login.py
+git commit -m "feat(auth): emit audit_log for auth.login + auth.register"
+```
+
+---
+
+### Task 19: Hook `audit_log("workspace.invite_created")` in invite endpoint
+
+**Files:**
+- Modify: `backend/cubebox/api/routes/v1/workspaces.py`
+- Create: `backend/tests/test_audit_invite.py`
+
+- [ ] **Step 1: Find the create-invite handler**
+
+```bash
+cd backend && grep -n "invite" cubebox/api/routes/v1/workspaces.py
+```
+
+Identify the handler (likely `async def create_invite(...)`).
+
+- [ ] **Step 2: Write failing test**
+
+```python
+# backend/tests/test_audit_invite.py
+"""End-to-end: creating a workspace invite emits an audit event."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+
+from cubebox.plugins import get_registry
+
+
+@pytest.mark.asyncio
+async def test_create_invite_emits_audit(client: AsyncClient, admin_user_cookie):
+    sink = AsyncMock()
+    reg = get_registry()
+    reg._audit_sinks = [sink]
+
+    resp = await client.post(
+        "/api/v1/workspaces/some-ws-id/invites",
+        json={"email": "newuser@example.com"},
+        cookies=admin_user_cookie,
+    )
+    assert resp.status_code in (200, 201)
+    sink.record.assert_awaited()
+    actions = [c.args[0].action for c in sink.record.await_args_list]
+    assert "workspace.invite_created" in actions
+```
+
+NOTE: Adjust `client` and `admin_user_cookie` fixtures to match existing test infrastructure (see `backend/tests/conftest.py`).
+
+- [ ] **Step 3: Run, expected to fail**
+
+Run: `cd backend && uv run pytest tests/test_audit_invite.py -v`
+Expected: FAIL.
+
+- [ ] **Step 4: Add `audit_log` call in invite handler**
+
+In `backend/cubebox/api/routes/v1/workspaces.py`, find the create-invite handler. After successful invite creation:
+
+```python
+from cubebox.plugins.audit import audit_log
+
+# inside handler, after invite is persisted:
+await audit_log(
+    action="workspace.invite_created",
+    user_id=ctx.user.id,
+    org_id=ctx.org_id,
+    workspace_id=ctx.workspace_id,
+    target_type="invite",
+    target_id=str(invite.id),
+    ip=request.client.host if request.client else None,
+    metadata={"invitee_email": invite.email},
+)
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/test_audit_invite.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/api/routes/v1/workspaces.py backend/tests/test_audit_invite.py
+git commit -m "feat(workspaces): emit audit_log for workspace.invite_created"
+```
+
+---
+
+### Task 20: AdminPanelExtension startup scan + manifest endpoint
+
+**Files:**
+- Create: `backend/cubebox/api/routes/v1/admin_extensions.py`
+- Modify: `backend/cubebox/api/app.py`
+- Create: `backend/tests/test_admin_extensions.py`
+
+- [ ] **Step 1: Write failing test for empty manifest in CE**
+
+```python
+# backend/tests/test_admin_extensions.py
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_admin_manifest_empty_in_ce(client: AsyncClient, admin_user_cookie) -> None:
+    resp = await client.get(
+        "/api/v1/admin/_extensions/manifest",
+        cookies=admin_user_cookie,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    # CE-only deployment: no plugin extensions registered
+    assert data == []
+```
+
+- [ ] **Step 2: Run, expected to fail (404)**
+
+Run: `cd backend && uv run pytest tests/test_admin_extensions.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Create the manifest endpoint**
+
+```python
+# backend/cubebox/api/routes/v1/admin_extensions.py
+"""GET /api/v1/admin/_extensions/manifest — aggregated nav items + iframe URLs."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from cubebox.auth.dependencies import current_active_user
+from cubebox.models import User
+from cubebox.plugins import get_registry
+
+router = APIRouter(prefix="/admin/_extensions", tags=["admin"])
+
+
+@router.get("/manifest")
+async def get_manifest(_user: User = Depends(current_active_user)) -> list[dict]:
+    out: list[dict] = []
+    for ext in get_registry().get_admin_panel_extensions():
+        nav_items = ext.get_nav_items()
+        if not nav_items:
+            continue
+        # We don't know the plugin name from the instance; use class module as proxy.
+        plugin_name = type(ext).__module__.split(".")[0]
+        out.append(
+            {
+                "plugin": plugin_name,
+                "nav_items": [
+                    {
+                        "id": item.id,
+                        "label": item.label,
+                        "icon": item.icon,
+                        "section": item.section,
+                        "order": item.order,
+                        "url_path": item.url_path,
+                    }
+                    for item in nav_items
+                ],
+                "iframe_base_url": f"/api/v1/admin/_extensions/{plugin_name}/",
+            }
+        )
+    return out
+```
+
+- [ ] **Step 4: Mount router + admin extension routers + static at startup**
+
+In `backend/cubebox/api/app.py` lifespan, after `bind_defaults`:
+
+```python
+from cubebox.api.routes.v1 import admin_extensions
+from fastapi.staticfiles import StaticFiles
+
+# inside lifespan:
+app.include_router(admin_extensions.router, prefix="/api/v1")
+
+for ext in reg.get_admin_panel_extensions():
+    plugin_name = type(ext).__module__.split(".")[0]
+    if (router := ext.get_router()) is not None:
+        app.include_router(
+            router, prefix=f"/api/v1/admin/_extensions/{plugin_name}"
+        )
+    if (static_path := ext.get_static_path()) is not None:
+        app.mount(
+            f"/api/v1/admin/_extensions/{plugin_name}/static",
+            StaticFiles(directory=str(static_path)),
+        )
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/test_admin_extensions.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/api/routes/v1/admin_extensions.py backend/cubebox/api/app.py backend/tests/test_admin_extensions.py
+git commit -m "feat(admin): manifest endpoint + dynamic mount of AdminPanelExtension routers/static"
+```
+
+---
+
+### Task 21: Build the in-tree fake plugin fixture
+
+**Files:**
+- Create: `backend/tests/fixtures/fake_plugin/pyproject.toml`
+- Create: `backend/tests/fixtures/fake_plugin/fake_plugin/__init__.py`
+- Create: `backend/tests/fixtures/fake_plugin/fake_plugin/auth.py`
+- Create: `backend/tests/fixtures/fake_plugin/fake_plugin/permissions.py`
+- Create: `backend/tests/fixtures/fake_plugin/fake_plugin/audit.py`
+- Create: `backend/tests/fixtures/fake_plugin/fake_plugin/directory.py`
+- Create: `backend/tests/fixtures/fake_plugin/fake_plugin/admin_panel.py`
+
+- [ ] **Step 1: Write `pyproject.toml`**
+
+```toml
+# backend/tests/fixtures/fake_plugin/pyproject.toml
+[project]
+name = "fake-plugin"
+version = "0.0.1"
+description = "Fake cubebox plugin used by Layer 1 contract tests."
+requires-python = ">=3.12"
+dependencies = []
+
+[project.entry-points."cubebox.plugin_manifest"]
+main = "fake_plugin:MANIFEST"
+
+[project.entry-points."cubebox.auth_provider"]
+fake = "fake_plugin.auth:FakeAuthProvider"
+
+[project.entry-points."cubebox.permission_checker"]
+fake = "fake_plugin.permissions:FakePermissionChecker"
+
+[project.entry-points."cubebox.audit_sink"]
+fake = "fake_plugin.audit:FakeAuditSink"
+
+[project.entry-points."cubebox.user_directory_syncer"]
+fake = "fake_plugin.directory:FakeUserDirectorySyncer"
+
+[project.entry-points."cubebox.admin_panel_extension"]
+fake = "fake_plugin.admin_panel:FakeAdminPanelExtension"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+```
+
+- [ ] **Step 2: Write `fake_plugin/__init__.py`**
+
+```python
+# backend/tests/fixtures/fake_plugin/fake_plugin/__init__.py
+from cubebox.plugins import CUBEBOX_PLUGIN_API_VERSION, PluginManifest
+
+MANIFEST = PluginManifest(
+    api_version=CUBEBOX_PLUGIN_API_VERSION,
+    name="fake",
+    version="0.0.1",
+    description="Fixture plugin for Layer 1 contract tests.",
+)
+```
+
+- [ ] **Step 3: Write 5 plugin impl files**
+
+`fake_plugin/auth.py`:
+
+```python
+from cubebox.plugins import AuthProvider
+
+
+class FakeAuthProvider:
+    async def authenticate(self, request):  # type: ignore[no-untyped-def]
+        return None
+
+    def get_auth_routers(self):  # type: ignore[no-untyped-def]
+        return []
+```
+
+`fake_plugin/permissions.py`:
+
+```python
+class FakePermissionChecker:
+    async def check(self, user, action, resource):  # type: ignore[no-untyped-def]
+        return True  # always permit (test stub)
+```
+
+`fake_plugin/audit.py`:
+
+```python
+class FakeAuditSink:
+    async def record(self, event):  # type: ignore[no-untyped-def]
+        pass
+```
+
+`fake_plugin/directory.py`:
+
+```python
+from cubebox.plugins import SyncResult, SyncSchedule
+
+
+class FakeUserDirectorySyncer:
+    async def sync(self):  # type: ignore[no-untyped-def]
+        return SyncResult(added=0, updated=0, removed=0, errors=[])
+
+    def get_schedule(self):  # type: ignore[no-untyped-def]
+        return SyncSchedule(interval_seconds=None)
+```
+
+`fake_plugin/admin_panel.py`:
+
+```python
+from cubebox.plugins import AdminNavItem
+
+
+class FakeAdminPanelExtension:
+    def get_router(self):  # type: ignore[no-untyped-def]
+        return None
+
+    def get_nav_items(self):  # type: ignore[no-untyped-def]
+        return [
+            AdminNavItem(
+                id="fake-tab",
+                label="Fake",
+                icon=None,
+                section="custom",
+                order=999,
+                url_path="fake",
+            )
+        ]
+
+    def get_static_path(self):  # type: ignore[no-untyped-def]
+        return None
+```
+
+- [ ] **Step 4: Verify fixture installs**
+
+```bash
+cd backend && uv pip install -e tests/fixtures/fake_plugin --no-deps
+cd backend && uv run python -c "from fake_plugin import MANIFEST; print(MANIFEST)"
+cd backend && uv pip uninstall -y fake-plugin
+```
+
+Expected: prints PluginManifest content; uninstall completes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/fixtures/fake_plugin/
+git commit -m "test(plugins): in-tree fake plugin fixture for Layer 1 contract tests"
+```
+
+---
+
+### Task 22: Layer 1 contract tests (`test_contracts.py` with 11 assertions)
+
+**Files:**
+- Create: `backend/tests/plugins/test_contracts.py`
+
+Each contract test installs the fake plugin temporarily, exercises one rule, then uninstalls.
+
+- [ ] **Step 1: Write `test_contracts.py` with 11 assertions**
+
+```python
+# backend/tests/plugins/test_contracts.py
+"""Layer 1 contract tests — exercise PluginRegistry against in-tree fake_plugin."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from cubebox.plugins import (
+    CUBEBOX_PLUGIN_API_VERSION,
+    AuthProvider,
+    PluginManifest,
+    reset_registry_for_tests,
+)
+from cubebox.plugins.registry import PluginRegistry
+
+FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "fake_plugin"
+
+
+@pytest.fixture
+def installed_fake_plugin():
+    subprocess.run(
+        ["uv", "pip", "install", "-e", str(FIXTURE_DIR), "--no-deps"],
+        check=True,
+        capture_output=True,
+    )
+    importlib.invalidate_caches()
+    yield
+    subprocess.run(
+        ["uv", "pip", "uninstall", "-y", "fake-plugin"],
+        check=True,
+        capture_output=True,
+    )
+    importlib.invalidate_caches()
+    sys.modules.pop("fake_plugin", None)
+    reset_registry_for_tests()
+
+
+@pytest.fixture
+def fresh_registry():
+    reset_registry_for_tests()
+    yield
+    reset_registry_for_tests()
+
+
+# ──────────────────────── 11 assertions ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_discovery_finds_fake_plugin(installed_fake_plugin, fresh_registry) -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    assert "fake" in reg._manifests
+
+
+@pytest.mark.asyncio
+async def test_singular_zero_external_uses_default(fresh_registry) -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    from cubebox.plugins.defaults.auth import DefaultAuthProvider
+    assert isinstance(reg.get_auth_provider(), DefaultAuthProvider)
+
+
+@pytest.mark.asyncio
+async def test_singular_one_external_replaces_default(installed_fake_plugin, fresh_registry) -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    from fake_plugin.auth import FakeAuthProvider
+    assert isinstance(reg.get_auth_provider(), FakeAuthProvider)
+
+
+@pytest.mark.asyncio
+async def test_singular_selected_builtin_forces_default(installed_fake_plugin, fresh_registry) -> None:
+    class _Cfg:
+        class plugins:
+            class auth_provider:
+                selected = "builtin"
+            class permission_checker:
+                selected = None
+            class audit_sink:
+                disabled = []
+            class user_directory_syncer:
+                disabled = []
+            class admin_panel_extension:
+                disabled = []
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults(config=_Cfg())
+    from cubebox.plugins.defaults.auth import DefaultAuthProvider
+    assert isinstance(reg.get_auth_provider(), DefaultAuthProvider)
+
+
+@pytest.mark.asyncio
+async def test_singular_selected_by_name(installed_fake_plugin, fresh_registry) -> None:
+    class _Cfg:
+        class plugins:
+            class auth_provider:
+                selected = "fake"
+            class permission_checker:
+                selected = None
+            class audit_sink:
+                disabled = []
+            class user_directory_syncer:
+                disabled = []
+            class admin_panel_extension:
+                disabled = []
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults(config=_Cfg())
+    from fake_plugin.auth import FakeAuthProvider
+    assert isinstance(reg.get_auth_provider(), FakeAuthProvider)
+
+
+@pytest.mark.asyncio
+async def test_singular_selected_not_found_fails(fresh_registry) -> None:
+    class _Cfg:
+        class plugins:
+            class auth_provider:
+                selected = "nonexistent"
+            class permission_checker:
+                selected = None
+            class audit_sink:
+                disabled = []
+            class user_directory_syncer:
+                disabled = []
+            class admin_panel_extension:
+                disabled = []
+    reg = PluginRegistry()
+    await reg.discover()
+    with pytest.raises(RuntimeError, match="not registered"):
+        reg.bind_defaults(config=_Cfg())
+
+
+@pytest.mark.asyncio
+async def test_plural_aggregates_default_plus_external(installed_fake_plugin, fresh_registry) -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    sinks = reg.get_audit_sinks()
+    from cubebox.plugins.defaults.audit import DefaultAuditSink
+    from fake_plugin.audit import FakeAuditSink
+    types = {type(s) for s in sinks}
+    assert DefaultAuditSink in types
+    assert FakeAuditSink in types
+
+
+@pytest.mark.asyncio
+async def test_plural_disabled_filters_out(installed_fake_plugin, fresh_registry) -> None:
+    class _Cfg:
+        class plugins:
+            class auth_provider:
+                selected = None
+            class permission_checker:
+                selected = None
+            class audit_sink:
+                disabled = ["builtin"]
+            class user_directory_syncer:
+                disabled = []
+            class admin_panel_extension:
+                disabled = []
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults(config=_Cfg())
+    sinks = reg.get_audit_sinks()
+    from cubebox.plugins.defaults.audit import DefaultAuditSink
+    assert not any(isinstance(s, DefaultAuditSink) for s in sinks)
+
+
+@pytest.mark.asyncio
+async def test_missing_manifest_rejects_plugin(tmp_path, fresh_registry) -> None:
+    """Manually install a wheel with an entry_point but no plugin_manifest → reject."""
+    pkg = tmp_path / "rogue_pkg"
+    pkg.mkdir()
+    (pkg / "rogue").mkdir()
+    (pkg / "rogue" / "__init__.py").write_text("class R: pass")
+    (pkg / "pyproject.toml").write_text(
+        "[project]\n"
+        "name = 'rogue'\n"
+        "version = '0.0.1'\n"
+        "requires-python = '>=3.12'\n"
+        "[project.entry-points.\"cubebox.auth_provider\"]\n"
+        "rogue = 'rogue:R'\n"
+        "[build-system]\n"
+        "requires = ['setuptools>=61']\n"
+        "build-backend = 'setuptools.build_meta'\n"
+    )
+    subprocess.run(
+        ["uv", "pip", "install", "-e", str(pkg), "--no-deps"],
+        check=True,
+        capture_output=True,
+    )
+    importlib.invalidate_caches()
+    try:
+        reg = PluginRegistry()
+        with pytest.raises(RuntimeError, match="missing.*manifest"):
+            await reg.discover()
+    finally:
+        subprocess.run(
+            ["uv", "pip", "uninstall", "-y", "rogue"],
+            check=True,
+            capture_output=True,
+        )
+        importlib.invalidate_caches()
+
+
+@pytest.mark.asyncio
+async def test_api_version_mismatch_rejects(tmp_path, fresh_registry) -> None:
+    """Plugin manifest with mismatched api_version is rejected."""
+    pkg = tmp_path / "old_plugin"
+    pkg.mkdir()
+    (pkg / "old_pkg").mkdir()
+    (pkg / "old_pkg" / "__init__.py").write_text(
+        "from cubebox.plugins import PluginManifest\n"
+        "MANIFEST = PluginManifest(api_version=999, name='old', version='0.0.1')\n"
+    )
+    (pkg / "pyproject.toml").write_text(
+        "[project]\n"
+        "name = 'old-pkg'\n"
+        "version = '0.0.1'\n"
+        "requires-python = '>=3.12'\n"
+        "[project.entry-points.\"cubebox.plugin_manifest\"]\n"
+        "main = 'old_pkg:MANIFEST'\n"
+        "[build-system]\n"
+        "requires = ['setuptools>=61']\n"
+        "build-backend = 'setuptools.build_meta'\n"
+    )
+    subprocess.run(
+        ["uv", "pip", "install", "-e", str(pkg), "--no-deps"],
+        check=True,
+        capture_output=True,
+    )
+    importlib.invalidate_caches()
+    try:
+        reg = PluginRegistry()
+        with pytest.raises(RuntimeError, match="api_version"):
+            await reg.discover()
+    finally:
+        subprocess.run(
+            ["uv", "pip", "uninstall", "-y", "old-pkg"],
+            check=True,
+            capture_output=True,
+        )
+        importlib.invalidate_caches()
+
+
+@pytest.mark.asyncio
+async def test_external_plugin_named_builtin_rejected(tmp_path, fresh_registry) -> None:
+    """External entry_point name 'builtin' is reserved."""
+    pkg = tmp_path / "rsv"
+    pkg.mkdir()
+    (pkg / "rsv_pkg").mkdir()
+    (pkg / "rsv_pkg" / "__init__.py").write_text(
+        "from cubebox.plugins import PluginManifest, CUBEBOX_PLUGIN_API_VERSION\n"
+        "MANIFEST = PluginManifest(api_version=CUBEBOX_PLUGIN_API_VERSION, name='rsv', version='0.0.1')\n"
+        "class A:\n"
+        "    async def authenticate(self, r): return None\n"
+        "    def get_auth_routers(self): return []\n"
+    )
+    (pkg / "pyproject.toml").write_text(
+        "[project]\n"
+        "name = 'rsv-pkg'\n"
+        "version = '0.0.1'\n"
+        "requires-python = '>=3.12'\n"
+        "[project.entry-points.\"cubebox.plugin_manifest\"]\n"
+        "main = 'rsv_pkg:MANIFEST'\n"
+        "[project.entry-points.\"cubebox.auth_provider\"]\n"
+        "builtin = 'rsv_pkg:A'\n"
+        "[build-system]\n"
+        "requires = ['setuptools>=61']\n"
+        "build-backend = 'setuptools.build_meta'\n"
+    )
+    subprocess.run(
+        ["uv", "pip", "install", "-e", str(pkg), "--no-deps"],
+        check=True,
+        capture_output=True,
+    )
+    importlib.invalidate_caches()
+    try:
+        reg = PluginRegistry()
+        with pytest.raises(RuntimeError, match="reserved"):
+            await reg.discover()
+    finally:
+        subprocess.run(
+            ["uv", "pip", "uninstall", "-y", "rsv-pkg"],
+            check=True,
+            capture_output=True,
+        )
+        importlib.invalidate_caches()
+```
+
+- [ ] **Step 2: Run all contract tests**
+
+Run: `cd backend && uv run pytest tests/plugins/test_contracts.py -v`
+Expected: PASS for all 11 tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/tests/plugins/test_contracts.py
+git commit -m "test(plugins): Layer 1 contract tests (11 assertions for discovery + resolution)"
+```
+
+---
+
+### Task 23: CI workflow `test-ee-compat` placeholder job
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Read current ci.yml structure**
+
+```bash
+cd backend && cat ../.github/workflows/ci.yml | head -100
+```
+
+Identify where existing jobs are declared (e.g., `backend-check`, `frontend-check`, `e2e`).
+
+- [ ] **Step 2: Append placeholder job**
+
+Append to `.github/workflows/ci.yml`:
+
+```yaml
+  test-ee-compat:
+    # Layer 1: in-repo contract tests (always run)
+    # Layer 2: real cubebox-ee integration is gated until the EE repo exists
+    runs-on: ubuntu-latest
+    needs: [backend-check]   # adjust to your existing job name
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - name: Install backend
+        run: cd backend && uv sync --all-extras
+      - name: Run plugin contract tests
+        run: cd backend && uv run pytest tests/plugins/test_contracts.py -v
+
+  test-ee-compat-cross-repo:
+    # Layer 2 placeholder: enable once cubebox/cubebox-ee repo exists
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { path: cubebox }
+      - uses: actions/checkout@v4
+        with: { repository: cubebox/cubebox-ee, path: cubebox-ee, token: ${{ secrets.EE_REPO_READ_TOKEN }} }
+      - uses: astral-sh/setup-uv@v3
+      - name: Install CE from working tree + EE
+        run: |
+          cd cubebox-ee
+          uv pip install -e ../cubebox/backend
+          uv pip install -e .
+      - name: Run EE smoke tests
+        run: cd cubebox-ee && uv run pytest
+```
+
+- [ ] **Step 3: Validate workflow YAML**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
+Expected: no error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci(plugins): add test-ee-compat job for Layer 1 contract tests + Layer 2 placeholder"
+```
+
+---
+
+### Task 24: Final integration smoke test
+
+**Files:**
+- Run all tests + start server
+
+- [ ] **Step 1: Full backend test sweep**
+
+```bash
+cd backend && uv run pytest tests/ -v
+```
+
+Expected: ALL pass (including unmodified test_rbac, auth, etc.).
+
+- [ ] **Step 2: Start server, hit endpoints**
+
+```bash
+cd backend && uv run python main.py &
+sleep 5
+curl -s -i http://localhost:8000/api/v1/admin/_extensions/manifest \
+  -H "Cookie: <admin_jwt>" | head -20
+kill %1
+```
+
+Expected:
+- Admin extensions manifest returns `[]` (CE-only deployment)
+- No exceptions on startup
+
+- [ ] **Step 3: Verify mypy / ruff passes**
+
+```bash
+cd backend && make check
+```
+
+Expected: All green.
+
+- [ ] **Step 4: Commit no-op (or push to feature branch)**
+
+```bash
+git status   # should be clean
+```
+
+If clean, M0 is implementation-complete; ready for branch merge / PR review.
+
+---
+
+## Self-Review Notes (planner ran)
+
+- ✅ Spec coverage:
+  - 5 Protocols → Tasks 4
+  - manifest + version → Tasks 2, 5
+  - registry resolution (singular + plural + selected/disabled) → Tasks 5, 6, 7, 12
+  - 4 CE defaults → Tasks 8-11
+  - PermissionChecker integration → Task 14
+  - AuthProvider integration → Tasks 15-16
+  - audit_log + 3 hooks → Tasks 17-19
+  - AdminPanelExtension scan + manifest endpoint → Task 20
+  - fake_plugin fixture + 11 contract tests → Tasks 21-22
+  - CI placeholder → Task 23
+- ✅ Existing test_rbac.py + auth tests must remain green (Tasks 14, 15 validate)
+- ✅ All entry_point group names match: `cubebox.plugin_manifest`, `cubebox.auth_provider`, `cubebox.permission_checker`, `cubebox.audit_sink`, `cubebox.user_directory_syncer`, `cubebox.admin_panel_extension`
+- ✅ Reserved name `"builtin"` consistent across resolve_singular / resolve_plural / contract test
+- ✅ `CUBEBOX_PLUGIN_API_VERSION = 1` consistent
+- ⚠ DefaultAuthProvider's lazy schema import (`__import__`) may need refactor when implementer verifies actual `cubebox.api.schemas.auth` paths. Flagged in Task 8.
+- ⚠ Plugin Schema imports for fastapi-users (`UserRead`/`UserCreate`/`UserUpdate`) expected in `cubebox.api.schemas.auth`; if missing, implementer may need to create them as part of Task 8.

--- a/docs/superpowers/plans/2026-04-23-m2-admin-console-skeleton.md
+++ b/docs/superpowers/plans/2026-04-23-m2-admin-console-skeleton.md
@@ -1748,7 +1748,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-NOTE: The `default-src` portion includes `'unsafe-inline' 'unsafe-eval'` because Next.js dev mode requires them. For production tightening, narrow this in a follow-up.
+NOTE: The `default-src` portion includes `'unsafe-inline' 'unsafe-eval'` because Next.js dev mode requires them (React Refresh injects inline scripts; HMR uses `eval()`). The **security-critical** part of this CSP is `frame-src 'self'` (prevents arbitrary iframe URLs from manifest), which is enforced regardless of dev/prod mode. Production CSP tightening (NODE_ENV-driven, nonce-based `script-src`, drop unsafe-eval) is tracked in **M12 · 开源工程基建** scope per backlog — out of M2 batch 1 scope.
 
 - [ ] **Step 3: Verify dev server starts without errors**
 

--- a/docs/superpowers/plans/2026-04-23-m2-admin-console-skeleton.md
+++ b/docs/superpowers/plans/2026-04-23-m2-admin-console-skeleton.md
@@ -1769,7 +1769,84 @@ git commit -m "feat(admin): set CSP frame-src 'self' for /admin routes (plugin i
 
 ---
 
-### Task 16: Final integration smoke test
+### Task 16: E2E — admin console sidebar + /admin gating
+
+Per CLAUDE.md project rule "Focus on E2E tests". Protocol / hook-level tests from earlier tasks are not sufficient; this task drives the browser against real backend + frontend to cover: sidebar structure, admin popover gating, `/admin` route, `org_admin` enforcement, and non-admin redirect. Uses the existing frontend e2e harness.
+
+**Files:**
+- Create: `frontend/packages/web/e2e/admin-console-skeleton.spec.ts`
+
+- [ ] **Step 1: Write failing Playwright e2e**
+
+```ts
+// frontend/packages/web/e2e/admin-console-skeleton.spec.ts
+import { test, expect } from "@playwright/test";
+import { loginAs } from "./helpers/auth";
+
+test.describe("admin console skeleton", () => {
+  test("admin sees 管理后台 in avatar popover and can reach /admin", async ({ page, context }) => {
+    await loginAs(page, "admin");
+    await page.goto("/");
+    await expect(page.getByRole("complementary", { name: /sidebar/i })).toBeVisible();
+    await page.getByRole("button", { name: /avatar/i }).click();
+    const adminLink = page.getByRole("menuitem", { name: "管理后台" });
+    await expect(adminLink).toBeVisible();
+
+    const pagePromise = context.waitForEvent("page");
+    await adminLink.click();
+    const adminPage = await pagePromise;
+    await adminPage.waitForLoadState();
+
+    await expect(adminPage).toHaveURL(/\/admin(\/|$)/);
+    await expect(adminPage.getByText(/cubebox · 管理后台/)).toBeVisible();
+    for (const tab of ["模型", "技能", "MCP", "成员", "审计"]) {
+      await expect(adminPage.getByRole("link", { name: new RegExp(tab) })).toBeVisible();
+    }
+  });
+
+  test("non-admin member cannot access /admin", async ({ page }) => {
+    await loginAs(page, "member");
+
+    await page.goto("/");
+    await page.getByRole("button", { name: /avatar/i }).click();
+    await expect(page.getByRole("menuitem", { name: "管理后台" })).toHaveCount(0);
+
+    await page.goto("/admin");
+    await expect(page).toHaveURL(/^.*\/$/); // redirected to root
+  });
+
+  test("CE deployment: extensions manifest returns empty and no external tabs render", async ({ page }) => {
+    await loginAs(page, "admin");
+    await page.goto("/admin");
+    // Only the 5 built-in CE tabs should be present in the sub-nav.
+    const navLinks = page.getByRole("navigation", { name: /admin sub-nav/i }).getByRole("link");
+    await expect(navLinks).toHaveCount(5);
+  });
+});
+```
+
+- [ ] **Step 2: Ensure `loginAs(page, "admin" | "member")` helper exists**
+
+If `frontend/packages/web/e2e/helpers/auth.ts` does not already expose a dual-role `loginAs`, extend it to accept `"admin" | "member"` and seed / reuse both fixture users against the backend's auth endpoints. Reuse the same fixtures the streaming e2e already depends on — do not create a parallel auth harness.
+
+- [ ] **Step 3: Run**
+
+```bash
+cd frontend && pnpm --filter @cubebox/web exec playwright test admin-console-skeleton.spec.ts
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/packages/web/e2e/admin-console-skeleton.spec.ts frontend/packages/web/e2e/helpers/auth.ts
+git commit -m "test(admin): e2e admin console skeleton (sidebar + /admin gating + CE extensions)"
+```
+
+---
+
+### Task 17: Final integration smoke test
 
 **Files:**
 - Run all tests + manual smoke

--- a/docs/superpowers/plans/2026-04-23-m2-admin-console-skeleton.md
+++ b/docs/superpowers/plans/2026-04-23-m2-admin-console-skeleton.md
@@ -1,0 +1,1849 @@
+# M2 · 管理员控制台骨架 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the `/admin` independent-layout route group (org admin shell, opens in new tab via `<a target="_blank">`); refactor main app sidebar (remove AppTopBar, hoist sidebar to `(app)/layout.tsx`, add Workspaces nav section + AvatarPopover); consume M0's `/api/v1/admin/_extensions/manifest` to render plugin nav items + iframe pages. Batch 1 strictly skeleton: all 5 CE-native tabs (Models / Web tools / Skills / MCP / Sandbox) ship as "Coming Soon" placeholders.
+
+**Architecture:** New `app/admin/` route group with its own layout (no main app sidebar); auth gate via new backend `GET /api/v1/admin/me` endpoint backed by `require_org_admin` dependency (current org's any-workspace admin). Main app sidebar moves up to `(app)/layout.tsx` so every authenticated page (homepage, /workspaces, /w/[wsId]/...) sees it. Plugin extension iframes loaded same-origin; CSP `frame-src 'self'`.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript, Tailwind CSS 4, shadcn/ui (popover already present, tabs to add), SWR, FastAPI, fastapi-users, SQLModel.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-admin-console-design.md`
+
+---
+
+## File Structure
+
+### Create
+
+```
+backend/cubebox/api/routes/v1/admin.py            # GET /admin/me; mounts manifest sub-router (already from M0)
+backend/cubebox/api/schemas/admin.py              # AdminMeResponse pydantic model
+backend/tests/test_admin_me.py                    # /admin/me admin / member / no-membership cases
+backend/tests/test_require_org_admin.py           # dependency + repo method coverage
+
+frontend/packages/web/app/admin/layout.tsx        # Independent admin layout: top bar + sub-nav + content
+frontend/packages/web/app/admin/page.tsx          # redirects to /admin/models
+frontend/packages/web/app/admin/models/page.tsx
+frontend/packages/web/app/admin/web-tools/page.tsx
+frontend/packages/web/app/admin/skills/page.tsx
+frontend/packages/web/app/admin/mcp/page.tsx
+frontend/packages/web/app/admin/sandbox/page.tsx
+frontend/packages/web/app/admin/ext/[plugin]/[...path]/page.tsx    # iframe extension page
+
+frontend/packages/web/components/admin/AdminTopBar.tsx
+frontend/packages/web/components/admin/AdminSubNav.tsx
+frontend/packages/web/components/admin/AdminAvatarMenu.tsx
+frontend/packages/web/components/admin/ComingSoonCard.tsx
+
+frontend/packages/web/components/sidebar/WorkspacesSection.tsx
+frontend/packages/web/components/sidebar/AvatarPopover.tsx
+
+frontend/packages/web/hooks/useAdminAccess.ts
+frontend/packages/web/hooks/useAdminExtensions.ts
+
+frontend/packages/web/components/ui/tabs.tsx       # via npx shadcn add tabs
+```
+
+### Modify
+
+```
+backend/cubebox/auth/dependencies.py               # Add require_org_admin
+backend/cubebox/repositories/membership.py         # Add user_has_role_in_org method
+backend/cubebox/api/app.py                         # Mount admin router
+backend/cubebox/api/routes/v1/workspaces.py        # GET /workspaces add last_activity_at field
+
+frontend/packages/web/app/(app)/layout.tsx         # Drop AppTopBar; mount Sidebar around children
+frontend/packages/web/app/(app)/w/[wsId]/layout.tsx # No structural change (already minimal); just confirm Sidebar isn't double-rendered
+frontend/packages/web/components/layout/Sidebar.tsx  # Compose WorkspacesSection + AvatarPopover; keep recent-conversations
+frontend/packages/web/components/layout/AppShell.tsx  # Drop its own <Sidebar/> (now provided by outer layout); keep resizable-panel logic
+frontend/packages/web/components/workspace/WorkspaceSwitcher.tsx  # Either delete (replaced by sidebar list) or simplify to nav-section variant
+frontend/packages/web/components/layout/AppTopBar.tsx  # Delete
+frontend/packages/web/components/layout/AvatarMenu.tsx  # Delete (replaced by AvatarPopover)
+frontend/packages/web/next.config.ts                # Add CSP header frame-src 'self'
+frontend/packages/core/src/stores/workspaceStore.ts  # Add last_activity_at to Workspace type
+```
+
+---
+
+## Tasks
+
+### Task 1: Add shadcn `tabs` component
+
+**Files:**
+- Create: `frontend/packages/web/components/ui/tabs.tsx`
+
+- [ ] **Step 1: Run shadcn add**
+
+```bash
+cd frontend/packages/web && npx shadcn@latest add tabs
+```
+
+If it prompts for confirmation, accept defaults. The file lands at `components/ui/tabs.tsx`.
+
+- [ ] **Step 2: Verify import works**
+
+```bash
+cd frontend && pnpm --filter @cubebox/web exec tsc --noEmit 2>&1 | head -5
+```
+Expected: no errors mentioning `tabs.tsx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/packages/web/components/ui/tabs.tsx
+git commit -m "chore(ui): add shadcn tabs component for admin console"
+```
+
+---
+
+### Task 2: Backend `MembershipRepository.user_has_role_in_org`
+
+**Files:**
+- Modify: `backend/cubebox/repositories/membership.py`
+- Create: `backend/tests/test_membership_org_role.py`
+
+- [ ] **Step 1: Inspect current MembershipRepository structure**
+
+```bash
+sed -n '1,60p' backend/cubebox/repositories/membership.py
+```
+
+Note the existing async session pattern + `get_role(user_id, workspace_id)` method.
+
+- [ ] **Step 2: Write failing tests**
+
+```python
+# backend/tests/test_membership_org_role.py
+"""Tests for MembershipRepository.user_has_role_in_org (added by M2)."""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.models import Role
+from cubebox.repositories import MembershipRepository, OrganizationRepository, WorkspaceRepository
+
+
+@pytest.mark.asyncio
+async def test_user_with_admin_membership_in_org_returns_true(session: AsyncSession) -> None:
+    org = await OrganizationRepository(session).create(name="Acme")
+    ws = await WorkspaceRepository(session).create(org_id=org.id, name="Team")
+    user_id = str(uuid4())
+    await MembershipRepository(session).grant(user_id=user_id, workspace_id=ws.id, role=Role.ADMIN)
+
+    repo = MembershipRepository(session)
+    assert await repo.user_has_role_in_org(user_id=user_id, org_id=org.id, role=Role.ADMIN) is True
+
+
+@pytest.mark.asyncio
+async def test_user_with_only_member_role_admin_check_returns_false(session: AsyncSession) -> None:
+    org = await OrganizationRepository(session).create(name="Acme")
+    ws = await WorkspaceRepository(session).create(org_id=org.id, name="Team")
+    user_id = str(uuid4())
+    await MembershipRepository(session).grant(user_id=user_id, workspace_id=ws.id, role=Role.MEMBER)
+
+    repo = MembershipRepository(session)
+    assert await repo.user_has_role_in_org(user_id=user_id, org_id=org.id, role=Role.ADMIN) is False
+
+
+@pytest.mark.asyncio
+async def test_user_with_no_membership_in_org_returns_false(session: AsyncSession) -> None:
+    org = await OrganizationRepository(session).create(name="Acme")
+    user_id = str(uuid4())
+    repo = MembershipRepository(session)
+    assert await repo.user_has_role_in_org(user_id=user_id, org_id=org.id, role=Role.ADMIN) is False
+
+
+@pytest.mark.asyncio
+async def test_admin_in_one_workspace_grants_org_admin(session: AsyncSession) -> None:
+    """User who is ADMIN in any workspace of the org passes the check."""
+    org = await OrganizationRepository(session).create(name="Acme")
+    ws_a = await WorkspaceRepository(session).create(org_id=org.id, name="A")
+    ws_b = await WorkspaceRepository(session).create(org_id=org.id, name="B")
+    user_id = str(uuid4())
+    # Member in A, Admin in B → admin in org
+    await MembershipRepository(session).grant(user_id=user_id, workspace_id=ws_a.id, role=Role.MEMBER)
+    await MembershipRepository(session).grant(user_id=user_id, workspace_id=ws_b.id, role=Role.ADMIN)
+
+    repo = MembershipRepository(session)
+    assert await repo.user_has_role_in_org(user_id=user_id, org_id=org.id, role=Role.ADMIN) is True
+```
+
+- [ ] **Step 3: Run, verify fail**
+
+```bash
+cd backend && uv run pytest tests/test_membership_org_role.py -v
+```
+Expected: FAIL with `AttributeError: 'MembershipRepository' object has no attribute 'user_has_role_in_org'`.
+
+- [ ] **Step 4: Implement the method**
+
+Append to `backend/cubebox/repositories/membership.py` (inside `MembershipRepository` class):
+
+```python
+    async def user_has_role_in_org(
+        self,
+        *,
+        user_id: str,
+        org_id: str,
+        role: Role,
+    ) -> bool:
+        """True if `user_id` has `role` in any workspace belonging to `org_id`.
+
+        v1: "org admin" = admin in any workspace of the org. M2 uses this as the
+        gate for /admin/* until a real org-level role concept is introduced.
+        """
+        from sqlalchemy import select
+
+        from cubebox.models import Membership, Workspace
+
+        stmt = (
+            select(Membership.user_id)
+            .join(Workspace, Workspace.id == Membership.workspace_id)
+            .where(
+                Workspace.org_id == org_id,
+                Membership.user_id == user_id,
+                Membership.role == role.value,
+            )
+            .limit(1)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none() is not None
+```
+
+NOTE: Adjust `from sqlalchemy import select` placement to follow project conventions; if `Workspace` isn't imported at top, add the import.
+
+- [ ] **Step 5: Run tests, verify pass**
+
+```bash
+cd backend && uv run pytest tests/test_membership_org_role.py -v
+```
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/repositories/membership.py backend/tests/test_membership_org_role.py
+git commit -m "feat(repos): MembershipRepository.user_has_role_in_org for org-level admin gate"
+```
+
+---
+
+### Task 3: Backend `require_org_admin` dependency
+
+**Files:**
+- Modify: `backend/cubebox/auth/dependencies.py`
+- Create: `backend/tests/test_require_org_admin.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/test_require_org_admin.py
+"""Tests for require_org_admin FastAPI dependency."""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from cubebox.auth.dependencies import require_org_admin
+from cubebox.auth.context import RequestContext
+from cubebox.models import Role
+
+
+@pytest.mark.asyncio
+async def test_passes_for_org_admin() -> None:
+    user = MagicMock(id=str(uuid4()))
+    ctx = RequestContext(user=user, org_id=str(uuid4()), workspace_id=str(uuid4()), role=Role.ADMIN)
+    repo = AsyncMock()
+    repo.user_has_role_in_org = AsyncMock(return_value=True)
+
+    result = await require_org_admin(user=user, request_context=ctx, membership_repo=repo)
+    assert result is user
+
+
+@pytest.mark.asyncio
+async def test_raises_403_for_non_admin() -> None:
+    user = MagicMock(id=str(uuid4()))
+    ctx = RequestContext(user=user, org_id=str(uuid4()), workspace_id=str(uuid4()), role=Role.MEMBER)
+    repo = AsyncMock()
+    repo.user_has_role_in_org = AsyncMock(return_value=False)
+
+    with pytest.raises(HTTPException) as exc:
+        await require_org_admin(user=user, request_context=ctx, membership_repo=repo)
+    assert exc.value.status_code == 403
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+cd backend && uv run pytest tests/test_require_org_admin.py -v
+```
+Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Implement `require_org_admin`**
+
+Append to `backend/cubebox/auth/dependencies.py`:
+
+```python
+async def require_org_admin(
+    user: Annotated[User, Depends(current_active_user)],
+    request_context: Annotated[RequestContext, Depends(request_context)],
+    membership_repo: Annotated[
+        MembershipRepository,
+        Depends(lambda session=Depends(get_session): MembershipRepository(session)),
+    ],
+) -> User:
+    """v1: user is "org admin" iff they hold ADMIN in ANY workspace of current org.
+
+    Future: when org-level role concept exists, this implementation is replaced;
+    callers (admin routes, /admin/me endpoint) are unchanged.
+    """
+    is_admin = await membership_repo.user_has_role_in_org(
+        user_id=user.id, org_id=request_context.org_id, role=Role.ADMIN
+    )
+    if not is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Org admin role required",
+        )
+    return user
+```
+
+NOTE: The dependency requires `request_context` which itself needs a `workspace_id` path parameter. For `/admin/*` routes (no workspace in URL), wrap differently — either accept `org_id` from a different source (cookie / user default org) OR skip `request_context` for admin routes. Simpler v1 path: add a separate `current_org_context` dependency that resolves org_id from `user.default_workspace.org_id` (or similar) without needing a path param. See Task 4 for the exact wiring.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```bash
+cd backend && uv run pytest tests/test_require_org_admin.py -v
+```
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/auth/dependencies.py backend/tests/test_require_org_admin.py
+git commit -m "feat(auth): require_org_admin dependency (v1 = any-workspace admin in current org)"
+```
+
+---
+
+### Task 4: Backend `GET /api/v1/admin/me` endpoint
+
+**Files:**
+- Create: `backend/cubebox/api/schemas/admin.py`
+- Create: `backend/cubebox/api/routes/v1/admin.py`
+- Modify: `backend/cubebox/api/app.py` (mount router)
+- Create: `backend/tests/test_admin_me.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/test_admin_me.py
+"""End-to-end test for GET /api/v1/admin/me."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_admin_user_gets_is_admin_true(client: AsyncClient, admin_user_cookie) -> None:
+    resp = await client.get("/api/v1/admin/me", cookies=admin_user_cookie)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["is_admin"] is True
+    assert "org_id" in data
+    assert "org_name" in data
+
+
+@pytest.mark.asyncio
+async def test_member_user_gets_is_admin_false(client: AsyncClient, member_user_cookie) -> None:
+    resp = await client.get("/api/v1/admin/me", cookies=member_user_cookie)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["is_admin"] is False
+    # org info still returned (frontend uses for display)
+    assert "org_id" in data
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_returns_401(client: AsyncClient) -> None:
+    resp = await client.get("/api/v1/admin/me")
+    assert resp.status_code == 401
+```
+
+NOTE: `admin_user_cookie` and `member_user_cookie` fixtures must exist in `backend/tests/conftest.py`. If absent, scaffold them (register a user → grant ADMIN/MEMBER → return the auth cookie). Pattern matches existing `test_rbac.py` fixtures.
+
+- [ ] **Step 2: Run, verify fail (404 — endpoint doesn't exist yet)**
+
+```bash
+cd backend && uv run pytest tests/test_admin_me.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Define response schema**
+
+```python
+# backend/cubebox/api/schemas/admin.py
+"""Admin route response schemas."""
+
+from pydantic import BaseModel
+
+
+class AdminMeResponse(BaseModel):
+    is_admin: bool
+    org_id: str
+    org_name: str
+```
+
+- [ ] **Step 4: Define current-org dependency + admin router**
+
+```python
+# backend/cubebox/api/routes/v1/admin.py
+"""Admin routes: /admin/me + manifest mount.
+
+The /admin/me endpoint returns 200 with is_admin=true|false (NOT 403)
+because the frontend uses it to decide whether to show admin entry
+points; only the ROUTING gate (require_org_admin) returns 403.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.api.schemas.admin import AdminMeResponse
+from cubebox.auth.users import current_active_user
+from cubebox.db import get_session
+from cubebox.models import Role, User
+from cubebox.repositories import MembershipRepository, OrganizationRepository
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+async def _resolve_current_org_id(
+    user: User,
+    session: AsyncSession,
+) -> str:
+    """v1: take the user's first workspace's org as 'current org'.
+
+    Future: cookie-driven multi-org switching reads current_org_id from a
+    cookie set by an OrgSwitcher endpoint. v1 has no switcher → just pick.
+    """
+    from sqlalchemy import select
+
+    from cubebox.models import Membership, Workspace
+
+    stmt = (
+        select(Workspace.org_id)
+        .join(Membership, Membership.workspace_id == Workspace.id)
+        .where(Membership.user_id == user.id)
+        .order_by(Workspace.created_at)
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    org_id = result.scalar_one_or_none()
+    if org_id is None:
+        # User has no workspace memberships at all — shouldn't happen for a
+        # registered user (register bootstrap creates one), but guard anyway.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No org membership found for user",
+        )
+    return org_id
+
+
+@router.get("/me", response_model=AdminMeResponse)
+async def get_admin_me(
+    user: Annotated[User, Depends(current_active_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> AdminMeResponse:
+    org_id = await _resolve_current_org_id(user, session)
+    is_admin = await MembershipRepository(session).user_has_role_in_org(
+        user_id=user.id, org_id=org_id, role=Role.ADMIN
+    )
+    org = await OrganizationRepository(session).get(org_id)
+    return AdminMeResponse(
+        is_admin=is_admin,
+        org_id=org_id,
+        org_name=org.name if org else "",
+    )
+```
+
+- [ ] **Step 5: Mount router in app.py**
+
+In `backend/cubebox/api/app.py`, find the section where routers are included (typically near `include_router(workspaces.router, ...)`). Add:
+
+```python
+from cubebox.api.routes.v1 import admin
+app.include_router(admin.router, prefix="/api/v1")
+```
+
+- [ ] **Step 6: Run tests, verify pass**
+
+```bash
+cd backend && uv run pytest tests/test_admin_me.py -v
+```
+Expected: PASS (3 tests). If `admin_user_cookie` fixture is missing, scaffold it first.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/cubebox/api/schemas/admin.py backend/cubebox/api/routes/v1/admin.py backend/cubebox/api/app.py backend/tests/test_admin_me.py
+git commit -m "feat(api): GET /api/v1/admin/me returning is_admin + org info"
+```
+
+---
+
+### Task 5: Backend `GET /api/v1/workspaces` add `last_activity_at`
+
+**Files:**
+- Modify: `backend/cubebox/api/routes/v1/workspaces.py`
+- Modify: `backend/cubebox/api/schemas/workspace.py` (or wherever WorkspaceResponse lives)
+- Create: `backend/tests/test_workspaces_last_activity.py`
+
+- [ ] **Step 1: Locate the existing GET workspaces handler + schema**
+
+```bash
+grep -n "GET\|@router.get\|workspaces" backend/cubebox/api/routes/v1/workspaces.py | head
+grep -rn "class Workspace.*Response\|WorkspaceRead" backend/cubebox/api/schemas/ 2>/dev/null
+```
+
+- [ ] **Step 2: Write failing test**
+
+```python
+# backend/tests/test_workspaces_last_activity.py
+"""GET /api/v1/workspaces includes last_activity_at."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_workspace_response_has_last_activity_at(
+    client: AsyncClient, member_user_cookie
+) -> None:
+    resp = await client.get("/api/v1/workspaces", cookies=member_user_cookie)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    assert "last_activity_at" in data[0]
+    # ISO-8601 string or null
+    val = data[0]["last_activity_at"]
+    assert val is None or isinstance(val, str)
+```
+
+- [ ] **Step 3: Run, verify fail**
+
+```bash
+cd backend && uv run pytest tests/test_workspaces_last_activity.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 4: Add `last_activity_at` to response schema + computation**
+
+In the workspace schema (e.g. `backend/cubebox/api/schemas/workspace.py`):
+
+```python
+class WorkspaceResponse(BaseModel):
+    id: str
+    org_id: str
+    name: str
+    role: str
+    last_activity_at: str | None = None  # ISO-8601 UTC; null if no conversations yet
+```
+
+In the GET handler in `backend/cubebox/api/routes/v1/workspaces.py`, compute via aggregate:
+
+```python
+from sqlalchemy import func, select
+
+from cubebox.models import Conversation, Message
+from cubebox.utils.time import utc_isoformat  # use project's standard helper
+
+
+async def list_workspaces(...) -> list[WorkspaceResponse]:
+    # ... existing code that fetches the user's workspaces ...
+
+    # Bulk last-activity lookup: max(message.updated_at) per workspace
+    activity_stmt = (
+        select(
+            Conversation.workspace_id,
+            func.max(Message.updated_at).label("last_at"),
+        )
+        .join(Message, Message.conversation_id == Conversation.id)
+        .where(Conversation.workspace_id.in_([ws.id for ws in workspaces]))
+        .group_by(Conversation.workspace_id)
+    )
+    activity_rows = (await session.execute(activity_stmt)).all()
+    activity_map = {r.workspace_id: r.last_at for r in activity_rows}
+
+    return [
+        WorkspaceResponse(
+            id=ws.id,
+            org_id=ws.org_id,
+            name=ws.name,
+            role=role_for_user(ws, user),
+            last_activity_at=utc_isoformat(activity_map.get(ws.id)) if activity_map.get(ws.id) else None,
+        )
+        for ws in workspaces
+    ]
+```
+
+NOTE: Use `utc_isoformat()` per memory `feedback_timestamp_handling.md` — DB datetimes need explicit UTC offset for frontend.
+
+NOTE 2: If cubebox doesn't have a Message model directly (perhaps messages are checkpointer-backed only), substitute Conversation.updated_at as a proxy:
+
+```python
+activity_stmt = (
+    select(Conversation.workspace_id, func.max(Conversation.updated_at).label("last_at"))
+    .where(Conversation.workspace_id.in_([ws.id for ws in workspaces]))
+    .group_by(Conversation.workspace_id)
+)
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+```bash
+cd backend && uv run pytest tests/test_workspaces_last_activity.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 6: Update frontend `Workspace` type in `@cubebox/core`**
+
+In `frontend/packages/core/src/stores/workspaceStore.ts`, add to the `Workspace` type:
+
+```typescript
+export type Workspace = {
+  id: string
+  org_id: string
+  name: string
+  role: 'admin' | 'member'
+  last_activity_at: string | null  // ISO-8601 with offset, or null
+}
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/cubebox/api/schemas/workspace.py backend/cubebox/api/routes/v1/workspaces.py backend/tests/test_workspaces_last_activity.py frontend/packages/core/src/stores/workspaceStore.ts
+git commit -m "feat(workspaces): expose last_activity_at for sidebar sort + frontend type"
+```
+
+---
+
+### Task 6: Frontend `useAdminAccess` hook
+
+**Files:**
+- Create: `frontend/packages/web/hooks/useAdminAccess.ts`
+
+- [ ] **Step 1: Verify SWR is installed**
+
+```bash
+cd frontend && pnpm --filter @cubebox/web list swr 2>&1 | head -5
+```
+If absent: `cd frontend && pnpm --filter @cubebox/web add swr`
+
+- [ ] **Step 2: Implement the hook**
+
+```typescript
+// frontend/packages/web/hooks/useAdminAccess.ts
+'use client'
+
+import useSWR from 'swr'
+
+type AdminMeResponse = {
+  is_admin: boolean
+  org_id: string
+  org_name: string
+}
+
+const fetcher = async (url: string): Promise<AdminMeResponse> => {
+  const res = await fetch(url, { credentials: 'include' })
+  if (res.status === 401) {
+    throw new Error('unauthorized')
+  }
+  if (!res.ok) {
+    throw new Error(`admin/me failed: ${res.status}`)
+  }
+  return res.json()
+}
+
+export function useAdminAccess() {
+  const { data, error, isLoading } = useSWR<AdminMeResponse>(
+    '/api/v1/admin/me',
+    fetcher,
+    { revalidateOnFocus: false, shouldRetryOnError: false },
+  )
+  return {
+    isAdmin: data?.is_admin ?? false,
+    orgId: data?.org_id ?? null,
+    orgName: data?.org_name ?? '',
+    loading: isLoading,
+    error: error as Error | undefined,
+  }
+}
+```
+
+- [ ] **Step 3: Manually smoke (skip if test framework wired)**
+
+Start dev server, log in as an admin user, open browser console:
+```javascript
+fetch('/api/v1/admin/me', { credentials: 'include' }).then(r => r.json()).then(console.log)
+```
+Expected: `{is_admin: true, org_id: "...", org_name: "..."}`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/packages/web/hooks/useAdminAccess.ts
+git commit -m "feat(web): useAdminAccess hook backed by /admin/me"
+```
+
+---
+
+### Task 7: Frontend `<WorkspacesSection />` component
+
+**Files:**
+- Create: `frontend/packages/web/components/sidebar/WorkspacesSection.tsx`
+
+- [ ] **Step 1: Implement WorkspacesSection**
+
+```typescript
+// frontend/packages/web/components/sidebar/WorkspacesSection.tsx
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useState, useMemo } from 'react'
+import { useWorkspaceStore } from '@cubebox/core'
+import { Folder, Plus } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const DEFAULT_VISIBLE = 5
+
+export function WorkspacesSection() {
+  const workspaces = useWorkspaceStore((s) => s.workspaces)
+  const pathname = usePathname()
+  const [showAll, setShowAll] = useState(false)
+
+  // Sort by last_activity_at desc; nulls last
+  const sorted = useMemo(() => {
+    return [...workspaces].sort((a, b) => {
+      const at = a.last_activity_at ? Date.parse(a.last_activity_at) : 0
+      const bt = b.last_activity_at ? Date.parse(b.last_activity_at) : 0
+      return bt - at
+    })
+  }, [workspaces])
+
+  const visible = showAll ? sorted : sorted.slice(0, DEFAULT_VISIBLE)
+  const hidden = sorted.length - DEFAULT_VISIBLE
+
+  // Detect current workspace from URL: /w/[wsId]/...
+  const currentWsId = useMemo(() => {
+    const match = pathname.match(/^\/w\/([^/]+)/)
+    return match ? match[1] : null
+  }, [pathname])
+
+  return (
+    <div className="px-2 py-2">
+      <p className="px-2 text-xs font-medium text-muted-foreground mb-1">工作区</p>
+      <ul className="space-y-0.5">
+        {visible.map((ws) => (
+          <li key={ws.id}>
+            <Link
+              href={`/w/${ws.id}`}
+              className={cn(
+                'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors',
+                ws.id === currentWsId && 'bg-accent font-medium',
+              )}
+            >
+              <Folder className="size-3.5 text-muted-foreground shrink-0" />
+              <span className="truncate flex-1">{ws.name}</span>
+              {ws.id === currentWsId && (
+                <span className="size-1.5 rounded-full bg-primary shrink-0" />
+              )}
+            </Link>
+          </li>
+        ))}
+        {hidden > 0 && !showAll && (
+          <li>
+            <button
+              type="button"
+              onClick={() => setShowAll(true)}
+              className="w-full text-left px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              更多 ({hidden}) ↓
+            </button>
+          </li>
+        )}
+        <li>
+          <Link
+            href="/workspaces"
+            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-accent"
+          >
+            <Plus className="size-3.5" />
+            <span>新建工作区</span>
+          </Link>
+        </li>
+      </ul>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd frontend && pnpm --filter @cubebox/web exec tsc --noEmit 2>&1 | head -10
+```
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/packages/web/components/sidebar/WorkspacesSection.tsx
+git commit -m "feat(sidebar): WorkspacesSection list with last-activity sort + show-more"
+```
+
+---
+
+### Task 8: Frontend `<AvatarPopover />` component
+
+**Files:**
+- Create: `frontend/packages/web/components/sidebar/AvatarPopover.tsx`
+
+- [ ] **Step 1: Implement AvatarPopover**
+
+```typescript
+// frontend/packages/web/components/sidebar/AvatarPopover.tsx
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Button } from '@/components/ui/button'
+import { ThemeToggle } from '@/components/ui/theme-toggle'
+import {
+  createApiClient,
+  logoutUser,
+  useAuthStore,
+  useConversationStore,
+  useWorkspaceStore,
+} from '@cubebox/core'
+import { useAdminAccess } from '@/hooks/useAdminAccess'
+import { Shield, LogOut } from 'lucide-react'
+
+export function AvatarPopover() {
+  const router = useRouter()
+  const user = useAuthStore((s) => s.user)
+  const { isAdmin } = useAdminAccess()
+
+  const initials = user?.email ? user.email[0].toUpperCase() : '?'
+
+  const onLogout = async () => {
+    const client = createApiClient('')
+    try {
+      await logoutUser(client)
+    } catch {
+      /* ignore */
+    }
+    useAuthStore.setState({ user: null })
+    useConversationStore.setState({ conversations: [], activeId: null })
+    useWorkspaceStore.setState({ workspaces: [] })
+    router.replace('/login')
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="w-full flex items-center gap-2 px-2 py-2 rounded-md hover:bg-accent transition-colors"
+        >
+          <div className="size-7 rounded-full bg-primary text-white flex items-center justify-center text-xs font-medium shrink-0">
+            {initials}
+          </div>
+          <span className="text-sm truncate flex-1 text-left">{user?.email ?? '...'}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="start"
+        className="w-56 p-1"
+        sideOffset={4}
+      >
+        <div className="px-2 py-1.5 text-xs text-muted-foreground border-b mb-1">
+          {user?.email}
+        </div>
+
+        {isAdmin && (
+          <a
+            href="/admin"
+            target="_blank"
+            rel="noopener"
+            className="flex items-center gap-2 px-2 py-1.5 rounded-sm text-sm hover:bg-accent"
+          >
+            <Shield className="size-4" />
+            <span>管理后台</span>
+          </a>
+        )}
+
+        <div className="flex items-center gap-2 px-2 py-1.5 rounded-sm text-sm hover:bg-accent">
+          <ThemeToggle />
+          <span>主题</span>
+        </div>
+
+        <button
+          type="button"
+          onClick={onLogout}
+          className="w-full flex items-center gap-2 px-2 py-1.5 rounded-sm text-sm hover:bg-accent text-destructive"
+        >
+          <LogOut className="size-4" />
+          <span>退出</span>
+        </button>
+      </PopoverContent>
+    </Popover>
+  )
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd frontend && pnpm --filter @cubebox/web exec tsc --noEmit 2>&1 | head -10
+```
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/packages/web/components/sidebar/AvatarPopover.tsx
+git commit -m "feat(sidebar): AvatarPopover with admin-only entry + theme + logout"
+```
+
+---
+
+### Task 9: Refactor `Sidebar.tsx` to compose new sections
+
+**Files:**
+- Modify: `frontend/packages/web/components/layout/Sidebar.tsx`
+
+- [ ] **Step 1: Inspect current Sidebar behavior**
+
+```bash
+cat frontend/packages/web/components/layout/Sidebar.tsx
+```
+
+The current Sidebar is workspace-coupled (uses `useWorkspaceContext`); we need it to work on every page including non-workspace ones.
+
+- [ ] **Step 2: Refactor Sidebar**
+
+Replace the contents of `frontend/packages/web/components/layout/Sidebar.tsx` with:
+
+```typescript
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useConversationStore, createApiClient } from '@cubebox/core'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Plus, Trash2, Box } from 'lucide-react'
+import { WorkspacesSection } from '@/components/sidebar/WorkspacesSection'
+import { AvatarPopover } from '@/components/sidebar/AvatarPopover'
+
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMs / 3600000)
+  const diffDays = Math.floor(diffMs / 86400000)
+
+  if (diffMins < 1) return '刚刚'
+  if (diffMins < 60) return `${diffMins}m 前`
+  if (diffHours < 24) return `${diffHours}h 前`
+  return `${diffDays}d 前`
+}
+
+export function Sidebar() {
+  const { conversations, activeId, remove } = useConversationStore()
+  const pathname = usePathname()
+
+  // Detect current workspace from URL (no longer requires WorkspaceContext)
+  const wsMatch = pathname.match(/^\/w\/([^/]+)/)
+  const currentWsId = wsMatch ? wsMatch[1] : null
+  const newChatHref = currentWsId ? `/w/${currentWsId}` : '/'
+
+  const handleDeleteClick = async (e: React.MouseEvent, id: string) => {
+    e.preventDefault()
+    const client = createApiClient('')
+    if (currentWsId) client.setWorkspaceId(currentWsId)
+    try {
+      await remove(client, id)
+    } catch (err) {
+      console.error('Failed to delete conversation:', err)
+    }
+  }
+
+  return (
+    <div className="w-56 bg-card border-r border-border flex flex-col h-screen shrink-0">
+      {/* Brand + new chat */}
+      <div className="px-4 pt-4 pb-3 border-b border-border">
+        <div className="flex items-center gap-2 mb-3">
+          <div className="w-6 h-6 rounded-md bg-primary flex items-center justify-center shrink-0">
+            <Box className="size-3.5 text-white" strokeWidth={2.5} />
+          </div>
+          <span className="text-sm font-semibold tracking-tight">cubebox</span>
+        </div>
+        <Link href={newChatHref}>
+          <Button variant="default" className="w-full gap-2" size="sm">
+            <Plus className="size-3.5" />
+            新建对话
+          </Button>
+        </Link>
+      </div>
+
+      {/* Workspaces section */}
+      <WorkspacesSection />
+
+      {/* Recent conversations */}
+      <div className="px-2 pt-2 pb-1">
+        <p className="px-2 text-xs font-medium text-muted-foreground">最近会话</p>
+      </div>
+      <ScrollArea className="flex-1 px-2">
+        <ul className="space-y-0.5">
+          {conversations.map((c) => (
+            <li key={c.id}>
+              <Link
+                href={currentWsId ? `/w/${currentWsId}/conversations/${c.id}` : '#'}
+                className={`group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent ${
+                  c.id === activeId ? 'bg-accent' : ''
+                }`}
+              >
+                <span className="truncate flex-1">{c.title || '(untitled)'}</span>
+                <span className="text-[10px] text-muted-foreground shrink-0">
+                  {formatRelativeTime(c.updated_at)}
+                </span>
+                <button
+                  onClick={(e) => handleDeleteClick(e, c.id)}
+                  className="opacity-0 group-hover:opacity-100 p-0.5 hover:text-destructive"
+                  aria-label="Delete conversation"
+                >
+                  <Trash2 className="size-3" />
+                </button>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </ScrollArea>
+
+      {/* Footer: avatar popover */}
+      <div className="border-t border-border p-2">
+        <AvatarPopover />
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd frontend && pnpm --filter @cubebox/web exec tsc --noEmit 2>&1 | head -10
+```
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/packages/web/components/layout/Sidebar.tsx
+git commit -m "refactor(sidebar): compose WorkspacesSection + AvatarPopover; drop workspace-context coupling"
+```
+
+---
+
+### Task 10: Hoist Sidebar to `(app)/layout.tsx`; remove `AppTopBar`
+
+**Files:**
+- Modify: `frontend/packages/web/app/(app)/layout.tsx`
+- Modify: `frontend/packages/web/components/layout/AppShell.tsx`
+- Delete: `frontend/packages/web/components/layout/AppTopBar.tsx`
+- Delete: `frontend/packages/web/components/layout/AvatarMenu.tsx`
+- Delete: `frontend/packages/web/components/workspace/WorkspaceSwitcher.tsx`
+
+- [ ] **Step 1: Refactor `(app)/layout.tsx` to mount Sidebar**
+
+Replace `frontend/packages/web/app/(app)/layout.tsx` with:
+
+```typescript
+'use client'
+
+import { useEffect, useMemo } from 'react'
+import { createApiClient, useAuthStore, useWorkspaceStore } from '@cubebox/core'
+import { useAuthRedirect } from '@/hooks/useAuthRedirect'
+import { Sidebar } from '@/components/layout/Sidebar'
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  const client = useMemo(() => createApiClient(''), [])
+  useAuthRedirect(client)
+
+  useEffect(() => {
+    useAuthStore.getState().loadMe(client)
+    useWorkspaceStore.getState().fetchList(client)
+  }, [client])
+
+  return (
+    <div className="flex h-screen bg-background text-foreground">
+      <Sidebar />
+      <div className="flex-1 flex flex-col overflow-hidden">{children}</div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Refactor `AppShell.tsx` to drop its own Sidebar**
+
+The Sidebar is now provided by the outer layout. Strip `<Sidebar />` and the brand-flex-row from AppShell, leaving only the resizable artifact-panel layout:
+
+```typescript
+'use client'
+
+import { ReactNode } from 'react'
+import { ThemeToggle } from '@/components/ui/theme-toggle'
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
+import { ToolDetailPanel } from '@/components/panel/ToolDetailPanel'
+import { ArtifactPanel } from '@/components/panel/artifact/ArtifactPanel'
+import { usePanelStore } from '@cubebox/core'
+
+interface AppShellProps {
+  children: ReactNode
+  headerTitle?: string
+}
+
+export function AppShell({ children, headerTitle }: AppShellProps) {
+  const viewType = usePanelStore((s) => s.view.type)
+  const panelOpen = viewType !== 'closed'
+
+  return (
+    <ResizablePanelGroup orientation="horizontal" className="h-full">
+      <ResizablePanel defaultSize={panelOpen ? 50 : 100} minSize={30}>
+        <div className="flex flex-col h-full overflow-hidden">
+          <header className="h-11 border-b border-border flex items-center px-4 shrink-0">
+            <span className="text-sm text-muted-foreground truncate flex-1">
+              {headerTitle || ''}
+            </span>
+            <ThemeToggle />
+          </header>
+          <main className="flex-1 flex flex-col overflow-hidden">{children}</main>
+        </div>
+      </ResizablePanel>
+
+      {panelOpen && (
+        <>
+          <ResizableHandle withHandle />
+          <ResizablePanel defaultSize={50} minSize={25}>
+            {viewType === 'artifact' ? <ArtifactPanel /> : <ToolDetailPanel />}
+          </ResizablePanel>
+        </>
+      )}
+    </ResizablePanelGroup>
+  )
+}
+```
+
+- [ ] **Step 3: Delete obsolete files**
+
+```bash
+git rm frontend/packages/web/components/layout/AppTopBar.tsx
+git rm frontend/packages/web/components/layout/AvatarMenu.tsx
+git rm frontend/packages/web/components/workspace/WorkspaceSwitcher.tsx
+```
+
+- [ ] **Step 4: Update any remaining imports**
+
+```bash
+grep -rn "AppTopBar\|AvatarMenu\|WorkspaceSwitcher" frontend/packages/web/ --include="*.tsx" --include="*.ts" 2>/dev/null
+```
+Expected: no results. Fix any leftovers (they should be only in the deleted files themselves).
+
+- [ ] **Step 5: Smoke test (start dev server, verify all pages)**
+
+```bash
+cd frontend && pnpm --filter @cubebox/web dev &
+sleep 5
+# Open in browser:
+#   http://localhost:3000/                  -- sidebar visible
+#   http://localhost:3000/workspaces        -- sidebar visible
+#   http://localhost:3000/w/<wsId>/...      -- sidebar visible (no double sidebar)
+kill %1
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/packages/web/app/\(app\)/layout.tsx frontend/packages/web/components/layout/AppShell.tsx
+git commit -m "refactor(layout): hoist Sidebar to (app)/layout; drop AppTopBar / AvatarMenu / WorkspaceSwitcher"
+```
+
+---
+
+### Task 11: Frontend `useAdminExtensions` hook
+
+**Files:**
+- Create: `frontend/packages/web/hooks/useAdminExtensions.ts`
+
+- [ ] **Step 1: Implement hook**
+
+```typescript
+// frontend/packages/web/hooks/useAdminExtensions.ts
+'use client'
+
+import useSWR from 'swr'
+
+export type AdminNavItem = {
+  id: string
+  label: string
+  icon: string | null
+  section: string
+  order: number
+  url_path: string
+}
+
+export type AdminExtensionEntry = {
+  plugin: string
+  nav_items: AdminNavItem[]
+  iframe_base_url: string
+}
+
+const fetcher = async (url: string): Promise<AdminExtensionEntry[]> => {
+  const res = await fetch(url, { credentials: 'include' })
+  if (!res.ok) throw new Error(`manifest fetch failed: ${res.status}`)
+  return res.json()
+}
+
+export function useAdminExtensions() {
+  const { data, error, isLoading } = useSWR<AdminExtensionEntry[]>(
+    '/api/v1/admin/_extensions/manifest',
+    fetcher,
+    { revalidateOnFocus: false },
+  )
+  return {
+    extensions: data ?? [],
+    loading: isLoading,
+    error: error as Error | undefined,
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/packages/web/hooks/useAdminExtensions.ts
+git commit -m "feat(web): useAdminExtensions hook for plugin manifest"
+```
+
+---
+
+### Task 12: Frontend `<AdminTopBar />` + `<AdminSubNav />` + `<AdminAvatarMenu />`
+
+**Files:**
+- Create: `frontend/packages/web/components/admin/AdminTopBar.tsx`
+- Create: `frontend/packages/web/components/admin/AdminSubNav.tsx`
+- Create: `frontend/packages/web/components/admin/AdminAvatarMenu.tsx`
+- Create: `frontend/packages/web/components/admin/ComingSoonCard.tsx`
+
+- [ ] **Step 1: Implement AdminTopBar**
+
+```typescript
+// frontend/packages/web/components/admin/AdminTopBar.tsx
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { Box } from 'lucide-react'
+import { AdminAvatarMenu } from './AdminAvatarMenu'
+
+interface AdminTopBarProps {
+  orgName: string
+}
+
+function handleBackToApp() {
+  if (typeof window !== 'undefined') {
+    if (window.opener) {
+      window.close()
+    } else {
+      window.location.href = '/'
+    }
+  }
+}
+
+export function AdminTopBar({ orgName }: AdminTopBarProps) {
+  return (
+    <header className="flex items-center gap-4 border-b border-border bg-card px-4 py-3 h-14 shrink-0">
+      <div className="flex items-center gap-2">
+        <div className="w-6 h-6 rounded-md bg-primary flex items-center justify-center shrink-0">
+          <Box className="size-3.5 text-white" strokeWidth={2.5} />
+        </div>
+        <span className="text-sm font-semibold">cubebox</span>
+      </div>
+      <Separator orientation="vertical" className="h-6" />
+      <h1 className="text-sm font-medium">管理后台</h1>
+      {/* v1: static org label; multi-org future replaces this with OrgSwitcher dropdown */}
+      <span className="text-sm text-muted-foreground">· {orgName}</span>
+
+      <div className="ml-auto flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={handleBackToApp}>
+          回应用
+        </Button>
+        <AdminAvatarMenu />
+      </div>
+    </header>
+  )
+}
+```
+
+- [ ] **Step 2: Implement AdminAvatarMenu (simpler than sidebar AvatarPopover — just user info + logout)**
+
+```typescript
+// frontend/packages/web/components/admin/AdminAvatarMenu.tsx
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { createApiClient, logoutUser, useAuthStore } from '@cubebox/core'
+
+export function AdminAvatarMenu() {
+  const router = useRouter()
+  const user = useAuthStore((s) => s.user)
+  const initials = user?.email ? user.email[0].toUpperCase() : '?'
+
+  const onLogout = async () => {
+    const client = createApiClient('')
+    try {
+      await logoutUser(client)
+    } catch {
+      /* ignore */
+    }
+    router.replace('/login')
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="size-8 rounded-full bg-primary text-white flex items-center justify-center text-xs font-medium"
+        >
+          {initials}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent side="bottom" align="end" className="w-48 p-1">
+        <div className="px-2 py-1.5 text-xs text-muted-foreground border-b mb-1">
+          {user?.email}
+        </div>
+        <button
+          type="button"
+          onClick={onLogout}
+          className="w-full text-left px-2 py-1.5 rounded-sm text-sm hover:bg-accent text-destructive"
+        >
+          退出
+        </button>
+      </PopoverContent>
+    </Popover>
+  )
+}
+```
+
+- [ ] **Step 3: Implement AdminSubNav**
+
+```typescript
+// frontend/packages/web/components/admin/AdminSubNav.tsx
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Cpu, Globe, Sparkles, Plug, Box, Puzzle } from 'lucide-react'
+import { Separator } from '@/components/ui/separator'
+import { useAdminExtensions } from '@/hooks/useAdminExtensions'
+import { cn } from '@/lib/utils'
+
+const NATIVE_ITEMS = [
+  { href: '/admin/models', label: '模型', icon: Cpu },
+  { href: '/admin/web-tools', label: 'Web 工具', icon: Globe },
+  { href: '/admin/skills', label: '技能管理', icon: Sparkles },
+  { href: '/admin/mcp', label: 'MCP 连接器', icon: Plug },
+  { href: '/admin/sandbox', label: '沙盒', icon: Box },
+]
+
+export function AdminSubNav() {
+  const pathname = usePathname()
+  const { extensions } = useAdminExtensions()
+
+  // Flatten plugin nav items: each entry contributes 0+ items
+  const extItems = extensions.flatMap((ext) =>
+    ext.nav_items.map((item) => ({
+      href: `/admin/ext/${ext.plugin}/${item.url_path}`,
+      label: item.label,
+      icon: Puzzle,  // fallback; future: dynamic lucide icon by name
+    })),
+  )
+
+  return (
+    <nav className="w-56 border-r border-border bg-card flex flex-col p-2 overflow-y-auto">
+      <ul className="space-y-0.5">
+        {NATIVE_ITEMS.map((item) => {
+          const Icon = item.icon
+          const active = pathname === item.href || pathname.startsWith(item.href + '/')
+          return (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                className={cn(
+                  'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors',
+                  active && 'bg-accent font-medium',
+                )}
+              >
+                <Icon className="size-3.5 text-muted-foreground" />
+                <span className="truncate">{item.label}</span>
+              </Link>
+            </li>
+          )
+        })}
+
+        {extItems.length > 0 && (
+          <>
+            <li className="py-1">
+              <Separator />
+            </li>
+            <li>
+              <p className="px-2 py-1 text-xs text-muted-foreground">扩展</p>
+            </li>
+            {extItems.map((item) => {
+              const Icon = item.icon
+              const active = pathname === item.href
+              return (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className={cn(
+                      'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors',
+                      active && 'bg-accent font-medium',
+                    )}
+                  >
+                    <Icon className="size-3.5 text-muted-foreground" />
+                    <span className="truncate">{item.label}</span>
+                  </Link>
+                </li>
+              )
+            })}
+          </>
+        )}
+      </ul>
+    </nav>
+  )
+}
+```
+
+- [ ] **Step 4: Implement ComingSoonCard**
+
+```typescript
+// frontend/packages/web/components/admin/ComingSoonCard.tsx
+interface ComingSoonCardProps {
+  title: string
+  description: string
+  backlogRef: string
+}
+
+export function ComingSoonCard({ title, description, backlogRef }: ComingSoonCardProps) {
+  return (
+    <div className="max-w-2xl mx-auto mt-12 px-6">
+      <h2 className="text-2xl font-semibold mb-3">{title}</h2>
+      <p className="text-muted-foreground mb-8">{description}</p>
+      <div className="rounded-lg border border-dashed border-border p-8 text-center">
+        <p className="text-sm font-medium mb-1">本版本不可用</p>
+        <p className="text-xs text-muted-foreground">实现归属：{backlogRef}</p>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/packages/web/components/admin/
+git commit -m "feat(admin): AdminTopBar + AdminSubNav + AdminAvatarMenu + ComingSoonCard"
+```
+
+---
+
+### Task 13: Admin layout + 5 CE tab placeholder pages
+
+**Files:**
+- Create: `frontend/packages/web/app/admin/layout.tsx`
+- Create: `frontend/packages/web/app/admin/page.tsx`
+- Create: `frontend/packages/web/app/admin/models/page.tsx`
+- Create: `frontend/packages/web/app/admin/web-tools/page.tsx`
+- Create: `frontend/packages/web/app/admin/skills/page.tsx`
+- Create: `frontend/packages/web/app/admin/mcp/page.tsx`
+- Create: `frontend/packages/web/app/admin/sandbox/page.tsx`
+
+- [ ] **Step 1: Implement admin layout with auth gate**
+
+```typescript
+// frontend/packages/web/app/admin/layout.tsx
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { AdminTopBar } from '@/components/admin/AdminTopBar'
+import { AdminSubNav } from '@/components/admin/AdminSubNav'
+import { useAdminAccess } from '@/hooks/useAdminAccess'
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const { isAdmin, orgName, loading, error } = useAdminAccess()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (loading) return
+    if (error) {
+      router.replace('/login?next=/admin')
+      return
+    }
+    if (!isAdmin) {
+      router.replace('/')
+    }
+  }, [loading, isAdmin, error, router])
+
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center text-sm text-muted-foreground">
+        Loading…
+      </div>
+    )
+  }
+  if (!isAdmin) return null
+
+  return (
+    <div className="flex h-screen flex-col bg-background text-foreground">
+      <AdminTopBar orgName={orgName} />
+      <div className="flex flex-1 overflow-hidden">
+        <AdminSubNav />
+        <main className="flex-1 overflow-auto">{children}</main>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Implement admin index → redirect**
+
+```typescript
+// frontend/packages/web/app/admin/page.tsx
+import { redirect } from 'next/navigation'
+
+export default function AdminIndex() {
+  redirect('/admin/models')
+}
+```
+
+- [ ] **Step 3: Implement 5 CE tab pages (all "Coming Soon")**
+
+`frontend/packages/web/app/admin/models/page.tsx`:
+```typescript
+import { ComingSoonCard } from '@/components/admin/ComingSoonCard'
+
+export default function ModelsPage() {
+  return (
+    <ComingSoonCard
+      title="模型管理"
+      description="按 provider 列出可用模型，配置组织默认模型与 fallback 链。"
+      backlogRef="M2 完整版（v1 后续 spec）"
+    />
+  )
+}
+```
+
+`frontend/packages/web/app/admin/web-tools/page.tsx`:
+```typescript
+import { ComingSoonCard } from '@/components/admin/ComingSoonCard'
+
+export default function WebToolsPage() {
+  return (
+    <ComingSoonCard
+      title="Web 工具"
+      description="搜索服务提供商配置（除默认外至少支持 1-2 个可切换）。"
+      backlogRef="M2 完整版（v1 后续 spec）"
+    />
+  )
+}
+```
+
+`frontend/packages/web/app/admin/skills/page.tsx`:
+```typescript
+import { ComingSoonCard } from '@/components/admin/ComingSoonCard'
+
+export default function SkillsPage() {
+  return (
+    <ComingSoonCard
+      title="技能管理"
+      description="安装 / 禁用 / 版本 / workspace 可见性。"
+      backlogRef="M3 Skills 市场"
+    />
+  )
+}
+```
+
+`frontend/packages/web/app/admin/mcp/page.tsx`:
+```typescript
+import { ComingSoonCard } from '@/components/admin/ComingSoonCard'
+
+export default function McpPage() {
+  return (
+    <ComingSoonCard
+      title="MCP 连接器"
+      description="新增 / 编辑 MCP 服务，凭证绑定走 Credential Vault。"
+      backlogRef="M2 完整版 + M1-E4 Credential Vault"
+    />
+  )
+}
+```
+
+`frontend/packages/web/app/admin/sandbox/page.tsx`:
+```typescript
+import { ComingSoonCard } from '@/components/admin/ComingSoonCard'
+
+export default function SandboxPage() {
+  return (
+    <ComingSoonCard
+      title="沙盒"
+      description="指定默认镜像与资源上限。"
+      backlogRef="M2 完整版（v1 后续 spec）"
+    />
+  )
+}
+```
+
+- [ ] **Step 4: Smoke test**
+
+```bash
+cd frontend && pnpm --filter @cubebox/web dev &
+sleep 5
+# In browser, log in as admin user, then:
+#   http://localhost:3000/admin           -- should redirect to /admin/models
+#   http://localhost:3000/admin/skills    -- should show "技能管理 / Coming Soon"
+# Then log in as non-admin user:
+#   http://localhost:3000/admin           -- should redirect to /
+kill %1
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/packages/web/app/admin/
+git commit -m "feat(admin): /admin layout with auth gate + 5 CE tab Coming Soon placeholders"
+```
+
+---
+
+### Task 14: Plugin extension iframe page
+
+**Files:**
+- Create: `frontend/packages/web/app/admin/ext/[plugin]/[...path]/page.tsx`
+
+- [ ] **Step 1: Implement extension page**
+
+```typescript
+// frontend/packages/web/app/admin/ext/[plugin]/[...path]/page.tsx
+'use client'
+
+import { use } from 'react'
+import { useAdminExtensions } from '@/hooks/useAdminExtensions'
+
+interface ExtensionPageProps {
+  params: Promise<{ plugin: string; path?: string[] }>
+}
+
+export default function ExtensionPage({ params }: ExtensionPageProps) {
+  const { plugin, path } = use(params)
+  const { extensions, loading } = useAdminExtensions()
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Loading extension…
+      </div>
+    )
+  }
+
+  const ext = extensions.find((e) => e.plugin === plugin)
+  if (!ext) {
+    return (
+      <div className="max-w-2xl mx-auto mt-12 px-6">
+        <h2 className="text-2xl font-semibold mb-3">未知扩展</h2>
+        <p className="text-muted-foreground">
+          找不到名为 <code>{plugin}</code> 的插件 —— 它可能未安装或已禁用。
+        </p>
+      </div>
+    )
+  }
+
+  const subPath = (path ?? []).join('/')
+  const iframeUrl = `${ext.iframe_base_url}${subPath}`
+
+  return (
+    <iframe
+      src={iframeUrl}
+      className="h-full w-full border-0"
+      sandbox="allow-scripts allow-forms allow-same-origin"
+      title={`Extension: ${plugin}`}
+    />
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/packages/web/app/admin/ext/
+git commit -m "feat(admin): plugin extension iframe page (consumes M0 manifest)"
+```
+
+---
+
+### Task 15: CSP `frame-src 'self'` in `next.config.ts`
+
+**Files:**
+- Modify: `frontend/packages/web/next.config.ts`
+
+- [ ] **Step 1: Inspect current next.config.ts**
+
+```bash
+cat frontend/packages/web/next.config.ts
+```
+
+- [ ] **Step 2: Add CSP header in headers() callback**
+
+Modify `next.config.ts` to add a `headers()` async function (or extend existing one):
+
+```typescript
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  // ... existing config (compress: false from prior fix; keep) ...
+  async headers() {
+    return [
+      {
+        source: '/admin/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: "frame-src 'self'; default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:",
+          },
+        ],
+      },
+    ]
+  },
+}
+
+export default nextConfig
+```
+
+NOTE: The `default-src` portion includes `'unsafe-inline' 'unsafe-eval'` because Next.js dev mode requires them. For production tightening, narrow this in a follow-up.
+
+- [ ] **Step 3: Verify dev server starts without errors**
+
+```bash
+cd frontend && pnpm --filter @cubebox/web dev &
+sleep 5
+curl -s -I http://localhost:3000/admin/models | grep -i content-security-policy
+kill %1
+```
+Expected: header present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/packages/web/next.config.ts
+git commit -m "feat(admin): set CSP frame-src 'self' for /admin routes (plugin iframe safety)"
+```
+
+---
+
+### Task 16: Final integration smoke test
+
+**Files:**
+- Run all tests + manual smoke
+
+- [ ] **Step 1: Backend full test sweep**
+
+```bash
+cd backend && uv run pytest tests/ -v
+```
+Expected: all PASS (including pre-existing test_rbac, auth tests).
+
+- [ ] **Step 2: Frontend type-check + build**
+
+```bash
+cd frontend && pnpm --filter @cubebox/web exec tsc --noEmit
+cd frontend && pnpm --filter @cubebox/web build
+```
+Expected: no errors.
+
+- [ ] **Step 3: Manual smoke matrix**
+
+Start backend + frontend dev servers. Log in as an admin user. Walk through:
+
+| URL | Expected |
+|---|---|
+| `/` | Sidebar visible at left; main content area; avatar at sidebar bottom |
+| `/workspaces` | Sidebar visible; workspace list in main |
+| `/w/<wsId>` | Sidebar visible; current workspace marked with dot in WorkspacesSection |
+| `/w/<wsId>/conversations/<id>` | Sidebar visible; AppShell renders main + (optional) artifact panel |
+| Click avatar in sidebar | Popover opens upward; "管理后台" item shown |
+| Click "管理后台" | Opens `/admin` in NEW TAB |
+| `/admin` (new tab) | Independent layout; top bar shows "cubebox · 管理后台 · <org name>"; left sub-nav with 5 native items + (no extensions in CE-only); content redirects to `/admin/models` |
+| `/admin/skills` | "技能管理 / Coming Soon" card |
+| Click "回应用" | New tab closes (because window.opener exists) |
+
+Then log out, log in as a non-admin (member-only) user. Walk through:
+
+| Action | Expected |
+|---|---|
+| Open avatar popover | "管理后台" entry NOT shown |
+| Manually navigate to `/admin` | Redirects to `/` |
+
+- [ ] **Step 4: Commit if anything was tweaked during smoke**
+
+```bash
+git status
+# If anything changed, fix + commit. Otherwise M2 is implementation-complete.
+```
+
+---
+
+## Self-Review Notes (planner ran)
+
+- ✅ Spec coverage:
+  - Sidebar refactor (D3, D4, D5, D6, D7, D8) → Tasks 7, 8, 9, 10
+  - `/admin` independent layout (D1, D11) → Tasks 12, 13
+  - Avatar popover (D4, D2) → Task 8
+  - Plugin extension iframe (D14) → Tasks 11, 14
+  - Auth gate (D12) → Tasks 2, 3, 4
+  - URL stays `/admin` + org-name slot (D9, D10) → Task 12 AdminTopBar
+  - Workspace settings NOT included (D8 / D10) → confirmed not in plan
+  - shadcn tabs + popover (D15) → Task 1 (popover already present per /components/ui/ inspection)
+  - CSP frame-src self (D14) → Task 15
+  - Back-to-app via window.close fallback (D16) → Task 12 AdminTopBar
+- ✅ Backend new endpoints (`/api/v1/admin/me`) + new dependency (`require_org_admin`) + new repo method (`user_has_role_in_org`) all explicit
+- ✅ Frontend file paths use existing `@/` alias and `@cubebox/core` package
+- ✅ Existing AppTopBar / AvatarMenu / WorkspaceSwitcher explicitly deleted
+- ✅ AppShell refactor preserves resizable artifact-panel logic (only Sidebar removed since outer layout provides it)
+- ⚠ Task 5 `last_activity_at` SQL has alternative (Conversation.updated_at vs Message.updated_at) depending on whether Message model exists in cubebox; implementer picks the one that compiles
+- ⚠ Task 4 `_resolve_current_org_id` v1 picks user's first workspace's org. Multi-org users see only one org's admin until OrgSwitcher lands (Path A in spec §8). Acceptable per D9.
+- ⚠ Task 10 deletes WorkspaceSwitcher; before merging, grep for any non-(app)/layout reference (deep-linked imports). The plan's grep step covers this.

--- a/docs/superpowers/plans/2026-04-23-m2-admin-console-skeleton.md
+++ b/docs/superpowers/plans/2026-04-23-m2-admin-console-skeleton.md
@@ -557,25 +557,29 @@ class WorkspaceResponse(BaseModel):
     last_activity_at: str | None = None  # ISO-8601 UTC; null if no conversations yet
 ```
 
-In the GET handler in `backend/cubebox/api/routes/v1/workspaces.py`, compute via aggregate:
+In the GET handler in `backend/cubebox/api/routes/v1/workspaces.py`, compute via aggregate over `Conversation.updated_at`:
 
 ```python
 from sqlalchemy import func, select
 
-from cubebox.models import Conversation, Message
-from cubebox.utils.time import utc_isoformat  # use project's standard helper
+from cubebox.models import Conversation
+from cubebox.utils.time import utc_isoformat  # project standard for UTC-tagged ISO
 
 
 async def list_workspaces(...) -> list[WorkspaceResponse]:
     # ... existing code that fetches the user's workspaces ...
 
-    # Bulk last-activity lookup: max(message.updated_at) per workspace
+    # cubebox doesn't have a Message table — messages live in LangGraph
+    # checkpointer thread state. But Conversation.updated_at is bumped by
+    # ConversationRepository.update_timestamp() on every message round-trip
+    # (called from POST /api/v1/ws/{ws}/conversations/{id}/messages).
+    # So aggregating max(Conversation.updated_at) per workspace gives accurate
+    # "last activity" semantics.
     activity_stmt = (
         select(
             Conversation.workspace_id,
-            func.max(Message.updated_at).label("last_at"),
+            func.max(Conversation.updated_at).label("last_at"),
         )
-        .join(Message, Message.conversation_id == Conversation.id)
         .where(Conversation.workspace_id.in_([ws.id for ws in workspaces]))
         .group_by(Conversation.workspace_id)
     )
@@ -595,16 +599,6 @@ async def list_workspaces(...) -> list[WorkspaceResponse]:
 ```
 
 NOTE: Use `utc_isoformat()` per memory `feedback_timestamp_handling.md` — DB datetimes need explicit UTC offset for frontend.
-
-NOTE 2: If cubebox doesn't have a Message model directly (perhaps messages are checkpointer-backed only), substitute Conversation.updated_at as a proxy:
-
-```python
-activity_stmt = (
-    select(Conversation.workspace_id, func.max(Conversation.updated_at).label("last_at"))
-    .where(Conversation.workspace_id.in_([ws.id for ws in workspaces]))
-    .group_by(Conversation.workspace_id)
-)
-```
 
 - [ ] **Step 5: Run tests, verify pass**
 
@@ -1844,6 +1838,6 @@ git status
 - ✅ Frontend file paths use existing `@/` alias and `@cubebox/core` package
 - ✅ Existing AppTopBar / AvatarMenu / WorkspaceSwitcher explicitly deleted
 - ✅ AppShell refactor preserves resizable artifact-panel logic (only Sidebar removed since outer layout provides it)
-- ⚠ Task 5 `last_activity_at` SQL has alternative (Conversation.updated_at vs Message.updated_at) depending on whether Message model exists in cubebox; implementer picks the one that compiles
+- ✅ Task 5 `last_activity_at` confirmed to use `Conversation.updated_at` (verified that `ConversationRepository.update_timestamp()` is called from messages endpoint at conversations.py:55 on every message round-trip); no Message table exists in cubebox
 - ⚠ Task 4 `_resolve_current_org_id` v1 picks user's first workspace's org. Multi-org users see only one org's admin until OrgSwitcher lands (Path A in spec §8). Acceptable per D9.
 - ⚠ Task 10 deletes WorkspaceSwitcher; before merging, grep for any non-(app)/layout reference (deep-linked imports). The plan's grep step covers this.

--- a/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
+++ b/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
@@ -836,6 +836,35 @@ async def test_line_range_clamps_to_file_length() -> None:
 
 
 @pytest.mark.asyncio
+async def test_line_range_open_end() -> None:
+    """'3-' = from line 3 to end."""
+    p = TextParser()
+    body = "\n".join(f"line{i}" for i in range(1, 6)).encode()
+    out = await p.parse(body, mime="text/plain", options=ParseOptions(line_range="3-"))
+    assert out.content == "line3\nline4\nline5"
+    assert out.metadata["lines_returned"] == "3-5"
+
+
+@pytest.mark.asyncio
+async def test_line_range_negative_returns_last_n() -> None:
+    """'-3' = last 3 lines (tail-style)."""
+    p = TextParser()
+    body = "\n".join(f"line{i}" for i in range(1, 11)).encode()
+    out = await p.parse(body, mime="text/plain", options=ParseOptions(line_range="-3"))
+    assert out.content == "line8\nline9\nline10"
+    assert out.metadata["lines_returned"] == "8-10"
+
+
+@pytest.mark.asyncio
+async def test_line_range_negative_more_than_file_returns_all() -> None:
+    """'-100' on a 5-line file returns all 5 lines."""
+    p = TextParser()
+    body = "\n".join(f"line{i}" for i in range(1, 6)).encode()
+    out = await p.parse(body, mime="text/plain", options=ParseOptions(line_range="-100"))
+    assert out.metadata["lines_returned"] == "1-5"
+
+
+@pytest.mark.asyncio
 async def test_no_line_range_returns_all_with_truncation_hint() -> None:
     """Without line_range and content > 20K → truncated + hint to use line_range."""
     p = TextParser()
@@ -843,6 +872,22 @@ async def test_no_line_range_returns_all_with_truncation_hint() -> None:
     out = await p.parse(body, mime="text/plain", options=ParseOptions())
     assert out.truncated is True
     assert "line_range" in out.metadata.get("hint", "")
+
+
+@pytest.mark.asyncio
+async def test_truncation_emits_next_line_to_read() -> None:
+    """When truncated, metadata.next_line_to_read tells agent where to resume."""
+    p = TextParser()
+    # Each line is ~20 chars so 1500 lines ~= 30k chars (will truncate ~= line 1000)
+    body = ("x" * 19 + "\n").join(f"" for _ in range(1500)).encode()
+    out = await p.parse(body, mime="text/plain", options=ParseOptions())
+    assert out.truncated is True
+    assert "next_line_to_read" in out.metadata
+    assert out.metadata["next_line_to_read"] > 1
+    # next_line_to_read should equal end-of-returned-range + 1
+    returned = out.metadata["lines_returned"]
+    end = int(returned.split("-")[1])
+    assert out.metadata["next_line_to_read"] == end + 1
 ```
 
 - [ ] **Step 2: Run, verify fail**
@@ -903,23 +948,34 @@ class TextParser:
 
         # Apply line_range slice (1-indexed inclusive); ignore page_range.
         start_idx, end_idx = self._parse_line_range(options.line_range, total_lines)
-        sliced = "".join(all_lines[start_idx:end_idx])
+        sliced_lines = all_lines[start_idx:end_idx]
+        sliced = "".join(sliced_lines)
 
         truncated = False
+        last_line_returned = end_idx  # 1-indexed end (inclusive)
         metadata: dict[str, object] = {
             "parser": "text",
             "total_lines": total_lines,
-            "lines_returned": f"{start_idx + 1}-{end_idx}",
         }
         if decode_fallback:
             metadata["decode_fallback"] = decode_fallback
+
         if len(sliced) > MAX_CONTENT_CHARS:
+            # Truncate by chars, then back-compute how many full lines fit
             sliced = sliced[:MAX_CONTENT_CHARS]
             truncated = True
+            # Count complete lines (those ending in \n) within the truncated text
+            lines_kept = sliced.count("\n")
+            # Edge case: if no newline in truncated text but we kept content, count as 1 partial line
+            if lines_kept == 0 and sliced:
+                lines_kept = 1
+            last_line_returned = start_idx + lines_kept   # 1-indexed last fully-included line
             metadata["truncated_at_char"] = MAX_CONTENT_CHARS
-            metadata["total_chars"] = sum(len(l) for l in all_lines)
-        if options.line_range is None and truncated:
-            metadata["hint"] = "use line_range to read later sections"
+            metadata["next_line_to_read"] = last_line_returned + 1
+            if options.line_range is None:
+                metadata["hint"] = "content truncated; use line_range to navigate"
+
+        metadata["lines_returned"] = f"{start_idx + 1}-{last_line_returned}"
 
         return TextOutput(
             path="<set-by-caller>",
@@ -932,23 +988,42 @@ class TextParser:
 
     @staticmethod
     def _parse_line_range(spec: str | None, total_lines: int) -> tuple[int, int]:
-        """Parse '2-4' or '3' into (start_index, end_index_exclusive). 1-indexed input.
+        """Parse line_range syntax → (start_index_0based, end_index_exclusive).
 
-        Defaults to (0, total_lines) if spec is None or invalid. End is clamped to total_lines.
+        Supported syntaxes (1-indexed input):
+          "42"       → line 42 only
+          "100-200"  → lines 100 through 200
+          "100-"     → from line 100 to end (sed-style)
+          "-50"      → last 50 lines (tail-style)
+
+        Returns (0, total_lines) on None or invalid input. End clamped to total_lines.
         """
         if not spec:
             return 0, total_lines
         try:
+            if spec.startswith("-"):
+                # "-50" → last N lines
+                n = int(spec[1:])
+                if n <= 0:
+                    return 0, total_lines
+                start = max(total_lines - n, 0)
+                return start, total_lines
+            if spec.endswith("-"):
+                # "100-" → from N to end
+                start = max(int(spec[:-1]), 1) - 1
+                start = min(start, total_lines)
+                return start, total_lines
             if "-" in spec:
+                # "100-200" → range
                 a, b = spec.split("-", 1)
-                start = max(int(a), 1) - 1   # 1-indexed → 0-indexed
+                start = max(int(a), 1) - 1
                 end = min(int(b), total_lines)
-            else:
-                n = max(int(spec), 1) - 1
-                start, end = n, min(n + 1, total_lines)
+                return start, max(end, start)
+            # "42" → single line
+            n = max(int(spec), 1) - 1
+            return n, min(n + 1, total_lines)
         except (ValueError, TypeError):
             return 0, total_lines
-        return start, end
 ```
 
 NOTE: `path` is set to placeholder; the registry's `dispatch` overwrites with the actual path before returning. (Alternative: pass `path` into `parse`. Stick with current Protocol signature; registry overwrites.)
@@ -956,13 +1031,13 @@ NOTE: `path` is set to placeholder; the registry's `dispatch` overwrites with th
 - [ ] **Step 4: Run tests, verify pass**
 
 Run: `cd backend && uv run pytest tests/parsers/test_text_parser.py -v`
-Expected: PASS (8 tests).
+Expected: PASS (11 tests).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add backend/cubebox/parsers/plugins/text.py backend/tests/parsers/test_text_parser.py
-git commit -m "feat(parsers): TextParser plugin with line_range slicing + 20K char truncation"
+git commit -m "feat(parsers): TextParser with full line_range syntax + next_line_to_read on truncation"
 ```
 
 ---
@@ -1017,11 +1092,12 @@ async def test_parses_simple_notebook() -> None:
 
 
 @pytest.mark.asyncio
-async def test_truncates_when_exceeds_20k() -> None:
+async def test_truncates_when_exceeds_20k_with_next_cell_index() -> None:
     nb = {
         "cells": [
             {"cell_type": "markdown", "source": "x" * 25_000},
             {"cell_type": "code", "source": "y", "outputs": []},
+            {"cell_type": "code", "source": "z", "outputs": []},
         ]
     }
     p = NotebookParser()
@@ -1030,8 +1106,11 @@ async def test_truncates_when_exceeds_20k() -> None:
         mime="application/x-ipynb+json",
         options=ParseOptions(),
     )
-    # truncation happens at the cell level; first big cell included, second omitted
-    assert out.metadata.get("truncated_cells", 0) >= 1
+    # First big cell included, second + third omitted
+    assert out.metadata["truncated_cells"] == 2
+    assert out.metadata["cells_returned"] == 1
+    assert out.metadata["next_cell_index"] == 2  # 1-indexed
+    assert out.metadata["total_cells"] == 3
 ```
 
 - [ ] **Step 2: Run, verify fail**
@@ -1111,9 +1190,11 @@ class NotebookParser:
         metadata: dict[str, Any] = {
             "parser": "notebook",
             "total_cells": len(all_cells),
+            "cells_returned": len(result_cells),
         }
         if truncated_cells > 0:
             metadata["truncated_cells"] = truncated_cells
+            metadata["next_cell_index"] = len(result_cells) + 1  # 1-indexed
 
         return NotebookOutput(
             path="<set-by-caller>",
@@ -1234,6 +1315,36 @@ async def test_sync_path_truncates_long_content() -> None:
     assert isinstance(out, TextOutput)
     assert out.truncated is True
     assert len(out.content) == 20_000
+    # No page markers in this fake response → hint instead of next_page_to_read
+    assert "hint" in out.metadata
+    assert "page_range" in out.metadata["hint"]
+
+
+@pytest.mark.asyncio
+async def test_sync_path_extracts_last_page_from_markers() -> None:
+    """When docling output contains <!-- page N --> markers, metadata exposes them."""
+    md = "intro\n<!-- page 1 -->\n" + "filler\n" * 1000 + "<!-- page 7 -->\nmore content\n" + "filler\n" * 3000 + "<!-- page 12 -->\nlate stuff"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"document": {"md_content": md}})
+
+    transport = httpx.MockTransport(handler)
+    p = DoclingParser(
+        base_url="http://docling",
+        api_key=None,
+        timeout_sync_seconds=30,
+        timeout_async_minutes=10,
+        async_threshold_mb=3,
+        poll_interval_seconds=2,
+        _transport=transport,
+    )
+    out = await p.parse(b"x", mime="application/pdf", options=ParseOptions())
+    assert isinstance(out, TextOutput)
+    assert out.truncated is True
+    # Last page marker found within the truncated content
+    assert "last_page_returned" in out.metadata
+    assert "next_page_to_read" in out.metadata
+    assert out.metadata["next_page_to_read"] == out.metadata["last_page_returned"] + 1
 ```
 
 - [ ] **Step 2: Add httpx to deps if missing**
@@ -1398,9 +1509,20 @@ class DoclingParser:
         total = len(md)
         metadata: dict[str, object] = {"parser": "docling", "total_chars": total}
         if total > MAX_CONTENT_CHARS:
-            md = md[:MAX_CONTENT_CHARS]
+            truncated_md = md[:MAX_CONTENT_CHARS]
             truncated = True
             metadata["truncated_at_char"] = MAX_CONTENT_CHARS
+
+            # Best-effort: try to extract last page number visible in truncated md.
+            # Docling can emit page markers like "<!-- page 5 -->" or h1/h2 with page meta.
+            # We try common patterns; if none match, the agent gets just truncated_at_char.
+            last_page = self._extract_last_page(truncated_md)
+            if last_page is not None:
+                metadata["last_page_returned"] = last_page
+                metadata["next_page_to_read"] = last_page + 1
+            else:
+                metadata["hint"] = "use page_range to read later sections"
+            md = truncated_md
 
         return TextOutput(
             path="<set-by-caller>",
@@ -1410,6 +1532,32 @@ class DoclingParser:
             truncated=truncated,
             metadata=metadata,
         )
+
+    @staticmethod
+    def _extract_last_page(md: str) -> int | None:
+        """Best-effort scan for the last page marker in docling markdown.
+
+        Patterns checked (last occurrence wins):
+          - HTML comments:  <!-- page N -->
+          - Heading line:   ## Page N
+          - PageBreak:      <!-- PageBreak: N -->
+
+        Returns None if no marker found (caller falls back to char-only truncation info).
+        """
+        import re
+        patterns = [
+            re.compile(r"<!--\s*page[:\s]+(\d+)\s*-->", re.IGNORECASE),
+            re.compile(r"<!--\s*PageBreak[:\s]+(\d+)\s*-->", re.IGNORECASE),
+            re.compile(r"^#+\s+Page\s+(\d+)\s*$", re.MULTILINE | re.IGNORECASE),
+        ]
+        last_page: int | None = None
+        for pat in patterns:
+            for m in pat.finditer(md):
+                try:
+                    last_page = int(m.group(1))
+                except (ValueError, IndexError):
+                    pass
+        return last_page
 ```
 
 - [ ] **Step 5: Run tests, verify pass**
@@ -2323,14 +2471,29 @@ RETURN FORMAT (discriminated by `kind`):
 
 PARAMETERS:
 - path (required)         — absolute sandbox path
-- page_range (optional)   — "1-5" or "3"; PDF/DOCX/PPTX only; ignored elsewhere
-- line_range (optional)   — "100-200" or "42"; text/code/log only; ignored elsewhere
+- page_range (optional)   — paginated documents only: PDF/DOCX/PPTX
+- line_range (optional)   — text/code/log files only
+
+RANGE SYNTAX (page_range and line_range share these 4 forms):
+  "42"      — single line/page (item 42)
+  "100-200" — range from 100 to 200 inclusive
+  "100-"    — from 100 to end of file (sed '100,$' style)
+  "-50"     — last 50 lines/pages (tail -50 style)
+
+HOW TO CONTINUE READING WHEN truncated=true:
+- text/code/log: read metadata.next_line_to_read and call
+  file_read(path, line_range=f"{N}-") to continue from there.
+- PDF/DOCX/PPTX (best-effort): read metadata.next_page_to_read
+  and call file_read(path, page_range=f"{N}-"). If the field
+  is absent (parser couldn't map char-offset back to page),
+  fall back to ranges you guess or ask the user.
+- notebook: metadata.next_cell_index is informational only —
+  v1 has no cell_range param. The first batch is what you get.
 
 LIMITS:
 - Files > 100 MB are refused with kind="unsupported".
-- Content longer than 20,000 characters is truncated (truncated=True).
-  Use `page_range` (PDF/DOCX/PPTX) or `line_range` (text/code/log)
-  to retrieve a specific segment.
+- Content longer than 20,000 characters is truncated. See
+  "HOW TO CONTINUE READING" above.
 - Large files (>3 MB) trigger async parsing; up to 10 minutes.
 """
 

--- a/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
+++ b/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
@@ -1988,6 +1988,115 @@ async def test_dispatch_wraps_parser_exceptions_as_error() -> None:
         sandbox=sandbox, path="/tmp/x.ipynb", options=ParseOptions(), conversation_id=None
     )
     assert isinstance(out, ErrorOutput)
+    # Parse-format error: not retryable (re-parsing same bytes won't help).
+    assert out.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_marks_transient_errors_retryable() -> None:
+    """httpx.TransportError / timeout → retryable=True so agents can retry."""
+    import httpx
+
+    class FlakyParser:
+        name = "flaky"
+        priority = 50
+        mime_types = ("application/pdf",)
+        extensions = ("pdf",)
+
+        async def parse(self, content, *, mime, options):
+            raise httpx.ConnectError("connection refused")
+
+    sandbox = MagicMock()
+    sandbox._download_one = AsyncMock(return_value=b"%PDF-1.4\n...")
+    reg = ParserRegistry()
+    reg._parsers = [FlakyParser()]  # type: ignore[list-item]
+    out = await reg.dispatch(
+        sandbox=sandbox, path="/tmp/x.pdf", options=ParseOptions(), conversation_id=None
+    )
+    assert isinstance(out, ErrorOutput)
+    assert out.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_does_not_cache_unsupported_so_retry_works() -> None:
+    """Unsupported result must NOT update dedup; user can install a plugin and retry."""
+    import fakeredis.aioredis
+    from cubebox.cache import set_redis
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    set_redis(fake)
+
+    sandbox = MagicMock()
+    sandbox._download_one = AsyncMock(return_value=b"\x00\x01binary")
+    reg = ParserRegistry()
+    reg._parsers = []  # no plugins → unsupported
+    conv = uuid4()
+
+    first = await reg.dispatch(
+        sandbox=sandbox, path="/tmp/x.bin",
+        options=ParseOptions(), conversation_id=conv,
+    )
+    assert isinstance(first, UnsupportedOutput)
+
+    # Install a plugin and retry — must NOT short-circuit as UnchangedOutput.
+    class BinParser:
+        name = "bin"
+        priority = 10
+        mime_types = ("application/octet-stream",)
+        extensions = ("bin",)
+
+        async def parse(self, content, *, mime, options):
+            return TextOutput(path="", content="parsed", line_count=1, truncated=False)
+
+    reg._parsers = [BinParser()]  # type: ignore[list-item]
+    second = await reg.dispatch(
+        sandbox=sandbox, path="/tmp/x.bin",
+        options=ParseOptions(), conversation_id=conv,
+    )
+    assert isinstance(second, TextOutput), "unsupported must not be cached"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_does_not_cache_error_so_retry_works() -> None:
+    """ErrorOutput must NOT update dedup; transient failures should be retryable end-to-end."""
+    import fakeredis.aioredis
+    import httpx
+    from cubebox.cache import set_redis
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    set_redis(fake)
+
+    call_count = 0
+
+    class RecoveringParser:
+        name = "recovering"
+        priority = 50
+        mime_types = ("application/pdf",)
+        extensions = ("pdf",)
+
+        async def parse(self, content, *, mime, options):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.ConnectError("transient outage")
+            return TextOutput(path="", content="ok", line_count=1, truncated=False)
+
+    sandbox = MagicMock()
+    sandbox._download_one = AsyncMock(return_value=b"%PDF-1.4\n...")
+    reg = ParserRegistry()
+    reg._parsers = [RecoveringParser()]  # type: ignore[list-item]
+    conv = uuid4()
+
+    first = await reg.dispatch(
+        sandbox=sandbox, path="/tmp/x.pdf",
+        options=ParseOptions(), conversation_id=conv,
+    )
+    assert isinstance(first, ErrorOutput)
+    assert first.retryable is True
+
+    second = await reg.dispatch(
+        sandbox=sandbox, path="/tmp/x.pdf",
+        options=ParseOptions(), conversation_id=conv,
+    )
+    assert isinstance(second, TextOutput), "error must not be cached"
 ```
 
 - [ ] **Step 2: Run, verify fail**
@@ -2014,11 +2123,14 @@ docling = "cubebox.parsers.plugins.docling:DoclingParser"
 
 from __future__ import annotations
 
+import asyncio
 import importlib.metadata
 import logging
 from pathlib import Path
 from typing import Any
 from uuid import UUID
+
+import httpx
 
 from cubebox.parsers import dedup
 from cubebox.parsers.mime import sniff_mime_async
@@ -2035,6 +2147,21 @@ logger = logging.getLogger(__name__)
 
 GROUP = "cubebox.parsers"
 MAX_FILE_BYTES = 100 * 1024 * 1024
+
+
+def _is_retryable_exception(exc: BaseException) -> bool:
+    """Classify parser exceptions: transient faults are retryable.
+
+    Agents should retry network/timeout errors; parse-format errors should not
+    be retried since the file content itself is the problem.
+    """
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError, ConnectionError)):
+        return True
+    if isinstance(exc, httpx.TransportError):  # covers ConnectError, ReadTimeout, etc.
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return 500 <= exc.response.status_code < 600
+    return False
 
 
 class ParserRegistry:
@@ -2118,16 +2245,18 @@ class ParserRegistry:
         # 3. MIME sniff
         mime = await sniff_mime_async(path, content)
 
-        # 4. dedup check (Redis-backed; key includes ParseOptions signature)
+        # 4. dedup check only (write is deferred until after a successful parse so
+        # transient failures are not cached as "already read").
+        digest: str | None = None
         if conversation_id is not None:
-            digest = await dedup.hash_bytes(content)
             try:
+                digest = await dedup.hash_bytes(content)
                 if await dedup.check(conversation_id, path, options, digest):
                     return UnchangedOutput(path=path)
-                await dedup.update(conversation_id, path, options, digest)
             except Exception as exc:
                 # Redis unreachable → fall through (cache miss treatment)
                 logger.warning("dedup cache unavailable, proceeding without: %s", exc)
+                digest = None
 
         # 5. resolve plugin
         ext = Path(path).suffix.lstrip(".").lower()
@@ -2136,6 +2265,7 @@ class ParserRegistry:
             # No plugin claims this MIME. CE doesn't maintain a hardcoded
             # REJECT list (see spec D22) — extensibility means future plugins
             # can claim ANY format. Return unsupported with format-aware hint.
+            # Do NOT update dedup: user may install a plugin and retry.
             return UnsupportedOutput(
                 path=path, mime=mime, size_bytes=size,
                 reason=f"no parser registered for mime={mime}",
@@ -2147,7 +2277,19 @@ class ParserRegistry:
             out = await parser.parse(content, mime=mime, options=options)
         except Exception as exc:
             logger.exception("parser %s failed on %s", type(parser).__name__, path)
-            return ErrorOutput(path=path, error=str(exc), retryable=False)
+            # Do NOT update dedup on failure — allow retry. Classify transient
+            # failures (network/timeout) as retryable so agents can recover.
+            return ErrorOutput(
+                path=path, error=str(exc), retryable=_is_retryable_exception(exc)
+            )
+
+        # 7. dedup update only after a successful parse result
+        if conversation_id is not None and digest is not None:
+            try:
+                await dedup.update(conversation_id, path, options, digest)
+            except Exception as exc:
+                # Non-fatal: result is already computed; we just lose dedup benefit.
+                logger.warning("dedup update failed, continuing: %s", exc)
 
         # Overwrite the placeholder path; preserve all other fields
         out_dict = out.model_dump()
@@ -2685,7 +2827,137 @@ git commit -m "feat(api): discover parser plugins at app startup; add docling-se
 
 ---
 
-### Task 15: Final integration + check
+### Task 15: E2E test — real docling parse end-to-end
+
+Per CLAUDE.md project rule "Focus on E2E tests" and spec D18: CI does **not** bundle docling-serve, but e2e exercises the real parse path against an externally hosted docling-serve. Mocks are forbidden here — if docling is unreachable the test must skip-with-warning, not fall back.
+
+**Files:**
+- Create: `backend/tests/e2e/test_file_read_docling_e2e.py`
+- Modify: `backend/tests/e2e/conftest.py` (add `docling_url` session fixture)
+
+- [ ] **Step 1: Add `docling_url` session fixture**
+
+Append to `backend/tests/e2e/conftest.py`:
+
+```python
+import os
+import httpx
+import pytest
+
+
+@pytest.fixture(scope="session")
+def docling_url() -> str:
+    """Return reachable DOCLING_URL or skip. Never mocks."""
+    url = os.environ.get("DOCLING_URL")
+    if not url:
+        pytest.skip("DOCLING_URL not set — external docling-serve required for e2e")
+    try:
+        resp = httpx.get(f"{url.rstrip('/')}/health", timeout=5)
+        resp.raise_for_status()
+    except Exception as exc:  # noqa: BLE001 — any probe failure → skip
+        pytest.skip(f"docling-serve at {url} unreachable: {exc}")
+    return url
+```
+
+- [ ] **Step 2: Write e2e that exercises the real parser**
+
+```python
+# backend/tests/e2e/test_file_read_docling_e2e.py
+"""E2E: agent calls file_read on a PDF → real docling-serve parses → markdown returns."""
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from cubebox.config import config
+from cubebox.parsers import ParseOptions, TextOutput, get_parser_registry
+
+FIXTURE = Path(__file__).parent / "fixtures" / "hello.pdf"  # small (<100 KB) fixture PDF
+
+
+@pytest.mark.asyncio
+@pytest.mark.e2e
+async def test_pdf_flows_through_real_docling(docling_url: str, monkeypatch) -> None:
+    """Read a small PDF via the real docling-serve endpoint; assert markdown + parser metadata."""
+    monkeypatch.setenv("CUBEBOX_PARSERS__DOCLING_SERVE__BASE_URL", docling_url)
+    config.reload()
+
+    from cubebox.parsers.registry import reset_parser_registry_for_tests
+    reset_parser_registry_for_tests()
+    reg = get_parser_registry()
+    await reg.discover()
+
+    class _LocalSandbox:
+        async def _download_one(self, path: str) -> bytes:
+            return FIXTURE.read_bytes()
+
+    out = await reg.dispatch(
+        sandbox=_LocalSandbox(),
+        path=str(FIXTURE),
+        options=ParseOptions(),
+        conversation_id=uuid4(),
+    )
+    assert isinstance(out, TextOutput), f"expected markdown text output, got {type(out).__name__}"
+    assert out.metadata.get("parser") == "docling"
+    assert len(out.content) > 0
+    assert "hello" in out.content.lower()  # fixture contains the word "hello"
+
+
+@pytest.mark.asyncio
+@pytest.mark.e2e
+async def test_unchanged_second_read_hits_dedup(docling_url: str, monkeypatch) -> None:
+    """Same conversation + same bytes + same ParseOptions → second read returns UnchangedOutput."""
+    from cubebox.parsers import UnchangedOutput
+
+    monkeypatch.setenv("CUBEBOX_PARSERS__DOCLING_SERVE__BASE_URL", docling_url)
+    config.reload()
+
+    from cubebox.parsers.registry import reset_parser_registry_for_tests
+    reset_parser_registry_for_tests()
+    reg = get_parser_registry()
+    await reg.discover()
+
+    class _LocalSandbox:
+        async def _download_one(self, path: str) -> bytes:
+            return FIXTURE.read_bytes()
+
+    sandbox = _LocalSandbox()
+    conv = uuid4()
+    first = await reg.dispatch(
+        sandbox=sandbox, path=str(FIXTURE),
+        options=ParseOptions(), conversation_id=conv,
+    )
+    assert isinstance(first, TextOutput)
+
+    second = await reg.dispatch(
+        sandbox=sandbox, path=str(FIXTURE),
+        options=ParseOptions(), conversation_id=conv,
+    )
+    assert isinstance(second, UnchangedOutput)
+```
+
+- [ ] **Step 3: Commit fixture + test**
+
+Add a small hand-crafted PDF at `backend/tests/e2e/fixtures/hello.pdf` (≤ 10 KB). Ensure it renders the literal word "hello" so the assertion above is robust.
+
+```bash
+git add backend/tests/e2e/test_file_read_docling_e2e.py backend/tests/e2e/conftest.py backend/tests/e2e/fixtures/hello.pdf
+git commit -m "test(parsers): e2e file_read against real docling-serve"
+```
+
+- [ ] **Step 4: Run e2e locally against docling**
+
+```bash
+DOCLING_URL=http://localhost:5001 cd backend && uv run pytest tests/e2e/test_file_read_docling_e2e.py -v
+```
+
+Expected: 2 passed. (If DOCLING_URL is unset the tests skip — that is intended in developer environments but **not** acceptable in CI where the secret must be configured.)
+
+---
+
+### Task 16: Final integration + check
 
 **Files:**
 - Run all tests + smoke
@@ -2696,7 +2968,7 @@ git commit -m "feat(api): discover parser plugins at app startup; add docling-se
 cd backend && uv run pytest tests/ -v
 ```
 
-Expected: ALL pass.
+Expected: ALL pass (docling e2e skips with warning if `DOCLING_URL` is absent; must pass when set).
 
 - [ ] **Step 2: Run lint + type-check**
 
@@ -2706,20 +2978,7 @@ cd backend && make check
 
 Expected: All green.
 
-- [ ] **Step 3: Manual smoke against real docling-serve (optional)**
-
-If you have docling-serve running locally:
-
-```bash
-docker run -d -p 5001:5001 quay.io/docling-project/docling-serve-cpu
-cd backend && uv run python main.py &
-sleep 5
-# Trigger an agent conversation that uses file_read on a small PDF
-kill %1
-docker stop $(docker ps -q --filter ancestor=quay.io/docling-project/docling-serve-cpu)
-```
-
-- [ ] **Step 4: Verify clean git status**
+- [ ] **Step 3: Verify clean git status**
 
 ```bash
 git status

--- a/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
+++ b/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
@@ -511,86 +511,97 @@ git commit -m "feat(parsers): MIME sniffing helpers (libmagic + filetype + ext f
 - Create: `backend/tests/parsers/test_dedup.py`
 - Modify: `backend/pyproject.toml` (add `redis>=5.0`)
 
-**Note on prior art**: cubebox CE backend currently has **no Redis Python client**, **no `cubebox.cache` module**, and **no `redis:` config section**. Redis is only present as a CI service (`.github/workflows/ci.yml` line 129); no application code uses it. This task introduces all three from scratch. Verify before starting:
+**Note on prior art**: cubebox already has Redis fully wired up (introduced by the recent streaming/resumable-runs feature):
+- `redis>=5.2.0` is a direct dep in `backend/pyproject.toml` ✓
+- `Redis.from_url(...)` is constructed in `backend/cubebox/api/app.py:48-77` lifespan
+- Stored in `_app.state.redis`; routes access via `raw_request.app.state.redis`
+- Config: `streaming.redis_url` and `streaming.redis_key_prefix` in `config.yaml:191-194`
+- `backend/cubebox/streams/run_events.py` is the primary consumer
+
+What's MISSING: a way for non-route code (like `dedup.py`, called from `Sandbox.file_read` deep in the parser dispatch) to reach the Redis client without dragging app context through. We add a tiny `cubebox.cache` module with `get_redis()` / `set_redis()` that the lifespan registers after constructing the client. Dedup imports `from cubebox.cache import get_redis`. Streaming code keeps using `app.state.redis` (don't touch).
+
+Verify before starting:
+```bash
+grep -E '"redis>=' backend/pyproject.toml          # should print redis dep
+grep -n 'streaming.redis_url' backend/config.yaml   # should print line ~192
+grep -n 'app.state.redis' backend/cubebox/api/app.py # should print lines around 64
+```
+
+- [ ] **Step 1: Add fakeredis dev dep (only new dep needed)**
 
 ```bash
-ls backend/cubebox/cache 2>/dev/null || echo "(absent — confirmed)"
-grep -rn "import redis\|from redis" backend/cubebox/ 2>/dev/null | grep -v ".venv" || echo "(no redis imports — confirmed)"
+cd backend && uv add --dev fakeredis
 ```
 
-Both should report absent. If either exists (a parallel feature landed), reuse rather than recreate.
+(`redis>=5.2.0` is already installed; do NOT re-add.)
 
-- [ ] **Step 1: Add deps**
-
-```bash
-cd backend && uv add 'redis>=5.0' && uv add --dev fakeredis
-```
-
-- [ ] **Step 2: Add `redis:` section to YAML configs**
-
-Append to `backend/config.yaml`, `backend/config.development.yaml`, `backend/config.test.yaml`:
-
-```yaml
-redis:
-  url: redis://localhost:6379/0
-```
-
-(Production deployments override via `CUBEBOX_REDIS__URL` env var, per dynaconf convention.)
-
-- [ ] **Step 3: Create cache module with async Redis client factory**
+- [ ] **Step 2: Create `cubebox.cache` thin accessor module**
 
 ```python
 # backend/cubebox/cache/__init__.py
-"""Async Redis client factory shared across cubebox subsystems.
+"""Module-level accessor for the shared async Redis client.
 
-Introduced in M6 (file_read dedup). Other future consumers (rate_limit
-storage backend, session cache, etc.) reuse the same singleton.
+cubebox already constructs a single async Redis client in app lifespan
+(see api/app.py for the streaming feature). This module exposes that
+SAME client to non-route code (parsers/dedup, future filebox indexer)
+that doesn't have a Request handle.
+
+Lifespan calls `set_redis(client)` after building the connection;
+consumers call `get_redis()`. No second connection is opened.
 """
-
-from cubebox.cache.redis import get_redis, reset_redis_for_tests
-
-__all__ = ["get_redis", "reset_redis_for_tests"]
-```
-
-```python
-# backend/cubebox/cache/redis.py
-"""Async Redis client factory (dynaconf-driven)."""
 
 from __future__ import annotations
 
 import redis.asyncio as redis_asyncio
 
-from cubebox.config import config
-
 _client: redis_asyncio.Redis | None = None
 
 
-def get_redis() -> redis_asyncio.Redis:
-    """Return a singleton async Redis client.
-
-    URL from config.redis.url; defaults to localhost:6379/0 (matches CI service).
-    """
+def set_redis(client: redis_asyncio.Redis) -> None:
+    """Register the shared async Redis client (called by app lifespan)."""
     global _client
+    _client = client
+
+
+def get_redis() -> redis_asyncio.Redis:
+    """Return the registered shared async Redis client.
+
+    Raises RuntimeError if called before lifespan registered the client.
+    """
     if _client is None:
-        _client = redis_asyncio.from_url(
-            config.get("redis.url", "redis://localhost:6379/0"),
-            decode_responses=True,
+        raise RuntimeError(
+            "cubebox.cache.get_redis() called before lifespan set the client. "
+            "Either app startup is incomplete or test fixture didn't inject one."
         )
     return _client
 
 
-def reset_redis_for_tests() -> None:
-    """Tests call this to force re-creation of the singleton."""
+def reset_for_tests() -> None:
+    """Tests call this between cases to clear the registered client."""
     global _client
     _client = None
+
+
+__all__ = ["get_redis", "reset_for_tests", "set_redis"]
 ```
 
-- [ ] **Step 3.5: Smoke test the cache factory imports cleanly**
+- [ ] **Step 3: Wire lifespan to register the shared client**
+
+In `backend/cubebox/api/app.py`, find the line `_app.state.redis = redis_client` (around line 64). Immediately after it, add:
+
+```python
+        from cubebox.cache import set_redis as _set_shared_redis
+        _set_shared_redis(redis_client)
+```
+
+This shares the SAME client object via the module-level accessor. No second connection, no separate config.
+
+- [ ] **Step 4: Smoke test**
 
 ```bash
-cd backend && uv run python -c "from cubebox.cache import get_redis; r = get_redis(); print(type(r).__name__)"
+cd backend && uv run python -c "from cubebox.cache import get_redis, set_redis; print('cache module imports OK')"
 ```
-Expected: prints `Redis` (the client is constructed lazily — doesn't actually connect).
+Expected: `cache module imports OK`.
 
 - [ ] **Step 4: Write failing tests for dedup.py (using fakeredis)**
 
@@ -606,12 +617,14 @@ from cubebox.parsers.schema import ParseOptions
 
 
 @pytest.fixture
-async def fake_redis(monkeypatch):
+async def fake_redis():
+    """Inject a fakeredis instance via cubebox.cache.set_redis."""
+    from cubebox.cache import reset_for_tests, set_redis
     fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    from cubebox import cache as cache_mod
-    monkeypatch.setattr(cache_mod, "get_redis", lambda: fake)
+    set_redis(fake)
     yield fake
     await fake.flushall()
+    reset_for_tests()
 
 
 @pytest.mark.asyncio
@@ -1833,12 +1846,12 @@ async def test_resolve_picks_notebook_for_ipynb() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dispatch_unsupported_when_no_plugin_matches(monkeypatch) -> None:
+async def test_dispatch_unsupported_when_no_plugin_matches() -> None:
     """No plugin claims video/* → returns unsupported with format-aware hint."""
     import fakeredis.aioredis
-    from cubebox import cache as cache_mod
+    from cubebox.cache import set_redis
     fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(cache_mod, "get_redis", lambda: fake)
+    set_redis(fake)
 
     sandbox = MagicMock()
     # Plausible MP4 magic so libmagic detects video/mp4
@@ -1859,12 +1872,12 @@ async def test_dispatch_unsupported_when_no_plugin_matches(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_dispatch_unsupported_archive_hint(monkeypatch) -> None:
+async def test_dispatch_unsupported_archive_hint() -> None:
     """Archives suggest extract-then-read flow."""
     import fakeredis.aioredis
-    from cubebox import cache as cache_mod
+    from cubebox.cache import set_redis
     fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(cache_mod, "get_redis", lambda: fake)
+    set_redis(fake)
 
     sandbox = MagicMock()
     sandbox._download_one = AsyncMock(
@@ -1898,12 +1911,12 @@ async def test_dispatch_rejects_oversize() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dispatch_returns_unchanged_on_second_read(monkeypatch) -> None:
+async def test_dispatch_returns_unchanged_on_second_read() -> None:
     """Same content + same options + same conv → second call returns UnchangedOutput."""
     import fakeredis.aioredis
-    from cubebox import cache as cache_mod
+    from cubebox.cache import set_redis
     fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(cache_mod, "get_redis", lambda: fake)
+    set_redis(fake)
 
     sandbox = MagicMock()
     sandbox._download_one = AsyncMock(return_value=b"hello world")
@@ -1923,12 +1936,12 @@ async def test_dispatch_returns_unchanged_on_second_read(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_dispatch_different_line_range_does_not_unchanged(monkeypatch) -> None:
+async def test_dispatch_different_line_range_does_not_unchanged() -> None:
     """Different line_range = different cache key = re-parses."""
     import fakeredis.aioredis
-    from cubebox import cache as cache_mod
+    from cubebox.cache import set_redis
     fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
-    monkeypatch.setattr(cache_mod, "get_redis", lambda: fake)
+    set_redis(fake)
 
     sandbox = MagicMock()
     body = "\n".join(f"line{i}" for i in range(1, 21)).encode()

--- a/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
+++ b/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
@@ -385,7 +385,7 @@ git commit -m "feat(parsers): FileParser runtime_checkable Protocol"
 
 ---
 
-### Task 4: MIME sniff + REJECT lists
+### Task 4: MIME sniff (no REJECT lists — see D22)
 
 **Files:**
 - Create: `backend/cubebox/parsers/mime.py`
@@ -404,40 +404,7 @@ NOTE: `python-magic` requires libmagic shared library on the system. macOS: `bre
 
 ```python
 # backend/tests/parsers/test_mime.py
-from cubebox.parsers.mime import (
-    REJECT_EXT,
-    REJECT_MIME,
-    is_rejected,
-    sniff_mime,
-)
-
-
-def test_reject_ext_includes_video() -> None:
-    assert "mp4" in REJECT_EXT
-    assert "mov" in REJECT_EXT
-
-
-def test_reject_ext_includes_audio() -> None:
-    assert "mp3" in REJECT_EXT
-    assert "wav" in REJECT_EXT
-
-
-def test_reject_ext_includes_archives() -> None:
-    assert "zip" in REJECT_EXT
-    assert "tar" in REJECT_EXT
-
-
-def test_reject_ext_includes_executables() -> None:
-    assert "exe" in REJECT_EXT
-    assert "so" in REJECT_EXT
-
-
-def test_is_rejected_true_for_video_ext() -> None:
-    assert is_rejected("/tmp/foo.mp4", "video/mp4") is True
-
-
-def test_is_rejected_false_for_text() -> None:
-    assert is_rejected("/tmp/foo.txt", "text/plain") is False
+from cubebox.parsers.mime import sniff_mime, sniff_mime_async
 
 
 def test_sniff_mime_detects_pdf_from_bytes() -> None:
@@ -451,7 +418,23 @@ def test_sniff_mime_falls_back_to_extension() -> None:
     mime = sniff_mime("/tmp/x.py", b"print('hi')\n")
     # libmagic detects as text/x-python or text/plain; either acceptable
     assert mime.startswith("text/") or mime == "application/x-python"
+
+
+def test_sniff_mime_returns_octet_stream_for_unknown() -> None:
+    # Random bytes with no recognizable magic and no useful extension
+    mime = sniff_mime("/tmp/x", b"\x01\x02\x03\x04random")
+    # libmagic may detect as text/plain or octet-stream; either is acceptable
+    assert mime in {"application/octet-stream", "text/plain"}
+
+
+@pytest.mark.asyncio
+async def test_sniff_mime_async_returns_same_result() -> None:
+    pdf_magic = b"%PDF-1.4\nstuff"
+    mime = await sniff_mime_async("/tmp/a.pdf", pdf_magic)
+    assert mime == "application/pdf"
 ```
+
+(Add `import pytest` to the top of the file.)
 
 - [ ] **Step 3: Run, verify fail**
 
@@ -462,37 +445,20 @@ Expected: FAIL.
 
 ```python
 # backend/cubebox/parsers/mime.py
-"""MIME sniffing + REJECT lists for file_read pre-screening."""
+"""MIME sniffing helpers for file_read.
+
+Note: there is intentionally NO hardcoded REJECT list. "Unsupported"
+status is determined by whether any registered FileParser plugin claims
+the MIME type. See spec D22 for rationale.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import mimetypes
-from pathlib import Path
 
 import filetype
 import magic
-
-REJECT_EXT: set[str] = {
-    # video
-    "mp4", "mov", "mkv", "webm", "avi", "flv", "wmv", "m4v",
-    # audio
-    "mp3", "wav", "m4a", "ogg", "flac", "opus", "aac", "wma",
-    # binary / executable
-    "exe", "so", "dll", "dylib", "o", "a", "bin", "com",
-    # archive
-    "zip", "tar", "gz", "bz2", "rar", "7z", "tgz", "xz", "zst",
-}
-
-REJECT_MIME: set[str] = {
-    "video/mp4", "video/quicktime", "video/x-matroska", "video/webm",
-    "video/x-msvideo", "video/x-flv", "video/x-ms-wmv",
-    "audio/mpeg", "audio/wav", "audio/x-m4a", "audio/ogg", "audio/flac",
-    "application/x-executable", "application/x-shared-library",
-    "application/zip", "application/x-tar", "application/gzip",
-    "application/x-bzip2", "application/x-rar-compressed", "application/x-7z-compressed",
-    "application/x-xz", "application/zstd",
-}
 
 
 def sniff_mime(path: str, content: bytes) -> str:
@@ -520,40 +486,18 @@ def sniff_mime(path: str, content: bytes) -> str:
 
 async def sniff_mime_async(path: str, content: bytes) -> str:
     return await asyncio.to_thread(sniff_mime, path, content)
-
-
-def is_rejected(path: str, mime: str) -> bool:
-    ext = Path(path).suffix.lstrip(".").lower()
-    return ext in REJECT_EXT or mime in REJECT_MIME
-
-
-def reject_reason(path: str, mime: str) -> tuple[str, str | None]:
-    """Return (reason, hint) for a rejected file."""
-    ext = Path(path).suffix.lstrip(".").lower()
-    if ext in {"mp4", "mov", "mkv", "webm", "avi", "flv", "wmv", "m4v"} or mime.startswith("video/"):
-        return ("video file not supported", "video content cannot be read as text")
-    if ext in {"mp3", "wav", "m4a", "ogg", "flac", "opus", "aac", "wma"} or mime.startswith("audio/"):
-        return ("audio file not supported", "audio content cannot be read as text")
-    if ext in {"exe", "so", "dll", "dylib", "o", "a", "bin", "com"}:
-        return ("binary executable not supported", "use shell tools to inspect metadata")
-    if ext in {"zip", "tar", "gz", "bz2", "rar", "7z", "tgz", "xz", "zst"}:
-        return (
-            "archive file not supported",
-            "extract first with execute(\"unzip <file>\") then file_read on contents",
-        )
-    return ("file type not supported", None)
 ```
 
 - [ ] **Step 5: Run tests, verify pass**
 
 Run: `cd backend && uv run pytest tests/parsers/test_mime.py -v`
-Expected: PASS (8 tests). If a test fails because libmagic isn't installed, install it on the host.
+Expected: PASS (4 tests). If a test fails because libmagic isn't installed, install it on the host.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 git add backend/cubebox/parsers/mime.py backend/tests/parsers/test_mime.py backend/pyproject.toml backend/uv.lock
-git commit -m "feat(parsers): MIME sniffing via libmagic + REJECT lists for unsupported types"
+git commit -m "feat(parsers): MIME sniffing helpers (libmagic + filetype + ext fallback)"
 ```
 
 ---
@@ -1724,19 +1668,52 @@ async def test_resolve_picks_notebook_for_ipynb() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dispatch_rejects_video() -> None:
+async def test_dispatch_unsupported_when_no_plugin_matches(monkeypatch) -> None:
+    """No plugin claims video/* → returns unsupported with format-aware hint."""
+    import fakeredis.aioredis
+    from cubebox import cache as cache_mod
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(cache_mod, "get_redis", lambda: fake)
+
     sandbox = MagicMock()
-    sandbox._download_one = AsyncMock(return_value=b"\x00" * 100)
+    # Plausible MP4 magic so libmagic detects video/mp4
+    sandbox._download_one = AsyncMock(
+        return_value=b"\x00\x00\x00\x20ftypisom" + b"\x00" * 200
+    )
     reg = ParserRegistry()
     await reg.discover()
     out = await reg.dispatch(
-        sandbox=sandbox,
-        path="/tmp/movie.mp4",
-        options=ParseOptions(),
-        conversation_id=uuid4(),
+        sandbox=sandbox, path="/tmp/movie.mp4",
+        options=ParseOptions(), conversation_id=uuid4(),
     )
     assert isinstance(out, UnsupportedOutput)
-    assert "video" in out.reason
+    assert "no parser registered" in out.reason
+    # Hint mentions video transcription
+    assert out.hint is not None
+    assert "video" in out.hint.lower()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unsupported_archive_hint(monkeypatch) -> None:
+    """Archives suggest extract-then-read flow."""
+    import fakeredis.aioredis
+    from cubebox import cache as cache_mod
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(cache_mod, "get_redis", lambda: fake)
+
+    sandbox = MagicMock()
+    sandbox._download_one = AsyncMock(
+        return_value=b"PK\x03\x04" + b"\x00" * 200  # ZIP magic
+    )
+    reg = ParserRegistry()
+    await reg.discover()
+    out = await reg.dispatch(
+        sandbox=sandbox, path="/tmp/data.zip",
+        options=ParseOptions(), conversation_id=uuid4(),
+    )
+    assert isinstance(out, UnsupportedOutput)
+    assert out.hint is not None
+    assert "extract" in out.hint.lower() or "unzip" in out.hint.lower()
 
 
 @pytest.mark.asyncio
@@ -1866,11 +1843,7 @@ from typing import Any
 from uuid import UUID
 
 from cubebox.parsers import dedup
-from cubebox.parsers.mime import (
-    is_rejected,
-    reject_reason,
-    sniff_mime_async,
-)
+from cubebox.parsers.mime import sniff_mime_async
 from cubebox.parsers.protocols import FileParser
 from cubebox.parsers.schema import (
     ErrorOutput,
@@ -1956,25 +1929,18 @@ class ParserRegistry:
             content = files[0][1]
         size = len(content)
 
-        # 2. size precheck
+        # 2. size precheck (backend resource protection, format-agnostic)
         if size > MAX_FILE_BYTES:
             return UnsupportedOutput(
                 path=path, mime="application/octet-stream", size_bytes=size,
                 reason="file too large (100MB limit)",
-                hint="try reading specific pages with page_range",
+                hint="try reading specific pages with page_range or specific lines with line_range",
             )
 
         # 3. MIME sniff
         mime = await sniff_mime_async(path, content)
 
-        # 4. REJECT list
-        if is_rejected(path, mime):
-            reason, hint = reject_reason(path, mime)
-            return UnsupportedOutput(
-                path=path, mime=mime, size_bytes=size, reason=reason, hint=hint,
-            )
-
-        # 5. dedup check (Redis-backed; key includes ParseOptions signature)
+        # 4. dedup check (Redis-backed; key includes ParseOptions signature)
         if conversation_id is not None:
             digest = await dedup.hash_bytes(content)
             try:
@@ -1985,14 +1951,20 @@ class ParserRegistry:
                 # Redis unreachable → fall through (cache miss treatment)
                 logger.warning("dedup cache unavailable, proceeding without: %s", exc)
 
-        # 6. resolve plugin & parse
+        # 5. resolve plugin
         ext = Path(path).suffix.lstrip(".").lower()
         parser = self.resolve(mime=mime, ext=ext)
         if parser is None:
+            # No plugin claims this MIME. CE doesn't maintain a hardcoded
+            # REJECT list (see spec D22) — extensibility means future plugins
+            # can claim ANY format. Return unsupported with format-aware hint.
             return UnsupportedOutput(
                 path=path, mime=mime, size_bytes=size,
-                reason="no parser matched",
+                reason=f"no parser registered for mime={mime}",
+                hint=self._unsupported_hint(mime, ext),
             )
+
+        # 6. parse
         try:
             out = await parser.parse(content, mime=mime, options=options)
         except Exception as exc:
@@ -2003,6 +1975,25 @@ class ParserRegistry:
         out_dict = out.model_dump()
         out_dict["path"] = path
         return type(out).model_validate(out_dict)
+
+    @staticmethod
+    def _unsupported_hint(mime: str, ext: str) -> str | None:
+        """Format-family-aware hint for the no-parser-matched case."""
+        if mime.startswith("video/"):
+            return "video transcription requires a parser plugin (none installed)"
+        if mime.startswith("audio/"):
+            return "audio transcription requires a parser plugin (none installed)"
+        archive_mimes = {
+            "application/zip", "application/x-tar", "application/gzip",
+            "application/x-bzip2", "application/x-7z-compressed",
+            "application/x-rar-compressed", "application/x-xz",
+        }
+        archive_exts = {"zip", "tar", "gz", "bz2", "rar", "7z", "tgz", "xz"}
+        if mime in archive_mimes or ext in archive_exts:
+            return 'extract first via execute("unzip <file>") then file_read on contents'
+        if ext in {"exe", "so", "dll", "dylib", "bin"}:
+            return "binary executable; install a metadata parser plugin if needed"
+        return None
 
 
 _registry: ParserRegistry | None = None
@@ -2305,15 +2296,23 @@ USE THIS TOOL FOR:
 - Notebooks (.ipynb) — returns structured cells.
 - Images (.png .jpg .webp .tiff) — returns OCR'd text content.
 
-DO NOT USE THIS TOOL FOR:
-- Video / Audio — returns kind="unsupported".
-- Executables / Binaries — returns kind="unsupported".
-- Archives (.zip .tar .gz) — extract first via execute("unzip ..."),
-  then file_read on extracted files.
-- Remote URLs — file_read only reads sandbox paths.
-- Grep / search — execute("grep -n 'pattern' <file>") is more direct.
+WHEN OTHER TOOLS ARE BETTER:
+- Remote URLs — file_read only reads sandbox paths. Use a web-fetch
+  tool for URLs.
+- Grep / search — for pattern-find, execute("grep -n 'pattern' <file>")
+  is more direct than file_read + scan.
 - Tiny known-offset peeks — execute("sed -n '42p' <file>") skips
   parser overhead.
+
+HOW UNSUPPORTED FORMATS BEHAVE:
+- The tool returns kind="unsupported" with a `hint` when no parser
+  plugin handles the file's MIME type. Common cases — video, audio,
+  archives, binary executables — fall here in the default deployment.
+- The `hint` field tells you what alternative to try (e.g., for
+  archives: extract first via execute("unzip <file>") then file_read
+  on extracted files).
+- If you see kind="unsupported", surface the hint to the user; don't
+  retry file_read on the same path.
 
 RETURN FORMAT (discriminated by `kind`):
 - "text"        : {content, mime, size_bytes, truncated, metadata}

--- a/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
+++ b/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
@@ -19,16 +19,20 @@
 ```
 backend/cubebox/parsers/
 ├─ __init__.py                  # Re-exports
-├─ schema.py                    # FileReadOutput union + ParseOptions
+├─ schema.py                    # FileReadOutput union + ParseOptions (page_range + line_range)
 ├─ protocols.py                 # FileParser Protocol
 ├─ mime.py                      # libmagic + extension fallback + REJECT lists
-├─ dedup.py                     # asyncio.to_thread hash cache
+├─ dedup.py                     # Redis-backed hash cache; key includes ParseOptions sig
 ├─ registry.py                  # ParserRegistry (discover + dispatch)
 └─ plugins/
    ├─ __init__.py
-   ├─ text.py                   # TextParser (UTF-8 decode + truncation)
+   ├─ text.py                   # TextParser (UTF-8 + line_range slicing + truncation)
    ├─ notebook.py               # NotebookParser (Jupyter cells)
    └─ docling.py                # DoclingParser (HTTP to docling-serve)
+
+backend/cubebox/cache/
+├─ __init__.py                  # exposes get_redis()
+└─ redis.py                     # async Redis client factory (skip if exists)
 
 backend/tests/parsers/
 ├─ __init__.py
@@ -48,12 +52,12 @@ backend/tests/parsers/
 ```
 backend/cubebox/sandbox/base.py            # Add Sandbox.file_read non-abstract method
 backend/cubebox/middleware/sandbox.py      # Register file_read tool with description
-backend/cubebox/config.py                  # Add parsers.docling_serve schema
-backend/config.yaml                        # Add parsers: section
-backend/config.development.yaml            # Add parsers: section
-backend/config.test.yaml                   # Add parsers: section
-backend/pyproject.toml                     # Deps + entry_points group
-docker-compose.yml                         # Add docling-serve service
+backend/cubebox/config.py                  # Add parsers.docling_serve + redis.url schemas
+backend/config.yaml                        # Add parsers: + redis: sections
+backend/config.development.yaml            # Add parsers: + redis: sections
+backend/config.test.yaml                   # Add parsers: + redis: sections
+backend/pyproject.toml                     # Deps (redis>=5.0, python-magic, filetype, fakeredis dev) + entry_points group
+docker-compose.yml                         # Add docling-serve service (redis already present)
 ```
 
 ---
@@ -185,7 +189,21 @@ def test_discriminated_union_rejects_unknown_kind() -> None:
 def test_parse_options_default_empty() -> None:
     p = ParseOptions()
     assert p.page_range is None
+    assert p.line_range is None
     assert p.language_hint is None
+
+
+def test_parse_options_accepts_line_range() -> None:
+    p = ParseOptions(line_range="100-200")
+    assert p.line_range == "100-200"
+    assert p.page_range is None
+
+
+def test_parse_options_accepts_both_ranges() -> None:
+    """Both range params can coexist; each plugin honors only what it cares about."""
+    p = ParseOptions(page_range="1-5", line_range="100-200")
+    assert p.page_range == "1-5"
+    assert p.line_range == "100-200"
 ```
 
 - [ ] **Step 2: Run, verify fail**
@@ -257,7 +275,8 @@ FileReadOutput = Annotated[
 
 
 class ParseOptions(BaseModel):
-    page_range: str | None = None  # "1-5" or "3"
+    page_range: str | None = None  # PDF/DOCX/PPTX 用；"1-5" or "3"
+    line_range: str | None = None  # text/code/log 用；"100-200" or "42"
     language_hint: str | None = None
 ```
 
@@ -539,101 +558,196 @@ git commit -m "feat(parsers): MIME sniffing via libmagic + REJECT lists for unsu
 
 ---
 
-### Task 5: Async hash dedup cache
+### Task 5: Redis-backed dedup cache + async client setup
 
 **Files:**
+- Create: `backend/cubebox/cache/__init__.py`
+- Create: `backend/cubebox/cache/redis.py` (skip if `cubebox.cache` already exists; reuse existing client)
 - Create: `backend/cubebox/parsers/dedup.py`
 - Create: `backend/tests/parsers/test_dedup.py`
+- Modify: `backend/pyproject.toml` (add `redis>=5.0`)
 
-- [ ] **Step 1: Write failing tests**
+- [ ] **Step 1: Add redis dep**
+
+```bash
+cd backend && uv add 'redis>=5.0'
+```
+
+- [ ] **Step 2: Check whether `cubebox.cache` already exists**
+
+```bash
+ls backend/cubebox/cache 2>/dev/null && echo "exists; reuse get_redis from there" || echo "create new"
+```
+
+If exists, **skip Step 3** and just use existing `get_redis()`. Otherwise proceed:
+
+- [ ] **Step 3: Create cache module with async Redis client factory**
+
+```python
+# backend/cubebox/cache/__init__.py
+"""Async Redis client factory shared across cubebox subsystems."""
+
+from cubebox.cache.redis import get_redis, reset_redis_for_tests
+
+__all__ = ["get_redis", "reset_redis_for_tests"]
+```
+
+```python
+# backend/cubebox/cache/redis.py
+"""Async Redis client factory."""
+
+from __future__ import annotations
+
+import redis.asyncio as redis_asyncio
+
+from cubebox.config import config
+
+_client: redis_asyncio.Redis | None = None
+
+
+def get_redis() -> redis_asyncio.Redis:
+    """Return a singleton async Redis client.
+
+    Connection params from config; default localhost:6379 (matches CI service).
+    """
+    global _client
+    if _client is None:
+        _client = redis_asyncio.from_url(
+            config.get("redis.url", "redis://localhost:6379/0"),
+            decode_responses=True,
+        )
+    return _client
+
+
+def reset_redis_for_tests() -> None:
+    """Tests call this to force re-creation of the singleton."""
+    global _client
+    _client = None
+```
+
+Add `redis: { url: redis://localhost:6379/0 }` to `config.yaml`, `config.development.yaml`, `config.test.yaml` if not already present.
+
+- [ ] **Step 4: Write failing tests for dedup.py (using fakeredis for unit tests)**
+
+```bash
+cd backend && uv add --dev fakeredis
+```
 
 ```python
 # backend/tests/parsers/test_dedup.py
 from uuid import uuid4
 
+import fakeredis.aioredis
 import pytest
 
-from cubebox.parsers.dedup import (
-    check,
-    forget_conversation,
-    hash_bytes,
-    update,
-    _file_state,
-)
+from cubebox.parsers.dedup import check, hash_bytes, update
+from cubebox.parsers.schema import ParseOptions
 
 
-@pytest.fixture(autouse=True)
-def clear_state():
-    _file_state.clear()
-    yield
-    _file_state.clear()
+@pytest.fixture
+async def fake_redis(monkeypatch):
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    from cubebox import cache as cache_mod
+    monkeypatch.setattr(cache_mod, "get_redis", lambda: fake)
+    yield fake
+    await fake.flushall()
 
 
 @pytest.mark.asyncio
 async def test_hash_bytes_returns_sha256_hex() -> None:
     digest = await hash_bytes(b"hello")
-    # SHA-256 of "hello" = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
     assert digest == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
 
 
-def test_check_returns_false_when_empty() -> None:
+@pytest.mark.asyncio
+async def test_check_returns_false_when_empty(fake_redis) -> None:
     conv = uuid4()
-    assert check(conv, "/p", "abc") is False
+    assert await check(conv, "/p", ParseOptions(), "abc") is False
 
 
-def test_update_then_check_matches() -> None:
+@pytest.mark.asyncio
+async def test_update_then_check_matches(fake_redis) -> None:
     conv = uuid4()
-    update(conv, "/p", "abc")
-    assert check(conv, "/p", "abc") is True
-    assert check(conv, "/p", "different") is False
+    await update(conv, "/p", ParseOptions(), "abc")
+    assert await check(conv, "/p", ParseOptions(), "abc") is True
+    assert await check(conv, "/p", ParseOptions(), "different") is False
 
 
-def test_check_isolates_per_conversation() -> None:
+@pytest.mark.asyncio
+async def test_check_isolates_per_conversation(fake_redis) -> None:
     a, b = uuid4(), uuid4()
-    update(a, "/p", "abc")
-    assert check(b, "/p", "abc") is False
+    await update(a, "/p", ParseOptions(), "abc")
+    assert await check(b, "/p", ParseOptions(), "abc") is False
 
 
-def test_forget_conversation_clears_only_that_conv() -> None:
-    a, b = uuid4(), uuid4()
-    update(a, "/p", "abc")
-    update(b, "/p", "abc")
-    forget_conversation(a)
-    assert check(a, "/p", "abc") is False
-    assert check(b, "/p", "abc") is True
+@pytest.mark.asyncio
+async def test_check_isolates_per_page_range(fake_redis) -> None:
+    """Different page_range = different cache slot."""
+    conv = uuid4()
+    await update(conv, "/p", ParseOptions(page_range="1-5"), "abc")
+    assert await check(conv, "/p", ParseOptions(page_range="6-10"), "abc") is False
+    assert await check(conv, "/p", ParseOptions(page_range="1-5"), "abc") is True
+
+
+@pytest.mark.asyncio
+async def test_check_isolates_per_line_range(fake_redis) -> None:
+    """Different line_range = different cache slot."""
+    conv = uuid4()
+    await update(conv, "/p", ParseOptions(line_range="1-100"), "abc")
+    assert await check(conv, "/p", ParseOptions(line_range="200-300"), "abc") is False
+
+
+@pytest.mark.asyncio
+async def test_ttl_set_on_update(fake_redis) -> None:
+    """Update sets TTL so cache eventually expires."""
+    conv = uuid4()
+    await update(conv, "/p", ParseOptions(), "abc")
+    # fakeredis exposes ttl
+    keys = await fake_redis.keys("parsers:dedup:v1:*")
+    assert len(keys) == 1
+    ttl = await fake_redis.ttl(keys[0])
+    assert ttl > 0  # TTL is set
 
 
 @pytest.mark.asyncio
 async def test_hash_bytes_offloads_to_thread() -> None:
-    """Verifies the call returns awaitable (i.e. async-safe for large inputs)."""
+    """Verifies async-safe for large inputs."""
     big = b"x" * (10 * 1024 * 1024)  # 10 MB
     digest = await hash_bytes(big)
     assert len(digest) == 64
 ```
 
-- [ ] **Step 2: Run, verify fail**
+- [ ] **Step 5: Run, verify fail**
 
 Run: `cd backend && uv run pytest tests/parsers/test_dedup.py -v`
 Expected: FAIL with ImportError.
 
-- [ ] **Step 3: Implement dedup.py**
+- [ ] **Step 6: Implement dedup.py**
 
 ```python
 # backend/cubebox/parsers/dedup.py
-"""Conversation-scoped SHA-256 file_state dedup cache.
+"""Redis-backed conversation-scoped SHA-256 file_state dedup cache.
 
-v1: in-process dict. SaaS multi-replica needs session-sticky routing OR
-swap to Redis-backed cache (TTL = conversation lifetime).
+Cache key: (conversation_id, path, options-signature). The options-signature
+includes page_range + line_range so different range-slices land in different
+cache slots and don't incorrectly return UnchangedOutput.
+
+TTL: 6 hours of inactivity → auto-expire (Redis-managed; conversation has
+no explicit "end" event in cubebox).
 """
 
 from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 from uuid import UUID
 
-# Keyed by (conversation_id, path); value = SHA-256 hex digest.
-_file_state: dict[tuple[UUID, str], str] = {}
+from cubebox.cache import get_redis
+from cubebox.parsers.schema import ParseOptions
+
+DEDUP_TTL_SECONDS = 6 * 3600
+KEY_PREFIX = "parsers:dedup:v1:"
 
 
 async def hash_bytes(data: bytes) -> str:
@@ -641,32 +755,56 @@ async def hash_bytes(data: bytes) -> str:
     return await asyncio.to_thread(lambda: hashlib.sha256(data).hexdigest())
 
 
-def check(conversation_id: UUID, path: str, digest: str) -> bool:
-    """True if digest matches cached value (→ caller emits UnchangedOutput)."""
-    return _file_state.get((conversation_id, path)) == digest
+def _options_signature(options: ParseOptions) -> str:
+    """JSON-serialize range params (sorted) so equivalent options → same key."""
+    return json.dumps(
+        {"page_range": options.page_range, "line_range": options.line_range},
+        sort_keys=True,
+    )
 
 
-def update(conversation_id: UUID, path: str, digest: str) -> None:
-    _file_state[(conversation_id, path)] = digest
+def _key(conversation_id: UUID, path: str, options: ParseOptions) -> str:
+    return f"{KEY_PREFIX}{conversation_id}:{path}:{_options_signature(options)}"
 
 
-def forget_conversation(conversation_id: UUID) -> None:
-    """Drop all keys for the given conversation. Hook from ConversationManager.close."""
-    keys = [k for k in _file_state if k[0] == conversation_id]
-    for k in keys:
-        _file_state.pop(k, None)
+async def check(
+    conversation_id: UUID,
+    path: str,
+    options: ParseOptions,
+    digest: str,
+) -> bool:
+    """True if digest matches Redis-cached value (→ caller emits UnchangedOutput)."""
+    redis = get_redis()
+    cached = await redis.get(_key(conversation_id, path, options))
+    if cached is None:
+        return False
+    return cached == digest if isinstance(cached, str) else cached == digest.encode()
+
+
+async def update(
+    conversation_id: UUID,
+    path: str,
+    options: ParseOptions,
+    digest: str,
+) -> None:
+    redis = get_redis()
+    await redis.set(
+        _key(conversation_id, path, options),
+        digest,
+        ex=DEDUP_TTL_SECONDS,
+    )
 ```
 
-- [ ] **Step 4: Run tests, verify pass**
+- [ ] **Step 7: Run tests, verify pass**
 
 Run: `cd backend && uv run pytest tests/parsers/test_dedup.py -v`
-Expected: PASS (6 tests).
+Expected: PASS (8 tests).
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
-git add backend/cubebox/parsers/dedup.py backend/tests/parsers/test_dedup.py
-git commit -m "feat(parsers): async SHA-256 file_state dedup cache (conversation-scoped)"
+git add backend/cubebox/cache/ backend/cubebox/parsers/dedup.py backend/tests/parsers/test_dedup.py backend/pyproject.toml backend/uv.lock backend/config*.yaml
+git commit -m "feat(parsers): Redis-backed dedup cache with ParseOptions signature key"
 ```
 
 ---
@@ -721,6 +859,46 @@ async def test_falls_back_to_latin1_on_decode_error() -> None:
     out = await p.parse(body, mime="text/plain", options=ParseOptions())
     assert isinstance(out, TextOutput)
     assert out.metadata.get("decode_fallback") == "latin-1"
+
+
+@pytest.mark.asyncio
+async def test_line_range_returns_specific_lines() -> None:
+    """line_range='2-4' returns lines 2 through 4 (1-indexed, inclusive)."""
+    p = TextParser()
+    body = "\n".join(f"line{i}" for i in range(1, 11)).encode()
+    out = await p.parse(body, mime="text/plain", options=ParseOptions(line_range="2-4"))
+    assert out.content == "line2\nline3\nline4"
+    assert out.metadata["lines_returned"] == "2-4"
+    assert out.metadata["total_lines"] == 10
+
+
+@pytest.mark.asyncio
+async def test_line_range_single_line() -> None:
+    p = TextParser()
+    body = "\n".join(f"line{i}" for i in range(1, 6)).encode()
+    out = await p.parse(body, mime="text/plain", options=ParseOptions(line_range="3"))
+    assert out.content == "line3"
+    assert out.metadata["lines_returned"] == "3-3"
+
+
+@pytest.mark.asyncio
+async def test_line_range_clamps_to_file_length() -> None:
+    """Out-of-range end is clamped silently."""
+    p = TextParser()
+    body = "\n".join(f"line{i}" for i in range(1, 6)).encode()
+    out = await p.parse(body, mime="text/plain", options=ParseOptions(line_range="3-100"))
+    assert out.content == "line3\nline4\nline5"
+    assert out.metadata["lines_returned"] == "3-5"
+
+
+@pytest.mark.asyncio
+async def test_no_line_range_returns_all_with_truncation_hint() -> None:
+    """Without line_range and content > 20K → truncated + hint to use line_range."""
+    p = TextParser()
+    body = ("line\n" * 5000).encode()  # 25k chars total
+    out = await p.parse(body, mime="text/plain", options=ParseOptions())
+    assert out.truncated is True
+    assert "line_range" in out.metadata.get("hint", "")
 ```
 
 - [ ] **Step 2: Run, verify fail**
@@ -775,24 +953,58 @@ class TextParser:
             text = content.decode("latin-1", errors="replace")
             decode_fallback = "latin-1"
 
+        # Split into lines preserving line endings
+        all_lines = text.splitlines(keepends=True)
+        total_lines = len(all_lines)
+
+        # Apply line_range slice (1-indexed inclusive); ignore page_range.
+        start_idx, end_idx = self._parse_line_range(options.line_range, total_lines)
+        sliced = "".join(all_lines[start_idx:end_idx])
+
         truncated = False
-        total_chars = len(text)
-        metadata: dict[str, object] = {"parser": "text", "total_chars": total_chars}
+        metadata: dict[str, object] = {
+            "parser": "text",
+            "total_lines": total_lines,
+            "lines_returned": f"{start_idx + 1}-{end_idx}",
+        }
         if decode_fallback:
             metadata["decode_fallback"] = decode_fallback
-        if len(text) > MAX_CONTENT_CHARS:
-            text = text[:MAX_CONTENT_CHARS]
+        if len(sliced) > MAX_CONTENT_CHARS:
+            sliced = sliced[:MAX_CONTENT_CHARS]
             truncated = True
             metadata["truncated_at_char"] = MAX_CONTENT_CHARS
+            metadata["total_chars"] = sum(len(l) for l in all_lines)
+        if options.line_range is None and truncated:
+            metadata["hint"] = "use line_range to read later sections"
 
         return TextOutput(
             path="<set-by-caller>",
             mime=mime,
-            content=text,
+            content=sliced,
             size_bytes=size,
             truncated=truncated,
             metadata=metadata,
         )
+
+    @staticmethod
+    def _parse_line_range(spec: str | None, total_lines: int) -> tuple[int, int]:
+        """Parse '2-4' or '3' into (start_index, end_index_exclusive). 1-indexed input.
+
+        Defaults to (0, total_lines) if spec is None or invalid. End is clamped to total_lines.
+        """
+        if not spec:
+            return 0, total_lines
+        try:
+            if "-" in spec:
+                a, b = spec.split("-", 1)
+                start = max(int(a), 1) - 1   # 1-indexed → 0-indexed
+                end = min(int(b), total_lines)
+            else:
+                n = max(int(spec), 1) - 1
+                start, end = n, min(n + 1, total_lines)
+        except (ValueError, TypeError):
+            return 0, total_lines
+        return start, end
 ```
 
 NOTE: `path` is set to placeholder; the registry's `dispatch` overwrites with the actual path before returning. (Alternative: pass `path` into `parse`. Stick with current Protocol signature; registry overwrites.)
@@ -800,13 +1012,13 @@ NOTE: `path` is set to placeholder; the registry's `dispatch` overwrites with th
 - [ ] **Step 4: Run tests, verify pass**
 
 Run: `cd backend && uv run pytest tests/parsers/test_text_parser.py -v`
-Expected: PASS (4 tests).
+Expected: PASS (8 tests).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add backend/cubebox/parsers/plugins/text.py backend/tests/parsers/test_text_parser.py
-git commit -m "feat(parsers): TextParser plugin (UTF-8 decode + 20K char truncation)"
+git commit -m "feat(parsers): TextParser plugin with line_range slicing + 20K char truncation"
 ```
 
 ---
@@ -1544,7 +1756,13 @@ async def test_dispatch_rejects_oversize() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dispatch_returns_unchanged_on_second_read() -> None:
+async def test_dispatch_returns_unchanged_on_second_read(monkeypatch) -> None:
+    """Same content + same options + same conv → second call returns UnchangedOutput."""
+    import fakeredis.aioredis
+    from cubebox import cache as cache_mod
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(cache_mod, "get_redis", lambda: fake)
+
     sandbox = MagicMock()
     sandbox._download_one = AsyncMock(return_value=b"hello world")
     reg = ParserRegistry()
@@ -1560,6 +1778,36 @@ async def test_dispatch_returns_unchanged_on_second_read() -> None:
         sandbox=sandbox, path="/tmp/a.txt", options=ParseOptions(), conversation_id=conv
     )
     assert isinstance(second, UnchangedOutput)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_different_line_range_does_not_unchanged(monkeypatch) -> None:
+    """Different line_range = different cache key = re-parses."""
+    import fakeredis.aioredis
+    from cubebox import cache as cache_mod
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(cache_mod, "get_redis", lambda: fake)
+
+    sandbox = MagicMock()
+    body = "\n".join(f"line{i}" for i in range(1, 21)).encode()
+    sandbox._download_one = AsyncMock(return_value=body)
+    reg = ParserRegistry()
+    await reg.discover()
+    conv = uuid4()
+
+    first = await reg.dispatch(
+        sandbox=sandbox, path="/tmp/log.txt",
+        options=ParseOptions(line_range="1-5"), conversation_id=conv,
+    )
+    assert isinstance(first, TextOutput)
+
+    second = await reg.dispatch(
+        sandbox=sandbox, path="/tmp/log.txt",
+        options=ParseOptions(line_range="10-15"), conversation_id=conv,
+    )
+    # Different line_range → different cache slot → re-parses, returns TextOutput, not Unchanged
+    assert isinstance(second, TextOutput)
+    assert "line10" in second.content
 
 
 @pytest.mark.asyncio
@@ -1726,12 +1974,16 @@ class ParserRegistry:
                 path=path, mime=mime, size_bytes=size, reason=reason, hint=hint,
             )
 
-        # 5. dedup check
+        # 5. dedup check (Redis-backed; key includes ParseOptions signature)
         if conversation_id is not None:
             digest = await dedup.hash_bytes(content)
-            if dedup.check(conversation_id, path, digest):
-                return UnchangedOutput(path=path)
-            dedup.update(conversation_id, path, digest)
+            try:
+                if await dedup.check(conversation_id, path, options, digest):
+                    return UnchangedOutput(path=path)
+                await dedup.update(conversation_id, path, options, digest)
+            except Exception as exc:
+                # Redis unreachable → fall through (cache miss treatment)
+                logger.warning("dedup cache unavailable, proceeding without: %s", exc)
 
         # 6. resolve plugin & parse
         ext = Path(path).suffix.lstrip(".").lower()
@@ -2026,7 +2278,15 @@ class _FileReadArgs(BaseModel):
         default=None,
         description=(
             "Optional 1-indexed page range, e.g. '1-5' or '3'. "
-            "Only honored for paginated formats (PDF, DOCX, PPTX)."
+            "Paginated documents only: PDF / DOCX / PPTX."
+        ),
+    )
+    line_range: str | None = PField(
+        default=None,
+        description=(
+            "Optional 1-indexed line range, e.g. '100-200' or '42'. "
+            "Text / code / log files only. Lets you navigate large text "
+            "files (e.g. 100k-line logs) by line number."
         ),
     )
 
@@ -2051,7 +2311,9 @@ DO NOT USE THIS TOOL FOR:
 - Archives (.zip .tar .gz) — extract first via execute("unzip ..."),
   then file_read on extracted files.
 - Remote URLs — file_read only reads sandbox paths.
-- Quick line peeks — execute("sed -n '42p' <file>") is faster.
+- Grep / search — execute("grep -n 'pattern' <file>") is more direct.
+- Tiny known-offset peeks — execute("sed -n '42p' <file>") skips
+  parser overhead.
 
 RETURN FORMAT (discriminated by `kind`):
 - "text"        : {content, mime, size_bytes, truncated, metadata}
@@ -2060,10 +2322,16 @@ RETURN FORMAT (discriminated by `kind`):
 - "unchanged"   : file unchanged since previous file_read in this session
 - "error"       : {error, retryable}
 
+PARAMETERS:
+- path (required)         — absolute sandbox path
+- page_range (optional)   — "1-5" or "3"; PDF/DOCX/PPTX only; ignored elsewhere
+- line_range (optional)   — "100-200" or "42"; text/code/log only; ignored elsewhere
+
 LIMITS:
 - Files > 100 MB are refused with kind="unsupported".
 - Content longer than 20,000 characters is truncated (truncated=True).
-  Use `page_range` for narrower slices.
+  Use `page_range` (PDF/DOCX/PPTX) or `line_range` (text/code/log)
+  to retrieve a specific segment.
 - Large files (>3 MB) trigger async parsing; up to 10 minutes.
 """
 
@@ -2071,10 +2339,14 @@ LIMITS:
 def _create_file_read_tool(sandbox: Sandbox, conversation_id: UUID | None) -> BaseTool:
     """Build the file_read tool backed by a sandbox + conversation."""
 
-    async def _file_read(path: str, page_range: str | None = None):
+    async def _file_read(
+        path: str,
+        page_range: str | None = None,
+        line_range: str | None = None,
+    ):
         result = await sandbox.file_read(
             path,
-            options=ParseOptions(page_range=page_range),
+            options=ParseOptions(page_range=page_range, line_range=line_range),
             conversation_id=conversation_id,
         )
         # Return the dict; LangChain will JSON-serialize for the LLM.

--- a/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
+++ b/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
@@ -511,25 +511,41 @@ git commit -m "feat(parsers): MIME sniffing helpers (libmagic + filetype + ext f
 - Create: `backend/tests/parsers/test_dedup.py`
 - Modify: `backend/pyproject.toml` (add `redis>=5.0`)
 
-- [ ] **Step 1: Add redis dep**
+**Note on prior art**: cubebox CE backend currently has **no Redis Python client**, **no `cubebox.cache` module**, and **no `redis:` config section**. Redis is only present as a CI service (`.github/workflows/ci.yml` line 129); no application code uses it. This task introduces all three from scratch. Verify before starting:
 
 ```bash
-cd backend && uv add 'redis>=5.0'
+ls backend/cubebox/cache 2>/dev/null || echo "(absent — confirmed)"
+grep -rn "import redis\|from redis" backend/cubebox/ 2>/dev/null | grep -v ".venv" || echo "(no redis imports — confirmed)"
 ```
 
-- [ ] **Step 2: Check whether `cubebox.cache` already exists**
+Both should report absent. If either exists (a parallel feature landed), reuse rather than recreate.
+
+- [ ] **Step 1: Add deps**
 
 ```bash
-ls backend/cubebox/cache 2>/dev/null && echo "exists; reuse get_redis from there" || echo "create new"
+cd backend && uv add 'redis>=5.0' && uv add --dev fakeredis
 ```
 
-If exists, **skip Step 3** and just use existing `get_redis()`. Otherwise proceed:
+- [ ] **Step 2: Add `redis:` section to YAML configs**
+
+Append to `backend/config.yaml`, `backend/config.development.yaml`, `backend/config.test.yaml`:
+
+```yaml
+redis:
+  url: redis://localhost:6379/0
+```
+
+(Production deployments override via `CUBEBOX_REDIS__URL` env var, per dynaconf convention.)
 
 - [ ] **Step 3: Create cache module with async Redis client factory**
 
 ```python
 # backend/cubebox/cache/__init__.py
-"""Async Redis client factory shared across cubebox subsystems."""
+"""Async Redis client factory shared across cubebox subsystems.
+
+Introduced in M6 (file_read dedup). Other future consumers (rate_limit
+storage backend, session cache, etc.) reuse the same singleton.
+"""
 
 from cubebox.cache.redis import get_redis, reset_redis_for_tests
 
@@ -538,7 +554,7 @@ __all__ = ["get_redis", "reset_redis_for_tests"]
 
 ```python
 # backend/cubebox/cache/redis.py
-"""Async Redis client factory."""
+"""Async Redis client factory (dynaconf-driven)."""
 
 from __future__ import annotations
 
@@ -552,7 +568,7 @@ _client: redis_asyncio.Redis | None = None
 def get_redis() -> redis_asyncio.Redis:
     """Return a singleton async Redis client.
 
-    Connection params from config; default localhost:6379 (matches CI service).
+    URL from config.redis.url; defaults to localhost:6379/0 (matches CI service).
     """
     global _client
     if _client is None:
@@ -569,13 +585,14 @@ def reset_redis_for_tests() -> None:
     _client = None
 ```
 
-Add `redis: { url: redis://localhost:6379/0 }` to `config.yaml`, `config.development.yaml`, `config.test.yaml` if not already present.
-
-- [ ] **Step 4: Write failing tests for dedup.py (using fakeredis for unit tests)**
+- [ ] **Step 3.5: Smoke test the cache factory imports cleanly**
 
 ```bash
-cd backend && uv add --dev fakeredis
+cd backend && uv run python -c "from cubebox.cache import get_redis; r = get_redis(); print(type(r).__name__)"
 ```
+Expected: prints `Redis` (the client is constructed lazily — doesn't actually connect).
+
+- [ ] **Step 4: Write failing tests for dedup.py (using fakeredis)**
 
 ```python
 # backend/tests/parsers/test_dedup.py
@@ -2541,40 +2558,18 @@ git commit -m "feat(sandbox): register file_read agent tool in SandboxMiddleware
 
 ---
 
-### Task 13: Backend `parsers.docling_serve` config schema + YAML
+### Task 13: Backend `parsers.docling_serve` YAML config
 
 **Files:**
-- Modify: `backend/cubebox/config.py`
 - Modify: `backend/config.yaml`
 - Modify: `backend/config.development.yaml`
 - Modify: `backend/config.test.yaml`
 
-- [ ] **Step 1: Add config schema (if pydantic-based)**
+**Note**: cubebox uses **dynaconf**, not pydantic Settings (see `backend/cubebox/config.py`). There is no top-level `Settings` class; configuration is accessed via `config.get("parsers.docling_serve.base_url", default)`. No schema class needs to be added to `config.py` — YAML alone is the source of truth for defaults; env vars (`CUBEBOX_PARSERS__DOCLING_SERVE__BASE_URL`) override at runtime.
 
-In `backend/cubebox/config.py`:
+- [ ] **Step 1: Append to YAML configs**
 
-```python
-class _DoclingServeConfig(BaseModel):
-    base_url: str = "http://docling-serve:5001"
-    api_key: str | None = None
-    timeout_sync_seconds: int = 30
-    timeout_async_minutes: int = 10
-    async_threshold_mb: int = 3
-    poll_interval_seconds: int = 2
-
-
-class ParsersConfig(BaseModel):
-    docling_serve: _DoclingServeConfig = _DoclingServeConfig()
-
-
-# Add `parsers: ParsersConfig = ParsersConfig()` to top-level Settings
-```
-
-(If using dynaconf, just rely on the YAML defaults — no schema class needed.)
-
-- [ ] **Step 2: Append to YAML configs**
-
-To `backend/config.yaml`, `backend/config.development.yaml`, `backend/config.test.yaml`:
+Append to `backend/config.yaml` and `backend/config.development.yaml`:
 
 ```yaml
 parsers:
@@ -2587,24 +2582,31 @@ parsers:
     poll_interval_seconds: 2
 ```
 
-For test config, use a localhost URL that won't be hit during tests (mocked):
+For `backend/config.test.yaml`, use a localhost URL that won't be hit during tests (httpx mock transport intercepts):
 
 ```yaml
 parsers:
   docling_serve:
     base_url: http://localhost-test-no-hit
+    timeout_sync_seconds: 30
+    timeout_async_minutes: 10
+    async_threshold_mb: 3
+    poll_interval_seconds: 2
 ```
 
-- [ ] **Step 3: Verify config loads**
-
-Run: `cd backend && uv run python -c "from cubebox.config import config; print(config.get('parsers.docling_serve.base_url'))"`
-Expected: prints `http://docling-serve:5001`.
-
-- [ ] **Step 4: Commit**
+- [ ] **Step 2: Verify config loads**
 
 ```bash
-git add backend/cubebox/config.py backend/config.yaml backend/config.development.yaml backend/config.test.yaml
-git commit -m "feat(parsers): add parsers.docling_serve config schema with sensible defaults"
+cd backend && uv run python -c "from cubebox.config import config; print(config.get('parsers.docling_serve.base_url'))"
+```
+
+Expected: prints `http://docling-serve:5001` (or the development.yaml override).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/config.yaml backend/config.development.yaml backend/config.test.yaml
+git commit -m "feat(parsers): add parsers.docling_serve YAML config (dynaconf-driven)"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
+++ b/docs/superpowers/plans/2026-04-23-m6-file-read-tool.md
@@ -1,0 +1,2300 @@
+# M6 · file_read 通用工具 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an agent-facing `file_read` tool that reads files from the sandbox and returns LLM-ready content (markdown / structured cells / unsupported sentinel / unchanged sentinel / error). Parser implementations live in a backend-side `cubebox.parsers` plugin registry; the default Docling parser delegates to an external `docling-serve` HTTP service so heavy ML deps stay out of backend.
+
+**Architecture:** New `cubebox.parsers` package owns the `FileParser` Protocol + entry_points-based plugin registry + 3 default plugins (`TextParser`, `NotebookParser`, `DoclingParser`). `Sandbox` abstract base class gains a non-abstract `file_read(path, options)` method that downloads bytes + dispatches via the parser registry + applies conversation-scoped SHA-256 dedup. `SandboxMiddleware` registers a new `file_read` agent tool that calls `sandbox.file_read(...)`.
+
+**Tech Stack:** Python 3.12, FastAPI, httpx (for docling-serve client), python-magic (libmagic wrapper), filetype (libmagic-free fallback), structlog, Pydantic, pytest, pytest-asyncio.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-file-read-tool-design.md`
+
+---
+
+## File Structure
+
+### Create
+
+```
+backend/cubebox/parsers/
+├─ __init__.py                  # Re-exports
+├─ schema.py                    # FileReadOutput union + ParseOptions
+├─ protocols.py                 # FileParser Protocol
+├─ mime.py                      # libmagic + extension fallback + REJECT lists
+├─ dedup.py                     # asyncio.to_thread hash cache
+├─ registry.py                  # ParserRegistry (discover + dispatch)
+└─ plugins/
+   ├─ __init__.py
+   ├─ text.py                   # TextParser (UTF-8 decode + truncation)
+   ├─ notebook.py               # NotebookParser (Jupyter cells)
+   └─ docling.py                # DoclingParser (HTTP to docling-serve)
+
+backend/tests/parsers/
+├─ __init__.py
+├─ conftest.py                  # parser registry fixtures + mock docling
+├─ test_schema.py
+├─ test_mime.py
+├─ test_dedup.py
+├─ test_text_parser.py
+├─ test_notebook_parser.py
+├─ test_docling_parser.py       # httpx mock server
+├─ test_registry.py
+└─ test_sandbox_file_read.py    # integration with Sandbox.file_read
+```
+
+### Modify
+
+```
+backend/cubebox/sandbox/base.py            # Add Sandbox.file_read non-abstract method
+backend/cubebox/middleware/sandbox.py      # Register file_read tool with description
+backend/cubebox/config.py                  # Add parsers.docling_serve schema
+backend/config.yaml                        # Add parsers: section
+backend/config.development.yaml            # Add parsers: section
+backend/config.test.yaml                   # Add parsers: section
+backend/pyproject.toml                     # Deps + entry_points group
+docker-compose.yml                         # Add docling-serve service
+```
+
+---
+
+## Tasks
+
+### Task 1: Create `cubebox.parsers` package skeleton
+
+**Files:**
+- Create: `backend/cubebox/parsers/__init__.py`
+- Create: `backend/cubebox/parsers/plugins/__init__.py`
+- Create: `backend/tests/parsers/__init__.py`
+
+- [ ] **Step 1: Create directories + empty __init__.py files**
+
+```bash
+mkdir -p backend/cubebox/parsers/plugins
+mkdir -p backend/tests/parsers
+touch backend/cubebox/parsers/plugins/__init__.py
+touch backend/tests/parsers/__init__.py
+```
+
+- [ ] **Step 2: Write package docstring**
+
+```python
+# backend/cubebox/parsers/__init__.py
+"""File parser plugin registry shared by file_read tool and future filebox.
+
+See docs/superpowers/specs/2026-04-22-file-read-tool-design.md.
+"""
+```
+
+- [ ] **Step 3: Verify import**
+
+Run: `cd backend && uv run python -c "import cubebox.parsers"`
+Expected: no error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/cubebox/parsers/ backend/tests/parsers/
+git commit -m "chore(parsers): create package skeleton for M6 file_read"
+```
+
+---
+
+### Task 2: Define `FileReadOutput` discriminated union + supporting types
+
+**Files:**
+- Create: `backend/cubebox/parsers/schema.py`
+- Create: `backend/tests/parsers/test_schema.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/parsers/test_schema.py
+"""FileReadOutput discriminated union schema tests."""
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from cubebox.parsers.schema import (
+    ErrorOutput,
+    FileReadOutput,
+    NotebookCell,
+    NotebookOutput,
+    ParseOptions,
+    TextOutput,
+    UnchangedOutput,
+    UnsupportedOutput,
+)
+
+
+def test_text_output_minimal() -> None:
+    o = TextOutput(path="/tmp/a.txt", mime="text/plain", content="hi", size_bytes=2)
+    assert o.kind == "text"
+    assert o.truncated is False
+    assert o.metadata == {}
+
+
+def test_notebook_output_with_cells() -> None:
+    o = NotebookOutput(
+        path="/tmp/n.ipynb",
+        cells=[NotebookCell(cell_type="code", source="print(1)", outputs=[{"text": "1"}])],
+    )
+    assert o.kind == "notebook"
+    assert o.cells[0].cell_type == "code"
+
+
+def test_unsupported_output() -> None:
+    o = UnsupportedOutput(
+        path="/tmp/v.mp4", mime="video/mp4", size_bytes=1024,
+        reason="video file not supported",
+    )
+    assert o.kind == "unsupported"
+    assert o.hint is None
+
+
+def test_unchanged_output() -> None:
+    o = UnchangedOutput(path="/tmp/a.txt")
+    assert o.kind == "unchanged"
+
+
+def test_error_output_default_not_retryable() -> None:
+    o = ErrorOutput(path="/tmp/x", error="boom")
+    assert o.retryable is False
+
+
+def test_discriminated_union_parses_text() -> None:
+    adapter = TypeAdapter(FileReadOutput)
+    data = {"kind": "text", "path": "/p", "mime": "text/plain", "content": "x", "size_bytes": 1}
+    result = adapter.validate_python(data)
+    assert isinstance(result, TextOutput)
+
+
+def test_discriminated_union_parses_unsupported() -> None:
+    adapter = TypeAdapter(FileReadOutput)
+    data = {"kind": "unsupported", "path": "/p", "mime": "video/mp4", "size_bytes": 1, "reason": "x"}
+    result = adapter.validate_python(data)
+    assert isinstance(result, UnsupportedOutput)
+
+
+def test_discriminated_union_rejects_unknown_kind() -> None:
+    adapter = TypeAdapter(FileReadOutput)
+    with pytest.raises(ValidationError):
+        adapter.validate_python({"kind": "weirdo", "path": "/p"})
+
+
+def test_parse_options_default_empty() -> None:
+    p = ParseOptions()
+    assert p.page_range is None
+    assert p.language_hint is None
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/parsers/test_schema.py -v`
+Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Implement schema.py**
+
+```python
+# backend/cubebox/parsers/schema.py
+"""Discriminated union of FileReadOutput kinds returned by file_read."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class TextOutput(BaseModel):
+    kind: Literal["text"] = "text"
+    path: str
+    mime: str
+    content: str
+    size_bytes: int
+    truncated: bool = False
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class NotebookCell(BaseModel):
+    cell_type: Literal["code", "markdown", "raw"]
+    source: str
+    outputs: list[dict[str, Any]] | None = None
+
+
+class NotebookOutput(BaseModel):
+    kind: Literal["notebook"] = "notebook"
+    path: str
+    cells: list[NotebookCell]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class UnsupportedOutput(BaseModel):
+    kind: Literal["unsupported"] = "unsupported"
+    path: str
+    mime: str
+    size_bytes: int
+    reason: str
+    hint: str | None = None
+
+
+class UnchangedOutput(BaseModel):
+    kind: Literal["unchanged"] = "unchanged"
+    path: str
+
+
+class ErrorOutput(BaseModel):
+    kind: Literal["error"] = "error"
+    path: str
+    error: str
+    retryable: bool = False
+
+
+FileReadOutput = Annotated[
+    TextOutput | NotebookOutput | UnsupportedOutput | UnchangedOutput | ErrorOutput,
+    Field(discriminator="kind"),
+]
+
+
+class ParseOptions(BaseModel):
+    page_range: str | None = None  # "1-5" or "3"
+    language_hint: str | None = None
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/parsers/test_schema.py -v`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/parsers/schema.py backend/tests/parsers/test_schema.py
+git commit -m "feat(parsers): FileReadOutput discriminated union + ParseOptions"
+```
+
+---
+
+### Task 3: Define `FileParser` Protocol
+
+**Files:**
+- Create: `backend/cubebox/parsers/protocols.py`
+- Create: `backend/tests/parsers/test_protocols.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/parsers/test_protocols.py
+from cubebox.parsers.protocols import FileParser
+from cubebox.parsers.schema import ParseOptions, TextOutput
+
+
+class _ConformingParser:
+    mime_types = ["text/plain"]
+    extensions = ["txt"]
+    priority = 0
+
+    async def parse(self, content, *, mime, options):  # type: ignore[no-untyped-def]
+        return TextOutput(path="/tmp/x", mime=mime, content="x", size_bytes=len(content))
+
+
+class _MissingParse:
+    mime_types: list[str] = []
+    extensions: list[str] = []
+    priority = 0
+
+
+def test_protocol_accepts_conforming() -> None:
+    assert isinstance(_ConformingParser(), FileParser)
+
+
+def test_protocol_rejects_missing_parse() -> None:
+    assert not isinstance(_MissingParse(), FileParser)
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/parsers/test_protocols.py -v`
+Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Implement protocols.py**
+
+```python
+# backend/cubebox/parsers/protocols.py
+"""FileParser plugin Protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from cubebox.parsers.schema import FileReadOutput, ParseOptions
+
+
+@runtime_checkable
+class FileParser(Protocol):
+    """A plugin that parses file bytes for a specific format family.
+
+    mime_types: list of MIME patterns ("application/pdf", "text/*")
+    extensions: list of extensions without leading dot ("pdf", "docx")
+    priority:   within-family tie-breaker; higher wins
+    """
+
+    mime_types: list[str]
+    extensions: list[str]
+    priority: int
+
+    async def parse(
+        self,
+        content: bytes,
+        *,
+        mime: str,
+        options: ParseOptions,
+    ) -> FileReadOutput: ...
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/parsers/test_protocols.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/parsers/protocols.py backend/tests/parsers/test_protocols.py
+git commit -m "feat(parsers): FileParser runtime_checkable Protocol"
+```
+
+---
+
+### Task 4: MIME sniff + REJECT lists
+
+**Files:**
+- Create: `backend/cubebox/parsers/mime.py`
+- Create: `backend/tests/parsers/test_mime.py`
+- Modify: `backend/pyproject.toml` (add `python-magic` + `filetype` deps)
+
+- [ ] **Step 1: Add deps**
+
+```bash
+cd backend && uv add python-magic filetype
+```
+
+NOTE: `python-magic` requires libmagic shared library on the system. macOS: `brew install libmagic`. Debian: `apt install libmagic1`. Alpine: `apk add libmagic`. CI image: ensure libmagic is installed.
+
+- [ ] **Step 2: Write failing tests**
+
+```python
+# backend/tests/parsers/test_mime.py
+from cubebox.parsers.mime import (
+    REJECT_EXT,
+    REJECT_MIME,
+    is_rejected,
+    sniff_mime,
+)
+
+
+def test_reject_ext_includes_video() -> None:
+    assert "mp4" in REJECT_EXT
+    assert "mov" in REJECT_EXT
+
+
+def test_reject_ext_includes_audio() -> None:
+    assert "mp3" in REJECT_EXT
+    assert "wav" in REJECT_EXT
+
+
+def test_reject_ext_includes_archives() -> None:
+    assert "zip" in REJECT_EXT
+    assert "tar" in REJECT_EXT
+
+
+def test_reject_ext_includes_executables() -> None:
+    assert "exe" in REJECT_EXT
+    assert "so" in REJECT_EXT
+
+
+def test_is_rejected_true_for_video_ext() -> None:
+    assert is_rejected("/tmp/foo.mp4", "video/mp4") is True
+
+
+def test_is_rejected_false_for_text() -> None:
+    assert is_rejected("/tmp/foo.txt", "text/plain") is False
+
+
+def test_sniff_mime_detects_pdf_from_bytes() -> None:
+    pdf_magic = b"%PDF-1.4\n"
+    mime = sniff_mime("/tmp/a.pdf", pdf_magic + b"x" * 100)
+    assert mime == "application/pdf"
+
+
+def test_sniff_mime_falls_back_to_extension() -> None:
+    # ASCII content with .py extension
+    mime = sniff_mime("/tmp/x.py", b"print('hi')\n")
+    # libmagic detects as text/x-python or text/plain; either acceptable
+    assert mime.startswith("text/") or mime == "application/x-python"
+```
+
+- [ ] **Step 3: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/parsers/test_mime.py -v`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement mime.py**
+
+```python
+# backend/cubebox/parsers/mime.py
+"""MIME sniffing + REJECT lists for file_read pre-screening."""
+
+from __future__ import annotations
+
+import asyncio
+import mimetypes
+from pathlib import Path
+
+import filetype
+import magic
+
+REJECT_EXT: set[str] = {
+    # video
+    "mp4", "mov", "mkv", "webm", "avi", "flv", "wmv", "m4v",
+    # audio
+    "mp3", "wav", "m4a", "ogg", "flac", "opus", "aac", "wma",
+    # binary / executable
+    "exe", "so", "dll", "dylib", "o", "a", "bin", "com",
+    # archive
+    "zip", "tar", "gz", "bz2", "rar", "7z", "tgz", "xz", "zst",
+}
+
+REJECT_MIME: set[str] = {
+    "video/mp4", "video/quicktime", "video/x-matroska", "video/webm",
+    "video/x-msvideo", "video/x-flv", "video/x-ms-wmv",
+    "audio/mpeg", "audio/wav", "audio/x-m4a", "audio/ogg", "audio/flac",
+    "application/x-executable", "application/x-shared-library",
+    "application/zip", "application/x-tar", "application/gzip",
+    "application/x-bzip2", "application/x-rar-compressed", "application/x-7z-compressed",
+    "application/x-xz", "application/zstd",
+}
+
+
+def sniff_mime(path: str, content: bytes) -> str:
+    """Detect MIME via libmagic; fall back to filetype lib then extension.
+
+    Synchronous on purpose — caller offloads to thread for very large files.
+    """
+    try:
+        mime = magic.from_buffer(content[:8192], mime=True)
+        if mime and mime != "application/octet-stream":
+            return mime
+    except Exception:
+        pass
+
+    kind = filetype.guess(content[:8192])
+    if kind is not None:
+        return kind.mime
+
+    # Fall back to extension-based guess
+    guessed, _ = mimetypes.guess_type(path)
+    if guessed:
+        return guessed
+    return "application/octet-stream"
+
+
+async def sniff_mime_async(path: str, content: bytes) -> str:
+    return await asyncio.to_thread(sniff_mime, path, content)
+
+
+def is_rejected(path: str, mime: str) -> bool:
+    ext = Path(path).suffix.lstrip(".").lower()
+    return ext in REJECT_EXT or mime in REJECT_MIME
+
+
+def reject_reason(path: str, mime: str) -> tuple[str, str | None]:
+    """Return (reason, hint) for a rejected file."""
+    ext = Path(path).suffix.lstrip(".").lower()
+    if ext in {"mp4", "mov", "mkv", "webm", "avi", "flv", "wmv", "m4v"} or mime.startswith("video/"):
+        return ("video file not supported", "video content cannot be read as text")
+    if ext in {"mp3", "wav", "m4a", "ogg", "flac", "opus", "aac", "wma"} or mime.startswith("audio/"):
+        return ("audio file not supported", "audio content cannot be read as text")
+    if ext in {"exe", "so", "dll", "dylib", "o", "a", "bin", "com"}:
+        return ("binary executable not supported", "use shell tools to inspect metadata")
+    if ext in {"zip", "tar", "gz", "bz2", "rar", "7z", "tgz", "xz", "zst"}:
+        return (
+            "archive file not supported",
+            "extract first with execute(\"unzip <file>\") then file_read on contents",
+        )
+    return ("file type not supported", None)
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/parsers/test_mime.py -v`
+Expected: PASS (8 tests). If a test fails because libmagic isn't installed, install it on the host.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/parsers/mime.py backend/tests/parsers/test_mime.py backend/pyproject.toml backend/uv.lock
+git commit -m "feat(parsers): MIME sniffing via libmagic + REJECT lists for unsupported types"
+```
+
+---
+
+### Task 5: Async hash dedup cache
+
+**Files:**
+- Create: `backend/cubebox/parsers/dedup.py`
+- Create: `backend/tests/parsers/test_dedup.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/parsers/test_dedup.py
+from uuid import uuid4
+
+import pytest
+
+from cubebox.parsers.dedup import (
+    check,
+    forget_conversation,
+    hash_bytes,
+    update,
+    _file_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_state():
+    _file_state.clear()
+    yield
+    _file_state.clear()
+
+
+@pytest.mark.asyncio
+async def test_hash_bytes_returns_sha256_hex() -> None:
+    digest = await hash_bytes(b"hello")
+    # SHA-256 of "hello" = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+    assert digest == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+
+
+def test_check_returns_false_when_empty() -> None:
+    conv = uuid4()
+    assert check(conv, "/p", "abc") is False
+
+
+def test_update_then_check_matches() -> None:
+    conv = uuid4()
+    update(conv, "/p", "abc")
+    assert check(conv, "/p", "abc") is True
+    assert check(conv, "/p", "different") is False
+
+
+def test_check_isolates_per_conversation() -> None:
+    a, b = uuid4(), uuid4()
+    update(a, "/p", "abc")
+    assert check(b, "/p", "abc") is False
+
+
+def test_forget_conversation_clears_only_that_conv() -> None:
+    a, b = uuid4(), uuid4()
+    update(a, "/p", "abc")
+    update(b, "/p", "abc")
+    forget_conversation(a)
+    assert check(a, "/p", "abc") is False
+    assert check(b, "/p", "abc") is True
+
+
+@pytest.mark.asyncio
+async def test_hash_bytes_offloads_to_thread() -> None:
+    """Verifies the call returns awaitable (i.e. async-safe for large inputs)."""
+    big = b"x" * (10 * 1024 * 1024)  # 10 MB
+    digest = await hash_bytes(big)
+    assert len(digest) == 64
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/parsers/test_dedup.py -v`
+Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Implement dedup.py**
+
+```python
+# backend/cubebox/parsers/dedup.py
+"""Conversation-scoped SHA-256 file_state dedup cache.
+
+v1: in-process dict. SaaS multi-replica needs session-sticky routing OR
+swap to Redis-backed cache (TTL = conversation lifetime).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from uuid import UUID
+
+# Keyed by (conversation_id, path); value = SHA-256 hex digest.
+_file_state: dict[tuple[UUID, str], str] = {}
+
+
+async def hash_bytes(data: bytes) -> str:
+    """Compute SHA-256 hex; offload to thread (CPU-bound for large inputs)."""
+    return await asyncio.to_thread(lambda: hashlib.sha256(data).hexdigest())
+
+
+def check(conversation_id: UUID, path: str, digest: str) -> bool:
+    """True if digest matches cached value (→ caller emits UnchangedOutput)."""
+    return _file_state.get((conversation_id, path)) == digest
+
+
+def update(conversation_id: UUID, path: str, digest: str) -> None:
+    _file_state[(conversation_id, path)] = digest
+
+
+def forget_conversation(conversation_id: UUID) -> None:
+    """Drop all keys for the given conversation. Hook from ConversationManager.close."""
+    keys = [k for k in _file_state if k[0] == conversation_id]
+    for k in keys:
+        _file_state.pop(k, None)
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/parsers/test_dedup.py -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/parsers/dedup.py backend/tests/parsers/test_dedup.py
+git commit -m "feat(parsers): async SHA-256 file_state dedup cache (conversation-scoped)"
+```
+
+---
+
+### Task 6: `TextParser` plugin
+
+**Files:**
+- Create: `backend/cubebox/parsers/plugins/text.py`
+- Create: `backend/tests/parsers/test_text_parser.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/parsers/test_text_parser.py
+import pytest
+
+from cubebox.parsers.plugins.text import TextParser
+from cubebox.parsers.protocols import FileParser
+from cubebox.parsers.schema import ParseOptions, TextOutput
+
+
+def test_satisfies_protocol() -> None:
+    assert isinstance(TextParser(), FileParser)
+
+
+@pytest.mark.asyncio
+async def test_decodes_utf8() -> None:
+    p = TextParser()
+    out = await p.parse(b"hello world", mime="text/plain", options=ParseOptions())
+    assert isinstance(out, TextOutput)
+    assert out.content == "hello world"
+    assert out.size_bytes == 11
+    assert out.truncated is False
+
+
+@pytest.mark.asyncio
+async def test_truncates_at_20k() -> None:
+    p = TextParser()
+    body = "x" * 30_000
+    out = await p.parse(body.encode(), mime="text/plain", options=ParseOptions())
+    assert out.truncated is True
+    assert len(out.content) == 20_000
+    assert out.metadata["total_chars"] == 30_000
+    assert out.metadata["truncated_at_char"] == 20_000
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_latin1_on_decode_error() -> None:
+    p = TextParser()
+    # bytes that aren't valid UTF-8
+    body = b"\xff\xfe hello"
+    out = await p.parse(body, mime="text/plain", options=ParseOptions())
+    assert isinstance(out, TextOutput)
+    assert out.metadata.get("decode_fallback") == "latin-1"
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/parsers/test_text_parser.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement TextParser**
+
+```python
+# backend/cubebox/parsers/plugins/text.py
+"""TextParser: UTF-8 decode for code/config/text files."""
+
+from __future__ import annotations
+
+from cubebox.parsers.schema import ParseOptions, TextOutput
+
+MAX_CONTENT_CHARS = 20_000
+
+
+class TextParser:
+    mime_types = ["text/*"]
+    extensions = [
+        "txt", "md", "markdown", "rst", "org",
+        "py", "pyi",
+        "js", "ts", "jsx", "tsx", "mjs", "cjs",
+        "json", "json5", "yaml", "yml", "toml", "ini", "conf", "env",
+        "csv", "tsv",
+        "html", "htm", "xhtml", "xml", "svg",
+        "css", "scss", "sass", "less",
+        "sh", "bash", "zsh", "fish",
+        "sql", "graphql",
+        "go", "rs", "java", "kt", "kts", "scala", "groovy",
+        "c", "h", "cpp", "cc", "cxx", "hpp", "hxx",
+        "rb", "php", "pl", "pm",
+        "log", "lock", "properties",
+    ]
+    priority = 0
+
+    async def parse(
+        self,
+        content: bytes,
+        *,
+        mime: str,
+        options: ParseOptions,
+    ) -> TextOutput:
+        size = len(content)
+        decode_fallback: str | None = None
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError:
+            text = content.decode("latin-1", errors="replace")
+            decode_fallback = "latin-1"
+
+        truncated = False
+        total_chars = len(text)
+        metadata: dict[str, object] = {"parser": "text", "total_chars": total_chars}
+        if decode_fallback:
+            metadata["decode_fallback"] = decode_fallback
+        if len(text) > MAX_CONTENT_CHARS:
+            text = text[:MAX_CONTENT_CHARS]
+            truncated = True
+            metadata["truncated_at_char"] = MAX_CONTENT_CHARS
+
+        return TextOutput(
+            path="<set-by-caller>",
+            mime=mime,
+            content=text,
+            size_bytes=size,
+            truncated=truncated,
+            metadata=metadata,
+        )
+```
+
+NOTE: `path` is set to placeholder; the registry's `dispatch` overwrites with the actual path before returning. (Alternative: pass `path` into `parse`. Stick with current Protocol signature; registry overwrites.)
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/parsers/test_text_parser.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/parsers/plugins/text.py backend/tests/parsers/test_text_parser.py
+git commit -m "feat(parsers): TextParser plugin (UTF-8 decode + 20K char truncation)"
+```
+
+---
+
+### Task 7: `NotebookParser` plugin
+
+**Files:**
+- Create: `backend/cubebox/parsers/plugins/notebook.py`
+- Create: `backend/tests/parsers/test_notebook_parser.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/parsers/test_notebook_parser.py
+import json
+
+import pytest
+
+from cubebox.parsers.plugins.notebook import NotebookParser
+from cubebox.parsers.protocols import FileParser
+from cubebox.parsers.schema import NotebookOutput, ParseOptions
+
+
+def test_satisfies_protocol() -> None:
+    assert isinstance(NotebookParser(), FileParser)
+
+
+@pytest.mark.asyncio
+async def test_parses_simple_notebook() -> None:
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "source": ["# Title\n", "intro\n"]},
+            {
+                "cell_type": "code",
+                "source": "print('hi')",
+                "outputs": [{"output_type": "stream", "text": "hi\n"}],
+            },
+        ]
+    }
+    p = NotebookParser()
+    out = await p.parse(
+        json.dumps(nb).encode(),
+        mime="application/x-ipynb+json",
+        options=ParseOptions(),
+    )
+    assert isinstance(out, NotebookOutput)
+    assert len(out.cells) == 2
+    assert out.cells[0].cell_type == "markdown"
+    assert "Title" in out.cells[0].source
+    assert out.cells[1].cell_type == "code"
+    assert out.cells[1].outputs is not None
+
+
+@pytest.mark.asyncio
+async def test_truncates_when_exceeds_20k() -> None:
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "source": "x" * 25_000},
+            {"cell_type": "code", "source": "y", "outputs": []},
+        ]
+    }
+    p = NotebookParser()
+    out = await p.parse(
+        json.dumps(nb).encode(),
+        mime="application/x-ipynb+json",
+        options=ParseOptions(),
+    )
+    # truncation happens at the cell level; first big cell included, second omitted
+    assert out.metadata.get("truncated_cells", 0) >= 1
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/parsers/test_notebook_parser.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement NotebookParser**
+
+```python
+# backend/cubebox/parsers/plugins/notebook.py
+"""NotebookParser: parse Jupyter .ipynb into structured cells."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from cubebox.parsers.schema import NotebookCell, NotebookOutput, ParseOptions
+
+MAX_CONTENT_CHARS = 20_000
+
+
+class NotebookParser:
+    mime_types = ["application/x-ipynb+json"]
+    extensions = ["ipynb"]
+    priority = 10
+
+    async def parse(
+        self,
+        content: bytes,
+        *,
+        mime: str,
+        options: ParseOptions,
+    ) -> NotebookOutput:
+        try:
+            nb = json.loads(content)
+        except json.JSONDecodeError as e:
+            # Caller registry will catch + wrap as ErrorOutput; raise to propagate
+            raise ValueError(f"invalid notebook JSON: {e}") from e
+
+        all_cells = nb.get("cells", [])
+        result_cells: list[NotebookCell] = []
+        running_chars = 0
+        truncated_cells = 0
+
+        for raw in all_cells:
+            cell_type = raw.get("cell_type", "raw")
+            if cell_type not in ("code", "markdown", "raw"):
+                cell_type = "raw"
+            source = raw.get("source", "")
+            if isinstance(source, list):
+                source = "".join(source)
+
+            outputs: list[dict[str, Any]] | None = None
+            if cell_type == "code":
+                outputs = []
+                for o in raw.get("outputs", []):
+                    if "text" in o:
+                        text = o["text"]
+                        if isinstance(text, list):
+                            text = "".join(text)
+                        outputs.append({"type": o.get("output_type", "stream"), "text": text})
+                    else:
+                        # Drop image base64 blobs; keep a marker only
+                        outputs.append({"type": o.get("output_type", "unknown")})
+
+            cell_chars = len(source) + sum(len(o.get("text", "")) for o in (outputs or []))
+            if running_chars + cell_chars > MAX_CONTENT_CHARS:
+                truncated_cells = len(all_cells) - len(result_cells)
+                break
+            running_chars += cell_chars
+            result_cells.append(
+                NotebookCell(cell_type=cell_type, source=source, outputs=outputs)
+            )
+
+        metadata: dict[str, Any] = {
+            "parser": "notebook",
+            "total_cells": len(all_cells),
+        }
+        if truncated_cells > 0:
+            metadata["truncated_cells"] = truncated_cells
+
+        return NotebookOutput(
+            path="<set-by-caller>",
+            cells=result_cells,
+            metadata=metadata,
+        )
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/parsers/test_notebook_parser.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/parsers/plugins/notebook.py backend/tests/parsers/test_notebook_parser.py
+git commit -m "feat(parsers): NotebookParser preserves Jupyter cell structure"
+```
+
+---
+
+### Task 8: `DoclingParser` — sync path + http client
+
+**Files:**
+- Create: `backend/cubebox/parsers/plugins/docling.py`
+- Create: `backend/tests/parsers/test_docling_parser.py`
+
+- [ ] **Step 1: Write failing test for sync path with httpx mock**
+
+```python
+# backend/tests/parsers/test_docling_parser.py
+import base64
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from cubebox.parsers.plugins.docling import DoclingParser
+from cubebox.parsers.protocols import FileParser
+from cubebox.parsers.schema import ErrorOutput, ParseOptions, TextOutput
+
+
+def test_satisfies_protocol() -> None:
+    assert isinstance(DoclingParser(base_url="http://test"), FileParser)
+
+
+@pytest.mark.asyncio
+async def test_sync_path_for_small_file() -> None:
+    """File < async_threshold_mb hits sync /v1/convert/source endpoint."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/convert/source"
+        body = json.loads(request.content)
+        assert body["sources"][0]["kind"] == "file"
+        return httpx.Response(
+            200,
+            json={"document": {"md_content": "# Parsed\n\nhello"}},
+        )
+
+    transport = httpx.MockTransport(handler)
+    p = DoclingParser(
+        base_url="http://docling",
+        api_key=None,
+        timeout_sync_seconds=30,
+        timeout_async_minutes=10,
+        async_threshold_mb=3,
+        poll_interval_seconds=2,
+        _transport=transport,
+    )
+    content = b"%PDF-1.4 stub"
+    out = await p.parse(content, mime="application/pdf", options=ParseOptions())
+    assert isinstance(out, TextOutput)
+    assert "Parsed" in out.content
+    assert out.metadata["parser"] == "docling"
+
+
+@pytest.mark.asyncio
+async def test_sync_path_returns_error_on_5xx() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "internal"})
+
+    transport = httpx.MockTransport(handler)
+    p = DoclingParser(
+        base_url="http://docling",
+        api_key=None,
+        timeout_sync_seconds=30,
+        timeout_async_minutes=10,
+        async_threshold_mb=3,
+        poll_interval_seconds=2,
+        _transport=transport,
+    )
+    out = await p.parse(b"x" * 100, mime="application/pdf", options=ParseOptions())
+    assert isinstance(out, ErrorOutput)
+    assert out.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_sync_path_truncates_long_content() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"document": {"md_content": "x" * 30_000}},
+        )
+
+    transport = httpx.MockTransport(handler)
+    p = DoclingParser(
+        base_url="http://docling",
+        api_key=None,
+        timeout_sync_seconds=30,
+        timeout_async_minutes=10,
+        async_threshold_mb=3,
+        poll_interval_seconds=2,
+        _transport=transport,
+    )
+    out = await p.parse(b"x", mime="application/pdf", options=ParseOptions())
+    assert isinstance(out, TextOutput)
+    assert out.truncated is True
+    assert len(out.content) == 20_000
+```
+
+- [ ] **Step 2: Add httpx to deps if missing**
+
+```bash
+cd backend && uv add httpx
+```
+
+(Likely already installed, but ensure.)
+
+- [ ] **Step 3: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/parsers/test_docling_parser.py -v`
+Expected: FAIL with ImportError.
+
+- [ ] **Step 4: Implement DoclingParser sync path**
+
+```python
+# backend/cubebox/parsers/plugins/docling.py
+"""DoclingParser: HTTP client to docling-serve."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from pathlib import Path
+
+import httpx
+
+from cubebox.parsers.schema import ErrorOutput, FileReadOutput, ParseOptions, TextOutput
+
+MAX_CONTENT_CHARS = 20_000
+
+
+class DoclingParser:
+    mime_types = [
+        "application/pdf",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/epub+zip",
+        "image/*",
+    ]
+    extensions = ["pdf", "docx", "pptx", "xlsx", "epub", "png", "jpg", "jpeg", "gif", "webp", "tiff", "bmp"]
+    priority = 20
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str | None = None,
+        timeout_sync_seconds: int = 30,
+        timeout_async_minutes: int = 10,
+        async_threshold_mb: int = 3,
+        poll_interval_seconds: int = 2,
+        _transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout_sync = timeout_sync_seconds
+        self.timeout_async_seconds = timeout_async_minutes * 60
+        self.async_threshold_bytes = async_threshold_mb * 1024 * 1024
+        self.poll_interval = poll_interval_seconds
+        self._transport = _transport
+
+    def _headers(self) -> dict[str, str]:
+        h: dict[str, str] = {"Content-Type": "application/json"}
+        if self.api_key:
+            h["X-Api-Key"] = self.api_key
+        return h
+
+    def _client(self, timeout: float) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=self.base_url,
+            timeout=timeout,
+            transport=self._transport,
+        )
+
+    async def parse(
+        self,
+        content: bytes,
+        *,
+        mime: str,
+        options: ParseOptions,
+    ) -> FileReadOutput:
+        if len(content) < self.async_threshold_bytes:
+            return await self._parse_sync(content, mime, options)
+        return await self._parse_async(content, mime, options)
+
+    async def _parse_sync(
+        self,
+        content: bytes,
+        mime: str,
+        options: ParseOptions,
+    ) -> FileReadOutput:
+        body = {
+            "sources": [
+                {
+                    "kind": "file",
+                    "filename": "input",
+                    "base64": base64.b64encode(content).decode("ascii"),
+                }
+            ],
+            "options": self._build_options(options),
+        }
+        try:
+            async with self._client(timeout=self.timeout_sync) as client:
+                resp = await client.post(
+                    "/v1/convert/source",
+                    json=body,
+                    headers=self._headers(),
+                )
+                if resp.status_code >= 500:
+                    return ErrorOutput(
+                        path="<set-by-caller>",
+                        error=f"docling-serve {resp.status_code}: {resp.text[:200]}",
+                        retryable=True,
+                    )
+                if resp.status_code >= 400:
+                    return ErrorOutput(
+                        path="<set-by-caller>",
+                        error=f"docling-serve {resp.status_code}: {resp.text[:200]}",
+                        retryable=False,
+                    )
+                data = resp.json()
+        except (httpx.TimeoutException, httpx.NetworkError) as e:
+            return ErrorOutput(
+                path="<set-by-caller>",
+                error=f"docling-serve unreachable: {e}",
+                retryable=True,
+            )
+        return self._make_text_output(data, content, mime)
+
+    async def _parse_async(
+        self,
+        content: bytes,
+        mime: str,
+        options: ParseOptions,
+    ) -> FileReadOutput:
+        # Implemented in Task 9
+        return ErrorOutput(
+            path="<set-by-caller>",
+            error="async path not implemented",
+            retryable=False,
+        )
+
+    def _build_options(self, options: ParseOptions) -> dict:
+        opts: dict[str, object] = {}
+        if options.page_range:
+            opts["page_range"] = options.page_range
+        if options.language_hint:
+            opts["lang"] = options.language_hint
+        return opts
+
+    def _make_text_output(self, data: dict, content: bytes, mime: str) -> TextOutput:
+        # docling-serve response shape: {"document": {"md_content": "..."}}
+        md = (data.get("document") or {}).get("md_content", "")
+        if not isinstance(md, str):
+            md = str(md)
+
+        truncated = False
+        total = len(md)
+        metadata: dict[str, object] = {"parser": "docling", "total_chars": total}
+        if total > MAX_CONTENT_CHARS:
+            md = md[:MAX_CONTENT_CHARS]
+            truncated = True
+            metadata["truncated_at_char"] = MAX_CONTENT_CHARS
+
+        return TextOutput(
+            path="<set-by-caller>",
+            mime=mime,
+            content=md,
+            size_bytes=len(content),
+            truncated=truncated,
+            metadata=metadata,
+        )
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/parsers/test_docling_parser.py -v`
+Expected: 3 tests PASS, async-path tests not yet present.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/parsers/plugins/docling.py backend/tests/parsers/test_docling_parser.py
+git commit -m "feat(parsers): DoclingParser sync HTTP path + httpx mock tests"
+```
+
+---
+
+### Task 9: `DoclingParser` async path + polling
+
+**Files:**
+- Modify: `backend/cubebox/parsers/plugins/docling.py`
+- Modify: `backend/tests/parsers/test_docling_parser.py`
+
+- [ ] **Step 1: Append failing async-path tests**
+
+Append to `backend/tests/parsers/test_docling_parser.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_async_path_for_large_file() -> None:
+    """File ≥ async_threshold_mb hits async submit + poll."""
+    poll_count = {"n": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1alpha/convert/source/async":
+            return httpx.Response(202, json={"task_id": "tk_123"})
+        if request.url.path == "/v1alpha/convert/tasks/tk_123":
+            poll_count["n"] += 1
+            if poll_count["n"] < 2:
+                return httpx.Response(200, json={"status": "STARTED"})
+            return httpx.Response(
+                200,
+                json={
+                    "status": "COMPLETED",
+                    "result": {"document": {"md_content": "# Big\n\ndata"}},
+                },
+            )
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    p = DoclingParser(
+        base_url="http://docling",
+        api_key=None,
+        timeout_sync_seconds=30,
+        timeout_async_minutes=10,
+        async_threshold_mb=1,
+        poll_interval_seconds=0,  # tests should not actually sleep
+        _transport=transport,
+    )
+    big = b"x" * (2 * 1024 * 1024)  # 2 MB > 1 MB threshold
+    out = await p.parse(big, mime="application/pdf", options=ParseOptions())
+    assert isinstance(out, TextOutput)
+    assert "Big" in out.content
+
+
+@pytest.mark.asyncio
+async def test_async_path_task_failed_returns_error() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1alpha/convert/source/async":
+            return httpx.Response(202, json={"task_id": "tk_x"})
+        return httpx.Response(
+            200,
+            json={"status": "FAILED", "error": "corrupt input"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    p = DoclingParser(
+        base_url="http://docling",
+        api_key=None,
+        timeout_sync_seconds=30,
+        timeout_async_minutes=10,
+        async_threshold_mb=1,
+        poll_interval_seconds=0,
+        _transport=transport,
+    )
+    big = b"x" * (2 * 1024 * 1024)
+    out = await p.parse(big, mime="application/pdf", options=ParseOptions())
+    assert isinstance(out, ErrorOutput)
+    assert out.retryable is False
+    assert "corrupt" in out.error
+```
+
+- [ ] **Step 2: Run, verify fail (async path returns "not implemented")**
+
+Run: `cd backend && uv run pytest tests/parsers/test_docling_parser.py -v`
+Expected: 2 new tests FAIL.
+
+- [ ] **Step 3: Replace `_parse_async` body in `docling.py`**
+
+Replace the `_parse_async` method:
+
+```python
+    async def _parse_async(
+        self,
+        content: bytes,
+        mime: str,
+        options: ParseOptions,
+    ) -> FileReadOutput:
+        body = {
+            "sources": [
+                {
+                    "kind": "file",
+                    "filename": "input",
+                    "base64": base64.b64encode(content).decode("ascii"),
+                }
+            ],
+            "options": self._build_options(options),
+        }
+        try:
+            async with self._client(timeout=self.timeout_async_seconds) as client:
+                # Submit
+                resp = await client.post(
+                    "/v1alpha/convert/source/async",
+                    json=body,
+                    headers=self._headers(),
+                )
+                if resp.status_code >= 400:
+                    return ErrorOutput(
+                        path="<set-by-caller>",
+                        error=f"docling-serve submit {resp.status_code}: {resp.text[:200]}",
+                        retryable=resp.status_code >= 500,
+                    )
+                task_id = resp.json().get("task_id")
+                if not task_id:
+                    return ErrorOutput(
+                        path="<set-by-caller>",
+                        error="docling-serve async submit returned no task_id",
+                        retryable=False,
+                    )
+
+                # Poll
+                deadline = asyncio.get_event_loop().time() + self.timeout_async_seconds
+                while asyncio.get_event_loop().time() < deadline:
+                    poll = await client.get(
+                        f"/v1alpha/convert/tasks/{task_id}",
+                        headers=self._headers(),
+                    )
+                    if poll.status_code >= 500:
+                        await asyncio.sleep(self.poll_interval)
+                        continue
+                    if poll.status_code >= 400:
+                        return ErrorOutput(
+                            path="<set-by-caller>",
+                            error=f"docling-serve poll {poll.status_code}: {poll.text[:200]}",
+                            retryable=False,
+                        )
+                    data = poll.json()
+                    status = data.get("status")
+                    if status == "COMPLETED":
+                        result = data.get("result", {})
+                        return self._make_text_output(result, content, mime)
+                    if status == "FAILED":
+                        return ErrorOutput(
+                            path="<set-by-caller>",
+                            error=f"docling-serve task FAILED: {data.get('error', 'no detail')}",
+                            retryable=False,
+                        )
+                    await asyncio.sleep(self.poll_interval)
+
+                return ErrorOutput(
+                    path="<set-by-caller>",
+                    error="docling-serve async timeout",
+                    retryable=True,
+                )
+        except (httpx.TimeoutException, httpx.NetworkError) as e:
+            return ErrorOutput(
+                path="<set-by-caller>",
+                error=f"docling-serve unreachable: {e}",
+                retryable=True,
+            )
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/parsers/test_docling_parser.py -v`
+Expected: PASS (5 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/parsers/plugins/docling.py backend/tests/parsers/test_docling_parser.py
+git commit -m "feat(parsers): DoclingParser async submit + poll path with COMPLETED/FAILED handling"
+```
+
+---
+
+### Task 10: `ParserRegistry` (discover + dispatch + REJECT precheck)
+
+**Files:**
+- Create: `backend/cubebox/parsers/registry.py`
+- Modify: `backend/cubebox/parsers/__init__.py`
+- Create: `backend/tests/parsers/test_registry.py`
+- Modify: `backend/pyproject.toml` (add entry_points group)
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/parsers/test_registry.py
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from cubebox.parsers.registry import ParserRegistry, get_parser_registry, reset_parser_registry_for_tests
+from cubebox.parsers.schema import (
+    ErrorOutput,
+    NotebookOutput,
+    ParseOptions,
+    TextOutput,
+    UnchangedOutput,
+    UnsupportedOutput,
+)
+
+
+@pytest.fixture(autouse=True)
+def fresh_registry():
+    reset_parser_registry_for_tests()
+    yield
+    reset_parser_registry_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_resolve_picks_text_for_python_file() -> None:
+    reg = ParserRegistry()
+    await reg.discover()
+    parser = reg.resolve(mime="text/x-python", ext="py")
+    assert parser is not None
+    assert "text" in type(parser).__name__.lower()
+
+
+@pytest.mark.asyncio
+async def test_resolve_picks_docling_for_pdf() -> None:
+    reg = ParserRegistry()
+    await reg.discover()
+    parser = reg.resolve(mime="application/pdf", ext="pdf")
+    assert parser is not None
+    assert "docling" in type(parser).__name__.lower()
+
+
+@pytest.mark.asyncio
+async def test_resolve_picks_notebook_for_ipynb() -> None:
+    reg = ParserRegistry()
+    await reg.discover()
+    parser = reg.resolve(mime="application/x-ipynb+json", ext="ipynb")
+    assert parser is not None
+    assert "notebook" in type(parser).__name__.lower()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_video() -> None:
+    sandbox = MagicMock()
+    sandbox._download_one = AsyncMock(return_value=b"\x00" * 100)
+    reg = ParserRegistry()
+    await reg.discover()
+    out = await reg.dispatch(
+        sandbox=sandbox,
+        path="/tmp/movie.mp4",
+        options=ParseOptions(),
+        conversation_id=uuid4(),
+    )
+    assert isinstance(out, UnsupportedOutput)
+    assert "video" in out.reason
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_oversize() -> None:
+    sandbox = MagicMock()
+    sandbox._download_one = AsyncMock(return_value=b"\x00" * (101 * 1024 * 1024))
+    reg = ParserRegistry()
+    await reg.discover()
+    out = await reg.dispatch(
+        sandbox=sandbox,
+        path="/tmp/big.txt",
+        options=ParseOptions(),
+        conversation_id=uuid4(),
+    )
+    assert isinstance(out, UnsupportedOutput)
+    assert "100" in out.reason or "large" in out.reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_returns_unchanged_on_second_read() -> None:
+    sandbox = MagicMock()
+    sandbox._download_one = AsyncMock(return_value=b"hello world")
+    reg = ParserRegistry()
+    await reg.discover()
+    conv = uuid4()
+
+    first = await reg.dispatch(
+        sandbox=sandbox, path="/tmp/a.txt", options=ParseOptions(), conversation_id=conv
+    )
+    assert isinstance(first, TextOutput)
+
+    second = await reg.dispatch(
+        sandbox=sandbox, path="/tmp/a.txt", options=ParseOptions(), conversation_id=conv
+    )
+    assert isinstance(second, UnchangedOutput)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_overwrites_path_in_output() -> None:
+    sandbox = MagicMock()
+    sandbox._download_one = AsyncMock(return_value=b"x = 1")
+    reg = ParserRegistry()
+    await reg.discover()
+    out = await reg.dispatch(
+        sandbox=sandbox, path="/tmp/script.py", options=ParseOptions(), conversation_id=None
+    )
+    assert isinstance(out, TextOutput)
+    assert out.path == "/tmp/script.py"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wraps_parser_exceptions_as_error() -> None:
+    sandbox = MagicMock()
+    sandbox._download_one = AsyncMock(return_value=b"not valid json {")
+    reg = ParserRegistry()
+    await reg.discover()
+    out = await reg.dispatch(
+        sandbox=sandbox, path="/tmp/x.ipynb", options=ParseOptions(), conversation_id=None
+    )
+    assert isinstance(out, ErrorOutput)
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/parsers/test_registry.py -v`
+Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Add entry_points to pyproject.toml**
+
+Edit `backend/pyproject.toml` to add (under `[project.entry-points]` section, create if absent):
+
+```toml
+[project.entry-points."cubebox.parsers"]
+text = "cubebox.parsers.plugins.text:TextParser"
+notebook = "cubebox.parsers.plugins.notebook:NotebookParser"
+docling = "cubebox.parsers.plugins.docling:DoclingParser"
+```
+
+- [ ] **Step 4: Implement registry.py**
+
+```python
+# backend/cubebox/parsers/registry.py
+"""ParserRegistry: discover plugins via entry_points + dispatch by MIME."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from cubebox.parsers import dedup
+from cubebox.parsers.mime import (
+    is_rejected,
+    reject_reason,
+    sniff_mime_async,
+)
+from cubebox.parsers.protocols import FileParser
+from cubebox.parsers.schema import (
+    ErrorOutput,
+    FileReadOutput,
+    ParseOptions,
+    UnchangedOutput,
+    UnsupportedOutput,
+)
+
+logger = logging.getLogger(__name__)
+
+GROUP = "cubebox.parsers"
+MAX_FILE_BYTES = 100 * 1024 * 1024
+
+
+class ParserRegistry:
+    def __init__(self) -> None:
+        self._parsers: list[FileParser] = []
+
+    async def discover(self) -> None:
+        """Load all FileParser plugins from entry_points."""
+        for ep in importlib.metadata.entry_points(group=GROUP):
+            cls = ep.load()
+            instance = cls() if isinstance(cls, type) else cls
+            if not isinstance(instance, FileParser):
+                raise RuntimeError(
+                    f"entry_point {ep.value} does not satisfy FileParser Protocol"
+                )
+            self._parsers.append(instance)
+            logger.info("registered FileParser: %s (priority=%d)", ep.name, instance.priority)
+
+        # DoclingParser may need config-injected base_url etc.
+        # If a DoclingParser was loaded with default args, swap in a config-bound one.
+        from cubebox.config import config  # lazy import to avoid cycles
+        from cubebox.parsers.plugins.docling import DoclingParser
+
+        for i, p in enumerate(self._parsers):
+            if isinstance(p, DoclingParser):
+                self._parsers[i] = DoclingParser(
+                    base_url=config.get("parsers.docling_serve.base_url", "http://docling-serve:5001"),
+                    api_key=config.get("parsers.docling_serve.api_key") or None,
+                    timeout_sync_seconds=int(config.get("parsers.docling_serve.timeout_sync_seconds", 30)),
+                    timeout_async_minutes=int(config.get("parsers.docling_serve.timeout_async_minutes", 10)),
+                    async_threshold_mb=int(config.get("parsers.docling_serve.async_threshold_mb", 3)),
+                    poll_interval_seconds=int(config.get("parsers.docling_serve.poll_interval_seconds", 2)),
+                )
+
+    def resolve(self, *, mime: str, ext: str) -> FileParser | None:
+        """Pick the best parser for a (mime, ext) pair."""
+        candidates: list[tuple[int, FileParser]] = []
+        for p in self._parsers:
+            score = self._match_score(p, mime, ext)
+            if score > 0:
+                candidates.append((score + p.priority, p))
+        if not candidates:
+            return None
+        candidates.sort(key=lambda x: x[0], reverse=True)
+        return candidates[0][1]
+
+    @staticmethod
+    def _match_score(parser: FileParser, mime: str, ext: str) -> int:
+        for pattern in parser.mime_types:
+            if pattern == mime:
+                return 100  # exact MIME match
+            if pattern.endswith("/*") and mime.startswith(pattern[:-1]):
+                return 50  # MIME wildcard
+        if ext in parser.extensions:
+            return 25  # extension fallback
+        return 0
+
+    async def dispatch(
+        self,
+        sandbox: Any,
+        path: str,
+        options: ParseOptions,
+        conversation_id: UUID | None,
+    ) -> FileReadOutput:
+        # 1. download
+        files = await sandbox.download([path]) if hasattr(sandbox, "download") else None
+        if files is None:
+            content = await sandbox._download_one(path)
+        else:
+            content = files[0][1]
+        size = len(content)
+
+        # 2. size precheck
+        if size > MAX_FILE_BYTES:
+            return UnsupportedOutput(
+                path=path, mime="application/octet-stream", size_bytes=size,
+                reason="file too large (100MB limit)",
+                hint="try reading specific pages with page_range",
+            )
+
+        # 3. MIME sniff
+        mime = await sniff_mime_async(path, content)
+
+        # 4. REJECT list
+        if is_rejected(path, mime):
+            reason, hint = reject_reason(path, mime)
+            return UnsupportedOutput(
+                path=path, mime=mime, size_bytes=size, reason=reason, hint=hint,
+            )
+
+        # 5. dedup check
+        if conversation_id is not None:
+            digest = await dedup.hash_bytes(content)
+            if dedup.check(conversation_id, path, digest):
+                return UnchangedOutput(path=path)
+            dedup.update(conversation_id, path, digest)
+
+        # 6. resolve plugin & parse
+        ext = Path(path).suffix.lstrip(".").lower()
+        parser = self.resolve(mime=mime, ext=ext)
+        if parser is None:
+            return UnsupportedOutput(
+                path=path, mime=mime, size_bytes=size,
+                reason="no parser matched",
+            )
+        try:
+            out = await parser.parse(content, mime=mime, options=options)
+        except Exception as exc:
+            logger.exception("parser %s failed on %s", type(parser).__name__, path)
+            return ErrorOutput(path=path, error=str(exc), retryable=False)
+
+        # Overwrite the placeholder path; preserve all other fields
+        out_dict = out.model_dump()
+        out_dict["path"] = path
+        return type(out).model_validate(out_dict)
+
+
+_registry: ParserRegistry | None = None
+
+
+def get_parser_registry() -> ParserRegistry:
+    global _registry
+    if _registry is None:
+        _registry = ParserRegistry()
+    return _registry
+
+
+def reset_parser_registry_for_tests() -> None:
+    global _registry
+    _registry = None
+```
+
+- [ ] **Step 5: Re-export from `__init__.py`**
+
+Replace `backend/cubebox/parsers/__init__.py`:
+
+```python
+"""File parser plugin registry shared by file_read tool and future filebox."""
+
+from cubebox.parsers.protocols import FileParser
+from cubebox.parsers.registry import (
+    ParserRegistry,
+    get_parser_registry,
+    reset_parser_registry_for_tests,
+)
+from cubebox.parsers.schema import (
+    ErrorOutput,
+    FileReadOutput,
+    NotebookCell,
+    NotebookOutput,
+    ParseOptions,
+    TextOutput,
+    UnchangedOutput,
+    UnsupportedOutput,
+)
+
+__all__ = [
+    "ErrorOutput",
+    "FileParser",
+    "FileReadOutput",
+    "NotebookCell",
+    "NotebookOutput",
+    "ParseOptions",
+    "ParserRegistry",
+    "TextOutput",
+    "UnchangedOutput",
+    "UnsupportedOutput",
+    "get_parser_registry",
+    "reset_parser_registry_for_tests",
+]
+```
+
+- [ ] **Step 6: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/parsers/ -v`
+Expected: All parser tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/cubebox/parsers/registry.py backend/cubebox/parsers/__init__.py backend/tests/parsers/test_registry.py backend/pyproject.toml backend/uv.lock
+git commit -m "feat(parsers): ParserRegistry discover + dispatch with REJECT/dedup precheck"
+```
+
+---
+
+### Task 11: `Sandbox.file_read` non-abstract method
+
+**Files:**
+- Modify: `backend/cubebox/sandbox/base.py`
+- Create: `backend/tests/parsers/test_sandbox_file_read.py`
+
+- [ ] **Step 1: Write failing integration test**
+
+```python
+# backend/tests/parsers/test_sandbox_file_read.py
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from cubebox.parsers.schema import ParseOptions, TextOutput
+from cubebox.sandbox.base import Sandbox
+
+
+class _FakeSandbox(Sandbox):
+    @property
+    def id(self) -> str:
+        return "fake"
+
+    @property
+    def workdir(self) -> str:
+        return "/work"
+
+    async def execute(self, command, *, timeout=None):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def upload(self, files):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def download(self, paths):  # type: ignore[no-untyped-def]
+        return [(paths[0], b"hello world")]
+
+    async def close(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_file_read_default_impl_dispatches_via_registry() -> None:
+    s = _FakeSandbox()
+    out = await s.file_read("/tmp/a.txt", conversation_id=uuid4())
+    assert isinstance(out, TextOutput)
+    assert out.content == "hello world"
+    assert out.path == "/tmp/a.txt"
+
+
+@pytest.mark.asyncio
+async def test_file_read_passes_options() -> None:
+    s = _FakeSandbox()
+    out = await s.file_read(
+        "/tmp/a.txt",
+        options=ParseOptions(page_range="1-3"),
+        conversation_id=None,
+    )
+    assert isinstance(out, TextOutput)
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/parsers/test_sandbox_file_read.py -v`
+Expected: FAIL with `AttributeError: ... has no attribute 'file_read'`.
+
+- [ ] **Step 3: Add `Sandbox.file_read` non-abstract default**
+
+Edit `backend/cubebox/sandbox/base.py`. After existing class methods:
+
+```python
+    async def file_read(
+        self,
+        path: str,
+        *,
+        options: "ParseOptions | None" = None,
+        conversation_id: "UUID | None" = None,
+    ) -> "FileReadOutput":
+        """Read and parse a file at <path> inside the sandbox.
+
+        Default impl: download bytes via self.download + dispatch via
+        cubebox.parsers registry. Subclasses may override (future Sandbox
+        implementations with native parsing may call their own API).
+        """
+        from cubebox.parsers import ParseOptions, get_parser_registry
+
+        return await get_parser_registry().dispatch(
+            sandbox=self,
+            path=path,
+            options=options or ParseOptions(),
+            conversation_id=conversation_id,
+        )
+```
+
+Add type-only imports at the top:
+
+```python
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from uuid import UUID
+    from cubebox.parsers import FileReadOutput, ParseOptions
+```
+
+NOTE: registry must be `discover()`-ed before `file_read` is called. App startup will do this in Task 14.
+
+- [ ] **Step 4: Bootstrap registry in test conftest**
+
+Add to `backend/tests/parsers/conftest.py` (create if missing):
+
+```python
+import pytest
+
+from cubebox.parsers import get_parser_registry, reset_parser_registry_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _bind_parser_registry():
+    reset_parser_registry_for_tests()
+    import asyncio
+    asyncio.get_event_loop().run_until_complete(get_parser_registry().discover())
+```
+
+(Adjust to your test event loop pattern; if pytest-asyncio mode is "auto", use an `@pytest.fixture(autouse=True)` async fixture instead.)
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/parsers/test_sandbox_file_read.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/sandbox/base.py backend/tests/parsers/test_sandbox_file_read.py backend/tests/parsers/conftest.py
+git commit -m "feat(sandbox): add Sandbox.file_read non-abstract method dispatching to parser registry"
+```
+
+---
+
+### Task 12: Register `file_read` agent tool in SandboxMiddleware
+
+**Files:**
+- Modify: `backend/cubebox/middleware/sandbox.py`
+- Create: `backend/tests/middleware/test_sandbox_file_read_tool.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/middleware/test_sandbox_file_read_tool.py
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from cubebox.middleware.sandbox import _create_file_read_tool
+from cubebox.parsers.schema import TextOutput
+
+
+@pytest.mark.asyncio
+async def test_file_read_tool_calls_sandbox() -> None:
+    sandbox = MagicMock()
+    sandbox.file_read = AsyncMock(
+        return_value=TextOutput(
+            path="/tmp/a.txt", mime="text/plain",
+            content="hi", size_bytes=2, metadata={},
+        )
+    )
+    tool = _create_file_read_tool(sandbox, conversation_id=uuid4())
+    assert tool.name == "file_read"
+    result = await tool.coroutine(path="/tmp/a.txt")  # type: ignore[union-attr]
+    assert "hi" in str(result)
+
+
+def test_file_read_tool_description_mentions_use_cases() -> None:
+    sandbox = MagicMock()
+    tool = _create_file_read_tool(sandbox, conversation_id=None)
+    desc = tool.description.lower()
+    # The description must mention what to use it for + what NOT to
+    assert "pdf" in desc
+    assert "video" in desc or "audio" in desc
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd backend && uv run pytest tests/middleware/test_sandbox_file_read_tool.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `_create_file_read_tool` in `middleware/sandbox.py`**
+
+Append to `backend/cubebox/middleware/sandbox.py`:
+
+```python
+from uuid import UUID
+
+from cubebox.parsers import ParseOptions
+from pydantic import BaseModel, Field as PField
+
+
+class _FileReadArgs(BaseModel):
+    path: str = PField(description="Absolute path inside the sandbox to the file to read.")
+    page_range: str | None = PField(
+        default=None,
+        description=(
+            "Optional 1-indexed page range, e.g. '1-5' or '3'. "
+            "Only honored for paginated formats (PDF, DOCX, PPTX)."
+        ),
+    )
+
+
+_FILE_READ_DESCRIPTION = """\
+Read a file from the sandbox workspace and return its content in a form
+you can reason about. Use this whenever you need to inspect user uploads,
+agent-generated artifacts, or any file inside the sandbox — not shell
+output, not network resources.
+
+USE THIS TOOL FOR:
+- Text / source code (.txt .md .py .js .ts .json .yaml .toml .csv .html
+  .css .go .rs .java .cpp etc.) — returns raw UTF-8 text.
+- Documents (.pdf .docx .pptx .xlsx .epub) — returns markdown
+  preserving headings, tables, lists.
+- Notebooks (.ipynb) — returns structured cells.
+- Images (.png .jpg .webp .tiff) — returns OCR'd text content.
+
+DO NOT USE THIS TOOL FOR:
+- Video / Audio — returns kind="unsupported".
+- Executables / Binaries — returns kind="unsupported".
+- Archives (.zip .tar .gz) — extract first via execute("unzip ..."),
+  then file_read on extracted files.
+- Remote URLs — file_read only reads sandbox paths.
+- Quick line peeks — execute("sed -n '42p' <file>") is faster.
+
+RETURN FORMAT (discriminated by `kind`):
+- "text"        : {content, mime, size_bytes, truncated, metadata}
+- "notebook"    : {cells: [{cell_type, source, outputs}, ...]}
+- "unsupported" : {reason, hint, mime, size_bytes}
+- "unchanged"   : file unchanged since previous file_read in this session
+- "error"       : {error, retryable}
+
+LIMITS:
+- Files > 100 MB are refused with kind="unsupported".
+- Content longer than 20,000 characters is truncated (truncated=True).
+  Use `page_range` for narrower slices.
+- Large files (>3 MB) trigger async parsing; up to 10 minutes.
+"""
+
+
+def _create_file_read_tool(sandbox: Sandbox, conversation_id: UUID | None) -> BaseTool:
+    """Build the file_read tool backed by a sandbox + conversation."""
+
+    async def _file_read(path: str, page_range: str | None = None):
+        result = await sandbox.file_read(
+            path,
+            options=ParseOptions(page_range=page_range),
+            conversation_id=conversation_id,
+        )
+        # Return the dict; LangChain will JSON-serialize for the LLM.
+        return result.model_dump()
+
+    return StructuredTool.from_function(
+        coroutine=_file_read,
+        name="file_read",
+        description=_FILE_READ_DESCRIPTION,
+        args_schema=_FileReadArgs,
+        metadata={"content_type": "file_read"},
+    )
+```
+
+Then in the SandboxMiddleware class where tools are assembled, add `_create_file_read_tool(sandbox, conversation_id=...)` to the tool list.
+
+NOTE: The exact `conversation_id` source depends on existing middleware plumbing. If `SandboxMiddleware` already receives it via context, pass through; otherwise default to None for v1 (dedup will simply not engage).
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd backend && uv run pytest tests/middleware/test_sandbox_file_read_tool.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/middleware/sandbox.py backend/tests/middleware/test_sandbox_file_read_tool.py
+git commit -m "feat(sandbox): register file_read agent tool in SandboxMiddleware"
+```
+
+---
+
+### Task 13: Backend `parsers.docling_serve` config schema + YAML
+
+**Files:**
+- Modify: `backend/cubebox/config.py`
+- Modify: `backend/config.yaml`
+- Modify: `backend/config.development.yaml`
+- Modify: `backend/config.test.yaml`
+
+- [ ] **Step 1: Add config schema (if pydantic-based)**
+
+In `backend/cubebox/config.py`:
+
+```python
+class _DoclingServeConfig(BaseModel):
+    base_url: str = "http://docling-serve:5001"
+    api_key: str | None = None
+    timeout_sync_seconds: int = 30
+    timeout_async_minutes: int = 10
+    async_threshold_mb: int = 3
+    poll_interval_seconds: int = 2
+
+
+class ParsersConfig(BaseModel):
+    docling_serve: _DoclingServeConfig = _DoclingServeConfig()
+
+
+# Add `parsers: ParsersConfig = ParsersConfig()` to top-level Settings
+```
+
+(If using dynaconf, just rely on the YAML defaults — no schema class needed.)
+
+- [ ] **Step 2: Append to YAML configs**
+
+To `backend/config.yaml`, `backend/config.development.yaml`, `backend/config.test.yaml`:
+
+```yaml
+parsers:
+  docling_serve:
+    base_url: http://docling-serve:5001
+    api_key: ${DOCLING_SERVE_API_KEY:-}
+    timeout_sync_seconds: 30
+    timeout_async_minutes: 10
+    async_threshold_mb: 3
+    poll_interval_seconds: 2
+```
+
+For test config, use a localhost URL that won't be hit during tests (mocked):
+
+```yaml
+parsers:
+  docling_serve:
+    base_url: http://localhost-test-no-hit
+```
+
+- [ ] **Step 3: Verify config loads**
+
+Run: `cd backend && uv run python -c "from cubebox.config import config; print(config.get('parsers.docling_serve.base_url'))"`
+Expected: prints `http://docling-serve:5001`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/cubebox/config.py backend/config.yaml backend/config.development.yaml backend/config.test.yaml
+git commit -m "feat(parsers): add parsers.docling_serve config schema with sensible defaults"
+```
+
+---
+
+### Task 14: App startup parser registry discover + docling-serve in docker-compose
+
+**Files:**
+- Modify: `backend/cubebox/api/app.py`
+- Modify: `docker-compose.yml`
+
+- [ ] **Step 1: Wire registry discover in lifespan**
+
+In `backend/cubebox/api/app.py` lifespan async context manager, add:
+
+```python
+from cubebox.parsers import get_parser_registry
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # ... existing setup ...
+    await get_parser_registry().discover()
+    # ... rest of lifespan ...
+```
+
+- [ ] **Step 2: Add docling-serve service to docker-compose.yml**
+
+If `docker-compose.yml` exists at repo root, append:
+
+```yaml
+  docling-serve:
+    image: quay.io/docling-project/docling-serve-cpu
+    environment:
+      DOCLING_SERVE_API_KEY: ${DOCLING_SERVE_API_KEY:-}
+    ports:
+      - "5001:5001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+```
+
+If no `docker-compose.yml`, skip this step (deployment will follow per-environment patterns).
+
+- [ ] **Step 3: Smoke test — server starts and discovers parsers**
+
+```bash
+cd backend && uv run python main.py &
+sleep 5
+curl -s http://localhost:8000/health || true
+kill %1
+```
+
+Expected: server starts without exception. `cubebox.parsers` log line shows 3 plugins registered.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/cubebox/api/app.py docker-compose.yml
+git commit -m "feat(api): discover parser plugins at app startup; add docling-serve compose service"
+```
+
+---
+
+### Task 15: Final integration + check
+
+**Files:**
+- Run all tests + smoke
+
+- [ ] **Step 1: Full backend test sweep**
+
+```bash
+cd backend && uv run pytest tests/ -v
+```
+
+Expected: ALL pass.
+
+- [ ] **Step 2: Run lint + type-check**
+
+```bash
+cd backend && make check
+```
+
+Expected: All green.
+
+- [ ] **Step 3: Manual smoke against real docling-serve (optional)**
+
+If you have docling-serve running locally:
+
+```bash
+docker run -d -p 5001:5001 quay.io/docling-project/docling-serve-cpu
+cd backend && uv run python main.py &
+sleep 5
+# Trigger an agent conversation that uses file_read on a small PDF
+kill %1
+docker stop $(docker ps -q --filter ancestor=quay.io/docling-project/docling-serve-cpu)
+```
+
+- [ ] **Step 4: Verify clean git status**
+
+```bash
+git status
+```
+
+Expected: clean. M6 implementation complete.
+
+---
+
+## Self-Review Notes (planner ran)
+
+- ✅ Spec coverage:
+  - FileReadOutput discriminated union (5 kinds) → Task 2
+  - FileParser Protocol → Task 3
+  - MIME sniff + REJECT → Task 4
+  - dedup → Task 5
+  - 3 default plugins → Tasks 6, 7, 8, 9
+  - ParserRegistry → Task 10
+  - Sandbox.file_read → Task 11
+  - file_read agent tool registration → Task 12
+  - Config schema → Task 13
+  - Docker compose + startup discover → Task 14
+- ✅ Tool description matches spec §6 verbatim
+- ✅ All limit numbers consistent (20K chars, 100MB file, 3MB async threshold, 30s sync, 10min async)
+- ✅ async-safe hashing via `asyncio.to_thread` in dedup.py
+- ⚠ Docling-serve API request shape (`FileSourceRequest`, exact field names) is best-effort per public docs; implementer should verify against running docling-serve `/docs` page and adjust if needed.
+- ⚠ Pytest-asyncio test event loop pattern in `conftest.py` may need adjustment depending on `pyproject.toml` asyncio_mode setting; current cubebox uses pytest-asyncio — confirm style matches existing tests.

--- a/docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md
+++ b/docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md
@@ -112,7 +112,7 @@
 - skills/MCP 管理界面为 M3 市场提供"我的组织"视图
 **不做**: 审计查看 UI（v1 先走日志导出）；成本看板（归 M1-E1 自己做）
 **依赖**: M1-E4（凭证）、M3（skills 管理复用市场 UI）
-**Spec**: `2026-04-XX-admin-console-design.md`
+**Spec**: `2026-04-23-admin-console-design.md`（骨架部分；完整 5 tab 各 1 份后续 spec）
 
 ---
 

--- a/docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md
+++ b/docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md
@@ -190,21 +190,19 @@
 
 **做什么**: 处理用户上传的非纯文本文件，把各种格式归一化为 LLM 可消费的内容。参考 Claude Code 的 `FileReadTool` 思路（硬编码工具 + discriminated output），但覆盖面更广。
 **Scope (v1)** — **硬编码工具**（非 skill）:
-- 输出 discriminated union：`text` / `image` / `notebook` / `pdf` / `office_markdown` / `parts` / `file_unchanged`
-- **主方案**: **MarkItDown**（Microsoft）作为默认解析器
-  - 覆盖 PDF / DOCX / XLSX / PPTX / HTML / CSV / JSON / image / audio
-  - 轻量依赖，输出 Markdown，LLM 友好
-- **可选补强**: 复杂排版 PDF 场景允许装 **Docling**（IBM）作为可选 skill 接管 PDF 分支（安装 1GB+，按需启用）
-- **Notebook**: 内置 parser（Jupyter 结构化处理）
-- **图片**: `Pillow` resize + token 预算感知压缩（Python 等价 sharp）
-- **去重**: file state 去重机制，避免重读未变文件
+- 输出 discriminated union（v1 共 5 种 kind）：`text` / `notebook` / `unsupported` / `unchanged` / `error`
+- **主方案**: 独立 **docling-serve** 服务（CPU 镜像 4.4 GB，HTTP API），不把 heavy 依赖引入核心库
+- **架构**: `Sandbox.file_read()` 抽象方法 + `cubebox.parsers` 后台共享库（FileParser Protocol + entry_points 插件机制）
+- **v1 三个内置 plugin**: `TextParser`（文本/代码）+ `NotebookParser`（.ipynb）+ `DoclingParser`（PDF/DOCX/PPTX/XLSX/EPUB/图像 OCR）
+- **去重**: conversation 级 SHA-256 hash cache，无副作用 invalidation
 **关键决定**:
-- 选 MarkItDown 而非从零硬编码单格式解析器，覆盖面大、落地快
-- 硬编码而非 skill：核心工具可靠可测，扩展走 skill（例：Docling skill）
-- 明确**拒绝** 视频 / 可执行二进制；未知格式降级为"内容摘要 + 元数据"提示
-**不做**: OCR 识别图片文字（v1 不做，留给后续 skill）；流式大文件
+- Parser 跑 backend，sandbox 只暴露文件；`cubebox.parsers` 后续给 filebox（workspace RAG）复用
+- 走插件架构（参考 MarkItDown converter registry）：用户后续可发 wheel 注册自定义 parser
+- 明确**拒绝** 视频 / 音频 / 可执行 / 归档；HTML 走文本不走 docling（因 agent 常读写 HTML artifacts）
+- v1 砍掉 backlog 原列的 `image` / `pdf` / `office_markdown` / `parts` 这些无下游消费者的 kind（待 vision 管线接通后非破坏性扩展）
+**不做**: 视觉/模型原生 PDF（vision 管线未接通）；OCR 之外的图像理解；远程 URL；artifact 反向读取
 **依赖**: —
-**Spec**: `2026-04-XX-file-read-tool-design.md`
+**Spec**: `2026-04-22-file-read-tool-design.md`
 
 ---
 

--- a/docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md
+++ b/docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md
@@ -121,7 +121,7 @@
 **做什么**: skills 是 agent 能力扩展主入口，必须有市场才有生态。
 **Scope (v1)**:
 - 市场 UI：浏览、搜索、按 tag 过滤
-- 发布：上传 skill 包（Openclaw 格式，见 M5）
+- 发布：上传 skill 包（Openclaw 格式）；frontmatter 解析器扩展（原 M5 范围）随此 spec 一起定义
 - 版本：**只能传新版本，不能改旧版本**；展示版本列表 + changelog
 - 安装：装到组织级 → 控制台开关到具体 workspace
 - `skill-creator` skill：用户通过 agent 引导创建 skill 并一键发布到市场
@@ -129,8 +129,8 @@
 **关键决定**:
 - 首版是**简易**市场，无评分 / 评论 / 下载量排行；留给开源后迭代
 - 市场后端放 CE；企业私有 registry 留给 EE
-**不做**: skill 依赖自动解析；跨组织签名/审核流程
-**依赖**: M5（Openclaw 格式）
+**不做**: skill 依赖自动解析；跨组织签名/审核流程；运行时 `requires` 校验与 `install[]` 执行（见 M5 说明）
+**依赖**: —（原依赖 M5 已并入本 spec）
 **Spec**: `2026-04-XX-skills-marketplace-design.md`
 
 ---
@@ -169,21 +169,20 @@
 
 ---
 
-## M5 · Openclaw Skill 格式兼容 · P0
+## M5 · Openclaw Skill 格式兼容 · 已并入 M3（2026-04-22 修订）
 
-**做什么**: skill 打包格式统一到 Openclaw 规范，保证生态兼容。
-**参考**: https://docs.openclaw.ai/tools/skills
-**Scope (v1)**:
-- `SKILL.md`：YAML frontmatter + Markdown 正文
-- Frontmatter 包含 `metadata.openclaw.requires.{bins, env, config}`
-- `install[]` 安装步骤（支持 `brew` / `node` / `go` / `uv` / `download`）
-- 加载器：解析 frontmatter → 校验依赖（bins / env）→ 执行 install 步骤（沙盒内）
-- 不满足依赖的 skill 走降级提示，不阻塞其他 skill
-**关键决定**:
-- 完整按 Openclaw 规范，**不自造格式**，利于跨生态流通
-**不做**: 扩展自有字段（保持纯 Openclaw 子集）
-**依赖**: 沙盒镜像可执行 install 步骤
-**Spec**: `2026-04-XX-openclaw-skill-format-design.md`
+**演进**: brainstorming 过程中发现 M5 可实际落地的工作量过小，无需独立 spec。
+
+**合并路径**:
+- **frontmatter 解析器扩展**（`SkillSpec` dataclass 扩字段 + `yaml.safe_load` 替换正则解析 + `metadata.openclaw` / `clawdbot` / `clawdis` alias 合并 + `raw_metadata` 保留未知字段）→ 随 **M3 skills 市场** spec 定义并实现（市场 UI 直接消费这些字段，天然同处一个 spec）
+- **`requires.env` / `requires.bins` 校验**（判断 skill 当前是否可用）→ 留给未来 **sandbox egress / env 代理** spec
+- **`install[]` 执行** → 不计划做（Openclaw 自己的 lazy-install 模型是"agent 遇错再装"，LLM 驱动而非 loader 驱动，不是 cubebox 的独立设计问题）
+
+**兼容承诺**: 用户上传 Openclaw 包，系统能加载、使用；特有字段保留下来供市场 UI 展示。向下兼容 Claude Code / Codex 的 Agent Skills 基底（他们无 `requires`/`install`，是 Openclaw 的子集）。
+
+**参考**:
+- Openclaw spec: https://docs.openclaw.ai/tools/skills
+- Agent Skills 基底（Claude Code + Codex 共同基底）: https://agentskills.io
 
 ---
 
@@ -315,7 +314,7 @@
 | Batch | 周 | 模块 | 目标产物 |
 |---|---|---|---|
 | 0 | W1 前置 | **M-CI** | CI 流水线建立（所有后续模块在其上运行） |
-| 1 | W1-W2 | M0, M5, M6, M2（骨架） | 插件接口冻结、skill 格式可加载、file_read 可用、管理员控制台 shell 就位 |
+| 1 | W1-W2 | M0, M6, M2（骨架） | 插件接口冻结、file_read 可用、管理员控制台 shell 就位（原 M5 已并入 M3，见 M5 说明） |
 | 2 | W2-W3 | M1-E1, M1-E2, M4, M4a, M9, M7 | 成本看板 + Trace + workspace/首页双入口 + 文件上传 + 单租户 UX |
 | 3 | W3-W4 | M1-E3, M1-E4, M1-E5, M3, M8, M12 | 企业五件套齐 + skills 市场上线 + 会话分享 + 工程基建 |
 | 4 | W4 | M10, M11 | Hero 场景跑通、demo 视频 + README 定稿 |
@@ -324,7 +323,6 @@
 - **M-CI 最先**，后续所有模块必须在 CI 绿灯基础上开发
 - M0 接口定义先于 M1-E5（AuditSink）、M2（AdminPanelExtension）
 - M2 骨架先于 M1-E1（成本看板挂靠）
-- M5 先于 M3（市场依赖格式）
 - M1-E2 需要 cubemanus tracing 代码迁移准备，可并行启动但晚于 M-CI
 - M11 最后（需要 M10 + M1-E2 的产物）
 
@@ -334,7 +332,7 @@
 
 - [ ] 最终仓库名：`cubebox` / `cubeplex` / 其他
 - [ ] 预装 skills 清单（实现 M3 时结合社区内容确定）
-- [ ] sandbox 默认镜像选型（实现 M2 / M5 时定）
+- [ ] sandbox 默认镜像选型（实现 M2 时定）
 - [ ] `cubebox-ee` 仓的首个真实 EE 功能（发布后迭代选 1-2 项）
 - [ ] M9 单租户 UX 的具体交互细节（进 spec 阶段确认）
 - [ ] cubemanus tracing 代码迁移许可与边界（M1-E2 开工前确认）

--- a/docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md
+++ b/docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md
@@ -299,11 +299,12 @@
 - Issue 模板 / PR 模板 / branch protection 建议配置
 - Release 流程：tag → changelog → GitHub Release
 - 仓库名最终定：暂用 `cubebox`，后续可能改 `cubeplex` 等（发布前最终决定）
+- **生产 CSP 收紧**：M2 batch 1 的 `frame-src 'self'` 安全目标已达成；但 `default-src` 仍开 `'unsafe-inline'` / `'unsafe-eval'`（Next.js dev 需要）。生产模式应改为 `script-src 'self' 'nonce-{x}'` + 删 unsafe-eval；按 NODE_ENV 动态生成 CSP；配合 `SECURITY.md` 一起做
 **关键决定**:
 - 所有 CI 作业必须在公开状态下通过（不依赖内部凭证）
 - 发布流程手动触发，v1 不做自动发包
 **不做**: 自动生成文档站；docker hub 镜像自动推送
-**依赖**: M0（EE 兼容 CI 作业）
+**依赖**: M0（EE 兼容 CI 作业）、M2（CSP 在 next.config.ts 已埋点，M12 收紧）
 
 ---
 

--- a/docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md
+++ b/docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md
@@ -54,7 +54,7 @@
 - 接口不做 ACL 兜底，调用方必须显式注册；未注册 → fallback 到 CE 默认
 **不做**: 插件热加载；EE 功能真实实现（留到开源后首个 EE 发布）
 **依赖**: —
-**Spec**: `2026-04-XX-ce-ee-plugin-architecture-design.md`
+**Spec**: `2026-04-22-ce-ee-plugin-architecture-design.md`
 
 ---
 

--- a/docs/superpowers/specs/2026-04-22-ce-ee-plugin-architecture-design.md
+++ b/docs/superpowers/specs/2026-04-22-ce-ee-plugin-architecture-design.md
@@ -56,6 +56,7 @@
 | D11 | 单一 `CUBEBOX_PLUGIN_API_VERSION: int`，不做 per-Protocol 版本 | 每 Protocol 独立版本 | 一年内生态小，简单 trump 精细 |
 | D12 | 每个插件 wheel **必须** 声明 `cubebox.plugin_manifest` 入口；无则拒启 | 缺省当 v1 | 强制兼容性声明，避免"静默用错版本" |
 | D13 | `test-ee-compat` 分两层：Layer 1（CE 自测 + fake plugin fixture）Batch 1 真做；Layer 2（跨仓跑真 cubebox-ee）占位 `if: false` | 一步到位 | 无真 EE 仓可跑 Layer 2；Layer 1 先做保证契约有自动化回归 |
+| D14 | v1 `cubebox-ee` 走"**单一大包**"打包策略（一个 wheel 同时注册多组 entry_points） | 按功能拆成多 wheel / 命名空间子包 | 对齐"按 seat 单 EE license"商业模式；v1 EE 功能少、提前拆粒度是过度设计；切换策略零 CE 改动（见 §5.5） |
 
 ---
 
@@ -351,6 +352,24 @@ CE 的 `defaults/*.py` 由 `PluginRegistry` 在缺失候选或 `selected == "bui
 
 **保留名 `"builtin"`**：外部插件的 entry_point name 不得为 `"builtin"`；若发现，启动失败并给出可读错误（`PluginRegistry` 显式校验）。
 
+### 5.5 打包策略与 API 契约相互独立
+
+Protocol 契约以"每个 entry_point 独立发现、独立装载"为语义，**不约束**插件作者如何把实现打成 wheel。同一 API 契约下，以下打包粒度都合法且对 CE 透明：
+
+| 策略 | 示例 | 典型场景 |
+|---|---|---|
+| 单一大包 | `cubebox-ee` 同时注册 SAML + SIEM + Billing 等多组 entry_points | v1 商业模式：按 seat 单 EE license 对齐一个 wheel |
+| 独立多包 | `cubebox-ee-sso` / `cubebox-ee-audit` / `cubebox-ee-billing` 各自一个 wheel | EE 功能繁多、想按需装或独立计费时 |
+| 命名空间子包 | `cubebox-ee-core` + 可选 `cubebox-ee-sso` 等 | 共享 core utils + 可选 extras |
+| 3rd-party 插件 | 独立仓 `cubebox-plugin-xxx` 与 EE 并存 | 开源社区插件（与 EE **一视同仁**，同样走 entry_points） |
+
+**关键不变式**：
+- Protocol 发现遍历**全部**已装 wheel 的 entry_points；一个 wheel 装 1 个还是 5 个 entry_points，CE 侧代码完全相同
+- 每个 wheel **各自**声明一次 `cubebox.plugin_manifest`（manifest 属于 wheel，不属于 Protocol）
+- 切换打包粒度**不需要任何 CE 代码改动**；仅是 EE 仓内部 pyproject 的拆分重组
+
+**v1 打包决定**：`cubebox-ee` 以**单一大包**形态发布，对齐"按 seat 单 EE license"的商业模式。将来若需按功能拆分，仅在 EE 仓内部演进，CE 不受影响。
+
 ---
 
 ## 6. Plugin API 版本策略
@@ -397,7 +416,7 @@ class PluginManifest:
 
 ## 7. `cubebox-ee` 仓骨架蓝图
 
-**Batch 1 不真建仓**。以下结构在首个真实 EE 功能立项时作为仓库初始化模板。
+**Batch 1 不真建仓**。以下结构在首个真实 EE 功能立项时作为仓库初始化模板。结构示例按 §5.5 的 v1 打包决定采用"单一大包"形态；若将来拆分，按 §5.5 表格中的其它策略演进即可。
 
 ### 7.1 目录结构
 

--- a/docs/superpowers/specs/2026-04-22-ce-ee-plugin-architecture-design.md
+++ b/docs/superpowers/specs/2026-04-22-ce-ee-plugin-architecture-design.md
@@ -1,0 +1,602 @@
+# M0 · CE/EE 插件架构设计
+
+**Status**: Draft · 2026-04-22
+**Owner**: @xfgong
+**Scope**: 冻结 5 个 Protocol 扩展接口、基于 `entry_points` 的发现机制、CE 默认实现、以及 `cubebox-ee` 插件仓骨架蓝图。Batch 1 内把 AuthProvider 与 PermissionChecker 真接入 CE，AuditSink 以 no-op 默认接入 3 个调用点，其余 2 个 Protocol 仅冻结接口。
+**属于**: v1 开源发布待办 · M0
+**Backlog 索引**: `docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md`
+**依赖**: M-CI（占位 `test-ee-compat` 作业）
+
+---
+
+## 1. 背景与目标
+
+### 1.1 现状
+
+- Backend 的身份认证 (`fastapi-users` + JWT cookie) 与 2-role RBAC（`require_admin` / `require_member`）**全部硬编码**在 `backend/cubebox/auth/` 下。
+- 不存在 audit log、外部目录同步、admin 扩展点这三类机制。
+- 工具 / skills / MCP 的注册走静态注册表或目录扫描，**没有**任何 `entry_points` 发现路径。
+- `pyproject.toml` 未声明任何扩展点。
+- CE/EE 边界 day-1 就要定死（商业/开源边界见 backlog）。
+
+### 1.2 目标
+
+- 冻结 5 个 `Protocol` 扩展接口：`AuthProvider`、`PermissionChecker`、`AuditSink`、`UserDirectorySyncer`、`AdminPanelExtension`。
+- 提供 `pip entry_points` 插件发现 + CE 默认 fallback 机制。
+- CE 自己必须通过这些接口调用自己的默认实现 —— 至少 2 个 Protocol（AuthProvider / PermissionChecker）+ 1 个 no-op 桩（AuditSink）—— 以验证契约可用。
+- 写 `cubebox-ee` 仓骨架蓝图（**不真建仓**），为 M-CI 的 `test-ee-compat` 作业提供真实形态。
+- 通过一个**内置 fake 插件** fixture 对 Protocol 契约做自动化回归。
+
+### 1.3 非目标
+
+- 真建 `cubebox-ee` GitHub 仓（等首个真实 EE 功能要上线时再建）。
+- Casbin / 细粒度字段级权限（归 M1-E3）。
+- AuditSink 落 DB + 查询 UI（归 M1-E5）。
+- 真实的 SSO / SCIM / LDAP 实现。
+- AdminPanelExtension 在前端真渲染出 iframe（M2 骨架承接后端 seam）。
+- Plugin 热加载 / 热卸载 / 版本并存。
+- 给 CE 默认实现注册 `entry_points`（默认实现由 CE 代码直接实例化；`entry_points` 只供外部 wheel 使用）。
+
+---
+
+## 2. 决策记录
+
+| # | 决策 | 备选 | 选用理由 |
+|---|---|---|---|
+| D1 | CE/EE 采用**出仓 + entry_points** 发现机制 | GitLab 风格 `ee/` monorepo | 降低社区 PR 与 EE 代码冲突；`entry_points` 是 Python 生态标准 |
+| D2 | Batch 1 范围：5 Protocol 全定义，AuthProvider + PermissionChecker 真接入 CE，AuditSink no-op + 3 调用点，其余 2 个纯接口 | 极简（纯接口）/ 全接入 | 契约被 CE 自己消费一轮确保可用；AuditSink 落库是 M1-E5 的活儿 |
+| D3 | AuthProvider / PermissionChecker 为**单实例** Protocol | 多实例 chain | 一个请求只能被一种身份方案认证；权限决策必须唯一 |
+| D4 | 单实例冲突策略：CE 默认兜底 → 1 外部取代 → ≥2 外部**启动失败** | 按名字字母序自选 / 强制要求显式配置 | 装错了立即失败；零配置情形仍能跑 |
+| D5 | 单实例支持 `plugins.<protocol>.selected` 显式挑选 | 不提供挑选 | 给管理员 escape hatch（强制兜底 CE / 多外部共存时挑一个） |
+| D6 | AuditSink / UserDirectorySyncer / AdminPanelExtension 为**多实例** | 单实例 | Audit 要 fan-out；syncer 可同时 LDAP + SCIM；后台页多插件各注册 |
+| D7 | 多实例支持 `plugins.<protocol>.disabled: [name]` 白名单 | 布尔开关 | 按插件名禁用；单条配置覆盖多个实现 |
+| D8 | `PermissionChecker` 迁移采用"保留调用点、替换内部"路径 —— `require_admin/member` 改为包装 `check(user, action, resource)` | 引入 `requires(resource, action)` 新依赖替换所有路由 | 业务路由 0 行改动；签名给 M1-E3 Casbin 留空间不破 Protocol |
+| D9 | AdminPanelExtension 采用 **iframe + pip wheel `package_data` 前端静态托管** 模型（对标 Atlassian Forge Custom UI） | MF 模块联邦 / 独立 npm 包 / admin 上传 zip | 无业内主流平台用 MF 做插件（Forge/Grafana/Kibana/WP 都 iframe）；一 wheel 一交付，Python+JS 版本一致 |
+| D10 | 每个 Protocol 一个 entry_points group（如 `cubebox.auth_provider`） | 单一 group + 按 class 分派 | 对齐 Python 生态习惯；发现时按需加载；错误定位精确 |
+| D11 | 单一 `CUBEBOX_PLUGIN_API_VERSION: int`，不做 per-Protocol 版本 | 每 Protocol 独立版本 | 一年内生态小，简单 trump 精细 |
+| D12 | 每个插件 wheel **必须** 声明 `cubebox.plugin_manifest` 入口；无则拒启 | 缺省当 v1 | 强制兼容性声明，避免"静默用错版本" |
+| D13 | `test-ee-compat` 分两层：Layer 1（CE 自测 + fake plugin fixture）Batch 1 真做；Layer 2（跨仓跑真 cubebox-ee）占位 `if: false` | 一步到位 | 无真 EE 仓可跑 Layer 2；Layer 1 先做保证契约有自动化回归 |
+
+---
+
+## 3. 整体架构
+
+### 3.1 文件布局（新增）
+
+```
+backend/cubebox/plugins/
+├── __init__.py              # PluginManifest、CUBEBOX_PLUGIN_API_VERSION、registry getters
+├── protocols.py             # 5 Protocol + 所有 dataclasses
+├── registry.py              # 发现、解析、PluginRegistry 单例
+└── defaults/
+    ├── __init__.py
+    ├── auth.py              # 包装 fastapi-users 现有实现
+    ├── permissions.py       # 包装现有 Role 查询
+    ├── audit.py             # no-op（structlog INFO）
+    └── admin_panel.py       # 空 nav items / 空 router / 空 static
+```
+
+不建 `defaults/directory.py` —— `UserDirectorySyncer` 无 CE 默认（目前无外部目录源可同步）。
+
+### 3.2 Protocol 分类速查
+
+| Protocol | 语义 | Batch 1 接入 | CE 默认 |
+|---|---|---|---|
+| `AuthProvider` | 单实例 | 真接入 | 包装 fastapi-users |
+| `PermissionChecker` | 单实例 | 真接入 | 包装现有 Role 查询 |
+| `AuditSink` | 多实例 fan-out | no-op 默认 + 3 调用点 | structlog INFO |
+| `UserDirectorySyncer` | 多实例 | 仅接口 | 无（Batch 1 不注册） |
+| `AdminPanelExtension` | 多实例 | 接口 + CE 端注册骨架 | 空（get_router=None / nav_items=[] / static_path=None） |
+
+---
+
+## 4. Protocol 契约
+
+所有定义位于 `backend/cubebox/plugins/protocols.py`。
+
+### 4.1 `AuthProvider`（单实例）
+
+```python
+class AuthProvider(Protocol):
+    """Authenticate requests and yield a User principal."""
+
+    async def authenticate(self, request: Request) -> User | None:
+        """Inspect cookies/headers; return authenticated User or None."""
+
+    def get_auth_routers(self) -> list[APIRouter]:
+        """Login/logout/callback endpoints. CE default returns fastapi-users
+        router; SAML/OIDC plugins return their own challenge flow."""
+```
+
+**CE 默认 (`defaults/auth.py`)**：基于现有 `cubebox.auth.jwt.auth_backend` + `fastapi-users` `UserManager` 构造一个薄包装类。`authenticate` 复用现有 JWT cookie 策略；`get_auth_routers` 返回 `fastapi_users.get_auth_router(auth_backend)` + `get_register_router()` + `get_users_router()`。
+
+**外部示例**：`cubebox_ee.auth.saml:SAMLAuthProvider` —— 实现 SP-initiated SAML，`authenticate` 读 `X-SAML-Session` cookie 解出 user_id 并从 DB 查 User。
+
+**集成点**：
+- `backend/cubebox/api/app.py` 启动时：`app.include_router(registry.get_auth_provider().get_auth_routers())`
+- `backend/cubebox/auth/dependencies.py::current_active_user` 改写为薄壳，内部委托 `registry.get_auth_provider().authenticate(request)`
+
+### 4.2 `PermissionChecker`（单实例）
+
+```python
+class PermissionChecker(Protocol):
+    async def check(
+        self,
+        user: User,
+        action: str,
+        resource: PermissionResource,
+    ) -> bool: ...
+
+
+@dataclass(frozen=True)
+class PermissionResource:
+    type: str                          # "workspace" | "organization" | "conversation" | ...
+    id: UUID | None                    # 具体资源；None = 类型级策略
+    org_id: UUID | None = None
+    workspace_id: UUID | None = None
+```
+
+**CE 默认 (`defaults/permissions.py`)**：
+
+```python
+class DefaultPermissionChecker:
+    async def check(self, user, action, resource):
+        if action == "admin_access" and resource.workspace_id:
+            return await membership_repo.get_role(user.id, resource.workspace_id) == Role.ADMIN
+        if action == "member_access" and resource.workspace_id:
+            return await membership_repo.get_role(user.id, resource.workspace_id) in (Role.ADMIN, Role.MEMBER)
+        return False   # 未知 action 默认拒绝，为 M1-E3 留空间
+```
+
+**外部示例**：M1-E3 的 `CasbinPermissionChecker` —— 用 `pycasbin` 匹配声明式策略文件。
+
+**现有路由迁移**：`auth/dependencies.py:70-71` 的 `require_admin` / `require_member` 改写：
+
+```python
+def require_admin(
+    user: User = Depends(current_active_user),
+    workspace_id: UUID = Depends(path_workspace_id),
+    checker: PermissionChecker = Depends(get_permission_checker),
+) -> User:
+    resource = PermissionResource(type="workspace", id=workspace_id, workspace_id=workspace_id)
+    if not await checker.check(user, "admin_access", resource):
+        raise HTTPException(status_code=403)
+    return user
+```
+
+业务路由的 `Depends(require_admin)` 调用**零改动**。
+
+### 4.3 `AuditSink`（多实例）
+
+```python
+class AuditSink(Protocol):
+    async def record(self, event: AuditEvent) -> None: ...
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    timestamp: datetime
+    user_id: UUID | None
+    org_id: UUID | None
+    workspace_id: UUID | None
+    action: str                        # "auth.login" | "auth.register" | "workspace.invite_created" | ...
+    target_type: str | None
+    target_id: str | None
+    ip: str | None
+    user_agent: str | None
+    metadata: dict[str, Any]           # escape hatch：各 action 专属数据
+```
+
+**CE 默认 (`defaults/audit.py`)**：`structlog` 打 INFO 级结构化日志，字段名与 `AuditEvent` 对齐。**不落库**。
+
+**Batch 1 接入的 3 个调用点**（选择依据：现有代码 + 权限相关）：
+
+| action | 调用位置 | 触发 |
+|---|---|---|
+| `auth.login` | `cubebox.auth.users.UserManager.on_after_login` | 登录成功 |
+| `auth.register` | `cubebox.auth.users.UserManager.on_after_register` | 注册成功 |
+| `workspace.invite_created` | `cubebox.workspaces.invites.create_invite` 成功分支 | 管理员创建邀请 |
+
+**统一 helper**：`cubebox.plugins.audit.audit_log(action, target=None, **metadata) -> None`，内部构造 `AuditEvent` 并 `await` 所有已注册 `AuditSink.record`。
+
+**未来扩展**：M1-E5 在 `cubebox.audit.sinks.db:DBAuditSink` 里实现落库 sink，届时通过 `entry_points` 作为 CE 内置额外 sink 注册（CE 版 M0 default 保留）。
+
+### 4.4 `UserDirectorySyncer`（多实例）
+
+```python
+class UserDirectorySyncer(Protocol):
+    async def sync(self) -> SyncResult: ...
+    def get_schedule(self) -> SyncSchedule: ...
+
+
+@dataclass
+class SyncResult:
+    added: int
+    updated: int
+    removed: int
+    errors: list[str]
+
+
+@dataclass
+class SyncSchedule:
+    interval_seconds: int | None       # None = 仅手动触发
+```
+
+**CE 默认**：无（Batch 1 不注册默认实现）。
+
+**未来扩展**：独立的背景 worker 周期轮询所有注册的 syncer 并调用 `sync()`。Batch 1 不建 worker；接口冻结以便之后的 EE LDAP/SCIM 插件接入。
+
+### 4.5 `AdminPanelExtension`（多实例）
+
+```python
+class AdminPanelExtension(Protocol):
+    def get_router(self) -> APIRouter | None: ...
+    def get_nav_items(self) -> list[AdminNavItem]: ...
+    def get_static_path(self) -> Path | None: ...    # 指向 frontend/dist/
+
+
+@dataclass(frozen=True)
+class AdminNavItem:
+    id: str                            # 插件内部唯一
+    label: str
+    icon: str | None                   # lucide 图标名
+    section: str                       # "identity" | "integrations" | "settings" | "custom"
+    order: int
+    url_path: str                      # 例 "billing/usage"
+```
+
+**CE 默认**：`get_router() -> None`；`get_nav_items() -> []`；`get_static_path() -> None`。
+
+**CE 端启动扫描**（Batch 1 完成；位于 `api/app.py` 启动钩子）：
+
+```python
+for name, ext in registry.get_admin_panel_extensions().items():
+    if (router := ext.get_router()) is not None:
+        app.include_router(router, prefix=f"/api/v1/admin/_extensions/{name}")
+    if (static_path := ext.get_static_path()) is not None:
+        app.mount(
+            f"/api/v1/admin/_extensions/{name}/static",
+            StaticFiles(directory=static_path),
+        )
+```
+
+**聚合 manifest 端点**（Batch 1 完成；CE 环境下返回空列表）：
+
+```
+GET /api/v1/admin/_extensions/manifest
+→ [
+    {
+      "plugin": "cubebox-ee",
+      "nav_items": [...AdminNavItem],
+      "iframe_base_url": "/api/v1/admin/_extensions/cubebox-ee/"
+    },
+    ...
+  ]
+```
+
+前端 admin shell（M2 骨架做）拉 manifest → 渲染侧栏导航 → 点击时打开 iframe 指向 `iframe_base_url + url_path`。iframe 里的 HTML 由插件的 router 服务端渲染。
+
+---
+
+## 5. 发现与注册机制
+
+### 5.1 Entry points 分组
+
+```
+cubebox.plugin_manifest         # 每个 wheel 必须声明 1 个
+cubebox.auth_provider           # 单实例
+cubebox.permission_checker      # 单实例
+cubebox.audit_sink              # 多实例
+cubebox.user_directory_syncer   # 多实例
+cubebox.admin_panel_extension   # 多实例
+```
+
+### 5.2 启动流程（`PluginRegistry.discover()`）
+
+1. **扫描 manifest**：遍历 `importlib.metadata.entry_points(group="cubebox.plugin_manifest")` 加载每个 `PluginManifest`。
+2. **版本校验**：`manifest.api_version != CUBEBOX_PLUGIN_API_VERSION` → `RuntimeError` 含插件名/期望值/实际值。
+3. **按 Protocol 扫描**：对每个 Protocol group，遍历 entry points，`load()` 得到实现类，记入候选集合。
+4. **单实例解析**（以 `auth_provider` 为例）：
+
+   ```python
+   selected = config.plugins.auth_provider.selected   # None / "builtin" / "<name>"
+
+   if selected == "builtin":
+       impl = DefaultAuthProvider()
+   elif selected is not None:
+       if selected not in candidates:
+           raise RuntimeError(f"auth_provider '{selected}' not registered")
+       impl = candidates[selected]()
+   else:   # 隐式规则
+       match len(candidates):
+           case 0: impl = DefaultAuthProvider()
+           case 1: impl = next(iter(candidates.values()))()
+           case _: raise RuntimeError(f"multiple auth_provider registered: {list(candidates)}")
+   ```
+
+5. **多实例解析**（以 `audit_sink` 为例）：
+
+   ```python
+   disabled = set(config.plugins.audit_sink.disabled)
+   impls = [cls() for name, cls in candidates.items() if name not in disabled]
+   if "builtin" not in disabled:       # "builtin" 是 CE 默认实现的保留名
+       impls.append(DefaultAuditSink())
+   ```
+
+6. **结果暴露**：`PluginRegistry` 单例通过 getter 提供访问（`get_auth_provider()`, `get_permission_checker()`, `get_audit_sinks()`, `get_user_directory_syncers()`, `get_admin_panel_extensions()`）。
+
+### 5.3 配置 schema（`config.yaml`）
+
+```yaml
+plugins:
+  auth_provider:
+    selected: null           # null / "builtin" / "<plugin_name>"
+  permission_checker:
+    selected: null
+  audit_sink:
+    disabled: []             # 例：["builtin"] 禁用 CE 默认 sink
+  user_directory_syncer:
+    disabled: []
+  admin_panel_extension:
+    disabled: []
+```
+
+默认全为 `null` / `[]`（无外部插件时零配置可跑）。
+
+### 5.4 CE 默认实现不走 `entry_points`
+
+CE 的 `defaults/*.py` 由 `PluginRegistry` 在缺失候选或 `selected == "builtin"` 时**直接实例化**，**不**在 `backend/pyproject.toml` 里声明 `entry_points`。原因：
+- 避免默认实现作为"插件"被 Layer 1 契约测试当外部 plugin 发现
+- 降低 `entry_points` 表条目噪声
+
+**保留名 `"builtin"`**：外部插件的 entry_point name 不得为 `"builtin"`；若发现，启动失败并给出可读错误（`PluginRegistry` 显式校验）。
+
+---
+
+## 6. Plugin API 版本策略
+
+### 6.1 常量
+
+```python
+# backend/cubebox/plugins/protocols.py
+from typing import Final
+
+CUBEBOX_PLUGIN_API_VERSION: Final[int] = 1
+```
+
+### 6.2 PluginManifest
+
+```python
+@dataclass(frozen=True)
+class PluginManifest:
+    api_version: int           # 必须等于 CE 的 CUBEBOX_PLUGIN_API_VERSION
+    name: str                  # 人可读名，日志/错误信息用
+    version: str               # 插件自身语义版本（与 api_version 独立）
+    description: str = ""
+```
+
+### 6.3 变更分类
+
+| 变更类型 | 是否触发 API version 升级 | 示例 |
+|---|---|---|
+| 加 Protocol 方法（有默认实现） | 否 | 给 `AuditSink` 加 `async def flush(): pass` |
+| 加 dataclass 可选字段（带默认） | 否 | `AdminNavItem.badge: str \| None = None` |
+| 加新 Protocol | 否（新 group 即可） | 以后加 `BillingProvider` |
+| 改 Protocol 方法签名 | **是** | `check(user, action, resource)` → `check(user, action, resource, context)` |
+| 改 dataclass 必填字段 | **是** | `AuditEvent.action` → 改成枚举 |
+| 改 entry_points group 名 | **是** | `cubebox.auth_provider` → `cubebox.identity_provider` |
+| 删 Protocol 方法 | **是** | 删 `AuthProvider.get_auth_routers` |
+
+### 6.4 Deprecation 流程
+
+- 破坏性变更前**至少一个 minor release** 在旧方法/字段上标 `@deprecated`（`typing_extensions.deprecated`）
+- 记入 `CHANGELOG.md` 的 "Deprecated" section
+- 次一个 major release 才真的删
+
+---
+
+## 7. `cubebox-ee` 仓骨架蓝图
+
+**Batch 1 不真建仓**。以下结构在首个真实 EE 功能立项时作为仓库初始化模板。
+
+### 7.1 目录结构
+
+```
+cubebox-ee/
+├── README.md                          # EE 说明 + 商业协议链接
+├── LICENSE                            # commercial license
+├── pyproject.toml
+├── cubebox_ee/
+│   ├── __init__.py                    # exports MANIFEST
+│   ├── auth/
+│   │   └── saml.py                    # placeholder SAMLAuthProvider
+│   ├── audit/
+│   │   └── siem.py                    # placeholder SIEMAuditSink
+│   ├── admin/
+│   │   └── billing_page.py            # placeholder BillingPageExtension
+│   └── frontend/
+│       └── dist/
+│           └── .gitkeep               # 前端 bundle 预编译产物
+├── scripts/
+│   └── build_frontend.sh              # 前端编译到 frontend/dist/
+└── tests/
+    ├── conftest.py
+    └── test_compat.py                 # 对每个 plugin impl 做实例化 smoke
+```
+
+### 7.2 `pyproject.toml`（关键段）
+
+```toml
+[project]
+name = "cubebox-ee"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["cubebox>=1.0,<2.0"]
+
+[project.entry-points."cubebox.plugin_manifest"]
+main = "cubebox_ee:MANIFEST"
+
+[project.entry-points."cubebox.auth_provider"]
+saml = "cubebox_ee.auth.saml:SAMLAuthProvider"
+
+[project.entry-points."cubebox.audit_sink"]
+siem = "cubebox_ee.audit.siem:SIEMAuditSink"
+
+[project.entry-points."cubebox.admin_panel_extension"]
+billing = "cubebox_ee.admin.billing_page:BillingPageExtension"
+
+[tool.hatch.build.targets.wheel]
+include = ["cubebox_ee/frontend/dist/**"]
+```
+
+### 7.3 `cubebox_ee/__init__.py`
+
+```python
+from cubebox.plugins import PluginManifest, CUBEBOX_PLUGIN_API_VERSION
+
+MANIFEST = PluginManifest(
+    api_version=CUBEBOX_PLUGIN_API_VERSION,
+    name="cubebox-ee",
+    version="0.1.0",
+    description="Cubebox Enterprise Edition",
+)
+```
+
+---
+
+## 8. `test-ee-compat` CI 作业
+
+### 8.1 Layer 1 · CE 自测（Batch 1 真做）
+
+**位置**：`backend/tests/plugins/test_contracts.py`
+**Fixture**：`backend/tests/fixtures/fake_plugin/` —— 独立的最小插件包，自带 `pyproject.toml` + 5 个 Protocol 的 stub 实现 + manifest。
+
+**断言清单**：
+
+| 测试 | 验证 |
+|---|---|
+| `test_discovery_finds_fake_plugin` | 装了 fake plugin 后 `registry.discover()` 能扫到 |
+| `test_singular_zero_external_uses_default` | 卸掉 fake plugin 后单实例 Protocol 走 CE 默认 |
+| `test_singular_one_external_replaces_default` | 装 1 个 fake AuthProvider → 取代 CE 默认 |
+| `test_singular_two_external_fails_startup` | 装 2 个 AuthProvider → `RuntimeError` |
+| `test_singular_selected_builtin_forces_ce` | `selected: "builtin"` 即便装了 fake 仍走 CE 默认 |
+| `test_singular_selected_by_name` | `selected: "fake"` 明确挑选 |
+| `test_singular_selected_not_found_fails` | `selected: "nonexistent"` → `RuntimeError` |
+| `test_plural_aggregates_default_plus_external` | `audit_sink` 装 fake → 同时触发 CE 默认 + fake |
+| `test_plural_disabled_filters_out` | `disabled: ["builtin"]` → CE 默认不执行 |
+| `test_external_plugin_named_builtin_rejected` | 外部 entry_point name `"builtin"` → 启动失败 |
+| `test_missing_manifest_rejects_plugin` | 无 `cubebox.plugin_manifest` 的 wheel 拒启 |
+| `test_api_version_mismatch_rejects` | `manifest.api_version != CE version` 拒启 |
+
+CI 跑法：`pytest backend/tests/plugins/` 作为 backend unit 阶段的一部分（对齐 M-CI 的 test 分层）。
+
+### 8.2 Layer 2 · 跨仓真插件集成（Batch 1 占位）
+
+`.github/workflows/ci.yml` 追加：
+
+```yaml
+test-ee-compat:
+  runs-on: ubuntu-latest
+  if: false    # Batch 1 占位；cubebox-ee 仓真建起来后移除
+  steps:
+    - uses: actions/checkout@v4
+      with: { path: cubebox }
+    - uses: actions/checkout@v4
+      with: { repository: cubebox/cubebox-ee, path: cubebox-ee, token: ${{ secrets.EE_REPO_READ_TOKEN }} }
+    - uses: astral-sh/setup-uv@v3
+    - run: |
+        cd cubebox-ee
+        uv pip install -e ../cubebox/backend   # CE from HEAD（不用 PyPI 版）
+        uv pip install -e .
+        uv run pytest
+```
+
+关键：**EE 测试导入 working tree 的 CE** —— 这样 CE 里的 Protocol 破坏性变更在 merge 前就被 EE 的 CI 捕获。
+
+---
+
+## 9. Batch 1 M0 交付清单
+
+### 9.1 新增文件
+
+- `backend/cubebox/plugins/__init__.py`
+- `backend/cubebox/plugins/protocols.py`
+- `backend/cubebox/plugins/registry.py`
+- `backend/cubebox/plugins/audit.py`（`audit_log()` helper）
+- `backend/cubebox/plugins/defaults/__init__.py`
+- `backend/cubebox/plugins/defaults/auth.py`
+- `backend/cubebox/plugins/defaults/permissions.py`
+- `backend/cubebox/plugins/defaults/audit.py`
+- `backend/cubebox/plugins/defaults/admin_panel.py`
+- `backend/tests/plugins/__init__.py`
+- `backend/tests/plugins/test_contracts.py`
+- `backend/tests/fixtures/fake_plugin/` （含 `pyproject.toml` + `fake_plugin/__init__.py` + 5 个 Protocol 实现）
+
+### 9.2 修改文件
+
+- `backend/cubebox/auth/dependencies.py` —— `require_admin` / `require_member` 改为 `PermissionChecker.check` 薄壳；`current_active_user` 委托 `AuthProvider.authenticate`
+- `backend/cubebox/auth/users.py` —— `on_after_login` / `on_after_register` 调 `audit_log`
+- `backend/cubebox/api/app.py` —— 启动钩子：`registry.discover()`、挂载 `AuthProvider.get_auth_routers()`、迭代 `AdminPanelExtension` 注册 router + StaticFiles、注册 manifest 端点
+- `backend/cubebox/workspaces/*invites*.py` —— invite 成功分支调 `audit_log`
+- `backend/cubebox/config.py` —— 加 `plugins.*` pydantic schema
+- `backend/config.yaml` / `config.development.yaml` / `config.test.yaml` —— 加 `plugins:` section（默认值）
+- `.github/workflows/ci.yml` —— 追加 `test-ee-compat` 占位 job
+- （**不**改 `backend/pyproject.toml`：CE 不声明自己的 entry_points）
+
+### 9.3 实现阶段（implementation plan 会细化）
+
+| Stage | 内容 | 回归检查 |
+|---|---|---|
+| 1 | `protocols.py` + dataclasses + `PluginManifest` | 单元测试 |
+| 2 | `registry.py` 发现/解析逻辑 | Layer 1 test_contracts 部分通过 |
+| 3 | `defaults/*.py` 四个 CE 默认 | |
+| 4 | `PermissionChecker` 迁移（修 `require_admin/member`） | 现有 `test_rbac.py` 全绿 |
+| 5 | `AuthProvider` 迁移（修 `current_active_user` + 启动路由挂载） | 现有 auth e2e 全绿 |
+| 6 | `audit_log` helper + 3 个调用点 | 新单测 + 抽检日志输出 |
+| 7 | `AdminPanelExtension` 启动扫描 + `manifest` 端点 | 新端点返回 `[]` |
+| 8 | fake_plugin fixture + `test_contracts.py` 全 11 项 | 全绿 |
+| 9 | CI workflow 占位 job | workflow YAML lint 过 |
+
+**估算**：单人 ~5 工作日（stage 4-5 是最大风险，touch 现有 auth 代码，每步必跑回归）。
+
+---
+
+## 10. 一次性原则自检
+
+"day-1 定死"的含义：以下扩展**不破坏** API version 即可完成。
+
+### 10.1 非破坏性扩展示例
+
+- 新增 action 名（如 `"conversation.share"`）—— `PermissionChecker` 查不认识的 action 默认返回 False；插件自由识别
+- 新增 audit event type —— `action: str` 即可；语义在 `metadata` 里
+- 新增 `PermissionResource.type` 类型 —— `type: str`
+- 新增 `AdminNavItem` 可选字段（加默认值）
+- 新增 Protocol（整体新增一个 entry_points group）
+- 给 `UserDirectorySyncer` 加新调度频率
+
+### 10.2 破坏性变更（**必须**触发 version bump）
+
+- 改 Protocol 方法签名
+- 改 dataclass 必填字段
+- 改 entry_points group 名
+- 删 Protocol 方法
+
+---
+
+## 11. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| PermissionChecker 迁移打断现有 RBAC | Stage 4 每步必跑 `test_rbac.py` 回归，失败回滚 |
+| AuthProvider 迁移打断登录流程 | Stage 5 完成后必跑 auth e2e（login / register / logout） |
+| Protocol 设计漏点，真 EE 接入时需破坏性改 | `test_contracts.py` Layer 1 在 CE 侧**消费自己的 Protocol** 验证签名；Layer 2 等真 EE 仓建起再防第二层 |
+| 插件 entry_points 加载慢 | `importlib.metadata` 首次调用有 IO；启动延迟预算内（<200ms） |
+| EE 插件带的前端 bundle 未被 iframe 信任 | M2 前端渲染 iframe 时设定 CSP `frame-src 'self'`（同源即可） |
+
+---
+
+## 12. 未决事项
+
+- [ ] `AdminNavItem.section` 是否固定枚举还是自由字符串 —— 目前按自由字符串；M2 skeleton 做时可能 narrow
+- [ ] `cubebox-ee` 仓 GitHub 组织归属（`cubebox/cubebox-ee` vs 独立组织）—— 建仓时定
+- [ ] `test-ee-compat` Layer 2 的 `EE_REPO_READ_TOKEN` 是否设为 organization secret —— 等真建仓时定

--- a/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
+++ b/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
@@ -597,7 +597,7 @@ import hashlib
 import json
 from uuid import UUID
 
-from cubebox.cache import get_redis  # async redis client (已在 M-CI 接入)
+from cubebox.cache import get_redis  # async redis client (新增；CI 已挂 redis service，但 backend 此前无 client)
 from cubebox.parsers.schema import ParseOptions
 
 DEDUP_TTL_SECONDS = 6 * 3600       # 6 小时不活跃自动过期
@@ -804,9 +804,9 @@ Unit 测试覆盖：
 - `backend/cubebox/sandbox/base.py` —— 新增 `Sandbox.file_read(...)` 默认实现
 - `backend/cubebox/sandbox/opensandbox.py` —— 继承默认即可，无需 override
 - `backend/cubebox/middleware/sandbox.py` —— `SandboxMiddleware` 注册 `file_read` 工具到 tools 列表
-- `backend/cubebox/config.py` —— 加 `parsers.*` pydantic schema
-- `backend/config.yaml` / `config.development.yaml` / `config.test.yaml` —— 加 `parsers:` 节
-- `backend/pyproject.toml` —— `[project.entry-points."cubebox.parsers"]` + 新依赖：`python-magic` (libmagic 包装) + `filetype`（fallback）+ `redis>=5.0`（async client；CI 已起 redis service）；`httpx` 已有
+- `backend/cubebox/config.py` —— **不改**（cubebox 用 dynaconf，无 pydantic Settings 类；配置通过 `config.get(...)` 访问，YAML 是默认值的源）
+- `backend/config.yaml` / `config.development.yaml` / `config.test.yaml` —— 加 `parsers:` + `redis:` 两节
+- `backend/pyproject.toml` —— `[project.entry-points."cubebox.parsers"]` + 新依赖：`python-magic` (libmagic 包装) + `filetype`（fallback）+ `redis>=5.0`（**新引入** —— backend 此前无 redis client；CI 已挂 redis service 但应用层未接入）+ `fakeredis`（dev only，单测用）；`httpx` 已有
 - `docker-compose.yml` / 部署编排 —— 加 docling-serve service
 - `.github/workflows/ci.yml` —— e2e job 配置 mock `DoclingParser` 的 fixture 路径
 
@@ -868,4 +868,4 @@ Unit 测试覆盖：
 - [ ] docling-serve `FileSourceRequest` 的确切 JSON schema（multipart vs base64）—— 读 OpenAPI 后确认
 - [ ] Redis dedup TTL（默认 6h）是否需要按 conversation 活跃度自适应延长 —— 上线观察后再调
 - [ ] `UnchangedOutput` 是否应包含首次读取的 metadata 摘要（便于 agent 不回翻历史也能快速引用）—— v1 先不加，等使用反馈
-- [ ] `cubebox.cache` 模块若已存在（M-CI 引入 redis service 时是否同步加了 client）—— 实现时复用，不重复实现
+- [ ] `cubebox.cache` 当前**不存在**（CI 起了 redis service 但 backend 没接入 Python client）；本 spec 顺带新增。命名空间 `cubebox.cache.redis` 是否合理 —— 实现时若 future 还有别的 cache backend 再调整

--- a/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
+++ b/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
@@ -597,7 +597,7 @@ import hashlib
 import json
 from uuid import UUID
 
-from cubebox.cache import get_redis  # async redis client (新增；CI 已挂 redis service，但 backend 此前无 client)
+from cubebox.cache import get_redis  # 复用 streaming 已建立的 Redis client（M6 新增的 thin accessor）
 from cubebox.parsers.schema import ParseOptions
 
 DEDUP_TTL_SECONDS = 6 * 3600       # 6 小时不活跃自动过期
@@ -785,7 +785,7 @@ Unit 测试覆盖：
 - `backend/cubebox/parsers/schema.py`（`FileReadOutput` / `ParseOptions` / dataclasses）
 - `backend/cubebox/parsers/registry.py`（discover + dispatch + resolve）
 - `backend/cubebox/parsers/dedup.py`（Redis-backed hash cache，key 含 ParseOptions 签名）
-- `backend/cubebox/cache/__init__.py` + `backend/cubebox/cache/redis.py`（async redis 客户端工厂；若已存在则复用）
+- `backend/cubebox/cache/__init__.py`（thin accessor `get_redis()` / `set_redis()`；复用 streaming 已建立的 Redis client）
 - `backend/cubebox/parsers/plugins/__init__.py`
 - `backend/cubebox/parsers/plugins/text.py`
 - `backend/cubebox/parsers/plugins/notebook.py`
@@ -805,8 +805,9 @@ Unit 测试覆盖：
 - `backend/cubebox/sandbox/opensandbox.py` —— 继承默认即可，无需 override
 - `backend/cubebox/middleware/sandbox.py` —— `SandboxMiddleware` 注册 `file_read` 工具到 tools 列表
 - `backend/cubebox/config.py` —— **不改**（cubebox 用 dynaconf，无 pydantic Settings 类；配置通过 `config.get(...)` 访问，YAML 是默认值的源）
-- `backend/config.yaml` / `config.development.yaml` / `config.test.yaml` —— 加 `parsers:` + `redis:` 两节
-- `backend/pyproject.toml` —— `[project.entry-points."cubebox.parsers"]` + 新依赖：`python-magic` (libmagic 包装) + `filetype`（fallback）+ `redis>=5.0`（**新引入** —— backend 此前无 redis client；CI 已挂 redis service 但应用层未接入）+ `fakeredis`（dev only，单测用）；`httpx` 已有
+- `backend/cubebox/api/app.py` —— lifespan 里在创建 Redis client 后追加一行 `cache.set_redis(redis_client)` 注册到模块级 accessor（保留现有 `app.state.redis` 不动）
+- `backend/config.yaml` / `config.development.yaml` / `config.test.yaml` —— 加 `parsers:` 节（**不**加 `redis:`：复用现有 `streaming.redis_url`）
+- `backend/pyproject.toml` —— `[project.entry-points."cubebox.parsers"]` + 新依赖：`python-magic` (libmagic 包装) + `filetype`（fallback）+ `fakeredis`（dev only，dedup 单测用）；`redis>=5.2.0` 与 `httpx` 已有
 - `docker-compose.yml` / 部署编排 —— 加 docling-serve service
 - `.github/workflows/ci.yml` —— e2e job 配置 mock `DoclingParser` 的 fixture 路径
 
@@ -868,4 +869,4 @@ Unit 测试覆盖：
 - [ ] docling-serve `FileSourceRequest` 的确切 JSON schema（multipart vs base64）—— 读 OpenAPI 后确认
 - [ ] Redis dedup TTL（默认 6h）是否需要按 conversation 活跃度自适应延长 —— 上线观察后再调
 - [ ] `UnchangedOutput` 是否应包含首次读取的 metadata 摘要（便于 agent 不回翻历史也能快速引用）—— v1 先不加，等使用反馈
-- [ ] `cubebox.cache` 当前**不存在**（CI 起了 redis service 但 backend 没接入 Python client）；本 spec 顺带新增。命名空间 `cubebox.cache.redis` 是否合理 —— 实现时若 future 还有别的 cache backend 再调整
+- [ ] `cubebox.cache` 当前不存在；streaming 通过 `app.state.redis` 直接访问 Redis client。本 spec 加一个模块级 thin accessor 让 dedup（无 app context）也能拿到同一 client。是否要顺带把 streaming 的几处 `app.state.redis` 用法迁到 `cubebox.cache.get_redis()` —— 可选清理，**不在** M6 范围

--- a/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
+++ b/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
@@ -61,7 +61,7 @@
 | D15 | sync / async 路径按 file_size **硬分流**（阈值 3 MB），**不**自动降级 | sync 先试 → 超时降级 async | 代码路径清晰；避免服务端 CPU 被吃两次；timeout 做 retryable error 由 agent 决策重试 |
 | D16 | docling-serve 超时：sync **30s** / async **10 min**；双硬上限 | 无限制 / 动态 | 配置可调；超时 → `error(retryable=True)` |
 | D17 | v1 只发 CPU 镜像；GPU 镜像留给用户自换 | 三镜像矩阵（cpu / cu128 / cu130） | 单变体减少文档分叉与首装复杂度；自部署想加速自换 |
-| D18 | CI **不**起真 docling-serve；mock `DoclingParser` | 真实服务跑 e2e | docling-serve 不在 backend 关键链路（挂掉只影响 file_read）；mock 充分 |
+| D18 | CI **不**动态起 docling-serve 容器；但 e2e 跑真 docling — 通过环境变量 `DOCLING_URL` 指向外部托管实例；不可达时 `pytest.skip(...)` 并告警，不回退 mock | CI 内拉起容器（4.4 GB 镜像太慢）／mock `DoclingParser` | CLAUDE.md 项目约束 "Focus on E2E tests" —— mock 把真实解析路径留白；外部托管服务由维护者提供，CI 只消费；skip-with-warning 保证 docling 不可用时 CI 仍可推进，但不会伪装通过 |
 | D19 | Tool description 是本 spec 的**固定产出**，逐字进 StructuredTool | 只写大致 | agent 使用率/误用率高度依赖 description；一字一句都要审 |
 | D20 | dedup cache 直接走 **Redis**（CI 已挂 redis service；backend 增加 redis-py async client） | 进程内 dict + session-sticky routing | conversation 没有明确"结束"事件，Redis TTL 替代 lifecycle 钩子；多副本天然共享；重启不丢热缓存 |
 | D21 | `ParseOptions` 提供两个独立 range 参数：`page_range`（PDF/DOCX/PPTX）+ `line_range`（text/code/log）；两者共享 4 种语法 `"N"` / `"M-N"` / `"M-"` / `"-N"` | 单一通用 `range` 字段 / 只 page_range / 只支持 `"M-N"` | text 文件用行号比页号自然；分两参数语义清晰；语法对齐 sed/tail 直觉（`"3-"` = 从第 3 起；`"-3"` = 末尾 3 个）；plugin 各取所需，互不影响 |
@@ -753,26 +753,37 @@ services:
 
 ### 9.4 CI
 
-**不**起真 docling-serve。e2e 测试在 `conftest.py` 注入 mock `DoclingParser`：
+**不**在 CI 内动态拉起 docling-serve（镜像 4.4 GB，启动不经济），**但** e2e 必须跑真实解析路径——由维护者托管一个外部 docling-serve 实例，CI 通过环境变量消费：
 
-```python
-class MockDoclingParser:
-    mime_types = [...]
-    extensions = [...]
-    priority = 20
-    async def parse(self, content, *, mime, options):
-        return TextOutput(
-            path="<mock>", mime=mime,
-            content=f"<MOCK docling parsed {len(content)} bytes>",
-            size_bytes=len(content),
-            metadata={"parser": "mock-docling"},
-        )
+```yaml
+# .github/workflows/ci.yml (e2e job)
+env:
+  DOCLING_URL: ${{ secrets.DOCLING_E2E_URL }}         # e.g. https://docling-e2e.internal:5001
+  DOCLING_SERVE_API_KEY: ${{ secrets.DOCLING_E2E_KEY }}
 ```
 
-Unit 测试覆盖：
+e2e `conftest.py` 模式：
+
+```python
+@pytest.fixture(scope="session")
+def docling_url() -> str:
+    url = os.environ.get("DOCLING_URL")
+    if not url:
+        pytest.skip("DOCLING_URL not set — skipping docling e2e")
+    # Probe once per session; skip if unreachable (do NOT fall back to mock).
+    try:
+        httpx.get(f"{url.rstrip('/')}/health", timeout=5).raise_for_status()
+    except Exception as exc:
+        pytest.skip(f"docling-serve at {url} unreachable: {exc}")
+    return url
+```
+
+关键原则：**不** mock `DoclingParser`；docling 不可达 → `skip-with-warning`，而不是伪装通过。
+
+Unit 测试仅覆盖纯逻辑层（不替代 e2e）：
 - registry 启动、Protocol 校验失败、plugin 解析
 - TextParser / NotebookParser 纯逻辑（不依赖外部）
-- DoclingParser 用 httpx mock server 测 HTTP 交互（sync/async/超时/task FAILED）
+- DoclingParser 的 HTTP 客户端边界：sync/async 分流、超时包装、task FAILED 映射 —— 用 httpx `MockTransport` 而非假 server
 
 ---
 
@@ -795,7 +806,7 @@ Unit 测试覆盖：
 - `backend/tests/parsers/test_registry.py`
 - `backend/tests/parsers/test_text_parser.py`
 - `backend/tests/parsers/test_notebook_parser.py`
-- `backend/tests/parsers/test_docling_parser.py`（httpx mock server）
+- `backend/tests/parsers/test_docling_parser.py`（httpx `MockTransport` 覆盖 sync/async 分流、超时、FAILED 映射）
 - `backend/tests/parsers/test_dedup.py`
 - `backend/tests/sandbox/test_file_read.py`
 
@@ -809,7 +820,7 @@ Unit 测试覆盖：
 - `backend/config.yaml` / `config.development.yaml` / `config.test.yaml` —— 加 `parsers:` 节（**不**加 `redis:`：复用现有 `streaming.redis_url`）
 - `backend/pyproject.toml` —— `[project.entry-points."cubebox.parsers"]` + 新依赖：`python-magic` (libmagic 包装) + `filetype`（fallback）+ `fakeredis`（dev only，dedup 单测用）；`redis>=5.2.0` 与 `httpx` 已有
 - `docker-compose.yml` / 部署编排 —— 加 docling-serve service
-- `.github/workflows/ci.yml` —— e2e job 配置 mock `DoclingParser` 的 fixture 路径
+- `.github/workflows/ci.yml` —— e2e job 注入 `DOCLING_URL` / `DOCLING_SERVE_API_KEY` secrets；缺失时对应 e2e skip
 
 ### 10.3 实现阶段
 
@@ -819,7 +830,7 @@ Unit 测试覆盖：
 | 2 | mime.py + dedup.py | 单元测试 |
 | 3 | registry.py（discover + resolve + dispatch） + 3 默认 plugin 骨架（只实现 text） | registry tests 通过；text parser e2e 通过 |
 | 4 | NotebookParser 完整实现 | notebook tests 全绿 |
-| 5 | DoclingParser 完整实现（httpx client + sync + async + 超时 + mock server tests） | docling parser tests 全绿 |
+| 5 | DoclingParser 完整实现（httpx client + sync + async + 超时 + `MockTransport` 边界测试） | docling parser unit tests 全绿 |
 | 6 | Sandbox.file_read 默认实现接入；conversation_id 从 middleware context 传入 | sandbox integration tests 全绿 |
 | 7 | `file_read` agent 工具注册到 SandboxMiddleware；StructuredTool description 逐字对齐 | agent e2e 能调通；工具出现在工具列表 |
 | 8 | config schema 扩展；docker-compose 加 docling-serve；手动启动一次真 docling-serve 做冒烟 | 冒烟通过 |
@@ -856,7 +867,7 @@ Unit 测试覆盖：
 | docling-serve 单点 | v1 单实例可接受；后续按请求量 HPA；parser 是非关键链路（挂掉不阻塞 agent 对话，只是 file_read 不可用） |
 | 20K 截断对长文档过紧 | `page_range` 参数 + description 明示截断 + metadata 暴露 total_chars；agent 可多次调用补全 |
 | Redis 不可达让 dedup 失效 | dispatch 里 try/except，把 Redis 错误降级为 cache miss（继续解析）；告警日志；不影响 file_read 主路径 |
-| docling 对极端布局 PDF 解析错 | `error(retryable=False)` 可读 reason；agent 告诉用户；未来可装 Marker / LlamaParse 做 fallback plugin |
+| docling 对极端布局 PDF 解析错 | `error(retryable=False)` 可读 reason（文件内容本身的问题，重试无益）；agent 告诉用户；未来可装 Marker / LlamaParse 做 fallback plugin。仅网络 / 超时 / HTTP 5xx 才 `retryable=True` |
 | Protocol runtime_checkable 性能 | 仅启动时用一次（`discover()`），运行时不重复 check；无影响 |
 | libmagic 跨平台依赖 | `python-magic-bin` 自带 libmagic binary；不依赖系统包；macOS/Linux/Windows 统一 |
 | `.html` 走 TextParser 但 HTML 内嵌 `<script>` 等含大量无意义代码 | agent description 明说 HTML 返 raw；agent 按需要 `execute("html2text ...")` 或让用户转换 |

--- a/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
+++ b/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
@@ -64,7 +64,8 @@
 | D18 | CI **不**起真 docling-serve；mock `DoclingParser` | 真实服务跑 e2e | docling-serve 不在 backend 关键链路（挂掉只影响 file_read）；mock 充分 |
 | D19 | Tool description 是本 spec 的**固定产出**，逐字进 StructuredTool | 只写大致 | agent 使用率/误用率高度依赖 description；一字一句都要审 |
 | D20 | dedup cache 直接走 **Redis**（CI 已挂 redis service；backend 增加 redis-py async client） | 进程内 dict + session-sticky routing | conversation 没有明确"结束"事件，Redis TTL 替代 lifecycle 钩子；多副本天然共享；重启不丢热缓存 |
-| D21 | `ParseOptions` 提供两个独立 range 参数：`page_range`（PDF/DOCX/PPTX）+ `line_range`（text/code/log） | 单一通用 `range` 字段 / 只 page_range / 不做 | text 文件用行号比页号自然；分两参数语义清晰；plugin 各取所需，互不影响；cache key 由 dispatch 层把 options 整体签入即可 |
+| D21 | `ParseOptions` 提供两个独立 range 参数：`page_range`（PDF/DOCX/PPTX）+ `line_range`（text/code/log）；两者共享 4 种语法 `"N"` / `"M-N"` / `"M-"` / `"-N"` | 单一通用 `range` 字段 / 只 page_range / 只支持 `"M-N"` | text 文件用行号比页号自然；分两参数语义清晰；语法对齐 sed/tail 直觉（`"3-"` = 从第 3 起；`"-3"` = 末尾 3 个）；plugin 各取所需，互不影响 |
+| D23 | 截断时 metadata 必含"下一个该读位置"：`next_line_to_read`（text）/ `next_page_to_read`（PDF，best-effort）/ `next_cell_index`（notebook） | 仅返 truncated=True，agent 自己猜 | agent 续读 round-trip 零思考成本；DoclingParser 的 page 信息是 best-effort（取决于 docling-serve 输出能否解析到页号） |
 | D22 | **不维护 REJECT_EXT / REJECT_MIME 硬名单**；"哪些格式支持"完全由 plugin 注册决定，未匹配 → `unsupported` + 智能 hint | hardcoded REJECT 视频/音频/归档/可执行 | 双数据源维护成本；REJECT 阻断合法扩展（mp4 转写 / zip listing / exe 元数据等 plugin 被预先枪毙）；零性能收益；零安全收益（file_read 是只读，读 .exe 字节无副作用） |
 
 ---
@@ -264,9 +265,20 @@ def discover() -> ParserRegistry:
 **parse 行为**：
 1. UTF-8 解码；失败 fallback 到 latin-1（仅避免 crash，`metadata.decode_fallback = "latin-1"` 标注）
 2. 按 `\n` 切行 → `total_lines`
-3. 若 `options.line_range` 不为空（如 `"100-200"` 或 `"42"`），切片该行范围；否则取全部行
+3. 解析 `options.line_range` 为 `(start_idx, end_idx)`，支持 4 种语法：
+   - `"42"` → 第 42 行
+   - `"100-200"` → 第 100-200 行
+   - `"100-"` → 第 100 行到末尾
+   - `"-50"` → 末尾 50 行
+   - `None` → 全部
 4. 切片后内容超 20K 字符 → 截断 + `truncated=True`
-5. metadata 必含：`{parser, total_lines, lines_returned: "<start>-<end>"}`；line_range 未传且发生截断时附 `hint: "use line_range to read later sections"`
+5. metadata 必含字段：
+   - `parser: "text"`
+   - `total_lines: <int>`
+   - `lines_returned: "<start>-<end>"`（实际返回的行范围，1-indexed）
+   - 若 `truncated=True`：
+     - `next_line_to_read: <int>`（agent 续读用，1-indexed）
+     - 若 `line_range` 未传：附 `hint: "content truncated; use line_range to navigate"`
 
 `page_range` 参数对 TextParser **不生效**（silently ignored）；`line_range` 是 text 文件的"切片"语义。
 
@@ -279,7 +291,15 @@ def discover() -> ParserRegistry:
 - `source`: join cell.source 数组
 - `outputs`（仅 code cell）：简化为 `[{type, text_repr}]`，舍弃图像 base64 blob（M6 无 vision 路径）
 
-总输出内容（`sum(len(cell.source) + len(cell.outputs_text)) for cells`）超 20K → 截断到前 N 个 cell 填满 20K，剩余 cell 省略，metadata 标 `truncated_cells: M`。
+总输出内容（`sum(len(cell.source) + len(cell.outputs_text)) for cells`）超 20K → 截断到前 N 个 cell 填满 20K，剩余 cell 省略。
+
+metadata 必含字段：
+- `parser: "notebook"`
+- `total_cells: <int>`
+- `cells_returned: <int>`（实际返回的 cell 数）
+- 若截断：`truncated_cells: <int>` + `next_cell_index: <int>`（1-indexed）
+
+NotebookParser 当前不接受 cell_range 参数；agent 续读靠 cache（hash 不变 → unchanged sentinel；想看后面 cells 只能等未来扩展 cell_range，本 spec 不做）。
 
 #### `DoclingParser`（`cubebox/parsers/plugins/docling.py`）
 
@@ -299,7 +319,14 @@ def discover() -> ParserRegistry:
    - 总超时 `timeout_async_minutes` (默认 10)
 4. 超时 / HTTP 错 / task FAILED → `ErrorOutput(error=..., retryable=...)`
 5. 超 20K 字符 → 截断 + `truncated=True`
-6. `page_range` 通过 docling options 传递（具体字段名实现时确认）；对 DOCX/PPTX 若 docling 不支持 page_range，在 markdown 输出层做后处理截取（按 heading 或 `---` 分隔）
+6. `page_range` 通过 docling options 传递（4 种语法 `"N"` / `"M-N"` / `"M-"` / `"-N"`，由 plugin 翻译为 docling 实际请求字段；具体字段名实现时确认）；对 DOCX/PPTX 若 docling 不支持 page_range，在 markdown 输出层做后处理截取（按 heading 或 `---` 分隔）
+
+metadata 必含字段：
+- `parser: "docling"`
+- `total_chars: <int>`（解析后 markdown 总长度）
+- 若 `truncated=True`：
+  - `truncated_at_char: 20000`
+  - **best-effort** `last_page_returned: <int>` + `next_page_to_read: <int>`：仅当 docling 输出含可解析的 page 标记（如 `<!-- page N -->` 或 heading metadata）时填入；否则附 `hint: "use page_range to read later sections"`
 
 ### 4.4 调度逻辑（`registry.dispatch`）
 
@@ -522,20 +549,36 @@ to the user; don't keep retrying file_read on the same path.
 ═══════════════════════ PARAMETERS ══════════════════════════════
 • path (required)         — absolute sandbox path, e.g.
                             /home/user/uploads/report.pdf
-• page_range (optional)   — "1-5" or "3". Paginated documents only:
-                            PDF / DOCX / PPTX. Silently ignored
-                            for other formats.
-• line_range (optional)   — "100-200" or "42". Text / code / log
-                            files only. Lets you navigate large
-                            text files (e.g. 100k-line logs) by
-                            line number. Silently ignored for
-                            paginated docs and notebooks.
+• page_range (optional)   — paginated documents only: PDF/DOCX/PPTX.
+                            Silently ignored for other formats.
+• line_range (optional)   — text/code/log files only. Lets you
+                            navigate large text files (e.g. 100k-line
+                            logs) by line number. Silently ignored
+                            for paginated docs and notebooks.
+
+═══════════════════ RANGE SYNTAX (page_range and line_range) ════
+Both parameters share 4 syntactic forms:
+  "42"      — single line/page (item 42)
+  "100-200" — range from 100 to 200 inclusive
+  "100-"    — from 100 to end of file (like sed '100,$')
+  "-50"     — last 50 lines/pages (like tail -50)
+
+═══════════════ HOW TO CONTINUE READING WHEN TRUNCATED ═════════
+When truncated=true, metadata tells you where to resume:
+• text/code/log: `metadata.next_line_to_read` →
+  call file_read(path, line_range=f"{N}-") to continue.
+• PDF/DOCX/PPTX (best-effort): `metadata.next_page_to_read` →
+  call file_read(path, page_range=f"{N}-") to continue. If the
+  field is absent, the parser couldn't map char-offset back to
+  page; fall back to guessing or asking the user.
+• notebook: `metadata.next_cell_index` (informational only —
+  v1 has no cell_range param; this batch is the most you'll get
+  for now).
 
 ═══════════════════════ LIMITS ══════════════════════════════════
 • Files > 100 MB are refused with kind="unsupported".
 • Content longer than 20,000 characters is truncated (truncated=True).
-  Use `page_range` (PDF/DOCX/PPTX) or `line_range` (text/code/log)
-  to retrieve a specific segment, or read in multiple narrower calls.
+  Use the metadata fields above to read the next segment.
 • Large files (>3 MB) trigger async parsing and may take up to
   10 minutes; do not retry prematurely.
 ```

--- a/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
+++ b/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
@@ -54,7 +54,7 @@
 | D8 | TEXT_DIRECT 扩展名列表**宽**（含 `.py .js .ts .go .rs .c .cpp .java .rb .php .html .svg .xml` 等） | 严格文本 `.txt .md` | cubebox 是 dev-friendly agent 平台；读代码文件是常态；TextParser 只做 UTF-8 decode 代价极小 |
 | D9 | OCR 图片归 `text` kind，`metadata.parser = "docling-ocr"` 区分 | 独立 `image` kind | v1 无 vision 管线；OCR 结果本质是文本；union 不提前扩展 |
 | D10 | Output union 共 **5 种 kind**：`text` / `notebook` / `unsupported` / `unchanged` / `error` | 7 种（含 image / pdf_native / parts / office_markdown） | 砍掉无下游消费者的 kind；`image` / `pdf_native` 未来加为纯新增，非破坏性 |
-| D11 | `unchanged` sentinel 走 **conversation 级 SHA-256 hash cache**，无显式 invalidation | 显式 write_file / execute 回调 invalidate | hash 对比天然捕获写入变化；代码面无 cross-module 耦合 |
+| D11 | `unchanged` sentinel 走 **conversation 级 SHA-256 hash cache，存 Redis**；无显式 invalidation；TTL 6h 自动过期 | 显式 write_file / execute 回调 invalidate | hash 对比天然捕获写入变化；Redis TTL 处理空闲清理（conversation 没有明确"结束"事件）；多 backend 副本天然共享 |
 | D12 | hash 一律走 `asyncio.to_thread(hashlib.sha256, ...)` | 直接同步 hash | 100MB SHA-256 约 300ms；不能阻塞 event loop |
 | D13 | 超大 parsed content 截断阈值：**20,000 字符**（约 4-6K tokens） | 500K 字符 / 无限制 | 不把单次 file_read 占满 context；agent 有 `page_range` 和分段重读的手段 |
 | D14 | 文件硬上限：**100 MB** | 无限制 | docling-serve 和 backend memory 的合理上限；超大文件应该预处理后再读 |
@@ -63,7 +63,8 @@
 | D17 | v1 只发 CPU 镜像；GPU 镜像留给用户自换 | 三镜像矩阵（cpu / cu128 / cu130） | 单变体减少文档分叉与首装复杂度；自部署想加速自换 |
 | D18 | CI **不**起真 docling-serve；mock `DoclingParser` | 真实服务跑 e2e | docling-serve 不在 backend 关键链路（挂掉只影响 file_read）；mock 充分 |
 | D19 | Tool description 是本 spec 的**固定产出**，逐字进 StructuredTool | 只写大致 | agent 使用率/误用率高度依赖 description；一字一句都要审 |
-| D20 | 多 backend 副本场景需 **session-sticky routing** 或后续改 Redis-backed cache | 进程外共享 | v1 进程内 dict 简单；SaaS 扩展时再换 |
+| D20 | dedup cache 直接走 **Redis**（CI 已挂 redis service；backend 增加 redis-py async client） | 进程内 dict + session-sticky routing | conversation 没有明确"结束"事件，Redis TTL 替代 lifecycle 钩子；多副本天然共享；重启不丢热缓存 |
+| D21 | `ParseOptions` 提供两个独立 range 参数：`page_range`（PDF/DOCX/PPTX）+ `line_range`（text/code/log） | 单一通用 `range` 字段 / 只 page_range / 不做 | text 文件用行号比页号自然；分两参数语义清晰；plugin 各取所需，互不影响；cache key 由 dispatch 层把 options 整体签入即可 |
 
 ---
 
@@ -259,7 +260,14 @@ def discover() -> ParserRegistry:
   ```
 - `priority = 0`（最低；特定格式 plugin 优先）
 
-**parse 行为**：UTF-8 解码；失败 fallback 到 latin-1（仅为避免 crash，`metadata.decode_fallback = true` 标注）。超 20K 字符截断，`truncated=True`。
+**parse 行为**：
+1. UTF-8 解码；失败 fallback 到 latin-1（仅避免 crash，`metadata.decode_fallback = "latin-1"` 标注）
+2. 按 `\n` 切行 → `total_lines`
+3. 若 `options.line_range` 不为空（如 `"100-200"` 或 `"42"`），切片该行范围；否则取全部行
+4. 切片后内容超 20K 字符 → 截断 + `truncated=True`
+5. metadata 必含：`{parser, total_lines, lines_returned: "<start>-<end>"}`；line_range 未传且发生截断时附 `hint: "use line_range to read later sections"`
+
+`page_range` 参数对 TextParser **不生效**（silently ignored）；`line_range` 是 text 文件的"切片"语义。
 
 #### `NotebookParser`（`cubebox/parsers/plugins/notebook.py`）
 
@@ -442,7 +450,8 @@ FileReadOutput = Annotated[
 
 
 class ParseOptions(BaseModel):
-    page_range: str | None = None   # "1-5" or "3"
+    page_range: str | None = None   # PDF/DOCX/PPTX 用；"1-5" or "3"
+    line_range: str | None = None   # text/code/log 用；"100-200" or "42"
     language_hint: str | None = None
 ```
 
@@ -458,7 +467,7 @@ class ParseOptions(BaseModel):
 ## 6. Tool Description（逐字进 StructuredTool）
 
 ```
-file_read(path: str, page_range: str | None = None) -> FileReadOutput
+file_read(path: str, page_range: str | None = None, line_range: str | None = None) -> FileReadOutput
 
 Read a file from the sandbox workspace and return its content in a form
 you can reason about. Use this whenever you need to inspect user uploads,
@@ -486,9 +495,10 @@ output, not network resources.
   then file_read on extracted files.
 • Remote URLs — file_read only reads sandbox paths. Use web-fetch
   tools for URLs.
-• Quick single-line peeks — if you only need a specific line or
-  want to grep, `execute("sed -n '42p' <file>")` or
-  `execute("grep -n 'pattern' <file>")` is faster and cheaper.
+• Grep / search — for pattern-find within files, `execute("grep -n
+  'pattern' <file>")` is more direct than file_read + scan.
+• Tiny single-line peeks where you already know the byte offset —
+  `execute("sed -n '42p' <file>")` skips parser overhead.
 
 ═══════════════════ RETURN FORMAT (by `kind`) ═══════════════════
 • "text"       — {content, mime, size_bytes, truncated, metadata}
@@ -506,15 +516,20 @@ output, not network resources.
 ═══════════════════════ PARAMETERS ══════════════════════════════
 • path (required)         — absolute sandbox path, e.g.
                             /home/user/uploads/report.pdf
-• page_range (optional)   — "1-5" or "3". Only honored for PDF /
-                            DOCX / PPTX; silently ignored for
-                            other formats.
+• page_range (optional)   — "1-5" or "3". Paginated documents only:
+                            PDF / DOCX / PPTX. Silently ignored
+                            for other formats.
+• line_range (optional)   — "100-200" or "42". Text / code / log
+                            files only. Lets you navigate large
+                            text files (e.g. 100k-line logs) by
+                            line number. Silently ignored for
+                            paginated docs and notebooks.
 
 ═══════════════════════ LIMITS ══════════════════════════════════
 • Files > 100 MB are refused with kind="unsupported".
 • Content longer than 20,000 characters is truncated (truncated=True).
-  Use `page_range` to retrieve a specific segment, or read in
-  multiple calls with narrower ranges.
+  Use `page_range` (PDF/DOCX/PPTX) or `line_range` (text/code/log)
+  to retrieve a specific segment, or read in multiple narrower calls.
 • Large files (>3 MB) trigger async parsing and may take up to
   10 minutes; do not retry prematurely.
 ```
@@ -523,55 +538,70 @@ output, not network resources.
 
 ## 7. File state dedup（`unchanged` 实现）
 
-### 7.1 Hash cache
+### 7.1 Redis-backed hash cache
 
 **`backend/cubebox/parsers/dedup.py`**：
 
 ```python
 import asyncio
 import hashlib
+import json
 from uuid import UUID
 
-# Keyed by (conversation_id, path). Stores SHA-256 hex digest.
-# v1 进程内 dict；多 backend 副本需 session-sticky 或迁移 Redis.
-_file_state: dict[tuple[UUID, str], str] = {}
+from cubebox.cache import get_redis  # async redis client (已在 M-CI 接入)
+from cubebox.parsers.schema import ParseOptions
+
+DEDUP_TTL_SECONDS = 6 * 3600       # 6 小时不活跃自动过期
+KEY_PREFIX = "parsers:dedup:v1:"
 
 
 async def hash_bytes(data: bytes) -> str:
-    # 100MB SHA-256 约 ~300ms；offload 到 thread pool 避免阻塞 event loop
-    return await asyncio.to_thread(
-        lambda: hashlib.sha256(data).hexdigest()
+    """SHA-256 hex；offload 到 thread pool 避免阻塞 event loop。"""
+    return await asyncio.to_thread(lambda: hashlib.sha256(data).hexdigest())
+
+
+def _options_signature(options: ParseOptions) -> str:
+    """每个 parser 关心 options 的不同子集；这里把 range 类参数整体签入。
+    无关参数最多浪费一次 cache miss，可接受。"""
+    return json.dumps(
+        {"page_range": options.page_range, "line_range": options.line_range},
+        sort_keys=True,
     )
 
 
-def check(conversation_id: UUID, path: str, digest: str) -> bool:
-    """Returns True if digest matches cached (→ unchanged)."""
-    return _file_state.get((conversation_id, path)) == digest
+def _key(conversation_id: UUID, path: str, options: ParseOptions) -> str:
+    return f"{KEY_PREFIX}{conversation_id}:{path}:{_options_signature(options)}"
 
 
-def update(conversation_id: UUID, path: str, digest: str) -> None:
-    _file_state[(conversation_id, path)] = digest
+async def check(conversation_id: UUID, path: str, options: ParseOptions, digest: str) -> bool:
+    redis = get_redis()
+    cached = await redis.get(_key(conversation_id, path, options))
+    if cached is None:
+        return False
+    return cached == digest if isinstance(cached, str) else cached == digest.encode()
 
 
-def forget_conversation(conversation_id: UUID) -> None:
-    # 会话结束时清理（挂入 ConversationManager 的 on_close 钩子）
-    keys = [k for k in _file_state if k[0] == conversation_id]
-    for k in keys:
-        _file_state.pop(k, None)
+async def update(conversation_id: UUID, path: str, options: ParseOptions, digest: str) -> None:
+    redis = get_redis()
+    await redis.set(
+        _key(conversation_id, path, options), digest, ex=DEDUP_TTL_SECONDS
+    )
 ```
 
 ### 7.2 行为
 
-- **首次 read** → 计算 hash → 存 `(conv_id, path) -> digest` → 返回完整内容
-- **后续同 path read** → hash 相同 → `UnchangedOutput`（content 省略）
-- **文件被改过**（agent 用 execute / write_file / edit_file 写过）→ hash 变化 → 正常解析返回
-- **无需显式 invalidation**：hash-based detection 自动捕获变化
+- **首次 read** → 计算 hash → `SET key digest EX 21600` → 返回完整内容
+- **后续同 path 同 options read** → hash 相同 → `UnchangedOutput`
+- **文件被改过**（agent 用 execute / write_file / edit_file 写过）→ hash 变化 → 正常解析返回 + 更新缓存
+- **6 小时不活跃自动过期**（Redis TTL）—— 不需要 conversation lifecycle 钩子
+- **多 backend 副本天然共享**（无需 session-sticky）
 
 ### 7.3 边界
 
-- `page_range` 参数**不**计入 key；同文件用不同 page_range 重读仍可能 `unchanged`（期望 agent 从历史全量结果自取片段）
-- `unsupported` / `error` 结果也缓存 hash；后续同 path 同 hash 读仍走 `unchanged`（无副作用，agent 查历史即可）
-- 多 backend 副本：进程内 dict 不跨副本。SaaS 部署需 session-sticky（将 conversation 路由到固定 backend）；后续可扩展到 Redis-backed cache
+- **`page_range` / `line_range` 都计入 cache key**：不同 range 参数 = 不同 cache slot，agent 能正确拿到对应内容
+- **不相关 range 参数会浪费 cache slot**：例如 agent 对 .txt 文件传 `page_range="1-5"`（TextParser 忽略），与不传 page_range 的调用是不同 slot；浪费一次解析，acceptable（agents 通常按 description 用对参数）
+- **`unsupported` / `error` 结果也缓存 hash**：后续同条件读仍走 `unchanged`（无副作用，agent 查历史即可）
+- **Redis 不可达**：`check` / `update` 抛错 → 调用方应 try/except 把错误转化为"按 cache miss 处理"（不阻塞 file_read），日志告警；具体策略实现时确定
 
 ---
 
@@ -705,7 +735,8 @@ Unit 测试覆盖：
 - `backend/cubebox/parsers/protocols.py`（`FileParser`）
 - `backend/cubebox/parsers/schema.py`（`FileReadOutput` / `ParseOptions` / dataclasses）
 - `backend/cubebox/parsers/registry.py`（discover + dispatch + resolve）
-- `backend/cubebox/parsers/dedup.py`（hash cache）
+- `backend/cubebox/parsers/dedup.py`（Redis-backed hash cache，key 含 ParseOptions 签名）
+- `backend/cubebox/cache/__init__.py` + `backend/cubebox/cache/redis.py`（async redis 客户端工厂；若已存在则复用）
 - `backend/cubebox/parsers/plugins/__init__.py`
 - `backend/cubebox/parsers/plugins/text.py`
 - `backend/cubebox/parsers/plugins/notebook.py`
@@ -726,7 +757,7 @@ Unit 测试覆盖：
 - `backend/cubebox/middleware/sandbox.py` —— `SandboxMiddleware` 注册 `file_read` 工具到 tools 列表
 - `backend/cubebox/config.py` —— 加 `parsers.*` pydantic schema
 - `backend/config.yaml` / `config.development.yaml` / `config.test.yaml` —— 加 `parsers:` 节
-- `backend/pyproject.toml` —— `[project.entry-points."cubebox.parsers"]` + 新依赖：`libmagic` (python-magic-bin) + `httpx`（已有）+ `filetype`（libmagic 不可用时 fallback）
+- `backend/pyproject.toml` —— `[project.entry-points."cubebox.parsers"]` + 新依赖：`python-magic` (libmagic 包装) + `filetype`（fallback）+ `redis>=5.0`（async client；CI 已起 redis service）；`httpx` 已有
 - `docker-compose.yml` / 部署编排 —— 加 docling-serve service
 - `.github/workflows/ci.yml` —— e2e job 配置 mock `DoclingParser` 的 fixture 路径
 
@@ -774,7 +805,7 @@ Unit 测试覆盖：
 | docling-serve 启动慢（镜像 4.4 GB） | 部署文档写清预拉镜像步骤；K8s 用 initContainer 预热 |
 | docling-serve 单点 | v1 单实例可接受；后续按请求量 HPA；parser 是非关键链路（挂掉不阻塞 agent 对话，只是 file_read 不可用） |
 | 20K 截断对长文档过紧 | `page_range` 参数 + description 明示截断 + metadata 暴露 total_chars；agent 可多次调用补全 |
-| hash cache 多副本不一致 | v1 session-sticky；文档化后续 Redis 迁移路径 |
+| Redis 不可达让 dedup 失效 | dispatch 里 try/except，把 Redis 错误降级为 cache miss（继续解析）；告警日志；不影响 file_read 主路径 |
 | docling 对极端布局 PDF 解析错 | `error(retryable=False)` 可读 reason；agent 告诉用户；未来可装 Marker / LlamaParse 做 fallback plugin |
 | Protocol runtime_checkable 性能 | 仅启动时用一次（`discover()`），运行时不重复 check；无影响 |
 | libmagic 跨平台依赖 | `python-magic-bin` 自带 libmagic binary；不依赖系统包；macOS/Linux/Windows 统一 |
@@ -786,6 +817,6 @@ Unit 测试覆盖：
 
 - [ ] `DoclingParser` 对 DOCX/PPTX 的 `page_range` 实现策略（docling-serve 本身是否支持 page_range / 若不支持的 markdown 后处理剪裁算法）—— 实现时确认
 - [ ] docling-serve `FileSourceRequest` 的确切 JSON schema（multipart vs base64）—— 读 OpenAPI 后确认
-- [ ] SaaS 场景多副本 backend 的 session-sticky routing vs Redis-backed hash cache 切换时机 —— 后续扩展观察
+- [ ] Redis dedup TTL（默认 6h）是否需要按 conversation 活跃度自适应延长 —— 上线观察后再调
 - [ ] `UnchangedOutput` 是否应包含首次读取的 metadata 摘要（便于 agent 不回翻历史也能快速引用）—— v1 先不加，等使用反馈
-- [ ] Conversation 关闭钩子接入 `dedup.forget_conversation` 的具体位置 —— 实现时确认
+- [ ] `cubebox.cache` 模块若已存在（M-CI 引入 redis service 时是否同步加了 client）—— 实现时复用，不重复实现

--- a/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
+++ b/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
@@ -65,6 +65,7 @@
 | D19 | Tool description 是本 spec 的**固定产出**，逐字进 StructuredTool | 只写大致 | agent 使用率/误用率高度依赖 description；一字一句都要审 |
 | D20 | dedup cache 直接走 **Redis**（CI 已挂 redis service；backend 增加 redis-py async client） | 进程内 dict + session-sticky routing | conversation 没有明确"结束"事件，Redis TTL 替代 lifecycle 钩子；多副本天然共享；重启不丢热缓存 |
 | D21 | `ParseOptions` 提供两个独立 range 参数：`page_range`（PDF/DOCX/PPTX）+ `line_range`（text/code/log） | 单一通用 `range` 字段 / 只 page_range / 不做 | text 文件用行号比页号自然；分两参数语义清晰；plugin 各取所需，互不影响；cache key 由 dispatch 层把 options 整体签入即可 |
+| D22 | **不维护 REJECT_EXT / REJECT_MIME 硬名单**；"哪些格式支持"完全由 plugin 注册决定，未匹配 → `unsupported` + 智能 hint | hardcoded REJECT 视频/音频/归档/可执行 | 双数据源维护成本；REJECT 阻断合法扩展（mp4 转写 / zip listing / exe 元数据等 plugin 被预先枪毙）；零性能收益；零安全收益（file_read 是只读，读 .exe 字节无副作用） |
 
 ---
 
@@ -314,63 +315,67 @@ async def dispatch(
     content = await sandbox._download_one(path)
     size = len(content)
 
-    # 2. size precheck
+    # 2. size precheck（backend 资源保护，与格式无关）
     if size > 100 * 1024 * 1024:
         return UnsupportedOutput(
-            path=path, mime="?", size_bytes=size,
+            path=path, mime="application/octet-stream", size_bytes=size,
             reason="file too large (100MB limit)",
-            hint="try reading specific pages with page_range",
+            hint="try reading specific pages with page_range or specific lines with line_range",
         )
 
     # 3. MIME sniff
-    mime = await _sniff_mime(path, content)  # libmagic → ext fallback
+    mime = await sniff_mime_async(path, content)
     ext = Path(path).suffix.lstrip(".").lower()
 
-    # 4. hard REJECT list
-    if ext in REJECT_EXT or mime in REJECT_MIME:
-        return UnsupportedOutput(
-            path=path, mime=mime, size_bytes=size,
-            reason=_reject_reason(ext, mime),
-            hint=_reject_hint(ext),
-        )
-
-    # 5. dedup check (conversation-scoped hash cache)
+    # 4. dedup check (Redis-backed; key includes ParseOptions signature)
     if conversation_id is not None:
-        digest = await _hash_bytes(content)
-        if dedup.check(conversation_id, path, digest):
-            return UnchangedOutput(path=path)
-        dedup.update(conversation_id, path, digest)
+        digest = await dedup.hash_bytes(content)
+        try:
+            if await dedup.check(conversation_id, path, options, digest):
+                return UnchangedOutput(path=path)
+            await dedup.update(conversation_id, path, options, digest)
+        except Exception as exc:
+            logger.warning("dedup cache unavailable, proceeding without: %s", exc)
 
-    # 6. resolve plugin & parse
+    # 5. resolve plugin
     parser = self.resolve(mime=mime, ext=ext)
     if parser is None:
+        # No plugin claims this format. CE doesn't maintain a hardcoded REJECT
+        # list — extensibility means future plugins can claim ANY format
+        # (transcribers for video/audio, listers for archives, etc.). When no
+        # plugin matches, return unsupported with a format-family hint.
         return UnsupportedOutput(
             path=path, mime=mime, size_bytes=size,
-            reason="no parser matched",
+            reason=f"no parser registered for mime={mime}",
+            hint=self._unsupported_hint(mime, ext),
         )
+
+    # 6. parse
     try:
         return await parser.parse(content, mime=mime, options=options)
     except Exception as exc:
         return ErrorOutput(path=path, error=str(exc), retryable=_is_retryable(exc))
+
+
+@staticmethod
+def _unsupported_hint(mime: str, ext: str) -> str | None:
+    """Generate a format-family-aware hint for the unsupported case."""
+    if mime.startswith("video/"):
+        return "video transcription requires a parser plugin (none installed)"
+    if mime.startswith("audio/"):
+        return "audio transcription requires a parser plugin (none installed)"
+    if mime in {
+        "application/zip", "application/x-tar", "application/gzip",
+        "application/x-bzip2", "application/x-7z-compressed",
+        "application/x-rar-compressed", "application/x-xz",
+    }:
+        return 'extract first via execute("unzip <file>") then file_read on contents'
+    if ext in {"exe", "so", "dll", "dylib", "bin"}:
+        return "binary executable; install a metadata parser plugin if needed"
+    return None
 ```
 
-**REJECT 列表**（硬拒绝，不走任何 plugin）：
-
-```python
-REJECT_EXT = {
-    # video
-    "mp4", "mov", "mkv", "webm", "avi", "flv", "wmv", "m4v",
-    # audio
-    "mp3", "wav", "m4a", "ogg", "flac", "opus", "aac", "wma",
-    # binary / executable
-    "exe", "so", "dll", "dylib", "o", "a", "bin", "com",
-    # archive
-    "zip", "tar", "gz", "bz2", "rar", "7z", "tgz", "xz", "zst",
-}
-REJECT_MIME = {
-    # ... 对应 MIME
-}
-```
+**没有 REJECT 列表**：CE 不维护"哪些格式禁读"硬名单。哪些格式被支持，**完全由 plugin 注册决定**。未匹配 plugin → `UnsupportedOutput` + 智能 hint。详见 D22。
 
 ---
 
@@ -484,21 +489,22 @@ output, not network resources.
 • Images — .png .jpg .webp .tiff. Returns OCR'd text content (no
   visual understanding in v1).
 
-═══════════════════ DO NOT USE THIS TOOL FOR ═══════════════════
-• Video / Audio (.mp4 .mov .mp3 .wav etc.) — will return
-  kind="unsupported". Acknowledge to the user that these cannot
-  be read as text.
-• Executables / Binaries (.exe .so .dll .bin) — will return
-  kind="unsupported".
-• Archives (.zip .tar .gz) — will return kind="unsupported".
-  To access contents, first `execute("unzip <file> -d <dest>")`
-  then file_read on extracted files.
-• Remote URLs — file_read only reads sandbox paths. Use web-fetch
-  tools for URLs.
+═══════════════ WHEN OTHER TOOLS ARE BETTER ═══════════════════
+• Remote URLs — file_read only reads sandbox paths. Use a web-fetch
+  tool for URLs.
 • Grep / search — for pattern-find within files, `execute("grep -n
   'pattern' <file>")` is more direct than file_read + scan.
-• Tiny single-line peeks where you already know the byte offset —
-  `execute("sed -n '42p' <file>")` skips parser overhead.
+• Tiny known-offset peeks — `execute("sed -n '42p' <file>")` skips
+  parser overhead.
+
+═══════════════ HOW UNSUPPORTED FORMATS BEHAVE ═══════════════════
+The tool returns kind="unsupported" with a `hint` when no parser
+plugin handles the file's MIME type. Common cases — video, audio,
+archives (.zip / .tar / .gz), binary executables — fall here in the
+default deployment. The `hint` field tells you what alternative to
+try (e.g., extract archive first via execute, then file_read on
+extracted files). If you see kind="unsupported", surface the hint
+to the user; don't keep retrying file_read on the same path.
 
 ═══════════════════ RETURN FORMAT (by `kind`) ═══════════════════
 • "text"       — {content, mime, size_bytes, truncated, metadata}

--- a/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
+++ b/docs/superpowers/specs/2026-04-22-file-read-tool-design.md
@@ -1,0 +1,791 @@
+# M6 · file_read 通用工具设计
+
+**Status**: Draft · 2026-04-22
+**Owner**: @xfgong
+**Scope**: 为 agent 新增通用 `file_read` 工具；抽象 `Sandbox.file_read` 方法；引入 `cubebox.parsers` 共享后台库 + `FileParser` 插件架构；v1 内置 text / notebook / docling 三个默认 parser；docling-serve 作为独立 HTTP 服务承担多格式解析。
+**属于**: v1 开源发布待办 · M6
+**Backlog 索引**: `docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md`
+**依赖**: M-CI（占位 job）；不依赖 M0（独立 plugin group `cubebox.parsers` 而非 `cubebox.*`）
+
+---
+
+## 1. 背景与目标
+
+### 1.1 现状
+
+- Agent 工具集中**没有**通用文件读取能力。`load_skill` 只读 skill 的 SKILL.md，`execute` / `write_file` / `edit_file` 是沙盒操作工具（来自 `SandboxMiddleware`，`sandbox.py:68-98`），不做内容归一化
+- 无 PDF / DOCX / XLSX / PPTX 等非文本文件的读取支持
+- 沙盒抽象（`backend/cubebox/sandbox/base.py:15-54`）只有 `execute / upload / download`，没有"读取并解析文件"的高层语义
+- Agent 若需读 PDF，现在只能 `execute("pdftotext ...")` 凭沙盒镜像里装了什么工具运气处理
+- 视觉/图像管线未接通：`convert.py:115` / `stream.py:95` 只支持 `msg.content: str`；`ModelConfig.input` 虽有 image/pdf 字段但运行时未消费
+
+### 1.2 目标
+
+- Agent 调用 `file_read(path)` 即可读沙盒里任何支持格式的文件，返回 LLM 可直接消费的 markdown / 结构化输出
+- 沙盒抽象层新增 `Sandbox.file_read(path, options) -> FileReadOutput`，与 `execute` 同层；不同 Sandbox 实现可各自 override
+- 解析器走**后台插件架构**（参考 MarkItDown 的 converter registry）：每类文件一个 plugin；docling-serve 是默认多格式 parser 的实现细节
+- `cubebox.parsers` 是共享后台库：本次 file_read 第一个消费；未来 filebox（workspace RAG）也调用同一 registry
+- Tool description 充分详述"能用/不能用/返回什么"，直接影响 agent 使用率与错误率
+
+### 1.3 非目标
+
+- **视觉 / 模型原生 PDF**：vision content block 管线未接通；v1 不定义 `image` / `pdf_native` kind（union 扩展时非破坏性加）
+- **OCR 之外的图像理解**：图片走 docling OCR 返文本；不做 LLM vision 描述
+- **视频 / 音频**：明确拒绝
+- **远程 URL / HTTP 资源**：只读沙盒路径；URL 走 web-fetch 类工具（不在本 spec）
+- **Artifact 反向读取**：只读沙盒文件系统；artifact / user upload 的"落地"由 M7 / artifact 子系统负责，M6 不涉及
+- **跨 sandbox 实现的 parser 兼容**：v1 默认实现一种（backend 调 docling-serve）；未来有不同 sandbox 实现时再按需 override `Sandbox.file_read`
+- **Vision 接通后的 image kind**：是未来版本的增量扩展，**不**在本 spec
+- **`install[]` 执行 / requires 校验**：Openclaw skill 侧问题（原 M5 已并入 M3），与本 spec 无关
+
+---
+
+## 2. 决策记录
+
+| # | 决策 | 备选 | 选用理由 |
+|---|---|---|---|
+| D1 | Parser 跑在 **backend Python 进程**；sandbox 只暴露文件、不 bake parser 依赖 | Parser 跑在 sandbox 容器内 | 未来 filebox 等后台 worker 可复用；sandbox 镜像保持轻量；不同 sandbox 实现无需各自 bake 同套依赖 |
+| D2 | Sandbox 抽象新增方法 `Sandbox.file_read(path, options) -> FileReadOutput`，与 `execute` 同层 | 单独做一个 backend 模块不走 Sandbox | agent 上下文围绕 sandbox；未来 sandbox 实现自带原生解析能力（假设）可 override 本方法 |
+| D3 | `cubebox.parsers` 作为 backend 子模块（非独立 PyPI 包） | 独立发 `cubebox-parsers` 包 | filebox future 也在 backend 进程，直接 import；发布维护成本低 |
+| D4 | `FileParser` Protocol + `@runtime_checkable` + entry_points group `cubebox.parsers` | class base + 手动注册 | 与 M0 plugin 思路一致（Protocol + entry_points）；装错签名启动即失败 |
+| D5 | v1 内置 3 个 plugin：`TextParser` / `NotebookParser` / `DoclingParser` | 单 parser 或更多 | 覆盖全部 v1 需求；粒度清晰；都按 Protocol 挂接 |
+| D6 | 默认多格式走 `DoclingParser` → HTTP 到独立 **docling-serve** 容器（CPU 镜像 `docling-serve-cpu`，4.4 GB） | MarkItDown 嵌入 / LlamaParse 云 / 无 | 不把 heavy ML 依赖引入核心库；docling 精度高；Apache-2.0 许可可与 CE 共发；自部署单容器即可 |
+| D7 | `.html` 走文本路径（`TextParser`），不走 docling | 走 docling 做 HTML 清洗 | agent 常读写 HTML artifacts（源码级），避免被重写 |
+| D8 | TEXT_DIRECT 扩展名列表**宽**（含 `.py .js .ts .go .rs .c .cpp .java .rb .php .html .svg .xml` 等） | 严格文本 `.txt .md` | cubebox 是 dev-friendly agent 平台；读代码文件是常态；TextParser 只做 UTF-8 decode 代价极小 |
+| D9 | OCR 图片归 `text` kind，`metadata.parser = "docling-ocr"` 区分 | 独立 `image` kind | v1 无 vision 管线；OCR 结果本质是文本；union 不提前扩展 |
+| D10 | Output union 共 **5 种 kind**：`text` / `notebook` / `unsupported` / `unchanged` / `error` | 7 种（含 image / pdf_native / parts / office_markdown） | 砍掉无下游消费者的 kind；`image` / `pdf_native` 未来加为纯新增，非破坏性 |
+| D11 | `unchanged` sentinel 走 **conversation 级 SHA-256 hash cache**，无显式 invalidation | 显式 write_file / execute 回调 invalidate | hash 对比天然捕获写入变化；代码面无 cross-module 耦合 |
+| D12 | hash 一律走 `asyncio.to_thread(hashlib.sha256, ...)` | 直接同步 hash | 100MB SHA-256 约 300ms；不能阻塞 event loop |
+| D13 | 超大 parsed content 截断阈值：**20,000 字符**（约 4-6K tokens） | 500K 字符 / 无限制 | 不把单次 file_read 占满 context；agent 有 `page_range` 和分段重读的手段 |
+| D14 | 文件硬上限：**100 MB** | 无限制 | docling-serve 和 backend memory 的合理上限；超大文件应该预处理后再读 |
+| D15 | sync / async 路径按 file_size **硬分流**（阈值 3 MB），**不**自动降级 | sync 先试 → 超时降级 async | 代码路径清晰；避免服务端 CPU 被吃两次；timeout 做 retryable error 由 agent 决策重试 |
+| D16 | docling-serve 超时：sync **30s** / async **10 min**；双硬上限 | 无限制 / 动态 | 配置可调；超时 → `error(retryable=True)` |
+| D17 | v1 只发 CPU 镜像；GPU 镜像留给用户自换 | 三镜像矩阵（cpu / cu128 / cu130） | 单变体减少文档分叉与首装复杂度；自部署想加速自换 |
+| D18 | CI **不**起真 docling-serve；mock `DoclingParser` | 真实服务跑 e2e | docling-serve 不在 backend 关键链路（挂掉只影响 file_read）；mock 充分 |
+| D19 | Tool description 是本 spec 的**固定产出**，逐字进 StructuredTool | 只写大致 | agent 使用率/误用率高度依赖 description；一字一句都要审 |
+| D20 | 多 backend 副本场景需 **session-sticky routing** 或后续改 Redis-backed cache | 进程外共享 | v1 进程内 dict 简单；SaaS 扩展时再换 |
+
+---
+
+## 3. 整体架构
+
+### 3.1 三层拓扑
+
+```
+┌────────────────────────────────────────────────┐
+│  Backend                                       │
+│                                                │
+│  Layer 1 · Agent Tool                          │
+│  ┌──────────────────┐                          │
+│  │  file_read tool  │ ← SandboxMiddleware 注册 │
+│  └──────────┬───────┘   (与 execute 同位置)    │
+│             │                                  │
+│             ▼ sandbox.file_read(path, options) │
+│                                                │
+│  Layer 2 · Sandbox 抽象                         │
+│  ┌──────────────────────────┐                  │
+│  │ Sandbox(ABC)             │                  │
+│  │   .execute()   (现有)    │                  │
+│  │   .upload()/.download()  │                  │
+│  │   .file_read()  ← 新     │                  │
+│  └──────────┬───────────────┘                  │
+│             │ 默认实现                          │
+│             ▼                                  │
+│                                                │
+│  Layer 3 · Parser 共享库                        │
+│  ┌────────────────────────────────────────┐    │
+│  │ cubebox.parsers                        │    │
+│  │  ├─ protocols.py  (FileParser)         │    │
+│  │  ├─ registry.py   (entry_points)       │    │
+│  │  ├─ schema.py     (FileReadOutput 等)  │    │
+│  │  ├─ dedup.py      (hash cache)         │    │
+│  │  └─ plugins/                           │    │
+│  │     ├─ text.py      (内置)             │    │
+│  │     ├─ notebook.py  (内置)             │    │
+│  │     └─ docling.py   (内置，默认)       │    │
+│  └──────────┬─────────────────────────────┘    │
+└─────────────┼──────────────────────────────────┘
+              │ HTTP（仅 DoclingParser 使用）
+              ▼
+   ┌──────────────────────┐
+   │ docling-serve:5001   │  独立容器，CPU 镜像
+   └──────────────────────┘
+
+   未来 filebox（workspace RAG indexer）：
+     不经 sandbox，直接 `from cubebox.parsers import registry`
+     → 复用同一 registry。
+```
+
+### 3.2 Sandbox 抽象增强
+
+**`backend/cubebox/sandbox/base.py`**（新增方法）：
+
+```python
+from cubebox.parsers import ParseOptions, registry as parser_registry
+from cubebox.parsers.schema import FileReadOutput
+
+class Sandbox(ABC):
+    # ... existing methods ...
+
+    async def file_read(
+        self,
+        path: str,
+        *,
+        options: ParseOptions | None = None,
+        conversation_id: UUID | None = None,
+    ) -> FileReadOutput:
+        """
+        Read a file from the sandbox and return a discriminated output
+        (text / notebook / unsupported / unchanged / error).
+
+        Default implementation:
+        1. downloads bytes via self._download_one(path)
+        2. sniffs MIME (libmagic + extension fallback)
+        3. dispatches to registry.resolve(mime, ext)
+        4. applies conversation-scoped dedup (SHA-256 hash cache)
+
+        Subclasses may override (e.g., a future Sandbox implementation
+        with native parsing may call its own API without downloading).
+        """
+        return await parser_registry.dispatch(
+            sandbox=self,
+            path=path,
+            options=options or ParseOptions(),
+            conversation_id=conversation_id,
+        )
+```
+
+`OpenSandbox`（现有唯一实现）用默认实现；无需 override。
+
+### 3.3 `cubebox.parsers` 的定位
+
+- **后台工具库**，不对外暴露 plugin 发现 API 给 agent / sandbox caller
+- 三个职责：
+  1. 定义 `FileParser` Protocol 与 output schema
+  2. 启动期发现并校验所有已注册 plugin
+  3. 暴露 `dispatch(...)` 统一入口，内部按 MIME 路由到对应 plugin
+- 对 file_read：通过 `Sandbox.file_read` 间接使用
+- 对 filebox future：直接 `from cubebox.parsers import registry` 调用
+
+---
+
+## 4. Parser Protocol 与插件
+
+### 4.1 `FileParser` Protocol
+
+**`backend/cubebox/parsers/protocols.py`**：
+
+```python
+from typing import Protocol, runtime_checkable
+from cubebox.parsers.schema import ParseOptions, FileReadOutput
+
+
+@runtime_checkable
+class FileParser(Protocol):
+    """
+    Implementations parse file bytes for a specific format family.
+
+    mime_types: list of MIME patterns ("application/pdf", "text/*")
+    extensions: list of extensions without leading dot ("pdf", "docx")
+    priority:   within-family tie-breaker; higher wins
+    """
+
+    mime_types: list[str]
+    extensions: list[str]
+    priority: int
+
+    async def parse(
+        self,
+        content: bytes,
+        *,
+        mime: str,
+        options: ParseOptions,
+    ) -> FileReadOutput: ...
+```
+
+### 4.2 Entry points 发现
+
+**`backend/pyproject.toml`**（新增）：
+
+```toml
+[project.entry-points."cubebox.parsers"]
+text     = "cubebox.parsers.plugins.text:TextParser"
+notebook = "cubebox.parsers.plugins.notebook:NotebookParser"
+docling  = "cubebox.parsers.plugins.docling:DoclingParser"
+```
+
+**Registry 启动流程**（`cubebox/parsers/registry.py`）：
+
+```python
+def discover() -> ParserRegistry:
+    reg = ParserRegistry()
+    for ep in importlib.metadata.entry_points(group="cubebox.parsers"):
+        cls = ep.load()
+        instance = cls()
+        if not isinstance(instance, FileParser):
+            raise RuntimeError(
+                f"{ep.name} ({ep.value}) does not satisfy FileParser Protocol"
+            )
+        reg._register(name=ep.name, parser=instance)
+    return reg
+```
+
+- **运行时 Protocol 校验**：装错签名启动即失败（与 M0 一致）
+- **外部插件发现**：第三方 wheel 只需声明 `cubebox.parsers` group，装进 backend 的 Python path 即可
+- **保留名**：`text` / `notebook` / `docling` 三个名 v1 cubebox 占用；外部插件若注册同名 → Registry 按 `priority` 或字母序择一（v1 保守地使外部优先级高 → 替换默认）
+
+### 4.3 v1 三个默认 plugin
+
+#### `TextParser`（`cubebox/parsers/plugins/text.py`）
+
+**响应范围**：
+- MIME 通配：`text/*`
+- 扩展名（MIME 探测失败时兜底）：
+  ```
+  txt md markdown  rst  org  adoc_source
+  py pyi ipynb_non_nbformat
+  js ts jsx tsx mjs cjs
+  json json5 yaml yml toml ini conf env
+  csv tsv
+  html htm xhtml xml svg
+  css scss sass less
+  sh bash zsh fish
+  sql graphql
+  go rs java kt kts scala groovy
+  c h cpp cc cxx hpp hxx
+  rb php pl pm
+  log lock properties
+  dockerfile makefile (特殊名无扩展名)
+  ```
+- `priority = 0`（最低；特定格式 plugin 优先）
+
+**parse 行为**：UTF-8 解码；失败 fallback 到 latin-1（仅为避免 crash，`metadata.decode_fallback = true` 标注）。超 20K 字符截断，`truncated=True`。
+
+#### `NotebookParser`（`cubebox/parsers/plugins/notebook.py`）
+
+**响应范围**：MIME `application/x-ipynb+json` / 扩展名 `ipynb`；`priority = 10`。
+
+**parse 行为**：JSON 解析 → 按 `cells[]` 遍历 → 每 cell 转 `NotebookCell`：
+- `cell_type`: 取 `code` / `markdown` / `raw`
+- `source`: join cell.source 数组
+- `outputs`（仅 code cell）：简化为 `[{type, text_repr}]`，舍弃图像 base64 blob（M6 无 vision 路径）
+
+总输出内容（`sum(len(cell.source) + len(cell.outputs_text)) for cells`）超 20K → 截断到前 N 个 cell 填满 20K，剩余 cell 省略，metadata 标 `truncated_cells: M`。
+
+#### `DoclingParser`（`cubebox/parsers/plugins/docling.py`）
+
+**响应范围**：MIME `application/pdf`, `application/vnd.openxmlformats-officedocument.{wordprocessingml.document,presentationml.presentation,spreadsheetml.sheet}`, `application/epub+zip`, `image/*` (PNG/JPEG/GIF/WebP/TIFF/BMP) 等 / 扩展名 `pdf docx pptx xlsx epub png jpg jpeg gif webp tiff bmp` / `priority = 20`。
+
+**parse 行为**：
+1. `file_size = len(content)`
+2. if `file_size < parsers.docling_serve.async_threshold_mb` (默认 3 MB) → sync 路径：
+   - `POST {base_url}/v1/convert/source` with `FileSourceRequest` (multipart/base64；视 docling-serve 实际接口确定)
+   - Body: `{ "sources": [{"kind": "file", "filename": "...", "base64": "..."}], "options": {...}}`
+   - Headers: `X-Api-Key` (if config 配了)
+   - Timeout: `timeout_sync_seconds` (默认 30s)
+   - 返回: JSON `{ "md_content": "..." }` 或对应字段 → 转 `TextOutput(content=...)`
+3. else → async 路径：
+   - `POST {base_url}/v1alpha/convert/source/async` → 拿 `task_id`
+   - 轮询 `GET {base_url}/v1alpha/convert/tasks/{task_id}` 直到 status ∈ {COMPLETED, FAILED}，间隔 `poll_interval_seconds` (默认 2s)
+   - 总超时 `timeout_async_minutes` (默认 10)
+4. 超时 / HTTP 错 / task FAILED → `ErrorOutput(error=..., retryable=...)`
+5. 超 20K 字符 → 截断 + `truncated=True`
+6. `page_range` 通过 docling options 传递（具体字段名实现时确认）；对 DOCX/PPTX 若 docling 不支持 page_range，在 markdown 输出层做后处理截取（按 heading 或 `---` 分隔）
+
+### 4.4 调度逻辑（`registry.dispatch`）
+
+```python
+async def dispatch(
+    self,
+    sandbox: Sandbox,
+    path: str,
+    options: ParseOptions,
+    conversation_id: UUID | None,
+) -> FileReadOutput:
+    # 1. download
+    content = await sandbox._download_one(path)
+    size = len(content)
+
+    # 2. size precheck
+    if size > 100 * 1024 * 1024:
+        return UnsupportedOutput(
+            path=path, mime="?", size_bytes=size,
+            reason="file too large (100MB limit)",
+            hint="try reading specific pages with page_range",
+        )
+
+    # 3. MIME sniff
+    mime = await _sniff_mime(path, content)  # libmagic → ext fallback
+    ext = Path(path).suffix.lstrip(".").lower()
+
+    # 4. hard REJECT list
+    if ext in REJECT_EXT or mime in REJECT_MIME:
+        return UnsupportedOutput(
+            path=path, mime=mime, size_bytes=size,
+            reason=_reject_reason(ext, mime),
+            hint=_reject_hint(ext),
+        )
+
+    # 5. dedup check (conversation-scoped hash cache)
+    if conversation_id is not None:
+        digest = await _hash_bytes(content)
+        if dedup.check(conversation_id, path, digest):
+            return UnchangedOutput(path=path)
+        dedup.update(conversation_id, path, digest)
+
+    # 6. resolve plugin & parse
+    parser = self.resolve(mime=mime, ext=ext)
+    if parser is None:
+        return UnsupportedOutput(
+            path=path, mime=mime, size_bytes=size,
+            reason="no parser matched",
+        )
+    try:
+        return await parser.parse(content, mime=mime, options=options)
+    except Exception as exc:
+        return ErrorOutput(path=path, error=str(exc), retryable=_is_retryable(exc))
+```
+
+**REJECT 列表**（硬拒绝，不走任何 plugin）：
+
+```python
+REJECT_EXT = {
+    # video
+    "mp4", "mov", "mkv", "webm", "avi", "flv", "wmv", "m4v",
+    # audio
+    "mp3", "wav", "m4a", "ogg", "flac", "opus", "aac", "wma",
+    # binary / executable
+    "exe", "so", "dll", "dylib", "o", "a", "bin", "com",
+    # archive
+    "zip", "tar", "gz", "bz2", "rar", "7z", "tgz", "xz", "zst",
+}
+REJECT_MIME = {
+    # ... 对应 MIME
+}
+```
+
+---
+
+## 5. Output discriminated union
+
+### 5.1 全部 kind（v1）
+
+| kind | 含义 | 何时产生 |
+|---|---|---|
+| `text` | 文本/markdown 内容 | 主成功路径（所有文本类 / 文档类 / OCR 图片） |
+| `notebook` | Jupyter 结构化 cells | `.ipynb` 专用 |
+| `unsupported` | 拒绝读取 | REJECT 列表 / 超 100MB / 无 plugin 匹配 |
+| `unchanged` | 文件未变 sentinel | 同 conversation 内同 path 同 hash 二次 read |
+| `error` | 解析或网络错误 | parser 抛错 / docling-serve 超时或不可达 |
+
+### 5.2 Schema（`cubebox/parsers/schema.py`）
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal, Annotated, Any
+
+
+class TextOutput(BaseModel):
+    kind: Literal["text"] = "text"
+    path: str
+    mime: str
+    content: str
+    size_bytes: int
+    truncated: bool = False
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    # e.g. {parser: "docling" | "text" | "docling-ocr",
+    #       pages: 12,
+    #       total_chars: 34567,
+    #       truncated_at_char: 20000,
+    #       decode_fallback: "latin-1"}
+
+
+class NotebookCell(BaseModel):
+    cell_type: Literal["code", "markdown", "raw"]
+    source: str
+    outputs: list[dict[str, Any]] | None = None
+
+
+class NotebookOutput(BaseModel):
+    kind: Literal["notebook"] = "notebook"
+    path: str
+    cells: list[NotebookCell]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    # e.g. {total_cells: 42, truncated_cells: 15}
+
+
+class UnsupportedOutput(BaseModel):
+    kind: Literal["unsupported"] = "unsupported"
+    path: str
+    mime: str
+    size_bytes: int
+    reason: str
+    hint: str | None = None
+
+
+class UnchangedOutput(BaseModel):
+    kind: Literal["unchanged"] = "unchanged"
+    path: str
+
+
+class ErrorOutput(BaseModel):
+    kind: Literal["error"] = "error"
+    path: str
+    error: str
+    retryable: bool = False
+
+
+FileReadOutput = Annotated[
+    TextOutput | NotebookOutput | UnsupportedOutput | UnchangedOutput | ErrorOutput,
+    Field(discriminator="kind"),
+]
+
+
+class ParseOptions(BaseModel):
+    page_range: str | None = None   # "1-5" or "3"
+    language_hint: str | None = None
+```
+
+### 5.3 非破坏性扩展路径
+
+未来增加以下 kind 为**纯新增**，union 扩展兼容：
+- `image` —— 当 vision content block 管线就绪时
+- `pdf_native` —— 当模型原生 PDF byte 输入支持时
+- `parts` —— 需要返回混合类型（文本 + 图）时
+
+---
+
+## 6. Tool Description（逐字进 StructuredTool）
+
+```
+file_read(path: str, page_range: str | None = None) -> FileReadOutput
+
+Read a file from the sandbox workspace and return its content in a form
+you can reason about. Use this whenever you need to inspect user uploads,
+agent-generated artifacts, or any file inside the sandbox — not shell
+output, not network resources.
+
+═══════════════════════ USE THIS TOOL FOR ═══════════════════════
+• Text / source code — .txt .md .py .js .ts .json .yaml .toml .csv
+  .html .css .go .rs .java .cpp (and similar). Returns raw UTF-8 text.
+• Documents — .pdf .docx .pptx .xlsx .epub. Returns markdown
+  preserving headings, tables, lists.
+• Notebooks — .ipynb. Returns structured cells (code/markdown/raw)
+  with cell outputs.
+• Images — .png .jpg .webp .tiff. Returns OCR'd text content (no
+  visual understanding in v1).
+
+═══════════════════ DO NOT USE THIS TOOL FOR ═══════════════════
+• Video / Audio (.mp4 .mov .mp3 .wav etc.) — will return
+  kind="unsupported". Acknowledge to the user that these cannot
+  be read as text.
+• Executables / Binaries (.exe .so .dll .bin) — will return
+  kind="unsupported".
+• Archives (.zip .tar .gz) — will return kind="unsupported".
+  To access contents, first `execute("unzip <file> -d <dest>")`
+  then file_read on extracted files.
+• Remote URLs — file_read only reads sandbox paths. Use web-fetch
+  tools for URLs.
+• Quick single-line peeks — if you only need a specific line or
+  want to grep, `execute("sed -n '42p' <file>")` or
+  `execute("grep -n 'pattern' <file>")` is faster and cheaper.
+
+═══════════════════ RETURN FORMAT (by `kind`) ═══════════════════
+• "text"       — {content, mime, size_bytes, truncated, metadata}
+                 The main success path. `content` is markdown for
+                 structured docs, raw text for code.
+• "notebook"   — {cells: [{cell_type, source, outputs}, ...]}
+• "unsupported"— {reason, hint, mime, size_bytes}
+                 Propose an alternative or tell the user.
+• "unchanged"  — file has not been modified since your previous
+                 file_read on this path in this session; refer
+                 to that earlier result in your reasoning.
+• "error"      — {error, retryable}. Surface to user; retry only
+                 if retryable=True.
+
+═══════════════════════ PARAMETERS ══════════════════════════════
+• path (required)         — absolute sandbox path, e.g.
+                            /home/user/uploads/report.pdf
+• page_range (optional)   — "1-5" or "3". Only honored for PDF /
+                            DOCX / PPTX; silently ignored for
+                            other formats.
+
+═══════════════════════ LIMITS ══════════════════════════════════
+• Files > 100 MB are refused with kind="unsupported".
+• Content longer than 20,000 characters is truncated (truncated=True).
+  Use `page_range` to retrieve a specific segment, or read in
+  multiple calls with narrower ranges.
+• Large files (>3 MB) trigger async parsing and may take up to
+  10 minutes; do not retry prematurely.
+```
+
+---
+
+## 7. File state dedup（`unchanged` 实现）
+
+### 7.1 Hash cache
+
+**`backend/cubebox/parsers/dedup.py`**：
+
+```python
+import asyncio
+import hashlib
+from uuid import UUID
+
+# Keyed by (conversation_id, path). Stores SHA-256 hex digest.
+# v1 进程内 dict；多 backend 副本需 session-sticky 或迁移 Redis.
+_file_state: dict[tuple[UUID, str], str] = {}
+
+
+async def hash_bytes(data: bytes) -> str:
+    # 100MB SHA-256 约 ~300ms；offload 到 thread pool 避免阻塞 event loop
+    return await asyncio.to_thread(
+        lambda: hashlib.sha256(data).hexdigest()
+    )
+
+
+def check(conversation_id: UUID, path: str, digest: str) -> bool:
+    """Returns True if digest matches cached (→ unchanged)."""
+    return _file_state.get((conversation_id, path)) == digest
+
+
+def update(conversation_id: UUID, path: str, digest: str) -> None:
+    _file_state[(conversation_id, path)] = digest
+
+
+def forget_conversation(conversation_id: UUID) -> None:
+    # 会话结束时清理（挂入 ConversationManager 的 on_close 钩子）
+    keys = [k for k in _file_state if k[0] == conversation_id]
+    for k in keys:
+        _file_state.pop(k, None)
+```
+
+### 7.2 行为
+
+- **首次 read** → 计算 hash → 存 `(conv_id, path) -> digest` → 返回完整内容
+- **后续同 path read** → hash 相同 → `UnchangedOutput`（content 省略）
+- **文件被改过**（agent 用 execute / write_file / edit_file 写过）→ hash 变化 → 正常解析返回
+- **无需显式 invalidation**：hash-based detection 自动捕获变化
+
+### 7.3 边界
+
+- `page_range` 参数**不**计入 key；同文件用不同 page_range 重读仍可能 `unchanged`（期望 agent 从历史全量结果自取片段）
+- `unsupported` / `error` 结果也缓存 hash；后续同 path 同 hash 读仍走 `unchanged`（无副作用，agent 查历史即可）
+- 多 backend 副本：进程内 dict 不跨副本。SaaS 部署需 session-sticky（将 conversation 路由到固定 backend）；后续可扩展到 Redis-backed cache
+
+---
+
+## 8. 超时、大小限制、错误处理
+
+### 8.1 大小与内容限制
+
+| 规则 | 阈值 | 响应 |
+|---|---|---|
+| 硬上限拒绝 | file_size > **100 MB** | `unsupported`, reason="file too large (100MB limit)" |
+| Content 截断 | parsed `content` > **20,000 字符** | `text` with `truncated=True`；content 取前 20K |
+| PDF async 超时 | async 路径 > **10 min** | `error(retryable=True)` |
+| 单次 page_range 段落仍超 20K | 截断 | 同 content 截断规则 |
+
+### 8.2 超时（修订 §3.1 / D15-D16）
+
+```python
+async def convert_via_docling(content: bytes, mime: str, options):
+    size = len(content)
+    threshold_bytes = config.parsers.docling_serve.async_threshold_mb * 1024 * 1024
+    if size < threshold_bytes:
+        return await _docling_sync(
+            content, mime, options,
+            timeout=config.parsers.docling_serve.timeout_sync_seconds,  # 30
+        )
+    else:
+        task_id = await _docling_async_submit(content, mime, options)
+        return await _docling_async_poll(
+            task_id,
+            timeout=config.parsers.docling_serve.timeout_async_minutes * 60,  # 600
+            interval=config.parsers.docling_serve.poll_interval_seconds,      # 2
+        )
+```
+
+**硬分流，不自动降级**：
+- sync 30s 超时 → `error(retryable=True)`
+- async 10 min 超时 → `error(retryable=True)`
+- Agent 可根据 retryable=True 决定自己重试一次，或切换策略（如传 `page_range` 读分段）
+
+### 8.3 错误分类
+
+| 来源 | kind | retryable |
+|---|---|---|
+| Path 不存在 / 权限拒绝 | `error` | False |
+| Sandbox 挂了 / 连接失败 | `error` | True |
+| REJECT 列表命中 | `unsupported` | — |
+| 文件 > 100 MB | `unsupported` | — |
+| Parser plugin bug / 未捕获异常 | `error` | True（让 agent 可重试） |
+| docling-serve 不可达 | `error` | True |
+| docling-serve 返回 FAILED（如文件损坏） | `error` | False |
+| sync / async 超时 | `error` | True |
+
+---
+
+## 9. 部署：docling-serve
+
+### 9.1 服务形态
+
+- **镜像**：`quay.io/docling-project/docling-serve-cpu`（4.4 GB）
+- **Port**：默认 `5001`
+- **环境变量**：`DOCLING_SERVE_API_KEY`（可选）
+- **资源建议**：2 CPU / 4 GB RAM 起步；GPU 镜像 (`docling-serve-cu128`) 用户自换
+- **许可**：Apache-2.0，与 cubebox CE 可共发布
+
+### 9.2 Backend 配置
+
+**`backend/config.yaml`** 新增 `parsers:` 节：
+
+```yaml
+parsers:
+  docling_serve:
+    base_url: http://docling-serve:5001
+    api_key: ${DOCLING_SERVE_API_KEY:-}
+    timeout_sync_seconds: 30
+    timeout_async_minutes: 10
+    async_threshold_mb: 3
+    poll_interval_seconds: 2
+```
+
+### 9.3 部署编排
+
+**`docker-compose.yml`**（新增服务）：
+
+```yaml
+services:
+  docling-serve:
+    image: quay.io/docling-project/docling-serve-cpu
+    environment:
+      DOCLING_SERVE_API_KEY: ${DOCLING_SERVE_API_KEY:-}
+    ports:
+      - "5001:5001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+```
+
+**K8s**：以 Deployment + Service 发布；资源 request/limit 自定。
+
+### 9.4 CI
+
+**不**起真 docling-serve。e2e 测试在 `conftest.py` 注入 mock `DoclingParser`：
+
+```python
+class MockDoclingParser:
+    mime_types = [...]
+    extensions = [...]
+    priority = 20
+    async def parse(self, content, *, mime, options):
+        return TextOutput(
+            path="<mock>", mime=mime,
+            content=f"<MOCK docling parsed {len(content)} bytes>",
+            size_bytes=len(content),
+            metadata={"parser": "mock-docling"},
+        )
+```
+
+Unit 测试覆盖：
+- registry 启动、Protocol 校验失败、plugin 解析
+- TextParser / NotebookParser 纯逻辑（不依赖外部）
+- DoclingParser 用 httpx mock server 测 HTTP 交互（sync/async/超时/task FAILED）
+
+---
+
+## 10. Batch 1 M6 交付清单
+
+### 10.1 新增文件
+
+- `backend/cubebox/parsers/__init__.py`
+- `backend/cubebox/parsers/protocols.py`（`FileParser`）
+- `backend/cubebox/parsers/schema.py`（`FileReadOutput` / `ParseOptions` / dataclasses）
+- `backend/cubebox/parsers/registry.py`（discover + dispatch + resolve）
+- `backend/cubebox/parsers/dedup.py`（hash cache）
+- `backend/cubebox/parsers/plugins/__init__.py`
+- `backend/cubebox/parsers/plugins/text.py`
+- `backend/cubebox/parsers/plugins/notebook.py`
+- `backend/cubebox/parsers/plugins/docling.py`
+- `backend/cubebox/parsers/mime.py`（libmagic wrapper + 扩展名 fallback）
+- `backend/cubebox/tools/builtin/file_read.py`（StructuredTool 定义 + description）
+- `backend/tests/parsers/test_registry.py`
+- `backend/tests/parsers/test_text_parser.py`
+- `backend/tests/parsers/test_notebook_parser.py`
+- `backend/tests/parsers/test_docling_parser.py`（httpx mock server）
+- `backend/tests/parsers/test_dedup.py`
+- `backend/tests/sandbox/test_file_read.py`
+
+### 10.2 修改文件
+
+- `backend/cubebox/sandbox/base.py` —— 新增 `Sandbox.file_read(...)` 默认实现
+- `backend/cubebox/sandbox/opensandbox.py` —— 继承默认即可，无需 override
+- `backend/cubebox/middleware/sandbox.py` —— `SandboxMiddleware` 注册 `file_read` 工具到 tools 列表
+- `backend/cubebox/config.py` —— 加 `parsers.*` pydantic schema
+- `backend/config.yaml` / `config.development.yaml` / `config.test.yaml` —— 加 `parsers:` 节
+- `backend/pyproject.toml` —— `[project.entry-points."cubebox.parsers"]` + 新依赖：`libmagic` (python-magic-bin) + `httpx`（已有）+ `filetype`（libmagic 不可用时 fallback）
+- `docker-compose.yml` / 部署编排 —— 加 docling-serve service
+- `.github/workflows/ci.yml` —— e2e job 配置 mock `DoclingParser` 的 fixture 路径
+
+### 10.3 实现阶段
+
+| Stage | 内容 | 回归检查 |
+|---|---|---|
+| 1 | schema.py + protocols.py + ParseOptions | 单元测试（类型） |
+| 2 | mime.py + dedup.py | 单元测试 |
+| 3 | registry.py（discover + resolve + dispatch） + 3 默认 plugin 骨架（只实现 text） | registry tests 通过；text parser e2e 通过 |
+| 4 | NotebookParser 完整实现 | notebook tests 全绿 |
+| 5 | DoclingParser 完整实现（httpx client + sync + async + 超时 + mock server tests） | docling parser tests 全绿 |
+| 6 | Sandbox.file_read 默认实现接入；conversation_id 从 middleware context 传入 | sandbox integration tests 全绿 |
+| 7 | `file_read` agent 工具注册到 SandboxMiddleware；StructuredTool description 逐字对齐 | agent e2e 能调通；工具出现在工具列表 |
+| 8 | config schema 扩展；docker-compose 加 docling-serve；手动启动一次真 docling-serve 做冒烟 | 冒烟通过 |
+
+**估算**：单人 ~4-5 工作日。
+
+---
+
+## 11. 一次性原则自检
+
+### 11.1 不破坏 API version 即可扩展
+
+- 新增 kind（`image` / `pdf_native` / `parts`）：union 扩展，老 agent 不认识的 kind 走 fallback 处理
+- 新增 `FileParser` 的可选方法（带默认）：Protocol 向后兼容
+- 新增第三方 plugin：entry_points 即可，无 CE 改动
+- 新增 `ParseOptions` 可选字段（带默认）：向后兼容
+- 新增 `AdminNavItem` 类似的可选字段：同上
+- 修改 reject 列表 / TEXT_DIRECT 列表：运行时配置级变化，无破坏
+
+### 11.2 破坏性变更（触发 major bump）
+
+- 改 `FileParser.parse` 签名（参数增减 / 返回类型变）
+- 改 kind 的 discriminator 值（"text" → 改名）
+- 改 dataclass 必填字段（`TextOutput.content` 变必选可选）
+- 改 entry_points group 名（`cubebox.parsers` → 别的）
+
+---
+
+## 12. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| docling-serve 启动慢（镜像 4.4 GB） | 部署文档写清预拉镜像步骤；K8s 用 initContainer 预热 |
+| docling-serve 单点 | v1 单实例可接受；后续按请求量 HPA；parser 是非关键链路（挂掉不阻塞 agent 对话，只是 file_read 不可用） |
+| 20K 截断对长文档过紧 | `page_range` 参数 + description 明示截断 + metadata 暴露 total_chars；agent 可多次调用补全 |
+| hash cache 多副本不一致 | v1 session-sticky；文档化后续 Redis 迁移路径 |
+| docling 对极端布局 PDF 解析错 | `error(retryable=False)` 可读 reason；agent 告诉用户；未来可装 Marker / LlamaParse 做 fallback plugin |
+| Protocol runtime_checkable 性能 | 仅启动时用一次（`discover()`），运行时不重复 check；无影响 |
+| libmagic 跨平台依赖 | `python-magic-bin` 自带 libmagic binary；不依赖系统包；macOS/Linux/Windows 统一 |
+| `.html` 走 TextParser 但 HTML 内嵌 `<script>` 等含大量无意义代码 | agent description 明说 HTML 返 raw；agent 按需要 `execute("html2text ...")` 或让用户转换 |
+
+---
+
+## 13. 未决事项
+
+- [ ] `DoclingParser` 对 DOCX/PPTX 的 `page_range` 实现策略（docling-serve 本身是否支持 page_range / 若不支持的 markdown 后处理剪裁算法）—— 实现时确认
+- [ ] docling-serve `FileSourceRequest` 的确切 JSON schema（multipart vs base64）—— 读 OpenAPI 后确认
+- [ ] SaaS 场景多副本 backend 的 session-sticky routing vs Redis-backed hash cache 切换时机 —— 后续扩展观察
+- [ ] `UnchangedOutput` 是否应包含首次读取的 metadata 摘要（便于 agent 不回翻历史也能快速引用）—— v1 先不加，等使用反馈
+- [ ] Conversation 关闭钩子接入 `dedup.forget_conversation` 的具体位置 —— 实现时确认

--- a/docs/superpowers/specs/2026-04-23-admin-console-design.md
+++ b/docs/superpowers/specs/2026-04-23-admin-console-design.md
@@ -1,0 +1,589 @@
+# M2 · 管理员控制台骨架设计
+
+**Status**: Draft · 2026-04-23
+**Owner**: @xfgong
+**Scope**: 引入 `/admin` 组织管理后台 shell（独立 layout，新 tab 打开）；重构主 app sidebar，将 AppTopBar 内容下移到 sidebar；接入 M0 的 `AdminPanelExtension` 插件 manifest 端点。Batch 1 不实现任何 admin tab 的实际功能（5 个 CE 原生 tab 全部"Coming Soon"）。
+**属于**: v1 开源发布待办 · M2（骨架）
+**Backlog 索引**: `docs/superpowers/specs/2026-04-21-v1-oss-release-backlog.md`
+**依赖**: M0（`AdminPanelExtension` Protocol + `/api/v1/admin/_extensions/manifest` 端点）
+
+---
+
+## 1. 背景与目标
+
+### 1.1 现状
+
+- 前后端**零** admin 代码（无 `/admin` 路由 / 无 `Admin*` 组件 / 无 `cubebox/api/routes/admin*`）
+- 模型 / MCP 服务器 / Skills 加载路径 / 沙盒配置全部走 `config.yaml`，无 UI 入口
+- Frontend 现有结构：
+  - `app/(app)/layout.tsx` 挂 `AppTopBar`（无 sidebar）
+  - `app/(app)/w/[wsId]/layout.tsx` 挂 `WorkspaceContext` + `Sidebar`（**仅** workspace 路由下可见）
+  - 首页 `/` 是 `redirect()` 到第一个 workspace；`/workspaces` 页面**没有 sidebar**
+  - `components/layout/AppTopBar.tsx` 含 logo / `WorkspaceSwitcher` / `AvatarMenu`
+- 角色：只有 workspace 级 `Role.ADMIN | MEMBER`，无 org 级 admin 概念
+- M0 spec（已 commit）定义了 `AdminPanelExtension` Protocol 与 `/api/v1/admin/_extensions/manifest` 端点骨架；M2 是其前端消费方
+- M9（单租户 UX Bridge）会隐藏 org 概念但**数据模型保留多 org**；M2 的设计要兼容未来多 org 切换
+
+### 1.2 目标
+
+- **`/admin` 独立 route group + 独立 layout**，新 tab 打开（`<a target="_blank">`）
+- **Sidebar 重构**：移除 AppTopBar；workspace 切换 / avatar / 管理后台入口下移到 sidebar；让 sidebar 在所有 authenticated 页面可见（含首页）
+- **5 个 CE 原生 tab 路由占位**：Models / Web tools / Skills / MCP / Sandbox，内容 "Coming Soon"，留给后续模块 spec 真正实现
+- **`AdminPanelExtension` 前端消费**：拉 manifest → 渲染插件 nav → iframe 加载（Plugin tab）
+- 角色 gate：`/admin/*` 全部要求 "user 在 current org 任一 workspace 是 ADMIN"
+- 保持 URL 干净 `/admin`（不入 org_id）；多 org 来时通过 cookie 切换 + 顶 bar OrgSwitcher，URL 不变
+
+### 1.3 非目标
+
+- 5 个 CE 原生 tab 的**实际功能**（Models / Web tools / Skills / MCP / Sandbox 的列表/编辑/绑定 UI 与对应 backend API）—— 各自后续模块 spec
+- Workspace 设置页 —— M4 在 workspace 首页内嵌设置面板（不走 admin URL）
+- Admin 操作的 audit log —— M1-E5（auditSink）
+- OrgSwitcher 真实实现 —— v1 单 org，仅占位静态 label
+- 真实 `cubebox-ee` admin 插件 —— 等首个 EE 功能立项时
+- I18n —— 沿主 app 现有"中英文混杂"现状；admin 文案中文为主
+- 移动端适配 —— admin 是 desktop-first 工具
+
+---
+
+## 2. 决策记录
+
+| # | 决策 | 备选 | 选用理由 |
+|---|---|---|---|
+| D1 | `/admin` 独立 layout 路由组（`app/admin/`），不复用 `(app)` | 在 `(app)` 内部加 `/admin` | admin 是独立 ops 心智，与主 app 不共享 sidebar；layout 自由设计 |
+| D2 | `/admin` 入口走 `<a target="_blank" rel="noopener">` 新 tab；不用程序化 `window.open()` | 同 tab navigation | 对齐 AWS Console / Stripe Dashboard / Slack Admin；用户发起的链接不触发 popup blocker；中键 / Cmd-Click 自然行为；context 隔离 |
+| D3 | 移除 `AppTopBar`；其内容（workspace switcher + avatar）下移到新 Sidebar | 保留 AppTopBar | 对齐 Manus / ChatGPT / Claude 主流 agent 平台模式；主内容区获得更多垂直空间 |
+| D4 | Avatar 用 popover **向上**展开，不用 dropdown | dropdown 向下 | 参考 ChatGPT；popover 在 sidebar 底部不会被屏幕边缘截断；视觉与 chat 主区不冲突 |
+| D5 | Sidebar 提升到 `app/(app)/layout.tsx` 顶层；`(app)/w/[wsId]/layout.tsx` 仅保留 `WorkspaceContext` | 维持 sidebar 仅 workspace 内 | 首页 / `/workspaces` 等所有 authenticated 页都需要导航；M4a 上线时无需再处理 sidebar |
+| D6 | `WorkspaceSwitcher` 改为 sidebar 内 list section（list 形态而非 dropdown） | 保留 dropdown | 参考 Manus 项目 / Claude Projects / ChatGPT 项目；列表更显眼利于切换 |
+| D7 | Workspace 列表按"最近活动时间"排序；默认显示前 5 + "show more" | 显示全部 / 字母序 | 用户多 workspace 时长尾不挤占 sidebar；最近活动是常用场景 |
+| D8 | 工作区 ⚙ 设置入口**取消**；workspace 设置嵌入 workspace 首页（M4） | hover 显示 ⚙ icon | M4 的 workspace 项目化已规划在首页内嵌"指令/连接器/文件/技能"等面板（参考 Manus 项目页）；不需要单独路由 |
+| D9 | `/admin` URL **不**包含 org_id；多 org 来时走 cookie 切换 | `/o/[orgId]/admin` 包 org | 类比 GitHub `/settings/...`、Google Workspace 账号切换器；现 v1 单 org 不需要；未来 cookie + 顶 bar OrgSwitcher 升级零 URL 破坏 |
+| D10 | Org 名永远显示在 admin 顶 bar；v1 静态 label，多 org 进化为 OrgSwitcher | 不显示 org 名 | 预留 OrgSwitcher 槽位；v1 显示"Acme Inc"等 org name 让用户知道在管哪个 org |
+| D11 | 5 CE 原生 tab v1 全 "Coming Soon"，只占路由不实现功能 | 全部不建路由 / 实现 1-2 个 | "Coming Soon" 让用户看到完整菜单；每项 placeholder 含一行说明指向对应 backlog 模块 |
+| D12 | 角色 gate v1 = "current org 任一 workspace 是 ADMIN" | 独立 org admin role / 第一个 workspace admin / org owner | v1 无 org-level role；"任一 workspace admin" 是合理近似；未来 org-level role 上线时仅改 `require_org_admin` 实现 |
+| D13 | 子 nav v1 扁平列表；CE / 扩展用横线分隔，多了再分 section | 一开始就按 M0 的 section 分（identity/integrations/settings/custom） | v1 总共 5-7 项，扁平更清晰；M0 的 `AdminNavItem.section` 字段保留但 v1 渲染时不分组 |
+| D14 | Plugin tab 渲染走 `<iframe src={iframe_url}>`；CSP `frame-src 'self'` | inline iframe 无 CSP / 直接 fetch HTML 嵌入 | M0 D9 已定 iframe + pip wheel package_data 模型；同源安全靠 CSP 限定；v1 cubebox-ee 未真建仓时 manifest 返空，无 iframe 实际加载 |
+| D15 | shadcn 组件补：`tabs` + `popover`（`npx shadcn-ui@latest add tabs popover`） | 自实现 / 用其它库 | 与现有 `components/ui/*` 风格一致；现成可用 |
+| D16 | "回应用"链接用 `window.close()`（仅在 `window.opener != null` 时）+ fallback 跳 `/` | 永远跳 `/` | 用户从主 app 新 tab 打开 admin，关 tab 自然回；不在 opener 上下文（手动开 admin）则 fallback 跳首页 |
+
+---
+
+## 3. 整体结构
+
+### 3.1 路由 / 文件布局
+
+```
+frontend/packages/web/app/
+├─ layout.tsx                        # 全局 root layout（已有）
+├─ (auth)/                           # 未登录路由组（已有）
+│  ├─ login/
+│  └─ register/
+├─ (app)/                            # 已登录主 app 路由组
+│  ├─ layout.tsx                     # ← 修改：删 AppTopBar，加 Sidebar 包裹
+│  ├─ page.tsx                       # 今天是 redirect；M4a 后是首页
+│  ├─ workspaces/                    # ← 自动继承 sidebar
+│  │  └─ page.tsx
+│  └─ w/[wsId]/
+│     ├─ layout.tsx                  # ← 修改：仅保留 WorkspaceContext，不再渲染 sidebar
+│     └─ ...
+└─ admin/                            # ← 新增独立 route group（不挂 (app)）
+   ├─ layout.tsx                     # AdminTopBar + AdminSubNav + 内容区
+   ├─ page.tsx                       # redirect 到 /admin/models
+   ├─ models/page.tsx                # Coming Soon
+   ├─ web-tools/page.tsx             # Coming Soon
+   ├─ skills/page.tsx                # Coming Soon
+   ├─ mcp/page.tsx                   # Coming Soon
+   ├─ sandbox/page.tsx               # Coming Soon
+   └─ ext/[plugin]/[...path]/page.tsx  # iframe 渲染插件 tab
+```
+
+### 3.2 Layout 拓扑
+
+```
+authenticated 主 app 页面（/, /workspaces, /w/[wsId]/...）
+┌────────────────────────────────────────────────────────────┐
+│ Sidebar               │  Main content                      │
+│ ┌─────────────────┐   │  ┌──────────────────────────────┐  │
+│ │ logo  [+ 新建]   │   │  │                              │  │
+│ │                 │   │  │   route page.tsx             │  │
+│ │ 工作区          │   │  │                              │  │
+│ │   📁 Personal ● │   │  │                              │  │
+│ │   📁 Work       │   │  │                              │  │
+│ │   ➕ 新建        │   │  │                              │  │
+│ │                 │   │  │                              │  │
+│ │ 最近会话        │   │  │                              │  │
+│ │   • ...         │   │  │                              │  │
+│ │                 │   │  │                              │  │
+│ │ (滚动)           │   │  │                              │  │
+│ │                 │   │  │                              │  │
+│ │ ─── footer ───  │   │  │                              │  │
+│ │ [👤 user]       │   │  └──────────────────────────────┘  │
+│ │  ↑ popover      │   │                                    │
+│ └─────────────────┘   │                                    │
+└────────────────────────────────────────────────────────────┘
+
+/admin 路由（新 tab 打开）
+┌────────────────────────────────────────────────────────────┐
+│ AdminTopBar                                                │
+│ [logo] 管理后台 · Acme Inc ▾    [回应用] [👤]                │
+├────────────┬───────────────────────────────────────────────┤
+│ AdminSubNav│  Tab content                                  │
+│            │                                               │
+│ ▸ 模型     │   <route page.tsx for current admin tab>     │
+│ ▸ Web 工具 │                                               │
+│ ▸ 技能管理 │                                               │
+│ ▸ MCP 连接 │                                               │
+│ ▸ 沙盒     │                                               │
+│ ────────   │                                               │
+│ ▸ [扩展…]  │                                               │
+└────────────┴───────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Sidebar 重构
+
+### 4.1 结构
+
+```
+Sidebar
+├─ Header
+│  ├─ <Logo />
+│  └─ <NewChatButton />
+├─ <WorkspacesSection />
+│  ├─ section title "工作区"
+│  ├─ list of <WorkspaceItem currentMarker={...} />
+│  │  • 默认显示前 5（按 last_activity_at 倒序）
+│  │  • "show more" 展开剩余
+│  └─ <CreateWorkspaceButton />
+├─ <RecentConversationsSection />     # 现有逻辑保留
+│  ├─ section title "最近会话"
+│  └─ list of conversations
+│     • 当前在 workspace 路由：show that workspace's conversations
+│     • 当前在 / 或 /workspaces：show all workspaces' recent (M4a 后会重构成分组)
+├─ <ScrollSpacer />                   # 中间弹性占位，把 footer 推到底
+└─ <Footer />
+   └─ <AvatarPopover />
+      • 触发：点击底部 avatar 头像
+      • 弹出方向：向上（`side="top"` 的 shadcn popover）
+      • 内容：
+        - User info 区（avatar + name + email）
+        - Divider
+        - 🛡️ 管理后台 (admin 才渲染)，<a href="/admin" target="_blank" rel="noopener">
+        - 🌗 主题（复用现有 ThemeToggle）
+        - ↪ 退出（调现有 logout）
+```
+
+### 4.2 Workspace section 排序与"show more"
+
+- **排序**：后端为每个 workspace 维护 `last_activity_at`（v1 为 conversations 表里该 workspace 最近 message updated_at 的 max；可在 `GET /api/v1/workspaces` 响应里加字段）
+- **默认显示**：前 5 个；展开按钮 "更多 (N)" 显示剩余
+- **当前 workspace marker**：在 `/w/[wsId]/...` 路由下，对应 item 显示一个圆点 / 高亮背景
+- **新建工作区**：list 末尾固定 "➕ 新建工作区" 项；点击跳 `/workspaces` 的创建模态
+
+### 4.3 Avatar popover
+
+- shadcn `<Popover>` 组件 + `side="top"` + `align="start"`
+- 触发器：sidebar 底部 avatar + name 行
+- popover 宽度 ≈ sidebar 宽度（贴齐 sidebar 左边）
+- 关键：admin 项**仅当 `useAdminAccess()` hook 返回 `is_admin: true` 时渲染**
+- 退出按钮：复用现有 `useAuthStore.logout()`
+
+### 4.4 Sidebar 在 admin 路由下不渲染
+
+- `/admin/*` 用 `app/admin/layout.tsx`（独立 layout），不继承 `(app)` 的 Sidebar
+- 主 app 用户跨 tab 打开 admin 时，主 tab 的 sidebar 仍在原状态，admin tab 完全独立
+
+---
+
+## 5. `/admin` 独立 layout
+
+### 5.1 `app/admin/layout.tsx`
+
+```tsx
+'use client';
+
+import { AdminTopBar } from '@/components/admin/AdminTopBar';
+import { AdminSubNav } from '@/components/admin/AdminSubNav';
+import { useAdminAccess } from '@/hooks/useAdminAccess';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const { isAdmin, orgName, loading, error } = useAdminAccess();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && (!isAdmin || error)) {
+      router.replace('/');  // gated out
+    }
+  }, [loading, isAdmin, error, router]);
+
+  if (loading) return <FullPageSpinner />;
+  if (!isAdmin) return null;
+
+  return (
+    <div className="flex h-screen flex-col bg-background">
+      <AdminTopBar orgName={orgName} />
+      <div className="flex flex-1 overflow-hidden">
+        <AdminSubNav />
+        <main className="flex-1 overflow-auto">{children}</main>
+      </div>
+    </div>
+  );
+}
+```
+
+### 5.2 `<AdminTopBar />` 结构
+
+```tsx
+<header className="flex items-center gap-4 border-b px-4 py-3">
+  <CubeboxLogo />
+  <h1 className="text-sm font-medium">管理后台</h1>
+  <Separator orientation="vertical" />
+  {/* v1: 静态 label；多 org 时换成 <OrgSwitcher /> */}
+  <span className="text-sm text-muted-foreground">{orgName}</span>
+
+  <div className="ml-auto flex items-center gap-2">
+    <Button variant="ghost" size="sm" onClick={handleBackToApp}>
+      回应用
+    </Button>
+    <AdminAvatarMenu />
+  </div>
+</header>
+```
+
+`handleBackToApp`：
+
+```ts
+function handleBackToApp() {
+  if (window.opener) {
+    window.close();
+  } else {
+    window.location.href = '/';
+  }
+}
+```
+
+### 5.3 `<AdminSubNav />` 结构
+
+```tsx
+<nav className="flex w-56 flex-col gap-1 border-r p-3">
+  <NavItem href="/admin/models" icon={Cpu}>模型</NavItem>
+  <NavItem href="/admin/web-tools" icon={Globe}>Web 工具</NavItem>
+  <NavItem href="/admin/skills" icon={Sparkles}>技能管理</NavItem>
+  <NavItem href="/admin/mcp" icon={Plug}>MCP 连接器</NavItem>
+  <NavItem href="/admin/sandbox" icon={Box}>沙盒</NavItem>
+
+  {extensionItems.length > 0 && (
+    <>
+      <Separator className="my-2" />
+      <p className="px-2 text-xs text-muted-foreground">扩展</p>
+      {extensionItems.map(item => (
+        <NavItem
+          key={item.id}
+          href={`/admin/ext/${item.plugin}/${item.url_path}`}
+          icon={lucideIconByName(item.icon)}
+        >
+          {item.label}
+        </NavItem>
+      ))}
+    </>
+  )}
+</nav>
+```
+
+`extensionItems` 由 `useAdminExtensions()` hook 拉 `/api/v1/admin/_extensions/manifest` 并扁平化。
+
+### 5.4 5 CE 原生 tab 占位
+
+每个 `app/admin/<tab>/page.tsx` 走同一 `<ComingSoonCard />`：
+
+```tsx
+// app/admin/models/page.tsx
+export default function ModelsPage() {
+  return (
+    <ComingSoonCard
+      title="模型"
+      description="按 provider 列出可用模型，配置默认模型与 fallback 链。"
+      backlogRef="M2 完整版（v1 后续 spec）"
+    />
+  );
+}
+```
+
+`<ComingSoonCard />` 渲染：标题 + 简介 + 一个 muted "敬请期待"提示。无 placeholder 表单（避免误导用户以为 v1 能用）。
+
+### 5.5 插件 tab `app/admin/ext/[plugin]/[...path]/page.tsx`
+
+```tsx
+'use client';
+import { useAdminExtensions } from '@/hooks/useAdminExtensions';
+
+export default function ExtensionPage({ params }: { params: { plugin: string; path: string[] } }) {
+  const { extensions } = useAdminExtensions();
+  const ext = extensions.find(e => e.plugin === params.plugin);
+  if (!ext) return <NotFoundCard />;
+
+  const iframeUrl = `${ext.iframe_base_url}${params.path.join('/')}`;
+  return (
+    <iframe
+      src={iframeUrl}
+      className="h-full w-full border-0"
+      sandbox="allow-scripts allow-forms allow-same-origin"
+    />
+  );
+}
+```
+
+CSP 在 next.config 中加 `frame-src 'self'`；插件 iframe URL 是 `/api/v1/admin/_extensions/<plugin>/...`，同源。
+
+---
+
+## 6. 角色 gate
+
+### 6.1 后端 `require_org_admin` dependency
+
+**`backend/cubebox/auth/dependencies.py`**（新增）：
+
+```python
+async def require_org_admin(
+    user: User = Depends(current_active_user),
+    request_context: RequestContext = Depends(get_request_context),
+    membership_repo: MembershipRepository = Depends(get_membership_repo),
+) -> User:
+    """
+    v1: user 在 current org 任一 workspace 是 ADMIN 即视为 org admin.
+    Future: 引入独立 org-level role 后此 dependency 改实现，调用方不变.
+    """
+    org_id = request_context.org_id  # 从当前请求上下文（cookie / session）拿
+    is_org_admin = await membership_repo.user_has_role_in_org(
+        user_id=user.id, org_id=org_id, role=Role.ADMIN
+    )
+    if not is_org_admin:
+        raise HTTPException(status_code=403, detail="org admin required")
+    return user
+```
+
+需要在 `MembershipRepository` 加 `user_has_role_in_org(user_id, org_id, role)` 方法。
+
+### 6.2 后端端点 `GET /api/v1/admin/me`
+
+**`backend/cubebox/api/routes/v1/admin.py`**（新增）：
+
+```python
+@router.get("/me", response_model=AdminMeResponse)
+async def get_admin_me(
+    user: User = Depends(current_active_user),
+    request_context: RequestContext = Depends(get_request_context),
+    membership_repo: MembershipRepository = Depends(get_membership_repo),
+):
+    """
+    Returns admin gate info. Returns 200 with is_admin=true/false.
+    Does not 403 — frontend uses this to decide UI display + admin-only routing.
+    """
+    is_admin = await membership_repo.user_has_role_in_org(
+        user_id=user.id, org_id=request_context.org_id, role=Role.ADMIN
+    )
+    org = await org_repo.get(request_context.org_id)
+    return AdminMeResponse(
+        is_admin=is_admin,
+        org_id=request_context.org_id,
+        org_name=org.name,
+    )
+```
+
+**端点不 403**：返回 `is_admin: false` 让前端处理（sidebar 隐藏管理后台入口；admin layout 拉到此端点后 redirect）。
+
+### 6.3 前端 `useAdminAccess` hook
+
+```ts
+// hooks/useAdminAccess.ts
+export function useAdminAccess() {
+  const { data, error, isLoading } = useSWR(
+    '/api/v1/admin/me',
+    fetcher,
+    { revalidateOnFocus: false }
+  );
+  return {
+    isAdmin: data?.is_admin ?? false,
+    orgName: data?.org_name ?? '',
+    orgId: data?.org_id,
+    loading: isLoading,
+    error,
+  };
+}
+```
+
+- `app/admin/layout.tsx` 用此 hook，`isAdmin === false` → `router.replace('/')` + toast
+- `Sidebar` 的 `<AvatarPopover />` 用此 hook 决定是否渲染"管理后台"项
+- SWR 的去重 + cache 让两处共享同一请求
+
+### 6.4 后端 `/api/v1/admin/*` 全部挂 `require_org_admin`
+
+新建 admin router：
+
+```python
+# backend/cubebox/api/routes/v1/admin.py
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+# /me 不挂（要返 is_admin: false 而非 403）
+router.add_api_route("/me", get_admin_me, methods=["GET"])
+
+# 其他 admin 端点（manifest / 未来 5 tab 的 API）全挂 require_org_admin
+admin_protected = APIRouter(
+    prefix="",
+    dependencies=[Depends(require_org_admin)],
+)
+admin_protected.add_api_route("/_extensions/manifest", get_extensions_manifest, methods=["GET"])
+router.include_router(admin_protected)
+```
+
+**`/_extensions/manifest`** 端点 M0 已实现；M2 仅确保挂在 `require_org_admin` 之下。
+
+---
+
+## 7. 后端新增端点汇总
+
+| 端点 | 方法 | 说明 | 由谁实现 |
+|---|---|---|---|
+| `/api/v1/admin/me` | GET | 当前 user 是否 org admin + org 信息 | **M2** |
+| `/api/v1/admin/_extensions/manifest` | GET | 聚合插件 nav items | M0（已 commit） |
+| `/api/v1/admin/_extensions/<plugin>/...` | * | 插件路由（iframe 后端） | M0（已 commit） |
+| `/api/v1/admin/_extensions/<plugin>/static/*` | GET | 插件静态资源（StaticFiles） | M0（已 commit） |
+
+---
+
+## 8. 多 org 未来演进路径
+
+v1 单 org，所有 admin 操作隐式作用于用户所在的唯一 org。多 org 来时按 **Path A**（保留 `/admin` URL，cookie 切换 current org）演进：
+
+1. 后端：`request_context.org_id` 来源从"用户 default org"改为"cookie `current_org_id` + 校验"
+2. 后端：`/api/v1/users/me/orgs` 返回用户所在所有 org（list）
+3. 后端：`POST /api/v1/users/me/current-org` 切换当前 org（写 cookie）
+4. 前端：admin 顶 bar 静态 org name → 替换为 `<OrgSwitcher />` dropdown，调切换 API
+5. 前端：sidebar 的 workspaces section 跟随 current org 过滤
+6. **`/admin` URL 不变**
+
+零路由破坏。
+
+---
+
+## 9. Batch 1 M2 交付清单
+
+### 9.1 Frontend 新增
+
+- `frontend/packages/web/app/admin/layout.tsx`
+- `frontend/packages/web/app/admin/page.tsx`（redirect 到 `/admin/models`）
+- `frontend/packages/web/app/admin/models/page.tsx`（Coming Soon）
+- `frontend/packages/web/app/admin/web-tools/page.tsx`（Coming Soon）
+- `frontend/packages/web/app/admin/skills/page.tsx`（Coming Soon）
+- `frontend/packages/web/app/admin/mcp/page.tsx`（Coming Soon）
+- `frontend/packages/web/app/admin/sandbox/page.tsx`（Coming Soon）
+- `frontend/packages/web/app/admin/ext/[plugin]/[...path]/page.tsx`
+- `frontend/packages/web/components/admin/AdminTopBar.tsx`
+- `frontend/packages/web/components/admin/AdminSubNav.tsx`
+- `frontend/packages/web/components/admin/ComingSoonCard.tsx`
+- `frontend/packages/web/components/admin/AdminAvatarMenu.tsx`
+- `frontend/packages/web/components/sidebar/WorkspacesSection.tsx`
+- `frontend/packages/web/components/sidebar/AvatarPopover.tsx`
+- `frontend/packages/web/hooks/useAdminAccess.ts`
+- `frontend/packages/web/hooks/useAdminExtensions.ts`
+- `frontend/packages/web/components/ui/tabs.tsx`（shadcn add）
+- `frontend/packages/web/components/ui/popover.tsx`（shadcn add）
+
+### 9.2 Frontend 修改
+
+- `frontend/packages/web/app/(app)/layout.tsx` —— 删除 `<AppTopBar />`；包裹 `<Sidebar>`
+- `frontend/packages/web/app/(app)/w/[wsId]/layout.tsx` —— 移除 `<Sidebar />`，仅保留 `WorkspaceContext`
+- `frontend/packages/web/components/layout/Sidebar.tsx` —— 重构（新增 WorkspacesSection / AvatarPopover；保留 Recent conversations 现有逻辑）
+- `frontend/packages/web/components/layout/AppShell.tsx` —— 调整为不假设有 top bar
+- `frontend/packages/web/components/layout/AvatarMenu.tsx` —— 删除（合并到 `AvatarPopover`）
+- `frontend/packages/web/components/layout/AppTopBar.tsx` —— **删除**
+- `frontend/packages/web/components/workspace/WorkspaceSwitcher.tsx` —— 重写为 `<WorkspacesSection />` 内嵌 list（或拆分为单独的 SidebarWorkspaceItem）
+- `frontend/packages/web/next.config.ts` —— 加 CSP header `frame-src 'self'`
+- `frontend/packages/core/src/stores/workspaceStore.ts` —— `Workspace` 类型加 `last_activity_at: string`
+
+### 9.3 Backend 新增
+
+- `backend/cubebox/api/routes/v1/admin.py`（`/me` + 挂 `require_org_admin` 的 protected sub-router）
+- `backend/cubebox/api/schemas/admin.py`（`AdminMeResponse` 等 pydantic）
+
+### 9.4 Backend 修改
+
+- `backend/cubebox/auth/dependencies.py` —— 新增 `require_org_admin`
+- `backend/cubebox/repositories/membership.py` —— 新增 `user_has_role_in_org(user_id, org_id, role)` 方法
+- `backend/cubebox/api/routes/v1/workspaces.py` —— `GET /api/v1/workspaces` 响应加 `last_activity_at` 字段
+- `backend/cubebox/api/app.py` —— 挂载新 admin router
+
+### 9.5 测试
+
+- Frontend:
+  - `app/admin/layout.tsx` auth gate（admin 通过 / 非 admin 跳 `/`）
+  - `<AdminSubNav />` 渲染原生 tab + 扩展 tab（mock manifest）
+  - `<AvatarPopover />` 管理后台项仅 admin 可见
+  - 插件 iframe 渲染（mock manifest 返 1 项，断言 iframe src 正确）
+- Backend:
+  - `require_org_admin` 通过 / 拒绝 / 用户无 membership 三场景
+  - `GET /api/v1/admin/me` 返回正确字段
+  - `MembershipRepository.user_has_role_in_org` 正负样本
+
+---
+
+## 10. 实现阶段（implementation plan 会细化）
+
+| Stage | 内容 | 回归检查 |
+|---|---|---|
+| 1 | shadcn add tabs + popover；新建 `<AvatarPopover />` 单组件验证 | popover 显示 / 点击不闪烁 |
+| 2 | 重构 `Sidebar`（加 WorkspacesSection + AvatarPopover；保留 Recent conversations） | 现有 chat 流仍可用 |
+| 3 | 提升 Sidebar 到 `(app)/layout.tsx`；删 AppTopBar；调整 `(app)/w/[wsId]/layout.tsx` | 所有 authenticated 页 sidebar 可见；workspace 路由不双层 |
+| 4 | 后端 `require_org_admin` + `MembershipRepository.user_has_role_in_org` + `/api/v1/admin/me` 端点 | 单测 + 手测 |
+| 5 | 前端 `useAdminAccess` hook；sidebar 管理后台项条件渲染 | admin / 普通 user 各登录看见对应内容 |
+| 6 | `app/admin/layout.tsx` + `AdminTopBar` + `AdminSubNav`；5 CE tab Coming Soon 页 | `/admin` 新 tab 打开能进 + 路由切换正常 |
+| 7 | `useAdminExtensions` hook + 插件 nav 渲染；`app/admin/ext/[plugin]/[...path]/page.tsx` iframe | mock manifest e2e |
+| 8 | CSP `frame-src 'self'`；CSRF / cookie 跨 tab 验证 | admin 在新 tab 直接通过 cookie 认证 |
+
+**估算**：单人 ~3.5-4 工作日。
+
+---
+
+## 11. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| Sidebar 上提到 `(app)` 后 workspace 路由的 `WorkspaceContext` 与 sidebar 的 workspaces 列表数据脱节 | `WorkspacesSection` 直接用 `useWorkspaceStore`（已存在）；`WorkspaceContext` 只对当前 workspace 路由有效；两者数据源一致 |
+| Avatar popover 在 sidebar 折叠时位置错乱 | 暂不实现 sidebar 折叠（v1 sidebar 固定宽度）；后续做折叠时重测 popover anchor |
+| 多 org 未来需要 cookie 切换，但 v1 backend 未实现 cookie 路径 | v1 `request_context.org_id` 取 user 第一个 / 唯一 org；多 org 来时 backend 加 cookie 解析逻辑；前端 hook 接口不变 |
+| `/admin` 新 tab 的"回应用"在用户手动开 admin（无 opener）时 `window.close()` 失败 | 实现里检查 `window.opener` 决定 close vs `location.href = '/'` |
+| Sidebar 提升后 `/workspaces` 现有页面布局可能与新 sidebar 冲突（如自带 padding） | Stage 3 验证时手测 `/workspaces`；如有视觉问题随手调 |
+| `last_activity_at` 字段计算成本高（每个 workspace 扫 conversations） | 直接在 `Workspace` 表加列，每次 conversation message 写入时 trigger 更新；或 v1 简化为"该 workspace 任一 conversation 的 max(updated_at)"用 SQL aggregate（一次性查 N workspaces ≤ 100ms） |
+| Plugin iframe 跨域 / CSP 配错让插件页加载不出 | v1 cubebox-ee 未真建仓时 manifest 返空，iframe 无实际加载；真有插件时手测 |
+| 5 个 "Coming Soon" tab 给用户错觉以为 v1 能用 | 每个 page 文案明确 "本版本不可用" + 指向 backlog 模块编号；不放任何看似可点击的伪 UI |
+| Admin 路由 cookie session 跨 tab 不生效 | fastapi-users JWT cookie 默认 `SameSite=Lax`，新同源 tab 自动带 cookie；手测验证 |
+
+---
+
+## 12. 一次性原则自检
+
+### 12.1 不破坏即可扩展
+
+- 加新 CE 原生 tab：在 `app/admin/<new>/page.tsx` 加路由 + `<AdminSubNav />` 加项
+- 加新 Plugin nav item：通过 M0 manifest 即可，frontend 自动渲染
+- 多 org 加 OrgSwitcher：`<AdminTopBar />` 内 org name 标签换组件
+- Workspace 列表 pagination：`<WorkspacesSection />` 内部加分页逻辑，外部接口不动
+
+### 12.2 破坏性变更需谨慎
+
+- 改 `/admin` 为 `/o/[orgId]/admin`：URL 破坏；要发 redirect + 通知用户更新 bookmark
+- 改 `AdminMeResponse` schema：前端 `useAdminAccess` 同步改
+- 改 sidebar 整体布局（如改 collapse 模式）：所有页面视觉重测
+
+---
+
+## 13. 未决事项
+
+- [ ] Sidebar 的"sidebar collapse"功能（移动端 / 小屏）—— v1 不做，未来需要时再设计 collapse 状态机
+- [ ] `last_activity_at` 触发更新机制（DB trigger / 应用层写入时更新）—— 实现时确认；v1 可简化用 SQL aggregate 算
+- [ ] 插件 iframe 的 `sandbox` 属性精确组合（`allow-scripts allow-forms allow-same-origin`）—— 实现时手测各能力
+- [ ] Admin tab 完整功能 spec 路径：Models / Web tools / Skills / MCP / Sandbox 各自 spec 何时立项 —— 见 backlog batch 2/3
+- [ ] OrgSwitcher 的真实交互细节（多 org 来时）—— 进 spec 阶段确认


### PR DESCRIPTION
## Summary

批次 1（W1-W2）开源发布前置规划全部落地。**仅 docs 改动，零代码**。

- **3 份 design spec**：M0 (CE/EE 插件架构) · M6 (file_read 通用工具) · M2 (管理员控制台骨架)
- **3 份 TDD 实现 plan**（共 55 tasks，~7150 行）：每 task 含失败测试 → 实现 → 通过 → commit 颗粒度
- **Backlog 收敛**：M5 (Openclaw skill 格式) 解散并入 M3 skills 市场；M12 工程基建追加 "生产 CSP 收紧" 项

## Modules

| Module | Spec | Plan | Scope |
|---|---|---|---|
| **M0** CE/EE 插件架构 | `2026-04-22-ce-ee-plugin-architecture-design.md` | `2026-04-23-m0-ce-ee-plugin-architecture.md` (24 tasks) | 5 个 Protocol 接口 (AuthProvider / PermissionChecker / AuditSink / UserDirectorySyncer / AdminPanelExtension) + entry_points 发现 + CE 默认 fallback + AuthProvider/PermissionChecker 真接入 + 3 个 audit 调用点 + cubebox-ee 仓骨架蓝图 + test-ee-compat CI 占位 |
| **M6** file_read 通用工具 | `2026-04-22-file-read-tool-design.md` | `2026-04-23-m6-file-read-tool.md` (15 tasks) | Sandbox.file_read + cubebox.parsers 插件库 + FileParser Protocol + 3 默认 plugin (Text / Notebook / Docling) + Redis 复用现有 streaming client + line_range/page_range 4 种语法 + 截断续读 metadata + 5 种 output union |
| **M2** 管理员控制台骨架 | `2026-04-23-admin-console-design.md` | `2026-04-23-m2-admin-console-skeleton.md` (16 tasks) | Sidebar 重构（移除 AppTopBar；workspace 切换器 → list section；avatar popover）+ /admin 独立 layout (新 tab) + require_org_admin gate + 5 CE 原生 tab Coming Soon 占位 + AdminPanelExtension iframe 渲染 |

## Key design decisions

- **M0**: pip wheel + entry_points 发现机制（GitHub 风格 monorepo 排除）；singular Protocols (AuthProvider, PermissionChecker) 冲突走 hard-fail；reserved name `"builtin"` 给 CE 默认；plugin manifest 强制声明 api_version
- **M6**: docling-serve 独立容器（不把 ML 依赖打进 backend）；Redis dedup **复用 streaming 已建的 client**（不开第二个连接）；**无 hardcoded REJECT 列表**（plugin registry 单一事实源）；line_range/page_range 共享 `"N"` / `"M-N"` / `"M-"` / `"-N"` 4 种语法
- **M2**: \`/admin\` 独立 route group + 新 tab 打开（对标 AWS Console / Stripe Dashboard）；URL 不含 org_id（多 org 来时 cookie 切换零路由破坏）；workspace 设置不在本 spec（M4 在 workspace 首页内嵌）

## Architectural inflows / outflows

- **M0 ⇒ M2**: M0 实现 \`/api/v1/admin/_extensions/manifest\` 端点，M2 前端消费
- **M0 ⇒ M1-E5 (audit log)**: M0 冻结 AuditSink Protocol，M1-E5 实现 DB sink
- **M6 ⇒ M3 (skills 市场)**: cubebox.parsers 是后台共享库，M3 / 未来 filebox 都能复用
- **M2 ⇒ M12**: CSP 在 next.config.ts 已埋 \`frame-src 'self'\`；M12 收紧 prod 模式的 default-src

## Test plan

- [ ] Spec review：3 份 spec 的决策记录 (D-rows)、Protocol 契约、Tool description 是否覆盖所有 batch 1 用户故事
- [ ] Plan review：每个 task 的 file paths 准确（已基于实际代码验证 \`AppShell\` / \`Sidebar\` / \`require_role\` / streaming Redis client 等位置）
- [ ] Backlog 一致性：M5 已并入 M3 + M12 含 CSP 项 + Batch 1 表格收敛为 (M0, M6, M2 骨架)
- [ ] 实现阶段：单独 PR 跑 M0 → M6 → M2 plan（按依赖顺序），每份 plan 独立可执行可测试

## Stats

- **15 commits** ahead of \`main\`
- **9616 insertions** / 36 deletions
- **7 files changed** (3 specs + 3 plans + 1 backlog)
- **0 production code changed** —— 实现工作分别走 M0/M6/M2 各自的执行 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)