### PR TITLE
feat(plugins): M0 CE/EE plugin architecture (5 Protocols + registry + CE defaults + audit hooks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,8 +243,52 @@ jobs:
             frontend/playwright-report/
 
   test-ee-compat:
-    name: EE Compat (placeholder)
+    name: EE Compat (Layer 1 contract tests)
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 5
+    needs: [backend-check]
     steps:
-      - run: echo "EE compat placeholder — will be wired after M0 lands."
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+          enable-cache: true
+      - name: Install backend
+        working-directory: backend
+        run: uv sync --all-extras
+      - name: Run plugin contract tests
+        working-directory: backend
+        env:
+          # Contract tests don't touch LLM/sandbox/DB but tests/conftest.py
+          # loads the full config which requires these env vars (see backend-check).
+          CUBEBOX_E2E_LLM_BASE_URL: http://dummy
+          CUBEBOX_E2E_LLM_API_KEY: dummy
+          CUBEBOX_E2E_LLM_MODEL_ID: dummy
+          CUBEBOX_SANDBOX__DOMAIN: dummy:9000
+          CUBEBOX_SANDBOX__IMAGE: dummy:image
+          CUBEBOX_SANDBOX__API_KEY: dummy
+        run: uv run pytest tests/plugins/test_contracts.py -v --no-cov
+
+  test-ee-compat-cross-repo:
+    name: EE Compat Cross-Repo (Layer 2 placeholder)
+    # Enable once cubebox-ee repo exists and has integration tests.
+    if: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with: { path: cubebox }
+      - uses: actions/checkout@v5
+        with:
+          repository: cubebox/cubebox-ee
+          path: cubebox-ee
+          token: ${{ secrets.EE_REPO_READ_TOKEN }}
+      - uses: astral-sh/setup-uv@v6
+      - name: Install CE from working tree + EE
+        run: |
+          cd cubebox-ee
+          uv pip install -e ../cubebox/backend
+          uv pip install -e .
+      - name: Run EE smoke tests
+        working-directory: cubebox-ee
+        run: uv run pytest

--- a/backend/config.development.yaml
+++ b/backend/config.development.yaml
@@ -53,3 +53,15 @@ development:
   parsers:
     docling_serve:
       base_url: "http://localhost:5001"
+
+  plugins:
+    auth_provider:
+      selected: null           # null / "builtin" / "<plugin_name>"
+    permission_checker:
+      selected: null
+    audit_sink:
+      disabled: []
+    user_directory_syncer:
+      disabled: []
+    admin_panel_extension:
+      disabled: []

--- a/backend/config.test.yaml
+++ b/backend/config.test.yaml
@@ -77,3 +77,15 @@ test:
       timeout_async_minutes: 10
       async_threshold_mb: 3
       poll_interval_seconds: 2
+
+  plugins:
+    auth_provider:
+      selected: null           # null / "builtin" / "<plugin_name>"
+    permission_checker:
+      selected: null
+    audit_sink:
+      disabled: []
+    user_directory_syncer:
+      disabled: []
+    admin_panel_extension:
+      disabled: []

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -215,3 +215,15 @@ default:
       timeout_async_minutes: 10
       async_threshold_mb: 3
       poll_interval_seconds: 2
+
+  plugins:
+    auth_provider:
+      selected: null           # null / "builtin" / "<plugin_name>"
+    permission_checker:
+      selected: null
+    audit_sink:
+      disabled: []
+    user_directory_syncer:
+      disabled: []
+    admin_panel_extension:
+      disabled: []

--- a/backend/cubebox/api/app.py
+++ b/backend/cubebox/api/app.py
@@ -30,8 +30,11 @@ async def lifespan(_app: FastAPI):  # type: ignore
     logger.info("Application starting up")
 
     # Discover + bind plugin registry; mount AuthProvider routers.
+    from typing import cast
+
     from cubebox.config import config as _cubebox_config
     from cubebox.plugins import get_registry
+    from cubebox.plugins.protocols import AdminPanelExtension
     from cubebox.plugins.protocols import AuthProvider as _AuthProvider
 
     _reg = get_registry()
@@ -43,6 +46,33 @@ async def lifespan(_app: FastAPI):  # type: ignore
     for _auth_router in _auth_routers:
         _app.include_router(_auth_router, prefix="/api/v1")
     logger.info("Mounted {} AuthProvider router(s)", len(_auth_routers))
+
+    # Mount the admin-extensions manifest endpoint + each extension's router/static.
+    from fastapi.staticfiles import StaticFiles
+
+    from cubebox.api.routes.v1 import admin_extensions
+
+    _app.include_router(admin_extensions.router, prefix="/api/v1")
+
+    for _ext_obj in _reg.get_admin_panel_extensions():
+        _ext = cast(AdminPanelExtension, _ext_obj)
+        _plugin_name = type(_ext).__module__.split(".")[0]
+        _ext_router = _ext.get_router()
+        if _ext_router is not None:
+            _app.include_router(
+                _ext_router,
+                prefix=f"/api/v1/admin/_extensions/{_plugin_name}",
+            )
+        _ext_static = _ext.get_static_path()
+        if _ext_static is not None:
+            _app.mount(
+                f"/api/v1/admin/_extensions/{_plugin_name}/static",
+                StaticFiles(directory=str(_ext_static)),
+            )
+    logger.info(
+        "Mounted {} AdminPanelExtension(s)",
+        len(_reg.get_admin_panel_extensions()),
+    )
 
     # Load MCP tools into the global registry
     from cubebox.tools import init_mcp_tools

--- a/backend/cubebox/api/app.py
+++ b/backend/cubebox/api/app.py
@@ -29,6 +29,21 @@ async def lifespan(_app: FastAPI):  # type: ignore
     log.init()
     logger.info("Application starting up")
 
+    # Discover + bind plugin registry; mount AuthProvider routers.
+    from cubebox.config import config as _cubebox_config
+    from cubebox.plugins import get_registry
+    from cubebox.plugins.protocols import AuthProvider as _AuthProvider
+
+    _reg = get_registry()
+    await _reg.discover()
+    _reg.bind_defaults(config=_cubebox_config)
+    _auth_provider = _reg.get_auth_provider()
+    assert isinstance(_auth_provider, _AuthProvider)
+    _auth_routers = _auth_provider.get_auth_routers()
+    for _auth_router in _auth_routers:
+        _app.include_router(_auth_router, prefix="/api/v1")
+    logger.info("Mounted {} AuthProvider router(s)", len(_auth_routers))
+
     # Load MCP tools into the global registry
     from cubebox.tools import init_mcp_tools
 
@@ -216,12 +231,10 @@ def create_app(
     from cubebox.api.routes.v1 import (
         admin_router,
         artifacts_router,
-        auth_router,
         conversations_router,
         workspaces_router,
     )
 
-    app.include_router(auth_router, prefix="/api/v1")
     app.include_router(workspaces_router, prefix="/api/v1")
     app.include_router(conversations_router, prefix="/api/v1")
     app.include_router(artifacts_router, prefix="/api/v1")

--- a/backend/cubebox/api/routes/v1/admin_extensions.py
+++ b/backend/cubebox/api/routes/v1/admin_extensions.py
@@ -1,0 +1,45 @@
+"""GET /api/v1/admin/_extensions/manifest — aggregated nav items + iframe URLs."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from fastapi import APIRouter, Depends
+
+from cubebox.auth.dependencies import current_active_user
+from cubebox.models import User
+from cubebox.plugins import get_registry
+from cubebox.plugins.protocols import AdminPanelExtension
+
+router = APIRouter(prefix="/admin/_extensions", tags=["admin"])
+
+
+@router.get("/manifest")
+async def get_manifest(
+    _user: User = Depends(current_active_user),
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for ext_obj in get_registry().get_admin_panel_extensions():
+        ext = cast(AdminPanelExtension, ext_obj)
+        nav_items = ext.get_nav_items()
+        if not nav_items:
+            continue
+        plugin_name = type(ext).__module__.split(".")[0]
+        out.append(
+            {
+                "plugin": plugin_name,
+                "nav_items": [
+                    {
+                        "id": item.id,
+                        "label": item.label,
+                        "icon": item.icon,
+                        "section": item.section,
+                        "order": item.order,
+                        "url_path": item.url_path,
+                    }
+                    for item in nav_items
+                ],
+                "iframe_base_url": f"/api/v1/admin/_extensions/{plugin_name}/",
+            }
+        )
+    return out

--- a/backend/cubebox/api/routes/v1/workspaces.py
+++ b/backend/cubebox/api/routes/v1/workspaces.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends, HTTPException, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -103,6 +103,7 @@ async def create_invite(
     body: Annotated[InviteCreate, Body()],
     ctx: Annotated[RequestContext, Depends(require_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    request: Request,
 ) -> dict[str, str]:
     if body.role not in ("admin", "member"):
         raise HTTPException(
@@ -110,6 +111,19 @@ async def create_invite(
         )
     inv_repo = InviteTokenRepository(session)
     tok = await inv_repo.issue(workspace_id=workspace_id, role=body.role, created_by=ctx.user.id)
+
+    from cubebox.plugins.audit import audit_log
+
+    await audit_log(
+        action="workspace.invite_created",
+        user_id=ctx.user.id,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        target_type="invite",
+        target_id=tok.token,
+        ip=request.client.host if request.client else None,
+        metadata={"role": body.role},
+    )
     return {"token": tok.token, "expires_at": utc_isoformat(tok.expires_at)}
 
 

--- a/backend/cubebox/auth/dependencies.py
+++ b/backend/cubebox/auth/dependencies.py
@@ -3,19 +3,33 @@
 from collections.abc import Awaitable, Callable
 from typing import Annotated, cast
 
-from fastapi import Depends, HTTPException, Path, status
+from fastapi import Depends, HTTPException, Path, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.auth.context import RequestContext
-from cubebox.auth.users import fastapi_users
 from cubebox.db import get_session
 from cubebox.models import Membership, Role, User, Workspace
 from cubebox.plugins import PermissionChecker, PermissionResource, get_registry
 from cubebox.plugins.defaults.permissions import DefaultPermissionChecker
 from cubebox.repositories import MembershipRepository, WorkspaceRepository
 
-current_active_user = fastapi_users.current_user(active=True)
+
+async def current_active_user(
+    request: Request,
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> User:
+    """Resolve the active user via the configured AuthProvider.
+
+    CE default = fastapi-users JWT cookie. EE plugins (e.g. SAML) override.
+    """
+    user = await get_registry().get_auth_provider().authenticate(request, session)  # type: ignore[attr-defined]
+    if user is None or not getattr(user, "is_active", True):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+    return user  # type: ignore[no-any-return]
 
 
 async def request_context(

--- a/backend/cubebox/auth/dependencies.py
+++ b/backend/cubebox/auth/dependencies.py
@@ -15,15 +15,12 @@ from cubebox.plugins.defaults.permissions import DefaultPermissionChecker
 from cubebox.repositories import MembershipRepository, WorkspaceRepository
 
 
-async def current_active_user(
-    request: Request,
-    session: Annotated[AsyncSession, Depends(get_session)],
-) -> User:
+async def current_active_user(request: Request) -> User:
     """Resolve the active user via the configured AuthProvider.
 
     CE default = fastapi-users JWT cookie. EE plugins (e.g. SAML) override.
     """
-    user = await get_registry().get_auth_provider().authenticate(request, session)  # type: ignore[attr-defined]
+    user = await get_registry().get_auth_provider().authenticate(request)  # type: ignore[attr-defined]
     if user is None or not getattr(user, "is_active", True):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/cubebox/auth/dependencies.py
+++ b/backend/cubebox/auth/dependencies.py
@@ -1,7 +1,7 @@
 """FastAPI dependencies for auth + scoping."""
 
 from collections.abc import Awaitable, Callable
-from typing import Annotated
+from typing import Annotated, cast
 
 from fastapi import Depends, HTTPException, Path, status
 from sqlalchemy import select
@@ -11,6 +11,8 @@ from cubebox.auth.context import RequestContext
 from cubebox.auth.users import fastapi_users
 from cubebox.db import get_session
 from cubebox.models import Membership, Role, User, Workspace
+from cubebox.plugins import PermissionChecker, PermissionResource, get_registry
+from cubebox.plugins.defaults.permissions import DefaultPermissionChecker
 from cubebox.repositories import MembershipRepository, WorkspaceRepository
 
 current_active_user = fastapi_users.current_user(active=True)
@@ -47,21 +49,40 @@ async def request_context(
     return RequestContext(user=user, org_id=workspace.org_id, workspace_id=workspace_id, role=role)
 
 
+def _action_for_roles(allowed: tuple[Role, ...]) -> str:
+    """Map allowed-role set → action name for PermissionChecker."""
+    s = set(allowed)
+    if s == {Role.ADMIN}:
+        return "admin_access"
+    if s == {Role.ADMIN, Role.MEMBER}:
+        return "member_access"
+    raise NotImplementedError(f"role set {s} has no mapped action")
+
+
 def require_role(
     *allowed: Role,
 ) -> Callable[..., Awaitable[RequestContext]]:
-    """Dependency factory: enforce that ctx.role is in `allowed`."""
+    """Dependency factory: enforce permission via PermissionChecker."""
+
+    action = _action_for_roles(allowed)
 
     async def _check(
         ctx: Annotated[RequestContext, Depends(request_context)],
+        session: Annotated[AsyncSession, Depends(get_session)],
     ) -> RequestContext:
-        if ctx.role not in allowed:
+        checker = cast(PermissionChecker, get_registry().get_permission_checker())
+        # CE default needs a session-bound repo factory at call time.
+        if isinstance(checker, DefaultPermissionChecker):
+            checker._repo_factory = lambda _s: MembershipRepository(session)
+        resource = PermissionResource(
+            type="workspace",
+            id=ctx.workspace_id,  # type: ignore[arg-type]
+            workspace_id=ctx.workspace_id,  # type: ignore[arg-type]
+        )
+        if not await checker.check(ctx.user, action, resource):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail=(
-                    f"Role {ctx.role.value} is not allowed; "
-                    f"need one of {[r.value for r in allowed]}"
-                ),
+                detail=f"Permission denied: action={action}",
             )
         return ctx
 

--- a/backend/cubebox/auth/users.py
+++ b/backend/cubebox/auth/users.py
@@ -3,7 +3,7 @@
 from collections.abc import AsyncIterator
 from typing import Annotated
 
-from fastapi import Depends, Request
+from fastapi import Depends, Request, Response
 from fastapi_users import BaseUserManager, FastAPIUsers
 from fastapi_users.db import SQLAlchemyUserDatabase
 from loguru import logger
@@ -62,6 +62,30 @@ class UserManager(BaseUserManager[User, str]):
             ) from exc
 
         user._default_workspace_id = ws.id
+
+        from cubebox.plugins.audit import audit_log
+
+        await audit_log(
+            action="auth.register",
+            user_id=user.id,
+            ip=request.client.host if request and request.client else None,
+            user_agent=request.headers.get("user-agent") if request else None,
+        )
+
+    async def on_after_login(
+        self,
+        user: User,
+        request: Request | None = None,
+        response: Response | None = None,
+    ) -> None:
+        from cubebox.plugins.audit import audit_log
+
+        await audit_log(
+            action="auth.login",
+            user_id=user.id,
+            ip=request.client.host if request and request.client else None,
+            user_agent=request.headers.get("user-agent") if request else None,
+        )
 
 
 async def get_user_manager(

--- a/backend/cubebox/plugins/__init__.py
+++ b/backend/cubebox/plugins/__init__.py
@@ -1,0 +1,5 @@
+"""CE/EE plugin protocols + entry_points-based discovery.
+
+This package defines the contracts that external plugins (e.g. cubebox-ee)
+implement to extend cubebox CE. See docs/superpowers/specs/2026-04-22-ce-ee-plugin-architecture-design.md.
+"""

--- a/backend/cubebox/plugins/__init__.py
+++ b/backend/cubebox/plugins/__init__.py
@@ -34,6 +34,14 @@ __all__ = [
     "SyncResult",
     "SyncSchedule",
     "UserDirectorySyncer",
+    "ensure_registry_bound",
     "get_registry",
     "reset_registry_for_tests",
 ]
+
+
+def ensure_registry_bound() -> None:
+    """Idempotent: call from app startup or test fixtures to seed defaults."""
+    reg = get_registry()
+    if reg._auth_provider is None:  # not yet bound
+        reg.bind_defaults()

--- a/backend/cubebox/plugins/__init__.py
+++ b/backend/cubebox/plugins/__init__.py
@@ -14,6 +14,11 @@ from cubebox.plugins.protocols import (
     SyncSchedule,
     UserDirectorySyncer,
 )
+from cubebox.plugins.registry import (
+    PluginRegistry,
+    get_registry,
+    reset_registry_for_tests,
+)
 
 __all__ = [
     "CUBEBOX_PLUGIN_API_VERSION",
@@ -25,7 +30,10 @@ __all__ = [
     "PermissionChecker",
     "PermissionResource",
     "PluginManifest",
+    "PluginRegistry",
     "SyncResult",
     "SyncSchedule",
     "UserDirectorySyncer",
+    "get_registry",
+    "reset_registry_for_tests",
 ]

--- a/backend/cubebox/plugins/__init__.py
+++ b/backend/cubebox/plugins/__init__.py
@@ -1,5 +1,31 @@
-"""CE/EE plugin protocols + entry_points-based discovery.
+"""CE/EE plugin protocols + entry_points-based discovery."""
 
-This package defines the contracts that external plugins (e.g. cubebox-ee)
-implement to extend cubebox CE. See docs/superpowers/specs/2026-04-22-ce-ee-plugin-architecture-design.md.
-"""
+from cubebox.plugins.protocols import (
+    CUBEBOX_PLUGIN_API_VERSION,
+    AdminNavItem,
+    AdminPanelExtension,
+    AuditEvent,
+    AuditSink,
+    AuthProvider,
+    PermissionChecker,
+    PermissionResource,
+    PluginManifest,
+    SyncResult,
+    SyncSchedule,
+    UserDirectorySyncer,
+)
+
+__all__ = [
+    "CUBEBOX_PLUGIN_API_VERSION",
+    "AdminNavItem",
+    "AdminPanelExtension",
+    "AuditEvent",
+    "AuditSink",
+    "AuthProvider",
+    "PermissionChecker",
+    "PermissionResource",
+    "PluginManifest",
+    "SyncResult",
+    "SyncSchedule",
+    "UserDirectorySyncer",
+]

--- a/backend/cubebox/plugins/audit.py
+++ b/backend/cubebox/plugins/audit.py
@@ -1,0 +1,39 @@
+"""Helper for emitting AuditEvents to all registered AuditSinks."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, cast
+from uuid import UUID
+
+from cubebox.plugins.protocols import AuditEvent, AuditSink
+from cubebox.plugins.registry import get_registry
+
+
+async def audit_log(
+    action: str,
+    *,
+    user_id: UUID | str | None = None,
+    org_id: UUID | str | None = None,
+    workspace_id: UUID | str | None = None,
+    target_type: str | None = None,
+    target_id: str | None = None,
+    ip: str | None = None,
+    user_agent: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Construct AuditEvent + dispatch to every registered AuditSink."""
+    event = AuditEvent(
+        timestamp=datetime.now(UTC),
+        user_id=user_id,  # type: ignore[arg-type]
+        org_id=org_id,  # type: ignore[arg-type]
+        workspace_id=workspace_id,  # type: ignore[arg-type]
+        action=action,
+        target_type=target_type,
+        target_id=target_id,
+        ip=ip,
+        user_agent=user_agent,
+        metadata=metadata or {},
+    )
+    for sink in get_registry().get_audit_sinks():
+        await cast(AuditSink, sink).record(event)

--- a/backend/cubebox/plugins/defaults/admin_panel.py
+++ b/backend/cubebox/plugins/defaults/admin_panel.py
@@ -1,0 +1,20 @@
+"""CE default AdminPanelExtension: empty (CE itself contributes nothing)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter
+
+from cubebox.plugins.protocols import AdminNavItem
+
+
+class DefaultAdminPanelExtension:
+    def get_router(self) -> APIRouter | None:
+        return None
+
+    def get_nav_items(self) -> list[AdminNavItem]:
+        return []
+
+    def get_static_path(self) -> Path | None:
+        return None

--- a/backend/cubebox/plugins/defaults/audit.py
+++ b/backend/cubebox/plugins/defaults/audit.py
@@ -1,0 +1,24 @@
+"""CE default AuditSink: structlog INFO no-op (no DB write)."""
+
+from __future__ import annotations
+
+import logging
+
+from cubebox.plugins.protocols import AuditEvent
+
+logger = logging.getLogger("cubebox.audit")
+
+
+class DefaultAuditSink:
+    async def record(self, event: AuditEvent) -> None:
+        logger.info(
+            "audit.%s user=%s org=%s ws=%s target=%s/%s ip=%s",
+            event.action,
+            event.user_id,
+            event.org_id,
+            event.workspace_id,
+            event.target_type,
+            event.target_id,
+            event.ip,
+            extra={"audit_event": event},
+        )

--- a/backend/cubebox/plugins/defaults/auth.py
+++ b/backend/cubebox/plugins/defaults/auth.py
@@ -1,11 +1,9 @@
 """CE default AuthProvider: wraps CE's existing cookie/JWT auth router.
 
-Unlike the plan's original sketch, CE does NOT use fastapi-users' default
-get_auth_router/get_register_router/get_users_router — CE has hand-rolled
-handlers in cubebox.api.routes.v1.auth that bundle rate limiting (slowapi),
-CSRF cookie issuance on login, and the Organization/Workspace/Membership
-bootstrap on register. We expose that composite router as-is so the plugin
-contract doesn't alter production behavior.
+The AuthProvider Protocol contract accepts only a Request, so the CE
+default opens its own database session inline to look up the authenticated
+user. This keeps the plugin contract DB-agnostic — EE plugins (SAML/OIDC)
+may not need a session at all and should not be forced to accept one.
 """
 
 from __future__ import annotations
@@ -13,52 +11,50 @@ from __future__ import annotations
 from typing import Any, cast
 
 from fastapi import APIRouter, Request
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from cubebox.auth.jwt import auth_backend
-from cubebox.auth.users import get_user_manager
+import cubebox.db as _db
 from cubebox.models import User
 
 
 class DefaultAuthProvider:
     """CE default: cookie-based JWT via fastapi-users + custom route layer."""
 
-    async def authenticate(self, request: Request, session: AsyncSession) -> User | None:
-        """Authenticate user by extracting and validating JWT from cookies.
+    async def authenticate(self, request: Request) -> User | None:
+        """Extract JWT from cookie and resolve it to an active User.
 
-        Mimics fastapi-users.current_user(active=True, optional=True) by:
-        1. Extracting token from cookie via transport.scheme
-        2. Validating token and getting user via strategy.read_token
-        3. Returning user if active, None otherwise
+        Opens a short-lived DB session for the user lookup. This is the
+        auth-time session; the route's own Depends(get_session) still
+        opens a separate session for the business logic.
+
+        Heavy fastapi-users imports are deferred to call-time to avoid
+        triggering the fastapi_users.db import chain during plugin loading
+        (the plugin test suite instantiates DefaultAuthProvider without a
+        running DB, so module-level imports of fastapi-users internals would
+        fail there).
         """
-        # Extract token from cookies using the backend's transport
-        token: str | None = None
+        from fastapi_users_db_sqlalchemy import SQLAlchemyUserDatabase
+
+        from cubebox.auth.jwt import auth_backend
+        from cubebox.auth.users import get_user_manager
+
         try:
             token = await auth_backend.transport.scheme(request)  # type: ignore[operator]
         except Exception:
-            # Transport returns None if token missing or invalid
-            pass
-
+            token = None
         if token is None:
             return None
 
-        # Get user manager to look up user from token
-        from cubebox.auth.db import get_user_db
-
-        user_db_inst = await get_user_db(session).__anext__()
-        async for user_mgr in get_user_manager(user_db_inst):
-            # Validate token and get user
-            strategy: Any = auth_backend.get_strategy()
-            user = cast(User | None, await strategy.read_token(token, user_mgr))
-            if user and user.is_active:
-                return user
-            return None
+        async with _db.async_session_maker() as session:
+            user_db: SQLAlchemyUserDatabase[User] = SQLAlchemyUserDatabase(session, User)  # type: ignore[type-arg]
+            async for user_mgr in get_user_manager(user_db):
+                strategy: Any = auth_backend.get_strategy()
+                user = cast(User | None, await strategy.read_token(token, user_mgr))
+                if user is not None and user.is_active:
+                    return user
+                return None
         return None
 
     def get_auth_routers(self) -> list[APIRouter]:
-        # Import here to avoid circular import at module load (auth routes
-        # depend on the auth module which, in Task 16, will depend on the
-        # plugin registry that may want to resolve this class at startup).
         from cubebox.api.routes.v1.auth import router as auth_router
 
         return [auth_router]

--- a/backend/cubebox/plugins/defaults/auth.py
+++ b/backend/cubebox/plugins/defaults/auth.py
@@ -10,18 +10,50 @@ contract doesn't alter production behavior.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Request
+from typing import Any, cast
 
-from cubebox.auth.users import fastapi_users
+from fastapi import APIRouter, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.auth.jwt import auth_backend
+from cubebox.auth.users import get_user_manager
 from cubebox.models import User
 
 
 class DefaultAuthProvider:
     """CE default: cookie-based JWT via fastapi-users + custom route layer."""
 
-    async def authenticate(self, request: Request) -> User | None:
-        get_user = fastapi_users.current_user(active=True, optional=True)
-        return await get_user(request)  # type: ignore[no-any-return]
+    async def authenticate(self, request: Request, session: AsyncSession) -> User | None:
+        """Authenticate user by extracting and validating JWT from cookies.
+
+        Mimics fastapi-users.current_user(active=True, optional=True) by:
+        1. Extracting token from cookie via transport.scheme
+        2. Validating token and getting user via strategy.read_token
+        3. Returning user if active, None otherwise
+        """
+        # Extract token from cookies using the backend's transport
+        token: str | None = None
+        try:
+            token = await auth_backend.transport.scheme(request)  # type: ignore[operator]
+        except Exception:
+            # Transport returns None if token missing or invalid
+            pass
+
+        if token is None:
+            return None
+
+        # Get user manager to look up user from token
+        from cubebox.auth.db import get_user_db
+
+        user_db_inst = await get_user_db(session).__anext__()
+        async for user_mgr in get_user_manager(user_db_inst):
+            # Validate token and get user
+            strategy: Any = auth_backend.get_strategy()
+            user = cast(User | None, await strategy.read_token(token, user_mgr))
+            if user and user.is_active:
+                return user
+            return None
+        return None
 
     def get_auth_routers(self) -> list[APIRouter]:
         # Import here to avoid circular import at module load (auth routes

--- a/backend/cubebox/plugins/defaults/auth.py
+++ b/backend/cubebox/plugins/defaults/auth.py
@@ -1,0 +1,32 @@
+"""CE default AuthProvider: wraps CE's existing cookie/JWT auth router.
+
+Unlike the plan's original sketch, CE does NOT use fastapi-users' default
+get_auth_router/get_register_router/get_users_router — CE has hand-rolled
+handlers in cubebox.api.routes.v1.auth that bundle rate limiting (slowapi),
+CSRF cookie issuance on login, and the Organization/Workspace/Membership
+bootstrap on register. We expose that composite router as-is so the plugin
+contract doesn't alter production behavior.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from cubebox.auth.users import fastapi_users
+from cubebox.models import User
+
+
+class DefaultAuthProvider:
+    """CE default: cookie-based JWT via fastapi-users + custom route layer."""
+
+    async def authenticate(self, request: Request) -> User | None:
+        get_user = fastapi_users.current_user(active=True, optional=True)
+        return await get_user(request)  # type: ignore[no-any-return]
+
+    def get_auth_routers(self) -> list[APIRouter]:
+        # Import here to avoid circular import at module load (auth routes
+        # depend on the auth module which, in Task 16, will depend on the
+        # plugin registry that may want to resolve this class at startup).
+        from cubebox.api.routes.v1.auth import router as auth_router
+
+        return [auth_router]

--- a/backend/cubebox/plugins/defaults/permissions.py
+++ b/backend/cubebox/plugins/defaults/permissions.py
@@ -1,0 +1,52 @@
+"""CE default PermissionChecker: wraps existing Membership.get_role lookup."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from cubebox.models import Role
+from cubebox.plugins.protocols import PermissionResource
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession  # noqa: F401
+
+    from cubebox.repositories import MembershipRepository
+
+
+class DefaultPermissionChecker:
+    """Maps known actions to Role checks; unknown actions deny."""
+
+    def __init__(
+        self,
+        membership_repo_factory: Callable[[Any], MembershipRepository] | None = None,
+    ) -> None:
+        # Allow injection for tests; default obtains a fresh repo from current session.
+        self._repo_factory = membership_repo_factory
+
+    async def check(
+        self,
+        user: Any,
+        action: str,
+        resource: PermissionResource,
+    ) -> bool:
+        if resource.workspace_id is None:
+            return False
+        repo = self._get_repo()
+        role = await repo.get_role(user_id=user.id, workspace_id=str(resource.workspace_id))
+        if role is None:
+            return False
+        if action == "admin_access":
+            return role == Role.ADMIN
+        if action == "member_access":
+            return role in (Role.ADMIN, Role.MEMBER)
+        return False
+
+    def _get_repo(self) -> MembershipRepository:
+        if self._repo_factory is None:
+            raise RuntimeError(
+                "DefaultPermissionChecker requires a membership_repo_factory "
+                "in production (FastAPI dependency injection)"
+            )
+        # In production this will be wired via FastAPI Depends; for tests it's injected.
+        return self._repo_factory(None)

--- a/backend/cubebox/plugins/protocols.py
+++ b/backend/cubebox/plugins/protocols.py
@@ -13,6 +13,8 @@ from uuid import UUID
 from fastapi import APIRouter, Request
 
 if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
     from cubebox.models import User
 
 CUBEBOX_PLUGIN_API_VERSION: Final[int] = 1
@@ -79,7 +81,7 @@ class AdminNavItem:
 class AuthProvider(Protocol):
     """Authenticate requests and yield a User principal."""
 
-    async def authenticate(self, request: Request) -> "User | None": ...
+    async def authenticate(self, request: Request, session: "AsyncSession") -> "User | None": ...
 
     def get_auth_routers(self) -> list[APIRouter]: ...
 

--- a/backend/cubebox/plugins/protocols.py
+++ b/backend/cubebox/plugins/protocols.py
@@ -6,11 +6,14 @@ their PluginManifest. Mismatch → registry refuses to load the plugin.
 
 from dataclasses import dataclass, field  # noqa: F401
 from datetime import datetime
-from pathlib import Path  # noqa: F401
-from typing import Any, Final, Protocol, runtime_checkable  # noqa: F401
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final, Protocol, runtime_checkable
 from uuid import UUID
 
-from fastapi import APIRouter, Request  # noqa: F401
+from fastapi import APIRouter, Request
+
+if TYPE_CHECKING:
+    from cubebox.models import User
 
 CUBEBOX_PLUGIN_API_VERSION: Final[int] = 1
 
@@ -70,3 +73,43 @@ class AdminNavItem:
     section: str  # "identity" | "integrations" | "settings" | "custom"
     order: int
     url_path: str
+
+
+@runtime_checkable
+class AuthProvider(Protocol):
+    """Authenticate requests and yield a User principal."""
+
+    async def authenticate(self, request: Request) -> "User | None": ...
+
+    def get_auth_routers(self) -> list[APIRouter]: ...
+
+
+@runtime_checkable
+class PermissionChecker(Protocol):
+    async def check(
+        self,
+        user: "User",
+        action: str,
+        resource: PermissionResource,
+    ) -> bool: ...
+
+
+@runtime_checkable
+class AuditSink(Protocol):
+    async def record(self, event: AuditEvent) -> None: ...
+
+
+@runtime_checkable
+class UserDirectorySyncer(Protocol):
+    async def sync(self) -> SyncResult: ...
+
+    def get_schedule(self) -> SyncSchedule: ...
+
+
+@runtime_checkable
+class AdminPanelExtension(Protocol):
+    def get_router(self) -> APIRouter | None: ...
+
+    def get_nav_items(self) -> list[AdminNavItem]: ...
+
+    def get_static_path(self) -> Path | None: ...

--- a/backend/cubebox/plugins/protocols.py
+++ b/backend/cubebox/plugins/protocols.py
@@ -1,0 +1,25 @@
+"""Plugin Protocols + supporting dataclasses + version constant.
+
+CUBEBOX_PLUGIN_API_VERSION is the single integer plugins must declare via
+their PluginManifest. Mismatch → registry refuses to load the plugin.
+"""
+
+from dataclasses import dataclass, field  # noqa: F401
+from datetime import datetime  # noqa: F401
+from pathlib import Path  # noqa: F401
+from typing import Any, Final, Protocol, runtime_checkable  # noqa: F401
+from uuid import UUID  # noqa: F401
+
+from fastapi import APIRouter, Request  # noqa: F401
+
+CUBEBOX_PLUGIN_API_VERSION: Final[int] = 1
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    """Plugin self-describing metadata. Required entry_point per wheel."""
+
+    api_version: int
+    name: str
+    version: str
+    description: str = ""

--- a/backend/cubebox/plugins/protocols.py
+++ b/backend/cubebox/plugins/protocols.py
@@ -13,8 +13,6 @@ from uuid import UUID
 from fastapi import APIRouter, Request
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession
-
     from cubebox.models import User
 
 CUBEBOX_PLUGIN_API_VERSION: Final[int] = 1
@@ -81,7 +79,7 @@ class AdminNavItem:
 class AuthProvider(Protocol):
     """Authenticate requests and yield a User principal."""
 
-    async def authenticate(self, request: Request, session: "AsyncSession") -> "User | None": ...
+    async def authenticate(self, request: Request) -> "User | None": ...
 
     def get_auth_routers(self) -> list[APIRouter]: ...
 

--- a/backend/cubebox/plugins/protocols.py
+++ b/backend/cubebox/plugins/protocols.py
@@ -5,10 +5,10 @@ their PluginManifest. Mismatch → registry refuses to load the plugin.
 """
 
 from dataclasses import dataclass, field  # noqa: F401
-from datetime import datetime  # noqa: F401
+from datetime import datetime
 from pathlib import Path  # noqa: F401
 from typing import Any, Final, Protocol, runtime_checkable  # noqa: F401
-from uuid import UUID  # noqa: F401
+from uuid import UUID
 
 from fastapi import APIRouter, Request  # noqa: F401
 
@@ -23,3 +23,50 @@ class PluginManifest:
     name: str
     version: str
     description: str = ""
+
+
+@dataclass(frozen=True)
+class PermissionResource:
+    """Identifies the target of a permission check."""
+
+    type: str  # "workspace" | "organization" | "conversation" | ...
+    id: UUID | None  # None = type-level policy
+    org_id: UUID | None = None
+    workspace_id: UUID | None = None
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    timestamp: datetime
+    user_id: UUID | None
+    org_id: UUID | None
+    workspace_id: UUID | None
+    action: str
+    target_type: str | None
+    target_id: str | None
+    ip: str | None
+    user_agent: str | None
+    metadata: dict[str, Any]
+
+
+@dataclass
+class SyncResult:
+    added: int
+    updated: int
+    removed: int
+    errors: list[str]
+
+
+@dataclass
+class SyncSchedule:
+    interval_seconds: int | None  # None = on-demand only
+
+
+@dataclass(frozen=True)
+class AdminNavItem:
+    id: str
+    label: str
+    icon: str | None
+    section: str  # "identity" | "integrations" | "settings" | "custom"
+    order: int
+    url_path: str

--- a/backend/cubebox/plugins/registry.py
+++ b/backend/cubebox/plugins/registry.py
@@ -1,0 +1,102 @@
+"""Plugin discovery + resolution."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+from typing import TYPE_CHECKING
+
+from cubebox.plugins.protocols import (
+    CUBEBOX_PLUGIN_API_VERSION,
+    AdminPanelExtension,
+    AuditSink,
+    AuthProvider,
+    PermissionChecker,
+    PluginManifest,
+    UserDirectorySyncer,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Per-Protocol entry_points group names. External wheels publish here.
+GROUP_MANIFEST = "cubebox.plugin_manifest"
+GROUP_AUTH = "cubebox.auth_provider"
+GROUP_PERMISSIONS = "cubebox.permission_checker"
+GROUP_AUDIT = "cubebox.audit_sink"
+GROUP_DIRECTORY = "cubebox.user_directory_syncer"
+GROUP_ADMIN_PANEL = "cubebox.admin_panel_extension"
+
+PROTOCOL_GROUPS: dict[str, type] = {
+    GROUP_AUTH: AuthProvider,
+    GROUP_PERMISSIONS: PermissionChecker,
+    GROUP_AUDIT: AuditSink,
+    GROUP_DIRECTORY: UserDirectorySyncer,
+    GROUP_ADMIN_PANEL: AdminPanelExtension,
+}
+
+# Reserved entry_point name for CE built-in implementations. External plugins
+# may not use this name.
+RESERVED_NAME = "builtin"
+
+
+class PluginRegistry:
+    """Singleton-style holder of discovered plugin classes + CE defaults."""
+
+    def __init__(self) -> None:
+        self._manifests: dict[str, PluginManifest] = {}  # plugin_name → manifest
+        self._candidates: dict[str, dict[str, type]] = {
+            group: {} for group in PROTOCOL_GROUPS
+        }  # group → {entry_point_name → impl class}
+
+    async def discover(self) -> None:
+        """Scan all entry_points + validate manifests + collect candidates."""
+        manifest_eps = list(importlib.metadata.entry_points(group=GROUP_MANIFEST))
+        # Each plugin_manifest entry_point loads to a PluginManifest instance.
+        plugin_dist_to_manifest: dict[str, PluginManifest] = {}
+        for ep in manifest_eps:
+            manifest = ep.load()
+            if not isinstance(manifest, PluginManifest):
+                raise RuntimeError(f"entry_point {ep.value} did not return a PluginManifest")
+            if manifest.api_version != CUBEBOX_PLUGIN_API_VERSION:
+                raise RuntimeError(
+                    f"plugin {manifest.name!r}: api_version={manifest.api_version} "
+                    f"but cubebox CE requires api_version={CUBEBOX_PLUGIN_API_VERSION}"
+                )
+            self._manifests[manifest.name] = manifest
+            # Map dist name to manifest for cross-group lookup
+            dist_name = self._dist_name(ep)
+            if dist_name:
+                plugin_dist_to_manifest[dist_name] = manifest
+            logger.info(
+                "registered plugin manifest: %s v%s (api=%d)",
+                manifest.name,
+                manifest.version,
+                manifest.api_version,
+            )
+
+        # Walk per-Protocol groups; reject unknown plugins (no manifest)
+        for group, _ in PROTOCOL_GROUPS.items():
+            for ep in importlib.metadata.entry_points(group=group):
+                if ep.name == RESERVED_NAME:
+                    raise RuntimeError(
+                        f"entry_point name {RESERVED_NAME!r} is reserved for CE; "
+                        f"plugin {ep.value} cannot use it"
+                    )
+                dist_name = self._dist_name(ep)
+                if dist_name and dist_name not in plugin_dist_to_manifest:
+                    raise RuntimeError(
+                        f"plugin {ep.value} (dist={dist_name}) is missing a "
+                        f"{GROUP_MANIFEST} entry_point"
+                    )
+                self._candidates[group][ep.name] = ep.load()
+                logger.info("registered candidate %s.%s = %s", group, ep.name, ep.value)
+
+    @staticmethod
+    def _dist_name(ep) -> str | None:  # type: ignore[no-untyped-def]
+        try:
+            return ep.dist.name if ep.dist else None
+        except AttributeError:
+            return None

--- a/backend/cubebox/plugins/registry.py
+++ b/backend/cubebox/plugins/registry.py
@@ -137,3 +137,26 @@ class PluginRegistry:
             f"{group}: multiple entry_points registered ({sorted(candidates)}); "
             f"set plugins.{group.split('.')[1]}.selected = '<name>' to pick one"
         )
+
+    def resolve_plural(
+        self,
+        group: str,
+        *,
+        default: object | None,
+        disabled: list[str],
+    ) -> list[object]:
+        """Resolve all candidates for a plural Protocol; honor `disabled` filter.
+
+        - default: optional CE built-in instance (registered as RESERVED_NAME)
+        - disabled: list of entry_point names to exclude (incl. RESERVED_NAME for
+          default)
+        """
+        disabled_set = set(disabled)
+        out: list[object] = []
+        if default is not None and RESERVED_NAME not in disabled_set:
+            out.append(default)
+        for name, cls in self._candidates[group].items():
+            if name in disabled_set:
+                continue
+            out.append(cls())
+        return out

--- a/backend/cubebox/plugins/registry.py
+++ b/backend/cubebox/plugins/registry.py
@@ -160,3 +160,101 @@ class PluginRegistry:
                 continue
             out.append(cls())
         return out
+
+    # Resolved instances (set by bind_defaults after discover).
+    _auth_provider: object | None = None
+    _permission_checker: object | None = None
+    _audit_sinks: list[object] | None = None
+    _user_directory_syncers: list[object] | None = None
+    _admin_panel_extensions: list[object] | None = None
+
+    def bind_defaults(
+        self,
+        *,
+        auth_default: object | None = None,
+        permissions_default: object | None = None,
+        audit_default: object | None = None,
+        admin_panel_default: object | None = None,
+        config: object | None = None,
+    ) -> None:
+        """Resolve every Protocol with the supplied defaults + applied config."""
+        from cubebox.plugins.defaults.admin_panel import (
+            DefaultAdminPanelExtension,
+        )
+        from cubebox.plugins.defaults.audit import DefaultAuditSink
+        from cubebox.plugins.defaults.auth import DefaultAuthProvider
+        from cubebox.plugins.defaults.permissions import (
+            DefaultPermissionChecker,
+        )
+
+        auth_default = auth_default or DefaultAuthProvider()
+        permissions_default = permissions_default or DefaultPermissionChecker()
+        audit_default = audit_default or DefaultAuditSink()
+        admin_panel_default = admin_panel_default or DefaultAdminPanelExtension()
+
+        sel_auth: str | None = self._cfg(config, "auth_provider", "selected")  # type: ignore[assignment]
+        sel_perm: str | None = self._cfg(config, "permission_checker", "selected")  # type: ignore[assignment]
+        dis_audit: list[str] = self._cfg(config, "audit_sink", "disabled") or []  # type: ignore[assignment]
+        dis_dir: list[str] = self._cfg(config, "user_directory_syncer", "disabled") or []  # type: ignore[assignment]
+        dis_admin: list[str] = self._cfg(config, "admin_panel_extension", "disabled") or []  # type: ignore[assignment]
+
+        self._auth_provider = self.resolve_singular(
+            GROUP_AUTH, default=auth_default, selected=sel_auth
+        )
+        self._permission_checker = self.resolve_singular(
+            GROUP_PERMISSIONS, default=permissions_default, selected=sel_perm
+        )
+        self._audit_sinks = self.resolve_plural(
+            GROUP_AUDIT, default=audit_default, disabled=dis_audit
+        )
+        self._user_directory_syncers = self.resolve_plural(
+            GROUP_DIRECTORY, default=None, disabled=dis_dir
+        )
+        self._admin_panel_extensions = self.resolve_plural(
+            GROUP_ADMIN_PANEL, default=admin_panel_default, disabled=dis_admin
+        )
+
+    @staticmethod
+    def _cfg(config: object | None, group_name: str, key: str) -> object | None:
+        if config is None:
+            return None
+        return getattr(
+            getattr(getattr(config, "plugins", None), group_name, None),
+            key,
+            None,
+        )
+
+    def get_auth_provider(self) -> object:
+        if self._auth_provider is None:
+            raise RuntimeError("call bind_defaults() first")
+        return self._auth_provider
+
+    def get_permission_checker(self) -> object:
+        if self._permission_checker is None:
+            raise RuntimeError("call bind_defaults() first")
+        return self._permission_checker
+
+    def get_audit_sinks(self) -> list[object]:
+        return self._audit_sinks or []
+
+    def get_user_directory_syncers(self) -> list[object]:
+        return self._user_directory_syncers or []
+
+    def get_admin_panel_extensions(self) -> list[object]:
+        return self._admin_panel_extensions or []
+
+
+# Module-level singleton, populated by app startup.
+_registry: PluginRegistry | None = None
+
+
+def get_registry() -> PluginRegistry:
+    global _registry
+    if _registry is None:
+        _registry = PluginRegistry()
+    return _registry
+
+
+def reset_registry_for_tests() -> None:
+    global _registry
+    _registry = None

--- a/backend/cubebox/plugins/registry.py
+++ b/backend/cubebox/plugins/registry.py
@@ -100,3 +100,40 @@ class PluginRegistry:
             return ep.dist.name if ep.dist else None
         except AttributeError:
             return None
+
+    def resolve_singular(
+        self,
+        group: str,
+        *,
+        default: object,
+        selected: str | None,
+    ) -> object:
+        """Resolve a singular Protocol candidate; instantiate or pass through default.
+
+        Resolution rules:
+        - selected="builtin" → CE default (forces fallback even if externals present)
+        - selected="<name>"  → look up that entry_point name; raise if missing
+        - selected=None      → 0 ext: default; 1 ext: that one; ≥2 ext: RuntimeError
+        """
+        candidates = self._candidates[group]
+
+        if selected == RESERVED_NAME:
+            return default
+        if selected is not None:
+            if selected not in candidates:
+                raise RuntimeError(
+                    f"{group}: 'selected' is {selected!r} but no such entry_point is "
+                    f"not registered (available: {sorted(candidates)})"
+                )
+            return candidates[selected]()
+
+        # selected is None — implicit rules
+        if len(candidates) == 0:
+            return default
+        if len(candidates) == 1:
+            (cls,) = candidates.values()
+            return cls()
+        raise RuntimeError(
+            f"{group}: multiple entry_points registered ({sorted(candidates)}); "
+            f"set plugins.{group.split('.')[1]}.selected = '<name>' to pick one"
+        )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,3 +9,14 @@ if config.langsmith.enabled:
     print("setup langsmith")
     os.environ["LANGSMITH_TRACING"] = "true"
     os.environ["LANGSMITH_API_KEY"] = config.langsmith.key
+
+import pytest
+
+from cubebox.plugins import ensure_registry_bound, reset_registry_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _bind_plugin_registry():
+    reset_registry_for_tests()
+    ensure_registry_bound()
+    yield

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -153,17 +153,19 @@ async def client() -> AsyncIterator[TestClient]:
     """
     await _ensure_default_user_and_membership()
     app = _make_test_app()
-    sync_client = TestClient(app)
-    sync_client.get("/api/v1/auth/me")  # obtain CSRF cookie
-    csrf = sync_client.cookies.get("cubebox_csrf") or ""
-    r = sync_client.post(
-        "/api/v1/auth/login",
-        data={"username": DEFAULT_TEST_EMAIL, "password": DEFAULT_TEST_PASSWORD},
-        headers={"X-CSRF-Token": csrf},
-    )
-    assert r.status_code in (200, 204), f"login failed: {r.status_code} {r.text}"
-    sync_client.headers["X-CSRF-Token"] = sync_client.cookies.get("cubebox_csrf") or csrf
-    yield sync_client
+    # TestClient as a context manager runs the FastAPI lifespan — required
+    # since auth routers are now mounted at lifespan startup (not in create_app).
+    with TestClient(app) as sync_client:
+        sync_client.get("/api/v1/auth/me")  # obtain CSRF cookie
+        csrf = sync_client.cookies.get("cubebox_csrf") or ""
+        r = sync_client.post(
+            "/api/v1/auth/login",
+            data={"username": DEFAULT_TEST_EMAIL, "password": DEFAULT_TEST_PASSWORD},
+            headers={"X-CSRF-Token": csrf},
+        )
+        assert r.status_code in (200, 204), f"login failed: {r.status_code} {r.text}"
+        sync_client.headers["X-CSRF-Token"] = sync_client.cookies.get("cubebox_csrf") or csrf
+        yield sync_client
 
 
 @pytest_asyncio.fixture

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -14,6 +14,7 @@ from langgraph.checkpoint.memory import MemorySaver
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
+import cubebox.db as _cubebox_db
 from cubebox.api.app import create_app
 from cubebox.api.middleware.rate_limit import limiter
 from cubebox.auth.users import UserManager
@@ -66,6 +67,9 @@ def _make_test_app() -> FastAPI:
     test_session_maker = async_sessionmaker(
         test_engine, class_=AsyncSession, expire_on_commit=False
     )
+    # Patch module-level async_session_maker so DefaultAuthProvider.authenticate
+    # (which opens its own session inline) also uses NullPool in tests.
+    _cubebox_db.async_session_maker = test_session_maker
 
     async def override_get_session() -> AsyncIterator[AsyncSession]:
         async with test_session_maker() as session:
@@ -83,6 +87,9 @@ def _make_memory_test_app() -> FastAPI:
     test_session_maker = async_sessionmaker(
         test_engine, class_=AsyncSession, expire_on_commit=False
     )
+    # Patch module-level async_session_maker so DefaultAuthProvider.authenticate
+    # (which opens its own session inline) also uses NullPool in tests.
+    _cubebox_db.async_session_maker = test_session_maker
 
     async def override_get_session() -> AsyncIterator[AsyncSession]:
         async with test_session_maker() as session:

--- a/backend/tests/e2e/test_admin_extensions.py
+++ b/backend/tests/e2e/test_admin_extensions.py
@@ -1,0 +1,14 @@
+"""E2E: GET /api/v1/admin/_extensions/manifest in CE-only deployment returns []."""
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_admin_manifest_empty_in_ce(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    client, _ws_id = admin_client
+    resp = await client.get("/api/v1/admin/_extensions/manifest")
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/backend/tests/e2e/test_admin_extensions.py
+++ b/backend/tests/e2e/test_admin_extensions.py
@@ -3,6 +3,8 @@
 import httpx
 import pytest
 
+pytestmark = pytest.mark.e2e
+
 
 @pytest.mark.asyncio
 async def test_admin_manifest_empty_in_ce(

--- a/backend/tests/e2e/test_plugin_architecture_e2e.py
+++ b/backend/tests/e2e/test_plugin_architecture_e2e.py
@@ -13,6 +13,8 @@ import logging
 import httpx
 import pytest
 
+pytestmark = pytest.mark.e2e
+
 
 @pytest.mark.asyncio
 async def test_ce_defaults_load_after_lifespan(

--- a/backend/tests/e2e/test_plugin_architecture_e2e.py
+++ b/backend/tests/e2e/test_plugin_architecture_e2e.py
@@ -1,0 +1,111 @@
+"""E2E tests for the CE/EE plugin architecture (Task 24).
+
+These tests exercise the real FastAPI application (with DB + lifespan) to verify
+that the PluginRegistry resolves CE defaults correctly, that the admin extensions
+manifest endpoint is auth-gated, that require_admin enforces role-based access, and
+that the DefaultAuditSink records events via the stdlib logger.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_ce_defaults_load_after_lifespan(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """CE-only deployment: registry binds all singular Protocols to defaults;
+    audit has at least the default sink; no syncers; admin_panel has at most default.
+    """
+    from cubebox.plugins import get_registry
+    from cubebox.plugins.defaults.admin_panel import DefaultAdminPanelExtension
+    from cubebox.plugins.defaults.audit import DefaultAuditSink
+    from cubebox.plugins.defaults.auth import DefaultAuthProvider
+    from cubebox.plugins.defaults.permissions import DefaultPermissionChecker
+
+    _client, _ws_id = admin_client  # ensure lifespan has run via the fixture
+
+    reg = get_registry()
+    assert isinstance(reg.get_auth_provider(), DefaultAuthProvider)
+    assert isinstance(reg.get_permission_checker(), DefaultPermissionChecker)
+
+    sinks = reg.get_audit_sinks()
+    assert any(isinstance(s, DefaultAuditSink) for s in sinks)
+
+    syncers = reg.get_user_directory_syncers()
+    assert syncers == []
+
+    exts = reg.get_admin_panel_extensions()
+    assert all(isinstance(e, DefaultAdminPanelExtension) for e in exts)
+
+
+@pytest.mark.asyncio
+async def test_admin_extensions_manifest_ce_is_empty(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """Authenticated user gets an empty manifest in CE-only deployment."""
+    client, _ws_id = admin_client
+    resp = await client.get("/api/v1/admin/_extensions/manifest")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_admin_extensions_manifest_requires_auth(
+    unauthenticated_memory_client: httpx.AsyncClient,
+) -> None:
+    """Unauthenticated request to manifest returns 401."""
+    resp = await unauthenticated_memory_client.get("/api/v1/admin/_extensions/manifest")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_admin_only_route_denies_member(
+    member_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """require_admin -> PermissionChecker.check -> denies non-admin."""
+    client, ws_id = member_client
+    resp = await client.post(
+        f"/api/v1/workspaces/{ws_id}/invites",
+        json={"role": "member"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_only_route_allows_admin(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """require_admin -> PermissionChecker.check -> allows admin."""
+    client, ws_id = admin_client
+    resp = await client.post(
+        f"/api/v1/workspaces/{ws_id}/invites",
+        json={"role": "member"},
+    )
+    assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_invite_creation_emits_audit_event(
+    admin_client: tuple[httpx.AsyncClient, str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """After invite creation, the DefaultAuditSink records workspace.invite_created."""
+    client, ws_id = admin_client
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="cubebox.audit"):
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/invites",
+            json={"role": "member"},
+        )
+        assert resp.status_code == 201
+
+    messages = [r.getMessage() for r in caplog.records if r.name == "cubebox.audit"]
+    assert any("workspace.invite_created" in m for m in messages), (
+        f"no audit log for invite_created; captured: {messages}"
+    )

--- a/backend/tests/fixtures/fake_plugin/fake_plugin/__init__.py
+++ b/backend/tests/fixtures/fake_plugin/fake_plugin/__init__.py
@@ -1,0 +1,8 @@
+from cubebox.plugins import CUBEBOX_PLUGIN_API_VERSION, PluginManifest
+
+MANIFEST = PluginManifest(
+    api_version=CUBEBOX_PLUGIN_API_VERSION,
+    name="fake",
+    version="0.0.1",
+    description="Fixture plugin for Layer 1 contract tests.",
+)

--- a/backend/tests/fixtures/fake_plugin/fake_plugin/admin_panel.py
+++ b/backend/tests/fixtures/fake_plugin/fake_plugin/admin_panel.py
@@ -1,0 +1,21 @@
+from cubebox.plugins import AdminNavItem
+
+
+class FakeAdminPanelExtension:
+    def get_router(self):  # type: ignore[no-untyped-def]
+        return None
+
+    def get_nav_items(self):  # type: ignore[no-untyped-def]
+        return [
+            AdminNavItem(
+                id="fake-tab",
+                label="Fake",
+                icon=None,
+                section="custom",
+                order=999,
+                url_path="fake",
+            )
+        ]
+
+    def get_static_path(self):  # type: ignore[no-untyped-def]
+        return None

--- a/backend/tests/fixtures/fake_plugin/fake_plugin/audit.py
+++ b/backend/tests/fixtures/fake_plugin/fake_plugin/audit.py
@@ -1,0 +1,3 @@
+class FakeAuditSink:
+    async def record(self, event):  # type: ignore[no-untyped-def]
+        pass

--- a/backend/tests/fixtures/fake_plugin/fake_plugin/auth.py
+++ b/backend/tests/fixtures/fake_plugin/fake_plugin/auth.py
@@ -1,0 +1,6 @@
+class FakeAuthProvider:
+    async def authenticate(self, request):  # type: ignore[no-untyped-def]
+        return None
+
+    def get_auth_routers(self):  # type: ignore[no-untyped-def]
+        return []

--- a/backend/tests/fixtures/fake_plugin/fake_plugin/directory.py
+++ b/backend/tests/fixtures/fake_plugin/fake_plugin/directory.py
@@ -1,0 +1,9 @@
+from cubebox.plugins import SyncResult, SyncSchedule
+
+
+class FakeUserDirectorySyncer:
+    async def sync(self):  # type: ignore[no-untyped-def]
+        return SyncResult(added=0, updated=0, removed=0, errors=[])
+
+    def get_schedule(self):  # type: ignore[no-untyped-def]
+        return SyncSchedule(interval_seconds=None)

--- a/backend/tests/fixtures/fake_plugin/fake_plugin/permissions.py
+++ b/backend/tests/fixtures/fake_plugin/fake_plugin/permissions.py
@@ -1,0 +1,3 @@
+class FakePermissionChecker:
+    async def check(self, user, action, resource):  # type: ignore[no-untyped-def]
+        return True  # always permit (test stub)

--- a/backend/tests/fixtures/fake_plugin/pyproject.toml
+++ b/backend/tests/fixtures/fake_plugin/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "fake-plugin"
+version = "0.0.1"
+description = "Fake cubebox plugin used by Layer 1 contract tests."
+requires-python = ">=3.12"
+dependencies = []
+
+[project.entry-points."cubebox.plugin_manifest"]
+main = "fake_plugin:MANIFEST"
+
+[project.entry-points."cubebox.auth_provider"]
+fake = "fake_plugin.auth:FakeAuthProvider"
+
+[project.entry-points."cubebox.permission_checker"]
+fake = "fake_plugin.permissions:FakePermissionChecker"
+
+[project.entry-points."cubebox.audit_sink"]
+fake = "fake_plugin.audit:FakeAuditSink"
+
+[project.entry-points."cubebox.user_directory_syncer"]
+fake = "fake_plugin.directory:FakeUserDirectorySyncer"
+
+[project.entry-points."cubebox.admin_panel_extension"]
+fake = "fake_plugin.admin_panel:FakeAdminPanelExtension"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/backend/tests/plugins/test_audit_helper.py
+++ b/backend/tests/plugins/test_audit_helper.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from cubebox.plugins import get_registry
+from cubebox.plugins.audit import audit_log
+
+
+@pytest.mark.asyncio
+async def test_audit_log_dispatches_to_all_sinks() -> None:
+    sink_a = AsyncMock()
+    sink_b = AsyncMock()
+    reg = get_registry()
+    reg._audit_sinks = [sink_a, sink_b]
+
+    await audit_log(
+        action="auth.login",
+        user_id=uuid4(),
+        org_id=uuid4(),
+        workspace_id=None,
+        ip="127.0.0.1",
+    )
+    sink_a.record.assert_awaited_once()
+    sink_b.record.assert_awaited_once()
+    event = sink_a.record.call_args.args[0]
+    assert event.action == "auth.login"
+    assert isinstance(event.timestamp, datetime)

--- a/backend/tests/plugins/test_contracts.py
+++ b/backend/tests/plugins/test_contracts.py
@@ -1,0 +1,351 @@
+"""Layer 1 contract tests — exercise PluginRegistry against in-tree fake_plugin."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import site
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from cubebox.plugins import (
+    reset_registry_for_tests,
+)
+from cubebox.plugins.registry import PluginRegistry
+
+FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "fake_plugin"
+
+
+def _refresh_metadata() -> None:
+    """Flush importlib.metadata's internal cache so newly installed/removed
+    distributions are visible without restarting the interpreter."""
+    for key in list(sys.modules):
+        if key == "importlib.metadata" or key.startswith("importlib.metadata."):
+            del sys.modules[key]
+    importlib.invalidate_caches()
+
+
+def _activate_editable_install() -> None:
+    """Process .pth files in site-packages so editable installs registered
+    after interpreter startup are found by the import machinery."""
+    for sp in site.getsitepackages():
+        site.addsitedir(sp)
+    importlib.invalidate_caches()
+
+
+@pytest.fixture
+def installed_fake_plugin():
+    subprocess.run(
+        ["uv", "pip", "install", "-e", str(FIXTURE_DIR), "--no-deps"],
+        check=True,
+        capture_output=True,
+    )
+    _activate_editable_install()
+    _refresh_metadata()
+    yield
+    subprocess.run(
+        ["uv", "pip", "uninstall", "fake-plugin"],
+        check=True,
+        capture_output=True,
+    )
+    sys.modules.pop("fake_plugin", None)
+    _refresh_metadata()
+    reset_registry_for_tests()
+
+
+@pytest.fixture
+def fresh_registry():
+    reset_registry_for_tests()
+    yield
+    reset_registry_for_tests()
+
+
+# ──────────────────────── 11 assertions ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_discovery_finds_fake_plugin(installed_fake_plugin, fresh_registry) -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    assert "fake" in reg._manifests
+
+
+@pytest.mark.asyncio
+async def test_singular_zero_external_uses_default(fresh_registry) -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    from cubebox.plugins.defaults.auth import DefaultAuthProvider
+
+    assert isinstance(reg.get_auth_provider(), DefaultAuthProvider)
+
+
+@pytest.mark.asyncio
+async def test_singular_one_external_replaces_default(
+    installed_fake_plugin, fresh_registry
+) -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    from fake_plugin.auth import FakeAuthProvider
+
+    assert isinstance(reg.get_auth_provider(), FakeAuthProvider)
+
+
+@pytest.mark.asyncio
+async def test_singular_selected_builtin_forces_default(
+    installed_fake_plugin, fresh_registry
+) -> None:
+    class _Cfg:
+        class plugins:
+            class auth_provider:
+                selected = "builtin"
+
+            class permission_checker:
+                selected = None
+
+            class audit_sink:
+                disabled: list[str] = []
+
+            class user_directory_syncer:
+                disabled: list[str] = []
+
+            class admin_panel_extension:
+                disabled: list[str] = []
+
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults(config=_Cfg())
+    from cubebox.plugins.defaults.auth import DefaultAuthProvider
+
+    assert isinstance(reg.get_auth_provider(), DefaultAuthProvider)
+
+
+@pytest.mark.asyncio
+async def test_singular_selected_by_name(installed_fake_plugin, fresh_registry) -> None:
+    class _Cfg:
+        class plugins:
+            class auth_provider:
+                selected = "fake"
+
+            class permission_checker:
+                selected = None
+
+            class audit_sink:
+                disabled: list[str] = []
+
+            class user_directory_syncer:
+                disabled: list[str] = []
+
+            class admin_panel_extension:
+                disabled: list[str] = []
+
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults(config=_Cfg())
+    from fake_plugin.auth import FakeAuthProvider
+
+    assert isinstance(reg.get_auth_provider(), FakeAuthProvider)
+
+
+@pytest.mark.asyncio
+async def test_singular_selected_not_found_fails(fresh_registry) -> None:
+    class _Cfg:
+        class plugins:
+            class auth_provider:
+                selected = "nonexistent"
+
+            class permission_checker:
+                selected = None
+
+            class audit_sink:
+                disabled: list[str] = []
+
+            class user_directory_syncer:
+                disabled: list[str] = []
+
+            class admin_panel_extension:
+                disabled: list[str] = []
+
+    reg = PluginRegistry()
+    await reg.discover()
+    with pytest.raises(RuntimeError, match="not registered"):
+        reg.bind_defaults(config=_Cfg())
+
+
+@pytest.mark.asyncio
+async def test_plural_aggregates_default_plus_external(
+    installed_fake_plugin, fresh_registry
+) -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    sinks = reg.get_audit_sinks()
+    from fake_plugin.audit import FakeAuditSink
+
+    from cubebox.plugins.defaults.audit import DefaultAuditSink
+
+    types = {type(s) for s in sinks}
+    assert DefaultAuditSink in types
+    assert FakeAuditSink in types
+
+
+@pytest.mark.asyncio
+async def test_plural_disabled_filters_out(installed_fake_plugin, fresh_registry) -> None:
+    class _Cfg:
+        class plugins:
+            class auth_provider:
+                selected = None
+
+            class permission_checker:
+                selected = None
+
+            class audit_sink:
+                disabled = ["builtin"]
+
+            class user_directory_syncer:
+                disabled: list[str] = []
+
+            class admin_panel_extension:
+                disabled: list[str] = []
+
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults(config=_Cfg())
+    sinks = reg.get_audit_sinks()
+    from cubebox.plugins.defaults.audit import DefaultAuditSink
+
+    assert not any(isinstance(s, DefaultAuditSink) for s in sinks)
+
+
+@pytest.mark.asyncio
+async def test_missing_manifest_rejects_plugin(tmp_path, fresh_registry) -> None:
+    """Manually install a wheel with an entry_point but no plugin_manifest → reject."""
+    pkg = tmp_path / "rogue_pkg"
+    pkg.mkdir()
+    (pkg / "rogue").mkdir()
+    (pkg / "rogue" / "__init__.py").write_text("class R:\n    pass\n")
+    (pkg / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "rogue"\n'
+        'version = "0.0.1"\n'
+        'requires-python = ">=3.12"\n'
+        '[project.entry-points."cubebox.auth_provider"]\n'
+        'rogue = "rogue:R"\n'
+        "[build-system]\n"
+        'requires = ["setuptools>=61"]\n'
+        'build-backend = "setuptools.build_meta"\n'
+    )
+    subprocess.run(
+        ["uv", "pip", "install", "-e", str(pkg), "--no-deps"],
+        check=True,
+        capture_output=True,
+    )
+    _activate_editable_install()
+    _refresh_metadata()
+    try:
+        reg = PluginRegistry()
+        with pytest.raises(RuntimeError, match="missing.*manifest"):
+            await reg.discover()
+    finally:
+        subprocess.run(
+            ["uv", "pip", "uninstall", "rogue"],
+            check=True,
+            capture_output=True,
+        )
+        sys.modules.pop("rogue", None)
+        _refresh_metadata()
+
+
+@pytest.mark.asyncio
+async def test_api_version_mismatch_rejects(tmp_path, fresh_registry) -> None:
+    """Plugin manifest with mismatched api_version is rejected."""
+    pkg = tmp_path / "old_plugin"
+    pkg.mkdir()
+    (pkg / "old_pkg").mkdir()
+    (pkg / "old_pkg" / "__init__.py").write_text(
+        "from cubebox.plugins import PluginManifest\n"
+        "MANIFEST = PluginManifest(api_version=999, name='old', version='0.0.1')\n"
+    )
+    (pkg / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "old-pkg"\n'
+        'version = "0.0.1"\n'
+        'requires-python = ">=3.12"\n'
+        '[project.entry-points."cubebox.plugin_manifest"]\n'
+        'main = "old_pkg:MANIFEST"\n'
+        "[build-system]\n"
+        'requires = ["setuptools>=61"]\n'
+        'build-backend = "setuptools.build_meta"\n'
+    )
+    subprocess.run(
+        ["uv", "pip", "install", "-e", str(pkg), "--no-deps"],
+        check=True,
+        capture_output=True,
+    )
+    _activate_editable_install()
+    _refresh_metadata()
+    try:
+        reg = PluginRegistry()
+        with pytest.raises(RuntimeError, match="api_version"):
+            await reg.discover()
+    finally:
+        subprocess.run(
+            ["uv", "pip", "uninstall", "old-pkg"],
+            check=True,
+            capture_output=True,
+        )
+        sys.modules.pop("old_pkg", None)
+        _refresh_metadata()
+
+
+@pytest.mark.asyncio
+async def test_external_plugin_named_builtin_rejected(tmp_path, fresh_registry) -> None:
+    """External entry_point name 'builtin' is reserved."""
+    pkg = tmp_path / "rsv"
+    pkg.mkdir()
+    (pkg / "rsv_pkg").mkdir()
+    (pkg / "rsv_pkg" / "__init__.py").write_text(
+        "from cubebox.plugins import PluginManifest, CUBEBOX_PLUGIN_API_VERSION\n"
+        "MANIFEST = PluginManifest(api_version=CUBEBOX_PLUGIN_API_VERSION, name='rsv', version='0.0.1')\n"
+        "class A:\n"
+        "    async def authenticate(self, r):\n"
+        "        return None\n"
+        "    def get_auth_routers(self):\n"
+        "        return []\n"
+    )
+    (pkg / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "rsv-pkg"\n'
+        'version = "0.0.1"\n'
+        'requires-python = ">=3.12"\n'
+        '[project.entry-points."cubebox.plugin_manifest"]\n'
+        'main = "rsv_pkg:MANIFEST"\n'
+        '[project.entry-points."cubebox.auth_provider"]\n'
+        'builtin = "rsv_pkg:A"\n'
+        "[build-system]\n"
+        'requires = ["setuptools>=61"]\n'
+        'build-backend = "setuptools.build_meta"\n'
+    )
+    subprocess.run(
+        ["uv", "pip", "install", "-e", str(pkg), "--no-deps"],
+        check=True,
+        capture_output=True,
+    )
+    _activate_editable_install()
+    _refresh_metadata()
+    try:
+        reg = PluginRegistry()
+        with pytest.raises(RuntimeError, match="reserved"):
+            await reg.discover()
+    finally:
+        subprocess.run(
+            ["uv", "pip", "uninstall", "rsv-pkg"],
+            check=True,
+            capture_output=True,
+        )
+        sys.modules.pop("rsv_pkg", None)
+        _refresh_metadata()

--- a/backend/tests/plugins/test_default_admin_panel.py
+++ b/backend/tests/plugins/test_default_admin_panel.py
@@ -1,0 +1,13 @@
+from cubebox.plugins import AdminPanelExtension
+from cubebox.plugins.defaults.admin_panel import DefaultAdminPanelExtension
+
+
+def test_default_admin_panel_satisfies_protocol() -> None:
+    assert isinstance(DefaultAdminPanelExtension(), AdminPanelExtension)
+
+
+def test_default_admin_panel_returns_empty() -> None:
+    e = DefaultAdminPanelExtension()
+    assert e.get_router() is None
+    assert e.get_nav_items() == []
+    assert e.get_static_path() is None

--- a/backend/tests/plugins/test_default_audit.py
+++ b/backend/tests/plugins/test_default_audit.py
@@ -1,0 +1,31 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from cubebox.plugins import AuditEvent, AuditSink
+from cubebox.plugins.defaults.audit import DefaultAuditSink
+
+
+def test_default_audit_sink_satisfies_protocol() -> None:
+    assert isinstance(DefaultAuditSink(), AuditSink)
+
+
+@pytest.mark.asyncio
+async def test_default_audit_sink_logs_via_structlog(caplog: pytest.LogCaptureFixture) -> None:
+    sink = DefaultAuditSink()
+    event = AuditEvent(
+        timestamp=datetime.now(UTC),
+        user_id=uuid4(),
+        org_id=uuid4(),
+        workspace_id=None,
+        action="auth.login",
+        target_type=None,
+        target_id=None,
+        ip="127.0.0.1",
+        user_agent="pytest",
+        metadata={},
+    )
+    with caplog.at_level("INFO"):
+        await sink.record(event)
+    assert any("auth.login" in r.getMessage() for r in caplog.records)

--- a/backend/tests/plugins/test_default_auth.py
+++ b/backend/tests/plugins/test_default_auth.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter
+
+from cubebox.plugins import AuthProvider
+from cubebox.plugins.defaults.auth import DefaultAuthProvider
+
+
+def test_default_auth_provider_satisfies_protocol() -> None:
+    p = DefaultAuthProvider()
+    assert isinstance(p, AuthProvider)
+
+
+def test_default_auth_provider_returns_routers() -> None:
+    """DefaultAuthProvider returns CE's existing auth router(s).
+
+    Adapted from plan: CE uses a single composite router at
+    cubebox.api.routes.v1.auth that bundles register/login/me/logout with
+    rate limits, CSRF, and register bootstrap — not fastapi-users' 3-router
+    default. The contract is `list[APIRouter]`; count is an implementation
+    detail.
+    """
+    p = DefaultAuthProvider()
+    routers = p.get_auth_routers()
+    assert isinstance(routers, list)
+    assert len(routers) >= 1
+    assert all(isinstance(r, APIRouter) for r in routers)

--- a/backend/tests/plugins/test_default_permissions.py
+++ b/backend/tests/plugins/test_default_permissions.py
@@ -1,0 +1,56 @@
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from cubebox.models import Role
+from cubebox.plugins import PermissionChecker, PermissionResource
+from cubebox.plugins.defaults.permissions import DefaultPermissionChecker
+
+
+def test_default_permission_checker_satisfies_protocol() -> None:
+    assert isinstance(DefaultPermissionChecker(), PermissionChecker)
+
+
+@pytest.mark.asyncio
+async def test_admin_access_grants_admin_role() -> None:
+    repo = AsyncMock()
+    repo.get_role = AsyncMock(return_value=Role.ADMIN)
+    checker = DefaultPermissionChecker(membership_repo_factory=lambda _s: repo)
+    user = MagicMock(id=str(uuid4()))
+    ws_id = uuid4()
+    res = PermissionResource(type="workspace", id=ws_id, workspace_id=ws_id)
+    assert await checker.check(user, "admin_access", res) is True
+
+
+@pytest.mark.asyncio
+async def test_admin_access_denies_member_role() -> None:
+    repo = AsyncMock()
+    repo.get_role = AsyncMock(return_value=Role.MEMBER)
+    checker = DefaultPermissionChecker(membership_repo_factory=lambda _s: repo)
+    user = MagicMock(id=str(uuid4()))
+    ws_id = uuid4()
+    res = PermissionResource(type="workspace", id=ws_id, workspace_id=ws_id)
+    assert await checker.check(user, "admin_access", res) is False
+
+
+@pytest.mark.asyncio
+async def test_member_access_grants_admin_or_member() -> None:
+    repo = AsyncMock()
+    repo.get_role = AsyncMock(return_value=Role.MEMBER)
+    checker = DefaultPermissionChecker(membership_repo_factory=lambda _s: repo)
+    user = MagicMock(id=str(uuid4()))
+    ws_id = uuid4()
+    res = PermissionResource(type="workspace", id=ws_id, workspace_id=ws_id)
+    assert await checker.check(user, "member_access", res) is True
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_denies() -> None:
+    repo = AsyncMock()
+    repo.get_role = AsyncMock(return_value=Role.ADMIN)
+    checker = DefaultPermissionChecker(membership_repo_factory=lambda _s: repo)
+    user = MagicMock(id=str(uuid4()))
+    ws_id = uuid4()
+    res = PermissionResource(type="workspace", id=ws_id, workspace_id=ws_id)
+    assert await checker.check(user, "delete_workspace", res) is False

--- a/backend/tests/plugins/test_protocols.py
+++ b/backend/tests/plugins/test_protocols.py
@@ -4,11 +4,16 @@ from uuid import uuid4
 from cubebox.plugins.protocols import (
     CUBEBOX_PLUGIN_API_VERSION,
     AdminNavItem,
+    AdminPanelExtension,
     AuditEvent,
+    AuditSink,
+    AuthProvider,
+    PermissionChecker,
     PermissionResource,
     PluginManifest,
     SyncResult,
     SyncSchedule,
+    UserDirectorySyncer,
 )
 
 
@@ -85,3 +90,59 @@ def test_sync_result_defaults_to_zero_counts() -> None:
 def test_sync_schedule_allows_none_for_on_demand() -> None:
     s = SyncSchedule(interval_seconds=None)
     assert s.interval_seconds is None
+
+
+class _SatisfiesAuthProvider:
+    async def authenticate(self, request):  # type: ignore[no-untyped-def]
+        return None
+
+    def get_auth_routers(self):  # type: ignore[no-untyped-def]
+        return []
+
+
+class _SatisfiesPermissionChecker:
+    async def check(self, user, action, resource):  # type: ignore[no-untyped-def]
+        return False
+
+
+class _SatisfiesAuditSink:
+    async def record(self, event):  # type: ignore[no-untyped-def]
+        return None
+
+
+class _SatisfiesUserDirectorySyncer:
+    async def sync(self):  # type: ignore[no-untyped-def]
+        return SyncResult(added=0, updated=0, removed=0, errors=[])
+
+    def get_schedule(self):  # type: ignore[no-untyped-def]
+        return SyncSchedule(interval_seconds=None)
+
+
+class _SatisfiesAdminPanelExtension:
+    def get_router(self):  # type: ignore[no-untyped-def]
+        return None
+
+    def get_nav_items(self):  # type: ignore[no-untyped-def]
+        return []
+
+    def get_static_path(self):  # type: ignore[no-untyped-def]
+        return None
+
+
+def test_protocols_are_runtime_checkable() -> None:
+    assert isinstance(_SatisfiesAuthProvider(), AuthProvider)
+    assert isinstance(_SatisfiesPermissionChecker(), PermissionChecker)
+    assert isinstance(_SatisfiesAuditSink(), AuditSink)
+    assert isinstance(_SatisfiesUserDirectorySyncer(), UserDirectorySyncer)
+    assert isinstance(_SatisfiesAdminPanelExtension(), AdminPanelExtension)
+
+
+class _MissingMethod:
+    """Doesn't satisfy AuthProvider — only has authenticate, no get_auth_routers."""
+
+    async def authenticate(self, request):  # type: ignore[no-untyped-def]
+        return None
+
+
+def test_protocol_rejects_incomplete_impl() -> None:
+    assert not isinstance(_MissingMethod(), AuthProvider)

--- a/backend/tests/plugins/test_protocols.py
+++ b/backend/tests/plugins/test_protocols.py
@@ -1,0 +1,19 @@
+from cubebox.plugins.protocols import CUBEBOX_PLUGIN_API_VERSION, PluginManifest
+
+
+def test_plugin_manifest_constructs_with_required_fields() -> None:
+    m = PluginManifest(api_version=1, name="test-plugin", version="0.1.0")
+    assert m.api_version == 1
+    assert m.name == "test-plugin"
+    assert m.version == "0.1.0"
+    assert m.description == ""
+
+
+def test_plugin_manifest_accepts_description() -> None:
+    m = PluginManifest(api_version=1, name="x", version="0.1.0", description="Hello")
+    assert m.description == "Hello"
+
+
+def test_api_version_constant_is_int_one() -> None:
+    assert CUBEBOX_PLUGIN_API_VERSION == 1
+    assert isinstance(CUBEBOX_PLUGIN_API_VERSION, int)

--- a/backend/tests/plugins/test_protocols.py
+++ b/backend/tests/plugins/test_protocols.py
@@ -1,4 +1,15 @@
-from cubebox.plugins.protocols import CUBEBOX_PLUGIN_API_VERSION, PluginManifest
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from cubebox.plugins.protocols import (
+    CUBEBOX_PLUGIN_API_VERSION,
+    AdminNavItem,
+    AuditEvent,
+    PermissionResource,
+    PluginManifest,
+    SyncResult,
+    SyncSchedule,
+)
 
 
 def test_plugin_manifest_constructs_with_required_fields() -> None:
@@ -17,3 +28,60 @@ def test_plugin_manifest_accepts_description() -> None:
 def test_api_version_constant_is_int_one() -> None:
     assert CUBEBOX_PLUGIN_API_VERSION == 1
     assert isinstance(CUBEBOX_PLUGIN_API_VERSION, int)
+
+
+def test_permission_resource_minimal() -> None:
+    r = PermissionResource(type="workspace", id=None)
+    assert r.type == "workspace"
+    assert r.id is None
+    assert r.org_id is None
+    assert r.workspace_id is None
+
+
+def test_permission_resource_full() -> None:
+    ws_id = uuid4()
+    org_id = uuid4()
+    r = PermissionResource(type="workspace", id=ws_id, org_id=org_id, workspace_id=ws_id)
+    assert r.workspace_id == ws_id
+    assert r.org_id == org_id
+
+
+def test_audit_event_constructs() -> None:
+    ev = AuditEvent(
+        timestamp=datetime.now(UTC),
+        user_id=uuid4(),
+        org_id=uuid4(),
+        workspace_id=None,
+        action="auth.login",
+        target_type=None,
+        target_id=None,
+        ip="127.0.0.1",
+        user_agent="pytest",
+        metadata={"foo": "bar"},
+    )
+    assert ev.action == "auth.login"
+    assert ev.metadata == {"foo": "bar"}
+
+
+def test_admin_nav_item_constructs() -> None:
+    item = AdminNavItem(
+        id="billing",
+        label="Billing",
+        icon="dollar",
+        section="settings",
+        order=10,
+        url_path="billing/usage",
+    )
+    assert item.id == "billing"
+    assert item.section == "settings"
+
+
+def test_sync_result_defaults_to_zero_counts() -> None:
+    r = SyncResult(added=0, updated=0, removed=0, errors=[])
+    assert r.added == 0
+    assert r.errors == []
+
+
+def test_sync_schedule_allows_none_for_on_demand() -> None:
+    s = SyncSchedule(interval_seconds=None)
+    assert s.interval_seconds is None

--- a/backend/tests/plugins/test_registry_getters.py
+++ b/backend/tests/plugins/test_registry_getters.py
@@ -1,0 +1,54 @@
+import pytest
+
+from cubebox.plugins import (
+    AdminPanelExtension,
+    AuditSink,
+    AuthProvider,
+    PermissionChecker,
+)
+from cubebox.plugins.registry import PluginRegistry
+
+
+@pytest.mark.asyncio
+async def test_get_auth_provider_falls_back_to_default() -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    assert isinstance(reg.get_auth_provider(), AuthProvider)
+
+
+@pytest.mark.asyncio
+async def test_get_permission_checker_falls_back_to_default() -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    assert isinstance(reg.get_permission_checker(), PermissionChecker)
+
+
+@pytest.mark.asyncio
+async def test_get_audit_sinks_returns_at_least_default() -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    sinks = reg.get_audit_sinks()
+    assert len(sinks) >= 1
+    assert all(isinstance(s, AuditSink) for s in sinks)
+
+
+@pytest.mark.asyncio
+async def test_get_admin_panel_extensions_empty_in_ce() -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    exts = reg.get_admin_panel_extensions()
+    # CE-only: only the default returning empty everything
+    assert all(isinstance(e, AdminPanelExtension) for e in exts)
+
+
+@pytest.mark.asyncio
+async def test_get_user_directory_syncers_empty_in_ce() -> None:
+    reg = PluginRegistry()
+    await reg.discover()
+    reg.bind_defaults()
+    syncers = reg.get_user_directory_syncers()
+    assert syncers == []  # No CE default for syncer

--- a/backend/tests/plugins/test_registry_manifest.py
+++ b/backend/tests/plugins/test_registry_manifest.py
@@ -1,0 +1,72 @@
+"""PluginRegistry manifest discovery + version validation."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cubebox.plugins.protocols import CUBEBOX_PLUGIN_API_VERSION, PluginManifest
+from cubebox.plugins.registry import PluginRegistry
+
+
+def _ep(name: str, value, group: str = "cubebox.plugin_manifest"):
+    """Build a fake importlib.metadata.EntryPoint mock that load() returns `value`."""
+    m = MagicMock()
+    m.name = name
+    m.group = group
+    m.value = f"<fake>:{name}"
+    m.load.return_value = value
+    return m
+
+
+@pytest.mark.asyncio
+async def test_no_external_manifests_uses_defaults_only() -> None:
+    reg = PluginRegistry()
+    with patch("cubebox.plugins.registry.importlib.metadata.entry_points") as mock_eps:
+        mock_eps.return_value = []
+        await reg.discover()
+    # No external manifests → registry has no plugins beyond defaults.
+    assert reg._manifests == {}
+
+
+@pytest.mark.asyncio
+async def test_valid_manifest_is_registered() -> None:
+    manifest = PluginManifest(api_version=CUBEBOX_PLUGIN_API_VERSION, name="ee", version="0.1.0")
+    reg = PluginRegistry()
+    with patch("cubebox.plugins.registry.importlib.metadata.entry_points") as mock_eps:
+        mock_eps.side_effect = lambda group: (
+            [_ep("main", manifest)] if group == "cubebox.plugin_manifest" else []
+        )
+        await reg.discover()
+    assert "ee" in reg._manifests
+    assert reg._manifests["ee"].version == "0.1.0"
+
+
+@pytest.mark.asyncio
+async def test_version_mismatch_raises() -> None:
+    bad_manifest = PluginManifest(api_version=999, name="ee", version="0.1.0")
+    reg = PluginRegistry()
+    with patch("cubebox.plugins.registry.importlib.metadata.entry_points") as mock_eps:
+        mock_eps.side_effect = lambda group: (
+            [_ep("main", bad_manifest)] if group == "cubebox.plugin_manifest" else []
+        )
+        with pytest.raises(RuntimeError, match="api_version"):
+            await reg.discover()
+
+
+@pytest.mark.asyncio
+async def test_missing_manifest_for_plugin_with_entry_point_raises() -> None:
+    """A wheel registers an AuthProvider but no plugin_manifest → reject."""
+    fake_provider_cls = MagicMock()
+    reg = PluginRegistry()
+    with patch("cubebox.plugins.registry.importlib.metadata.entry_points") as mock_eps:
+
+        def by_group(group):
+            if group == "cubebox.auth_provider":
+                ep = _ep("rogue", fake_provider_cls, group)
+                ep.dist = MagicMock(name="rogue-pkg")
+                return [ep]
+            return []
+
+        mock_eps.side_effect = by_group
+        with pytest.raises(RuntimeError, match="missing.*manifest"):
+            await reg.discover()

--- a/backend/tests/plugins/test_registry_plural.py
+++ b/backend/tests/plugins/test_registry_plural.py
@@ -1,0 +1,62 @@
+from cubebox.plugins.registry import GROUP_AUDIT, PluginRegistry
+
+
+class _StubSink:
+    name = "stub"
+
+    async def record(self, event):  # type: ignore[no-untyped-def]
+        return None
+
+
+class _StubSink2:
+    name = "stub2"
+
+    async def record(self, event):  # type: ignore[no-untyped-def]
+        return None
+
+
+def _seed(reg: PluginRegistry, candidates: dict[str, type]) -> None:
+    reg._candidates[GROUP_AUDIT] = dict(candidates)
+
+
+def test_plural_with_no_external_returns_only_default() -> None:
+    reg = PluginRegistry()
+    default = _StubSink()
+    out = reg.resolve_plural(GROUP_AUDIT, default=default, disabled=[])
+    assert out == [default]
+
+
+def test_plural_with_one_external_returns_default_plus_external() -> None:
+    reg = PluginRegistry()
+    default = _StubSink()
+    _seed(reg, {"siem": _StubSink2})
+    out = reg.resolve_plural(GROUP_AUDIT, default=default, disabled=[])
+    assert default in out
+    assert any(isinstance(o, _StubSink2) for o in out)
+    assert len(out) == 2
+
+
+def test_plural_disabled_builtin_excludes_default() -> None:
+    reg = PluginRegistry()
+    default = _StubSink()
+    _seed(reg, {"siem": _StubSink2})
+    out = reg.resolve_plural(GROUP_AUDIT, default=default, disabled=["builtin"])
+    assert default not in out
+    assert any(isinstance(o, _StubSink2) for o in out)
+    assert len(out) == 1
+
+
+def test_plural_disabled_external_excludes_it() -> None:
+    reg = PluginRegistry()
+    default = _StubSink()
+    _seed(reg, {"siem": _StubSink2, "other": _StubSink})
+    out = reg.resolve_plural(GROUP_AUDIT, default=default, disabled=["siem"])
+    assert default in out
+    assert not any(isinstance(o, _StubSink2) for o in out)
+
+
+def test_plural_default_can_be_none() -> None:
+    """For multi-instance protocols without a CE default (e.g. UserDirectorySyncer)."""
+    reg = PluginRegistry()
+    out = reg.resolve_plural(GROUP_AUDIT, default=None, disabled=[])
+    assert out == []

--- a/backend/tests/plugins/test_registry_singular.py
+++ b/backend/tests/plugins/test_registry_singular.py
@@ -1,0 +1,72 @@
+import pytest
+
+from cubebox.plugins.protocols import CUBEBOX_PLUGIN_API_VERSION, PluginManifest
+from cubebox.plugins.registry import GROUP_AUTH, PluginRegistry
+
+
+class _StubAuthProvider:
+    name: str
+
+    def __init__(self, name="external"):
+        self.name = name
+
+    async def authenticate(self, request):  # type: ignore[no-untyped-def]
+        return None
+
+    def get_auth_routers(self):  # type: ignore[no-untyped-def]
+        return []
+
+
+def _seed_registry(reg: PluginRegistry, candidates: dict[str, type]) -> None:
+    reg._candidates[GROUP_AUTH] = dict(candidates)
+    reg._manifests = {
+        "ee": PluginManifest(api_version=CUBEBOX_PLUGIN_API_VERSION, name="ee", version="0.1.0")
+    }
+
+
+def test_zero_external_uses_default() -> None:
+    reg = PluginRegistry()
+    default = _StubAuthProvider("default")
+    chosen = reg.resolve_singular(GROUP_AUTH, default=default, selected=None)
+    assert chosen is default
+
+
+def test_one_external_replaces_default() -> None:
+    reg = PluginRegistry()
+    default = _StubAuthProvider("default")
+    _seed_registry(reg, {"saml": _StubAuthProvider})
+    chosen = reg.resolve_singular(GROUP_AUTH, default=default, selected=None)
+    assert isinstance(chosen, _StubAuthProvider)
+    assert chosen is not default
+
+
+def test_multiple_external_with_no_selected_raises() -> None:
+    reg = PluginRegistry()
+    default = _StubAuthProvider("default")
+    _seed_registry(reg, {"saml": _StubAuthProvider, "oidc": _StubAuthProvider})
+    with pytest.raises(RuntimeError, match="multiple"):
+        reg.resolve_singular(GROUP_AUTH, default=default, selected=None)
+
+
+def test_selected_builtin_forces_default() -> None:
+    reg = PluginRegistry()
+    default = _StubAuthProvider("default")
+    _seed_registry(reg, {"saml": _StubAuthProvider})
+    chosen = reg.resolve_singular(GROUP_AUTH, default=default, selected="builtin")
+    assert chosen is default
+
+
+def test_selected_by_name_picks_specific() -> None:
+    reg = PluginRegistry()
+    default = _StubAuthProvider("default")
+    _seed_registry(reg, {"saml": _StubAuthProvider, "oidc": _StubAuthProvider})
+    chosen = reg.resolve_singular(GROUP_AUTH, default=default, selected="saml")
+    assert isinstance(chosen, _StubAuthProvider)
+
+
+def test_selected_unknown_name_raises() -> None:
+    reg = PluginRegistry()
+    default = _StubAuthProvider("default")
+    _seed_registry(reg, {"saml": _StubAuthProvider})
+    with pytest.raises(RuntimeError, match="not registered"):
+        reg.resolve_singular(GROUP_AUTH, default=default, selected="nonexistent")

--- a/backend/tests/unit/test_user_manager_audit.py
+++ b/backend/tests/unit/test_user_manager_audit.py
@@ -1,0 +1,28 @@
+"""UserManager emits audit events on login and register."""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from cubebox.auth.users import UserManager
+from cubebox.plugins import get_registry
+
+
+@pytest.mark.asyncio
+async def test_on_after_login_emits_audit_event() -> None:
+    sink = AsyncMock()
+    reg = get_registry()
+    reg._audit_sinks = [sink]
+
+    user = MagicMock(id=str(uuid4()), email="a@b.com")
+    request = MagicMock(client=MagicMock(host="1.2.3.4"), headers={"user-agent": "test"})
+    user_db = MagicMock()
+    mgr = UserManager(user_db)
+
+    await mgr.on_after_login(user, request)
+    sink.record.assert_awaited_once()
+    ev = sink.record.call_args.args[0]
+    assert ev.action == "auth.login"
+    assert ev.ip == "1.2.3.4"
+    assert ev.user_agent == "test"


### PR DESCRIPTION
## Summary

Implements **M0 of the CE/EE plugin architecture** per `docs/superpowers/specs/2026-04-22-ce-ee-plugin-architecture-design.md` and plan `docs/superpowers/plans/2026-04-23-m0-ce-ee-plugin-architecture.md`.

- Freezes 5 `Protocol` extension interfaces: `AuthProvider` / `PermissionChecker` / `AuditSink` / `UserDirectorySyncer` / `AdminPanelExtension`
- Adds `pip entry_points`-based discovery with mandatory `PluginManifest` + API-version validation and a reserved `"builtin"` sentinel
- Integrates `AuthProvider` + `PermissionChecker` into existing CE auth flows; hooks `audit_log` into 3 call sites (login, register, invite creation); adds `AdminPanelExtension` startup scan + `/api/v1/admin/_extensions/manifest` endpoint
- All existing auth / RBAC E2E tests remain green; 11-assertion Layer 1 contract test suite + fresh plugin-architecture E2E added

## What's in the package

**New `cubebox.plugins` package:**
- `protocols.py` — 5 `@runtime_checkable` Protocols + 5 dataclasses (`PluginManifest`, `PermissionResource`, `AuditEvent`, `AdminNavItem`, `SyncResult`, `SyncSchedule`) + `CUBEBOX_PLUGIN_API_VERSION = 1`
- `registry.py` — `PluginRegistry` with `discover()`, `resolve_singular(selected=...)`, `resolve_plural(disabled=...)`, `bind_defaults(config=...)` + module-level singleton
- `audit.py` — `audit_log()` helper that fans out `AuditEvent` to every registered sink
- `defaults/` — CE defaults for 4 Protocols (`AuthProvider` wraps existing CE auth router; `PermissionChecker` wraps `MembershipRepository.get_role`; `AuditSink` logs via stdlib `cubebox.audit`; `AdminPanelExtension` empty)

**CE integration:**
- `auth/dependencies.py` — `require_role` delegates to `PermissionChecker.check`; `current_active_user` delegates to `AuthProvider.authenticate`
- `api/app.py` — lifespan discovers + binds registry, mounts `AuthProvider.get_auth_routers()` and `AdminPanelExtension` routers/static
- `auth/users.py` — `UserManager.on_after_login` + `on_after_register` emit audit events
- `api/routes/v1/workspaces.py` — `create_invite` emits `workspace.invite_created` audit event
- `api/routes/v1/admin_extensions.py` — new manifest endpoint

**Config:**
- `plugins.*` section added to `config.yaml` / `config.development.yaml` / `config.test.yaml` (null/[] defaults — CE-only deployments require no config)

**Tests (70 new passing):**
- `tests/plugins/` — 42 unit tests (Protocols, dataclasses, registry, defaults, audit helper)
- `tests/plugins/test_contracts.py` — 11 Layer 1 contract tests exercising the in-tree `fake_plugin` fixture via `uv pip install/uninstall`
- `tests/e2e/test_admin_extensions.py` + `tests/e2e/test_plugin_architecture_e2e.py` — end-to-end coverage through lifespan
- `tests/unit/test_user_manager_audit.py` — unit test for `on_after_login` audit emission

**CI:**
- `test-ee-compat` GitHub Actions job runs `tests/plugins/test_contracts.py`
- `test-ee-compat-cross-repo` placeholder (disabled via `if: false`) for future `cubebox-ee` integration

## Deviations from plan (documented in commit messages)

- **Task 8** — `DefaultAuthProvider.get_auth_routers()` returns CE's existing composite router at `cubebox.api.routes.v1.auth`, NOT fastapi-users' default 3-router stack. Preserves existing rate limits (slowapi), CSRF cookie issuance, and Org/Workspace/Membership register bootstrap.
- **Task 13** — YAML-only (project uses pure dynaconf, not pydantic `BaseSettings`).
- **Task 15 (reworked)** — `AuthProvider.authenticate(request)` Protocol stays DB-agnostic. CE default opens its own session inline via `async_session_maker`; the Protocol doesn't leak `AsyncSession` to EE plugin contracts.
- **Task 16 regression fix** — sync `TestClient` fixture in `tests/e2e/conftest.py` is now wrapped in a `with` block to trigger FastAPI lifespan (auth routers are no longer statically mounted in `create_app`).
- **Task 22** — contract tests add `site.addsitedir()` + `importlib.metadata` cache flush after subprocess installs, since `.pth` files are only processed at interpreter startup.
- **Task 24** — adapted to real API surface (registry accessor methods, real cookie name `cubebox_auth`, real login path `/api/v1/auth/login`, real admin-only route `POST /api/v1/workspaces/{ws}/invites`, existing `admin_client` / `member_client` / `unauthenticated_memory_client` fixtures).

## Test plan

- [x] `tests/plugins/` — 53/53 pass (42 unit + 11 contract)
- [x] `tests/e2e/test_auth.py` + `test_rbac.py` + `test_admin_extensions.py` + `test_plugin_architecture_e2e.py` — 19/19 pass
- [x] `tests/unit/test_user_manager_audit.py` — 1/1 pass
- [x] Full suite: 262 passed, 13 pre-existing failures (LLM/sandbox/dynaconf env — identical to pre-M0 baseline on main)
- [x] `ruff check`, `ruff format --check`, `mypy cubebox/` all clean
- [ ] CI: `backend-check` + `test-ee-compat` + `e2e` all green
- [ ] Manual smoke: `uv run python main.py` starts; `GET /api/v1/admin/_extensions/manifest` with admin cookie returns `[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)