### PR TITLE
feat: graceful restart with drain + stale-run detection

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -63,6 +63,36 @@ make pre-commit-install
 
 Single test file: `uv run pytest tests/e2e/test_agents.py`
 
+### Running E2E tests locally
+
+Local E2E runs use the `development` env (default). The dev env loads:
+
+- `backend/.env` — secret-bearing env vars (`OPENAI_API_KEY`, the
+  `CUBEBOX_E2E_LLM_*` and `CUBEBOX_SANDBOX__*` values that
+  `config.test.yaml` interpolates via dynaconf `@format`)
+- `backend/config.development.local.yaml` — machine-specific overrides
+  (LLM endpoint URL, sandbox domain, etc.)
+
+Both files are gitignored — copy them from a working machine, do NOT
+recreate from scratch. With them in place, `uv run pytest tests/e2e/`
+runs cleanly without exporting any env vars on the command line.
+
+When working from a worktree (`git worktree add ...`), the worktree
+gets a fresh `backend/` without these files. Copy them in before the
+first test run:
+
+```bash
+cp /path/to/main/backend/.env backend/.env
+cp /path/to/main/backend/config.development.local.yaml \
+   backend/config.development.local.yaml
+```
+
+Skipping this step shows up as `DynaconfFormatError: Dynaconf can't
+interpolate variable because 'CUBEBOX_E2E_LLM_*'` at config load, OR
+as quiet `'error' == 'text_delta'` SSE assertion failures inside agent
+tests (the agent crashes mid-stream on lazy interpolation and emits an
+error event instead of normal output).
+
 ## Architecture
 
 **Request flow:** `POST /api/v1/ws/{workspace_id}/conversations/{id}/messages` → `create_cubebox_agent()` → LangGraph `astream(stream_mode="messages", stream_subgraphs=True)` → SSE stream of typed events (`text_delta`, `reasoning`, `tool_call`, `tool_result`, `error`, `done`)

--- a/backend/config.development.yaml
+++ b/backend/config.development.yaml
@@ -8,6 +8,13 @@ development:
   api:
     reload: true
 
+  # Graceful Restart: keep dev reload fast — uvicorn StatReload sends SIGTERM
+  # on every file save, and the prod default of 3600s would block reload for
+  # up to an hour if a chat is in flight. 5s lets clean post-completion
+  # writes finish; anything still running gets cancelled.
+  lifecycle:
+    graceful_drain_timeout_seconds: 5
+
   # Sandbox Configuration for Development
   sandbox:
     enabled: true

--- a/backend/config.test.yaml
+++ b/backend/config.test.yaml
@@ -84,7 +84,12 @@ test:
       poll_interval_seconds: 2
 
   # Graceful Restart: fast test values
+  # NOTE: stale_run_threshold_seconds is intentionally NOT lowered here.
+  # The route-level stale tests plant timestamps 600s in the past and the
+  # unit tests pass an explicit `now=` kwarg, so a tight threshold buys
+  # nothing — but a tight threshold DOES make the playwright chat-flow
+  # test flaky, because CI has occasional >1s gaps between run creation
+  # and stream subscribe. Inherit the prod default (120s) instead.
   lifecycle:
     graceful_drain_timeout_seconds: 5
     dev_double_signal_force_exit: false
-    stale_run_threshold_seconds: 1

--- a/backend/config.test.yaml
+++ b/backend/config.test.yaml
@@ -82,9 +82,3 @@ test:
       timeout_async_minutes: 10
       async_threshold_mb: 3
       poll_interval_seconds: 2
-
-  # Graceful Restart: fast test values
-  lifecycle:
-    graceful_drain_timeout_seconds: 5
-    dev_double_signal_force_exit: false
-    stale_run_threshold_seconds: 1

--- a/backend/config.test.yaml
+++ b/backend/config.test.yaml
@@ -82,3 +82,9 @@ test:
       timeout_async_minutes: 10
       async_threshold_mb: 3
       poll_interval_seconds: 2
+
+  # Graceful Restart: fast test values
+  lifecycle:
+    graceful_drain_timeout_seconds: 5
+    dev_double_signal_force_exit: false
+    stale_run_threshold_seconds: 1

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -249,3 +249,9 @@ default:
       disabled: []
     admin_panel_extension:
       disabled: []
+
+  # Graceful Restart and Lifecycle Configuration
+  lifecycle:
+    graceful_drain_timeout_seconds: 3600
+    dev_double_signal_force_exit: true
+    stale_run_threshold_seconds: 120

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -249,9 +249,3 @@ default:
       disabled: []
     admin_panel_extension:
       disabled: []
-
-  # Graceful Restart and Lifecycle Configuration
-  lifecycle:
-    graceful_drain_timeout_seconds: 3600
-    dev_double_signal_force_exit: true
-    stale_run_threshold_seconds: 120

--- a/backend/cubebox/api/app.py
+++ b/backend/cubebox/api/app.py
@@ -50,9 +50,11 @@ async def lifespan(_app: FastAPI):  # type: ignore
             return
         if force_exit_enabled:
             logger.warning("Second {} received — force exiting", signame)
-            # Schedule cancel_all and exit immediately. We do not block on
-            # cancel_all because the developer pressed Ctrl-C twice
-            # precisely to skip the wait.
+            # Best-effort schedule of cancel_all, then immediate _exit. The
+            # scheduled coroutine almost certainly does NOT run because
+            # os._exit returns synchronously without yielding to the loop.
+            # That is intentional: the developer pressed Ctrl-C twice
+            # precisely to skip the wait. Do not "fix" this by awaiting.
             rm = getattr(_app.state, "run_manager", None)
             if rm is not None:
                 asyncio.ensure_future(rm.cancel_all())

--- a/backend/cubebox/api/app.py
+++ b/backend/cubebox/api/app.py
@@ -210,7 +210,7 @@ async def lifespan(_app: FastAPI):  # type: ignore
     # ==================== Shutdown ====================
     logger.info("Application shutting down")
     if run_manager is not None:
-        await run_manager.shutdown()
+        await run_manager.cancel_all()
     if redis_client is not None:
         await redis_client.aclose()
     if cleanup_task:

--- a/backend/cubebox/api/app.py
+++ b/backend/cubebox/api/app.py
@@ -284,4 +284,8 @@ def create_app(
     app.include_router(artifacts_router, prefix="/api/v1")
     app.include_router(admin_router, prefix="/api/v1")
 
+    from cubebox.api.routes.health import router as health_router
+
+    app.include_router(health_router)
+
     return app

--- a/backend/cubebox/api/app.py
+++ b/backend/cubebox/api/app.py
@@ -29,49 +29,16 @@ async def lifespan(_app: FastAPI):  # type: ignore
     log.init()
     logger.info("Application starting up")
 
-    # Install signal handlers as early as possible so a SIGTERM / SIGINT
-    # arriving during the rest of startup still flips drain mode rather
-    # than killing in-flight runs.
-    import os
-    import signal as _signal
-
-    from cubebox.config import config as _lifecycle_config
-
-    drain_state = _app.state.drain_state
-    loop = asyncio.get_running_loop()
-    force_exit_enabled = _lifecycle_config.get("lifecycle.dev_double_signal_force_exit", True)
-    _signal_seen: dict[str, bool] = {"first": False}
-
-    def _on_signal(signame: str) -> None:
-        if not _signal_seen["first"]:
-            _signal_seen["first"] = True
-            logger.info("{} received — entering drain mode", signame)
-            drain_state.enter_draining()
-            return
-        if force_exit_enabled:
-            logger.warning("Second {} received — force exiting", signame)
-            # Best-effort schedule of cancel_all, then immediate _exit. The
-            # scheduled coroutine almost certainly does NOT run because
-            # os._exit returns synchronously without yielding to the loop.
-            # That is intentional: the developer pressed Ctrl-C twice
-            # precisely to skip the wait. Do not "fix" this by awaiting.
-            rm = getattr(_app.state, "run_manager", None)
-            if rm is not None:
-                asyncio.ensure_future(rm.cancel_all())
-            os._exit(130)
-
-    for sig in (_signal.SIGTERM, _signal.SIGINT):
-        try:
-            loop.add_signal_handler(sig, _on_signal, sig.name)
-        except NotImplementedError:
-            # Non-POSIX (Windows): no graceful drain via signal there, but
-            # the lifespan-shutdown path still drains on uvicorn reload.
-            logger.debug("Signal {} not installable on this platform", sig.name)
-        except RuntimeError as exc:
-            # Off-main-thread (e.g. Starlette TestClient runs lifespan in a
-            # worker thread): signal.set_wakeup_fd refuses. The shutdown
-            # path still drains via lifespan, which is what tests exercise.
-            logger.debug("Signal {} not installable in this thread: {}", sig.name, exc)
+    # NOTE: we deliberately do NOT install signal handlers here. Uvicorn's
+    # own SIGTERM / SIGINT handlers trigger graceful shutdown, which awaits
+    # this lifespan's shutdown phase below. Drain happens there. Installing
+    # our own handlers via loop.add_signal_handler shadowed uvicorn's
+    # handlers and prevented the shutdown sequence from ever firing — the
+    # process would log "entering drain mode" and then sit forever because
+    # uvicorn never learned the signal arrived.
+    #
+    # Double Ctrl-C in dev: uvicorn already handles this natively
+    # (the second SIGINT flips force_exit and tears the server down).
 
     # Discover + bind plugin registry; mount AuthProvider routers.
     from typing import cast
@@ -254,8 +221,8 @@ async def lifespan(_app: FastAPI):  # type: ignore
     # ==================== Shutdown ====================
     logger.info("Application shutting down")
     if run_manager is not None:
-        # Idempotent: if a signal already flipped the state, this is a no-op.
-        # Covers uvicorn reload and other paths that don't deliver a signal.
+        from cubebox.config import config as _lifecycle_config
+
         _app.state.drain_state.enter_draining()
         drain_timeout = _lifecycle_config.get("lifecycle.graceful_drain_timeout_seconds", 3600)
         await run_manager.drain(timeout_seconds=float(drain_timeout))

--- a/backend/cubebox/api/app.py
+++ b/backend/cubebox/api/app.py
@@ -29,6 +29,48 @@ async def lifespan(_app: FastAPI):  # type: ignore
     log.init()
     logger.info("Application starting up")
 
+    # Install signal handlers as early as possible so a SIGTERM / SIGINT
+    # arriving during the rest of startup still flips drain mode rather
+    # than killing in-flight runs.
+    import os
+    import signal as _signal
+
+    from cubebox.config import config as _lifecycle_config
+
+    drain_state = _app.state.drain_state
+    loop = asyncio.get_running_loop()
+    force_exit_enabled = _lifecycle_config.get("lifecycle.dev_double_signal_force_exit", True)
+    _signal_seen: dict[str, bool] = {"first": False}
+
+    def _on_signal(signame: str) -> None:
+        if not _signal_seen["first"]:
+            _signal_seen["first"] = True
+            logger.info("{} received — entering drain mode", signame)
+            drain_state.enter_draining()
+            return
+        if force_exit_enabled:
+            logger.warning("Second {} received — force exiting", signame)
+            # Schedule cancel_all and exit immediately. We do not block on
+            # cancel_all because the developer pressed Ctrl-C twice
+            # precisely to skip the wait.
+            rm = getattr(_app.state, "run_manager", None)
+            if rm is not None:
+                asyncio.ensure_future(rm.cancel_all())
+            os._exit(130)
+
+    for sig in (_signal.SIGTERM, _signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _on_signal, sig.name)
+        except NotImplementedError:
+            # Non-POSIX (Windows): no graceful drain via signal there, but
+            # the lifespan-shutdown path still drains on uvicorn reload.
+            logger.debug("Signal {} not installable on this platform", sig.name)
+        except RuntimeError as exc:
+            # Off-main-thread (e.g. Starlette TestClient runs lifespan in a
+            # worker thread): signal.set_wakeup_fd refuses. The shutdown
+            # path still drains via lifespan, which is what tests exercise.
+            logger.debug("Signal {} not installable in this thread: {}", sig.name, exc)
+
     # Discover + bind plugin registry; mount AuthProvider routers.
     from typing import cast
 
@@ -210,7 +252,11 @@ async def lifespan(_app: FastAPI):  # type: ignore
     # ==================== Shutdown ====================
     logger.info("Application shutting down")
     if run_manager is not None:
-        await run_manager.cancel_all()
+        # Idempotent: if a signal already flipped the state, this is a no-op.
+        # Covers uvicorn reload and other paths that don't deliver a signal.
+        _app.state.drain_state.enter_draining()
+        drain_timeout = _lifecycle_config.get("lifecycle.graceful_drain_timeout_seconds", 3600)
+        await run_manager.drain(timeout_seconds=float(drain_timeout))
     if redis_client is not None:
         await redis_client.aclose()
     if cleanup_task:
@@ -249,15 +295,27 @@ def create_app(
     app.state.sandbox_factory = sandbox_factory
     app.state.redis_factory = redis_factory
 
+    # Drain state must be created before middleware registration so the
+    # DrainMiddleware can capture the same instance the lifespan + signal
+    # handlers will write to (add_middleware runs at construction time,
+    # before the lifespan starts).
+    from cubebox.lifecycle.drain import DrainState
+
+    app.state.drain_state = DrainState()
+
     # Register middleware
     from cubebox.api.middleware.cancellation import CancellationMiddleware
     from cubebox.api.middleware.csrf import CSRFMiddleware
+    from cubebox.api.middleware.drain import DrainMiddleware
     from cubebox.api.middleware.rate_limit import limiter
     from cubebox.api.middleware.user_identity import UserIdentityMiddleware
 
     app.add_middleware(CancellationMiddleware)
     app.add_middleware(UserIdentityMiddleware)
     app.add_middleware(CSRFMiddleware)
+    # Registered last → outermost on the request path. A draining server
+    # refuses new runs before any other middleware does work.
+    app.add_middleware(DrainMiddleware, drain_state=app.state.drain_state)
 
     # Wire slowapi limiter into app state + exception handler
     from slowapi import _rate_limit_exceeded_handler

--- a/backend/cubebox/api/middleware/drain.py
+++ b/backend/cubebox/api/middleware/drain.py
@@ -1,0 +1,63 @@
+"""Reject new run starts with 503 while the process is draining.
+
+This middleware is registered last in ``create_app`` so it runs as the
+outermost wrapper on the request path: a draining server should refuse new
+runs before doing CSRF or identity work.
+
+Only the run-start surface is gated. SSE subscription, bootstrap, auth,
+and health probes pass through unchanged so existing clients keep working
+during drain.
+"""
+
+from __future__ import annotations
+
+import json
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from cubebox.lifecycle.drain import DrainState
+
+_RETRY_AFTER_SECONDS = "5"
+_BLOCKED_BODY = json.dumps(
+    {"error": {"code": "draining", "message": "Server is draining; retry."}}
+).encode()
+
+
+def _is_run_start(scope: Scope) -> bool:
+    """Match POST /api/v1/ws/{ws}/conversations/{cid}/messages exactly."""
+    if scope.get("method") != "POST":
+        return False
+    path = scope.get("path", "")
+    if not path.startswith("/api/v1/ws/"):
+        return False
+    segments = path.strip("/").split("/")
+    # ['api', 'v1', 'ws', '{ws}', 'conversations', '{cid}', 'messages']
+    return len(segments) == 7 and segments[4] == "conversations" and segments[6] == "messages"
+
+
+class DrainMiddleware:
+    def __init__(self, app: ASGIApp, *, drain_state: DrainState) -> None:
+        self.app = app
+        self._state = drain_state
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or not self._state.is_draining():
+            await self.app(scope, receive, send)
+            return
+
+        if not _is_run_start(scope):
+            await self.app(scope, receive, send)
+            return
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 503,
+                "headers": [
+                    (b"retry-after", _RETRY_AFTER_SECONDS.encode()),
+                    (b"connection", b"close"),
+                    (b"content-type", b"application/json"),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": _BLOCKED_BODY})

--- a/backend/cubebox/api/routes/health.py
+++ b/backend/cubebox/api/routes/health.py
@@ -1,11 +1,25 @@
-"""Health check endpoints"""
+"""Health probes split for k8s.
 
-from fastapi import APIRouter
+- ``/health/live`` is the liveness probe. Always 200 while the process is up.
+  Must not flip during drain or k8s will kill the pod before drain completes.
+- ``/health/ready`` is the readiness probe. 503 while draining so the load
+  balancer stops sending new traffic to this pod.
+"""
+
+from fastapi import APIRouter, Request, Response
 
 router = APIRouter(prefix="/health", tags=["health"])
 
 
-@router.get("")
-async def health_check() -> dict[str, str]:
-    """Health check endpoint"""
+@router.get("/live")
+async def liveness() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/ready")
+async def readiness(request: Request, response: Response) -> dict[str, str]:
+    drain_state = getattr(request.app.state, "drain_state", None)
+    if drain_state is not None and drain_state.is_draining():
+        response.status_code = 503
+        return {"status": "draining"}
     return {"status": "ok"}

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -23,7 +23,9 @@ from cubebox.streams.run_events import (
     get_active_run,
     get_latest_event_id,
     get_run_meta,
+    is_stale_meta,
     iter_run_events,
+    mark_run_stale,
     read_run_events_after,
 )
 from cubebox.streams.run_manager import RunContext
@@ -539,10 +541,25 @@ async def get_conversation_bootstrap(
             detail=f"Conversation {conversation_id} not found",
         )
 
+    from cubebox.config import config as _cfg
+
     history = await _get_history_messages(raw_request, conversation_id)
     active_run = await get_active_run(
         rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
     )
+
+    last_run_status: str | None = None
+    if active_run is not None:
+        threshold = int(_cfg.get("lifecycle.stale_run_threshold_seconds", 120))
+        if is_stale_meta(active_run, threshold_seconds=threshold):
+            await mark_run_stale(
+                rds.client,
+                prefix=rds.key_prefix,
+                run_id=active_run.run_id,
+                conversation_id=conversation_id,
+            )
+            active_run = None
+            last_run_status = "stale"
 
     active_run_payload: dict[str, Any] | None = None
     if active_run is not None:
@@ -561,6 +578,7 @@ async def get_conversation_bootstrap(
         "messages": history["messages"],
         "total": history["total"],
         "active_run": active_run_payload,
+        "last_run_status": last_run_status,
     }
 
 
@@ -598,6 +616,33 @@ async def stream_run(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Run {run_id} not found",
         )
+
+    from cubebox.config import config as _cfg
+
+    threshold = int(_cfg.get("lifecycle.stale_run_threshold_seconds", 120))
+    if is_stale_meta(run_meta, threshold_seconds=threshold):
+        await mark_run_stale(
+            rds.client,
+            prefix=rds.key_prefix,
+            run_id=run_id,
+            conversation_id=conversation_id,
+        )
+
+        async def _stale_stream() -> AsyncIterator[bytes]:
+            from datetime import UTC, datetime
+
+            payload = {
+                "type": "error",
+                "timestamp": datetime.now(UTC).isoformat(),
+                "data": {
+                    "error_code": "run_stale",
+                    "message": "This run died before finishing.",
+                },
+            }
+            yield _format_sse_event("0-0", payload).encode()
+
+        return StreamingResponse(_stale_stream(), media_type="text/event-stream")
+
     return _build_run_streaming_response(
         raw_request=raw_request,
         conversation_id=conversation_id,

--- a/backend/cubebox/lifecycle/__init__.py
+++ b/backend/cubebox/lifecycle/__init__.py
@@ -1,0 +1,5 @@
+"""Process-level lifecycle primitives (drain, stale detection)."""
+
+from cubebox.lifecycle.drain import DrainState
+
+__all__ = ["DrainState"]

--- a/backend/cubebox/lifecycle/drain.py
+++ b/backend/cubebox/lifecycle/drain.py
@@ -1,0 +1,39 @@
+"""Process-level drain state machine.
+
+The state machine is read by request handlers (drain middleware, health
+probes) and written by signal handlers + the FastAPI lifespan shutdown
+hook. It does not own any async waiting — that lives in
+``RunManager.drain()``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+State = Literal["accepting", "draining"]
+
+
+class DrainState:
+    """Single-process drain flag.
+
+    Transitions:
+        accepting -> draining (via enter_draining; idempotent)
+
+    The 'exiting' phase from the design doc is a property of the lifespan
+    shutdown sequence, not a state we observe at runtime. Once
+    ``RunManager.drain()`` returns, the process tears down.
+    """
+
+    __slots__ = ("_state",)
+
+    def __init__(self) -> None:
+        self._state: State = "accepting"
+
+    def is_accepting(self) -> bool:
+        return self._state == "accepting"
+
+    def is_draining(self) -> bool:
+        return self._state == "draining"
+
+    def enter_draining(self) -> None:
+        self._state = "draining"

--- a/backend/cubebox/streams/run_events.py
+++ b/backend/cubebox/streams/run_events.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
 from typing import Any, cast
 
 from redis.asyncio import Redis
@@ -35,7 +34,6 @@ class RunMeta:
     user_message: str | None = None
     first_event_id: str | None = None
     last_event_id: str | None = None
-    last_event_at: str | None = None
 
 
 @dataclass(slots=True)
@@ -119,8 +117,7 @@ return 0
 
 # XADD + meta update + TTL refresh (including active-run lock) in one round trip.
 # KEYS[1] = stream_key, KEYS[2] = meta_key, KEYS[3] = active_key
-# ARGV[1] = payload_json, ARGV[2] = ttl_seconds, ARGV[3] = maxlen,
-# ARGV[4] = run_id, ARGV[5] = last_event_at (ISO-8601 wall-clock heartbeat)
+# ARGV[1] = payload_json, ARGV[2] = ttl_seconds, ARGV[3] = maxlen, ARGV[4] = run_id
 # The active-run TTL is refreshed only if it still points at this run_id, so a
 # late-arriving append from an already-superseded run can't keep a zombie lock
 # alive.
@@ -128,7 +125,7 @@ _APPEND_EVENT_LUA = """
 local eid = redis.call(
   'XADD', KEYS[1], 'MAXLEN', '~', tonumber(ARGV[3]), '*', 'payload', ARGV[1]
 )
-redis.call('HSET', KEYS[2], 'last_event_id', eid, 'last_event_at', ARGV[5])
+redis.call('HSET', KEYS[2], 'last_event_id', eid)
 redis.call('HSETNX', KEYS[2], 'first_event_id', eid)
 redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
 redis.call('EXPIRE', KEYS[2], tonumber(ARGV[2]))
@@ -160,7 +157,6 @@ def _meta_from_hash(raw: dict[str, str]) -> RunMeta | None:
         user_message=raw.get("user_message"),
         first_event_id=raw.get("first_event_id"),
         last_event_id=raw.get("last_event_id"),
-        last_event_at=raw.get("last_event_at"),
     )
 
 
@@ -307,12 +303,9 @@ async def append_run_event(
 ) -> str:
     """Append an event payload and update event bounds in a single call.
 
-    Stamps a wall-clock ``last_event_at`` heartbeat so stale-run detection
-    can spot dead workers. Also heartbeats the active-run lock for this
-    conversation so runs longer than ``ttl_seconds`` don't drop the lock
-    mid-execution.
+    Also heartbeats the active-run lock for this conversation so runs longer
+    than ``ttl_seconds`` don't drop the lock mid-execution.
     """
-    last_event_at = datetime.now(UTC).isoformat()
     return cast(
         str,
         await redis.eval(  # type: ignore[misc]
@@ -325,7 +318,6 @@ async def append_run_event(
             str(ttl_seconds),
             str(maxlen),
             run_id,
-            last_event_at,
         ),
     )
 

--- a/backend/cubebox/streams/run_events.py
+++ b/backend/cubebox/streams/run_events.py
@@ -138,6 +138,19 @@ end
 return eid
 """
 
+# Mark a run as stale and clear the active-run lock if it still points at it.
+# KEYS[1] = meta_key, KEYS[2] = active_key
+# ARGV[1] = expected_run_id
+_MARK_STALE_LUA = """
+if redis.call('HGET', KEYS[1], 'status') == 'running' then
+  redis.call('HSET', KEYS[1], 'status', 'stale')
+end
+if redis.call('GET', KEYS[2]) == ARGV[1] then
+  redis.call('DEL', KEYS[2])
+end
+return 1
+"""
+
 
 def _meta_hash_pairs(meta: RunMeta) -> list[str]:
     """Return a flat list of field/value pairs for HSET, skipping None values."""
@@ -403,3 +416,44 @@ async def expire_run_data(
     pipe.expire(_run_meta_key(prefix, run_id), ttl_seconds)
     pipe.expire(_run_events_key(prefix, run_id), ttl_seconds)
     await pipe.execute()
+
+
+async def mark_run_stale(
+    redis: Redis,
+    *,
+    prefix: str,
+    run_id: str,
+    conversation_id: str,
+) -> None:
+    """Atomically mark a run stale and release its active-run lock if held.
+
+    Idempotent: a no-op when status is already non-running and the active
+    key no longer points at this run.
+    """
+    await redis.eval(  # type: ignore[misc]
+        _MARK_STALE_LUA,
+        2,
+        _run_meta_key(prefix, run_id),
+        _active_run_key(prefix, conversation_id),
+        run_id,
+    )
+
+
+def is_stale_meta(
+    meta: RunMeta,
+    *,
+    threshold_seconds: int,
+    now: datetime | None = None,
+) -> bool:
+    """A run is stale when status='running' and last_event_at is too old.
+
+    A fresh run that hasn't appended its first event yet has
+    ``last_event_at = None``; in that case fall back to ``started_at`` so
+    the staleness window starts at run creation.
+    """
+    if meta.status != "running":
+        return False
+    current = now or datetime.now(UTC)
+    reference = meta.last_event_at or meta.started_at
+    last = datetime.fromisoformat(reference)
+    return (current - last).total_seconds() > threshold_seconds

--- a/backend/cubebox/streams/run_events.py
+++ b/backend/cubebox/streams/run_events.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
 from typing import Any, cast
 
 from redis.asyncio import Redis
@@ -34,6 +35,7 @@ class RunMeta:
     user_message: str | None = None
     first_event_id: str | None = None
     last_event_id: str | None = None
+    last_event_at: str | None = None
 
 
 @dataclass(slots=True)
@@ -117,7 +119,8 @@ return 0
 
 # XADD + meta update + TTL refresh (including active-run lock) in one round trip.
 # KEYS[1] = stream_key, KEYS[2] = meta_key, KEYS[3] = active_key
-# ARGV[1] = payload_json, ARGV[2] = ttl_seconds, ARGV[3] = maxlen, ARGV[4] = run_id
+# ARGV[1] = payload_json, ARGV[2] = ttl_seconds, ARGV[3] = maxlen,
+# ARGV[4] = run_id, ARGV[5] = last_event_at (ISO-8601 wall-clock heartbeat)
 # The active-run TTL is refreshed only if it still points at this run_id, so a
 # late-arriving append from an already-superseded run can't keep a zombie lock
 # alive.
@@ -125,7 +128,7 @@ _APPEND_EVENT_LUA = """
 local eid = redis.call(
   'XADD', KEYS[1], 'MAXLEN', '~', tonumber(ARGV[3]), '*', 'payload', ARGV[1]
 )
-redis.call('HSET', KEYS[2], 'last_event_id', eid)
+redis.call('HSET', KEYS[2], 'last_event_id', eid, 'last_event_at', ARGV[5])
 redis.call('HSETNX', KEYS[2], 'first_event_id', eid)
 redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
 redis.call('EXPIRE', KEYS[2], tonumber(ARGV[2]))
@@ -157,6 +160,7 @@ def _meta_from_hash(raw: dict[str, str]) -> RunMeta | None:
         user_message=raw.get("user_message"),
         first_event_id=raw.get("first_event_id"),
         last_event_id=raw.get("last_event_id"),
+        last_event_at=raw.get("last_event_at"),
     )
 
 
@@ -303,9 +307,12 @@ async def append_run_event(
 ) -> str:
     """Append an event payload and update event bounds in a single call.
 
-    Also heartbeats the active-run lock for this conversation so runs longer
-    than ``ttl_seconds`` don't drop the lock mid-execution.
+    Stamps a wall-clock ``last_event_at`` heartbeat so stale-run detection
+    can spot dead workers. Also heartbeats the active-run lock for this
+    conversation so runs longer than ``ttl_seconds`` don't drop the lock
+    mid-execution.
     """
+    last_event_at = datetime.now(UTC).isoformat()
     return cast(
         str,
         await redis.eval(  # type: ignore[misc]
@@ -318,6 +325,7 @@ async def append_run_event(
             str(ttl_seconds),
             str(maxlen),
             run_id,
+            last_event_at,
         ),
     )
 

--- a/backend/cubebox/streams/run_events.py
+++ b/backend/cubebox/streams/run_events.py
@@ -138,6 +138,22 @@ end
 return eid
 """
 
+# Conditional status transition: only HSET status if current status is 'running'.
+# Workers transition (running → completed|failed|cancelled) only when nobody else
+# has flipped the run's status in the meantime — e.g. inline stale-run detection
+# may have set status='stale' and DELed the active key while the worker was mid-
+# tool-call. Without this guard, the worker's success path silently overwrites
+# the stale flag, hiding the orphan from the operator.
+# KEYS[1] = meta_key, ARGV[1] = new_status
+# Returns 1 if status was 'running' (and now ARGV[1]); 0 otherwise.
+_TRANSITION_STATUS_FROM_RUNNING_LUA = """
+if redis.call('HGET', KEYS[1], 'status') ~= 'running' then
+  return 0
+end
+redis.call('HSET', KEYS[1], 'status', ARGV[1])
+return 1
+"""
+
 # Mark a run as stale and clear the active-run lock if it still points at it.
 # KEYS[1] = meta_key, KEYS[2] = active_key
 # ARGV[1] = expected_run_id
@@ -276,17 +292,38 @@ async def update_run_meta(
     last_event_id: str | None = None,
     ttl_seconds: int | None = None,
 ) -> RunMeta | None:
-    """Patch run metadata fields without read-modify-write races."""
+    """Patch run metadata fields without read-modify-write races.
+
+    ``status`` updates use CAS: the write only happens when the current status
+    is ``running``. If a worker tries to flip the status to a terminal state
+    after stale detection has already marked the run ``stale``, the CAS fails
+    and the existing ``stale`` value is preserved. Other fields are written
+    unconditionally because they are append-driven and don't conflict.
+    """
     meta_key = _run_meta_key(prefix, run_id)
-    updates: dict[str, str] = {}
     if status is not None:
-        updates["status"] = status
+        wrote = await redis.eval(  # type: ignore[misc]
+            _TRANSITION_STATUS_FROM_RUNNING_LUA,
+            1,
+            meta_key,
+            status,
+        )
+        if not wrote:
+            from loguru import logger
+
+            logger.warning(
+                "Run {} status transition to {} ignored — meta is no longer 'running' "
+                "(likely supplanted by stale detection)",
+                run_id,
+                status,
+            )
+    other_updates: dict[str, str] = {}
     if first_event_id is not None:
-        updates["first_event_id"] = first_event_id
+        other_updates["first_event_id"] = first_event_id
     if last_event_id is not None:
-        updates["last_event_id"] = last_event_id
-    if updates:
-        await redis.hset(meta_key, mapping=updates)  # type: ignore[misc]
+        other_updates["last_event_id"] = last_event_id
+    if other_updates:
+        await redis.hset(meta_key, mapping=other_updates)  # type: ignore[misc]
     if ttl_seconds is not None:
         await redis.expire(meta_key, ttl_seconds)
     return await get_run_meta(redis, prefix=prefix, run_id=run_id)

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -220,6 +220,13 @@ class RunManager:
         self._run_event_ttl_seconds = run_event_ttl_seconds
         self._run_stream_max_events = run_stream_max_events
         self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._tasks_empty: asyncio.Event = asyncio.Event()
+        self._tasks_empty.set()
+
+    def _on_task_done(self, run_id: str) -> None:
+        self._tasks.pop(run_id, None)
+        if not self._tasks:
+            self._tasks_empty.set()
 
     async def start_run(
         self,
@@ -260,18 +267,55 @@ class RunManager:
             ),
             name=f"run:{run_id}",
         )
+        self._tasks_empty.clear()
         self._tasks[run_id] = task
-        task.add_done_callback(lambda _: self._tasks.pop(run_id, None))
+        task.add_done_callback(lambda _: self._on_task_done(run_id))
         return run_id
 
-    async def shutdown(self) -> None:
-        """Cancel all in-flight run tasks."""
+    async def cancel_all(self) -> None:
+        """Cancel every in-flight run task. Forced shutdown path."""
         tasks = list(self._tasks.values())
         for task in tasks:
             task.cancel()
         for task in tasks:
             with suppress(asyncio.CancelledError):
                 await task
+
+    async def drain(self, timeout_seconds: float) -> None:
+        """Wait for in-flight runs to finish, then return.
+
+        On timeout, cancels residual tasks via ``cancel_all`` (which lets
+        the per-task cancel path mark status=cancelled and write an
+        ``error`` event before the lock is released).
+
+        Logs a progress line every 30 seconds while waiting.
+        """
+        if self._tasks_empty.is_set():
+            return
+
+        progress_task = asyncio.create_task(self._log_drain_progress())
+        try:
+            await asyncio.wait_for(self._tasks_empty.wait(), timeout=timeout_seconds)
+        except TimeoutError:
+            logger.warning(
+                "Drain timeout after {}s, cancelling {} residual run(s)",
+                timeout_seconds,
+                len(self._tasks),
+            )
+            await self.cancel_all()
+        finally:
+            progress_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await progress_task
+
+    async def _log_drain_progress(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(30)
+                if self._tasks:
+                    logger.info("Still draining: {} run(s) remaining", len(self._tasks))
+        except asyncio.CancelledError:
+            return
 
     async def _append_event(self, run_id: str, conversation_id: str, event: AgentEvent) -> str:
         payload = event.model_dump()

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -224,6 +224,7 @@ class RunManager:
         self._tasks_empty.set()
 
     def _on_task_done(self, run_id: str) -> None:
+        """Done-callback that removes the run task and signals drain when empty."""
         self._tasks.pop(run_id, None)
         if not self._tasks:
             self._tasks_empty.set()

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -289,11 +289,17 @@ class RunManager:
         the per-task cancel path mark status=cancelled and write an
         ``error`` event before the lock is released).
 
-        Logs a progress line every 30 seconds while waiting.
+        Logs a status line on entry when there's anything to wait for, plus
+        a progress line every 30 seconds while waiting.
         """
         if self._tasks_empty.is_set():
             return
 
+        logger.info(
+            "Draining {} in-flight run(s) (timeout {}s)",
+            len(self._tasks),
+            timeout_seconds,
+        )
         progress_task = asyncio.create_task(self._log_drain_progress())
         try:
             await asyncio.wait_for(self._tasks_empty.wait(), timeout=timeout_seconds)

--- a/backend/docs/deploy-k8s-graceful-restart.md
+++ b/backend/docs/deploy-k8s-graceful-restart.md
@@ -1,0 +1,46 @@
+# K8s Deployment — Graceful Restart
+
+The cubebox backend drains in-flight LangGraph runs on `SIGTERM` before
+exiting. To get zero-downtime rolling restarts, pair this with a long
+termination grace period and the split health probes.
+
+## Probes
+
+- `GET /health/live` → liveness. Always 200 while the process is up.
+- `GET /health/ready` → readiness. 503 while draining.
+
+## Recommended deployment fragment
+
+```yaml
+spec:
+  terminationGracePeriodSeconds: 3600   # match lifecycle.graceful_drain_timeout_seconds
+  containers:
+    - name: cubebox
+      readinessProbe:
+        httpGet: { path: /health/ready, port: 8000 }
+        periodSeconds: 5
+      livenessProbe:
+        httpGet: { path: /health/live, port: 8000 }
+        periodSeconds: 30
+```
+
+## Tunables
+
+`backend/config.yaml`:
+
+| Key | Default | Notes |
+|---|---|---|
+| `lifecycle.graceful_drain_timeout_seconds` | 3600 | Hard cap on drain wait before forced cancel. Match `terminationGracePeriodSeconds`. |
+| `lifecycle.stale_run_threshold_seconds` | 120 | Seconds without an event before bootstrap declares a `running` run stale and clears its active-run lock. |
+| `lifecycle.dev_double_signal_force_exit` | true | Second `Ctrl-C` forces immediate exit. Set false in prod if you want to require an external SIGKILL. |
+
+## Force-killing a slow drain
+
+For an unscheduled exit:
+
+```
+kubectl delete pod <pod> --grace-period=0 --force
+```
+
+This skips drain. In-flight runs die mid-stream and surface to clients as
+stale runs the next time the user opens the conversation.

--- a/backend/tests/e2e/test_graceful_restart.py
+++ b/backend/tests/e2e/test_graceful_restart.py
@@ -1,0 +1,64 @@
+"""E2E tests for graceful restart drain + stale-run detection."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from redis.asyncio import Redis
+
+from cubebox.config import config as _cubebox_config
+from cubebox.streams.run_events import (
+    append_run_event,
+    create_run,
+    get_run_meta,
+)
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> Redis:
+    client = Redis.from_url(
+        _cubebox_config.get("redis.url", "redis://127.0.0.1:6379/0"),
+        decode_responses=True,
+    )
+    yield client
+    await client.aclose()
+
+
+async def test_append_run_event_stamps_last_event_at(redis_client: Redis) -> None:
+    prefix = "test_graceful"
+    run_id = "run-heartbeat-1"
+    conv_id = "conv-heartbeat-1"
+    started = datetime.now(UTC).isoformat()
+
+    meta = await create_run(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=started,
+        ttl_seconds=60,
+    )
+    assert meta is not None
+
+    before = datetime.now(UTC)
+    await append_run_event(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        payload={"type": "status", "data": {"phase": "test"}},
+        ttl_seconds=60,
+        maxlen=100,
+    )
+    after = datetime.now(UTC)
+
+    fresh_meta = await get_run_meta(redis_client, prefix=prefix, run_id=run_id)
+    assert fresh_meta is not None
+    assert fresh_meta.last_event_at is not None
+    parsed = datetime.fromisoformat(fresh_meta.last_event_at)
+    assert before - timedelta(seconds=1) <= parsed <= after + timedelta(seconds=1)

--- a/backend/tests/e2e/test_graceful_restart.py
+++ b/backend/tests/e2e/test_graceful_restart.py
@@ -228,6 +228,13 @@ async def test_legacy_health_removed(memory_client: httpx.AsyncClient) -> None:
     assert resp.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_health_ready_200_when_accepting(memory_client: httpx.AsyncClient) -> None:
+    resp = await memory_client.get("/health/ready")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
 @pytest_asyncio.fixture
 async def app_state_drain(memory_client: httpx.AsyncClient) -> DrainState:
     """Pull the live DrainState from the app the test client targets."""
@@ -257,6 +264,23 @@ async def test_post_messages_returns_503_when_draining(
         )
         assert resp.status_code == 503
         assert resp.headers.get("retry-after") == "5"
+    finally:
+        app_state_drain._state = "accepting"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_health_ready_503_when_draining(
+    memory_client: httpx.AsyncClient,
+    app_state_drain: DrainState,
+) -> None:
+    app_state_drain.enter_draining()
+    try:
+        ready_resp = await memory_client.get("/health/ready")
+        assert ready_resp.status_code == 503
+        assert ready_resp.json() == {"status": "draining"}
+        # Liveness must remain 200 — k8s should not kill the pod during drain.
+        live_resp = await memory_client.get("/health/live")
+        assert live_resp.status_code == 200
     finally:
         app_state_drain._state = "accepting"  # type: ignore[attr-defined]
 
@@ -362,6 +386,62 @@ async def test_mark_run_stale_is_idempotent(redis_client: Redis) -> None:
     fresh = await get_run_meta(redis_client, prefix=prefix, run_id=run_id)
     assert fresh is not None
     assert fresh.status == "stale"
+
+
+@pytest.mark.asyncio
+async def test_update_run_meta_status_cas_preserves_stale(redis_client: Redis) -> None:
+    """If a worker tries to flip status from stale → completed, the CAS must reject it."""
+    from datetime import UTC, datetime
+
+    from cubebox.streams.run_events import create_run, update_run_meta
+
+    prefix = "test_cas_stale"
+    run_id = "r-cas-1"
+    conv_id = "c-cas-1"
+    await create_run(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=datetime.now(UTC).isoformat(),
+        ttl_seconds=60,
+    )
+
+    # Detection-then-recovery flips to stale.
+    await mark_run_stale(redis_client, prefix=prefix, run_id=run_id, conversation_id=conv_id)
+
+    # Worker's "I finished" path tries to overwrite. CAS must drop the write.
+    after = await update_run_meta(redis_client, prefix=prefix, run_id=run_id, status="completed")
+    assert after is not None
+    assert after.status == "stale", "CAS leaked through; stale flag was overwritten"
+
+
+@pytest.mark.asyncio
+async def test_update_run_meta_status_cas_allows_running_transition(
+    redis_client: Redis,
+) -> None:
+    """Normal running → completed transition must still happen."""
+    from datetime import UTC, datetime
+
+    from cubebox.streams.run_events import create_run, update_run_meta
+
+    prefix = "test_cas_running"
+    run_id = "r-cas-2"
+    conv_id = "c-cas-2"
+    await create_run(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=datetime.now(UTC).isoformat(),
+        ttl_seconds=60,
+    )
+
+    after = await update_run_meta(redis_client, prefix=prefix, run_id=run_id, status="completed")
+    assert after is not None
+    assert after.status == "completed"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/e2e/test_graceful_restart.py
+++ b/backend/tests/e2e/test_graceful_restart.py
@@ -7,6 +7,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
+import httpx
 import pytest
 import pytest_asyncio
 from redis.asyncio import Redis
@@ -210,3 +211,16 @@ async def test_drain_middleware_passes_through_non_run_paths_when_draining() -> 
     }
     await mw(scope, receive, send)
     assert called["yes"] is True
+
+
+@pytest.mark.asyncio
+async def test_health_live_always_200(memory_client: httpx.AsyncClient) -> None:
+    resp = await memory_client.get("/health/live")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_legacy_health_removed(memory_client: httpx.AsyncClient) -> None:
+    resp = await memory_client.get("/health")
+    assert resp.status_code == 404

--- a/backend/tests/e2e/test_graceful_restart.py
+++ b/backend/tests/e2e/test_graceful_restart.py
@@ -449,3 +449,56 @@ async def test_stream_subscribe_emits_stale_error_for_dead_run(
     text = body.decode()
     # SSE chunks are concatenated; find any data: line that contains run_stale.
     assert "run_stale" in text
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_in_flight_run_then_returns(
+    memory_client: httpx.AsyncClient,
+) -> None:
+    """Plant a slow async task in run_manager._tasks; drain should wait for it."""
+    app = memory_client._transport.app  # type: ignore[attr-defined]
+    rm = app.state.run_manager
+
+    completed = asyncio.Event()
+
+    async def slow_run() -> None:
+        try:
+            await asyncio.sleep(0.5)
+        finally:
+            completed.set()
+
+    task = asyncio.create_task(slow_run(), name="run:integration-slow")
+    rm._tasks["integration-slow"] = task
+    rm._tasks_empty.clear()
+    task.add_done_callback(lambda _: rm._on_task_done("integration-slow"))
+
+    start = time.monotonic()
+    await rm.drain(timeout_seconds=5.0)
+    elapsed = time.monotonic() - start
+    assert completed.is_set()
+    assert elapsed >= 0.4
+    assert "integration-slow" not in rm._tasks
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_force_cancels(memory_client: httpx.AsyncClient) -> None:
+    app = memory_client._transport.app  # type: ignore[attr-defined]
+    rm = app.state.run_manager
+
+    cancelled_seen = asyncio.Event()
+
+    async def long_run() -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled_seen.set()
+            raise
+
+    task = asyncio.create_task(long_run(), name="run:integration-long")
+    rm._tasks["integration-long"] = task
+    rm._tasks_empty.clear()
+    task.add_done_callback(lambda _: rm._on_task_done("integration-long"))
+
+    await rm.drain(timeout_seconds=0.2)
+    assert cancelled_seen.is_set()
+    assert "integration-long" not in rm._tasks

--- a/backend/tests/e2e/test_graceful_restart.py
+++ b/backend/tests/e2e/test_graceful_restart.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
@@ -14,6 +16,7 @@ from cubebox.streams.run_events import (
     create_run,
     get_run_meta,
 )
+from cubebox.streams.run_manager import RunManager
 
 pytestmark = pytest.mark.e2e
 
@@ -62,3 +65,58 @@ async def test_append_run_event_stamps_last_event_at(redis_client: Redis) -> Non
     assert fresh_meta.last_event_at is not None
     parsed = datetime.fromisoformat(fresh_meta.last_event_at)
     assert before - timedelta(seconds=1) <= parsed <= after + timedelta(seconds=1)
+
+
+def _make_run_manager(redis_client: Redis) -> RunManager:
+    app = SimpleNamespace(state=SimpleNamespace())
+    return RunManager(
+        app=app,  # type: ignore[arg-type]
+        redis=redis_client,
+        key_prefix="test_drain",
+        run_event_ttl_seconds=60,
+    )
+
+
+@pytest.mark.asyncio
+async def test_drain_returns_immediately_when_no_tasks(redis_client: Redis) -> None:
+    rm = _make_run_manager(redis_client)
+    start = asyncio.get_event_loop().time()
+    await rm.drain(timeout_seconds=10.0)
+    elapsed = asyncio.get_event_loop().time() - start
+    assert elapsed < 0.5
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_in_flight_task(redis_client: Redis) -> None:
+    rm = _make_run_manager(redis_client)
+
+    async def slow() -> None:
+        await asyncio.sleep(0.3)
+
+    task = asyncio.create_task(slow(), name="run:slow-1")
+    rm._tasks["slow-1"] = task
+    rm._tasks_empty.clear()
+    task.add_done_callback(lambda _: rm._on_task_done("slow-1"))
+
+    start = asyncio.get_event_loop().time()
+    await rm.drain(timeout_seconds=5.0)
+    elapsed = asyncio.get_event_loop().time() - start
+    assert 0.25 < elapsed < 1.5
+    assert "slow-1" not in rm._tasks
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_cancels_residual(redis_client: Redis) -> None:
+    rm = _make_run_manager(redis_client)
+
+    async def forever() -> None:
+        await asyncio.sleep(60)
+
+    task = asyncio.create_task(forever(), name="run:forever")
+    rm._tasks["forever"] = task
+    rm._tasks_empty.clear()
+    task.add_done_callback(lambda _: rm._on_task_done("forever"))
+
+    await rm.drain(timeout_seconds=0.2)
+    # cancel_all path completed: task is done (cancelled) and removed.
+    assert task.cancelled() or task.done()

--- a/backend/tests/e2e/test_graceful_restart.py
+++ b/backend/tests/e2e/test_graceful_restart.py
@@ -19,6 +19,8 @@ from cubebox.streams.run_events import (
     append_run_event,
     create_run,
     get_run_meta,
+    is_stale_meta,
+    mark_run_stale,
 )
 from cubebox.streams.run_manager import RunManager
 
@@ -257,3 +259,183 @@ async def test_post_messages_returns_503_when_draining(
         assert resp.headers.get("retry-after") == "5"
     finally:
         app_state_drain._state = "accepting"  # type: ignore[attr-defined]
+
+
+def test_is_stale_meta_detects_stale_running() -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from cubebox.streams.run_events import RunMeta
+
+    now = datetime.now(UTC)
+    fresh = RunMeta(
+        run_id="r1",
+        conversation_id="c1",
+        status="running",
+        started_at=now.isoformat(),
+        last_event_at=(now - timedelta(seconds=5)).isoformat(),
+    )
+    stale = RunMeta(
+        run_id="r2",
+        conversation_id="c2",
+        status="running",
+        started_at=now.isoformat(),
+        last_event_at=(now - timedelta(seconds=300)).isoformat(),
+    )
+    completed = RunMeta(
+        run_id="r3",
+        conversation_id="c3",
+        status="completed",
+        started_at=now.isoformat(),
+        last_event_at=(now - timedelta(seconds=300)).isoformat(),
+    )
+
+    assert not is_stale_meta(fresh, threshold_seconds=120, now=now)
+    assert is_stale_meta(stale, threshold_seconds=120, now=now)
+    # Completed runs are never stale, regardless of age.
+    assert not is_stale_meta(completed, threshold_seconds=120, now=now)
+
+
+@pytest.mark.asyncio
+async def test_mark_run_stale_clears_active_and_sets_status(redis_client: Redis) -> None:
+    from datetime import UTC, datetime
+
+    from cubebox.streams.run_events import (
+        create_run,
+        get_active_run,
+        get_run_meta,
+    )
+
+    prefix = "test_stale_mark"
+    run_id = "r-stale-1"
+    conv_id = "c-stale-1"
+    await create_run(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=datetime.now(UTC).isoformat(),
+        ttl_seconds=60,
+    )
+
+    await mark_run_stale(redis_client, prefix=prefix, run_id=run_id, conversation_id=conv_id)
+
+    fresh = await get_run_meta(redis_client, prefix=prefix, run_id=run_id)
+    assert fresh is not None
+    assert fresh.status == "stale"
+    active = await get_active_run(redis_client, prefix=prefix, conversation_id=conv_id)
+    assert active is None
+
+
+@pytest.mark.asyncio
+async def test_mark_run_stale_is_idempotent(redis_client: Redis) -> None:
+    from datetime import UTC, datetime
+
+    from cubebox.streams.run_events import create_run, get_run_meta
+
+    prefix = "test_stale_idem"
+    run_id = "r-stale-2"
+    conv_id = "c-stale-2"
+    await create_run(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=datetime.now(UTC).isoformat(),
+        ttl_seconds=60,
+    )
+
+    await mark_run_stale(redis_client, prefix=prefix, run_id=run_id, conversation_id=conv_id)
+    # Second call: status already stale, active_run already cleared — no-op.
+    await mark_run_stale(redis_client, prefix=prefix, run_id=run_id, conversation_id=conv_id)
+    fresh = await get_run_meta(redis_client, prefix=prefix, run_id=run_id)
+    assert fresh is not None
+    assert fresh.status == "stale"
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_clears_stale_run_and_sets_last_run_status(
+    memory_client: httpx.AsyncClient, redis_client: Redis
+) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from cubebox.streams.run_events import _active_run_key, create_run
+
+    create_resp = await memory_client.post(
+        "/api/v1/ws/default-ws/conversations", params={"title": "stale-test"}
+    )
+    assert create_resp.status_code == 201
+    conv_id = create_resp.json()["id"]
+
+    # The app under test uses prefix "test:test" (env=test). Reach it from app.state.
+    app = memory_client._transport.app  # type: ignore[attr-defined]
+    prefix = app.state.redis_key_prefix
+    run_id = "stale-run-1"
+    long_ago = (datetime.now(UTC) - timedelta(seconds=600)).isoformat()
+
+    # Plant a fake active run with an old last_event_at.
+    meta = await create_run(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=long_ago,
+        ttl_seconds=120,
+    )
+    assert meta is not None
+    # Stamp last_event_at directly (no real append, so we set the hash field).
+    await redis_client.hset(  # type: ignore[misc]
+        f"{prefix}:run_meta:v2:{run_id}", "last_event_at", long_ago
+    )
+
+    resp = await memory_client.get(f"/api/v1/ws/default-ws/conversations/{conv_id}/bootstrap")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["active_run"] is None
+    assert body["last_run_status"] == "stale"
+
+    # Active key cleared.
+    active = await redis_client.get(_active_run_key(prefix, conv_id))
+    assert active is None
+
+
+@pytest.mark.asyncio
+async def test_stream_subscribe_emits_stale_error_for_dead_run(
+    memory_client: httpx.AsyncClient, redis_client: Redis
+) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from cubebox.streams.run_events import create_run
+
+    create_resp = await memory_client.post(
+        "/api/v1/ws/default-ws/conversations", params={"title": "stale-stream"}
+    )
+    conv_id = create_resp.json()["id"]
+
+    app = memory_client._transport.app  # type: ignore[attr-defined]
+    prefix = app.state.redis_key_prefix
+    run_id = "stale-run-2"
+    long_ago = (datetime.now(UTC) - timedelta(seconds=600)).isoformat()
+    await create_run(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=long_ago,
+        ttl_seconds=120,
+    )
+    await redis_client.hset(  # type: ignore[misc]
+        f"{prefix}:run_meta:v2:{run_id}", "last_event_at", long_ago
+    )
+
+    async with memory_client.stream(
+        "GET",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/runs/{run_id}/stream",
+    ) as resp:
+        body = await resp.aread()
+    text = body.decode()
+    # SSE chunks are concatenated; find any data: line that contains run_stale.
+    assert "run_stale" in text

--- a/backend/tests/e2e/test_graceful_restart.py
+++ b/backend/tests/e2e/test_graceful_restart.py
@@ -289,10 +289,20 @@ def test_is_stale_meta_detects_stale_running() -> None:
         last_event_at=(now - timedelta(seconds=300)).isoformat(),
     )
 
+    # Worker died before producing the first event: last_event_at is None
+    # and is_stale_meta must fall back to started_at.
+    no_heartbeat = RunMeta(
+        run_id="r4",
+        conversation_id="c4",
+        status="running",
+        started_at=(now - timedelta(seconds=300)).isoformat(),
+    )
+
     assert not is_stale_meta(fresh, threshold_seconds=120, now=now)
     assert is_stale_meta(stale, threshold_seconds=120, now=now)
     # Completed runs are never stale, regardless of age.
     assert not is_stale_meta(completed, threshold_seconds=120, now=now)
+    assert is_stale_meta(no_heartbeat, threshold_seconds=120, now=now)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/e2e/test_graceful_restart.py
+++ b/backend/tests/e2e/test_graceful_restart.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
@@ -80,9 +81,9 @@ def _make_run_manager(redis_client: Redis) -> RunManager:
 @pytest.mark.asyncio
 async def test_drain_returns_immediately_when_no_tasks(redis_client: Redis) -> None:
     rm = _make_run_manager(redis_client)
-    start = asyncio.get_event_loop().time()
+    start = time.monotonic()
     await rm.drain(timeout_seconds=10.0)
-    elapsed = asyncio.get_event_loop().time() - start
+    elapsed = time.monotonic() - start
     assert elapsed < 0.5
 
 
@@ -98,10 +99,10 @@ async def test_drain_waits_for_in_flight_task(redis_client: Redis) -> None:
     rm._tasks_empty.clear()
     task.add_done_callback(lambda _: rm._on_task_done("slow-1"))
 
-    start = asyncio.get_event_loop().time()
+    start = time.monotonic()
     await rm.drain(timeout_seconds=5.0)
-    elapsed = asyncio.get_event_loop().time() - start
-    assert 0.25 < elapsed < 1.5
+    elapsed = time.monotonic() - start
+    assert 0.2 < elapsed < 1.5
     assert "slow-1" not in rm._tasks
 
 
@@ -119,4 +120,4 @@ async def test_drain_timeout_cancels_residual(redis_client: Redis) -> None:
 
     await rm.drain(timeout_seconds=0.2)
     # cancel_all path completed: task is done (cancelled) and removed.
-    assert task.cancelled() or task.done()
+    assert task.cancelled()

--- a/backend/tests/e2e/test_graceful_restart.py
+++ b/backend/tests/e2e/test_graceful_restart.py
@@ -224,3 +224,36 @@ async def test_health_live_always_200(memory_client: httpx.AsyncClient) -> None:
 async def test_legacy_health_removed(memory_client: httpx.AsyncClient) -> None:
     resp = await memory_client.get("/health")
     assert resp.status_code == 404
+
+
+@pytest_asyncio.fixture
+async def app_state_drain(memory_client: httpx.AsyncClient) -> DrainState:
+    """Pull the live DrainState from the app the test client targets."""
+    app = memory_client._transport.app  # type: ignore[attr-defined]
+    state = getattr(app.state, "drain_state", None)
+    assert isinstance(state, DrainState), "lifespan did not install drain_state"
+    return state
+
+
+@pytest.mark.asyncio
+async def test_post_messages_returns_503_when_draining(
+    memory_client: httpx.AsyncClient,
+    app_state_drain: DrainState,
+) -> None:
+    # Create a conversation first while still accepting.
+    create_resp = await memory_client.post(
+        "/api/v1/ws/default-ws/conversations", params={"title": "drain-test"}
+    )
+    assert create_resp.status_code == 201
+    conv_id = create_resp.json()["id"]
+
+    app_state_drain.enter_draining()
+    try:
+        resp = await memory_client.post(
+            f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
+            json={"content": "hi"},
+        )
+        assert resp.status_code == 503
+        assert resp.headers.get("retry-after") == "5"
+    finally:
+        app_state_drain._state = "accepting"  # type: ignore[attr-defined]

--- a/backend/tests/e2e/test_graceful_restart.py
+++ b/backend/tests/e2e/test_graceful_restart.py
@@ -11,7 +11,9 @@ import pytest
 import pytest_asyncio
 from redis.asyncio import Redis
 
+from cubebox.api.middleware.drain import DrainMiddleware
 from cubebox.config import config as _cubebox_config
+from cubebox.lifecycle.drain import DrainState
 from cubebox.streams.run_events import (
     append_run_event,
     create_run,
@@ -121,3 +123,90 @@ async def test_drain_timeout_cancels_residual(redis_client: Redis) -> None:
     await rm.drain(timeout_seconds=0.2)
     # cancel_all path completed: task is done (cancelled) and removed.
     assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_drain_middleware_passthrough_when_accepting() -> None:
+    state = DrainState()
+    received_scope: dict[str, object] = {}
+
+    async def downstream(scope, receive, send):
+        received_scope["called"] = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    mw = DrainMiddleware(downstream, drain_state=state)
+    sent: list[dict] = []
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(msg):
+        sent.append(msg)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/ws/ws-1/conversations/c-1/messages",
+    }
+    await mw(scope, receive, send)
+    assert received_scope.get("called") is True
+    assert sent[0]["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_drain_middleware_blocks_new_run_when_draining() -> None:
+    state = DrainState()
+    state.enter_draining()
+
+    async def downstream(scope, receive, send):
+        raise AssertionError("downstream must not be called during drain")
+
+    mw = DrainMiddleware(downstream, drain_state=state)
+    sent: list[dict] = []
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(msg):
+        sent.append(msg)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/ws/ws-1/conversations/c-1/messages",
+    }
+    await mw(scope, receive, send)
+    assert sent[0]["status"] == 503
+    headers = dict(sent[0]["headers"])
+    assert headers[b"retry-after"] == b"5"
+
+
+@pytest.mark.asyncio
+async def test_drain_middleware_passes_through_non_run_paths_when_draining() -> None:
+    state = DrainState()
+    state.enter_draining()
+
+    called = {"yes": False}
+
+    async def downstream(scope, receive, send):
+        called["yes"] = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    mw = DrainMiddleware(downstream, drain_state=state)
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(_msg):
+        pass
+
+    # SSE subscription should pass through
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/v1/ws/ws-1/conversations/c-1/runs/r-1/stream",
+    }
+    await mw(scope, receive, send)
+    assert called["yes"] is True

--- a/backend/tests/e2e/test_streaming.py
+++ b/backend/tests/e2e/test_streaming.py
@@ -296,7 +296,7 @@ async def test_client_disconnect_cancels_stream_before_closing_checkpointer(
     assert not slow_agent_cancelled.is_set()
     assert not checkpointer_closed_before_cancel.is_set()
 
-    await app.state.run_manager.shutdown()
+    await app.state.run_manager.cancel_all()
     await asyncio.wait_for(slow_agent_cancelled.wait(), timeout=1)
     assert not checkpointer_closed_before_cancel.is_set()
 

--- a/backend/tests/e2e/test_streaming.py
+++ b/backend/tests/e2e/test_streaming.py
@@ -296,7 +296,7 @@ async def test_client_disconnect_cancels_stream_before_closing_checkpointer(
     assert not slow_agent_cancelled.is_set()
     assert not checkpointer_closed_before_cancel.is_set()
 
-    await app.state.run_manager.cancel_all()
+    await app.state.run_manager.shutdown()
     await asyncio.wait_for(slow_agent_cancelled.wait(), timeout=1)
     assert not checkpointer_closed_before_cancel.is_set()
 

--- a/backend/tests/unit/test_drain_state.py
+++ b/backend/tests/unit/test_drain_state.py
@@ -1,0 +1,25 @@
+"""DrainState transitions."""
+
+from __future__ import annotations
+
+from cubebox.lifecycle.drain import DrainState
+
+
+def test_initial_state_is_accepting() -> None:
+    state = DrainState()
+    assert state.is_accepting()
+    assert not state.is_draining()
+
+
+def test_enter_draining_flips_flag() -> None:
+    state = DrainState()
+    state.enter_draining()
+    assert not state.is_accepting()
+    assert state.is_draining()
+
+
+def test_enter_draining_is_idempotent() -> None:
+    state = DrainState()
+    state.enter_draining()
+    state.enter_draining()
+    assert state.is_draining()

--- a/docs/superpowers/plans/2026-04-26-graceful-restart.md
+++ b/docs/superpowers/plans/2026-04-26-graceful-restart.md
@@ -1,0 +1,1757 @@
+# Graceful Restart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On `SIGTERM` / `SIGINT` / lifespan shutdown, drain in-flight LangGraph runs before exit, route new run starts to `503` while draining, split health probes for k8s, and add inline stale-run detection to recover from non-graceful death.
+
+**Architecture:** Process-level `DrainState` gates the run-start surface via an outermost ASGI middleware. `RunManager.drain()` waits on a `_tasks_empty` event with a long timeout (default 3600s); the existing per-task cancel path handles forced shutdown. Run metadata gains a wall-clock `last_event_at` heartbeat; `bootstrap` and stream subscribe atomically clear orphaned `active_run` keys via Lua CAS and surface `last_run_status: "stale"` so the frontend can render a failure bubble.
+
+**Tech Stack:** FastAPI ASGI middleware, asyncio signal handlers (`loop.add_signal_handler`), Redis Lua scripts (atomic CAS), pytest-asyncio with real Redis.
+
+**Spec:** `docs/superpowers/specs/2026-04-25-graceful-restart-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `backend/cubebox/lifecycle/__init__.py` — package marker
+- `backend/cubebox/lifecycle/drain.py` — `DrainState` class (process-level state machine)
+- `backend/cubebox/api/middleware/drain.py` — `DrainMiddleware` ASGI middleware
+- `backend/tests/unit/test_drain_state.py` — `DrainState` unit tests
+- `backend/tests/e2e/test_graceful_restart.py` — drain + stale detection E2E tests
+
+**Modified backend files:**
+- `backend/cubebox/streams/run_events.py` — add `last_event_at` field, extend `_APPEND_EVENT_LUA`, add `_MARK_STALE_LUA` + `mark_run_stale()` helper, add `is_stale_meta()` predicate
+- `backend/cubebox/streams/run_manager.py` — rename `shutdown()` → `cancel_all()`, add `drain()`, maintain `_tasks_empty` event, pass `last_event_at` to `append_run_event`
+- `backend/cubebox/api/app.py` — register signal handlers in lifespan, replace `shutdown()` with `enter_draining() + drain()`, register `DrainMiddleware`, mount health router
+- `backend/cubebox/api/routes/health.py` — split `/health/live` and `/health/ready`, drop `/health`
+- `backend/cubebox/api/routes/v1/conversations.py` — bootstrap stale check + `last_run_status`; stream subscribe stale check + synthetic error event
+- `backend/config.yaml`, `config.development.yaml`, `config.production.yaml`, `config.test.yaml` — add `lifecycle.*` keys
+
+**Modified frontend files:**
+- `frontend/packages/core/src/api/types.ts` — `last_run_status` on bootstrap
+- `frontend/packages/core/src/stores/messageStore.ts` — store stale flag from bootstrap
+- `frontend/packages/web/components/chat/MessageList.tsx` — render stale-run error bubble
+
+---
+
+## Task 1: Add `last_event_at` to RunMeta and Lua heartbeat
+
+**Files:**
+- Modify: `backend/cubebox/streams/run_events.py`
+- Modify: `backend/cubebox/streams/run_manager.py:276-286` (`_append_event`)
+- Test: `backend/tests/e2e/test_graceful_restart.py`
+
+The `last_event_at` ISO timestamp is stamped on every event append by `_APPEND_EVENT_LUA`. This enables stale detection later. Pure additive change — readers that don't know the field still work.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/e2e/test_graceful_restart.py
+"""E2E tests for graceful restart drain + stale-run detection."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from redis.asyncio import Redis
+
+from cubebox.config import config as _cubebox_config
+from cubebox.streams.run_events import (
+    append_run_event,
+    create_run,
+    get_run_meta,
+)
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.fixture
+async def redis_client():
+    client = Redis.from_url(
+        _cubebox_config.get("redis.url", "redis://127.0.0.1:6379/0"),
+        decode_responses=True,
+    )
+    yield client
+    await client.aclose()
+
+
+async def test_append_run_event_stamps_last_event_at(redis_client: Redis) -> None:
+    prefix = "test_graceful"
+    run_id = "run-heartbeat-1"
+    conv_id = "conv-heartbeat-1"
+    started = datetime.now(UTC).isoformat()
+
+    meta = await create_run(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=started,
+        ttl_seconds=60,
+    )
+    assert meta is not None
+
+    before = datetime.now(UTC)
+    await append_run_event(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        payload={"type": "status", "data": {"phase": "test"}},
+        ttl_seconds=60,
+        maxlen=100,
+    )
+    after = datetime.now(UTC)
+
+    fresh_meta = await get_run_meta(redis_client, prefix=prefix, run_id=run_id)
+    assert fresh_meta is not None
+    assert fresh_meta.last_event_at is not None
+    parsed = datetime.fromisoformat(fresh_meta.last_event_at)
+    assert before - timedelta(seconds=1) <= parsed <= after + timedelta(seconds=1)
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py::test_append_run_event_stamps_last_event_at -v`
+Expected: FAIL — `RunMeta` has no `last_event_at` attribute.
+
+- [ ] **Step 3: Add `last_event_at` to `RunMeta` dataclass and parser**
+
+In `backend/cubebox/streams/run_events.py`, modify the `RunMeta` dataclass:
+
+```python
+@dataclass(slots=True)
+class RunMeta:
+    """Metadata for a single run."""
+
+    run_id: str
+    conversation_id: str
+    status: str
+    started_at: str
+    user_message: str | None = None
+    first_event_id: str | None = None
+    last_event_id: str | None = None
+    last_event_at: str | None = None
+```
+
+Modify `_meta_from_hash`:
+
+```python
+def _meta_from_hash(raw: dict[str, str]) -> RunMeta | None:
+    if not raw:
+        return None
+    return RunMeta(
+        run_id=raw["run_id"],
+        conversation_id=raw["conversation_id"],
+        status=raw["status"],
+        started_at=raw["started_at"],
+        user_message=raw.get("user_message"),
+        first_event_id=raw.get("first_event_id"),
+        last_event_id=raw.get("last_event_id"),
+        last_event_at=raw.get("last_event_at"),
+    )
+```
+
+- [ ] **Step 4: Extend `_APPEND_EVENT_LUA` to stamp `last_event_at`**
+
+In the same file, replace the existing `_APPEND_EVENT_LUA` block:
+
+```python
+_APPEND_EVENT_LUA = """
+local eid = redis.call(
+  'XADD', KEYS[1], 'MAXLEN', '~', tonumber(ARGV[3]), '*', 'payload', ARGV[1]
+)
+redis.call('HSET', KEYS[2], 'last_event_id', eid, 'last_event_at', ARGV[5])
+redis.call('HSETNX', KEYS[2], 'first_event_id', eid)
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+redis.call('EXPIRE', KEYS[2], tonumber(ARGV[2]))
+if redis.call('GET', KEYS[3]) == ARGV[4] then
+  redis.call('EXPIRE', KEYS[3], tonumber(ARGV[2]))
+end
+return eid
+"""
+```
+
+- [ ] **Step 5: Update `append_run_event` to compute and pass `last_event_at`**
+
+Replace the existing `append_run_event` function body with:
+
+```python
+async def append_run_event(
+    redis: Redis,
+    *,
+    prefix: str,
+    run_id: str,
+    conversation_id: str,
+    payload: dict[str, Any],
+    ttl_seconds: int,
+    maxlen: int,
+) -> str:
+    """Append an event payload and update event bounds in a single call.
+
+    Stamps a wall-clock ``last_event_at`` heartbeat so stale-run detection
+    can spot dead workers. Also heartbeats the active-run lock for this
+    conversation so runs longer than ``ttl_seconds`` don't drop the lock
+    mid-execution.
+    """
+    from datetime import UTC, datetime
+
+    last_event_at = datetime.now(UTC).isoformat()
+    return cast(
+        str,
+        await redis.eval(  # type: ignore[misc]
+            _APPEND_EVENT_LUA,
+            3,
+            _run_events_key(prefix, run_id),
+            _run_meta_key(prefix, run_id),
+            _active_run_key(prefix, conversation_id),
+            json.dumps(payload),
+            str(ttl_seconds),
+            str(maxlen),
+            run_id,
+            last_event_at,
+        ),
+    )
+```
+
+- [ ] **Step 6: Run test, verify PASS**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py::test_append_run_event_stamps_last_event_at -v`
+Expected: PASS.
+
+- [ ] **Step 7: Confirm existing streaming tests still pass**
+
+Run: `cd backend && uv run pytest tests/e2e/test_streaming.py -v`
+Expected: all PASS (no regression in append behavior).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/cubebox/streams/run_events.py backend/tests/e2e/test_graceful_restart.py
+git commit -m "feat(streams): heartbeat last_event_at on run event append"
+```
+
+---
+
+## Task 2: Lifecycle configuration keys
+
+**Files:**
+- Modify: `backend/config.yaml`
+- Modify: `backend/config.development.yaml`
+- Modify: `backend/config.production.yaml`
+- Modify: `backend/config.test.yaml`
+
+Adds the three knobs the runtime reads. Default values match the spec.
+
+- [ ] **Step 1: Add lifecycle block to base `config.yaml`**
+
+In `backend/config.yaml`, append a top-level block (preserve existing keys, add this section):
+
+```yaml
+lifecycle:
+  graceful_drain_timeout_seconds: 3600
+  dev_double_signal_force_exit: true
+  stale_run_threshold_seconds: 120
+```
+
+- [ ] **Step 2: Override in `config.test.yaml` for fast tests**
+
+In `backend/config.test.yaml`, add or merge:
+
+```yaml
+lifecycle:
+  graceful_drain_timeout_seconds: 5
+  dev_double_signal_force_exit: false
+  stale_run_threshold_seconds: 1
+```
+
+The 5-second timeout keeps drain tests fast; 1-second stale threshold makes
+stale tests deterministic without sleeping.
+
+- [ ] **Step 3: Confirm dev and prod configs inherit base**
+
+Inspect `backend/config.development.yaml` and `backend/config.production.yaml`. If either explicitly sets unrelated lifecycle/runtime sections, leave them. If they need lifecycle overrides specific to that env, add an empty `lifecycle: {}` to make the inheritance explicit. Otherwise no change is needed.
+
+- [ ] **Step 4: Verify config loads**
+
+Run: `cd backend && uv run python -c "from cubebox.config import config; print(config.get('lifecycle.graceful_drain_timeout_seconds')); print(config.get('lifecycle.stale_run_threshold_seconds'))"`
+Expected: prints `3600` then `120`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/config.yaml backend/config.test.yaml backend/config.development.yaml backend/config.production.yaml
+git commit -m "feat(config): add lifecycle.* drain and stale-run keys"
+```
+
+---
+
+## Task 3: `DrainState` lifecycle module
+
+**Files:**
+- Create: `backend/cubebox/lifecycle/__init__.py`
+- Create: `backend/cubebox/lifecycle/drain.py`
+- Test: `backend/tests/unit/test_drain_state.py`
+
+Process-level state machine. Idempotent transitions. No async — purely synchronous flag flipping. The async waiting lives in `RunManager.drain()`.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/unit/test_drain_state.py
+"""DrainState transitions."""
+
+from __future__ import annotations
+
+from cubebox.lifecycle.drain import DrainState
+
+
+def test_initial_state_is_accepting() -> None:
+    state = DrainState()
+    assert state.is_accepting()
+    assert not state.is_draining()
+
+
+def test_enter_draining_flips_flag() -> None:
+    state = DrainState()
+    state.enter_draining()
+    assert not state.is_accepting()
+    assert state.is_draining()
+
+
+def test_enter_draining_is_idempotent() -> None:
+    state = DrainState()
+    state.enter_draining()
+    state.enter_draining()
+    assert state.is_draining()
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `cd backend && uv run pytest tests/unit/test_drain_state.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the package marker**
+
+Create `backend/cubebox/lifecycle/__init__.py`:
+
+```python
+"""Process-level lifecycle primitives (drain, stale detection)."""
+
+from cubebox.lifecycle.drain import DrainState
+
+__all__ = ["DrainState"]
+```
+
+- [ ] **Step 4: Implement `DrainState`**
+
+Create `backend/cubebox/lifecycle/drain.py`:
+
+```python
+"""Process-level drain state machine.
+
+The state machine is read by request handlers (drain middleware, health
+probes) and written by signal handlers + the FastAPI lifespan shutdown
+hook. It does not own any async waiting — that lives in
+``RunManager.drain()``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+State = Literal["accepting", "draining"]
+
+
+class DrainState:
+    """Single-process drain flag.
+
+    Transitions:
+        accepting -> draining (via enter_draining; idempotent)
+
+    The 'exiting' phase from the design doc is a property of the lifespan
+    shutdown sequence, not a state we observe at runtime. Once
+    ``RunManager.drain()`` returns, the process tears down.
+    """
+
+    __slots__ = ("_state",)
+
+    def __init__(self) -> None:
+        self._state: State = "accepting"
+
+    def is_accepting(self) -> bool:
+        return self._state == "accepting"
+
+    def is_draining(self) -> bool:
+        return self._state == "draining"
+
+    def enter_draining(self) -> None:
+        self._state = "draining"
+```
+
+- [ ] **Step 5: Run test, verify PASS**
+
+Run: `cd backend && uv run pytest tests/unit/test_drain_state.py -v`
+Expected: 3 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/lifecycle/ backend/tests/unit/test_drain_state.py
+git commit -m "feat(lifecycle): introduce DrainState"
+```
+
+---
+
+## Task 4: `RunManager.drain()` and `cancel_all()` rename
+
+**Files:**
+- Modify: `backend/cubebox/streams/run_manager.py:222-274` (constructor + shutdown method)
+- Test: `backend/tests/e2e/test_graceful_restart.py`
+
+Maintains an `asyncio.Event` set whenever `_tasks` becomes empty. `drain(timeout)` waits on it with a periodic 30s progress logger. Timeout falls through to the existing cancel path.
+
+- [ ] **Step 1: Write failing test for empty-tasks fast path**
+
+Append to `backend/tests/e2e/test_graceful_restart.py`:
+
+```python
+from types import SimpleNamespace
+from cubebox.streams.run_manager import RunManager
+
+
+def _make_run_manager(redis_client: Redis) -> RunManager:
+    app = SimpleNamespace(state=SimpleNamespace())
+    return RunManager(
+        app=app,
+        redis=redis_client,
+        key_prefix="test_drain",
+        run_event_ttl_seconds=60,
+    )
+
+
+@pytest.mark.asyncio
+async def test_drain_returns_immediately_when_no_tasks(redis_client: Redis) -> None:
+    rm = _make_run_manager(redis_client)
+    start = asyncio.get_event_loop().time()
+    await rm.drain(timeout_seconds=10.0)
+    elapsed = asyncio.get_event_loop().time() - start
+    assert elapsed < 0.5
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_in_flight_task(redis_client: Redis) -> None:
+    rm = _make_run_manager(redis_client)
+
+    async def slow() -> None:
+        await asyncio.sleep(0.3)
+
+    task = asyncio.create_task(slow(), name="run:slow-1")
+    rm._tasks["slow-1"] = task
+    task.add_done_callback(lambda _: rm._on_task_done("slow-1"))
+
+    start = asyncio.get_event_loop().time()
+    await rm.drain(timeout_seconds=5.0)
+    elapsed = asyncio.get_event_loop().time() - start
+    assert 0.25 < elapsed < 1.5
+    assert "slow-1" not in rm._tasks
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_cancels_residual(redis_client: Redis) -> None:
+    rm = _make_run_manager(redis_client)
+
+    async def forever() -> None:
+        await asyncio.sleep(60)
+
+    task = asyncio.create_task(forever(), name="run:forever")
+    rm._tasks["forever"] = task
+    task.add_done_callback(lambda _: rm._on_task_done("forever"))
+
+    await rm.drain(timeout_seconds=0.2)
+    # cancel_all path completed: task is done (cancelled) and removed.
+    assert task.cancelled() or task.done()
+```
+
+- [ ] **Step 2: Run tests, verify FAIL**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -k drain -v`
+Expected: FAIL — `RunManager.drain` does not exist; `_on_task_done` does not exist.
+
+- [ ] **Step 3: Modify `RunManager.__init__` to add the empty event and a helper**
+
+In `backend/cubebox/streams/run_manager.py`, replace the constructor block (around line 208-222) with:
+
+```python
+    def __init__(
+        self,
+        *,
+        app: FastAPI,
+        redis: Redis,
+        key_prefix: str,
+        run_event_ttl_seconds: int,
+        run_stream_max_events: int = 1000000,
+    ) -> None:
+        self._app = app
+        self._redis = redis
+        self._key_prefix = key_prefix
+        self._run_event_ttl_seconds = run_event_ttl_seconds
+        self._run_stream_max_events = run_stream_max_events
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._tasks_empty: asyncio.Event = asyncio.Event()
+        self._tasks_empty.set()
+
+    def _on_task_done(self, run_id: str) -> None:
+        self._tasks.pop(run_id, None)
+        if not self._tasks:
+            self._tasks_empty.set()
+```
+
+- [ ] **Step 4: Wire `_on_task_done` into the existing task callback**
+
+In `RunManager.start_run`, replace the existing callback registration:
+
+```python
+        task.add_done_callback(lambda _: self._tasks.pop(run_id, None))
+```
+
+with:
+
+```python
+        task.add_done_callback(lambda _: self._on_task_done(run_id))
+```
+
+Also clear the empty event when a new task is registered. Insert immediately before `self._tasks[run_id] = task`:
+
+```python
+        self._tasks_empty.clear()
+```
+
+- [ ] **Step 5: Rename `shutdown` → `cancel_all`, add `drain`**
+
+Replace the existing `shutdown` method (around line 267-274) with both methods:
+
+```python
+    async def cancel_all(self) -> None:
+        """Cancel every in-flight run task. Forced shutdown path."""
+        tasks = list(self._tasks.values())
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            with suppress(asyncio.CancelledError):
+                await task
+
+    async def drain(self, timeout_seconds: float) -> None:
+        """Wait for in-flight runs to finish, then return.
+
+        On timeout, cancels residual tasks via ``cancel_all`` (which lets
+        the per-task cancel path mark status=cancelled and write an
+        ``error`` event before the lock is released).
+
+        Logs a progress line every 30 seconds while waiting.
+        """
+        if self._tasks_empty.is_set():
+            return
+
+        progress_task = asyncio.create_task(self._log_drain_progress())
+        try:
+            await asyncio.wait_for(self._tasks_empty.wait(), timeout=timeout_seconds)
+        except TimeoutError:
+            logger.warning(
+                "Drain timeout after {}s, cancelling {} residual run(s)",
+                timeout_seconds,
+                len(self._tasks),
+            )
+            await self.cancel_all()
+        finally:
+            progress_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await progress_task
+
+    async def _log_drain_progress(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(30)
+                if self._tasks:
+                    logger.info("Still draining: {} run(s) remaining", len(self._tasks))
+        except asyncio.CancelledError:
+            return
+```
+
+- [ ] **Step 6: Run drain tests, verify PASS**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -k drain -v`
+Expected: 3 PASS.
+
+- [ ] **Step 7: Update existing call sites of `shutdown()`**
+
+`grep -rn "run_manager.shutdown\|\.shutdown()" backend/cubebox/ backend/tests/ | grep -v node_modules`
+
+The lifespan in `backend/cubebox/api/app.py:213` calls `run_manager.shutdown()`. Update to `run_manager.cancel_all()` for now — Task 7 will replace this with the proper drain call.
+
+```python
+    if run_manager is not None:
+        await run_manager.cancel_all()
+```
+
+- [ ] **Step 8: Run full streaming suite, verify no regression**
+
+Run: `cd backend && uv run pytest tests/e2e/test_streaming.py -v`
+Expected: all PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/cubebox/streams/run_manager.py backend/cubebox/api/app.py backend/tests/e2e/test_graceful_restart.py
+git commit -m "feat(run-manager): add drain() with task-empty event, rename shutdown to cancel_all"
+```
+
+---
+
+## Task 5: `DrainMiddleware`
+
+**Files:**
+- Create: `backend/cubebox/api/middleware/drain.py`
+- Test: `backend/tests/e2e/test_graceful_restart.py`
+
+Outermost ASGI middleware. Returns 503 on `POST /api/v1/ws/{ws}/conversations/{cid}/messages` when draining. Path-based check, no regex; method + segment count + tail equality is enough.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `backend/tests/e2e/test_graceful_restart.py`:
+
+```python
+from cubebox.api.middleware.drain import DrainMiddleware
+from cubebox.lifecycle.drain import DrainState
+
+
+@pytest.mark.asyncio
+async def test_drain_middleware_passthrough_when_accepting() -> None:
+    state = DrainState()
+    received_scope: dict[str, object] = {}
+
+    async def downstream(scope, receive, send):
+        received_scope["called"] = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    mw = DrainMiddleware(downstream, drain_state=state)
+    sent: list[dict] = []
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(msg):
+        sent.append(msg)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/ws/ws-1/conversations/c-1/messages",
+    }
+    await mw(scope, receive, send)
+    assert received_scope.get("called") is True
+    assert sent[0]["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_drain_middleware_blocks_new_run_when_draining() -> None:
+    state = DrainState()
+    state.enter_draining()
+
+    async def downstream(scope, receive, send):
+        raise AssertionError("downstream must not be called during drain")
+
+    mw = DrainMiddleware(downstream, drain_state=state)
+    sent: list[dict] = []
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(msg):
+        sent.append(msg)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/ws/ws-1/conversations/c-1/messages",
+    }
+    await mw(scope, receive, send)
+    assert sent[0]["status"] == 503
+    headers = dict(sent[0]["headers"])
+    assert headers[b"retry-after"] == b"5"
+
+
+@pytest.mark.asyncio
+async def test_drain_middleware_passes_through_non_run_paths_when_draining() -> None:
+    state = DrainState()
+    state.enter_draining()
+
+    called = {"yes": False}
+
+    async def downstream(scope, receive, send):
+        called["yes"] = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    mw = DrainMiddleware(downstream, drain_state=state)
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(_msg):
+        pass
+
+    # SSE subscription should pass through
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/v1/ws/ws-1/conversations/c-1/runs/r-1/stream",
+    }
+    await mw(scope, receive, send)
+    assert called["yes"] is True
+```
+
+- [ ] **Step 2: Run tests, verify FAIL**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -k drain_middleware -v`
+Expected: FAIL — `DrainMiddleware` does not exist.
+
+- [ ] **Step 3: Implement `DrainMiddleware`**
+
+Create `backend/cubebox/api/middleware/drain.py`:
+
+```python
+"""Reject new run starts with 503 while the process is draining.
+
+This middleware is registered last in ``create_app`` so it runs as the
+outermost wrapper on the request path: a draining server should refuse new
+runs before doing CSRF or identity work.
+
+Only the run-start surface is gated. SSE subscription, bootstrap, auth,
+and health probes pass through unchanged so existing clients keep working
+during drain.
+"""
+
+from __future__ import annotations
+
+import json
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from cubebox.lifecycle.drain import DrainState
+
+_RETRY_AFTER_SECONDS = "5"
+_BLOCKED_BODY = json.dumps(
+    {"error": {"code": "draining", "message": "Server is draining; retry."}}
+).encode()
+
+
+def _is_run_start(scope: Scope) -> bool:
+    """Match POST /api/v1/ws/{ws}/conversations/{cid}/messages exactly."""
+    if scope.get("method") != "POST":
+        return False
+    path = scope.get("path", "")
+    if not path.startswith("/api/v1/ws/"):
+        return False
+    segments = path.strip("/").split("/")
+    # ['api', 'v1', 'ws', '{ws}', 'conversations', '{cid}', 'messages']
+    return (
+        len(segments) == 7
+        and segments[4] == "conversations"
+        and segments[6] == "messages"
+    )
+
+
+class DrainMiddleware:
+    def __init__(self, app: ASGIApp, *, drain_state: DrainState) -> None:
+        self.app = app
+        self._state = drain_state
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or not self._state.is_draining():
+            await self.app(scope, receive, send)
+            return
+
+        if not _is_run_start(scope):
+            await self.app(scope, receive, send)
+            return
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 503,
+                "headers": [
+                    (b"retry-after", _RETRY_AFTER_SECONDS.encode()),
+                    (b"connection", b"close"),
+                    (b"content-type", b"application/json"),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": _BLOCKED_BODY})
+```
+
+- [ ] **Step 4: Run tests, verify PASS**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -k drain_middleware -v`
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/api/middleware/drain.py backend/tests/e2e/test_graceful_restart.py
+git commit -m "feat(api): DrainMiddleware refuses new run starts while draining"
+```
+
+---
+
+## Task 6: Health route split
+
+**Files:**
+- Modify: `backend/cubebox/api/routes/health.py`
+- Modify: `backend/cubebox/api/routes/v1/__init__.py` (add health export if missing)
+- Test: `backend/tests/e2e/test_graceful_restart.py`
+
+Replaces the single `/health` with `/health/live` (always 200) and `/health/ready` (503 while draining). The legacy `/health` is dropped per the design doc.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `backend/tests/e2e/test_graceful_restart.py`:
+
+```python
+import httpx
+
+
+@pytest.mark.asyncio
+async def test_health_live_always_200(memory_client: httpx.AsyncClient) -> None:
+    resp = await memory_client.get("/health/live")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_health_ready_200_when_accepting(memory_client: httpx.AsyncClient) -> None:
+    resp = await memory_client.get("/health/ready")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_health_ready_503_when_draining(
+    memory_client: httpx.AsyncClient, app_state_drain: DrainState
+) -> None:
+    app_state_drain.enter_draining()
+    try:
+        resp = await memory_client.get("/health/ready")
+        assert resp.status_code == 503
+        # Liveness must remain 200 — k8s should not kill the pod during drain.
+        live_resp = await memory_client.get("/health/live")
+        assert live_resp.status_code == 200
+    finally:
+        # Reset for subsequent tests in the session.
+        app_state_drain._state = "accepting"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_legacy_health_removed(memory_client: httpx.AsyncClient) -> None:
+    resp = await memory_client.get("/health")
+    assert resp.status_code == 404
+```
+
+The `app_state_drain` fixture will be added in Task 7 (lifespan wiring). For now, these tests are expected to fail at collection or at fixture lookup; that's fine.
+
+- [ ] **Step 2: Run tests, verify FAIL**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -k health -v`
+Expected: FAIL — endpoints don't exist (or `app_state_drain` fixture missing).
+
+- [ ] **Step 3: Replace the health router**
+
+Replace the entire contents of `backend/cubebox/api/routes/health.py` with:
+
+```python
+"""Health probes split for k8s.
+
+- ``/health/live`` is the liveness probe. Always 200 while the process is up.
+  Must not flip during drain or k8s will kill the pod before drain completes.
+- ``/health/ready`` is the readiness probe. 503 while draining so the load
+  balancer stops sending new traffic to this pod.
+"""
+
+from fastapi import APIRouter, Request, Response
+
+router = APIRouter(prefix="/health", tags=["health"])
+
+
+@router.get("/live")
+async def liveness() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/ready")
+async def readiness(request: Request, response: Response) -> dict[str, str]:
+    drain_state = getattr(request.app.state, "drain_state", None)
+    if drain_state is not None and drain_state.is_draining():
+        response.status_code = 503
+        return {"status": "draining"}
+    return {"status": "ok"}
+```
+
+- [ ] **Step 4: Export the router and mount it**
+
+Confirm `backend/cubebox/api/routes/__init__.py` does not need changes — it's just the package marker. The router is mounted directly from `app.py`.
+
+In `backend/cubebox/api/app.py`, inside `create_app`, add the import and mount near the other `include_router` calls (around line 274-285):
+
+```python
+    from cubebox.api.routes.health import router as health_router
+
+    app.include_router(health_router)
+```
+
+(No `/api/v1` prefix — `/health/*` is conventionally unversioned.)
+
+- [ ] **Step 5: Run live + legacy tests, verify partial PASS**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -k "health_live_always or legacy_health" -v`
+Expected: both PASS. The two readiness tests stay failing until Task 7 wires `app.state.drain_state`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/api/routes/health.py backend/cubebox/api/app.py
+git commit -m "feat(health): split /health/live and /health/ready, drop /health"
+```
+
+---
+
+## Task 7: Lifespan integration (signal handlers + drain + middleware)
+
+**Files:**
+- Modify: `backend/cubebox/api/app.py`
+- Test: `backend/tests/e2e/test_graceful_restart.py`
+
+Wires everything: install signal handlers, register `DrainMiddleware`, replace `cancel_all()` in lifespan shutdown with `enter_draining() + drain(timeout)`, expose `app.state.drain_state`.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `backend/tests/e2e/test_graceful_restart.py`:
+
+```python
+@pytest.fixture
+async def app_state_drain(memory_client: httpx.AsyncClient) -> DrainState:
+    """Pull the live DrainState from the app the test client targets."""
+    app = memory_client._transport.app  # type: ignore[attr-defined]
+    state = getattr(app.state, "drain_state", None)
+    assert isinstance(state, DrainState), "lifespan did not install drain_state"
+    return state
+
+
+@pytest.mark.asyncio
+async def test_post_messages_returns_503_when_draining(
+    memory_client: httpx.AsyncClient,
+    app_state_drain: DrainState,
+) -> None:
+    # Create a conversation first while still accepting.
+    create_resp = await memory_client.post(
+        "/api/v1/ws/default-ws/conversations", params={"title": "drain-test"}
+    )
+    assert create_resp.status_code == 200
+    conv_id = create_resp.json()["id"]
+
+    app_state_drain.enter_draining()
+    try:
+        resp = await memory_client.post(
+            f"/api/v1/ws/default-ws/conversations/{conv_id}/messages",
+            json={"content": "hi"},
+        )
+        assert resp.status_code == 503
+        assert resp.headers.get("retry-after") == "5"
+    finally:
+        app_state_drain._state = "accepting"  # type: ignore[attr-defined]
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -k post_messages_returns_503 -v`
+Expected: FAIL — middleware not registered, drain_state not on app.state.
+
+- [ ] **Step 3: Create `DrainState` in `create_app` (so middleware can capture it)**
+
+In `backend/cubebox/api/app.py`, inside `create_app`, BEFORE the existing `app.add_middleware(...)` calls (around line 252), insert:
+
+```python
+    from cubebox.lifecycle.drain import DrainState
+
+    app.state.drain_state = DrainState()
+```
+
+`add_middleware` runs at app-construction time, before the lifespan starts. The middleware needs the same `DrainState` instance the lifespan and signal handlers will write to, so we create it once here.
+
+- [ ] **Step 4: Register `DrainMiddleware` last (outermost)**
+
+In the same `create_app`, AFTER all existing `app.add_middleware(...)` calls (around line 260), add:
+
+```python
+    from cubebox.api.middleware.drain import DrainMiddleware
+
+    app.add_middleware(DrainMiddleware, drain_state=app.state.drain_state)
+```
+
+Last-registered = outermost on the request path: drain refuses new runs before any other middleware does work.
+
+- [ ] **Step 5: Install signal handlers in lifespan startup**
+
+In the lifespan function, immediately after `log.init()` (around line 29-30), insert:
+
+```python
+    import asyncio
+    import os
+    import signal as _signal
+
+    drain_state = _app.state.drain_state
+    loop = asyncio.get_running_loop()
+    force_exit_enabled = config.get("lifecycle.dev_double_signal_force_exit", True)
+    _signal_seen: dict[str, bool] = {"first": False}
+
+    def _on_signal(signame: str) -> None:
+        if not _signal_seen["first"]:
+            _signal_seen["first"] = True
+            logger.info("{} received — entering drain mode", signame)
+            drain_state.enter_draining()
+            return
+        if force_exit_enabled:
+            logger.warning("Second {} received — force exiting", signame)
+            # Schedule cancel_all and exit immediately. We do not block on
+            # cancel_all because the developer pressed Ctrl-C twice
+            # precisely to skip the wait.
+            rm = getattr(_app.state, "run_manager", None)
+            if rm is not None:
+                asyncio.ensure_future(rm.cancel_all())
+            os._exit(130)
+
+    for sig in (_signal.SIGTERM, _signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _on_signal, sig.name)
+        except NotImplementedError:
+            # Non-POSIX (Windows): no graceful drain via signal there, but
+            # the lifespan-shutdown path still drains on uvicorn reload.
+            logger.debug("Signal {} not installable on this platform", sig.name)
+```
+
+- [ ] **Step 6: Replace `cancel_all()` with `drain()` in lifespan shutdown**
+
+In the same file, in the shutdown section (around line 211-215), replace:
+
+```python
+    if run_manager is not None:
+        await run_manager.cancel_all()
+```
+
+with:
+
+```python
+    if run_manager is not None:
+        # Idempotent: if a signal already flipped the state, this is a no-op.
+        # Covers uvicorn reload and other paths that don't deliver a signal.
+        _app.state.drain_state.enter_draining()
+        drain_timeout = config.get("lifecycle.graceful_drain_timeout_seconds", 3600)
+        await run_manager.drain(timeout_seconds=float(drain_timeout))
+```
+
+- [ ] **Step 7: Run targeted tests, verify PASS**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -v`
+Expected: all `health_*` and `post_messages_returns_503` tests PASS.
+
+- [ ] **Step 8: Run full streaming suite, verify no regression**
+
+Run: `cd backend && uv run pytest tests/e2e/test_streaming.py tests/e2e/test_conversations.py -v`
+Expected: all PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/cubebox/api/app.py backend/tests/e2e/test_graceful_restart.py
+git commit -m "feat(api): wire DrainState, signal handlers, drain on lifespan shutdown"
+```
+
+---
+
+## Task 8: Stale-run detection (backend)
+
+**Files:**
+- Modify: `backend/cubebox/streams/run_events.py` — add `_MARK_STALE_LUA`, `mark_run_stale()`, `is_stale_meta()`
+- Modify: `backend/cubebox/api/routes/v1/conversations.py` — bootstrap + stream stale handling
+- Test: `backend/tests/e2e/test_graceful_restart.py`
+
+Bootstrap and stream subscribe both check `is_stale_meta`, run `mark_run_stale` (Lua-atomic), and surface the failure. Bootstrap returns `last_run_status: "stale"`; stream emits a synthetic `error` event with `error_code: "run_stale"` and closes.
+
+- [ ] **Step 1: Write failing tests for the helper layer**
+
+Append to `backend/tests/e2e/test_graceful_restart.py`:
+
+```python
+from cubebox.streams.run_events import (
+    is_stale_meta,
+    mark_run_stale,
+    set_active_run,
+)
+
+
+def test_is_stale_meta_detects_stale_running() -> None:
+    # Helper accepts the parsed RunMeta, computes locally — no Redis.
+    from datetime import UTC, datetime, timedelta
+
+    from cubebox.streams.run_events import RunMeta
+
+    now = datetime.now(UTC)
+    fresh = RunMeta(
+        run_id="r1",
+        conversation_id="c1",
+        status="running",
+        started_at=now.isoformat(),
+        last_event_at=(now - timedelta(seconds=5)).isoformat(),
+    )
+    stale = RunMeta(
+        run_id="r2",
+        conversation_id="c2",
+        status="running",
+        started_at=now.isoformat(),
+        last_event_at=(now - timedelta(seconds=300)).isoformat(),
+    )
+    completed = RunMeta(
+        run_id="r3",
+        conversation_id="c3",
+        status="completed",
+        started_at=now.isoformat(),
+        last_event_at=(now - timedelta(seconds=300)).isoformat(),
+    )
+
+    assert not is_stale_meta(fresh, threshold_seconds=120, now=now)
+    assert is_stale_meta(stale, threshold_seconds=120, now=now)
+    # Completed runs are never stale, regardless of age.
+    assert not is_stale_meta(completed, threshold_seconds=120, now=now)
+
+
+@pytest.mark.asyncio
+async def test_mark_run_stale_clears_active_and_sets_status(redis_client: Redis) -> None:
+    from datetime import UTC, datetime
+
+    from cubebox.streams.run_events import (
+        create_run,
+        get_active_run,
+        get_run_meta,
+    )
+
+    prefix = "test_stale_mark"
+    run_id = "r-stale-1"
+    conv_id = "c-stale-1"
+    await create_run(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=datetime.now(UTC).isoformat(),
+        ttl_seconds=60,
+    )
+
+    await mark_run_stale(
+        redis_client, prefix=prefix, run_id=run_id, conversation_id=conv_id
+    )
+
+    fresh = await get_run_meta(redis_client, prefix=prefix, run_id=run_id)
+    assert fresh is not None
+    assert fresh.status == "stale"
+    active = await get_active_run(
+        redis_client, prefix=prefix, conversation_id=conv_id
+    )
+    assert active is None
+
+
+@pytest.mark.asyncio
+async def test_mark_run_stale_is_idempotent(redis_client: Redis) -> None:
+    from datetime import UTC, datetime
+
+    from cubebox.streams.run_events import create_run, get_run_meta
+
+    prefix = "test_stale_idem"
+    run_id = "r-stale-2"
+    conv_id = "c-stale-2"
+    await create_run(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=datetime.now(UTC).isoformat(),
+        ttl_seconds=60,
+    )
+
+    await mark_run_stale(
+        redis_client, prefix=prefix, run_id=run_id, conversation_id=conv_id
+    )
+    # Second call: status already stale, active_run already cleared — no-op.
+    await mark_run_stale(
+        redis_client, prefix=prefix, run_id=run_id, conversation_id=conv_id
+    )
+    fresh = await get_run_meta(redis_client, prefix=prefix, run_id=run_id)
+    assert fresh is not None
+    assert fresh.status == "stale"
+```
+
+- [ ] **Step 2: Run helper tests, verify FAIL**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -k "is_stale_meta or mark_run_stale" -v`
+Expected: FAIL — symbols not imported.
+
+- [ ] **Step 3: Add `_MARK_STALE_LUA`, `mark_run_stale`, `is_stale_meta`**
+
+In `backend/cubebox/streams/run_events.py`, after the existing `_APPEND_EVENT_LUA` block, add:
+
+```python
+# Mark a run as stale and clear the active-run lock if it still points at it.
+# KEYS[1] = meta_key, KEYS[2] = active_key
+# ARGV[1] = expected_run_id
+_MARK_STALE_LUA = """
+if redis.call('HGET', KEYS[1], 'status') == 'running' then
+  redis.call('HSET', KEYS[1], 'status', 'stale')
+end
+if redis.call('GET', KEYS[2]) == ARGV[1] then
+  redis.call('DEL', KEYS[2])
+end
+return 1
+"""
+```
+
+After the existing `expire_run_data` function, append:
+
+```python
+async def mark_run_stale(
+    redis: Redis,
+    *,
+    prefix: str,
+    run_id: str,
+    conversation_id: str,
+) -> None:
+    """Atomically mark a run stale and release its active-run lock if held.
+
+    Idempotent: a no-op when status is already non-running and the active
+    key no longer points at this run.
+    """
+    await redis.eval(  # type: ignore[misc]
+        _MARK_STALE_LUA,
+        2,
+        _run_meta_key(prefix, run_id),
+        _active_run_key(prefix, conversation_id),
+        run_id,
+    )
+
+
+def is_stale_meta(
+    meta: RunMeta,
+    *,
+    threshold_seconds: int,
+    now: "datetime | None" = None,
+) -> bool:
+    """A run is stale when status='running' and last_event_at is too old."""
+    from datetime import UTC, datetime
+
+    if meta.status != "running":
+        return False
+    if not meta.last_event_at:
+        return False
+    current = now or datetime.now(UTC)
+    last = datetime.fromisoformat(meta.last_event_at)
+    return (current - last).total_seconds() > threshold_seconds
+```
+
+(Add the matching `from datetime import datetime` to the type-only block at the top of the module if mypy complains. Otherwise the inline import is sufficient.)
+
+- [ ] **Step 4: Run helper tests, verify PASS**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -k "is_stale_meta or mark_run_stale" -v`
+Expected: 3 PASS.
+
+- [ ] **Step 5: Write failing tests for the route layer**
+
+Append to `backend/tests/e2e/test_graceful_restart.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_bootstrap_clears_stale_run_and_sets_last_run_status(
+    memory_client: httpx.AsyncClient, redis_client: Redis
+) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from cubebox.streams.run_events import _APPEND_EVENT_LUA  # noqa
+    from cubebox.streams.run_events import create_run, _active_run_key
+
+    create_resp = await memory_client.post(
+        "/api/v1/ws/default-ws/conversations", params={"title": "stale-test"}
+    )
+    assert create_resp.status_code == 200
+    conv_id = create_resp.json()["id"]
+
+    # The app under test uses prefix "test:test" (env=test). Reach it from app.state.
+    app = memory_client._transport.app  # type: ignore[attr-defined]
+    prefix = app.state.redis_key_prefix
+    run_id = "stale-run-1"
+    long_ago = (datetime.now(UTC) - timedelta(seconds=600)).isoformat()
+
+    # Plant a fake active run with an old last_event_at.
+    meta = await create_run(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=long_ago,
+        ttl_seconds=120,
+    )
+    assert meta is not None
+    # Stamp last_event_at directly (no real append, so we set the hash field).
+    await redis_client.hset(  # type: ignore[misc]
+        f"{prefix}:run_meta:v2:{run_id}", "last_event_at", long_ago
+    )
+
+    resp = await memory_client.get(
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/bootstrap"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["active_run"] is None
+    assert body["last_run_status"] == "stale"
+
+    # Active key cleared.
+    active = await redis_client.get(_active_run_key(prefix, conv_id))
+    assert active is None
+
+
+@pytest.mark.asyncio
+async def test_stream_subscribe_emits_stale_error_for_dead_run(
+    memory_client: httpx.AsyncClient, redis_client: Redis
+) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from cubebox.streams.run_events import create_run
+
+    create_resp = await memory_client.post(
+        "/api/v1/ws/default-ws/conversations", params={"title": "stale-stream"}
+    )
+    conv_id = create_resp.json()["id"]
+
+    app = memory_client._transport.app  # type: ignore[attr-defined]
+    prefix = app.state.redis_key_prefix
+    run_id = "stale-run-2"
+    long_ago = (datetime.now(UTC) - timedelta(seconds=600)).isoformat()
+    await create_run(
+        redis_client,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=long_ago,
+        ttl_seconds=120,
+    )
+    await redis_client.hset(  # type: ignore[misc]
+        f"{prefix}:run_meta:v2:{run_id}", "last_event_at", long_ago
+    )
+
+    async with memory_client.stream(
+        "GET",
+        f"/api/v1/ws/default-ws/conversations/{conv_id}/runs/{run_id}/stream",
+    ) as resp:
+        body = await resp.aread()
+    text = body.decode()
+    # SSE chunks are concatenated; find any data: line that contains run_stale.
+    assert "run_stale" in text
+```
+
+- [ ] **Step 6: Run route tests, verify FAIL**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -k "bootstrap_clears_stale or stream_subscribe_emits_stale" -v`
+Expected: FAIL — bootstrap doesn't return `last_run_status`; stream doesn't emit synthetic error for stale.
+
+- [ ] **Step 7: Wire stale detection into bootstrap**
+
+In `backend/cubebox/api/routes/v1/conversations.py`:
+
+Add the import at the top with the other run_events imports:
+
+```python
+from cubebox.streams.run_events import (
+    get_active_run,
+    get_latest_event_id,
+    get_run_meta,
+    is_stale_meta,
+    iter_run_events,
+    mark_run_stale,
+    read_run_events_after,
+)
+```
+
+Replace the bootstrap function body (around line 520-564) with:
+
+```python
+@router.get("/{conversation_id}/bootstrap")
+async def get_conversation_bootstrap(
+    conversation_id: str,
+    raw_request: Request,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    ctx: Annotated[RequestContext, Depends(require_member)],
+    rds: Annotated[RedisHandle, Depends(redis_dep)],
+) -> dict[str, object]:
+    """Return history baseline plus active run metadata."""
+    from cubebox.config import config as _cfg
+
+    conv_repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
+    conversation = await conv_repo.get_by_id(conversation_id)
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Conversation {conversation_id} not found",
+        )
+
+    history = await _get_history_messages(raw_request, conversation_id)
+    active_run = await get_active_run(
+        rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
+    )
+
+    last_run_status: str | None = None
+    if active_run is not None:
+        threshold = int(_cfg.get("lifecycle.stale_run_threshold_seconds", 120))
+        if is_stale_meta(active_run, threshold_seconds=threshold):
+            await mark_run_stale(
+                rds.client,
+                prefix=rds.key_prefix,
+                run_id=active_run.run_id,
+                conversation_id=conversation_id,
+            )
+            active_run = None
+            last_run_status = "stale"
+
+    active_run_payload: dict[str, Any] | None = None
+    if active_run is not None:
+        active_run_payload = {
+            "run_id": active_run.run_id,
+            "status": active_run.status,
+            "user_message": active_run.user_message,
+            "last_event_id": active_run.last_event_id,
+            "started_at": active_run.started_at,
+        }
+
+    return {
+        "messages": history["messages"],
+        "total": history["total"],
+        "active_run": active_run_payload,
+        "last_run_status": last_run_status,
+    }
+```
+
+- [ ] **Step 8: Wire stale detection into stream subscribe**
+
+In the same file, find `stream_run` (around line 572). Locate the block that fetches `run_meta`:
+
+```python
+    run_meta = await get_run_meta(rds.client, prefix=rds.key_prefix, run_id=run_id)
+    if run_meta is None or run_meta.conversation_id != conversation_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Run {run_id} not found",
+        )
+```
+
+Immediately after this block, insert:
+
+```python
+    from cubebox.config import config as _cfg
+
+    threshold = int(_cfg.get("lifecycle.stale_run_threshold_seconds", 120))
+    if is_stale_meta(run_meta, threshold_seconds=threshold):
+        await mark_run_stale(
+            rds.client,
+            prefix=rds.key_prefix,
+            run_id=run_id,
+            conversation_id=conversation_id,
+        )
+
+        async def _stale_stream() -> AsyncIterator[bytes]:
+            from datetime import UTC, datetime
+
+            payload = {
+                "type": "error",
+                "timestamp": datetime.now(UTC).isoformat(),
+                "data": {
+                    "error_code": "run_stale",
+                    "message": "This run died before finishing.",
+                },
+            }
+            yield _format_sse_event("0-0", payload).encode()
+
+        return StreamingResponse(_stale_stream(), media_type="text/event-stream")
+```
+
+- [ ] **Step 9: Run route tests, verify PASS**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -k "bootstrap_clears_stale or stream_subscribe_emits_stale" -v`
+Expected: 2 PASS.
+
+- [ ] **Step 10: Run full conversations + streaming suites, verify no regression**
+
+Run: `cd backend && uv run pytest tests/e2e/test_streaming.py tests/e2e/test_conversations.py tests/e2e/test_conversation_flow.py -v`
+Expected: all PASS.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add backend/cubebox/streams/run_events.py backend/cubebox/api/routes/v1/conversations.py backend/tests/e2e/test_graceful_restart.py
+git commit -m "feat(streams): inline stale-run detection in bootstrap and stream"
+```
+
+---
+
+## Task 9: Drain timeout E2E (full integration)
+
+**Files:**
+- Test: `backend/tests/e2e/test_graceful_restart.py`
+
+The unit-style drain tests in Task 4 cover the `RunManager.drain()` mechanics directly. This task adds two integration scenarios that exercise the whole pipeline end-to-end through the FastAPI test client.
+
+- [ ] **Step 1: Write failing test for in-flight run completing during drain**
+
+Append to `backend/tests/e2e/test_graceful_restart.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_drain_waits_for_in_flight_run_then_returns(
+    memory_client: httpx.AsyncClient,
+) -> None:
+    """Plant a slow async task in run_manager._tasks; drain should wait for it."""
+    app = memory_client._transport.app  # type: ignore[attr-defined]
+    rm = app.state.run_manager
+
+    completed = asyncio.Event()
+
+    async def slow_run() -> None:
+        try:
+            await asyncio.sleep(0.5)
+        finally:
+            completed.set()
+
+    task = asyncio.create_task(slow_run(), name="run:integration-slow")
+    rm._tasks["integration-slow"] = task
+    rm._tasks_empty.clear()
+    task.add_done_callback(lambda _: rm._on_task_done("integration-slow"))
+
+    start = asyncio.get_event_loop().time()
+    await rm.drain(timeout_seconds=5.0)
+    elapsed = asyncio.get_event_loop().time() - start
+    assert completed.is_set()
+    assert elapsed >= 0.4
+    assert "integration-slow" not in rm._tasks
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_force_cancels(memory_client: httpx.AsyncClient) -> None:
+    app = memory_client._transport.app  # type: ignore[attr-defined]
+    rm = app.state.run_manager
+
+    cancelled_seen = asyncio.Event()
+
+    async def long_run() -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled_seen.set()
+            raise
+
+    task = asyncio.create_task(long_run(), name="run:integration-long")
+    rm._tasks["integration-long"] = task
+    rm._tasks_empty.clear()
+    task.add_done_callback(lambda _: rm._on_task_done("integration-long"))
+
+    await rm.drain(timeout_seconds=0.2)
+    assert cancelled_seen.is_set()
+    assert "integration-long" not in rm._tasks
+```
+
+- [ ] **Step 2: Run tests, verify PASS**
+
+Run: `cd backend && uv run pytest tests/e2e/test_graceful_restart.py -k "drain_waits_for_in_flight_run or drain_timeout_force" -v`
+Expected: 2 PASS. (The behavior is already implemented in Task 4; these tests verify integration through the live `app.state.run_manager`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/tests/e2e/test_graceful_restart.py
+git commit -m "test(graceful): integration coverage for drain through live RunManager"
+```
+
+---
+
+## Task 10: Frontend `last_run_status` rendering
+
+**Files:**
+- Modify: `frontend/packages/core/src/api/types.ts`
+- Modify: `frontend/packages/core/src/stores/messageStore.ts`
+- Modify: `frontend/packages/web/components/chat/MessageList.tsx`
+- Test: `frontend/packages/core/src/stores/messageStore.test.ts` (if test file exists; otherwise add to nearest store test)
+
+Surface stale-run failure as a tag on the most recent user message. Reducer is replay-safe — no stream subscription is opened when bootstrap returns `last_run_status: "stale"`.
+
+- [ ] **Step 1: Add `last_run_status` to bootstrap type**
+
+Read `frontend/packages/core/src/api/types.ts` to locate the bootstrap response type. Add `last_run_status: 'stale' | null` to the response shape. Example (adapt to actual location):
+
+```typescript
+export type ConversationBootstrap = {
+  messages: ChatMessage[];
+  total: number;
+  active_run: ActiveRun | null;
+  last_run_status: 'stale' | null;
+};
+```
+
+If the existing type has no name and is inline, lift it to a named type.
+
+- [ ] **Step 2: Carry the flag through the message store**
+
+In `frontend/packages/core/src/stores/messageStore.ts`, locate the action that consumes a bootstrap response (search for `active_run` references). Extend the slice state with `lastRunStatus: 'stale' | null` and set it from the response. Do NOT open an SSE subscription when `last_run_status === 'stale'`.
+
+```typescript
+// inside the bootstrap reducer / action
+set({
+  messages: response.messages,
+  activeRun: response.active_run,
+  lastRunStatus: response.last_run_status,
+});
+```
+
+- [ ] **Step 3: Render the stale-error bubble**
+
+In `frontend/packages/web/components/chat/MessageList.tsx`, after the existing message render loop, add a stale notice block. Use the existing error-bubble styling for consistency with mid-stream errors:
+
+```tsx
+{lastRunStatus === 'stale' && (
+  <ErrorBubble>
+    上次回答未完成，请重试。
+  </ErrorBubble>
+)}
+```
+
+If `ErrorBubble` does not exist, copy the markup from how the `error` SSE event renders today (search for `error_code` or `error.message` in the same file).
+
+- [ ] **Step 4: Run frontend lint + typecheck**
+
+Run: `cd frontend && pnpm -w lint && pnpm -w typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Manual sanity check**
+
+```
+cd backend && python main.py        # terminal 1
+cd frontend && pnpm dev              # terminal 2
+```
+
+Send a message; in terminal 1, kill the process with `kill -9 $(pgrep -f cubebox)` immediately after the assistant starts streaming. Refresh the browser. The chat should show the stale error bubble beneath your last user message and unlock the input.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/packages/core/src/api/types.ts frontend/packages/core/src/stores/messageStore.ts frontend/packages/web/components/chat/MessageList.tsx
+git commit -m "feat(frontend): render stale-run error bubble from bootstrap"
+```
+
+---
+
+## Task 11: k8s deployment example
+
+**Files:**
+- Create: `backend/docs/deploy-k8s-graceful-restart.md`
+
+Operator-facing reference. Pairs `terminationGracePeriodSeconds` with the new probes so a rolling restart finishes draining. Per CLAUDE.md "Do not create docs without permission" — but this is a deploy-time reference for a feature the user explicitly approved, and is the only way to document the k8s pairing.
+
+- [ ] **Step 1: Verify with user before creating**
+
+This step is a checkpoint: confirm the user wants this doc before creating it. If they say no, mark this task complete with no file created.
+
+- [ ] **Step 2: If approved, write the doc**
+
+Create `backend/docs/deploy-k8s-graceful-restart.md`:
+
+```markdown
+# K8s Deployment — Graceful Restart
+
+The cubebox backend drains in-flight LangGraph runs on `SIGTERM` before
+exiting. To get zero-downtime rolling restarts, pair this with a long
+termination grace period and the split health probes.
+
+## Probes
+
+- `GET /health/live` → liveness. Always 200 while the process is up.
+- `GET /health/ready` → readiness. 503 while draining.
+
+## Recommended deployment fragment
+
+```yaml
+spec:
+  terminationGracePeriodSeconds: 3600   # match lifecycle.graceful_drain_timeout_seconds
+  containers:
+    - name: cubebox
+      readinessProbe:
+        httpGet: { path: /health/ready, port: 8000 }
+        periodSeconds: 5
+      livenessProbe:
+        httpGet: { path: /health/live, port: 8000 }
+        periodSeconds: 30
+```
+
+## Tunables
+
+`backend/config.yaml`:
+
+| Key | Default | Notes |
+|---|---|---|
+| `lifecycle.graceful_drain_timeout_seconds` | 3600 | Hard cap on drain wait. Match `terminationGracePeriodSeconds`. |
+| `lifecycle.stale_run_threshold_seconds` | 120 | Seconds without an event before bootstrap declares a run stale. |
+| `lifecycle.dev_double_signal_force_exit` | true | Second `Ctrl-C` forces immediate exit. Disable in production if needed. |
+
+## Force-killing a slow drain
+
+For an unscheduled exit:
+
+```
+kubectl delete pod <pod> --grace-period=0 --force
+```
+
+This skips drain. In-flight runs die mid-stream and surface to clients as
+stale runs the next time the user opens the conversation.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/docs/deploy-k8s-graceful-restart.md
+git commit -m "docs: k8s graceful-restart deployment reference"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Sections 1 (drain protocol) → Tasks 5, 7. Section 2 (implementation surface) → Tasks 3-7. Section 3 (signal handling) → Task 7. Section 4 (lifespan) → Task 7. Section 5 (RunManager.drain) → Task 4. Section 6 (DrainMiddleware) → Task 5. Section 7 (health probes) → Task 6. Section 8 (stale detection) → Tasks 1, 8. Section 9 (frontend) → Task 10. Behavior matrix entries are all covered by E2E tests in Tasks 5, 7, 8, 9. Testing strategy section (E2E #1-9 + unit) → Tasks 3, 4, 5, 6, 7, 8, 9.
+- **Type consistency:** `RunMeta.last_event_at` is consistently `str | None`. `is_stale_meta` accepts `RunMeta` directly (not raw hash). `mark_run_stale` arguments mirror `create_run`. `DrainState` exposes `is_accepting`, `is_draining`, `enter_draining` — used identically in middleware, health, and lifespan.
+- **Frequent commits:** every task ends with a commit. Total: 10 commits across 11 tasks (Task 11 only commits if user approves the doc).
+- **TDD:** tests precede implementation in every code-touching task.

--- a/docs/superpowers/specs/2026-04-25-graceful-restart-design.md
+++ b/docs/superpowers/specs/2026-04-25-graceful-restart-design.md
@@ -1,0 +1,397 @@
+# Graceful Restart Design
+
+## Problem
+
+When the FastAPI process restarts, every in-flight agent run dies. The
+LangGraph execution is owned by an in-process `asyncio.Task` inside the API
+server, so `SIGTERM`, `uvicorn` reload, and pod replacement all interrupt the
+user's current answer mid-stream.
+
+The existing `resumable-run-streaming` design (2026-04-23) already decouples
+the browser connection from the run via a Redis event log. That solves
+**page refresh** during a run, but it does not protect the run from a
+**process restart** — once the worker `asyncio.Task` is cancelled, no further
+events are appended to Redis and the user is left with a half-finished
+response.
+
+This design introduces a process-level drain protocol so that on planned
+restart the server stops accepting new runs, waits for in-flight runs to
+finish naturally, and only then exits. It also adds stale-run detection to
+recover from non-graceful death (SIGKILL, OOM, host loss).
+
+## Goal
+
+- On `SIGTERM` / `SIGINT` / lifespan shutdown: stop accepting new runs and
+  wait until existing runs complete before exiting.
+- On k8s rolling restart: zero observable interruption for clients whose run
+  is already in flight, given a sufficiently long
+  `terminationGracePeriodSeconds`.
+- On non-graceful death: the next client interaction recovers — surface a
+  clear "previous run failed" signal instead of leaving a phantom in-flight
+  run forever.
+
+## Non-Goals
+
+- Cross-process run handoff. A run that started on pod A finishes on pod A
+  or fails on pod A. We do not transfer the LangGraph execution to pod B.
+- Resuming a run from the last LangGraph checkpoint. A killed run is a
+  failed run; the user re-issues the message.
+- Multi-instance scheduling fairness or queueing. Drain is per-pod; the
+  load balancer is responsible for steering new traffic away from a draining
+  pod via the readiness probe.
+
+## Solution
+
+A `DrainState` singleton on `app.state` gates write paths. Signal handlers
+flip the state to `draining`, the API begins refusing new run starts with
+`503`, the readiness probe begins reporting `503`, and `RunManager.drain()`
+waits for the in-flight task set to empty (or hits a long timeout, default
+3600s, after which it cancels remaining tasks via the existing cancel path).
+
+For non-graceful death, a wall-clock `last_event_at` field is added to run
+metadata and stamped on every event append. A bootstrap or stream-subscribe
+that observes `status=running` with `last_event_at` older than 120s treats
+the run as `stale`, atomically clears the active-run lock, and surfaces the
+failure to the frontend.
+
+## Architecture
+
+### 1. Drain state machine
+
+```
+ACCEPTING ──signal──▶ DRAINING ──tasks_empty─▶ EXITING
+                          │
+                          ├──timeout──▶ EXITING (cancel_all)
+                          └──2nd signal──▶ EXITING (force, dev)
+```
+
+`DrainState` is a small object with:
+
+- `_state: Literal["accepting", "draining", "exiting"]`
+- `is_draining() -> bool`
+- `enter_draining() -> None` (idempotent)
+
+The state is owned by the FastAPI app (`app.state.drain_state`) and read by
+the drain middleware and health routes.
+
+### 2. Signal handling
+
+Signal handlers are registered inside the lifespan startup (before `yield`)
+on the running asyncio loop:
+
+```python
+loop = asyncio.get_running_loop()
+for sig in (signal.SIGTERM, signal.SIGINT):
+    loop.add_signal_handler(sig, _on_signal, sig.name)
+```
+
+`loop.add_signal_handler` runs the callback inside the loop, avoiding the
+cross-thread synchronization issues of `signal.signal`.
+
+Behavior:
+
+- First signal: log, call `state.enter_draining()`, return.
+- Second signal during drain: if
+  `lifecycle.dev_double_signal_force_exit` is true, schedule
+  `run_manager.cancel_all()` and raise `SystemExit(130)`. This is the dev
+  convenience path so a developer is not held by a 60-minute timeout.
+
+### 3. Lifespan shutdown
+
+After `yield`, lifespan unconditionally calls
+`state.enter_draining()` (covering uvicorn reload and other paths that do
+not deliver a signal), then awaits
+`run_manager.drain(timeout=lifecycle.graceful_drain_timeout_seconds)` before
+closing Redis and other resources.
+
+### 4. RunManager changes
+
+- The existing `RunManager.shutdown()` is renamed to `cancel_all()` to
+  reflect its semantics (cancel every in-flight task, no waiting). It
+  remains the implementation of forced cancellation.
+- A new `RunManager.drain(timeout_seconds: float) -> None`:
+  - Maintains an `asyncio.Event` set whenever `_tasks` becomes empty (set
+    from the existing `task.add_done_callback`).
+  - `await asyncio.wait_for(self._tasks_empty.wait(), timeout)`.
+  - On `TimeoutError`: log a warning with the residual count, await
+    `cancel_all()`, return. The existing per-task cancel path already
+    writes an `error` event, marks `status=cancelled`, and releases the
+    `conversation_active_run` lock.
+- A periodic logger inside `drain()` emits `still draining: N runs
+  remaining` every 30 seconds for operator visibility.
+
+### 5. Drain middleware
+
+A new ASGI middleware `DrainMiddleware`:
+
+- For request paths matching the run-start surface (initially:
+  `POST /api/v1/ws/{ws}/conversations/{cid}/messages`), if
+  `state.is_draining()`, return:
+
+  ```
+  503 Service Unavailable
+  Retry-After: 5
+  Connection: close
+  Content-Type: application/json
+  {"error": {"code": "draining", "message": "Server is draining; retry."}}
+  ```
+
+- All other paths pass through unchanged. SSE subscription
+  (`GET /runs/{run_id}/stream`), bootstrap, auth, health, etc. continue to
+  work during drain.
+
+`DrainMiddleware` is registered last in `create_app`, which makes it the
+outermost wrapper on the request path. A draining server should refuse new
+runs before doing CSRF or identity work.
+
+### 6. Health probes
+
+The current single `/health` endpoint is replaced by:
+
+- `GET /health/live` — always `200` while the process is up. Used by k8s
+  liveness probe; should not flip during drain or k8s will kill the pod
+  before drain completes.
+- `GET /health/ready` — `200` when `state.is_accepting()`, `503` when
+  draining. Used by k8s readiness probe so the load balancer stops sending
+  new traffic during drain.
+
+The legacy `/health` is removed, not aliased.
+
+### 7. Stale run detection
+
+Required because non-graceful death (SIGKILL, OOM, host loss) leaves
+`active_run` pointing at a `running` run whose worker is dead.
+
+Schema change in `RunMeta`:
+
+- New field `last_event_at: str` (ISO-8601 UTC).
+- Stamped atomically inside `_APPEND_EVENT_LUA` on every event append. The
+  Lua script is extended to take `last_event_at` as an additional argv and
+  set it via `HSET`.
+
+Detection logic — pure helper, no background scanner:
+
+```python
+def is_stale(meta: RunMeta, now: datetime, threshold_s: int) -> bool:
+    return (
+        meta.status == "running"
+        and (now - parse(meta.last_event_at)).total_seconds() > threshold_s
+    )
+```
+
+Recovery is performed inline at two read sites:
+
+1. `GET /conversations/{id}/bootstrap`: if the active run is stale, run a
+   Lua CAS that
+   - `HSET run_meta status=stale` only if it is still `running`,
+   - `DEL active_run` only if it still points to that `run_id`,
+   then return `active_run: null` and `last_run_status: "stale"`.
+2. `GET /runs/{run_id}/stream`: same CAS, then immediately emit a synthetic
+   SSE event `{"type": "error", "data": {"error_code": "run_stale", ...}}`
+   and close the stream.
+
+The CAS is idempotent: concurrent bootstraps observe the cleared state on
+their second read.
+
+### 8. Frontend
+
+- `bootstrap` response gains `last_run_status: "stale" | null`. `"stale"`
+  is set only when this bootstrap call detected and cleared a stale run.
+  Healthy in-flight runs are signaled the existing way via the `active_run`
+  field; runs that completed normally produce `null`. The field exists only
+  to surface an inline-resolved failure to the user — it is not an audit
+  log of past run outcomes.
+- When `last_run_status === "stale"`, the frontend renders an error bubble
+  beneath the most recent user message ("上次回答未完成，请重试") and unlocks
+  the input. No active SSE subscription is opened.
+- An in-flight SSE subscription that receives an event with
+  `error_code: "run_stale"` flows through the existing error rendering
+  path; no special-case code is needed in the reducer.
+
+## Data Model
+
+### `RunMeta` (Redis hash, additive change)
+
+```
+run_id           string
+conversation_id  string
+status           string  # running | completed | cancelled | failed | stale
+started_at       string  # ISO-8601
+user_message     string
+first_event_id   string
+last_event_id    string
+last_event_at    string  # NEW. ISO-8601, stamped on every append.
+```
+
+The status value `stale` is new; the rest are unchanged.
+
+### Lua script changes
+
+`_APPEND_EVENT_LUA` gains a `last_event_at` argv:
+
+```
+KEYS[1]=stream  KEYS[2]=meta  KEYS[3]=active
+ARGV[1]=payload_json  ARGV[2]=ttl  ARGV[3]=maxlen
+ARGV[4]=run_id        ARGV[5]=last_event_at_iso
+```
+
+`HSET` receives `last_event_at` alongside `last_event_id`.
+
+A new `_MARK_STALE_LUA`:
+
+```
+KEYS[1]=meta_key  KEYS[2]=active_key
+ARGV[1]=expected_run_id
+if redis.call('HGET', KEYS[1], 'status') == 'running' then
+  redis.call('HSET', KEYS[1], 'status', 'stale')
+end
+if redis.call('GET', KEYS[2]) == ARGV[1] then
+  redis.call('DEL', KEYS[2])
+end
+return 1
+```
+
+## Configuration
+
+Added to `config.yaml`:
+
+```yaml
+lifecycle:
+  graceful_drain_timeout_seconds: 3600    # 60 min
+  dev_double_signal_force_exit: true
+  stale_run_threshold_seconds: 120
+```
+
+Recommended k8s deployment:
+
+```yaml
+spec:
+  terminationGracePeriodSeconds: 3600
+  containers:
+    - readinessProbe:
+        httpGet: { path: /health/ready, port: 8000 }
+        periodSeconds: 5
+      livenessProbe:
+        httpGet: { path: /health/live, port: 8000 }
+        periodSeconds: 30
+```
+
+## Files Affected
+
+New:
+
+- `backend/cubebox/lifecycle/__init__.py`
+- `backend/cubebox/lifecycle/drain.py` — `DrainState`
+- `backend/cubebox/api/middleware/drain.py` — `DrainMiddleware`
+- `backend/tests/e2e/test_graceful_restart.py`
+- `backend/tests/unit/test_drain_state.py`
+
+Modified:
+
+- `backend/cubebox/api/app.py` — signal registration, lifespan shutdown
+  ordering, middleware wiring
+- `backend/cubebox/api/routes/health.py` — split into `/health/live` and
+  `/health/ready`, drop `/health`
+- `backend/cubebox/api/routes/v1/conversations.py` — bootstrap stale
+  detection + `last_run_status` field; stream endpoint stale detection
+- `backend/cubebox/streams/run_manager.py` — rename `shutdown()` →
+  `cancel_all()`, add `drain()`, maintain `_tasks_empty` event, periodic
+  drain progress logger, stamp `last_event_at` on appends
+- `backend/cubebox/streams/run_events.py` — add `last_event_at` to
+  `RunMeta`, extend `_APPEND_EVENT_LUA`, add `_MARK_STALE_LUA`, add
+  `mark_run_stale()` helper
+- `backend/config.yaml`, `backend/config.development.yaml`,
+  `backend/config.production.yaml` — `lifecycle.*` keys
+- `frontend/packages/core/src/api/types.ts` — `last_run_status` on
+  bootstrap
+- `frontend/packages/core/src/stores/messageStore.ts` — render stale-run
+  error bubble
+- `frontend/packages/web/components/chat/MessageList.tsx` — wire the new
+  rendering
+
+## Behavior Matrix
+
+| Scenario | Outcome |
+|---|---|
+| Drain begins, run finishes naturally | Normal completion: `done` event, `active_run` cleared, task removed from `_tasks` |
+| Drain timeout exceeded | `cancel_all()` runs; per-task cancel path writes `error`, sets `status=cancelled`, releases lock |
+| New `POST /messages` during drain | `503` + `Retry-After: 5` |
+| Existing SSE subscription during drain | Continues; reads from Redis |
+| New SSE subscription during drain | Accepted; not gated by drain |
+| Same-conversation `POST /messages` while old run still drains | `503` (lock held); resolves once old run finishes |
+| `SIGKILL` / OOM (no drain) | Worker dies; `active_run` orphaned; next bootstrap or stream subscribe detects stale and clears |
+| Bootstrap detects stale | Returns `active_run: null`, `last_run_status: "stale"`; frontend shows error bubble |
+| Stream subscribe detects stale | Emits synthetic `error` event with `error_code: "run_stale"`, closes |
+| Two bootstraps race on the same stale run | CAS makes the second observe cleared state |
+| `uvicorn` reload (no signal) | Lifespan shutdown still runs `drain()` |
+| Second `Ctrl-C` in dev | `cancel_all()` + `SystemExit(130)` |
+
+## Testing Strategy
+
+E2E (real Redis, `tests/e2e/test_graceful_restart.py`):
+
+1. Drain rejects new `POST /messages` with `503` + `Retry-After`.
+2. Existing SSE subscription continues to receive events through drain.
+3. Drain returns immediately after the in-flight run finishes naturally
+   (run < timeout).
+4. Drain hits timeout, `cancel_all()` runs, `status=cancelled`, last event
+   is `error`.
+5. `/health/ready` returns `503` during drain; `/health/live` stays `200`.
+6. After drain, on a fresh app instance, the same conversation accepts new
+   `POST /messages` (lock released).
+7. Stale detection via bootstrap: planted `active_run` with old
+   `last_event_at` → bootstrap returns `last_run_status: "stale"` and
+   active-run key is removed.
+8. Stale detection via stream subscribe: same setup → SSE delivers a
+   synthetic `error_code: run_stale` event and closes.
+9. Stale detection idempotency: two concurrent bootstraps both observe
+   cleared state without crashing.
+
+Unit (`tests/unit/test_drain_state.py`):
+
+- `DrainState` transitions and idempotency.
+- `RunManager.drain()` against a stub task set: empty set returns
+  immediately; never-completing task triggers timeout path; running
+  task that completes mid-drain returns cleanly.
+
+Manual verification (documented, not automated):
+
+- Start `python main.py`, send a message, `Ctrl-C` once → see drain log
+  and run finish before exit.
+- `Ctrl-C` twice → immediate force exit.
+- k8s rollout restart with `terminationGracePeriodSeconds: 3600` and the
+  readiness probe wired to `/health/ready` → load balancer routes new
+  traffic to fresh pod, in-flight runs on draining pod finish.
+
+Signal handling itself is exercised manually rather than via pytest because
+`signal.signal` registration interacts poorly with pytest's threading.
+Code paths after `state.enter_draining()` are fully covered by directly
+calling that method in tests.
+
+## Why This Design
+
+- **No new infrastructure.** No worker pool, no message queue, no second
+  service. The existing in-process model is preserved; only its lifecycle
+  becomes well-defined.
+- **Forward-compatible with multi-instance.** A k8s rolling restart with
+  per-pod drain plus the readiness probe yields zero-downtime deploys
+  without any cross-pod coordination, because the Redis event log already
+  serves as the cross-process recovery substrate.
+- **Stale detection patches a pre-existing bug.** Even before this design,
+  a SIGKILL would orphan `active_run` keys; the inline detection costs
+  one Redis hash field and one Lua script and removes that footgun.
+
+## Tradeoffs
+
+- A pod that takes 60 minutes to drain blocks deploys for 60 minutes. This
+  is acceptable per product input ("一般上线时间长可以接受, 有特殊情况可以
+  强杀 pod"); operators can `kubectl delete pod --grace-period=0` for an
+  immediate exit at the cost of failing the longest-running runs.
+- Stale runs surface only on user interaction, not proactively. A
+  conversation that no one opens after a SIGKILL stays in `active_run` until
+  the 12h TTL expires. This is the intended trade for not running a
+  background scanner.
+- Drain refuses new starts on the draining pod, which during a single-pod
+  deployment briefly fails new `POST /messages` calls. Multi-pod deployments
+  hide this behind the load balancer; single-pod operators accept the brief
+  unavailability window.

--- a/frontend/packages/core/src/api/runStreams.ts
+++ b/frontend/packages/core/src/api/runStreams.ts
@@ -17,6 +17,7 @@ export interface ConversationBootstrap {
   messages: Message[]
   total: number
   active_run: ActiveRunBootstrap | null
+  last_run_status: 'stale' | null
 }
 
 export interface StartRunResponse {

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -34,6 +34,7 @@ export interface MessageStore {
   lastAppliedEventId: string | null
   statusPhase: string | null
   error: string | null
+  lastRunStatus: 'stale' | null
   todos: TodoItem[]
   toolStartedMap: Record<string, number>
   toolResultMap: Record<
@@ -44,6 +45,7 @@ export interface MessageStore {
   loadMessages(client: ApiClient, conversationId: string): Promise<void>
   send(client: ApiClient, conversationId: string, content: string): Promise<void>
   clearStream(): void
+  clearLastRunStatus(): void
 }
 
 const MAIN_AGENT_KEY = 'main'
@@ -609,6 +611,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
   lastAppliedEventId: null,
   statusPhase: null,
   error: null,
+  lastRunStatus: null,
   todos: [],
   toolStartedMap: {},
   toolResultMap: {},
@@ -642,6 +645,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
         messages: { ...s.messages, [conversationId]: messages },
         todos: restoredTodos,
         error: null,
+        lastRunStatus: bootstrap.last_run_status ?? null,
         streamAgents: nextStreamAgents,
         toolStartedMap: {},
         toolResultMap: {},
@@ -689,6 +693,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       lastAppliedEventId: null,
       statusPhase: null,
       error: null,
+      lastRunStatus: null,
       todos: [],
       toolStartedMap: {},
       toolResultMap: {},
@@ -763,5 +768,9 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       toolStartedMap: {},
       toolResultMap: {},
     })
+  },
+
+  clearLastRunStatus() {
+    set({ lastRunStatus: null })
   },
 }))

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -106,6 +106,7 @@ export function MessageList({ conversationId }: MessageListProps) {
     toolResultMap,
   } = useMessages(conversationId)
   const loadMessages = useMessageStore((s) => s.loadMessages)
+  const lastRunStatus = useMessageStore((s) => s.lastRunStatus)
   const { workspaceId } = useWorkspaceContext()
 
   useEffect(() => {
@@ -224,6 +225,16 @@ export function MessageList({ conversationId }: MessageListProps) {
           >
             <AlertCircle className="size-4 shrink-0 mt-0.5" />
             <span>{error}</span>
+          </div>
+        )}
+
+        {lastRunStatus === 'stale' && (
+          <div
+            className="flex items-start gap-2 px-3 py-2.5 rounded-lg
+            bg-amber-500/10 border border-amber-500/30 text-amber-700 dark:text-amber-400 text-sm"
+          >
+            <AlertCircle className="size-4 shrink-0 mt-0.5" />
+            <span>上次回答未完成（服务异常退出），请重试。</span>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Drain in-flight LangGraph runs on `SIGTERM` / `SIGINT` / lifespan shutdown so the FastAPI server doesn't kill mid-stream answers when restarted (k8s rolling restart now zero-disruption given a long `terminationGracePeriodSeconds`).
- Split `/health` into `/health/live` (always 200) and `/health/ready` (503 while draining) so the load balancer routes new traffic away from a draining pod via the readiness probe.
- Inline stale-run detection: a wall-clock `last_event_at` heartbeat on every event append plus a Lua-CAS recovery path. When a worker dies non-gracefully (SIGKILL/OOM/host loss), the next bootstrap or stream subscribe atomically clears the orphan and surfaces `last_run_status: \"stale\"` to the frontend, which renders an amber error bubble instead of leaving a phantom run hanging forever.

Spec: [docs/superpowers/specs/2026-04-25-graceful-restart-design.md](docs/superpowers/specs/2026-04-25-graceful-restart-design.md)
Plan: [docs/superpowers/plans/2026-04-26-graceful-restart.md](docs/superpowers/plans/2026-04-26-graceful-restart.md)
Operator reference: [backend/docs/deploy-k8s-graceful-restart.md](backend/docs/deploy-k8s-graceful-restart.md)

### Architecture

- `DrainState` (`backend/cubebox/lifecycle/drain.py`) — synchronous flag, single instance per process, created in `create_app` so middleware and lifespan share the same object.
- `DrainMiddleware` (`backend/cubebox/api/middleware/drain.py`) — outermost ASGI middleware. POST `/api/v1/ws/{ws}/conversations/{cid}/messages` returns `503` + `Retry-After: 5` while draining; everything else passes through.
- Signal handlers in lifespan startup install `_on_signal` for SIGTERM and SIGINT via `loop.add_signal_handler`. First signal → log + `enter_draining()`. Second signal (when `lifecycle.dev_double_signal_force_exit` is true) → `os._exit(130)` for dev convenience.
- `RunManager.drain(timeout_seconds)` waits on a `_tasks_empty` `asyncio.Event`, falls through to `cancel_all()` (renamed from `shutdown`) on timeout. The existing per-task cancel path writes `status=cancelled` + an `error` event before releasing the active-run lock.
- Stale detection: `_APPEND_EVENT_LUA` now stamps `last_event_at` atomically with `last_event_id`. `is_stale_meta` falls back to `started_at` when the heartbeat hasn't been written yet, so a worker that dies before producing any output is still caught. `_MARK_STALE_LUA` is an idempotent CAS that flips `status=stale` only if currently `running` and `DEL`s the active key only if it still points at the expected run id.
- Status-transition CAS: `update_run_meta(status=...)` now uses `_TRANSITION_STATUS_FROM_RUNNING_LUA` so a worker that finishes after stale detection has flipped its status can't silently overwrite the stale flag — it logs a warning instead.

### Configuration

```yaml
lifecycle:
  graceful_drain_timeout_seconds: 3600   # match k8s terminationGracePeriodSeconds
  dev_double_signal_force_exit: true
  stale_run_threshold_seconds: 120
```

### Test plan

- [x] 21/21 in `backend/tests/e2e/test_graceful_restart.py` (heartbeat, drain mechanics, middleware, health probes, lifespan integration, stale detection, status-transition CAS, run-stale SSE)
- [x] 3/3 in `backend/tests/unit/test_drain_state.py`
- [x] 7/7 in `backend/tests/e2e/test_streaming.py` (no regression)
- [x] 14/14 in `backend/tests/e2e/test_conversations.py` (no regression)
- [x] Frontend `pnpm type-check` + `pnpm build` (both packages)
- [ ] Manual: real Ctrl-C in dev → drain log → run finishes → exit
- [ ] Manual: second Ctrl-C → immediate force exit
- [ ] Manual: k8s rollout restart with the recommended deployment fragment from `backend/docs/deploy-k8s-graceful-restart.md`

### Notes

- Tradeoff accepted (documented in the spec): a slow legitimate tool call that exceeds `stale_run_threshold_seconds` (default 120s) without producing intermediate events can be falsely flagged stale. The CAS in this PR keeps the status field consistent and emits a warning log; structurally preventing the duplicate LangGraph thread (worker bail-out on stale detection) is left as a follow-up.
- No PR or merge action on `main` was taken during implementation; spec + plan docs were committed directly to `main` earlier (`cfb7906`, `11c59e1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)