### PR TITLE
Fix citation marker display after refresh during active run

### DIFF
--- a/backend/cubebox/auth/users.py
+++ b/backend/cubebox/auth/users.py
@@ -40,6 +40,12 @@ class UserManager(BaseUserManager[User, str]):
                 user_id=user.id, workspace_id=ws.id, role=Role.ADMIN
             )
         except Exception as exc:
+            logger.exception(
+                "register_bootstrap failed for user {} ({}): {!r}",
+                user.email,
+                user.id,
+                exc,
+            )
             # Repo create/grant methods commit internally, so org/ws rows may already
             # be persisted when bootstrap fails mid-flight. Best-effort DELETE of the
             # user row here — and translate to a 500 so clients see an HTTP error

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -662,7 +662,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
             client,
             conversationId,
             bootstrap.active_run!.run_id,
-            undefined,
+            bootstrap.active_run!.last_event_id ?? undefined,
             set,
             get,
           )

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -662,7 +662,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
             client,
             conversationId,
             bootstrap.active_run!.run_id,
-            bootstrap.active_run!.last_event_id ?? undefined,
+            undefined,
             set,
             get,
           )

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -137,6 +137,7 @@ interface HistoryProps {
   message: Message
   subagentDataMap?: Record<string, SubagentSummary>
   toolResultMap: Record<string, { content: string; receivedAt: number }>
+  conversationId?: string
   stream?: never
   isStreaming?: never
   statusPhase?: never
@@ -148,6 +149,7 @@ interface StreamingProps {
   message?: never
   subagentDataMap?: never
   toolResultMap: Record<string, { content: string; receivedAt: number }>
+  conversationId?: string
   stream: AgentStream
   isStreaming: boolean
   statusPhase?: string | null
@@ -216,6 +218,7 @@ function ContentBlockRenderer({
   messageCreatedAt,
   subagentIndex,
   agentId,
+  conversationId,
 }: {
   block: ContentBlock
   index: number
@@ -227,6 +230,7 @@ function ContentBlockRenderer({
   messageCreatedAt?: string
   subagentIndex?: number
   agentId?: string | null
+  conversationId?: string
 }) {
   if (block.type === 'reasoning') {
     return (
@@ -262,6 +266,7 @@ function ContentBlockRenderer({
         stream={stream ?? historicalStream}
         isRunning={isStreaming && !!stream && !toolResultMap[block.tool_call_id]}
         toolResultMap={toolResultMap}
+        conversationId={conversationId}
       />
     )
   }
@@ -358,7 +363,11 @@ function ContentBlockRenderer({
     )
   }
   if (block.type === 'text') {
-    return <MarkdownWithCitations className={proseClasses}>{block.content}</MarkdownWithCitations>
+    return (
+      <MarkdownWithCitations className={proseClasses} conversationId={conversationId}>
+        {block.content}
+      </MarkdownWithCitations>
+    )
   }
 
   const _exhaustive: never = block
@@ -403,6 +412,7 @@ export function AssistantMessage({
   subagentDataMap,
   toolResultMap,
   todos,
+  conversationId,
 }: AssistantMessageProps) {
   const streamAgentId = stream ? 'main' : undefined
   const blocks: ContentBlock[] = stream
@@ -472,6 +482,7 @@ export function AssistantMessage({
               messageCreatedAt={msgCreatedAt}
               subagentIndex={subagentIndexMap.get(i)}
               agentId={streamAgentId}
+              conversationId={conversationId}
             />
           )
         })}

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -193,6 +193,7 @@ export function MessageList({ conversationId }: MessageListProps) {
                 message={msg}
                 subagentDataMap={subagentDataMap}
                 toolResultMap={mergedToolResultMap}
+                conversationId={conversationId}
               />
             )}
           </div>
@@ -206,6 +207,7 @@ export function MessageList({ conversationId }: MessageListProps) {
             subAgentStreams={subAgentStreams}
             toolResultMap={mergedToolResultMap}
             todos={todos}
+            conversationId={conversationId}
           />
         )}
 

--- a/frontend/packages/web/components/chat/SubAgentCard.tsx
+++ b/frontend/packages/web/components/chat/SubAgentCard.tsx
@@ -18,6 +18,7 @@ interface Props {
   stream?: AgentStream
   isRunning: boolean
   toolResultMap: Record<string, { content: string; receivedAt: number }>
+  conversationId?: string
 }
 
 type ToolDisplayBlock = Extract<ContentBlock, { type: 'tool_call' | 'tool_call_streaming' }>
@@ -40,6 +41,7 @@ export const SubAgentCard = memo(function SubAgentCard({
   stream,
   isRunning,
   toolResultMap,
+  conversationId,
 }: Props) {
   const [expanded, setExpanded] = useState(false)
   const [elapsed, setElapsed] = useState(0)
@@ -201,7 +203,9 @@ export const SubAgentCard = memo(function SubAgentCard({
               {visibleToolBlocks.map((block, i) => renderToolBlock(block, i, i > 0))}
               {stream?.text && (
                 <div className={`px-3 py-2 border-t border-border ${proseClasses}`}>
-                  <MarkdownWithCitations>{stream.text}</MarkdownWithCitations>
+                  <MarkdownWithCitations conversationId={conversationId}>
+                    {stream.text}
+                  </MarkdownWithCitations>
                 </div>
               )}
             </div>

--- a/frontend/packages/web/components/shared/MarkdownWithCitations.tsx
+++ b/frontend/packages/web/components/shared/MarkdownWithCitations.tsx
@@ -24,6 +24,7 @@ function fixCjkBoldQuotes(text: string): string {
 interface MarkdownWithCitationsProps {
   children: string
   className?: string
+  conversationId?: string
 }
 
 /**
@@ -31,8 +32,13 @@ interface MarkdownWithCitationsProps {
  * them as interactive CitationMarker components. Falls back to plain
  * ReactMarkdown when no markers are present.
  */
-export function MarkdownWithCitations({ children, className }: MarkdownWithCitationsProps) {
-  const conversationId = useConversationStore((s) => s.activeId) ?? ''
+export function MarkdownWithCitations({
+  children,
+  className,
+  conversationId: conversationIdProp,
+}: MarkdownWithCitationsProps) {
+  const activeId = useConversationStore((s) => s.activeId)
+  const conversationId = conversationIdProp ?? activeId ?? ''
   const md = fixCjkBoldQuotes(children)
   const hasCitations = CITATION_RE.test(md)
 


### PR DESCRIPTION
## Summary
After page refresh during an active run, citation markers rendered as gray plain text (`【1-0】`) instead of interactive badges.

## Root cause
Citations were correctly written to `citationStore` under the URL conversation id (via both `hydrateCitationsFromHistory` and SSE `citation` events), but `MarkdownWithCitations` was reading from `s.citations[''][citationId]` because `useConversationStore.activeId` was `null` at render time — even though `ChatPage.setActive(conversationId)` had run.

The reason `activeId` was `null` for the renderer: `@cubebox/core/package.json` declares both `exports.default: ./src/index.ts` and `main: ./dist/index.js`. Next.js + Turbopack resolves these differently on SSR vs. client paths, so each side runs its own `zustand.create()` and ends up with a separate store instance. `ChatPage.setActive` updates one store; `MarkdownWithCitations` reads the other.

## Fix
Sidestep the duplicate-store issue by threading `conversationId` explicitly through:

```
MessageList → AssistantMessage → MarkdownWithCitations
                              → SubAgentCard → MarkdownWithCitations
```

The `activeId` fallback stays in `MarkdownWithCitations` for callers that genuinely have no conversation context (panel/artifact previews).

## Side change
`backend/cubebox/auth/users.py`: added `logger.exception(...)` in the `register_bootstrap` failure path so future failures surface a real traceback instead of an opaque `REGISTER_BOOTSTRAP_FAILED`.

## Commit history
This branch contains an initial wrong attempt (passed `last_event_id` to skip SSE replay) followed by a revert and the correct fix. The wrong attempt is documented for traceability — Codex flagged the regression and that pushed the investigation toward the real root cause.

## Test plan
- [x] TypeScript checks pass
- [x] Pre-commit hooks pass (ruff format, lint, mypy, eslint, prettier)
- [x] Manual repro: refresh mid-run, citation markers render as interactive badges instead of gray text

🤖 Generated with [Claude Code](https://claude.com/claude-code)