### PR TITLE
fix(backend): fix cost tracking always recording zero tokens

### DIFF
--- a/backend/cubebox/llm/factory.py
+++ b/backend/cubebox/llm/factory.py
@@ -376,6 +376,12 @@ class LLMFactory:
 
         # Handle different API types
         if provider_config.api == "openai-completions":
+            # Ensure streamed responses include token usage so CostMiddleware can
+            # populate billing rows. ChatOpenAI defaults stream_usage to False,
+            # which causes usage_metadata to be missing on streamed AIMessages
+            # and every billing event ends up with zero tokens.
+            llm_kwargs.setdefault("stream_usage", True)
+
             # Check if this is official OpenAI API
             is_official_openai = (
                 not provider_config.base_url or "api.openai.com" in provider_config.base_url

--- a/backend/cubebox/middleware/cost.py
+++ b/backend/cubebox/middleware/cost.py
@@ -143,7 +143,11 @@ def _extract_usage(response: Any) -> dict[str, int]:
             "cache_write_tokens": 0,
         }
 
+    # ModelResponse.result is list[BaseMessage]; AIMessage can be returned directly.
     result = getattr(response, "result", response)
+    if isinstance(result, list):
+        result = next((m for m in result if isinstance(m, AIMessage)), None)
+
     usage = getattr(result, "usage_metadata", None) or {}
     if callable(usage):
         usage = {}

--- a/backend/tests/e2e/test_billing.py
+++ b/backend/tests/e2e/test_billing.py
@@ -81,7 +81,8 @@ async def test_send_message_creates_billing_event(
         rows = result.all()
         assert len(rows) >= 1
         _be, le = rows[0]
-        assert le.input_tokens >= 0  # some test LLMs don't report usage metadata
+        assert le.input_tokens > 0, "input_tokens should be populated by stream_usage=True"
+        assert le.output_tokens > 0, "output_tokens should be populated by stream_usage=True"
         assert le.provider != "unknown"
         assert le.model_id != "unknown"
         assert _be.cost_amount_micro >= 0


### PR DESCRIPTION
## Summary

- **Bug 1 — wrong type in `_extract_usage`**: `ModelResponse.result` is `list[BaseMessage]`, but the code called `getattr(list, "usage_metadata")` — a list has no such attribute, so it always returned `None` and tokens were always 0. Fix: extract the `AIMessage` from the list first.
- **Bug 2 — streaming responses don't include usage by default**: `ChatOpenAI` defaults `stream_usage=False`, so no `stream_options: {include_usage: true}` was sent and `usage_metadata` was absent on streamed responses even if Bug 1 were fixed. Fix: set `stream_usage=True` in `LLMFactory` for all `openai-completions` providers.
- **Test assertion tightened**: E2E billing test now asserts `input_tokens > 0` (was `>= 0`) so future regressions are caught.

## Test plan

- [ ] `uv run pytest tests/e2e/test_billing.py -x -v` — both billing E2E tests pass with real model, `input_tokens > 0` confirmed
- [ ] `uv run pytest tests/test_cost_middleware.py tests/test_billing_repository.py` — all 8 unit tests pass
- [ ] `ruff check` + `mypy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)