### PR TITLE
fix(resume): drop duplicate history + clamp XREAD BLOCK under socket timeout

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -206,7 +206,11 @@ default:
     # on how long an in-flight run can stay active (active-run key TTL is
     # heartbeated up to this on every event append).
     run_event_ttl_seconds: 43200 # 12h
-    run_stream_block_ms: 15000
+    # XREAD BLOCK time. MUST be strictly less than redis.socket_timeout_seconds
+    # (in ms) — redis-py's socket_timeout applies to blocking commands too, and
+    # a BLOCK longer than the socket timeout raises TimeoutError mid-read.
+    # Doubles as the SSE heartbeat cadence when there are no events.
+    run_stream_block_ms: 5000
     # DoS safety net only: XADD ~ MAXLEN. Trimming is silent data loss
     # (breaks replay / resume), so size this well above any realistic run.
     # Normal runs should be orders of magnitude smaller.

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -212,7 +212,13 @@ def _build_run_streaming_response(
 
     from cubebox.config import config
 
-    block_ms = config.get("streaming.run_stream_block_ms", 15000)
+    # Clamp BLOCK to stay strictly under the Redis socket_timeout. redis-py
+    # applies socket_timeout to blocking commands, so a BLOCK >= socket_timeout
+    # causes XREAD to raise TimeoutError mid-read even though Redis is healthy.
+    socket_timeout_s = config.get("redis.socket_timeout_seconds", 10)
+    configured_block_ms = config.get("streaming.run_stream_block_ms", 5000)
+    safe_block_ms = max(1000, int(socket_timeout_s * 1000) - 2000)
+    block_ms = min(configured_block_ms, safe_block_ms)
     last_event_id = raw_request.headers.get("last-event-id")
 
     async def event_generator() -> AsyncIterator[str]:

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -215,9 +215,12 @@ def _build_run_streaming_response(
     # Clamp BLOCK to stay strictly under the Redis socket_timeout. redis-py
     # applies socket_timeout to blocking commands, so a BLOCK >= socket_timeout
     # causes XREAD to raise TimeoutError mid-read even though Redis is healthy.
+    # Use 80% of the socket timeout so the invariant holds for any socket
+    # timeout (a fixed subtraction would underflow for low timeouts and a
+    # 1000ms floor would equal a 1s socket_timeout — both regress to TimeoutError).
     socket_timeout_s = config.get("redis.socket_timeout_seconds", 10)
     configured_block_ms = config.get("streaming.run_stream_block_ms", 5000)
-    safe_block_ms = max(1000, int(socket_timeout_s * 1000) - 2000)
+    safe_block_ms = max(100, int(socket_timeout_s * 1000 * 0.8))
     block_ms = min(configured_block_ms, safe_block_ms)
     last_event_id = raw_request.headers.get("last-event-id")
 
@@ -548,6 +551,10 @@ async def get_conversation_bootstrap(
             "status": active_run.status,
             "user_message": active_run.user_message,
             "last_event_id": active_run.last_event_id,
+            # Disambiguates the active run's user message from a prior turn
+            # with identical content: any history user message older than
+            # this timestamp belongs to a completed turn, not this run.
+            "started_at": active_run.started_at,
         }
 
     return {

--- a/frontend/packages/core/src/api/runStreams.ts
+++ b/frontend/packages/core/src/api/runStreams.ts
@@ -6,6 +6,11 @@ export interface ActiveRunBootstrap {
   status: string
   user_message?: string | null
   last_event_id?: string | null
+  // ISO timestamp recorded when the run was claimed in Redis. Used by the
+  // frontend to tell the active run's user message apart from a prior turn
+  // with identical content (any history user message older than this
+  // belongs to a completed turn, not the active one).
+  started_at?: string | null
 }
 
 export interface ConversationBootstrap {

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -161,10 +161,20 @@ function buildPendingUserMessage(runId: string, content: string): Message {
   }
 }
 
-function ensurePendingUserMessage(messages: Message[], runId: string, content: string): Message[] {
-  const lastMessage = messages[messages.length - 1]
-  if (lastMessage?.role === 'user' && lastMessage.content === content) {
-    return messages
+/**
+ * History returned by `/bootstrap` may contain checkpoints from the active run
+ * (e.g. an AIMessage with tool calls saved between LangGraph nodes). The stream
+ * replay re-emits all of that content, so anything after the active run's user
+ * message would render twice. Trim history to end at that user message — or
+ * append a pending placeholder if the run is so early that the user message
+ * has not been checkpointed yet.
+ */
+function trimHistoryForActiveRun(messages: Message[], runId: string, content: string): Message[] {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]
+    if (msg.role !== 'user') continue
+    if (msg.content === content) return messages.slice(0, i + 1)
+    break
   }
   return [...messages, buildPendingUserMessage(runId, content)]
 }
@@ -594,7 +604,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
 
       let messages = bootstrap.messages ?? []
       if (bootstrap.active_run?.user_message) {
-        messages = ensurePendingUserMessage(
+        messages = trimHistoryForActiveRun(
           messages,
           bootstrap.active_run.run_id,
           bootstrap.active_run.user_message,

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -168,11 +168,31 @@ function buildPendingUserMessage(runId: string, content: string): Message {
  * message would render twice. Trim history to end at that user message — or
  * append a pending placeholder if the run is so early that the user message
  * has not been checkpointed yet.
+ *
+ * `startedAt` disambiguates a same-content user message from a prior turn:
+ * only consider history entries created at or after the run was claimed.
+ * Without it, a repeated prompt + a refresh during the brief window before
+ * the new user message lands in the checkpoint would bind to the prior
+ * turn's user message and silently drop the previous assistant reply.
  */
-function trimHistoryForActiveRun(messages: Message[], runId: string, content: string): Message[] {
+function trimHistoryForActiveRun(
+  messages: Message[],
+  runId: string,
+  content: string,
+  startedAt: string | null,
+): Message[] {
+  const startedAtMs = startedAt ? Date.parse(startedAt) : NaN
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i]
     if (msg.role !== 'user') continue
+    const msgMs = msg.created_at ? Date.parse(msg.created_at) : NaN
+    if (Number.isFinite(startedAtMs) && Number.isFinite(msgMs) && msgMs < startedAtMs) {
+      // This user message predates the active run — it belongs to a prior
+      // completed turn. Keep walking back? No: every earlier user message
+      // is also older. Bail out and treat the active run's user message
+      // as not-yet-checkpointed.
+      break
+    }
     if (msg.content === content) return messages.slice(0, i + 1)
     break
   }
@@ -608,6 +628,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
           messages,
           bootstrap.active_run.run_id,
           bootstrap.active_run.user_message,
+          bootstrap.active_run.started_at ?? null,
         )
       }
 

--- a/frontend/packages/web/__tests__/hooks/useMessages.test.ts
+++ b/frontend/packages/web/__tests__/hooks/useMessages.test.ts
@@ -231,6 +231,7 @@ describe('messageStore.send', () => {
             run_id: 'run-1',
             status: 'running',
             user_message: 'resume me',
+            started_at: '2026-04-25T00:00:00Z',
           },
         }),
         { headers: { 'content-type': 'application/json' } },
@@ -255,6 +256,65 @@ describe('messageStore.send', () => {
     // Partial assistant checkpoint must be trimmed — the stream replay will
     // re-emit it, so leaving it in history would render the response twice.
     expect(msgs.some((m) => m.role === 'assistant')).toBe(false)
+  })
+
+  it('does not bind to a prior turn when the same prompt is repeated and the new user message is not yet checkpointed', async () => {
+    // Reproduces the edge case where a user resends an identical prompt and
+    // refreshes during the brief window before LangGraph has checkpointed
+    // the new user message. The active run's started_at must steer the trim
+    // away from the prior turn's user message; otherwise the previous
+    // assistant reply gets dropped from the rendered history.
+    mockClient.get.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          messages: [
+            {
+              id: 'user-1',
+              role: 'user',
+              content: 'hi',
+              created_at: '2026-04-25T00:00:00Z',
+            },
+            {
+              id: 'assistant-1',
+              role: 'assistant',
+              content: 'hello',
+              created_at: '2026-04-25T00:00:01Z',
+            },
+          ],
+          total: 2,
+          active_run: {
+            run_id: 'run-2',
+            status: 'running',
+            user_message: 'hi',
+            started_at: '2026-04-25T00:00:05Z',
+          },
+        }),
+        { headers: { 'content-type': 'application/json' } },
+      ),
+    )
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('socket closed'))),
+    )
+
+    await act(async () => {
+      await useMessageStore.getState().loadMessages(mockClient as any, CONV_ID)
+      await Promise.resolve()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    const msgs = useMessageStore.getState().messages[CONV_ID] ?? []
+    // Prior turn must be preserved.
+    expect(msgs.some((m) => m.id === 'user-1')).toBe(true)
+    expect(msgs.some((m) => m.id === 'assistant-1')).toBe(true)
+    // A pending placeholder is appended for the active run since its user
+    // message has not been checkpointed yet.
+    expect(msgs[msgs.length - 1]).toMatchObject({
+      id: 'pending-run-2',
+      role: 'user',
+      content: 'hi',
+    })
   })
 
   it('renders todos from write_todos batch payload', async () => {

--- a/frontend/packages/web/__tests__/hooks/useMessages.test.ts
+++ b/frontend/packages/web/__tests__/hooks/useMessages.test.ts
@@ -205,6 +205,58 @@ describe('messageStore.send', () => {
     expect(state.error).toBe('socket closed')
   })
 
+  it('does not duplicate the user message when bootstrap history already contains it', async () => {
+    mockClient.get.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          messages: [
+            {
+              id: 'user-1',
+              role: 'user',
+              content: 'resume me',
+              created_at: '2026-04-25T00:00:00Z',
+            },
+            {
+              id: 'assistant-1',
+              role: 'assistant',
+              content: 'partial...',
+              tool_calls: [
+                { name: 'read_file', arguments: {}, tool_call_id: 'tc-1', started_at: null },
+              ],
+              created_at: '2026-04-25T00:00:01Z',
+            },
+          ],
+          total: 2,
+          active_run: {
+            run_id: 'run-1',
+            status: 'running',
+            user_message: 'resume me',
+          },
+        }),
+        { headers: { 'content-type': 'application/json' } },
+      ),
+    )
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('socket closed'))),
+    )
+
+    await act(async () => {
+      await useMessageStore.getState().loadMessages(mockClient as any, CONV_ID)
+      await Promise.resolve()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    const msgs = useMessageStore.getState().messages[CONV_ID] ?? []
+    const userMsgs = msgs.filter((m) => m.role === 'user')
+    expect(userMsgs).toHaveLength(1)
+    expect(userMsgs[0]).toMatchObject({ id: 'user-1', content: 'resume me' })
+    // Partial assistant checkpoint must be trimmed — the stream replay will
+    // re-emit it, so leaving it in history would render the response twice.
+    expect(msgs.some((m) => m.role === 'assistant')).toBe(false)
+  })
+
   it('renders todos from write_todos batch payload', async () => {
     vi.stubGlobal(
       'fetch',


### PR DESCRIPTION
## Summary

- **Frontend:** trim conversation history to end at the active run's user message during bootstrap; the SSE replay owns everything after it. Removes the duplicate user prompt and duplicate assistant response that appeared after a refresh mid-run.
- **Backend:** clamp the SSE long-poll `XREAD BLOCK` well below `redis.socket_timeout_seconds` (and lower the configured default from 15s → 5s). redis-py applies `socket_timeout` to blocking commands, so a 15s BLOCK on a 10s socket_timeout raised `TimeoutError` mid-read even though Redis was healthy.

## Why

Refresh-mid-run rendered the conversation twice:
1. LangGraph saves intermediate checkpoints between graph nodes, so `/bootstrap` returned `[user, partial_assistant, …]`. The old `ensurePendingUserMessage` only checked the last message, didn't see the user message already in history, and appended a `pending-${runId}` duplicate.
2. After fixing (1), the partial assistant from the checkpoint stayed visible while the SSE replay also re-emitted the same content, so `finalizeCompletedStream` produced a second assistant bubble. New helper `trimHistoryForActiveRun` lets the streaming view be the single source of truth for the active run.

Separately, the SSE stream raised `redis.exceptions.TimeoutError: Timeout reading from localhost:6379` whenever the run sat idle long enough for `XREAD BLOCK` to outlast the client's socket timeout. Lowered + clamped the BLOCK so this can't recur (and added a config comment recording the invariant).

## Test plan

- [x] `pnpm --filter web exec vitest run __tests__/hooks/useMessages.test.ts` (added regression: bootstrap with `[user, partial_assistant]` + active_run yields no duplicate user, no leftover partial assistant)
- [x] `uv run pytest tests/unit/test_run_streaming.py` (3 passed)
- [x] `mypy cubebox/api/routes/v1/conversations.py` clean
- [ ] Manual: refresh while a run is mid-LLM-stream → conversation appears once, response continues from where it left off
- [ ] Manual: refresh against a long-idle in-flight run → SSE emits `: heartbeat` every ~5s instead of dying with TimeoutError

🤖 Generated with [Claude Code](https://claude.com/claude-code)