### PR TITLE
feat(vault): route Provider.api_key through credential vault

### DIFF
--- a/backend/alembic/versions/d44dff875e38_vault_nullable_cred_org_id_provider_.py
+++ b/backend/alembic/versions/d44dff875e38_vault_nullable_cred_org_id_provider_.py
@@ -1,0 +1,173 @@
+"""vault: nullable cred org_id, provider credential_id fk
+
+Revision ID: d44dff875e38
+Revises: bd12d3efd95b
+Create Date: 2026-05-06 17:29:01.148772
+
+"""
+import os
+from datetime import UTC, datetime
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d44dff875e38"
+down_revision: Union[str, Sequence[str], None] = "bd12d3efd95b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _migrate_existing_api_keys() -> None:
+    """Encrypt every Provider.api_key into a Credential row, set credential_id.
+
+    Reads CUBEBOX_AUTH__VAULT_KEY from env (or auth.vault_key from config) and
+    uses MultiFernet so the primary key in the rotation list does the encryption,
+    matching the runtime FernetBackend.
+    """
+    from cubebox.config import config
+    from cubebox.credentials.encryption import FernetBackend
+    from cubebox.credentials.keys import parse_vault_keys
+    from cubebox.models.public_id import generate_public_id
+
+    raw_key = os.getenv("CUBEBOX_AUTH__VAULT_KEY") or config.get("auth.vault_key")
+    bind = op.get_bind()
+    rows = list(
+        bind.execute(
+            sa.text(
+                "SELECT id, org_id, name, api_key, created_by_user_id "
+                "FROM providers WHERE api_key IS NOT NULL AND api_key <> ''"
+            )
+        )
+    )
+    if not rows:
+        return
+    if not raw_key:
+        raise RuntimeError(
+            "CUBEBOX_AUTH__VAULT_KEY must be set to migrate existing Provider.api_key "
+            "values into the credential vault."
+        )
+    backend = FernetBackend(parse_vault_keys(str(raw_key)))
+    fernet = backend._fernet  # noqa: SLF001 -- intentional, sync use within migration
+    now = datetime.now(UTC)
+
+    for row in rows:
+        cred_id = generate_public_id("cred")
+        ciphertext = fernet.encrypt(row.api_key.encode("utf-8"))
+        bind.execute(
+            sa.text(
+                "INSERT INTO credentials (id, org_id, kind, name, value_encrypted,"
+                " cred_metadata, created_by_user_id, created_at, updated_at)"
+                " VALUES (:id, :org_id, :kind, :name, :value, :metadata::jsonb,"
+                "         :user_id, :now, :now)"
+            ),
+            {
+                "id": cred_id,
+                "org_id": row.org_id,
+                "kind": "provider_api_key",
+                "name": row.name,
+                "value": ciphertext,
+                "metadata": "{}",
+                "user_id": row.created_by_user_id,
+                "now": now,
+            },
+        )
+        bind.execute(
+            sa.text("UPDATE providers SET credential_id = :cred WHERE id = :pid"),
+            {"cred": cred_id, "pid": row.id},
+        )
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column(
+        "credentials",
+        "org_id",
+        existing_type=sa.VARCHAR(length=20),
+        nullable=True,
+    )
+    op.alter_column(
+        "credentials",
+        "created_by_user_id",
+        existing_type=sa.VARCHAR(length=20),
+        nullable=True,
+    )
+    op.drop_constraint(op.f("uq_credential_org_kind_name"), "credentials", type_="unique")
+    op.create_index(
+        "uq_credential_org_kind_name",
+        "credentials",
+        ["org_id", "kind", "name"],
+        unique=True,
+        postgresql_where="org_id IS NOT NULL",
+    )
+    op.create_index(
+        "uq_credential_system_kind_name",
+        "credentials",
+        ["kind", "name"],
+        unique=True,
+        postgresql_where="org_id IS NULL",
+    )
+    op.add_column(
+        "providers",
+        sa.Column(
+            "credential_id", sqlmodel.sql.sqltypes.AutoString(length=20), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_providers_credential_id"), "providers", ["credential_id"], unique=False
+    )
+    op.create_foreign_key(
+        "fk_providers_credential_id_credentials",
+        "providers",
+        "credentials",
+        ["credential_id"],
+        ["id"],
+    )
+
+    _migrate_existing_api_keys()
+
+    op.drop_column("providers", "api_key")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column(
+        "providers",
+        sa.Column("api_key", sa.VARCHAR(length=512), autoincrement=False, nullable=True),
+    )
+    op.drop_constraint(
+        "fk_providers_credential_id_credentials", "providers", type_="foreignkey"
+    )
+    op.drop_index(op.f("ix_providers_credential_id"), table_name="providers")
+    op.drop_column("providers", "credential_id")
+    op.drop_index(
+        "uq_credential_system_kind_name",
+        table_name="credentials",
+        postgresql_where="org_id IS NULL",
+    )
+    op.drop_index(
+        "uq_credential_org_kind_name",
+        table_name="credentials",
+        postgresql_where="org_id IS NOT NULL",
+    )
+    op.create_unique_constraint(
+        op.f("uq_credential_org_kind_name"),
+        "credentials",
+        ["org_id", "kind", "name"],
+        postgresql_nulls_not_distinct=False,
+    )
+    op.alter_column(
+        "credentials",
+        "created_by_user_id",
+        existing_type=sa.VARCHAR(length=20),
+        nullable=False,
+    )
+    op.alter_column(
+        "credentials",
+        "org_id",
+        existing_type=sa.VARCHAR(length=20),
+        nullable=False,
+    )

--- a/backend/cubebox/api/app.py
+++ b/backend/cubebox/api/app.py
@@ -244,7 +244,7 @@ async def lifespan(_app: FastAPI):  # type: ignore
         from cubebox.seeders import seed_system_providers_from_config
 
         async with async_session_maker() as seed_session:
-            await seed_system_providers_from_config(seed_session)
+            await seed_system_providers_from_config(seed_session, _app.state.encryption_backend)
         logger.info("System provider seed step completed")
     except Exception as e:
         logger.warning("Failed to seed system providers: {}", str(e))

--- a/backend/cubebox/api/routes/v1/admin_providers.py
+++ b/backend/cubebox/api/routes/v1/admin_providers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,6 +24,7 @@ from cubebox.api.schemas.provider import (
     TestResultOut,
 )
 from cubebox.auth.dependencies import require_org_admin, resolve_current_org_id
+from cubebox.credentials.dependencies import build_credential_service
 from cubebox.db import get_session
 from cubebox.models import User
 from cubebox.models.org_provider_override import OrgProviderOverride
@@ -45,13 +46,20 @@ from cubebox.services.provider_service import (
 router = APIRouter(prefix="/admin", tags=["admin-providers"])
 
 
-async def _svc(user: User, session: AsyncSession) -> ProviderService:
+async def _svc(user: User, session: AsyncSession, request: Request) -> ProviderService:
     org_id = await resolve_current_org_id(user, session)
+    cred_service = build_credential_service(
+        session,
+        request.app.state.encryption_backend,
+        org_id=org_id,
+        actor_user_id=user.id,
+    )
     return ProviderService(
         provider_repo=ProviderRepository(session, org_id=org_id),
         model_repo=ModelRepository(session),
         override_repo=OrgProviderOverrideRepository(session, org_id=org_id),
         org_settings_repo=OrgSettingsRepository(session, org_id=org_id),
+        credential_service=cred_service,
         session=session,
         org_id=org_id,
         actor_user_id=user.id,
@@ -93,7 +101,7 @@ def _provider_out(
         provider_type=p.provider_type,
         base_url=p.base_url,
         auth_type=p.auth_type,
-        has_api_key=bool(p.api_key),
+        has_api_key=bool(p.credential_id),
         logo_url=p.logo_url,
         enabled=p.enabled,
         is_system=p.org_id is None,
@@ -114,10 +122,11 @@ def _provider_out(
 @router.get("/providers", response_model=list[ProviderOut])
 async def list_providers(
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> list[ProviderOut]:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     providers = await svc.list_providers()
     if not providers:
         return []
@@ -137,10 +146,11 @@ async def list_providers(
 async def create_provider(
     body: ProviderCreate,
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> ProviderOut:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     try:
         p = await svc.create_provider(body)
     except ProviderOAuthNotImplementedError as e:
@@ -158,10 +168,11 @@ async def create_provider(
 async def get_provider(
     provider_id: str,
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> ProviderOut:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     try:
         p = await svc.get_provider(provider_id)
     except ProviderNotFoundError as e:
@@ -183,10 +194,11 @@ async def update_provider(
     provider_id: str,
     body: ProviderUpdate,
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> ProviderOut:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     try:
         p = await svc.update_provider(provider_id, body)
     except ProviderNotFoundError as e:
@@ -208,10 +220,11 @@ async def update_provider(
 async def delete_provider(
     provider_id: str,
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> None:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     try:
         await svc.delete_provider(provider_id)
     except ProviderNotFoundError as e:
@@ -228,10 +241,11 @@ async def create_model(
     provider_id: str,
     body: ModelCreate,
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> ModelOut:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     try:
         m = await svc.create_model(provider_id, body)
     except ProviderNotFoundError as e:
@@ -249,10 +263,11 @@ async def update_model(
     mid: str,
     body: ModelUpdate,
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> ModelOut:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     try:
         m = await svc.update_model(provider_id, mid, body)
     except ProviderNotFoundError as e:
@@ -271,10 +286,11 @@ async def delete_model(
     provider_id: str,
     mid: str,
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> None:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     try:
         await svc.delete_model(provider_id, mid)
     except ProviderNotFoundError as e:
@@ -292,10 +308,11 @@ async def delete_model(
 async def test_provider(
     body: ProviderTest,
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> TestResultOut:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     return await svc.test_connection(body)
 
 
@@ -304,10 +321,11 @@ async def test_provider_model(
     provider_id: str,
     body: ModelTest,
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> TestResultOut:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     try:
         return await svc.test_model_connection(provider_id, body.model_id)
     except ProviderNotFoundError as e:
@@ -321,10 +339,11 @@ async def test_provider_model(
 async def get_provider_override(
     provider_id: str,
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> OrgProviderOverrideOut:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     try:
         override = await svc.get_override(provider_id)
     except ProviderNotFoundError as e:
@@ -339,10 +358,11 @@ async def set_provider_override(
     provider_id: str,
     body: OrgProviderOverrideUpdate,
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> OrgProviderOverrideOut:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     try:
         override = await svc.set_override(provider_id, body.enabled)
     except ProviderNotFoundError as e:
@@ -360,10 +380,11 @@ async def set_provider_override(
 @router.get("/settings/llm", response_model=OrgLLMSettingsOut)
 async def get_llm_settings(
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> OrgLLMSettingsOut:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     return await svc.get_llm_settings()
 
 
@@ -371,10 +392,11 @@ async def get_llm_settings(
 async def update_llm_settings(
     body: OrgLLMSettingsUpdate,
     *,
+    request: Request,
     user: Annotated[User, Depends(require_org_admin)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> OrgLLMSettingsOut:
-    svc = await _svc(user, session)
+    svc = await _svc(user, session, request)
     try:
         return await svc.update_llm_settings(body)
     except ValueError as e:

--- a/backend/cubebox/credentials/dependencies.py
+++ b/backend/cubebox/credentials/dependencies.py
@@ -22,8 +22,8 @@ def build_credential_service(
     session: AsyncSession,
     backend: EncryptionBackend,
     *,
-    org_id: str,
-    actor_user_id: str,
+    org_id: str | None,
+    actor_user_id: str | None,
 ) -> CredentialService:
     repo = CredentialRepository(session, org_id=org_id)
     return CredentialService(

--- a/backend/cubebox/llm/factory.py
+++ b/backend/cubebox/llm/factory.py
@@ -12,6 +12,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.config import config
+from cubebox.credentials.encryption import EncryptionBackend
 from cubebox.llm.config import LLMConfig, ModelConfig, ProviderConfig
 from cubebox.llm.openai_compatible import ChatOpenAICompatible
 
@@ -26,6 +27,7 @@ class LLMFactory:
         llm_config: LLMConfig | None = None,
         session: AsyncSession | None = None,
         org_id: str | None = None,
+        encryption_backend: EncryptionBackend | None = None,
     ):
         """
         Initialize LLM factory.
@@ -34,9 +36,12 @@ class LLMFactory:
             llm_config: LLM configuration. If None, loads from global config.
             session: Optional async DB session for DB-driven config loading.
             org_id: Optional org ID for DB-driven config loading.
+            encryption_backend: Optional vault backend; required to decrypt
+                provider api_key credentials when loading from DB.
         """
         self._session = session
         self._org_id = org_id
+        self._backend = encryption_backend
         if llm_config is None:
             # Load from global config
             llm_config = LLMConfig(**config.llm)
@@ -52,6 +57,7 @@ class LLMFactory:
         if not self._session or not self._org_id:
             return {}, set()
 
+        from cubebox.models import Credential
         from cubebox.models.org_provider_override import OrgProviderOverride as DBO
         from cubebox.models.provider import Model as DBM
         from cubebox.models.provider import Provider as DBP
@@ -84,9 +90,33 @@ class LLMFactory:
             )
             db_models = models_result.scalars().all()
 
+            api_key: str | None = None
+            if p.credential_id and self._backend is not None:
+                cred_row = await self._session.get(Credential, p.credential_id)
+                if cred_row is None:
+                    logger.warning(
+                        "Provider %s references missing credential %s",
+                        p.name,
+                        p.credential_id,
+                    )
+                elif cred_row.kind == "provider_api_key":
+                    try:
+                        api_key = (await self._backend.decrypt(cred_row.value_encrypted)).decode(
+                            "utf-8"
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to decrypt credential %s for provider %s; "
+                            "skipping api_key. Likely cause: encryption key "
+                            "mismatch (rotate CUBEBOX_AUTH__VAULT_KEY back or "
+                            "rotate the credential).",
+                            p.credential_id,
+                            p.name,
+                        )
+
             db_configs[p.name] = {
                 "base_url": p.base_url,
-                "api_key": p.api_key,
+                "api_key": api_key,
                 "api": "openai-completions",
                 "extra_body": p.extra_body,
                 "extra_headers": p.extra_headers,

--- a/backend/cubebox/models/credential.py
+++ b/backend/cubebox/models/credential.py
@@ -2,24 +2,47 @@
 
 from typing import Any, ClassVar
 
-from sqlalchemy import JSON, Column, UniqueConstraint
+from sqlalchemy import JSON, Column, Index
 from sqlmodel import Field
 
 from cubebox.models.mixins import CubeboxBase
 
 
 class Credential(CubeboxBase, table=True):
-    """Vault entry. v1 only kind='mcp_server'; future kinds extend without schema changes."""
+    """Vault entry. Kinds: 'mcp_server', 'provider_api_key'.
+
+    System-level credentials (e.g. seeded provider api keys) have org_id=NULL;
+    org-scoped credentials have org_id set. Uniqueness is enforced separately
+    for each scope via partial unique indexes.
+    """
 
     _PREFIX: ClassVar[str] = "cred"
     __tablename__ = "credentials"
     __table_args__ = (
-        UniqueConstraint("org_id", "kind", "name", name="uq_credential_org_kind_name"),
+        Index(
+            "uq_credential_org_kind_name",
+            "org_id",
+            "kind",
+            "name",
+            unique=True,
+            postgresql_where="org_id IS NOT NULL",
+        ),
+        Index(
+            "uq_credential_system_kind_name",
+            "kind",
+            "name",
+            unique=True,
+            postgresql_where="org_id IS NULL",
+        ),
     )
 
-    org_id: str = Field(foreign_key="organizations.id", max_length=20, index=True)
+    org_id: str | None = Field(
+        default=None, foreign_key="organizations.id", max_length=20, index=True, nullable=True
+    )
     kind: str = Field(max_length=32)
     name: str = Field(max_length=128)
     value_encrypted: bytes
     cred_metadata: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
-    created_by_user_id: str = Field(foreign_key="users.id", max_length=20)
+    created_by_user_id: str | None = Field(
+        default=None, foreign_key="users.id", max_length=20, nullable=True
+    )

--- a/backend/cubebox/models/provider.py
+++ b/backend/cubebox/models/provider.py
@@ -23,8 +23,9 @@ class Provider(CubeboxBase, table=True):
     provider_type: str = Field(default="openai_compat", max_length=32)
     base_url: str = Field(max_length=2048)
     auth_type: str = Field(default="api_key", max_length=32)
-    api_key: str | None = Field(default=None, max_length=512)
-    # TODO(vault): Encrypt api_key when M1-E4 vault integration lands.
+    credential_id: str | None = Field(
+        default=None, foreign_key="credentials.id", max_length=20, nullable=True, index=True
+    )
     oauth_client_id: str | None = Field(default=None, max_length=256)
     oauth_client_secret: str | None = Field(default=None, max_length=256)
     oauth_auth_url: str | None = Field(default=None, max_length=2048)

--- a/backend/cubebox/repositories/credential.py
+++ b/backend/cubebox/repositories/credential.py
@@ -1,24 +1,41 @@
-"""Credential repository — org-scoped, no workspace dimension."""
+"""Credential repository — org-scoped or system (org_id NULL), no workspace dimension."""
 
 from datetime import UTC, datetime
 
-from sqlalchemy import select
+from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.models import Credential
 
 
 class CredentialRepository:
-    """Repository for vault credentials scoped by organization."""
+    """Repository for vault credentials.
 
-    def __init__(self, session: AsyncSession, *, org_id: str) -> None:
+    Pass ``org_id=None`` to operate on system-level credentials (e.g. seeded
+    provider api keys).
+    """
+
+    def __init__(self, session: AsyncSession, *, org_id: str | None) -> None:
         self.session = session
         self.org_id = org_id
 
+    def _scope(self, stmt: Select[tuple[Credential]]) -> Select[tuple[Credential]]:
+        if self.org_id is None:
+            return stmt.where(Credential.org_id.is_(None))  # type: ignore[union-attr]
+        return stmt.where(Credential.org_id == self.org_id)  # type: ignore[arg-type]
+
     async def get(self, credential_id: str) -> Credential | None:
-        stmt = select(Credential).where(
-            Credential.id == credential_id,  # type: ignore[arg-type]
-            Credential.org_id == self.org_id,  # type: ignore[arg-type]
+        stmt = self._scope(
+            select(Credential).where(Credential.id == credential_id)  # type: ignore[arg-type]
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    async def get_by_kind_name(self, *, kind: str, name: str) -> Credential | None:
+        stmt = self._scope(
+            select(Credential).where(
+                Credential.kind == kind,  # type: ignore[arg-type]
+                Credential.name == name,  # type: ignore[arg-type]
+            )
         )
         return (await self.session.execute(stmt)).scalar_one_or_none()
 

--- a/backend/cubebox/seeders/provider_seeder.py
+++ b/backend/cubebox/seeders/provider_seeder.py
@@ -1,4 +1,10 @@
-"""Seed system providers and models from config.yaml into DB (idempotent)."""
+"""Seed system providers and models from config.yaml into DB (idempotent).
+
+Provider api keys are written to the credential vault as system credentials
+(``org_id=NULL``, ``kind='provider_api_key'``) and Provider rows hold a
+``credential_id`` FK -- the api_key column itself was dropped in the vault
+migration.
+"""
 
 from typing import Any
 
@@ -7,15 +13,63 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.config import config as settings
+from cubebox.credentials.encryption import EncryptionBackend
+from cubebox.models import Credential
 from cubebox.models.provider import Model, Provider
 
+_PROVIDER_KEY_KIND = "provider_api_key"
 
-async def seed_system_providers_from_config(session: AsyncSession) -> None:
+
+async def _upsert_system_credential(
+    session: AsyncSession,
+    backend: EncryptionBackend,
+    *,
+    provider: Provider,
+    plaintext: str,
+) -> Credential:
+    """Create or update the system Credential that backs ``provider.api_key``.
+
+    System credentials live with ``org_id=NULL``; uniqueness on (kind, name)
+    is enforced by ``uq_credential_system_kind_name``.
+    """
+    existing_q = select(Credential).where(
+        Credential.org_id.is_(None),  # type: ignore[union-attr]
+        Credential.kind == _PROVIDER_KEY_KIND,  # type: ignore[arg-type]
+        Credential.name == provider.name,  # type: ignore[arg-type]
+    )
+    cred = (await session.execute(existing_q)).scalar_one_or_none()
+    ciphertext = await backend.encrypt(plaintext.encode("utf-8"))
+    if cred is None:
+        cred = Credential(
+            org_id=None,
+            kind=_PROVIDER_KEY_KIND,
+            name=provider.name,
+            value_encrypted=ciphertext,
+            cred_metadata={},
+            created_by_user_id=None,
+        )
+        session.add(cred)
+        await session.flush()
+        logger.info("Seeded system credential for provider: {}", provider.name)
+    else:
+        cred.value_encrypted = ciphertext
+        session.add(cred)
+        await session.flush()
+        logger.debug("Refreshed system credential ciphertext for provider: {}", provider.name)
+    return cred
+
+
+async def seed_system_providers_from_config(
+    session: AsyncSession,
+    backend: EncryptionBackend,
+) -> None:
     """Idempotent: insert/update system providers/models from config.yaml.
 
     - Creates missing providers and models (idempotent by name/model_id).
     - Updates existing system provider base_url/provider_type when config changes.
     - Marks models removed from config as ``enabled=False`` (does NOT delete).
+    - Writes the resolved ``api_key`` (already env-interpolated by dynaconf)
+      into the credential vault and sets ``Provider.credential_id``.
     """
     cfg: dict[str, Any] = dict(settings.get("llm", {}))
     config_providers: dict[str, Any] = dict(cfg.get("providers", {}))
@@ -56,6 +110,17 @@ async def seed_system_providers_from_config(session: AsyncSession) -> None:
             provider.base_url = base_url
             provider.provider_type = provider_type
             logger.debug("System provider '{}' already exists, updated", name)
+
+        api_key_raw = cfg_dict.get("api_key")
+        api_key: str | None = (
+            str(api_key_raw).strip() if api_key_raw is not None else None
+        ) or None
+        if api_key:
+            cred = await _upsert_system_credential(
+                session, backend, provider=provider, plaintext=api_key
+            )
+            if provider.credential_id != cred.id:
+                provider.credential_id = cred.id
 
         config_model_ids[name] = set()
         models_list: list[dict[str, Any]] = list(cfg_dict.get("models", []))

--- a/backend/cubebox/services/credential.py
+++ b/backend/cubebox/services/credential.py
@@ -20,8 +20,8 @@ class CredentialService:
         repo: CredentialRepository,
         backend: EncryptionBackend,
         *,
-        org_id: str,
-        actor_user_id: str,
+        org_id: str | None,
+        actor_user_id: str | None,
     ) -> None:
         self._repo = repo
         self._backend = backend
@@ -86,7 +86,10 @@ class CredentialService:
         await self._repo.delete(credential_id)
 
     async def _guard_references(self, credential_id: str) -> None:
-        """Refuse deletion while MCP tables still reference the credential."""
+        """Refuse deletion while other rows still reference the credential."""
+        from sqlalchemy import select
+
+        from cubebox.models.provider import Provider
         from cubebox.repositories.mcp import (
             MCPServerRepository,
             UserMCPCredentialRepository,
@@ -94,16 +97,33 @@ class CredentialService:
         )
 
         session = self._repo.session
-        for repo_class in (
-            MCPServerRepository,
-            WorkspaceMCPCredentialRepository,
-            UserMCPCredentialRepository,
-        ):
-            repo = repo_class(session, org_id=self._org_id)
-            references = await repo.find_by_credential_id(credential_id)
-            if references:
-                reference_ids = [getattr(reference, "id", "?") for reference in references]
-                raise CredentialInUseError(
-                    f"credential {credential_id} referenced by "
-                    f"{repo_class.__name__}: {reference_ids}"
+        if self._org_id is not None:
+            for repo_class in (
+                MCPServerRepository,
+                WorkspaceMCPCredentialRepository,
+                UserMCPCredentialRepository,
+            ):
+                repo = repo_class(session, org_id=self._org_id)
+                references = await repo.find_by_credential_id(credential_id)
+                if references:
+                    reference_ids = [getattr(reference, "id", "?") for reference in references]
+                    raise CredentialInUseError(
+                        f"credential {credential_id} referenced by "
+                        f"{repo_class.__name__}: {reference_ids}"
+                    )
+        provider_refs = (
+            (
+                await session.execute(
+                    select(Provider).where(
+                        Provider.credential_id == credential_id  # type: ignore[arg-type]
+                    )
                 )
+            )
+            .scalars()
+            .all()
+        )
+        if provider_refs:
+            raise CredentialInUseError(
+                f"credential {credential_id} referenced by Provider: "
+                f"{[p.id for p in provider_refs]}"
+            )

--- a/backend/cubebox/services/provider_service.py
+++ b/backend/cubebox/services/provider_service.py
@@ -17,6 +17,7 @@ from cubebox.api.schemas.provider import (
     ProviderUpdate,
     TestResultOut,
 )
+from cubebox.credentials.exceptions import CredentialNotFound
 from cubebox.llm.openai_compatible import ChatOpenAICompatible
 from cubebox.models.org_provider_override import OrgProviderOverride
 from cubebox.models.provider import Model, Provider
@@ -24,6 +25,9 @@ from cubebox.repositories.model import ModelRepository
 from cubebox.repositories.org_provider_override import OrgProviderOverrideRepository
 from cubebox.repositories.org_settings import OrgSettingsRepository
 from cubebox.repositories.provider import ProviderRepository
+from cubebox.services.credential import CredentialService
+
+_PROVIDER_KEY_KIND = "provider_api_key"
 
 
 class ProviderOAuthNotImplementedError(Exception):
@@ -58,6 +62,7 @@ class ProviderService:
         model_repo: ModelRepository,
         override_repo: OrgProviderOverrideRepository,
         org_settings_repo: OrgSettingsRepository,
+        credential_service: CredentialService,
         session: AsyncSession,
         org_id: str,
         actor_user_id: str,
@@ -66,6 +71,7 @@ class ProviderService:
         self._models = model_repo
         self._overrides = override_repo
         self._org_settings = org_settings_repo
+        self._credentials = credential_service
         self._session = session
         self.org_id = org_id
         self.actor_user_id = actor_user_id
@@ -78,14 +84,24 @@ class ProviderService:
         if auth_type == "oauth":
             raise ProviderOAuthNotImplementedError("OAuth authentication is not yet implemented")
 
-    def _validate_auth_creds(self, auth_type: str, api_key: str | None) -> None:
+    def _validate_auth_creds(self, auth_type: str, has_key: bool) -> None:
         """Enforce auth_type / api_key cross-invariants."""
-        if auth_type in ("api_key", "bearer_token"):
-            if not api_key:
-                raise ValueError(f"api_key is required for auth_type={auth_type}")
-        if auth_type == "none":
-            if api_key:
-                raise ValueError("api_key must be empty for auth_type='none'")
+        if auth_type in ("api_key", "bearer_token") and not has_key:
+            raise ValueError(f"api_key is required for auth_type={auth_type}")
+        if auth_type == "none" and has_key:
+            raise ValueError("api_key must be empty for auth_type='none'")
+
+    async def _resolve_api_key(self, provider: Provider) -> str | None:
+        """Decrypt the provider's stored api key, or None if no credential is set."""
+        if not provider.credential_id:
+            return None
+        try:
+            return await self._credentials.get_decrypted(
+                credential_id=provider.credential_id,
+                requesting_kind=_PROVIDER_KEY_KIND,
+            )
+        except CredentialNotFound:
+            return None
 
     # -- Provider CRUD -----------------------------------------------------------
 
@@ -100,18 +116,26 @@ class ProviderService:
 
     async def create_provider(self, data: ProviderCreate) -> Provider:
         self._check_oauth(data.auth_type)
-        self._validate_auth_creds(data.auth_type, data.api_key)
+        self._validate_auth_creds(data.auth_type, bool(data.api_key))
         existing = await self._providers.get_by_name(data.name)
         if existing is not None:
             raise ProviderNameConflictError(f"Provider name '{data.name}' already exists")
+
+        credential_id: str | None = None
+        if data.auth_type != "none" and data.api_key:
+            credential_id = await self._credentials.create(
+                kind=_PROVIDER_KEY_KIND,
+                name=data.name,
+                plaintext=data.api_key,
+            )
+
         p = Provider(
             org_id=self.org_id,
             name=data.name,
             provider_type=data.provider_type,
             base_url=data.base_url,
             auth_type=data.auth_type,
-            api_key=data.api_key if data.auth_type != "none" else None,
-            # TODO(vault): Encrypt api_key when M1-E4 vault integration lands.
+            credential_id=credential_id,
             logo_url=data.logo_url,
             extra_body=data.extra_body,
             extra_headers=data.extra_headers,
@@ -122,18 +146,25 @@ class ProviderService:
     async def update_provider(self, provider_id: str, data: ProviderUpdate) -> Provider:
         p = await self.get_provider(provider_id)
         self._check_not_system(p)
+
         effective_auth = data.auth_type if data.auth_type is not None else p.auth_type
-        effective_key = data.api_key if data.api_key is not None else p.api_key
+        will_have_key = (
+            bool(data.api_key)
+            if data.api_key is not None
+            else (p.credential_id is not None and effective_auth != "none")
+        )
         if data.auth_type is not None or data.api_key is not None:
             self._check_oauth(effective_auth)
-            self._validate_auth_creds(effective_auth, effective_key)
-        if data.auth_type == "none":
-            p.api_key = None
+            self._validate_auth_creds(effective_auth, will_have_key)
+
         if data.name is not None and data.name != p.name:
             existing = await self._providers.get_by_name(data.name)
             if existing is not None:
                 raise ProviderNameConflictError(f"Provider name '{data.name}' already exists")
+            if p.credential_id:
+                await self._credentials.update(credential_id=p.credential_id, name=data.name)
             p.name = data.name
+
         for field in (
             "provider_type",
             "base_url",
@@ -145,8 +176,30 @@ class ProviderService:
             val = getattr(data, field, None)
             if val is not None:
                 setattr(p, field, val)
-        if data.api_key is not None:
-            p.api_key = data.api_key
+
+        if effective_auth == "none" and p.credential_id:
+            old_cred = p.credential_id
+            p.credential_id = None
+            await self._providers.update(p)
+            await self._credentials.delete(credential_id=old_cred)
+        elif data.api_key is not None:
+            if data.api_key:
+                if p.credential_id:
+                    await self._credentials.update(
+                        credential_id=p.credential_id, plaintext=data.api_key
+                    )
+                else:
+                    p.credential_id = await self._credentials.create(
+                        kind=_PROVIDER_KEY_KIND,
+                        name=p.name,
+                        plaintext=data.api_key,
+                    )
+            elif p.credential_id:
+                old_cred = p.credential_id
+                p.credential_id = None
+                await self._providers.update(p)
+                await self._credentials.delete(credential_id=old_cred)
+
         if data.enabled is not None:
             p.enabled = data.enabled
         return await self._providers.update(p)
@@ -154,10 +207,13 @@ class ProviderService:
     async def delete_provider(self, provider_id: str) -> None:
         p = await self.get_provider(provider_id)
         self._check_not_system(p)
+        cred_id = p.credential_id
         await self._models.delete_by_provider(provider_id)
         await self._overrides.delete(provider_id)
         await self._providers.delete(p)
         await self._session.commit()
+        if cred_id:
+            await self._credentials.delete(credential_id=cred_id)
 
     # -- Model CRUD -------------------------------------------------------------
 
@@ -265,10 +321,11 @@ class ProviderService:
                 error=f"Unsupported provider_type: {provider.provider_type}",
                 latency_ms=0,
             )
+        api_key = await self._resolve_api_key(provider)
         try:
             llm = ChatOpenAICompatible(
                 base_url=provider.base_url,
-                api_key=provider.api_key or "placeholder",  # type: ignore[arg-type]
+                api_key=api_key or "placeholder",  # type: ignore[arg-type]
                 model=model_id,
                 timeout=15,
             )

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -557,7 +557,11 @@ class RunManager:
 
             try:
                 async with async_session_maker() as llm_session:
-                    llm = await LLMFactory(session=llm_session, org_id=ctx.org_id).create_default()
+                    llm = await LLMFactory(
+                        session=llm_session,
+                        org_id=ctx.org_id,
+                        encryption_backend=self._app.state.encryption_backend,
+                    ).create_default()
                     await llm_session.commit()
             except Exception:
                 logger.warning("LLMFactory DB load failed, falling back to config-only")

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -35,6 +35,16 @@ from cubebox.repositories import (
 from cubebox.sandbox.local import LocalSandbox
 
 
+def _csrf_cookie_name() -> str:
+    """Resolved CSRF cookie name; honours per-worktree env override."""
+    return str(_cubebox_config.get("auth.csrf_cookie_name", "cubebox_csrf"))
+
+
+def _auth_cookie_name() -> str:
+    """Resolved auth cookie name; honours per-worktree env override."""
+    return str(_cubebox_config.get("auth.cookie_name", "cubebox_auth"))
+
+
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """Force `@pytest.mark.e2e` on every test collected under `tests/e2e/`.
 
@@ -227,14 +237,14 @@ async def _ensure_default_user_and_membership() -> None:
 async def _login_and_attach(client: httpx.AsyncClient, email: str, password: str) -> None:
     """Log in and set the CSRF header on the client."""
     await client.get("/api/v1/auth/me")  # obtain CSRF cookie (401 but sets cookie)
-    csrf = client.cookies.get("cubebox_csrf") or ""
+    csrf = client.cookies.get(_csrf_cookie_name()) or ""
     r = await client.post(
         "/api/v1/auth/login",
         data={"username": email, "password": password},
         headers={"X-CSRF-Token": csrf},
     )
     assert r.status_code in (200, 204), f"login failed: {r.status_code} {r.text}"
-    client.headers["X-CSRF-Token"] = client.cookies.get("cubebox_csrf") or csrf
+    client.headers["X-CSRF-Token"] = client.cookies.get(_csrf_cookie_name()) or csrf
 
 
 @pytest_asyncio.fixture
@@ -249,14 +259,14 @@ async def client() -> AsyncIterator[TestClient]:
     # since auth routers are now mounted at lifespan startup (not in create_app).
     with TestClient(app) as sync_client:
         sync_client.get("/api/v1/auth/me")  # obtain CSRF cookie
-        csrf = sync_client.cookies.get("cubebox_csrf") or ""
+        csrf = sync_client.cookies.get(_csrf_cookie_name()) or ""
         r = sync_client.post(
             "/api/v1/auth/login",
             data={"username": DEFAULT_TEST_EMAIL, "password": DEFAULT_TEST_PASSWORD},
             headers={"X-CSRF-Token": csrf},
         )
         assert r.status_code in (200, 204), f"login failed: {r.status_code} {r.text}"
-        sync_client.headers["X-CSRF-Token"] = sync_client.cookies.get("cubebox_csrf") or csrf
+        sync_client.headers["X-CSRF-Token"] = sync_client.cookies.get(_csrf_cookie_name()) or csrf
         yield sync_client
 
 

--- a/backend/tests/e2e/test_auth.py
+++ b/backend/tests/e2e/test_auth.py
@@ -5,6 +5,7 @@ import secrets
 import pytest
 
 from cubebox.api.middleware.rate_limit import limiter
+from tests.e2e.conftest import _auth_cookie_name, _csrf_cookie_name
 
 pytestmark = pytest.mark.e2e
 
@@ -36,7 +37,7 @@ async def test_register_and_login_sets_cookie(unauthenticated_memory_client):
         "/api/v1/auth/login", data={"username": email, "password": pw}
     )
     assert r.status_code == 204
-    assert "cubebox_auth" in unauthenticated_memory_client.cookies
+    assert _auth_cookie_name() in unauthenticated_memory_client.cookies
 
 
 @pytest.mark.asyncio
@@ -78,7 +79,7 @@ async def test_logout_clears_cookie(unauthenticated_memory_client):
     # Seed CSRF cookie via a safe GET (logout is a mutating request on an
     # authenticated session, so CSRF middleware requires the double-submit token).
     await unauthenticated_memory_client.get("/api/v1/auth/me")
-    csrf = unauthenticated_memory_client.cookies.get("cubebox_csrf") or ""
+    csrf = unauthenticated_memory_client.cookies.get(_csrf_cookie_name()) or ""
     r = await unauthenticated_memory_client.post(
         "/api/v1/auth/logout", headers={"X-CSRF-Token": csrf}
     )
@@ -130,7 +131,7 @@ async def test_patch_me_updates_language(unauthenticated_memory_client):
 
     # Seed CSRF cookie via a safe GET.
     await unauthenticated_memory_client.get("/api/v1/auth/me")
-    csrf = unauthenticated_memory_client.cookies.get("cubebox_csrf") or ""
+    csrf = unauthenticated_memory_client.cookies.get(_csrf_cookie_name()) or ""
 
     # Update language
     resp = await unauthenticated_memory_client.patch(
@@ -162,7 +163,7 @@ async def test_patch_me_rejects_invalid_language(unauthenticated_memory_client):
 
     # Seed CSRF cookie via a safe GET.
     await unauthenticated_memory_client.get("/api/v1/auth/me")
-    csrf = unauthenticated_memory_client.cookies.get("cubebox_csrf") or ""
+    csrf = unauthenticated_memory_client.cookies.get(_csrf_cookie_name()) or ""
 
     # Attempt to set invalid language
     resp = await unauthenticated_memory_client.patch(

--- a/backend/tests/e2e/test_conversation_privacy.py
+++ b/backend/tests/e2e/test_conversation_privacy.py
@@ -10,6 +10,7 @@ import secrets
 import pytest
 
 from cubebox.api.middleware.rate_limit import limiter
+from tests.e2e.conftest import _csrf_cookie_name
 
 pytestmark = pytest.mark.e2e
 
@@ -23,7 +24,7 @@ def _reset_rate_limiter():
 
 async def _seed_csrf(client) -> str:
     await client.get("/api/v1/auth/me")
-    csrf = client.cookies.get("cubebox_csrf")
+    csrf = client.cookies.get(_csrf_cookie_name())
     assert csrf, "cubebox_csrf cookie not set after GET /api/v1/auth/me"
     return csrf
 

--- a/backend/tests/e2e/test_mcp_user_credentials.py
+++ b/backend/tests/e2e/test_mcp_user_credentials.py
@@ -4,10 +4,12 @@ import secrets
 
 import httpx
 
+from tests.e2e.conftest import _csrf_cookie_name
+
 
 async def _seed_csrf(client: httpx.AsyncClient) -> str:
     await client.get("/api/v1/auth/me")
-    csrf = client.cookies.get("cubebox_csrf")
+    csrf = client.cookies.get(_csrf_cookie_name())
     assert csrf is not None
     return csrf
 

--- a/backend/tests/e2e/test_provider_vault.py
+++ b/backend/tests/e2e/test_provider_vault.py
@@ -1,0 +1,337 @@
+"""E2E tests for Provider <-> Credential vault integration.
+
+Covers what unit-level mocking can't: real DB, real Fernet encryption,
+real LLMFactory wiring, and the seeder running against the live engine.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+from httpx import AsyncClient
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.credentials.encryption import FernetBackend
+from cubebox.llm.config import LLMConfig
+from cubebox.llm.factory import LLMFactory
+from cubebox.models import Credential
+from cubebox.models.provider import Provider
+from cubebox.seeders.provider_seeder import seed_system_providers_from_config
+
+pytestmark = pytest.mark.e2e
+
+
+async def _get_provider_by_id(session: AsyncSession, pid: str) -> Provider:
+    return (
+        await session.execute(select(Provider).where(Provider.id == pid))  # type: ignore[arg-type]
+    ).scalar_one()
+
+
+async def _get_credential(session: AsyncSession, cred_id: str) -> Credential:
+    return (
+        await session.execute(
+            select(Credential).where(Credential.id == cred_id)  # type: ignore[arg-type]
+        )
+    ).scalar_one()
+
+
+async def test_create_provider_writes_encrypted_credential(
+    admin_client: tuple[AsyncClient, str],
+    db_session: AsyncSession,
+) -> None:
+    """POST /admin/providers stores api_key as a Credential row, never plaintext."""
+    client, _ = admin_client
+    secret = "sk-vault-roundtrip-XYZ"
+
+    res = await client.post(
+        "/api/v1/admin/providers",
+        json={
+            "name": "vault-roundtrip",
+            "base_url": "https://example.com",
+            "auth_type": "api_key",
+            "api_key": secret,
+        },
+    )
+    assert res.status_code == 201
+    pid = res.json()["id"]
+    assert res.json()["has_api_key"] is True
+
+    provider = await _get_provider_by_id(db_session, pid)
+    assert provider.credential_id is not None
+    cred = await _get_credential(db_session, provider.credential_id)
+    assert cred.kind == "provider_api_key"
+    assert cred.value_encrypted != secret.encode()  # ciphertext, not plaintext
+    assert secret.encode() not in cred.value_encrypted
+
+    await client.delete(f"/api/v1/admin/providers/{pid}")
+
+
+async def test_update_api_key_replaces_ciphertext_keeps_credential_id(
+    admin_client: tuple[AsyncClient, str],
+    db_session: AsyncSession,
+) -> None:
+    """Updating api_key rotates ciphertext but keeps the same credential row."""
+    client, _ = admin_client
+
+    res = await client.post(
+        "/api/v1/admin/providers",
+        json={
+            "name": "vault-update",
+            "base_url": "https://example.com",
+            "auth_type": "api_key",
+            "api_key": "sk-old",
+        },
+    )
+    assert res.status_code == 201
+    pid = res.json()["id"]
+    p_old = await _get_provider_by_id(db_session, pid)
+    cred_old = await _get_credential(db_session, p_old.credential_id or "")
+    cipher_old = cred_old.value_encrypted
+
+    res = await client.patch(
+        f"/api/v1/admin/providers/{pid}",
+        json={"api_key": "sk-new"},
+    )
+    assert res.status_code == 200
+
+    db_session.expire_all()
+    p_new = await _get_provider_by_id(db_session, pid)
+    assert p_new.credential_id == p_old.credential_id
+    cred_new = await _get_credential(db_session, p_new.credential_id or "")
+    assert cred_new.value_encrypted != cipher_old
+
+    await client.delete(f"/api/v1/admin/providers/{pid}")
+
+
+async def test_delete_provider_removes_credential(
+    admin_client: tuple[AsyncClient, str],
+    db_session: AsyncSession,
+) -> None:
+    """DELETE provider also removes its credential vault entry."""
+    client, _ = admin_client
+    res = await client.post(
+        "/api/v1/admin/providers",
+        json={
+            "name": "vault-delete",
+            "base_url": "https://example.com",
+            "auth_type": "api_key",
+            "api_key": "sk-doomed",
+        },
+    )
+    assert res.status_code == 201
+    pid = res.json()["id"]
+    cred_id = (await _get_provider_by_id(db_session, pid)).credential_id
+    assert cred_id is not None
+
+    res = await client.delete(f"/api/v1/admin/providers/{pid}")
+    assert res.status_code == 204
+
+    cred = (
+        await db_session.execute(
+            select(Credential).where(Credential.id == cred_id)  # type: ignore[arg-type]
+        )
+    ).scalar_one_or_none()
+    assert cred is None
+
+
+async def test_factory_decrypts_provider_api_key(
+    admin_client: tuple[AsyncClient, str],
+    db_session: AsyncSession,
+) -> None:
+    """LLMFactory loads ProviderConfig.api_key by decrypting the credential."""
+    client, _ = admin_client
+
+    res = await client.post(
+        "/api/v1/admin/providers",
+        json={
+            "name": "vault-factory",
+            "base_url": "https://example.com",
+            "auth_type": "api_key",
+            "api_key": "sk-factory-XYZ",
+        },
+    )
+    assert res.status_code == 201
+    pid = res.json()["id"]
+
+    # Use the same backend the API used (lifespan-built, on app.state).
+    transport = client._transport  # type: ignore[attr-defined]
+    backend = transport.app.state.encryption_backend
+    provider = await _get_provider_by_id(db_session, pid)
+
+    factory = LLMFactory(
+        llm_config=LLMConfig(default_model="x/y", providers={}),
+        session=db_session,
+        org_id=provider.org_id,
+        encryption_backend=backend,
+    )
+    db_cfgs, _ = await factory._load_db_provider_configs()
+    assert db_cfgs["vault-factory"]["api_key"] == "sk-factory-XYZ"
+
+    await client.delete(f"/api/v1/admin/providers/{pid}")
+
+
+async def test_factory_decrypts_with_rotated_keys(
+    db_session: AsyncSession,
+) -> None:
+    """Encrypt with key1, then load with backend([key2, key1]) — still decrypts."""
+    secret = "sk-rotation-direct"
+    key1 = Fernet.generate_key()
+    key2 = Fernet.generate_key()
+    backend_old = FernetBackend([key1])
+    backend_rotated = FernetBackend([key2, key1])  # key2 encrypts, key1 still decrypts
+
+    # Seed a fake org + provider + credential using only key1 ciphertext.
+    org_id = "org-vault-rotate"
+    user_id = "user-vault-rotate"
+    await db_session.execute(
+        text(
+            "INSERT INTO organizations (id, name, slug, created_at)"
+            " VALUES (:id, :id, :id, NOW()) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": org_id},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO users (id, email, hashed_password, is_active, is_superuser,"
+            " is_verified, created_at, language) VALUES"
+            " (:id, :email, 'x', true, false, false, NOW(), 'en')"
+            " ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": user_id, "email": f"{user_id}@vault.local"},
+    )
+    ciphertext = await backend_old.encrypt(secret.encode())
+    cred = Credential(
+        org_id=org_id,
+        kind="provider_api_key",
+        name="rotation-target",
+        value_encrypted=ciphertext,
+        created_by_user_id=user_id,
+    )
+    db_session.add(cred)
+    await db_session.flush()
+    provider = Provider(
+        org_id=org_id,
+        name="rotation-target",
+        provider_type="openai_compat",
+        base_url="https://example.com",
+        auth_type="api_key",
+        credential_id=cred.id,
+        created_by_user_id=user_id,
+    )
+    db_session.add(provider)
+    await db_session.commit()
+
+    try:
+        factory = LLMFactory(
+            llm_config=LLMConfig(default_model="x/y", providers={}),
+            session=db_session,
+            org_id=org_id,
+            encryption_backend=backend_rotated,
+        )
+        db_cfgs, _ = await factory._load_db_provider_configs()
+        assert db_cfgs["rotation-target"]["api_key"] == secret
+    finally:
+        await db_session.execute(
+            text("DELETE FROM providers WHERE id = :pid"), {"pid": provider.id}
+        )
+        await db_session.execute(text("DELETE FROM credentials WHERE id = :cid"), {"cid": cred.id})
+        await db_session.commit()
+
+
+async def test_seeder_idempotent_with_changed_key(
+    db_session: AsyncSession,
+) -> None:
+    """Re-running the seeder with a different api_key updates ciphertext, keeps cred id."""
+    backend = FernetBackend([Fernet.generate_key()])
+    # Seed once with a sentinel api_key by patching config.llm.providers temporarily.
+    from cubebox.config import config as settings
+
+    # Snapshot original LLM providers, replace with a single test entry.
+    original_llm = dict(settings.get("llm", {}))
+    settings.set(
+        "llm.providers",
+        {
+            "vault-seeder-test": {
+                "base_url": "https://seeder.example.com",
+                "api_key": "seed-1",
+                "models": [
+                    {
+                        "id": "mtest",
+                        "name": "M",
+                        "context_window": 1000,
+                        "max_tokens": 100,
+                    }
+                ],
+            }
+        },
+    )
+    try:
+        await seed_system_providers_from_config(db_session, backend)
+        await db_session.commit()
+        provider1 = (
+            await db_session.execute(
+                select(Provider).where(
+                    Provider.org_id.is_(None),  # type: ignore[union-attr]
+                    Provider.name == "vault-seeder-test",  # type: ignore[arg-type]
+                )
+            )
+        ).scalar_one()
+        cred_id_1 = provider1.credential_id
+        cipher_1 = (await _get_credential(db_session, cred_id_1 or "")).value_encrypted
+        assert cred_id_1 is not None
+
+        settings.set(
+            "llm.providers",
+            {
+                "vault-seeder-test": {
+                    "base_url": "https://seeder.example.com",
+                    "api_key": "seed-2-rotated",
+                    "models": [
+                        {
+                            "id": "mtest",
+                            "name": "M",
+                            "context_window": 1000,
+                            "max_tokens": 100,
+                        }
+                    ],
+                }
+            },
+        )
+        await seed_system_providers_from_config(db_session, backend)
+        await db_session.commit()
+
+        db_session.expire_all()
+        provider2 = (
+            await db_session.execute(
+                select(Provider).where(
+                    Provider.org_id.is_(None),  # type: ignore[union-attr]
+                    Provider.name == "vault-seeder-test",  # type: ignore[arg-type]
+                )
+            )
+        ).scalar_one()
+        assert provider2.credential_id == cred_id_1
+        cipher_2 = (await _get_credential(db_session, cred_id_1 or "")).value_encrypted
+        assert cipher_2 != cipher_1
+        plaintext = (await backend.decrypt(cipher_2)).decode()
+        assert plaintext == "seed-2-rotated"
+    finally:
+        # Restore providers and clean up the test row.
+        settings.set("llm.providers", original_llm.get("providers", {}))
+        await db_session.execute(
+            text(
+                "DELETE FROM models WHERE provider_id IN ("
+                "SELECT id FROM providers WHERE name = 'vault-seeder-test')"
+            )
+        )
+        await db_session.execute(
+            text("UPDATE providers SET credential_id = NULL WHERE name = 'vault-seeder-test'")
+        )
+        await db_session.execute(text("DELETE FROM providers WHERE name = 'vault-seeder-test'"))
+        await db_session.execute(
+            text(
+                "DELETE FROM credentials WHERE name = 'vault-seeder-test'"
+                " AND kind = 'provider_api_key'"
+            )
+        )
+        await db_session.commit()

--- a/backend/tests/e2e/test_scoping.py
+++ b/backend/tests/e2e/test_scoping.py
@@ -5,6 +5,7 @@ import secrets
 import pytest
 
 from cubebox.api.middleware.rate_limit import limiter
+from tests.e2e.conftest import _auth_cookie_name, _csrf_cookie_name
 
 pytestmark = pytest.mark.e2e
 
@@ -30,7 +31,7 @@ async def _seed_csrf(client) -> str:
     in the `X-CSRF-Token` header on subsequent mutating requests.
     """
     await client.get("/api/v1/auth/me")
-    csrf = client.cookies.get("cubebox_csrf")
+    csrf = client.cookies.get(_csrf_cookie_name())
     assert csrf, "cubebox_csrf cookie not set after GET /api/v1/auth/me"
     return csrf
 
@@ -58,7 +59,7 @@ async def test_conversation_invisible_to_other_workspace(unauthenticated_memory_
     # --- User A: login, create workspace W_A, create conversation -----------
     r = await client.post("/api/v1/auth/login", data={"username": a_email, "password": pw})
     assert r.status_code in (200, 204), r.text
-    assert "cubebox_auth" in client.cookies
+    assert _auth_cookie_name() in client.cookies
 
     csrf_a = await _seed_csrf(client)
     # Fetch the org_id from A's auto-created workspace (created by on_after_register).

--- a/backend/tests/unit/test_credential_model.py
+++ b/backend/tests/unit/test_credential_model.py
@@ -1,6 +1,6 @@
 """Tests for the vault Credential SQLModel."""
 
-from sqlalchemy import LargeBinary, UniqueConstraint
+from sqlalchemy import Index, LargeBinary
 
 
 def test_credential_model_is_registered() -> None:
@@ -11,17 +11,26 @@ def test_credential_model_is_registered() -> None:
     assert Credential.__table__.c.cred_metadata.type.python_type is dict
 
 
-def test_credential_model_has_org_kind_name_unique_constraint() -> None:
+def test_credential_model_has_partial_unique_indexes() -> None:
+    """Org-scoped and system-scoped uniqueness are enforced by partial indexes.
+
+    System credentials carry ``org_id IS NULL``, so a single full unique
+    constraint cannot cover both system and org-scoped rows -- two partial
+    indexes do.
+    """
     from cubebox.models import Credential
 
-    constraints = [
-        constraint
-        for constraint in Credential.__table__.constraints
-        if isinstance(constraint, UniqueConstraint)
-    ]
+    indexes: list[Index] = list(Credential.__table__.indexes)
 
-    assert any(
-        constraint.name == "uq_credential_org_kind_name"
-        and [column.name for column in constraint.columns] == ["org_id", "kind", "name"]
-        for constraint in constraints
+    org_scoped = next(
+        (i for i in indexes if i.name == "uq_credential_org_kind_name"),
+        None,
     )
+    system_scoped = next(
+        (i for i in indexes if i.name == "uq_credential_system_kind_name"),
+        None,
+    )
+    assert org_scoped is not None and org_scoped.unique
+    assert [c.name for c in org_scoped.columns] == ["org_id", "kind", "name"]
+    assert system_scoped is not None and system_scoped.unique
+    assert [c.name for c in system_scoped.columns] == ["kind", "name"]

--- a/backend/tests/unit/test_provider_service_invariants.py
+++ b/backend/tests/unit/test_provider_service_invariants.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import pytest
+from cryptography.fernet import Fernet
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel
 
 from cubebox.api.schemas.provider import ProviderCreate, ProviderUpdate
+from cubebox.credentials.encryption import FernetBackend
+from cubebox.repositories.credential import CredentialRepository
+from cubebox.services.credential import CredentialService
 from cubebox.services.provider_service import (
     ProviderNameConflictError,
     ProviderOAuthNotImplementedError,
@@ -37,11 +41,19 @@ def _make_svc(session: AsyncSession, org_id: str = "org-1") -> ProviderService:
     from cubebox.repositories.org_settings import OrgSettingsRepository
     from cubebox.repositories.provider import ProviderRepository
 
+    backend = FernetBackend([Fernet.generate_key()])
+    cred_service = CredentialService(
+        CredentialRepository(session, org_id=org_id),
+        backend,
+        org_id=org_id,
+        actor_user_id="user-1",
+    )
     return ProviderService(
         provider_repo=ProviderRepository(session, org_id=org_id),
         model_repo=ModelRepository(session),
         override_repo=OrgProviderOverrideRepository(session, org_id=org_id),
         org_settings_repo=OrgSettingsRepository(session, org_id=org_id),
+        credential_service=cred_service,
         session=session,
         org_id=org_id,
         actor_user_id="user-1",
@@ -61,7 +73,7 @@ async def test_oauth_auth_type_rejected(db_session: AsyncSession) -> None:
 
 
 async def test_create_org_provider_sets_org_id(db_session: AsyncSession) -> None:
-    """Org-level provider must have org_id set."""
+    """Org-level provider must have org_id set and credential_id populated."""
     svc = _make_svc(db_session)
     data = ProviderCreate(
         name="my-provider",
@@ -72,7 +84,7 @@ async def test_create_org_provider_sets_org_id(db_session: AsyncSession) -> None
     provider = await svc.create_provider(data)
     assert provider.org_id == "org-1"
     assert provider.name == "my-provider"
-    assert provider.api_key == "sk-test"
+    assert provider.credential_id is not None
 
 
 async def test_name_conflict_raises(db_session: AsyncSession) -> None:
@@ -93,13 +105,11 @@ async def test_system_provider_readonly_on_update(db_session: AsyncSession) -> N
     """Updating a system provider (org_id=None) must raise."""
     from cubebox.models.provider import Provider
 
-    # Seed a system provider directly
     p = Provider(
         org_id=None,
         name="system-openai",
         base_url="https://api.openai.com",
         auth_type="api_key",
-        api_key="sk-system",
         created_by_user_id="system",
     )
     db_session.add(p)
@@ -119,7 +129,6 @@ async def test_system_provider_readonly_on_delete(db_session: AsyncSession) -> N
         name="system-anthropic",
         base_url="https://api.anthropic.com",
         auth_type="api_key",
-        api_key="sk-system",
         created_by_user_id="system",
     )
     db_session.add(p)

--- a/backend/tests/unit/test_seed_idempotent.py
+++ b/backend/tests/unit/test_seed_idempotent.py
@@ -1,11 +1,13 @@
 """Seed idempotency tests."""
 
 import pytest
+from cryptography.fernet import Fernet
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel
 
+from cubebox.credentials.encryption import FernetBackend
 from cubebox.models.provider import Model, Provider
 from cubebox.seeders import seed_system_providers_from_config
 
@@ -25,14 +27,19 @@ async def clean_db() -> AsyncSession:
     await engine.dispose()
 
 
-async def test_seed_is_idempotent(clean_db: AsyncSession) -> None:
+@pytest.fixture()
+def backend() -> FernetBackend:
+    return FernetBackend([Fernet.generate_key()])
+
+
+async def test_seed_is_idempotent(clean_db: AsyncSession, backend: FernetBackend) -> None:
     """Seeding twice must produce the same set of system providers and models."""
-    await seed_system_providers_from_config(clean_db)
+    await seed_system_providers_from_config(clean_db, backend)
     providers1 = (
         (await clean_db.execute(select(Provider).where(Provider.org_id.is_(None)))).scalars().all()
     )
 
-    await seed_system_providers_from_config(clean_db)
+    await seed_system_providers_from_config(clean_db, backend)
     providers2 = (
         (await clean_db.execute(select(Provider).where(Provider.org_id.is_(None)))).scalars().all()
     )
@@ -46,9 +53,9 @@ async def test_seed_is_idempotent(clean_db: AsyncSession) -> None:
         assert len(models) > 0, f"Provider {p.name} should have models after seed"
 
 
-async def test_seed_creates_providers(clean_db: AsyncSession) -> None:
+async def test_seed_creates_providers(clean_db: AsyncSession, backend: FernetBackend) -> None:
     """Seeding must create system providers with their models."""
-    await seed_system_providers_from_config(clean_db)
+    await seed_system_providers_from_config(clean_db, backend)
     providers = (
         (await clean_db.execute(select(Provider).where(Provider.org_id.is_(None)))).scalars().all()
     )
@@ -64,7 +71,9 @@ async def test_seed_creates_providers(clean_db: AsyncSession) -> None:
         assert len(models) > 0, f"Provider {p.name} should have models"
 
 
-async def test_seed_updates_existing_provider_url(clean_db: AsyncSession) -> None:
+async def test_seed_updates_existing_provider_url(
+    clean_db: AsyncSession, backend: FernetBackend
+) -> None:
     """Seeding an existing provider must update its base_url."""
     # Insert a provider manually with a different URL
     p = Provider(
@@ -79,7 +88,7 @@ async def test_seed_updates_existing_provider_url(clean_db: AsyncSession) -> Non
     clean_db.add(p)
     await clean_db.commit()
 
-    await seed_system_providers_from_config(clean_db)
+    await seed_system_providers_from_config(clean_db, backend)
 
     # Verify the URL was updated
     updated = (


### PR DESCRIPTION
## Summary

- Provider api keys (system + org) now live in `credentials` (`kind='provider_api_key'`), sharing the same MultiFernet rotation pipeline as MCP credentials. Plaintext is removed from the `providers` table.
- Seeded system providers stop showing up as "No API Key" — the seeder writes the env-resolved key into a system vault credential on startup, idempotently.
- LLMFactory takes an `EncryptionBackend` and decrypts on load; a single bad credential logs a warning and skips its api_key rather than breaking startup.
- Tests cover encryption roundtrip, ciphertext rotation, provider-delete cascade, factory decryption, key rotation `[key2, key1]`, and seeder idempotency with a mutated config api_key.

## Schema

Migration `d44dff875e38`:

- `credentials.org_id` and `credentials.created_by_user_id` become nullable so system credentials can live in the same table.
- Single `uq_credential_org_kind_name` constraint is replaced by two partial unique indexes — one for org-scoped rows (`org_id IS NOT NULL`) and one for system rows (`org_id IS NULL`).
- `providers.credential_id` FK added; data migration encrypts existing `providers.api_key` plaintext into a credential row using the configured `CUBEBOX_AUTH__VAULT_KEY`; then the `api_key` column is dropped.

## Side fix (separate commit)

`tests/e2e/conftest.py` and four E2E test files (`test_auth`, `test_scoping`, `test_conversation_privacy`, `test_mcp_user_credentials`) hardcoded `cubebox_auth` / `cubebox_csrf`, which broke after 5ed9203 made cookie names per-worktree. They now read from `auth.cookie_name` / `auth.csrf_cookie_name` via shared conftest helpers.

## Test plan

- [x] `uv run pytest tests/unit tests/e2e` — full suite passes locally
- [x] `uv run mypy cubebox/` — clean
- [x] `uv run ruff check cubebox/ tests/` + `ruff format --check` — clean
- [x] `alembic upgrade head` applies cleanly on a populated dev DB; existing provider api keys roundtrip through vault decrypt
- [ ] Manual smoke: in a fresh DB, install + start backend, confirm system provider has `has_api_key: true` (no "No API Key" UI label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)