### PR TITLE
feat(i18n): full sweep — migrate hardcoded UI strings across web app

### DIFF
--- a/frontend/packages/web/__tests__/e2e/i18n.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/i18n.spec.ts
@@ -43,8 +43,8 @@ test.describe('i18n — language preference', () => {
     await page.reload()
     await expect(page.getByPlaceholder('有什么可以帮你的？')).toBeVisible()
 
-    // Switch back to English
-    await page.getByRole('button', { name: 'Account menu' }).click()
+    // Switch back to English (aria-label is now localized to Chinese here)
+    await page.getByRole('button', { name: '账号菜单' }).click()
     await page.getByRole('button', { name: 'EN', exact: true }).click()
     await expect(page.getByPlaceholder('How can I help you?')).toBeVisible({ timeout: 8_000 })
   })

--- a/frontend/packages/web/app/(app)/w/[wsId]/conversations/[id]/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/conversations/[id]/page.tsx
@@ -7,6 +7,8 @@ import {
   useConversationStore,
   usePanelStore,
 } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { AppShell } from '@/components/layout/AppShell'
 import { MessageList } from '@/components/chat/MessageList'
 import { ArtifactGallery } from '@/components/chat/ArtifactGallery'
@@ -14,6 +16,7 @@ import { InputBar } from '@/components/layout/InputBar'
 import { ErrorState } from '@/components/shared/ErrorState'
 
 export default function ChatPage({ params }: { params: Promise<{ wsId: string; id: string }> }) {
+  const t = useTranslations('conversationPage')
   const { wsId, id: conversationId } = use(params)
   const setActive = useConversationStore((s) => s.setActive)
   const conversations = useConversationStore((s) => s.conversations)
@@ -42,20 +45,20 @@ export default function ChatPage({ params }: { params: Promise<{ wsId: string; i
   if (status === 'notfound') {
     return (
       <ErrorState
-        title="Conversation not found"
-        description="It may have been deleted, or it belongs to a different workspace."
+        title={t('notFoundTitle')}
+        description={t('notFoundBody')}
         backHref={`/w/${wsId}`}
-        backLabel="Back to workspace"
+        backLabel={t('notFoundBack')}
       />
     )
   }
   if (status === 'forbidden') {
     return (
       <ErrorState
-        title="No access"
-        description="You are not a member of this workspace."
+        title={t('noAccessTitle')}
+        description={t('noAccessBody')}
         backHref="/workspaces"
-        backLabel="Choose a workspace"
+        backLabel={t('noAccessBack')}
       />
     )
   }

--- a/frontend/packages/web/app/(app)/w/[wsId]/integrations/mcp/[id]/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/integrations/mcp/[id]/page.tsx
@@ -4,9 +4,12 @@ import { useEffect, useMemo, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { createApiClient, useWorkspaceMcpStore, wsGetServer } from '@cubebox/core'
 import type { MCPServer } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { MCPServerDetail } from '@/components/mcp/MCPServerDetail'
 
 export default function WorkspaceMcpDetailPage() {
+  const t = useTranslations('mcp.wsPage')
   const { wsId, id } = useParams<{ wsId: string; id: string }>()
   const router = useRouter()
   const client = useMemo(() => {
@@ -39,7 +42,7 @@ export default function WorkspaceMcpDetailPage() {
   }, [client, id, wsId])
 
   if (error) return <div className="text-sm text-destructive">{error}</div>
-  if (!server) return <div className="text-sm text-muted-foreground">Loading connector...</div>
+  if (!server) return <div className="text-sm text-muted-foreground">{t('loadingConnector')}</div>
 
   const isOwned = server.owner_workspace_id === wsId
 
@@ -55,7 +58,7 @@ export default function WorkspaceMcpDetailPage() {
       onDelete={
         isOwned
           ? async () => {
-              if (!window.confirm(`Delete ${server.name}?`)) return
+              if (!window.confirm(t('deleteConfirm', { name: server.name }))) return
               await remove(client, wsId, id)
               router.push(`/w/${wsId}/integrations/mcp`)
             }

--- a/frontend/packages/web/app/(app)/w/[wsId]/integrations/mcp/new/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/integrations/mcp/new/page.tsx
@@ -4,32 +4,12 @@ import { useMemo } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { createApiClient, useWorkspaceMcpStore } from '@cubebox/core'
 import type { MCPServerCreateWSBody } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { MCPServerForm, type MCPServerFormValues } from '@/components/mcp/MCPServerForm'
 
-function toWorkspaceBody(values: MCPServerFormValues): MCPServerCreateWSBody {
-  if (
-    values.credential_scope !== 'workspace' &&
-    values.credential_scope !== 'user' &&
-    values.credential_scope !== 'none'
-  ) {
-    throw new Error('Workspace connectors only support workspace, per-user, or passthrough scope.')
-  }
-
-  return {
-    name: values.name,
-    server_url: values.server_url,
-    transport: values.transport,
-    auth_method: values.auth_method,
-    credential_scope: values.credential_scope,
-    credential_plaintext: values.credential_plaintext || undefined,
-    credential_name: values.credential_name || undefined,
-    headers: values.headers,
-    timeout: values.timeout,
-    sse_read_timeout: values.sse_read_timeout,
-  }
-}
-
 export default function NewWorkspaceMcpPage() {
+  const t = useTranslations('mcp.wsPage')
   const { wsId } = useParams<{ wsId: string }>()
   const router = useRouter()
   const client = useMemo(() => {
@@ -39,6 +19,29 @@ export default function NewWorkspaceMcpPage() {
   }, [wsId])
   const { create, testConnection } = useWorkspaceMcpStore()
 
+  function toWorkspaceBody(values: MCPServerFormValues): MCPServerCreateWSBody {
+    if (
+      values.credential_scope !== 'workspace' &&
+      values.credential_scope !== 'user' &&
+      values.credential_scope !== 'none'
+    ) {
+      throw new Error(t('scopeError'))
+    }
+
+    return {
+      name: values.name,
+      server_url: values.server_url,
+      transport: values.transport,
+      auth_method: values.auth_method,
+      credential_scope: values.credential_scope,
+      credential_plaintext: values.credential_plaintext || undefined,
+      credential_name: values.credential_name || undefined,
+      headers: values.headers,
+      timeout: values.timeout,
+      sse_read_timeout: values.sse_read_timeout,
+    }
+  }
+
   async function handleSubmit(values: MCPServerFormValues): Promise<void> {
     const created = await create(client, wsId, toWorkspaceBody(values))
     router.push(`/w/${wsId}/integrations/mcp/${created.id}`)
@@ -47,10 +50,8 @@ export default function NewWorkspaceMcpPage() {
   return (
     <div className="flex max-w-3xl flex-col gap-6">
       <div className="flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold">Add MCP server</h1>
-        <p className="text-sm text-muted-foreground">
-          Configure a connector owned by this workspace.
-        </p>
+        <h1 className="text-2xl font-semibold">{t('addTitle')}</h1>
+        <p className="text-sm text-muted-foreground">{t('addSubtitle')}</p>
       </div>
       <MCPServerForm
         mode="ws-member"

--- a/frontend/packages/web/app/(app)/w/[wsId]/integrations/mcp/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/integrations/mcp/page.tsx
@@ -4,10 +4,13 @@ import { useEffect, useMemo } from 'react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
 import { createApiClient, useWorkspaceMcpStore } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { buttonVariants } from '@/components/ui/button'
 import { MCPServerList } from '@/components/mcp/MCPServerList'
 
 export default function WorkspaceMcpListPage() {
+  const t = useTranslations('mcp.wsPage')
   const { wsId } = useParams<{ wsId: string }>()
   const client = useMemo(() => {
     const next = createApiClient('')
@@ -24,40 +27,38 @@ export default function WorkspaceMcpListPage() {
     <div className="flex flex-col gap-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex flex-col gap-1">
-          <h1 className="text-2xl font-semibold">Workspace MCP connectors</h1>
-          <p className="text-sm text-muted-foreground">
-            Manage private connectors and credentials for this workspace.
-          </p>
+          <h1 className="text-2xl font-semibold">{t('title')}</h1>
+          <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
         </div>
         <Link
           href={`/w/${wsId}/integrations/mcp/new`}
           className={buttonVariants({ variant: 'default' })}
         >
-          Add server
+          {t('addServer')}
         </Link>
       </div>
 
       {error ? <p className="text-sm text-destructive">{error}</p> : null}
 
       <section className="flex flex-col gap-3">
-        <h2 className="text-base font-medium">Workspace private</h2>
+        <h2 className="text-base font-medium">{t('private')}</h2>
         <MCPServerList
           servers={owned}
           loading={loading}
           detailHrefBase={`/w/${wsId}/integrations/mcp`}
-          emptyTitle="No private MCP servers"
-          emptyDescription="Add a connector that is visible only inside this workspace."
+          emptyTitle={t('privateEmptyTitle')}
+          emptyDescription={t('privateEmptyDesc')}
         />
       </section>
 
       <section className="flex flex-col gap-3">
-        <h2 className="text-base font-medium">Shared from organization</h2>
+        <h2 className="text-base font-medium">{t('shared')}</h2>
         <MCPServerList
           servers={viaBinding}
           loading={loading}
           detailHrefBase={`/w/${wsId}/integrations/mcp`}
-          emptyTitle="No organization connectors shared here"
-          emptyDescription="Organization admins can bind org-level MCP servers to this workspace."
+          emptyTitle={t('sharedEmptyTitle')}
+          emptyDescription={t('sharedEmptyDesc')}
         />
       </section>
     </div>

--- a/frontend/packages/web/app/(app)/workspaces/page.tsx
+++ b/frontend/packages/web/app/(app)/workspaces/page.tsx
@@ -1,10 +1,15 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+
 import { WorkspaceList } from '@/components/workspace/WorkspaceList'
 import { WorkspaceCreateForm } from '@/components/workspace/WorkspaceCreateForm'
 
 export default function WorkspacesPage() {
+  const t = useTranslations('workspacesPage')
   return (
     <div className="max-w-2xl mx-auto w-full p-6 space-y-6">
-      <h1 className="text-lg font-semibold">Workspaces</h1>
+      <h1 className="text-lg font-semibold">{t('title')}</h1>
       <WorkspaceList />
       <WorkspaceCreateForm />
     </div>

--- a/frontend/packages/web/app/admin/ext/[plugin]/[...path]/page.tsx
+++ b/frontend/packages/web/app/admin/ext/[plugin]/[...path]/page.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { use } from 'react'
+import { useTranslations } from 'next-intl'
+
 import { useAdminExtensions } from '@/hooks/useAdminExtensions'
 
 interface ExtensionPageProps {
@@ -8,13 +10,14 @@ interface ExtensionPageProps {
 }
 
 export default function ExtensionPage({ params }: ExtensionPageProps) {
+  const t = useTranslations('adminExt')
   const { plugin, path } = use(params)
   const { extensions, loading } = useAdminExtensions()
 
   if (loading) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-        Loading extension…
+        {t('loading')}
       </div>
     )
   }
@@ -23,10 +26,10 @@ export default function ExtensionPage({ params }: ExtensionPageProps) {
   if (!ext) {
     return (
       <div className="max-w-2xl mx-auto mt-16 px-6">
-        <h2 className="text-2xl font-semibold tracking-tight mb-2">未知扩展</h2>
+        <h2 className="text-2xl font-semibold tracking-tight mb-2">{t('unknownTitle')}</h2>
         <p className="text-muted-foreground leading-relaxed">
-          找不到名为 <code className="rounded bg-muted px-1.5 py-0.5 text-sm">{plugin}</code> 的插件
-          —— 它可能未安装或已禁用。
+          {t('unknownBodyPrefix')}{' '}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-sm">{plugin}</code>。
         </p>
       </div>
     )

--- a/frontend/packages/web/app/admin/layout.tsx
+++ b/frontend/packages/web/app/admin/layout.tsx
@@ -3,11 +3,14 @@
 import { useEffect, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { createApiClient, useAuthStore } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { AdminSubNav } from '@/components/admin/AdminSubNav'
 import { AdminTopBar } from '@/components/admin/AdminTopBar'
 import { useAdminAccess } from '@/hooks/useAdminAccess'
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const t = useTranslations('adminLayout')
   const client = useMemo(() => createApiClient(''), [])
   const { isAdmin, orgName, loading, error } = useAdminAccess()
   const router = useRouter()
@@ -31,7 +34,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   if (loading) {
     return (
       <div className="flex h-screen items-center justify-center text-sm text-muted-foreground">
-        Loading…
+        {t('loading')}
       </div>
     )
   }

--- a/frontend/packages/web/app/admin/mcp/[id]/page.tsx
+++ b/frontend/packages/web/app/admin/mcp/[id]/page.tsx
@@ -4,9 +4,12 @@ import { useEffect, useMemo, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { adminGetServer, createApiClient, useMcpStore, useWorkspaceStore } from '@cubebox/core'
 import type { MCPServer } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { MCPServerDetail } from '@/components/mcp/MCPServerDetail'
 
 export default function AdminMcpDetailPage() {
+  const t = useTranslations('mcp.adminPage')
   const params = useParams<{ id: string }>()
   const router = useRouter()
   const client = useMemo(() => createApiClient(''), [])
@@ -39,7 +42,7 @@ export default function AdminMcpDetailPage() {
   }, [client, fetchWorkspaces, params.id])
 
   if (error) return <div className="text-sm text-destructive">{error}</div>
-  if (!server) return <div className="text-sm text-muted-foreground">Loading connector...</div>
+  if (!server) return <div className="text-sm text-muted-foreground">{t('loadingConnector')}</div>
 
   return (
     <MCPServerDetail
@@ -51,11 +54,7 @@ export default function AdminMcpDetailPage() {
         setServer(await refreshTools(client, server.id))
       }}
       onDelete={async () => {
-        if (
-          !window.confirm(
-            `Delete ${server.name}? Bindings and credentials owned by this connector will also be removed.`,
-          )
-        ) {
+        if (!window.confirm(t('deleteConfirm', { name: server.name }))) {
           return
         }
         await remove(client, server.id)

--- a/frontend/packages/web/app/admin/mcp/new/page.tsx
+++ b/frontend/packages/web/app/admin/mcp/new/page.tsx
@@ -4,35 +4,38 @@ import { useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { createApiClient, useMcpStore } from '@cubebox/core'
 import type { MCPServerCreateAdminBody } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { MCPServerForm, type MCPServerFormValues } from '@/components/mcp/MCPServerForm'
 
-function toAdminBody(values: MCPServerFormValues): MCPServerCreateAdminBody {
-  if (
-    values.credential_scope !== 'org' &&
-    values.credential_scope !== 'user' &&
-    values.credential_scope !== 'none'
-  ) {
-    throw new Error('Admin connectors only support organization, per-user, or passthrough scope.')
-  }
-
-  return {
-    name: values.name,
-    server_url: values.server_url,
-    transport: values.transport,
-    auth_method: values.auth_method,
-    credential_scope: values.credential_scope,
-    credential_plaintext: values.credential_plaintext || undefined,
-    credential_name: values.credential_name || undefined,
-    headers: values.headers,
-    timeout: values.timeout,
-    sse_read_timeout: values.sse_read_timeout,
-  }
-}
-
 export default function NewAdminMcpPage() {
+  const t = useTranslations('mcp.adminPage')
   const router = useRouter()
   const client = useMemo(() => createApiClient(''), [])
   const { create, testConnection } = useMcpStore()
+
+  function toAdminBody(values: MCPServerFormValues): MCPServerCreateAdminBody {
+    if (
+      values.credential_scope !== 'org' &&
+      values.credential_scope !== 'user' &&
+      values.credential_scope !== 'none'
+    ) {
+      throw new Error(t('scopeError'))
+    }
+
+    return {
+      name: values.name,
+      server_url: values.server_url,
+      transport: values.transport,
+      auth_method: values.auth_method,
+      credential_scope: values.credential_scope,
+      credential_plaintext: values.credential_plaintext || undefined,
+      credential_name: values.credential_name || undefined,
+      headers: values.headers,
+      timeout: values.timeout,
+      sse_read_timeout: values.sse_read_timeout,
+    }
+  }
 
   async function handleSubmit(values: MCPServerFormValues): Promise<void> {
     const created = await create(client, toAdminBody(values))
@@ -42,10 +45,8 @@ export default function NewAdminMcpPage() {
   return (
     <div className="flex max-w-3xl flex-col gap-6">
       <div className="flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold">Add MCP server</h1>
-        <p className="text-sm text-muted-foreground">
-          Configure an organization connector and discover its MCP tools.
-        </p>
+        <h1 className="text-2xl font-semibold">{t('addTitle')}</h1>
+        <p className="text-sm text-muted-foreground">{t('addSubtitle')}</p>
       </div>
       <MCPServerForm
         mode="admin"

--- a/frontend/packages/web/app/admin/mcp/page.tsx
+++ b/frontend/packages/web/app/admin/mcp/page.tsx
@@ -3,10 +3,13 @@
 import { useEffect, useMemo } from 'react'
 import Link from 'next/link'
 import { createApiClient, useMcpStore } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { buttonVariants } from '@/components/ui/button'
 import { MCPServerList } from '@/components/mcp/MCPServerList'
 
 export default function AdminMcpPage() {
+  const t = useTranslations('mcp.adminPage')
   const client = useMemo(() => createApiClient(''), [])
   const { servers, loading, error, fetchAll } = useMcpStore()
 
@@ -18,13 +21,11 @@ export default function AdminMcpPage() {
     <div className="flex flex-col gap-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex flex-col gap-1">
-          <h1 className="text-2xl font-semibold">MCP connectors</h1>
-          <p className="text-sm text-muted-foreground">
-            Manage organization-level MCP servers and credential scopes.
-          </p>
+          <h1 className="text-2xl font-semibold">{t('title')}</h1>
+          <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
         </div>
         <Link href="/admin/mcp/new" className={buttonVariants({ variant: 'default' })}>
-          Add server
+          {t('addServer')}
         </Link>
       </div>
 
@@ -33,8 +34,8 @@ export default function AdminMcpPage() {
         servers={servers}
         loading={loading}
         detailHrefBase="/admin/mcp"
-        emptyTitle="No MCP connectors yet"
-        emptyDescription="Add a server to expose external MCP tools to Cubebox agents."
+        emptyTitle={t('emptyTitle')}
+        emptyDescription={t('emptyDesc')}
       />
     </div>
   )

--- a/frontend/packages/web/app/admin/sandbox/page.tsx
+++ b/frontend/packages/web/app/admin/sandbox/page.tsx
@@ -1,10 +1,15 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+
 import { ComingSoonCard } from '@/components/admin/ComingSoonCard'
 
 export default function SandboxPage() {
+  const t = useTranslations('adminSandbox')
   return (
     <ComingSoonCard
-      title="沙盒"
-      description="指定默认镜像与资源上限。"
+      title={t('title')}
+      description={t('subtitle')}
       backlogRef="M2 完整版（v1 后续 spec）"
     />
   )

--- a/frontend/packages/web/app/admin/web-tools/page.tsx
+++ b/frontend/packages/web/app/admin/web-tools/page.tsx
@@ -1,10 +1,15 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+
 import { ComingSoonCard } from '@/components/admin/ComingSoonCard'
 
 export default function WebToolsPage() {
+  const t = useTranslations('adminWebTools')
   return (
     <ComingSoonCard
-      title="Web 工具"
-      description="搜索服务提供商配置（除默认外至少支持 1-2 个可切换）。"
+      title={t('title')}
+      description={t('subtitle')}
       backlogRef="M2 完整版（v1 后续 spec）"
     />
   )

--- a/frontend/packages/web/components/admin/AdminAvatarMenu.tsx
+++ b/frontend/packages/web/components/admin/AdminAvatarMenu.tsx
@@ -8,6 +8,7 @@ import { LogOut } from 'lucide-react'
 
 export function AdminAvatarMenu() {
   const t = useTranslations('adminSkills')
+  const tLayout = useTranslations('adminLayout')
   const router = useRouter()
   const user = useAuthStore((s) => s.user)
   const initials = user?.email ? user.email[0]?.toUpperCase() : '?'
@@ -26,7 +27,7 @@ export function AdminAvatarMenu() {
   return (
     <Popover>
       <PopoverTrigger
-        aria-label="Admin account menu"
+        aria-label={tLayout('avatarMenuAria')}
         className="size-8 rounded-full bg-gradient-to-br from-primary to-primary/70 text-primary-foreground flex items-center justify-center text-xs font-semibold ring-1 ring-primary/20 shadow-sm hover:shadow-md transition-shadow"
       >
         {initials}

--- a/frontend/packages/web/components/admin/AdminSubNav.tsx
+++ b/frontend/packages/web/components/admin/AdminSubNav.tsx
@@ -39,6 +39,7 @@ function NavItem({ href, label, icon: Icon, active }: NavDef & { active: boolean
 
 export function AdminSubNav() {
   const t = useTranslations('adminNav')
+  const tLayout = useTranslations('adminLayout')
   const pathname = usePathname() ?? ''
   const { extensions } = useAdminExtensions()
 
@@ -62,7 +63,7 @@ export function AdminSubNav() {
 
   return (
     <nav
-      aria-label="Admin sub-nav"
+      aria-label={tLayout('subNavAria')}
       className="w-56 border-r border-border/70 bg-card/40 flex flex-col p-2 overflow-y-auto"
     >
       <ul className="space-y-0.5">

--- a/frontend/packages/web/components/admin/ComingSoonCard.tsx
+++ b/frontend/packages/web/components/admin/ComingSoonCard.tsx
@@ -1,4 +1,7 @@
+'use client'
+
 import { Clock3 } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 
 interface ComingSoonCardProps {
   title: string
@@ -7,6 +10,7 @@ interface ComingSoonCardProps {
 }
 
 export function ComingSoonCard({ title, description, backlogRef }: ComingSoonCardProps) {
+  const t = useTranslations('adminLayout')
   return (
     <div className="max-w-2xl mx-auto mt-16 px-6">
       <h2 className="text-2xl font-semibold tracking-tight mb-2">{title}</h2>
@@ -15,8 +19,10 @@ export function ComingSoonCard({ title, description, backlogRef }: ComingSoonCar
         <div className="mx-auto mb-3 flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
           <Clock3 className="size-4" />
         </div>
-        <p className="text-sm font-medium mb-1">本版本不可用</p>
-        <p className="text-xs text-muted-foreground">实现归属：{backlogRef}</p>
+        <p className="text-sm font-medium mb-1">{t('comingSoon')}</p>
+        <p className="text-xs text-muted-foreground">
+          {t('backlogRefPrefix', { ref: backlogRef })}
+        </p>
       </div>
     </div>
   )

--- a/frontend/packages/web/components/admin/models/ModelRow.tsx
+++ b/frontend/packages/web/components/admin/models/ModelRow.tsx
@@ -23,6 +23,7 @@ function formatCost(cost: number): string {
 }
 
 export function ModelRow({ model, client, onEdit, onDelete, onTest }: ModelRowProps) {
+  const tExtra = useTranslations('adminModelsExtra')
   const t = useTranslations('adminModels')
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [testing, setTesting] = useState(false)
@@ -155,7 +156,7 @@ export function ModelRow({ model, client, onEdit, onDelete, onTest }: ModelRowPr
                 setConfirmOpen(false)
                 onDelete(model)
               }}
-              aria-label="confirm delete"
+              aria-label={tExtra('deleteModelConfirm')}
               data-testid={`model-row-${model.model_id}-confirm-delete`}
             >
               <Check className="size-3" />
@@ -164,7 +165,7 @@ export function ModelRow({ model, client, onEdit, onDelete, onTest }: ModelRowPr
               type="button"
               className="rounded p-0.5 text-muted-foreground hover:bg-muted"
               onClick={() => setConfirmOpen(false)}
-              aria-label="cancel delete"
+              aria-label={tExtra('deleteModelCancel')}
             >
               <X className="size-3" />
             </button>

--- a/frontend/packages/web/components/admin/models/ProviderDetail.tsx
+++ b/frontend/packages/web/components/admin/models/ProviderDetail.tsx
@@ -75,6 +75,7 @@ export function ProviderDetail({
   onTestModel,
 }: ProviderDetailProps) {
   const t = useTranslations('adminModels')
+  const tExtra = useTranslations('adminModelsExtra')
   const [editOpen, setEditOpen] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [deleting, setDeleting] = useState(false)
@@ -203,7 +204,7 @@ export function ProviderDetail({
                 className="rounded p-0.5 text-destructive hover:bg-destructive/20"
                 disabled={deleting}
                 onClick={() => void handleDelete()}
-                aria-label="confirm delete provider"
+                aria-label={tExtra('deleteProviderConfirm')}
                 data-testid="provider-delete-confirm"
               >
                 <Check className="size-3.5" />
@@ -212,7 +213,7 @@ export function ProviderDetail({
                 type="button"
                 className="rounded p-0.5 text-muted-foreground hover:bg-muted"
                 onClick={() => setConfirmDelete(false)}
-                aria-label="cancel delete provider"
+                aria-label={tExtra('deleteProviderCancel')}
               >
                 <X className="size-3.5" />
               </button>

--- a/frontend/packages/web/components/admin/skills/SkillDetailPanel.tsx
+++ b/frontend/packages/web/components/admin/skills/SkillDetailPanel.tsx
@@ -417,6 +417,7 @@ function CompareTab({ skillId, versions }: { skillId: string; versions: SkillVer
 
 export function SkillDetailPanel({ skillId, onActionDone }: SkillDetailPanelProps) {
   const t = useTranslations('adminSkills')
+  const tExtra = useTranslations('adminSkillsExtra')
   const { skill, loading, error, refresh } = useAdminSkill(skillId)
 
   const contentKey =
@@ -512,7 +513,7 @@ export function SkillDetailPanel({ skillId, onActionDone }: SkillDetailPanelProp
           </TabsTrigger>
           <TabsTrigger value="workspaces">
             <Network className="size-3.5" />
-            Workspace
+            {tExtra('workspace')}
           </TabsTrigger>
           <TabsTrigger value="versions">
             <History className="size-3.5" />

--- a/frontend/packages/web/components/admin/skills/WorkspaceBindingsTable.tsx
+++ b/frontend/packages/web/components/admin/skills/WorkspaceBindingsTable.tsx
@@ -39,6 +39,7 @@ export function WorkspaceBindingsTable({
   autoBind,
 }: WorkspaceBindingsTableProps) {
   const t = useTranslations('adminSkills')
+  const tExtra = useTranslations('adminSkillsExtra')
   const {
     data: workspaces,
     isLoading: wsLoading,
@@ -175,7 +176,7 @@ export function WorkspaceBindingsTable({
                     type="button"
                     className="cursor-pointer rounded p-0.5 text-destructive hover:bg-destructive/10"
                     onClick={() => void disableWs(ws.id)}
-                    aria-label="confirm disable"
+                    aria-label={tExtra('confirmDisable')}
                   >
                     <Check className="size-3.5" />
                   </button>

--- a/frontend/packages/web/components/chat/ArtifactCard.tsx
+++ b/frontend/packages/web/components/chat/ArtifactCard.tsx
@@ -4,6 +4,8 @@ import { memo, useCallback } from 'react'
 import { Download, Package, Eye } from 'lucide-react'
 import type { Artifact } from '@cubebox/core'
 import { usePanelStore } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { getArtifactIcon, getArtifactLabel } from '@/components/panel/artifact/artifactIcons'
 import { buildDownloadUrl } from '@/components/panel/artifact/previewUtils'
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
@@ -13,6 +15,7 @@ interface ArtifactCardProps {
 }
 
 export const ArtifactCard = memo(function ArtifactCard({ artifact }: ArtifactCardProps) {
+  const t = useTranslations('chatExtras')
   const Icon = getArtifactIcon(artifact)
   const label = getArtifactLabel(artifact)
   const openPreview = usePanelStore((s) => s.openArtifact)
@@ -65,7 +68,7 @@ export const ArtifactCard = memo(function ArtifactCard({ artifact }: ArtifactCar
             }}
             className="flex size-8 items-center justify-center rounded-md
               text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            title="Preview"
+            title={t('preview')}
           >
             <Eye className="size-4" />
           </button>
@@ -74,7 +77,7 @@ export const ArtifactCard = memo(function ArtifactCard({ artifact }: ArtifactCar
             onClick={(e) => e.stopPropagation()}
             className="flex size-8 items-center justify-center rounded-md
               text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            title="Download"
+            title={t('download')}
           >
             <Download className="size-4" />
           </a>

--- a/frontend/packages/web/components/chat/ArtifactGallery.tsx
+++ b/frontend/packages/web/components/chat/ArtifactGallery.tsx
@@ -77,6 +77,7 @@ function ArtifactGalleryItem({
   artifact: Artifact
   onPreview: () => void
 }) {
+  const tExtras = useTranslations('chatExtras')
   const Icon = getArtifactIcon(artifact)
   const { workspaceId } = useWorkspaceContext()
   const downloadUrl = workspaceId ? buildDownloadUrl(artifact, workspaceId) : '#'
@@ -100,7 +101,7 @@ function ArtifactGalleryItem({
             onPreview()
           }}
           className="p-1 rounded hover:bg-muted transition-colors"
-          title="Preview"
+          title={tExtras('preview')}
         >
           <Eye className="size-3 text-muted-foreground" />
         </button>
@@ -108,7 +109,7 @@ function ArtifactGalleryItem({
           href={downloadUrl}
           onClick={(e) => e.stopPropagation()}
           className="p-1 rounded hover:bg-muted transition-colors"
-          title="Download"
+          title={tExtras('download')}
         >
           <Download className="size-3 text-muted-foreground" />
         </a>

--- a/frontend/packages/web/components/chat/CitationMarker.tsx
+++ b/frontend/packages/web/components/chat/CitationMarker.tsx
@@ -4,6 +4,8 @@ import { useState, useCallback, useRef, useEffect } from 'react'
 import { Globe, Calendar } from 'lucide-react'
 import { useCitationStore, usePanelStore, useMessageStore } from '@cubebox/core'
 import type { CitationData } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { getFileVisual } from '@/lib/fileIcons'
 
@@ -173,6 +175,7 @@ function FileSourceHoverContent({
   chunkIndex: number
   onOpenPanel: () => void
 }) {
+  const t = useTranslations('chatExtras')
   const { metadata, chunks } = citation
   const sortedChunks = [...chunks].sort((a, b) => a.chunk_index - b.chunk_index)
   const visual = getFileVisual({ filename: basename(metadata.path), mime_type: metadata.mime })
@@ -213,7 +216,7 @@ function FileSourceHoverContent({
         {range && <span className="rounded bg-muted px-1.5 py-0.5 font-medium">{range}</span>}
         {metadata.truncated && (
           <span className="rounded bg-amber-500/10 px-1.5 py-0.5 font-medium text-amber-700 dark:text-amber-400">
-            Truncated
+            {t('citationTruncated')}
           </span>
         )}
         <span className="ml-auto rounded bg-muted px-1.5 py-0.5 font-medium">file</span>

--- a/frontend/packages/web/components/chat/ImageLightbox.tsx
+++ b/frontend/packages/web/components/chat/ImageLightbox.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import { X } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 
 interface Props {
   src: string
@@ -10,6 +11,7 @@ interface Props {
 }
 
 export function ImageLightbox({ src, alt, onClose }: Props) {
+  const t = useTranslations('chatExtras')
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
@@ -22,7 +24,7 @@ export function ImageLightbox({ src, alt, onClose }: Props) {
     <div className="fixed inset-0 z-50 grid place-items-center bg-black/80 p-6" onClick={onClose}>
       <button
         type="button"
-        aria-label="Close"
+        aria-label={t('imageClose')}
         className="absolute top-4 right-4 grid size-9 place-items-center rounded-full bg-background/30 text-white hover:bg-background/50"
         onClick={onClose}
       >

--- a/frontend/packages/web/components/chat/UploadDropzone.tsx
+++ b/frontend/packages/web/components/chat/UploadDropzone.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState, useCallback } from 'react'
 import { Upload } from 'lucide-react'
 import { useAttachmentStore, createApiClient } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
 
 interface Props {
@@ -10,6 +12,7 @@ interface Props {
 }
 
 export function UploadDropzone({ conversationId }: Props) {
+  const t = useTranslations('chatExtras')
   const [active, setActive] = useState(false)
   const upload = useAttachmentStore((s) => s.upload)
   const { workspaceId } = useWorkspaceContext()
@@ -61,10 +64,8 @@ export function UploadDropzone({ conversationId }: Props) {
     <div className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-background/60 backdrop-blur-sm">
       <div className="rounded-2xl border-2 border-dashed border-primary/60 bg-card px-12 py-10 text-center shadow-lg">
         <Upload className="mx-auto mb-3 size-10 text-primary" />
-        <p className="text-base font-medium">Drop to upload</p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Supports PNG/JPG/PDF/CSV/DOCX/XLSX/Markdown
-        </p>
+        <p className="text-base font-medium">{t('uploadDropzone')}</p>
+        <p className="mt-1 text-xs text-muted-foreground">{t('uploadFormats')}</p>
       </div>
     </div>
   )

--- a/frontend/packages/web/components/layout/InputBar.tsx
+++ b/frontend/packages/web/components/layout/InputBar.tsx
@@ -27,6 +27,7 @@ export function InputBar({
   isLoading = false,
 }: InputBarProps): React.ReactElement {
   const t = useTranslations('input')
+  const tShell = useTranslations('shellLayout')
   const [content, setContent] = useState('')
   const [pendingFiles, setPendingFiles] = useState<File[]>([])
   const [isHandlingSubmit, setIsHandlingSubmit] = useState(false)
@@ -203,7 +204,7 @@ export function InputBar({
       >
         <button
           type="button"
-          aria-label="Attach files"
+          aria-label={tShell('inputBarAttach')}
           onClick={() => fileInputRef.current?.click()}
           disabled={!canAttach}
           className="grid size-7 shrink-0 cursor-pointer place-items-center rounded-lg text-muted-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-30"

--- a/frontend/packages/web/components/layout/Sidebar.tsx
+++ b/frontend/packages/web/components/layout/Sidebar.tsx
@@ -32,6 +32,7 @@ function formatRelativeTime(
 export function Sidebar() {
   const tSidebar = useTranslations('sidebar')
   const tTime = useTranslations('time')
+  const tShell = useTranslations('shellLayout')
   const { conversations, activeId, remove, setActive } = useConversationStore()
   const pathname = usePathname()
 
@@ -56,7 +57,7 @@ export function Sidebar() {
 
   return (
     <aside
-      aria-label="Sidebar"
+      aria-label={tShell('sidebar')}
       className="w-56 bg-card border-r border-border flex flex-col h-screen shrink-0"
     >
       {/* Brand + new chat */}
@@ -113,7 +114,7 @@ export function Sidebar() {
                   <button
                     onClick={(e) => handleDeleteClick(e, convo.id)}
                     className="opacity-0 group-hover:opacity-40 hover:!opacity-80 transition-opacity shrink-0 p-0.5"
-                    aria-label="Delete conversation"
+                    aria-label={tShell('deleteConversation')}
                   >
                     <Trash2 className="size-3" />
                   </button>
@@ -144,7 +145,7 @@ export function Sidebar() {
                 ? 'text-primary bg-primary/10'
                 : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'
             }`}
-            aria-label="Workspace settings"
+            aria-label={tShell('workspaceSettings')}
           >
             <Settings className="size-4" />
           </Link>

--- a/frontend/packages/web/components/mcp/MCPBindingGrid.tsx
+++ b/frontend/packages/web/components/mcp/MCPBindingGrid.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react'
 import type { ApiClient, WorkspaceBinding } from '@cubebox/core'
 import { adminGetBindings, adminPutBindings } from '@cubebox/core'
 import { Loader2 } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import {
@@ -40,6 +42,7 @@ function bindingsToMap(bindings: WorkspaceBinding[]): Record<string, boolean> {
 }
 
 export function MCPBindingGrid({ client, serverId, workspaces }: MCPBindingGridProps) {
+  const t = useTranslations('mcp.bindings')
   const [bindings, setBindings] = useState<Record<string, boolean>>({})
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
@@ -105,22 +108,20 @@ export function MCPBindingGrid({ client, serverId, workspaces }: MCPBindingGridP
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Workspace bindings</CardTitle>
-        <CardDescription>
-          Enable this organization MCP server for specific workspaces.
-        </CardDescription>
+        <CardTitle>{t('title')}</CardTitle>
+        <CardDescription>{t('description')}</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {error && (
           <Alert variant="destructive">
-            <AlertTitle>Binding update failed</AlertTitle>
+            <AlertTitle>{t('updateFailed')}</AlertTitle>
             <AlertDescription>{error}</AlertDescription>
           </Alert>
         )}
 
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-sm text-muted-foreground">
-            {enabledCount} of {workspaces.length} workspaces enabled
+            {t('summary', { enabled: enabledCount, total: workspaces.length })}
           </p>
           <div className="flex items-center gap-2">
             <Button
@@ -130,7 +131,7 @@ export function MCPBindingGrid({ client, serverId, workspaces }: MCPBindingGridP
               disabled={loading || saving || workspaces.length === 0}
               onClick={() => setAll(true)}
             >
-              Enable all
+              {t('enableAll')}
             </Button>
             <Button
               type="button"
@@ -139,7 +140,7 @@ export function MCPBindingGrid({ client, serverId, workspaces }: MCPBindingGridP
               disabled={loading || saving || workspaces.length === 0}
               onClick={() => setAll(false)}
             >
-              Disable all
+              {t('disableAll')}
             </Button>
           </div>
         </div>
@@ -148,15 +149,15 @@ export function MCPBindingGrid({ client, serverId, workspaces }: MCPBindingGridP
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Workspace</TableHead>
-                <TableHead className="w-[120px] text-right">Enabled</TableHead>
+                <TableHead>{t('workspace')}</TableHead>
+                <TableHead className="w-[120px] text-right">{t('enabled')}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {workspaces.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={2} className="text-muted-foreground">
-                    No workspaces available.
+                    {t('noWorkspaces')}
                   </TableCell>
                 </TableRow>
               ) : (
@@ -170,7 +171,7 @@ export function MCPBindingGrid({ client, serverId, workspaces }: MCPBindingGridP
                     </TableCell>
                     <TableCell className="text-right">
                       <Switch
-                        aria-label={`Toggle ${workspace.name}`}
+                        aria-label={t('toggleAria', { name: workspace.name })}
                         checked={bindings[workspace.id] ?? false}
                         disabled={loading || saving}
                         onCheckedChange={(checked) => toggleWorkspace(workspace.id, checked)}
@@ -190,7 +191,7 @@ export function MCPBindingGrid({ client, serverId, workspaces }: MCPBindingGridP
           onClick={() => void saveBindings()}
         >
           {saving && <Loader2 data-icon="inline-start" className="animate-spin" />}
-          Save bindings
+          {t('save')}
         </Button>
       </CardFooter>
     </Card>

--- a/frontend/packages/web/components/mcp/MCPCredentialPanel.tsx
+++ b/frontend/packages/web/components/mcp/MCPCredentialPanel.tsx
@@ -10,6 +10,7 @@ import {
   wsPutMyCredential,
   wsPutWorkspaceCredential,
 } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
 
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -31,6 +32,8 @@ export function MCPCredentialPanel({
   scopeContext,
   onChange,
 }: MCPCredentialPanelProps) {
+  const t = useTranslations('mcp.credential')
+  const tSecret = useTranslations('mcp.secret')
   const [hasValue, setHasValue] = useState(false)
   const [draftPlain, setDraftPlain] = useState('')
   const [loading, setLoading] = useState(false)
@@ -70,12 +73,10 @@ export function MCPCredentialPanel({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Credential</CardTitle>
+          <CardTitle>{t('managedTitle')}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground">
-            This credential is managed by organization administrators.
-          </p>
+          <p className="text-sm text-muted-foreground">{t('managedBody')}</p>
         </CardContent>
       </Card>
     )
@@ -85,23 +86,21 @@ export function MCPCredentialPanel({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Authentication</CardTitle>
+          <CardTitle>{t('authTitle')}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground">
-            This connector uses Cubebox identity passthrough and does not store an API key.
-          </p>
+          <p className="text-sm text-muted-foreground">{t('passthroughBody')}</p>
         </CardContent>
       </Card>
     )
   }
 
-  const title = isUserScope ? 'My credential' : 'Workspace credential'
+  const title = isUserScope ? t('myCredential') : t('workspaceCredential')
   const missingCopy = isUserScope
-    ? 'Until you add a credential, this connector will not appear in your chat tools.'
+    ? t('missingUser')
     : scopeContext === 'via-binding'
-      ? 'This workspace needs its own credential before members can use this shared connector.'
-      : 'Until a workspace credential is added, this connector will not appear for workspace members.'
+      ? t('missingViaBinding')
+      : t('missingWorkspace')
 
   async function save(): Promise<void> {
     setError(null)
@@ -133,23 +132,21 @@ export function MCPCredentialPanel({
         <CardTitle>{title}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
-        {loading ? (
-          <p className="text-sm text-muted-foreground">Loading credential status...</p>
-        ) : null}
+        {loading ? <p className="text-sm text-muted-foreground">{t('loadingStatus')}</p> : null}
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
         <MCPSecretInput
-          label="API key / token"
+          label={tSecret('apiKeyPlaceholder')}
           hasValue={hasValue}
           required={!hasValue}
           onChange={setDraftPlain}
         />
         <div className="flex gap-2">
           <Button type="button" onClick={save} disabled={!draftPlain}>
-            Save
+            {t('save')}
           </Button>
           {hasValue ? (
             <Button type="button" variant="outline" onClick={clear}>
-              Clear
+              {t('clear')}
             </Button>
           ) : null}
         </div>

--- a/frontend/packages/web/components/mcp/MCPPromoteDialog.tsx
+++ b/frontend/packages/web/components/mcp/MCPPromoteDialog.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog'
 import type { MCPServer } from '@cubebox/core'
 import { Loader2, X } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
@@ -17,6 +19,7 @@ export interface MCPPromoteDialogProps {
 }
 
 export function MCPPromoteDialog({ server, open, onOpenChange, onConfirm }: MCPPromoteDialogProps) {
+  const t = useTranslations('mcp.promote')
   const canShareCredential = server.credential_scope === 'workspace'
   const [shareCredential, setShareCredential] = useState(canShareCredential)
   const [submitting, setSubmitting] = useState(false)
@@ -58,17 +61,17 @@ export function MCPPromoteDialog({ server, open, onOpenChange, onConfirm }: MCPP
           <div className="flex items-start justify-between gap-3">
             <div className="flex flex-col gap-1">
               <DialogPrimitive.Title className="text-base font-semibold">
-                Promote MCP server
+                {t('title')}
               </DialogPrimitive.Title>
               <DialogPrimitive.Description className="text-sm text-muted-foreground">
-                Move {server.name} to organization scope so admins can bind it to workspaces.
+                {t('description', { name: server.name })}
               </DialogPrimitive.Description>
             </div>
             <DialogPrimitive.Close
               render={
                 <button
                   type="button"
-                  aria-label="Close promote dialog"
+                  aria-label={t('close')}
                   className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
                   disabled={submitting}
                 >
@@ -81,7 +84,7 @@ export function MCPPromoteDialog({ server, open, onOpenChange, onConfirm }: MCPP
           <div className="mt-4 flex flex-col gap-4">
             {error && (
               <Alert variant="destructive">
-                <AlertTitle>Promotion failed</AlertTitle>
+                <AlertTitle>{t('failed')}</AlertTitle>
                 <AlertDescription>{error}</AlertDescription>
               </Alert>
             )}
@@ -94,28 +97,21 @@ export function MCPPromoteDialog({ server, open, onOpenChange, onConfirm }: MCPP
                 <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-border p-3">
                   <RadioGroupItem value="share" disabled={submitting} />
                   <span className="flex flex-col gap-1">
-                    <span className="text-sm font-medium">Share credential with organization</span>
-                    <span className="text-sm text-muted-foreground">
-                      Convert the workspace credential into an organization credential and attach it
-                      to the promoted server.
-                    </span>
+                    <span className="text-sm font-medium">{t('share')}</span>
+                    <span className="text-sm text-muted-foreground">{t('shareHelp')}</span>
                   </span>
                 </label>
                 <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-border p-3">
                   <RadioGroupItem value="keep-workspace" disabled={submitting} />
                   <span className="flex flex-col gap-1">
-                    <span className="text-sm font-medium">Promote without credential</span>
-                    <span className="text-sm text-muted-foreground">
-                      Keep credentials workspace-local. Admins can add an organization credential
-                      later.
-                    </span>
+                    <span className="text-sm font-medium">{t('without')}</span>
+                    <span className="text-sm text-muted-foreground">{t('withoutHelp')}</span>
                   </span>
                 </label>
               </RadioGroup>
             ) : (
               <p className="rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
-                This server has no workspace credential to share. It will be promoted without an
-                organization credential.
+                {t('noCredential')}
               </p>
             )}
 
@@ -123,13 +119,13 @@ export function MCPPromoteDialog({ server, open, onOpenChange, onConfirm }: MCPP
               <DialogPrimitive.Close
                 render={
                   <Button type="button" variant="ghost" disabled={submitting}>
-                    Cancel
+                    {t('cancel')}
                   </Button>
                 }
               />
               <Button type="button" disabled={submitting} onClick={() => void handleConfirm()}>
                 {submitting && <Loader2 data-icon="inline-start" className="animate-spin" />}
-                Promote server
+                {t('confirm')}
               </Button>
             </div>
           </div>

--- a/frontend/packages/web/components/mcp/MCPScopeBadge.tsx
+++ b/frontend/packages/web/components/mcp/MCPScopeBadge.tsx
@@ -1,5 +1,8 @@
+'use client'
+
 import type { MCPCredentialScope } from '@cubebox/core'
 import type { ComponentProps } from 'react'
+import { useTranslations } from 'next-intl'
 
 import { Badge } from '@/components/ui/badge'
 
@@ -10,13 +13,7 @@ const variants: Record<MCPCredentialScope, ComponentProps<typeof Badge>['variant
   none: 'ghost',
 }
 
-const labels: Record<MCPCredentialScope, string> = {
-  org: 'Org shared',
-  workspace: 'Workspace shared',
-  user: 'Per user',
-  none: 'Identity passthrough',
-}
-
 export function MCPScopeBadge({ scope }: { scope: MCPCredentialScope }) {
-  return <Badge variant={variants[scope]}>{labels[scope]}</Badge>
+  const t = useTranslations('mcp.scopeBadge')
+  return <Badge variant={variants[scope]}>{t(scope)}</Badge>
 }

--- a/frontend/packages/web/components/mcp/MCPSecretInput.tsx
+++ b/frontend/packages/web/components/mcp/MCPSecretInput.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useId, useState } from 'react'
+import { useTranslations } from 'next-intl'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -18,6 +19,7 @@ export function MCPSecretInput({
   onChange,
   required = false,
 }: MCPSecretInputProps) {
+  const t = useTranslations('mcp.secret')
   const inputId = useId()
   const [editing, setEditing] = useState(!hasValue)
   const [value, setValue] = useState('')
@@ -26,9 +28,9 @@ export function MCPSecretInput({
     return (
       <div className="flex items-center gap-3">
         <span className="text-sm font-medium">{label}</span>
-        <span className="font-mono text-sm text-muted-foreground">**** (set)</span>
+        <span className="font-mono text-sm text-muted-foreground">{t('set')}</span>
         <Button type="button" variant="outline" size="sm" onClick={() => setEditing(true)}>
-          Replace
+          {t('replace')}
         </Button>
       </div>
     )
@@ -50,7 +52,7 @@ export function MCPSecretInput({
             setValue(event.target.value)
             onChange(event.target.value)
           }}
-          placeholder="API key / token"
+          placeholder={t('apiKeyPlaceholder')}
           required={required && !hasValue}
         />
         {hasValue ? (
@@ -64,11 +66,11 @@ export function MCPSecretInput({
               setEditing(false)
             }}
           >
-            Cancel
+            {t('cancel')}
           </Button>
         ) : null}
       </div>
-      <p className="text-xs text-muted-foreground">The secret is write-only after saving.</p>
+      <p className="text-xs text-muted-foreground">{t('writeOnly')}</p>
     </div>
   )
 }

--- a/frontend/packages/web/components/mcp/MCPServerDetail.tsx
+++ b/frontend/packages/web/components/mcp/MCPServerDetail.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import type { ApiClient, MCPServer } from '@cubebox/core'
 import { CircleDot, Loader2, RefreshCw, Trash2 } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -25,11 +27,6 @@ export interface MCPServerDetailProps {
   onPromote?: (shareCredential: boolean) => Promise<void>
 }
 
-function formatDate(value: string | null): string {
-  if (!value) return 'not discovered yet'
-  return new Date(value).toLocaleString()
-}
-
 function InfoRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-1 rounded-lg bg-muted/30 p-3 sm:flex-row sm:items-center sm:justify-between">
@@ -49,12 +46,17 @@ export function MCPServerDetail({
   onDelete,
   onPromote,
 }: MCPServerDetailProps) {
+  const t = useTranslations('mcp.detail')
   const [refreshing, setRefreshing] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [promoteOpen, setPromoteOpen] = useState(false)
   const showBindingsTab = mode === 'admin' && server.owner_workspace_id === null
   const showCredentialPanel = (mode === 'ws-owned' || mode === 'ws-readonly') && wsId
   const canRefreshTools = mode !== 'ws-readonly'
+
+  const formattedTime = server.last_discovered_at
+    ? new Date(server.last_discovered_at).toLocaleString()
+    : t('notDiscoveredYet')
 
   async function handleRefresh(): Promise<void> {
     setRefreshing(true)
@@ -88,7 +90,7 @@ export function MCPServerDetail({
             <MCPScopeBadge scope={server.credential_scope} />
           </div>
           <p className="text-sm text-muted-foreground">
-            {server.transport} · last discovered {formatDate(server.last_discovered_at)}
+            {t('lastDiscoveredLine', { transport: server.transport, time: formattedTime })}
           </p>
           {server.last_error ? (
             <p className="max-w-3xl text-sm text-destructive">{server.last_error}</p>
@@ -109,7 +111,7 @@ export function MCPServerDetail({
               ) : (
                 <RefreshCw data-icon="inline-start" />
               )}
-              Refresh tools
+              {t('refreshTools')}
             </Button>
           ) : null}
           {mode === 'ws-owned' && onPromote ? (
@@ -120,7 +122,7 @@ export function MCPServerDetail({
               disabled={refreshing || deleting}
               onClick={() => setPromoteOpen(true)}
             >
-              Share to org
+              {t('shareToOrg')}
             </Button>
           ) : null}
           {onDelete ? (
@@ -136,7 +138,7 @@ export function MCPServerDetail({
               ) : (
                 <Trash2 data-icon="inline-start" />
               )}
-              Delete
+              {t('delete')}
             </Button>
           ) : null}
         </div>
@@ -144,23 +146,28 @@ export function MCPServerDetail({
 
       <Tabs defaultValue="overview">
         <TabsList variant="line" className="w-full justify-start border-b border-border/60 pb-0">
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="tools">Tools ({server.tools_cache?.length ?? 0})</TabsTrigger>
-          {showBindingsTab ? <TabsTrigger value="bindings">Workspaces</TabsTrigger> : null}
+          <TabsTrigger value="overview">{t('overview')}</TabsTrigger>
+          <TabsTrigger value="tools">
+            {t('toolsTab', { count: server.tools_cache?.length ?? 0 })}
+          </TabsTrigger>
+          {showBindingsTab ? <TabsTrigger value="bindings">{t('workspaces')}</TabsTrigger> : null}
         </TabsList>
 
         <TabsContent value="overview" className="mt-4 flex flex-col gap-4">
           <Card>
             <CardHeader>
-              <CardTitle>Server details</CardTitle>
+              <CardTitle>{t('serverDetails')}</CardTitle>
             </CardHeader>
             <CardContent className="flex flex-col gap-2 text-sm">
-              <InfoRow label="URL">{server.server_url}</InfoRow>
-              <InfoRow label="Transport">{server.transport}</InfoRow>
-              <InfoRow label="Auth method">{server.auth_method}</InfoRow>
-              <InfoRow label="Credential scope">{server.credential_scope}</InfoRow>
-              <InfoRow label="Timeout">
-                {server.timeout}s / SSE {server.sse_read_timeout}s
+              <InfoRow label={t('url')}>{server.server_url}</InfoRow>
+              <InfoRow label={t('transport')}>{server.transport}</InfoRow>
+              <InfoRow label={t('authMethod')}>{server.auth_method}</InfoRow>
+              <InfoRow label={t('credentialScope')}>{server.credential_scope}</InfoRow>
+              <InfoRow label={t('timeout')}>
+                {t('timeoutValue', {
+                  timeout: server.timeout,
+                  sseTimeout: server.sse_read_timeout,
+                })}
               </InfoRow>
             </CardContent>
           </Card>

--- a/frontend/packages/web/components/mcp/MCPServerForm.tsx
+++ b/frontend/packages/web/components/mcp/MCPServerForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import type { FormEvent } from 'react'
 import { Loader2 } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 import type {
   MCPAuthMethod,
   MCPCredentialScope,
@@ -62,27 +63,15 @@ const DEFAULT_VALUES: MCPServerFormValues = {
   sse_read_timeout: 300,
 }
 
-const scopeCopy: Record<MCPCredentialScope, { title: string; help: string }> = {
-  org: {
-    title: 'Organization shared',
-    help: 'One credential is shared by every enabled workspace in the organization.',
-  },
-  workspace: {
-    title: 'Workspace shared',
-    help: 'One credential is shared by all members of this workspace.',
-  },
-  user: {
-    title: 'Per user',
-    help: 'Each user provides their own credential before using this connector.',
-  },
-  none: {
-    title: 'Cubebox identity passthrough',
-    help: 'No API key is stored. The MCP server receives a short-lived Cubebox identity token.',
-  },
-}
-
 const adminScopes: MCPCredentialScope[] = ['org', 'user', 'none']
 const workspaceScopes: MCPCredentialScope[] = ['workspace', 'user', 'none']
+
+const scopeKey = {
+  org: { title: 'orgTitle', help: 'orgHelp' },
+  workspace: { title: 'workspaceTitle', help: 'workspaceHelp' },
+  user: { title: 'userTitle', help: 'userHelp' },
+  none: { title: 'noneTitle', help: 'noneHelp' },
+} as const satisfies Record<MCPCredentialScope, { title: string; help: string }>
 
 export function MCPServerForm({
   mode,
@@ -91,6 +80,8 @@ export function MCPServerForm({
   onTestConnection,
   onCancel,
 }: MCPServerFormProps) {
+  const t = useTranslations('mcp.form')
+  const tScope = useTranslations('mcp.scopeForm')
   const [values, setValues] = useState<MCPServerFormValues>({
     ...DEFAULT_VALUES,
     credential_scope: mode === 'admin' ? 'org' : 'workspace',
@@ -142,12 +133,12 @@ export function MCPServerForm({
     <form className="flex flex-col gap-6" onSubmit={handleSubmit}>
       <Card>
         <CardHeader>
-          <CardTitle>Basic information</CardTitle>
+          <CardTitle>{t('basicInfo')}</CardTitle>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
           <div className="flex flex-col gap-1.5">
             <label htmlFor="mcp-name" className="text-sm font-medium">
-              Name *
+              {t('nameLabel')}
             </label>
             <Input
               id="mcp-name"
@@ -159,19 +150,19 @@ export function MCPServerForm({
 
           <div className="flex flex-col gap-1.5">
             <label htmlFor="mcp-url" className="text-sm font-medium">
-              Server URL *
+              {t('serverUrlLabel')}
             </label>
             <Input
               id="mcp-url"
               required
               value={values.server_url}
-              placeholder="https://example.com/mcp or stdio command"
+              placeholder={t('serverUrlPlaceholder')}
               onChange={(event) => set('server_url', event.target.value)}
             />
           </div>
 
           <div className="flex flex-col gap-1.5">
-            <span className="text-sm font-medium">Transport</span>
+            <span className="text-sm font-medium">{t('transport')}</span>
             <Select
               value={values.transport}
               onValueChange={(value) => set('transport', value as MCPTransport)}
@@ -193,7 +184,7 @@ export function MCPServerForm({
 
       <Card>
         <CardHeader>
-          <CardTitle>Credential mode</CardTitle>
+          <CardTitle>{t('credentialMode')}</CardTitle>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
           <RadioGroup
@@ -209,20 +200,22 @@ export function MCPServerForm({
               >
                 <RadioGroupItem value={scope} id={`mcp-scope-${scope}`} />
                 <span className="flex flex-col gap-1">
-                  <span className="font-medium">{scopeCopy[scope].title}</span>
-                  <span className="text-sm text-muted-foreground">{scopeCopy[scope].help}</span>
+                  <span className="font-medium">{tScope(scopeKey[scope].title)}</span>
+                  <span className="text-sm text-muted-foreground">
+                    {tScope(scopeKey[scope].help)}
+                  </span>
                 </span>
               </label>
             ))}
             <label
               htmlFor="mcp-scope-oauth"
               className="flex cursor-not-allowed items-start gap-3 rounded-lg border p-4 opacity-60"
-              title="Coming soon"
+              title={t('comingSoonTooltip')}
             >
               <RadioGroupItem value="oauth-disabled" disabled id="mcp-scope-oauth" />
               <span className="flex flex-col gap-1">
-                <span className="font-medium">OAuth</span>
-                <span className="text-sm text-muted-foreground">Coming soon.</span>
+                <span className="font-medium">{t('oauth')}</span>
+                <span className="text-sm text-muted-foreground">{t('oauthComingSoon')}</span>
               </span>
             </label>
           </RadioGroup>
@@ -230,14 +223,14 @@ export function MCPServerForm({
           {requiresStoredSecret ? (
             <div className="flex flex-col gap-3">
               <MCPSecretInput
-                label="API key / token"
+                label={t('apiKeyLabel')}
                 hasValue={false}
                 required
                 onChange={(token) => set('credential_plaintext', token)}
               />
               <div className="flex flex-col gap-1.5">
                 <label htmlFor="mcp-credential-name" className="text-sm font-medium">
-                  Credential display name
+                  {t('credentialDisplayName')}
                 </label>
                 <Input
                   id="mcp-credential-name"
@@ -254,14 +247,15 @@ export function MCPServerForm({
       {testResult ? (
         <Alert variant={testResult.success ? 'default' : 'destructive'}>
           <AlertTitle>
-            {testResult.success ? 'Connection succeeded' : 'Connection failed'}
+            {testResult.success ? t('connectionSucceeded') : t('connectionFailed')}
           </AlertTitle>
           <AlertDescription>
             {testResult.success
-              ? `Discovered ${testResult.tools?.length ?? 0} tool(s): ${
-                  testResult.tools?.map((tool) => tool.name).join(', ') || 'none'
-                }`
-              : testResult.error || 'Unknown error'}
+              ? t('discovered', {
+                  count: testResult.tools?.length ?? 0,
+                  names: testResult.tools?.map((tool) => tool.name).join(', ') || t('noToolsName'),
+                })
+              : testResult.error || t('unknownError')}
           </AlertDescription>
         </Alert>
       ) : null}
@@ -274,15 +268,15 @@ export function MCPServerForm({
           onClick={handleTestConnection}
         >
           {testing ? <Loader2 data-icon="inline-start" className="animate-spin" /> : null}
-          Test connection
+          {t('testConnection')}
         </Button>
         <div className="flex items-center gap-2">
           <Button type="button" variant="ghost" onClick={onCancel}>
-            Cancel
+            {t('cancel')}
           </Button>
           <Button type="submit" disabled={submitting}>
             {submitting ? <Loader2 data-icon="inline-start" className="animate-spin" /> : null}
-            Save
+            {t('save')}
           </Button>
         </div>
       </div>

--- a/frontend/packages/web/components/mcp/MCPServerList.tsx
+++ b/frontend/packages/web/components/mcp/MCPServerList.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { CircleDot, Plug } from 'lucide-react'
 import type { MCPServer } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
 
 import { buttonVariants } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -33,12 +34,11 @@ export function MCPServerList({
   emptyTitle,
   emptyDescription,
 }: MCPServerListProps) {
+  const t = useTranslations('mcp.list')
   if (loading) {
     return (
       <Card>
-        <CardContent className="p-6 text-sm text-muted-foreground">
-          Loading connectors...
-        </CardContent>
+        <CardContent className="p-6 text-sm text-muted-foreground">{t('loading')}</CardContent>
       </Card>
     )
   }
@@ -60,12 +60,12 @@ export function MCPServerList({
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Scope</TableHead>
-            <TableHead>Transport</TableHead>
-            <TableHead>Tools</TableHead>
+            <TableHead>{t('name')}</TableHead>
+            <TableHead>{t('scope')}</TableHead>
+            <TableHead>{t('transport')}</TableHead>
+            <TableHead>{t('tools')}</TableHead>
             <TableHead>
-              <span className="sr-only">Actions</span>
+              <span className="sr-only">{t('actions')}</span>
             </TableHead>
           </TableRow>
         </TableHeader>
@@ -76,7 +76,7 @@ export function MCPServerList({
                 <span className="flex items-center gap-2">
                   <CircleDot
                     className={cn('size-3', server.authed ? 'text-primary' : 'text-destructive')}
-                    aria-label={server.authed ? 'authenticated' : 'connection error'}
+                    aria-label={server.authed ? t('authenticated') : t('connectionError')}
                   />
                   <span className="truncate">{server.name}</span>
                 </span>
@@ -98,7 +98,7 @@ export function MCPServerList({
                   href={`${detailHrefBase}/${server.id}`}
                   className={buttonVariants({ variant: 'ghost', size: 'sm' })}
                 >
-                  Details
+                  {t('details')}
                 </Link>
               </TableCell>
             </TableRow>

--- a/frontend/packages/web/components/mcp/MCPToolsTable.tsx
+++ b/frontend/packages/web/components/mcp/MCPToolsTable.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type { MCPToolEntry } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
 
 import {
   Accordion,
@@ -10,12 +11,9 @@ import {
 } from '@/components/ui/accordion'
 
 export function MCPToolsTable({ tools }: { tools: MCPToolEntry[] }) {
+  const t = useTranslations('mcp.tools')
   if (tools.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        No tools discovered yet. Refresh tools after the MCP server is reachable.
-      </p>
-    )
+    return <p className="text-sm text-muted-foreground">{t('empty')}</p>
   }
 
   return (

--- a/frontend/packages/web/components/panel/AttachmentPreviewView.tsx
+++ b/frontend/packages/web/components/panel/AttachmentPreviewView.tsx
@@ -5,6 +5,8 @@ import dynamic from 'next/dynamic'
 import { Download, X } from 'lucide-react'
 import type { AttachmentPanelInfo } from '@cubebox/core'
 import { usePanelStore } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { MarkdownWithCitations } from '@/components/shared/MarkdownWithCitations'
 import { PreviewLoading } from '@/components/panel/artifact/PreviewLoading'
@@ -32,6 +34,7 @@ function humanSize(n: number): string {
 }
 
 export function AttachmentPreviewView({ info }: Props): React.ReactElement {
+  const t = useTranslations('panel.attachment')
   const close = usePanelStore((s) => s.close)
   const visual = getFileVisual({ filename: info.filename, mime_type: info.mimeType })
 
@@ -53,7 +56,7 @@ export function AttachmentPreviewView({ info }: Props): React.ReactElement {
           href={info.downloadUrl}
           download
           className="ml-auto grid size-7 place-items-center rounded hover:bg-muted"
-          aria-label="Download"
+          aria-label={t('download')}
         >
           <Download className="size-3.5" />
         </a>
@@ -61,7 +64,7 @@ export function AttachmentPreviewView({ info }: Props): React.ReactElement {
           type="button"
           onClick={close}
           className="grid size-7 place-items-center rounded hover:bg-muted"
-          aria-label="Close"
+          aria-label={t('close')}
         >
           <X className="size-3.5" />
         </button>
@@ -72,6 +75,7 @@ export function AttachmentPreviewView({ info }: Props): React.ReactElement {
 }
 
 function Body({ info, family }: { info: AttachmentPanelInfo; family: string }): React.ReactElement {
+  const t = useTranslations('panel.attachment')
   if (family === 'pdf') {
     return (
       <div className="flex-1 min-h-0">
@@ -96,8 +100,7 @@ function Body({ info, family }: { info: AttachmentPanelInfo; family: string }): 
   if (info.sizeBytes > TEXT_MAX_BYTES) {
     return (
       <div className="flex-1 grid place-items-center p-8 text-center text-sm text-muted-foreground">
-        File is too large for inline preview ({(info.sizeBytes / 1024 / 1024).toFixed(1)} MB).
-        Please download to view.
+        {t('tooLarge', { size: (info.sizeBytes / 1024 / 1024).toFixed(1) })}
       </div>
     )
   }
@@ -111,6 +114,7 @@ function TextBody({
   info: AttachmentPanelInfo
   family: string
 }): React.ReactElement {
+  const t = useTranslations('panel.attachment')
   const [state, setState] = useState<
     { kind: 'loading' } | { kind: 'error'; message: string } | { kind: 'ready'; text: string }
   >({ kind: 'loading' })
@@ -143,14 +147,14 @@ function TextBody({
   if (state.kind === 'loading') {
     return (
       <div className="flex-1 grid place-items-center p-8 text-sm text-muted-foreground">
-        Loading…
+        {t('loading')}
       </div>
     )
   }
   if (state.kind === 'error') {
     return (
       <div className="flex-1 grid place-items-center p-8 text-sm text-destructive">
-        Failed to load: {state.message}
+        {t('loadFailed', { message: state.message })}
       </div>
     )
   }
@@ -182,8 +186,10 @@ function prettyJson(raw: string): string {
 }
 
 function CsvTable({ text }: { text: string }): React.ReactElement {
+  const t = useTranslations('panel.attachment')
   const lines = text.split(/\r?\n/).filter(Boolean).slice(0, 1000)
-  if (lines.length === 0) return <div className="p-4 text-sm text-muted-foreground">Empty</div>
+  if (lines.length === 0)
+    return <div className="p-4 text-sm text-muted-foreground">{t('empty')}</div>
   const rows = lines.map((line) => line.split(','))
   return (
     <div className="overflow-x-auto">

--- a/frontend/packages/web/components/panel/FileReadView.tsx
+++ b/frontend/packages/web/components/panel/FileReadView.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useRef } from 'react'
 import { AlertTriangle, FileQuestion, Info } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
 import { MarkdownWithCitations } from '@/components/shared/MarkdownWithCitations'
 import { getFileVisual } from '@/lib/fileIcons'
 import { cn } from '@/lib/utils'
@@ -84,6 +86,7 @@ export function FileReadView({
   highlightText,
   highlightKey,
 }: Props): React.ReactElement {
+  const t = useTranslations('panel.fileRead')
   const parsed = useMemo(() => parseResult(result), [result])
   const path = parsed?.path ?? String(args.path ?? '')
   const visual = getFileVisual({ filename: basename(path) })
@@ -96,7 +99,7 @@ export function FileReadView({
         </div>
         <div className="flex flex-col leading-tight min-w-0">
           <span className="truncate text-sm font-medium" title={path}>
-            {basename(path) || '(untitled)'}
+            {basename(path) || t('untitled')}
           </span>
           <span className="text-[10px] text-muted-foreground truncate" title={path}>
             {path}
@@ -116,6 +119,7 @@ function MetaStrip({
   parsed: FileReadResult | null
   args: Record<string, unknown>
 }): React.ReactElement | null {
+  const tr = useTranslations('panel.fileRead')
   if (!parsed) return null
   const range = (args.page_range || args.line_range) as string | undefined
   const chips: React.ReactNode[] = []
@@ -123,11 +127,11 @@ function MetaStrip({
     const t = parsed as TextOutput
     chips.push(<Chip key="mime">{t.mime}</Chip>)
     chips.push(<Chip key="size">{humanSize(t.size_bytes)}</Chip>)
-    chips.push(<Chip key="chars">{t.content.length.toLocaleString()} chars</Chip>)
+    chips.push(<Chip key="chars">{tr('chars', { count: t.content.length.toLocaleString() })}</Chip>)
     if (t.truncated) {
       chips.push(
         <Chip key="trunc" tone="warn">
-          <AlertTriangle className="size-3" /> Truncated
+          <AlertTriangle className="size-3" /> {tr('truncated')}
         </Chip>,
       )
     }
@@ -135,15 +139,15 @@ function MetaStrip({
     const nb = parsed as NotebookOutput
     const code = nb.cells.filter((c) => c.cell_type === 'code').length
     const md = nb.cells.filter((c) => c.cell_type === 'markdown').length
-    chips.push(<Chip key="cells">{nb.cells.length} cells</Chip>)
-    chips.push(<Chip key="code">{code} code</Chip>)
-    chips.push(<Chip key="md">{md} md</Chip>)
+    chips.push(<Chip key="cells">{tr('cells', { count: nb.cells.length })}</Chip>)
+    chips.push(<Chip key="code">{tr('code', { count: code })}</Chip>)
+    chips.push(<Chip key="md">{tr('md', { count: md })}</Chip>)
   } else if (parsed.kind === 'unsupported') {
     const u = parsed as UnsupportedOutput
     chips.push(<Chip key="mime">{u.mime}</Chip>)
     chips.push(<Chip key="size">{humanSize(u.size_bytes)}</Chip>)
   }
-  if (range) chips.push(<Chip key="range">Range: {range}</Chip>)
+  if (range) chips.push(<Chip key="range">{tr('rangePrefix', { range })}</Chip>)
   if (!chips.length) return null
   return <div className="flex flex-wrap gap-1.5 border-b border-border px-4 py-2">{chips}</div>
 }
@@ -178,6 +182,7 @@ function Body({
   highlightText?: string | null
   highlightKey?: number
 }): React.ReactElement {
+  const t = useTranslations('panel.fileRead')
   const bodyRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!highlightText || !bodyRef.current) return
@@ -194,7 +199,7 @@ function Body({
   }, [highlightText, highlightKey])
 
   if (!parsed) {
-    return <div className="flex-1 p-4 text-sm text-muted-foreground">No result.</div>
+    return <div className="flex-1 p-4 text-sm text-muted-foreground">{t('noResult')}</div>
   }
 
   if (parsed.kind === 'text') {
@@ -240,7 +245,7 @@ function Body({
       <div className="flex-1 grid place-items-center p-8 text-center">
         <div className="space-y-3 max-w-sm">
           <FileQuestion className="mx-auto size-10 text-muted-foreground" />
-          <h3 className="text-base font-medium">Unsupported format</h3>
+          <h3 className="text-base font-medium">{t('unsupported')}</h3>
           <p className="text-sm text-muted-foreground">{u.reason}</p>
           {u.hint && (
             <div className="flex items-start gap-2 rounded-md border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-left text-xs text-blue-700 dark:text-blue-400">
@@ -255,7 +260,7 @@ function Body({
   if (parsed.kind === 'unchanged') {
     return (
       <div className="flex-1 grid place-items-center p-8 text-sm text-muted-foreground">
-        File unchanged since the previous read.
+        {t('unchanged')}
       </div>
     )
   }
@@ -265,12 +270,12 @@ function Body({
       <div className="flex-1 p-4">
         <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
           {e.error}
-          {e.retryable ? ' (retryable)' : ''}
+          {e.retryable ? ` ${t('retryable')}` : ''}
         </div>
       </div>
     )
   }
-  return <div className="flex-1 p-4 text-sm text-muted-foreground">Unknown result kind.</div>
+  return <div className="flex-1 p-4 text-sm text-muted-foreground">{t('unknown')}</div>
 }
 
 function NotebookOutputBlock({ out }: { out: Record<string, unknown> }): React.ReactElement {

--- a/frontend/packages/web/components/panel/GenericToolView.tsx
+++ b/frontend/packages/web/components/panel/GenericToolView.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { Copy, Check } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 
 interface GenericToolViewProps {
   args: Record<string, unknown>
@@ -11,6 +12,7 @@ interface GenericToolViewProps {
 }
 
 function CopyButton({ text }: { text: string }) {
+  const t = useTranslations('panel.generic')
   const [copied, setCopied] = useState(false)
 
   const handleCopy = async () => {
@@ -24,7 +26,7 @@ function CopyButton({ text }: { text: string }) {
       onClick={handleCopy}
       className="p-1 rounded hover:bg-muted/50
         transition-colors"
-      title="Copy"
+      title={t('copy')}
     >
       {copied ? (
         <Check className="size-3 text-emerald-500" />
@@ -49,6 +51,7 @@ export function GenericToolView({
   highlightText,
   highlightKey,
 }: GenericToolViewProps) {
+  const t = useTranslations('panel.generic')
   const responseRef = useRef<HTMLPreElement>(null)
 
   useEffect(() => {
@@ -80,7 +83,7 @@ export function GenericToolView({
               text-muted-foreground uppercase
               tracking-wider"
           >
-            Request
+            {t('request')}
           </span>
           <CopyButton text={requestText} />
         </div>
@@ -104,7 +107,7 @@ export function GenericToolView({
                 text-muted-foreground uppercase
                 tracking-wider"
             >
-              Response
+              {t('response')}
             </span>
             <CopyButton text={responseText} />
           </div>

--- a/frontend/packages/web/components/panel/PanelHeader.tsx
+++ b/frontend/packages/web/components/panel/PanelHeader.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react'
 import { X, Copy, Check } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
 import { getToolIcon, getParamSummary } from '@/lib/toolIcons'
 
 interface PanelHeaderProps {
@@ -12,6 +14,7 @@ interface PanelHeaderProps {
 }
 
 export function PanelHeader({ toolName, toolArgs, toolResult, onClose }: PanelHeaderProps) {
+  const t = useTranslations('panel.header')
   const [copied, setCopied] = useState(false)
   const Icon = getToolIcon(toolName)
   const summary = getParamSummary(toolName, toolArgs, 40)
@@ -52,7 +55,7 @@ export function PanelHeader({ toolName, toolArgs, toolResult, onClose }: PanelHe
           onClick={handleCopy}
           className="p-1 rounded hover:bg-muted/50
             transition-colors"
-          title="Copy"
+          title={t('copy')}
         >
           {copied ? (
             <Check className="size-3.5 text-emerald-500" />
@@ -67,7 +70,7 @@ export function PanelHeader({ toolName, toolArgs, toolResult, onClose }: PanelHe
           onClick={onClose}
           className="p-1 rounded hover:bg-muted/50
             transition-colors"
-          title="Close"
+          title={t('close')}
         >
           <X className="size-3.5 text-muted-foreground" />
         </button>

--- a/frontend/packages/web/components/panel/SearchResultView.tsx
+++ b/frontend/packages/web/components/panel/SearchResultView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { Globe, ExternalLink, Search } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 
 interface SearchResult {
   title: string
@@ -21,7 +22,11 @@ interface SearchResultViewProps {
   highlightKey?: number
 }
 
-function parseSearchData(raw: string, args?: Record<string, unknown>): SearchData | null {
+function parseSearchData(
+  raw: string,
+  args: Record<string, unknown> | undefined,
+  fallbackQuery: string,
+): SearchData | null {
   try {
     const parsed = JSON.parse(raw)
     // Direct format: { query, results: [...] }
@@ -31,7 +36,7 @@ function parseSearchData(raw: string, args?: Record<string, unknown>): SearchDat
     // Array of results
     if (Array.isArray(parsed)) {
       return {
-        query: String(args?.query ?? '') || 'Search',
+        query: String(args?.query ?? '') || fallbackQuery,
         results: parsed,
       }
     }
@@ -64,6 +69,7 @@ export function SearchResultView({
   highlightText,
   highlightKey,
 }: SearchResultViewProps) {
+  const t = useTranslations('panel.search')
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -84,10 +90,10 @@ export function SearchResultView({
   }, [highlightText, highlightKey])
 
   if (!result) {
-    return <div className="p-6 text-sm text-muted-foreground">No results</div>
+    return <div className="p-6 text-sm text-muted-foreground">{t('noResults')}</div>
   }
 
-  const data = parseSearchData(result, args)
+  const data = parseSearchData(result, args, t('fallbackQuery'))
 
   if (!data) {
     return (
@@ -113,7 +119,7 @@ export function SearchResultView({
           <Search className="size-3.5 text-muted-foreground shrink-0" />
           <span className="font-medium text-foreground">{data.query}</span>
           <span className="text-muted-foreground ml-auto shrink-0">
-            {data.results.length} results
+            {t('resultsCount', { count: data.results.length })}
           </span>
         </div>
       </div>

--- a/frontend/packages/web/components/panel/SkillView.tsx
+++ b/frontend/packages/web/components/panel/SkillView.tsx
@@ -40,6 +40,7 @@ const contentFetcher = async (url: string): Promise<SkillContent> => {
 
 export function SkillView({ args, result, skillId }: SkillViewProps) {
   const t = useTranslations('adminSkills')
+  const tPanel = useTranslations('panel.skillView')
   const { workspaceId } = useWorkspaceContext()
   const skillNameFromArgs = String(args.skill_name ?? '')
   const parsed = parseResult(result)
@@ -70,7 +71,7 @@ export function SkillView({ args, result, skillId }: SkillViewProps) {
   return (
     <div className="space-y-3 p-4">
       <div className="flex items-center gap-2">
-        <span className="text-xs font-medium text-muted-foreground">Skill:</span>
+        <span className="text-xs font-medium text-muted-foreground">{tPanel('labelPrefix')}</span>
         <span className="font-mono text-sm font-semibold">{displayName}</span>
         {displayVersion && (
           <span className="font-mono text-[11px] text-muted-foreground/80">v{displayVersion}</span>
@@ -83,7 +84,7 @@ export function SkillView({ args, result, skillId }: SkillViewProps) {
                 : 'bg-red-500/10 text-red-600 dark:text-red-400'
             }`}
           >
-            {loaded ? 'loaded' : 'failed'}
+            {loaded ? tPanel('loaded') : tPanel('failed')}
           </span>
         )}
       </div>

--- a/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
+++ b/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
@@ -5,6 +5,8 @@ import dynamic from 'next/dynamic'
 import { useArtifactStore, usePanelStore, createApiClient } from '@cubebox/core'
 import type { Artifact, ArtifactVersion } from '@cubebox/core'
 import { X, Download, ChevronDown } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
 import { getArtifactIcon } from './artifactIcons'
@@ -29,17 +31,20 @@ function isPdf(artifact: Artifact): boolean {
   return /\.pdf$/i.test(filename)
 }
 
-function formatRelativeTime(dateStr: string): string {
-  const date = new Date(dateStr)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffMin = Math.floor(diffMs / 60000)
-  if (diffMin < 1) return 'just now'
-  if (diffMin < 60) return `${diffMin}m ago`
-  const diffHr = Math.floor(diffMin / 60)
-  if (diffHr < 24) return `${diffHr}h ago`
-  const diffDay = Math.floor(diffHr / 24)
-  return `${diffDay}d ago`
+function useFormatRelativeTime(): (dateStr: string) => string {
+  const t = useTranslations('panel.artifactPanel')
+  return (dateStr: string): string => {
+    const date = new Date(dateStr)
+    const now = new Date()
+    const diffMs = now.getTime() - date.getTime()
+    const diffMin = Math.floor(diffMs / 60000)
+    if (diffMin < 1) return t('justNow')
+    if (diffMin < 60) return t('minutesAgo', { n: diffMin })
+    const diffHr = Math.floor(diffMin / 60)
+    if (diffHr < 24) return t('hoursAgo', { n: diffHr })
+    const diffDay = Math.floor(diffHr / 24)
+    return t('daysAgo', { n: diffDay })
+  }
 }
 
 function VersionPopover({
@@ -53,6 +58,7 @@ function VersionPopover({
   selectedVersion: number | null
   onSelectVersion: (version: number | null) => void
 }) {
+  const formatRelativeTime = useFormatRelativeTime()
   const [open, setOpen] = useState(false)
   const currentVersion = selectedVersion ?? artifact.version
 
@@ -114,6 +120,7 @@ function ArtifactPanelHeader({
   onClose: () => void
   workspaceId: string
 }) {
+  const t = useTranslations('panel.artifactPanel')
   const Icon = getArtifactIcon(artifact)
   const downloadUrl = buildDownloadUrl(artifact, workspaceId, selectedVersion)
 
@@ -132,14 +139,14 @@ function ArtifactPanelHeader({
         <a
           href={downloadUrl}
           className="p-1 rounded hover:bg-muted/50 transition-colors"
-          title="Download"
+          title={t('download')}
         >
           <Download className="size-3.5 text-muted-foreground" />
         </a>
         <button
           onClick={onClose}
           className="p-1 rounded hover:bg-muted/50 transition-colors"
-          title="Close"
+          title={t('close')}
         >
           <X className="size-3.5 text-muted-foreground" />
         </button>

--- a/frontend/packages/web/components/panel/artifact/FallbackPreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/FallbackPreview.tsx
@@ -2,6 +2,8 @@
 
 import { File, Download } from 'lucide-react'
 import type { Artifact } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { buildDownloadUrl } from './previewUtils'
 
 interface FallbackPreviewProps {
@@ -11,6 +13,8 @@ interface FallbackPreviewProps {
 }
 
 export function FallbackPreview({ artifact, version, workspaceId }: FallbackPreviewProps) {
+  const t = useTranslations('panel.fallback')
+  const tArtifact = useTranslations('panel.artifactPanel')
   const downloadUrl = buildDownloadUrl(artifact, workspaceId, version)
 
   return (
@@ -24,11 +28,9 @@ export function FallbackPreview({ artifact, version, workspaceId }: FallbackPrev
           <p className="mt-1 text-xs text-muted-foreground">{artifact.description}</p>
         )}
         <p className="mt-1 text-xs text-muted-foreground/60">
-          {artifact.mime_type || 'Unknown type'} &middot; v{version ?? artifact.version}
+          {artifact.mime_type || tArtifact('unknownType')} &middot; v{version ?? artifact.version}
         </p>
-        <p className="mt-2 text-xs text-muted-foreground">
-          This file type does not support preview. Please download to view.
-        </p>
+        <p className="mt-2 text-xs text-muted-foreground">{t('unsupported')}</p>
       </div>
       <a
         href={downloadUrl}
@@ -36,7 +38,7 @@ export function FallbackPreview({ artifact, version, workspaceId }: FallbackPrev
           text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
       >
         <Download className="size-4" />
-        Download
+        {t('download')}
       </a>
     </div>
   )

--- a/frontend/packages/web/components/panel/artifact/PdfPreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/PdfPreview.tsx
@@ -10,6 +10,8 @@ import {
   List,
   ChevronRight as Chevron,
 } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
 import { PreviewLoading } from './PreviewLoading'
 
 import 'react-pdf/dist/Page/AnnotationLayer.css'
@@ -158,6 +160,7 @@ interface PdfPreviewProps {
 }
 
 export function PdfPreview({ fileUrl }: PdfPreviewProps) {
+  const t = useTranslations('panel.pdf')
   const [loading, setLoading] = useState(true)
   const [numPages, setNumPages] = useState(0)
   const [currentPage, setCurrentPage] = useState(1)
@@ -242,7 +245,7 @@ export function PdfPreview({ fileUrl }: PdfPreviewProps) {
               onClick={() => setTocOpen((v) => !v)}
               className={`p-1 rounded transition-colors
                 ${tocOpen ? 'bg-primary/10 text-primary' : 'hover:bg-muted text-foreground'}`}
-              title="Table of contents"
+              title={t('tableOfContents')}
             >
               <List className="size-4" />
             </button>
@@ -324,7 +327,7 @@ export function PdfPreview({ fileUrl }: PdfPreviewProps) {
             file={fileUrl}
             onLoadSuccess={onDocumentLoadSuccess}
             error={
-              <div className="p-4 text-sm text-destructive text-center">Failed to load PDF</div>
+              <div className="p-4 text-sm text-destructive text-center">{t('loadFailed')}</div>
             }
           >
             <div className="flex flex-col items-center py-4 gap-4">

--- a/frontend/packages/web/components/sidebar/AvatarPopover.tsx
+++ b/frontend/packages/web/components/sidebar/AvatarPopover.tsx
@@ -18,6 +18,7 @@ import { Languages, LogOut, Moon, Shield, Sun } from 'lucide-react'
 
 export function AvatarPopover() {
   const t = useTranslations('avatar')
+  const tShell = useTranslations('shellLayout')
   const router = useRouter()
   const user = useAuthStore((s) => s.user)
   const { isAdmin } = useAdminAccess()
@@ -58,7 +59,7 @@ export function AvatarPopover() {
   return (
     <Popover>
       <PopoverTrigger
-        aria-label="Account menu"
+        aria-label={tShell('accountMenu')}
         className="w-full min-w-0 flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent/60 transition-colors group"
       >
         <div className="size-7 rounded-full bg-gradient-to-br from-primary to-primary/70 text-primary-foreground flex items-center justify-center text-[11px] font-semibold shrink-0 ring-1 ring-primary/20 shadow-sm">
@@ -135,7 +136,7 @@ export function AvatarPopover() {
 
         <button
           type="button"
-          aria-label="Sign out"
+          aria-label={tShell('signOut')}
           onClick={onLogout}
           className="w-full flex items-center gap-2 px-2 py-1.5 rounded-sm text-[12.5px] hover:bg-destructive/10 text-destructive transition-colors"
         >

--- a/frontend/packages/web/components/workspace-settings/McpPanel.tsx
+++ b/frontend/packages/web/components/workspace-settings/McpPanel.tsx
@@ -5,6 +5,8 @@ import { useCallback, useEffect, useState } from 'react'
 import { CheckCircle2, Globe, Plug, Plus } from 'lucide-react'
 import { createApiClient, useWorkspaceSettingsStore } from '@cubebox/core'
 import type { MCPServerItem } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
@@ -27,6 +29,7 @@ function McpItemCard({
   onClick: () => void
   onToggle: (enabled: boolean) => void
 }) {
+  const t = useTranslations('mcp.wsPanel')
   const SourceIcon = srv.scope === 'workspace' ? Plug : Globe
   return (
     <button
@@ -51,7 +54,7 @@ function McpItemCard({
         {srv.enabled && (
           <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
             <CheckCircle2 className="size-3" />
-            on
+            {t('onBadge')}
           </span>
         )}
         <Switch
@@ -68,7 +71,7 @@ function McpItemCard({
           {srv.transport}
         </Badge>
         <Badge variant="outline" className="px-1.5 text-[10px]">
-          {srv.scope === 'workspace' ? 'workspace' : 'org'}
+          {srv.scope === 'workspace' ? t('workspaceLabel') : t('orgLabel')}
         </Badge>
       </div>
     </button>
@@ -76,6 +79,7 @@ function McpItemCard({
 }
 
 export function McpPanel({ wsId }: McpPanelProps) {
+  const t = useTranslations('mcp.wsPanel')
   const { mcp, loading, loadAll, toggleMCP } = useWorkspaceSettingsStore()
   const [selected, setSelected] = useState<MCPServerItem | null>(null)
   const [toggling, setToggling] = useState<string | null>(null)
@@ -110,39 +114,37 @@ export function McpPanel({ wsId }: McpPanelProps) {
     <div className="flex h-full flex-1 flex-col overflow-hidden">
       <header className="flex items-center justify-between gap-2 border-b border-border/70 px-6 py-4">
         <div>
-          <h2 className="text-lg font-semibold tracking-tight">MCP Connectors</h2>
+          <h2 className="text-lg font-semibold tracking-tight">{t('title')}</h2>
           <p className="mt-0.5 text-xs text-muted-foreground">
-            {enabledCount} of {allServers.length} enabled in this workspace
+            {t('summary', { enabled: enabledCount, total: allServers.length })}
           </p>
         </div>
         <Link href={`/w/${wsId}/integrations/mcp/new`}>
           <Button size="sm">
             <Plus className="size-3.5" />
-            Add connector
+            {t('addConnector')}
           </Button>
         </Link>
       </header>
 
       <div className="flex flex-1 overflow-hidden">
         <aside
-          aria-label="mcp-list"
+          aria-label={t('listAria')}
           className="w-[320px] shrink-0 overflow-y-auto border-r border-border/70 bg-card/20"
         >
           {loading && !mcp ? (
-            <p className="px-4 py-6 text-center text-xs text-muted-foreground">Loading…</p>
+            <p className="px-4 py-6 text-center text-xs text-muted-foreground">{t('loading')}</p>
           ) : allServers.length === 0 ? (
             <div className="flex h-full flex-col items-center justify-center gap-1 px-6 text-center">
-              <p className="text-sm text-muted-foreground">No MCP connectors yet</p>
-              <p className="text-xs text-muted-foreground/70">
-                Click &ldquo;Add connector&rdquo; to register one.
-              </p>
+              <p className="text-sm text-muted-foreground">{t('empty')}</p>
+              <p className="text-xs text-muted-foreground/70">{t('emptyHint')}</p>
             </div>
           ) : (
             <div className="flex flex-col gap-3 p-3">
               {orgServers.length > 0 && (
                 <section className="flex flex-col gap-1.5">
                   <p className="px-1 text-[10px] font-medium uppercase tracking-widest text-muted-foreground/60">
-                    Org-wide
+                    {t('orgWide')}
                   </p>
                   <ul className="flex flex-col gap-1.5">
                     {orgServers.map((srv) => (
@@ -162,7 +164,7 @@ export function McpPanel({ wsId }: McpPanelProps) {
               {workspaceServers.length > 0 && (
                 <section className="flex flex-col gap-1.5">
                   <p className="px-1 text-[10px] font-medium uppercase tracking-widest text-muted-foreground/60">
-                    Workspace-private
+                    {t('workspacePrivate')}
                   </p>
                   <ul className="flex flex-col gap-1.5">
                     {workspaceServers.map((srv) => (
@@ -191,7 +193,7 @@ export function McpPanel({ wsId }: McpPanelProps) {
                   <h3 className="text-xl font-semibold tracking-tight">{selected.name}</h3>
                   <Badge variant="outline">{selected.transport}</Badge>
                   <Badge variant={selected.scope === 'workspace' ? 'secondary' : 'default'}>
-                    {selected.scope === 'workspace' ? 'workspace-private' : 'org-wide'}
+                    {selected.scope === 'workspace' ? t('workspaceLabel') : t('orgLabel')}
                   </Badge>
                   <Badge
                     variant="outline"
@@ -201,14 +203,14 @@ export function McpPanel({ wsId }: McpPanelProps) {
                         : 'text-muted-foreground',
                     )}
                   >
-                    {selected.enabled ? 'enabled' : 'disabled'}
+                    {selected.enabled ? t('enabledLabel') : t('disabledLabel')}
                   </Badge>
                   {selected.scope === 'workspace' && (
                     <Link
                       href={`/w/${wsId}/integrations/mcp/${selected.server_id}`}
                       className="ml-auto text-xs text-primary hover:underline"
                     >
-                      Manage →
+                      {t('manage')}
                     </Link>
                   )}
                 </div>
@@ -216,20 +218,20 @@ export function McpPanel({ wsId }: McpPanelProps) {
 
               <div className="rounded-lg border border-border/70 bg-card/40 p-4">
                 <dl className="grid grid-cols-[140px_1fr] gap-y-2 text-sm">
-                  <dt className="text-muted-foreground">Server URL</dt>
+                  <dt className="text-muted-foreground">{t('serverUrl')}</dt>
                   <dd className="break-all font-mono text-xs">{selected.server_url}</dd>
-                  <dt className="text-muted-foreground">Transport</dt>
+                  <dt className="text-muted-foreground">{t('transport')}</dt>
                   <dd>{selected.transport}</dd>
-                  <dt className="text-muted-foreground">Scope</dt>
+                  <dt className="text-muted-foreground">{t('scope')}</dt>
                   <dd>{selected.scope}</dd>
-                  <dt className="text-muted-foreground">Enabled</dt>
-                  <dd>{selected.enabled ? 'Yes' : 'No'}</dd>
+                  <dt className="text-muted-foreground">{t('enabled')}</dt>
+                  <dd>{selected.enabled ? t('yes') : t('no')}</dd>
                 </dl>
               </div>
             </div>
           ) : (
             <div className="flex flex-1 items-center justify-center p-8 text-sm text-muted-foreground">
-              Select a connector to view details
+              {t('selectConnector')}
             </div>
           )}
         </section>

--- a/frontend/packages/web/components/workspace-settings/PersonaEditor.tsx
+++ b/frontend/packages/web/components/workspace-settings/PersonaEditor.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { createApiClient, useWorkspaceSettingsStore } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 
@@ -10,6 +12,7 @@ interface PersonaEditorProps {
 }
 
 export function PersonaEditor({ wsId }: PersonaEditorProps) {
+  const t = useTranslations('wsSettings.persona')
   const { agentConfig, loading, loadAll, savePersona } = useWorkspaceSettingsStore()
   const [draft, setDraft] = useState('')
   const [saving, setSaving] = useState(false)
@@ -48,35 +51,32 @@ export function PersonaEditor({ wsId }: PersonaEditorProps) {
   return (
     <div className="flex h-full flex-1 flex-col overflow-hidden">
       <header className="border-b border-border/70 px-6 py-4">
-        <h2 className="text-lg font-semibold tracking-tight">Persona</h2>
-        <p className="mt-0.5 text-xs text-muted-foreground">
-          Defines the agent&apos;s persona for every conversation in this workspace. Appended after
-          the base system prompt.
-        </p>
+        <h2 className="text-lg font-semibold tracking-tight">{t('title')}</h2>
+        <p className="mt-0.5 text-xs text-muted-foreground">{t('description')}</p>
       </header>
 
       <div className="flex flex-1 overflow-y-auto">
         <div className="flex w-full max-w-3xl flex-col gap-4 p-6">
           {loading && !agentConfig ? (
-            <p className="text-sm text-muted-foreground">Loading…</p>
+            <p className="text-sm text-muted-foreground">{t('loading')}</p>
           ) : (
             <>
               <Textarea
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
-                placeholder="e.g. You are a Python data analysis expert. Always provide runnable code examples."
+                placeholder={t('placeholder')}
                 className="min-h-[260px] resize-y font-mono text-sm leading-relaxed"
               />
               <div className="flex items-center justify-between">
                 <span className="text-xs text-muted-foreground">
-                  {draft.length} / 8000 characters
+                  {t('charCount', { count: draft.length })}
                 </span>
                 <div className="flex gap-2">
                   <Button variant="outline" size="sm" onClick={handleReset} disabled={saving}>
-                    Reset
+                    {t('reset')}
                   </Button>
                   <Button size="sm" onClick={() => void handleSave()} disabled={saving}>
-                    {saving ? 'Saving…' : 'Save'}
+                    {saving ? t('saving') : t('save')}
                   </Button>
                 </div>
               </div>

--- a/frontend/packages/web/components/workspace-settings/SettingsNav.tsx
+++ b/frontend/packages/web/components/workspace-settings/SettingsNav.tsx
@@ -3,26 +3,43 @@
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { Bot, Plug, Sparkles } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 
 interface SettingsNavProps {
   wsId: string
 }
 
-const TOP_LEVEL = [
+type TopLabelKey = 'navWorkspace' | 'navPersona' | 'navModel' | 'navSkills' | 'navMcp'
+
+interface SubItem {
+  key: string
+  labelKey: TopLabelKey
+  disabled?: boolean
+}
+
+interface TopItem {
+  key: string
+  labelKey: TopLabelKey
+  icon: typeof Bot
+  sub?: SubItem[]
+}
+
+const TOP_LEVEL: TopItem[] = [
   {
     key: 'workspace',
-    label: 'Workspace Settings',
+    labelKey: 'navWorkspace',
     icon: Bot,
     sub: [
-      { key: 'persona', label: 'Persona' },
-      { key: 'model', label: 'Model', disabled: true },
+      { key: 'persona', labelKey: 'navPersona' },
+      { key: 'model', labelKey: 'navModel', disabled: true },
     ],
   },
-  { key: 'skills', label: 'Skills', icon: Sparkles },
-  { key: 'mcp', label: 'MCP Connectors', icon: Plug },
+  { key: 'skills', labelKey: 'navSkills', icon: Sparkles },
+  { key: 'mcp', labelKey: 'navMcp', icon: Plug },
 ]
 
 export function SettingsNav({ wsId }: SettingsNavProps): React.ReactElement {
+  const t = useTranslations('wsSettings')
   const searchParams = useSearchParams()
   const currentTab = searchParams.get('tab') ?? 'workspace'
   const currentSub = searchParams.get('sub') ?? 'persona'
@@ -30,7 +47,7 @@ export function SettingsNav({ wsId }: SettingsNavProps): React.ReactElement {
   return (
     <div className="px-2 pt-2 pb-2 border-t border-border/60 bg-muted/20">
       <p className="px-2 pt-1 pb-1.5 text-[10px] font-medium uppercase tracking-widest text-muted-foreground/60">
-        Settings
+        {t('settingsLabel')}
       </p>
       <nav className="space-y-0.5">
         {TOP_LEVEL.map((item) => {
@@ -47,12 +64,12 @@ export function SettingsNav({ wsId }: SettingsNavProps): React.ReactElement {
                 }`}
               >
                 <Icon className="size-3.5 shrink-0" />
-                {item.label}
+                {t(item.labelKey)}
               </Link>
               {isActive && item.sub && (
                 <div className="ml-6 mt-0.5 space-y-0.5">
                   {item.sub.map((s) => {
-                    const isDisabled = 'disabled' in s && s.disabled
+                    const isDisabled = s.disabled
                     const itemClass = `flex items-center justify-between px-2 py-1 rounded-md text-[11.5px] transition-colors ${
                       currentSub === s.key
                         ? 'text-primary font-medium'
@@ -63,9 +80,9 @@ export function SettingsNav({ wsId }: SettingsNavProps): React.ReactElement {
                     if (isDisabled) {
                       return (
                         <span key={s.key} className={itemClass} aria-disabled="true">
-                          {s.label}
+                          {t(s.labelKey)}
                           <span className="text-[9px] bg-muted text-muted-foreground/60 rounded px-1">
-                            soon
+                            {t('soonBadge')}
                           </span>
                         </span>
                       )
@@ -76,7 +93,7 @@ export function SettingsNav({ wsId }: SettingsNavProps): React.ReactElement {
                         href={`/w/${wsId}/settings?tab=${item.key}&sub=${s.key}`}
                         className={itemClass}
                       >
-                        {s.label}
+                        {t(s.labelKey)}
                       </Link>
                     )
                   })}

--- a/frontend/packages/web/components/workspace-settings/SkillsPanel.tsx
+++ b/frontend/packages/web/components/workspace-settings/SkillsPanel.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useState } from 'react'
+import { useTranslations } from 'next-intl'
+
 import {
   useWorkspaceSkillsCatalog,
   type WorkspaceSkillEntry,
@@ -16,6 +18,7 @@ interface SkillsPanelProps {
 }
 
 export function SkillsPanel({ wsId }: SkillsPanelProps) {
+  const t = useTranslations('wsSettings.skillsList')
   const [filters, setFilters] = useState<WorkspaceSkillFilters>({})
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [uploadOpen, setUploadOpen] = useState(false)
@@ -26,10 +29,8 @@ export function SkillsPanel({ wsId }: SkillsPanelProps) {
   return (
     <div className="flex h-full flex-1 flex-col overflow-hidden">
       <header className="border-b border-border/70 px-6 py-4">
-        <h2 className="text-lg font-semibold tracking-tight">Skills</h2>
-        <p className="mt-0.5 text-xs text-muted-foreground">
-          Browse, enable, and install skills available to this workspace.
-        </p>
+        <h2 className="text-lg font-semibold tracking-tight">{t('title')}</h2>
+        <p className="mt-0.5 text-xs text-muted-foreground">{t('subtitle')}</p>
       </header>
 
       <WorkspaceSkillsToolbar
@@ -40,22 +41,19 @@ export function SkillsPanel({ wsId }: SkillsPanelProps) {
 
       <div className="flex flex-1 overflow-hidden">
         <aside
-          aria-label="skills-list"
+          aria-label={t('listAria')}
           className="w-[360px] shrink-0 overflow-y-auto border-r border-border/70 bg-card/20"
         >
           {loading && skills.length === 0 ? (
-            <p className="px-4 py-6 text-center text-xs text-muted-foreground">Loading…</p>
+            <p className="px-4 py-6 text-center text-xs text-muted-foreground">{t('loading')}</p>
           ) : error ? (
             <div className="m-3 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
               {error.message}
             </div>
           ) : skills.length === 0 ? (
             <div className="flex h-full flex-col items-center justify-center gap-1 px-6 text-center">
-              <p className="text-sm text-muted-foreground">No skills match these filters</p>
-              <p className="text-xs text-muted-foreground/70">
-                Adjust the search or filter, or upload a workspace-private skill via &ldquo;Add
-                skill&rdquo;.
-              </p>
+              <p className="text-sm text-muted-foreground">{t('noMatch')}</p>
+              <p className="text-xs text-muted-foreground/70">{t('noMatchHint')}</p>
             </div>
           ) : (
             <ul className="flex flex-col gap-1.5 p-3">
@@ -81,7 +79,7 @@ export function SkillsPanel({ wsId }: SkillsPanelProps) {
             />
           ) : (
             <div className="flex flex-1 items-center justify-center p-8 text-sm text-muted-foreground">
-              Select a skill to view details
+              {t('selectSkill')}
             </div>
           )}
         </section>

--- a/frontend/packages/web/components/workspace-settings/skills/UploadWorkspaceSkillModal.tsx
+++ b/frontend/packages/web/components/workspace-settings/skills/UploadWorkspaceSkillModal.tsx
@@ -3,6 +3,8 @@
 import { useRef, useState } from 'react'
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog'
 import { Upload, X } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
 import { Button } from '@/components/ui/button'
 import { csrfHeaders, readApiError } from '@/lib/csrf'
 import { cn } from '@/lib/utils'
@@ -20,6 +22,7 @@ export function UploadWorkspaceSkillModal({
   onOpenChange,
   onUploaded,
 }: UploadWorkspaceSkillModalProps) {
+  const t = useTranslations('wsSettings.uploadModal')
   const inputRef = useRef<HTMLInputElement | null>(null)
   const [file, setFile] = useState<File | null>(null)
   const [busy, setBusy] = useState(false)
@@ -42,7 +45,7 @@ export function UploadWorkspaceSkillModal({
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault()
     if (!file) {
-      setError('Select a .zip file to upload.')
+      setError(t('selectError'))
       return
     }
     setBusy(true)
@@ -59,7 +62,7 @@ export function UploadWorkspaceSkillModal({
       })
       if (!res.ok) throw new Error(await readApiError(res))
       const data = (await res.json()) as { skill_id: string; version: string }
-      setSuccess(`Installed ${data.skill_id} v${data.version} as workspace-private.`)
+      setSuccess(t('successPattern', { skill: data.skill_id, version: data.version }))
       onUploaded()
       // Auto-close after a short pause so the toast is visible.
       setTimeout(() => {
@@ -86,17 +89,17 @@ export function UploadWorkspaceSkillModal({
           <div className="flex items-start justify-between gap-3">
             <div>
               <DialogPrimitive.Title className="text-base font-semibold">
-                Upload skill (workspace-private)
+                {t('title')}
               </DialogPrimitive.Title>
               <DialogPrimitive.Description className="mt-0.5 text-xs text-muted-foreground">
-                Zip a SKILL.md plus its assets. The skill becomes installed only in this workspace.
+                {t('description')}
               </DialogPrimitive.Description>
             </div>
             <DialogPrimitive.Close
               render={
                 <button
                   type="button"
-                  aria-label="close"
+                  aria-label={t('close')}
                   className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
                 >
                   <X className="size-4" />
@@ -114,9 +117,9 @@ export function UploadWorkspaceSkillModal({
               )}
             >
               <Upload className="size-5 text-muted-foreground" />
-              <span className="text-sm font-medium">{file ? file.name : 'Select a .zip file'}</span>
+              <span className="text-sm font-medium">{file ? file.name : t('selectFile')}</span>
               <span className="text-[11px] text-muted-foreground">
-                {file ? `${(file.size / 1024).toFixed(1)} KB` : 'Up to 50 MB total'}
+                {file ? `${(file.size / 1024).toFixed(1)} KB` : t('filesizeHint')}
               </span>
               <input
                 ref={inputRef}
@@ -152,10 +155,10 @@ export function UploadWorkspaceSkillModal({
                 onClick={() => handleOpenChange(false)}
                 disabled={busy}
               >
-                Cancel
+                {t('cancel')}
               </Button>
               <Button type="submit" size="sm" disabled={busy || !file}>
-                {busy ? 'Uploading…' : 'Upload'}
+                {busy ? t('uploading') : t('upload')}
               </Button>
             </div>
           </form>

--- a/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillCard.tsx
+++ b/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillCard.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { CheckCircle2, CircleSlash, Lock, Package, Plus, Sparkles } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 import type { WorkspaceSkillEntry, WorkspaceSkillState } from '@/hooks/useWorkspaceSkillsCatalog'
@@ -12,11 +14,12 @@ interface WorkspaceSkillCardProps {
 }
 
 function StateBadge({ state }: { state: WorkspaceSkillState }) {
+  const t = useTranslations('wsSettings.skillCard')
   if (state === 'org-enabled') {
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
         <CheckCircle2 className="size-3" />
-        Enabled
+        {t('enabled')}
       </span>
     )
   }
@@ -24,7 +27,7 @@ function StateBadge({ state }: { state: WorkspaceSkillState }) {
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
         <CircleSlash className="size-3" />
-        Disabled
+        {t('disabled')}
       </span>
     )
   }
@@ -32,14 +35,14 @@ function StateBadge({ state }: { state: WorkspaceSkillState }) {
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
         <Lock className="size-3" />
-        Private
+        {t('private')}
       </span>
     )
   }
   return (
     <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">
       <Plus className="size-3" />
-      Available
+      {t('available')}
     </span>
   )
 }

--- a/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillDetail.tsx
+++ b/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillDetail.tsx
@@ -12,6 +12,8 @@ import {
   toggleWorkspaceSkill,
   type SkillContent,
 } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -28,12 +30,12 @@ function stripFrontmatter(content: string): string {
   return content.replace(/^---\s*\n[\s\S]*?\n---\s*(\n|$)/, '')
 }
 
-const STATE_LABEL: Record<WorkspaceSkillState, string> = {
-  'org-enabled': 'Enabled',
-  'org-disabled': 'Disabled',
-  'workspace-private': 'Workspace-private',
-  available: 'Available',
-}
+const STATE_KEY = {
+  'org-enabled': 'stateEnabled',
+  'org-disabled': 'stateDisabled',
+  'workspace-private': 'statePrivate',
+  available: 'stateAvailable',
+} as const satisfies Record<WorkspaceSkillState, string>
 
 const STATE_BADGE_VARIANT: Record<WorkspaceSkillState, { className: string }> = {
   'org-enabled': { className: 'border-emerald-500/40 text-emerald-600' },
@@ -57,6 +59,7 @@ function WorkspaceActions({
   skill: WorkspaceSkillEntry
   onDone: () => void
 }) {
+  const t = useTranslations('wsSettings.skillDetail')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -89,7 +92,7 @@ function WorkspaceActions({
           disabled={busy}
           onClick={() => void run(() => toggleWorkspaceSkill(client(), skill.installId!, false))}
         >
-          {busy ? 'Disabling…' : 'Disable in workspace'}
+          {busy ? t('actionDisabling') : t('actionDisable')}
         </Button>
       )}
       {skill.workspaceState === 'org-disabled' && skill.installId && (
@@ -98,7 +101,7 @@ function WorkspaceActions({
           disabled={busy}
           onClick={() => void run(() => toggleWorkspaceSkill(client(), skill.installId!, true))}
         >
-          {busy ? 'Enabling…' : 'Enable in workspace'}
+          {busy ? t('actionEnabling') : t('actionEnable')}
         </Button>
       )}
       {skill.workspaceState === 'workspace-private' && skill.installId && (
@@ -108,7 +111,7 @@ function WorkspaceActions({
           disabled={busy}
           onClick={() => void run(() => deleteWorkspaceSkill(client(), skill.installId!))}
         >
-          {busy ? 'Removing…' : 'Remove from workspace'}
+          {busy ? t('actionRemoving') : t('actionRemove')}
         </Button>
       )}
       {skill.workspaceState === 'available' && (
@@ -119,7 +122,7 @@ function WorkspaceActions({
             void run(() => installWorkspaceSkill(client(), skill.id, skill.current_version))
           }
         >
-          {busy ? 'Installing…' : 'Install in workspace'}
+          {busy ? t('actionInstalling') : t('actionInstall')}
         </Button>
       )}
     </div>
@@ -127,6 +130,7 @@ function WorkspaceActions({
 }
 
 export function WorkspaceSkillDetail({ wsId, skill, onActionDone }: WorkspaceSkillDetailProps) {
+  const t = useTranslations('wsSettings.skillDetail')
   const targetVersion = skill.installed_version ?? skill.current_version
   const contentKey = `/api/v1/ws/${wsId}/skills/${skill.id}?version=${encodeURIComponent(targetVersion)}`
   const { data: content, isLoading } = useSWR<SkillContent>(contentKey, contentFetcher, {
@@ -143,13 +147,13 @@ export function WorkspaceSkillDetail({ wsId, skill, onActionDone }: WorkspaceSki
             v{targetVersion}
           </Badge>
           <Badge variant={skill.source === 'preinstalled' ? 'default' : 'secondary'}>
-            {skill.source === 'preinstalled' ? 'Preinstalled' : 'Org-uploaded'}
+            {skill.source === 'preinstalled' ? t('sourcePreinstalled') : t('sourceUploaded')}
           </Badge>
           <Badge
             variant="outline"
             className={cn(STATE_BADGE_VARIANT[skill.workspaceState].className)}
           >
-            {STATE_LABEL[skill.workspaceState]}
+            {t(STATE_KEY[skill.workspaceState])}
           </Badge>
           <div className="ml-auto">
             <WorkspaceActions wsId={wsId} skill={skill} onDone={onActionDone} />
@@ -173,12 +177,12 @@ export function WorkspaceSkillDetail({ wsId, skill, onActionDone }: WorkspaceSki
         <TabsList variant="line" className="w-full justify-start border-b border-border/60 pb-0">
           <TabsTrigger value="overview">
             <FileText className="size-3.5" />
-            Overview
+            {t('overview')}
           </TabsTrigger>
         </TabsList>
 
         <TabsContent value="overview" className="mt-4">
-          {isLoading && <p className="text-xs text-muted-foreground">Loading content…</p>}
+          {isLoading && <p className="text-xs text-muted-foreground">{t('loadingContent')}</p>}
           {content && (
             <div className="rounded-lg border border-border/70 bg-card/40 px-4 py-3">
               <div className={proseClasses}>

--- a/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillsToolbar.tsx
+++ b/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillsToolbar.tsx
@@ -2,6 +2,8 @@
 
 import { Plus, Search } from 'lucide-react'
 import type { SkillSource } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
+
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
@@ -52,26 +54,27 @@ function PillGroup<T extends string>({
   )
 }
 
-const SOURCE_OPTIONS: { value: SkillSource | 'all'; label: string }[] = [
-  { value: 'all', label: 'All sources' },
-  { value: 'preinstalled', label: 'Preinstalled' },
-  { value: 'uploaded', label: 'Uploaded' },
-]
-
-const STATE_OPTIONS: { value: 'all' | 'enabled' | 'disabled' | 'available'; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: 'enabled', label: 'Enabled' },
-  { value: 'disabled', label: 'Disabled' },
-  { value: 'available', label: 'Available' },
-]
-
 export function WorkspaceSkillsToolbar({
   filters,
   onFiltersChange,
   onAddClick,
 }: WorkspaceSkillsToolbarProps) {
+  const t = useTranslations('wsSettings.skillsToolbar')
   const sourceValue: SkillSource | 'all' = filters.source ?? 'all'
   const stateValue = filters.state ?? 'all'
+
+  const sourceOptions: { value: SkillSource | 'all'; label: string }[] = [
+    { value: 'all', label: t('sourceAll') },
+    { value: 'preinstalled', label: t('sourcePreinstalled') },
+    { value: 'uploaded', label: t('sourceUploaded') },
+  ]
+
+  const stateOptions: { value: 'all' | 'enabled' | 'disabled' | 'available'; label: string }[] = [
+    { value: 'all', label: t('stateAll') },
+    { value: 'enabled', label: t('stateEnabled') },
+    { value: 'disabled', label: t('stateDisabled') },
+    { value: 'available', label: t('stateAvailable') },
+  ]
 
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-border/70 px-4 py-3">
@@ -79,17 +82,17 @@ export function WorkspaceSkillsToolbar({
         <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/70" />
         <Input
           type="search"
-          placeholder="Search by name or description"
+          placeholder={t('searchPlaceholder')}
           value={filters.q ?? ''}
           onChange={(e) => onFiltersChange({ ...filters, q: e.target.value || undefined })}
           className="pl-7"
-          aria-label="Search skills"
+          aria-label={t('searchAria')}
         />
       </div>
 
       <PillGroup
-        ariaLabel="Filter by source"
-        options={SOURCE_OPTIONS}
+        ariaLabel={t('filterSourceAria')}
+        options={sourceOptions}
         value={sourceValue}
         onChange={(next) =>
           onFiltersChange({ ...filters, source: next === 'all' ? undefined : next })
@@ -97,15 +100,15 @@ export function WorkspaceSkillsToolbar({
       />
 
       <PillGroup
-        ariaLabel="Filter by state"
-        options={STATE_OPTIONS}
+        ariaLabel={t('filterStateAria')}
+        options={stateOptions}
         value={stateValue}
         onChange={(next) => onFiltersChange({ ...filters, state: next })}
       />
 
       <Button size="sm" onClick={onAddClick} className="ml-auto">
         <Plus className="size-3.5" />
-        Add skill
+        {t('addSkill')}
       </Button>
     </div>
   )

--- a/frontend/packages/web/components/workspace/WorkspaceCreateForm.tsx
+++ b/frontend/packages/web/components/workspace/WorkspaceCreateForm.tsx
@@ -3,8 +3,10 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { createApiClient, useWorkspaceStore } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
 
 export function WorkspaceCreateForm() {
+  const t = useTranslations('workspaceCreate')
   const router = useRouter()
   const [name, setName] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -29,7 +31,7 @@ export function WorkspaceCreateForm() {
   return (
     <form onSubmit={onSubmit} className="space-y-3 rounded-md border border-border p-4">
       <label className="block">
-        <span className="text-sm text-foreground/80">New workspace name</span>
+        <span className="text-sm text-foreground/80">{t('nameLabel')}</span>
         <input
           type="text"
           required
@@ -37,7 +39,7 @@ export function WorkspaceCreateForm() {
           className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder="e.g. Side project"
+          placeholder={t('namePlaceholder')}
         />
       </label>
       {error && <div className="text-sm text-red-500">{error}</div>}
@@ -46,7 +48,7 @@ export function WorkspaceCreateForm() {
         disabled={submitting || !name.trim()}
         className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
       >
-        {submitting ? 'Creating…' : 'Create workspace'}
+        {submitting ? t('creating') : t('submit')}
       </button>
     </form>
   )

--- a/frontend/packages/web/components/workspace/WorkspaceList.tsx
+++ b/frontend/packages/web/components/workspace/WorkspaceList.tsx
@@ -2,12 +2,14 @@
 
 import Link from 'next/link'
 import { useWorkspaceStore } from '@cubebox/core'
+import { useTranslations } from 'next-intl'
 
 export function WorkspaceList() {
+  const t = useTranslations('workspaceList')
   const workspaces = useWorkspaceStore((s) => s.workspaces)
 
   if (workspaces.length === 0) {
-    return <div className="text-sm text-foreground/60">You have no workspaces yet.</div>
+    return <div className="text-sm text-foreground/60">{t('empty')}</div>
   }
 
   return (
@@ -16,13 +18,15 @@ export function WorkspaceList() {
         <li key={w.id} className="flex items-center justify-between px-4 py-3">
           <div>
             <div className="text-sm font-medium">{w.name}</div>
-            <div className="text-xs text-foreground/50">Role: {w.role ?? 'unknown'}</div>
+            <div className="text-xs text-foreground/50">
+              {t('rolePrefix', { role: w.role ?? t('unknownRole') })}
+            </div>
           </div>
           <Link
             href={`/w/${w.id}`}
             className="text-sm underline text-foreground/80 hover:text-foreground"
           >
-            Open
+            {t('open')}
           </Link>
         </li>
       ))}

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -278,5 +278,395 @@
     "saved": "Saved",
     "saveFailed": "Save failed: {message}",
     "discard": "Discard"
+  },
+  "mcp": {
+    "scopeBadge": {
+      "org": "Org shared",
+      "workspace": "Workspace shared",
+      "user": "Per user",
+      "none": "Identity passthrough"
+    },
+    "scopeForm": {
+      "orgTitle": "Organization shared",
+      "orgHelp": "One credential is shared by every enabled workspace in the organization.",
+      "workspaceTitle": "Workspace shared",
+      "workspaceHelp": "One credential is shared by all members of this workspace.",
+      "userTitle": "Per user",
+      "userHelp": "Each user provides their own credential before using this connector.",
+      "noneTitle": "Cubebox identity passthrough",
+      "noneHelp": "No API key is stored. The MCP server receives a short-lived Cubebox identity token."
+    },
+    "list": {
+      "loading": "Loading connectors...",
+      "name": "Name",
+      "scope": "Scope",
+      "transport": "Transport",
+      "tools": "Tools",
+      "actions": "Actions",
+      "details": "Details",
+      "authenticated": "authenticated",
+      "connectionError": "connection error"
+    },
+    "form": {
+      "basicInfo": "Basic information",
+      "nameLabel": "Name *",
+      "serverUrlLabel": "Server URL *",
+      "serverUrlPlaceholder": "https://example.com/mcp or stdio command",
+      "transport": "Transport",
+      "credentialMode": "Credential mode",
+      "oauth": "OAuth",
+      "oauthComingSoon": "Coming soon.",
+      "comingSoonTooltip": "Coming soon",
+      "apiKeyLabel": "API key / token",
+      "credentialDisplayName": "Credential display name",
+      "testConnection": "Test connection",
+      "cancel": "Cancel",
+      "save": "Save",
+      "connectionSucceeded": "Connection succeeded",
+      "connectionFailed": "Connection failed",
+      "discovered": "Discovered {count} tool(s): {names}",
+      "noToolsName": "none",
+      "unknownError": "Unknown error"
+    },
+    "detail": {
+      "notDiscoveredYet": "not discovered yet",
+      "lastDiscoveredLine": "{transport} · last discovered {time}",
+      "refreshTools": "Refresh tools",
+      "shareToOrg": "Share to org",
+      "delete": "Delete",
+      "overview": "Overview",
+      "toolsTab": "Tools ({count})",
+      "workspaces": "Workspaces",
+      "serverDetails": "Server details",
+      "url": "URL",
+      "transport": "Transport",
+      "authMethod": "Auth method",
+      "credentialScope": "Credential scope",
+      "timeout": "Timeout",
+      "timeoutValue": "{timeout}s / SSE {sseTimeout}s"
+    },
+    "promote": {
+      "title": "Promote MCP server",
+      "description": "Move {name} to organization scope so admins can bind it to workspaces.",
+      "close": "Close promote dialog",
+      "failed": "Promotion failed",
+      "share": "Share credential with organization",
+      "shareHelp": "Convert the workspace credential into an organization credential and attach it to the promoted server.",
+      "without": "Promote without credential",
+      "withoutHelp": "Keep credentials workspace-local. Admins can add an organization credential later.",
+      "noCredential": "This server has no workspace credential to share. It will be promoted without an organization credential.",
+      "cancel": "Cancel",
+      "confirm": "Promote server"
+    },
+    "bindings": {
+      "title": "Workspace bindings",
+      "description": "Enable this organization MCP server for specific workspaces.",
+      "updateFailed": "Binding update failed",
+      "summary": "{enabled} of {total} workspaces enabled",
+      "enableAll": "Enable all",
+      "disableAll": "Disable all",
+      "workspace": "Workspace",
+      "enabled": "Enabled",
+      "noWorkspaces": "No workspaces available.",
+      "toggleAria": "Toggle {name}",
+      "save": "Save bindings"
+    },
+    "credential": {
+      "managedTitle": "Credential",
+      "managedBody": "This credential is managed by organization administrators.",
+      "authTitle": "Authentication",
+      "passthroughBody": "This connector uses Cubebox identity passthrough and does not store an API key.",
+      "myCredential": "My credential",
+      "workspaceCredential": "Workspace credential",
+      "loadingStatus": "Loading credential status...",
+      "save": "Save",
+      "clear": "Clear",
+      "missingUser": "Until you add a credential, this connector will not appear in your chat tools.",
+      "missingViaBinding": "This workspace needs its own credential before members can use this shared connector.",
+      "missingWorkspace": "Until a workspace credential is added, this connector will not appear for workspace members."
+    },
+    "secret": {
+      "set": "**** (set)",
+      "replace": "Replace",
+      "cancel": "Cancel",
+      "writeOnly": "The secret is write-only after saving.",
+      "apiKeyPlaceholder": "API key / token"
+    },
+    "tools": {
+      "empty": "No tools discovered yet. Refresh tools after the MCP server is reachable."
+    },
+    "wsPanel": {
+      "title": "MCP Connectors",
+      "summary": "{enabled} of {total} enabled in this workspace",
+      "addConnector": "Add connector",
+      "loading": "Loading…",
+      "empty": "No MCP connectors yet",
+      "emptyHint": "Click \"Add connector\" to register one.",
+      "orgWide": "Org-wide",
+      "workspacePrivate": "Workspace-private",
+      "workspaceLabel": "workspace-private",
+      "orgLabel": "org-wide",
+      "enabledLabel": "enabled",
+      "disabledLabel": "disabled",
+      "manage": "Manage →",
+      "serverUrl": "Server URL",
+      "transport": "Transport",
+      "scope": "Scope",
+      "enabled": "Enabled",
+      "yes": "Yes",
+      "no": "No",
+      "selectConnector": "Select a connector to view details",
+      "listAria": "MCP server list",
+      "onBadge": "on"
+    },
+    "wsPage": {
+      "title": "Workspace MCP connectors",
+      "subtitle": "Manage private connectors and credentials for this workspace.",
+      "addServer": "Add server",
+      "private": "Workspace private",
+      "privateEmptyTitle": "No private MCP servers",
+      "privateEmptyDesc": "Add a connector that is visible only inside this workspace.",
+      "shared": "Shared from organization",
+      "sharedEmptyTitle": "No organization connectors shared here",
+      "sharedEmptyDesc": "Organization admins can bind org-level MCP servers to this workspace.",
+      "addTitle": "Add MCP server",
+      "addSubtitle": "Configure a connector owned by this workspace.",
+      "loadingConnector": "Loading connector...",
+      "deleteConfirm": "Delete {name}?",
+      "scopeError": "Workspace connectors only support workspace, per-user, or passthrough scope."
+    },
+    "adminPage": {
+      "title": "MCP connectors",
+      "subtitle": "Manage organization-level MCP servers and credential scopes.",
+      "addServer": "Add server",
+      "emptyTitle": "No MCP connectors yet",
+      "emptyDesc": "Add a server to expose external MCP tools to Cubebox agents.",
+      "addTitle": "Add MCP server",
+      "addSubtitle": "Configure an organization connector and discover its MCP tools.",
+      "loadingConnector": "Loading connector...",
+      "deleteConfirm": "Delete {name}? Bindings and credentials owned by this connector will also be removed.",
+      "scopeError": "Admin connectors only support organization, per-user, or passthrough scope."
+    }
+  },
+  "wsSettings": {
+    "settingsLabel": "Settings",
+    "navWorkspace": "Workspace Settings",
+    "navPersona": "Persona",
+    "navModel": "Model",
+    "navSkills": "Skills",
+    "navMcp": "MCP Connectors",
+    "soonBadge": "soon",
+    "persona": {
+      "title": "Persona",
+      "description": "Defines the agent's persona for every conversation in this workspace. Appended after the base system prompt.",
+      "loading": "Loading…",
+      "placeholder": "e.g. You are a Python data analysis expert. Always provide runnable code examples.",
+      "charCount": "{count} / 8000 characters",
+      "reset": "Reset",
+      "save": "Save",
+      "saving": "Saving…"
+    },
+    "skillsList": {
+      "title": "Skills",
+      "subtitle": "Browse, enable, and install skills available to this workspace.",
+      "loading": "Loading…",
+      "noMatch": "No skills match these filters",
+      "noMatchHint": "Adjust the search or filter, or upload a workspace-private skill via \"Add skill\".",
+      "selectSkill": "Select a skill to view details",
+      "listAria": "Skills list"
+    },
+    "skillCard": {
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "private": "Private",
+      "available": "Available"
+    },
+    "skillDetail": {
+      "stateEnabled": "Enabled",
+      "stateDisabled": "Disabled",
+      "statePrivate": "Workspace-private",
+      "stateAvailable": "Available",
+      "sourcePreinstalled": "Preinstalled",
+      "sourceUploaded": "Org-uploaded",
+      "overview": "Overview",
+      "loadingContent": "Loading content…",
+      "fetchFailed": "fetch failed: {status}",
+      "actionDisable": "Disable in workspace",
+      "actionDisabling": "Disabling…",
+      "actionEnable": "Enable in workspace",
+      "actionEnabling": "Enabling…",
+      "actionRemove": "Remove from workspace",
+      "actionRemoving": "Removing…",
+      "actionInstall": "Install in workspace",
+      "actionInstalling": "Installing…"
+    },
+    "skillsToolbar": {
+      "searchPlaceholder": "Search by name or description",
+      "searchAria": "Search skills",
+      "filterSourceAria": "Filter by source",
+      "filterStateAria": "Filter by state",
+      "sourceAll": "All sources",
+      "sourcePreinstalled": "Preinstalled",
+      "sourceUploaded": "Uploaded",
+      "stateAll": "All",
+      "stateEnabled": "Enabled",
+      "stateDisabled": "Disabled",
+      "stateAvailable": "Available",
+      "addSkill": "Add skill"
+    },
+    "uploadModal": {
+      "title": "Upload skill (workspace-private)",
+      "description": "Zip a SKILL.md plus its assets. The skill becomes installed only in this workspace.",
+      "close": "Close",
+      "selectFile": "Select a .zip file",
+      "filesizeHint": "Up to 50 MB total",
+      "selectError": "Select a .zip file to upload.",
+      "successPattern": "Installed {skill} v{version} as workspace-private.",
+      "cancel": "Cancel",
+      "upload": "Upload",
+      "uploading": "Uploading…"
+    }
+  },
+  "panel": {
+    "header": {
+      "copy": "Copy",
+      "close": "Close"
+    },
+    "skillView": {
+      "labelPrefix": "Skill:",
+      "loaded": "loaded",
+      "failed": "failed"
+    },
+    "attachment": {
+      "download": "Download",
+      "close": "Close",
+      "loading": "Loading…",
+      "loadFailed": "Failed to load: {message}",
+      "tooLarge": "File is too large for inline preview ({size} MB). Please download to view.",
+      "empty": "Empty"
+    },
+    "fileRead": {
+      "untitled": "(untitled)",
+      "chars": "{count} chars",
+      "cells": "{count} cells",
+      "code": "{count} code",
+      "md": "{count} md",
+      "rangePrefix": "Range: {range}",
+      "truncated": "Truncated",
+      "noResult": "No result.",
+      "unsupported": "Unsupported format",
+      "unchanged": "File unchanged since the previous read.",
+      "unknown": "Unknown result kind.",
+      "retryable": "(retryable)"
+    },
+    "search": {
+      "noResults": "No results",
+      "fallbackQuery": "Search",
+      "resultsCount": "{count} results"
+    },
+    "generic": {
+      "copy": "Copy",
+      "request": "Request",
+      "response": "Response"
+    },
+    "artifactPanel": {
+      "download": "Download",
+      "close": "Close",
+      "unknownType": "Unknown type",
+      "justNow": "just now",
+      "minutesAgo": "{n}m ago",
+      "hoursAgo": "{n}h ago",
+      "daysAgo": "{n}d ago"
+    },
+    "fallback": {
+      "unsupported": "This file type does not support preview. Please download to view.",
+      "download": "Download"
+    },
+    "pdf": {
+      "tableOfContents": "Table of contents",
+      "loadFailed": "Failed to load PDF"
+    }
+  },
+  "common": {
+    "loading": "Loading…",
+    "open": "Open",
+    "close": "Close",
+    "preview": "Preview",
+    "download": "Download",
+    "cancel": "Cancel",
+    "delete": "Delete"
+  },
+  "chatExtras": {
+    "imageClose": "Close",
+    "citationTruncated": "Truncated",
+    "uploadDropzone": "Drop to upload",
+    "uploadFormats": "Supports PNG/JPG/PDF/CSV/DOCX/XLSX/Markdown",
+    "preview": "Preview",
+    "download": "Download"
+  },
+  "workspaceCreate": {
+    "nameLabel": "New workspace name",
+    "namePlaceholder": "e.g. Side project",
+    "creating": "Creating…",
+    "submit": "Create workspace"
+  },
+  "workspaceList": {
+    "empty": "You have no workspaces yet.",
+    "open": "Open",
+    "rolePrefix": "Role: {role}",
+    "unknownRole": "unknown"
+  },
+  "workspacesPage": {
+    "title": "Workspaces"
+  },
+  "conversationPage": {
+    "notFoundTitle": "Conversation not found",
+    "notFoundBody": "It may have been deleted, or it belongs to a different workspace.",
+    "notFoundBack": "Back to workspace",
+    "noAccessTitle": "No access",
+    "noAccessBody": "You are not a member of this workspace.",
+    "noAccessBack": "Choose a workspace"
+  },
+  "adminLayout": {
+    "loading": "Loading…",
+    "subNavAria": "Admin sub-nav",
+    "avatarMenuAria": "Admin account menu",
+    "comingSoon": "Not available in this build",
+    "backlogRefPrefix": "Owner: {ref}"
+  },
+  "adminSandbox": {
+    "title": "Sandbox",
+    "subtitle": "Set the default image and resource limits."
+  },
+  "adminWebTools": {
+    "title": "Web Tools",
+    "subtitle": "Manage search-provider config (default plus 1–2 switchable)."
+  },
+  "adminExt": {
+    "loading": "Loading extension…",
+    "unknownTitle": "Unknown extension",
+    "unknownBodyPrefix": "Could not find an extension named"
+  },
+  "adminModelsExtra": {
+    "deleteProviderConfirm": "Confirm delete provider",
+    "deleteProviderCancel": "Cancel delete provider",
+    "deleteModelConfirm": "Confirm delete",
+    "deleteModelCancel": "Cancel delete",
+    "openaiPlaceholder": "OpenAI",
+    "modelIdPlaceholder": "GPT-4o"
+  },
+  "adminSkillsExtra": {
+    "fetchFailed": "fetch failed: {status}",
+    "skillsFetchFailed": "workspace skills fetch failed: {status}",
+    "workspace": "Workspace",
+    "confirmDisable": "Confirm disable"
+  },
+  "shellLayout": {
+    "inputBarAttach": "Attach files",
+    "sidebar": "Sidebar",
+    "deleteConversation": "Delete conversation",
+    "workspaceSettings": "Workspace settings",
+    "accountMenu": "Account menu",
+    "signOut": "Sign out"
   }
 }

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -278,5 +278,395 @@
     "saved": "已保存",
     "saveFailed": "保存失败：{message}",
     "discard": "放弃修改"
+  },
+  "mcp": {
+    "scopeBadge": {
+      "org": "组织共享",
+      "workspace": "工作区共享",
+      "user": "按用户",
+      "none": "身份直通"
+    },
+    "scopeForm": {
+      "orgTitle": "组织共享",
+      "orgHelp": "组织内启用该 connector 的所有工作区共用一份凭证。",
+      "workspaceTitle": "工作区共享",
+      "workspaceHelp": "本工作区所有成员共用一份凭证。",
+      "userTitle": "按用户",
+      "userHelp": "每位用户在使用前各自录入凭证。",
+      "noneTitle": "Cubebox 身份直通",
+      "noneHelp": "不存储 API key。MCP server 接收的是短期 Cubebox 身份令牌。"
+    },
+    "list": {
+      "loading": "加载 connector 中…",
+      "name": "名称",
+      "scope": "作用域",
+      "transport": "传输方式",
+      "tools": "工具",
+      "actions": "操作",
+      "details": "详情",
+      "authenticated": "已认证",
+      "connectionError": "连接错误"
+    },
+    "form": {
+      "basicInfo": "基础信息",
+      "nameLabel": "名称 *",
+      "serverUrlLabel": "服务地址 *",
+      "serverUrlPlaceholder": "https://example.com/mcp 或 stdio 命令",
+      "transport": "传输方式",
+      "credentialMode": "凭证模式",
+      "oauth": "OAuth",
+      "oauthComingSoon": "敬请期待。",
+      "comingSoonTooltip": "敬请期待",
+      "apiKeyLabel": "API key / token",
+      "credentialDisplayName": "凭证显示名",
+      "testConnection": "测试连接",
+      "cancel": "取消",
+      "save": "保存",
+      "connectionSucceeded": "连接成功",
+      "connectionFailed": "连接失败",
+      "discovered": "发现 {count} 个工具：{names}",
+      "noToolsName": "无",
+      "unknownError": "未知错误"
+    },
+    "detail": {
+      "notDiscoveredYet": "尚未发现",
+      "lastDiscoveredLine": "{transport} · 上次发现 {time}",
+      "refreshTools": "刷新工具",
+      "shareToOrg": "共享到组织",
+      "delete": "删除",
+      "overview": "概览",
+      "toolsTab": "工具 ({count})",
+      "workspaces": "工作区",
+      "serverDetails": "服务详情",
+      "url": "URL",
+      "transport": "传输方式",
+      "authMethod": "认证方式",
+      "credentialScope": "凭证作用域",
+      "timeout": "超时",
+      "timeoutValue": "{timeout} 秒 / SSE {sseTimeout} 秒"
+    },
+    "promote": {
+      "title": "提升为组织级 MCP",
+      "description": "把 {name} 改为组织级，由管理员绑定到各工作区。",
+      "close": "关闭提升对话框",
+      "failed": "提升失败",
+      "share": "把凭证一并共享给组织",
+      "shareHelp": "把工作区凭证转换为组织级凭证，并附在提升后的服务上。",
+      "without": "提升但不带凭证",
+      "withoutHelp": "凭证留在工作区本地。管理员可以稍后再添加组织级凭证。",
+      "noCredential": "该服务尚无可共享的工作区凭证，将仅做提升、不带凭证。",
+      "cancel": "取消",
+      "confirm": "确认提升"
+    },
+    "bindings": {
+      "title": "工作区绑定",
+      "description": "为指定工作区启用这个组织级 MCP 服务。",
+      "updateFailed": "绑定更新失败",
+      "summary": "已为 {enabled}/{total} 个工作区启用",
+      "enableAll": "全部启用",
+      "disableAll": "全部禁用",
+      "workspace": "工作区",
+      "enabled": "已启用",
+      "noWorkspaces": "暂无可用工作区。",
+      "toggleAria": "切换 {name}",
+      "save": "保存绑定"
+    },
+    "credential": {
+      "managedTitle": "凭证",
+      "managedBody": "这份凭证由组织管理员维护。",
+      "authTitle": "认证",
+      "passthroughBody": "此 connector 使用 Cubebox 身份直通，不存储 API key。",
+      "myCredential": "我的凭证",
+      "workspaceCredential": "工作区凭证",
+      "loadingStatus": "正在加载凭证状态…",
+      "save": "保存",
+      "clear": "清除",
+      "missingUser": "录入凭证之前，这个 connector 不会出现在你的对话工具里。",
+      "missingViaBinding": "工作区需要先录入自己的凭证，成员才能使用这个共享 connector。",
+      "missingWorkspace": "录入工作区凭证之前，这个 connector 不会对成员可见。"
+    },
+    "secret": {
+      "set": "**** （已设置）",
+      "replace": "替换",
+      "cancel": "取消",
+      "writeOnly": "保存后该秘密只能写入，无法读取。",
+      "apiKeyPlaceholder": "API key / token"
+    },
+    "tools": {
+      "empty": "尚未发现任何工具。MCP 服务可达后请刷新工具。"
+    },
+    "wsPanel": {
+      "title": "MCP Connectors",
+      "summary": "本工作区已启用 {enabled}/{total} 个",
+      "addConnector": "添加 connector",
+      "loading": "加载中…",
+      "empty": "还没有 MCP connector",
+      "emptyHint": "点击「添加 connector」来注册一个。",
+      "orgWide": "组织级",
+      "workspacePrivate": "工作区私有",
+      "workspaceLabel": "工作区私有",
+      "orgLabel": "组织级",
+      "enabledLabel": "已启用",
+      "disabledLabel": "已禁用",
+      "manage": "管理 →",
+      "serverUrl": "服务地址",
+      "transport": "传输方式",
+      "scope": "作用域",
+      "enabled": "启用",
+      "yes": "是",
+      "no": "否",
+      "selectConnector": "选择一个 connector 查看详情",
+      "listAria": "MCP 服务列表",
+      "onBadge": "开"
+    },
+    "wsPage": {
+      "title": "工作区 MCP connectors",
+      "subtitle": "管理本工作区的私有 connector 与凭证。",
+      "addServer": "添加服务",
+      "private": "工作区私有",
+      "privateEmptyTitle": "暂无私有 MCP 服务",
+      "privateEmptyDesc": "添加一个仅在本工作区可见的 connector。",
+      "shared": "组织共享给本工作区",
+      "sharedEmptyTitle": "组织尚未共享 connector 到这里",
+      "sharedEmptyDesc": "组织管理员可以把组织级 MCP 服务绑定到本工作区。",
+      "addTitle": "添加 MCP 服务",
+      "addSubtitle": "配置一个归属本工作区的 connector。",
+      "loadingConnector": "加载 connector 中…",
+      "deleteConfirm": "确认删除 {name}？",
+      "scopeError": "工作区 connector 只支持工作区共享、按用户或身份直通。"
+    },
+    "adminPage": {
+      "title": "MCP connectors",
+      "subtitle": "管理组织级 MCP 服务及其凭证作用域。",
+      "addServer": "添加服务",
+      "emptyTitle": "还没有 MCP connector",
+      "emptyDesc": "添加一个服务，把外部 MCP 工具暴露给 Cubebox agent。",
+      "addTitle": "添加 MCP 服务",
+      "addSubtitle": "配置一个组织级 connector，并发现它的 MCP 工具。",
+      "loadingConnector": "加载 connector 中…",
+      "deleteConfirm": "确认删除 {name}？该服务的绑定与凭证将一并删除。",
+      "scopeError": "组织 connector 只支持组织共享、按用户或身份直通。"
+    }
+  },
+  "wsSettings": {
+    "settingsLabel": "设置",
+    "navWorkspace": "工作区设置",
+    "navPersona": "Persona",
+    "navModel": "模型",
+    "navSkills": "技能",
+    "navMcp": "MCP Connectors",
+    "soonBadge": "即将推出",
+    "persona": {
+      "title": "Persona",
+      "description": "为本工作区里的每一次对话设置 agent 人设，附加在基础 system prompt 之后。",
+      "loading": "加载中…",
+      "placeholder": "比如：你是一名 Python 数据分析专家，回答时优先给出可运行的代码示例。",
+      "charCount": "{count} / 8000 字符",
+      "reset": "重置",
+      "save": "保存",
+      "saving": "保存中…"
+    },
+    "skillsList": {
+      "title": "技能",
+      "subtitle": "浏览、启用、安装本工作区可用的 skills。",
+      "loading": "加载中…",
+      "noMatch": "没有匹配当前筛选的 skill",
+      "noMatchHint": "调整搜索 / 筛选条件，或通过「添加 skill」上传工作区私有 skill。",
+      "selectSkill": "选择一个 skill 查看详情",
+      "listAria": "技能列表"
+    },
+    "skillCard": {
+      "enabled": "已启用",
+      "disabled": "已禁用",
+      "private": "私有",
+      "available": "可安装"
+    },
+    "skillDetail": {
+      "stateEnabled": "已启用",
+      "stateDisabled": "已禁用",
+      "statePrivate": "工作区私有",
+      "stateAvailable": "可安装",
+      "sourcePreinstalled": "内置",
+      "sourceUploaded": "组织上传",
+      "overview": "概览",
+      "loadingContent": "加载内容中…",
+      "fetchFailed": "拉取失败：{status}",
+      "actionDisable": "在工作区禁用",
+      "actionDisabling": "禁用中…",
+      "actionEnable": "在工作区启用",
+      "actionEnabling": "启用中…",
+      "actionRemove": "从工作区移除",
+      "actionRemoving": "移除中…",
+      "actionInstall": "安装到工作区",
+      "actionInstalling": "安装中…"
+    },
+    "skillsToolbar": {
+      "searchPlaceholder": "按名称或描述搜索",
+      "searchAria": "搜索 skills",
+      "filterSourceAria": "按来源筛选",
+      "filterStateAria": "按状态筛选",
+      "sourceAll": "全部来源",
+      "sourcePreinstalled": "内置",
+      "sourceUploaded": "上传",
+      "stateAll": "全部",
+      "stateEnabled": "已启用",
+      "stateDisabled": "已禁用",
+      "stateAvailable": "可安装",
+      "addSkill": "添加 skill"
+    },
+    "uploadModal": {
+      "title": "上传 skill（工作区私有）",
+      "description": "将 SKILL.md 与其资源打包为 zip，仅会安装到当前工作区。",
+      "close": "关闭",
+      "selectFile": "选择 .zip 文件",
+      "filesizeHint": "总大小最多 50 MB",
+      "selectError": "请先选择一个 .zip 文件。",
+      "successPattern": "已安装 {skill} v{version} 为工作区私有。",
+      "cancel": "取消",
+      "upload": "上传",
+      "uploading": "上传中…"
+    }
+  },
+  "panel": {
+    "header": {
+      "copy": "复制",
+      "close": "关闭"
+    },
+    "skillView": {
+      "labelPrefix": "Skill：",
+      "loaded": "已加载",
+      "failed": "失败"
+    },
+    "attachment": {
+      "download": "下载",
+      "close": "关闭",
+      "loading": "加载中…",
+      "loadFailed": "加载失败：{message}",
+      "tooLarge": "文件过大无法内联预览（{size} MB），请下载查看。",
+      "empty": "空"
+    },
+    "fileRead": {
+      "untitled": "（无标题）",
+      "chars": "{count} 个字符",
+      "cells": "{count} 个 cell",
+      "code": "{count} 个 code",
+      "md": "{count} 个 md",
+      "rangePrefix": "范围：{range}",
+      "truncated": "已截断",
+      "noResult": "无结果。",
+      "unsupported": "不支持的格式",
+      "unchanged": "自上次读取以来文件未变化。",
+      "unknown": "未知的结果类型。",
+      "retryable": "（可重试）"
+    },
+    "search": {
+      "noResults": "没有结果",
+      "fallbackQuery": "搜索",
+      "resultsCount": "{count} 条结果"
+    },
+    "generic": {
+      "copy": "复制",
+      "request": "请求",
+      "response": "响应"
+    },
+    "artifactPanel": {
+      "download": "下载",
+      "close": "关闭",
+      "unknownType": "未知类型",
+      "justNow": "刚刚",
+      "minutesAgo": "{n} 分钟前",
+      "hoursAgo": "{n} 小时前",
+      "daysAgo": "{n} 天前"
+    },
+    "fallback": {
+      "unsupported": "此文件类型不支持预览，请下载后查看。",
+      "download": "下载"
+    },
+    "pdf": {
+      "tableOfContents": "目录",
+      "loadFailed": "加载 PDF 失败"
+    }
+  },
+  "common": {
+    "loading": "加载中…",
+    "open": "打开",
+    "close": "关闭",
+    "preview": "预览",
+    "download": "下载",
+    "cancel": "取消",
+    "delete": "删除"
+  },
+  "chatExtras": {
+    "imageClose": "关闭",
+    "citationTruncated": "已截断",
+    "uploadDropzone": "拖到此处上传",
+    "uploadFormats": "支持 PNG/JPG/PDF/CSV/DOCX/XLSX/Markdown",
+    "preview": "预览",
+    "download": "下载"
+  },
+  "workspaceCreate": {
+    "nameLabel": "新工作区名称",
+    "namePlaceholder": "例如：副业项目",
+    "creating": "创建中…",
+    "submit": "创建工作区"
+  },
+  "workspaceList": {
+    "empty": "你还没有工作区。",
+    "open": "打开",
+    "rolePrefix": "角色：{role}",
+    "unknownRole": "未知"
+  },
+  "workspacesPage": {
+    "title": "工作区"
+  },
+  "conversationPage": {
+    "notFoundTitle": "找不到该对话",
+    "notFoundBody": "它可能已被删除，或归属于其他工作区。",
+    "notFoundBack": "返回工作区",
+    "noAccessTitle": "无权限",
+    "noAccessBody": "你不是这个工作区的成员。",
+    "noAccessBack": "选择工作区"
+  },
+  "adminLayout": {
+    "loading": "加载中…",
+    "subNavAria": "管理后台二级导航",
+    "avatarMenuAria": "管理后台账号菜单",
+    "comingSoon": "本版本不可用",
+    "backlogRefPrefix": "实现归属：{ref}"
+  },
+  "adminSandbox": {
+    "title": "沙盒",
+    "subtitle": "指定默认镜像与资源上限。"
+  },
+  "adminWebTools": {
+    "title": "Web 工具",
+    "subtitle": "搜索服务提供商配置（除默认外至少支持 1-2 个可切换）。"
+  },
+  "adminExt": {
+    "loading": "加载扩展中…",
+    "unknownTitle": "未知扩展",
+    "unknownBodyPrefix": "找不到名为"
+  },
+  "adminModelsExtra": {
+    "deleteProviderConfirm": "确认删除 provider",
+    "deleteProviderCancel": "取消删除 provider",
+    "deleteModelConfirm": "确认删除",
+    "deleteModelCancel": "取消删除",
+    "openaiPlaceholder": "OpenAI",
+    "modelIdPlaceholder": "GPT-4o"
+  },
+  "adminSkillsExtra": {
+    "fetchFailed": "拉取失败：{status}",
+    "skillsFetchFailed": "工作区 skills 拉取失败：{status}",
+    "workspace": "工作区",
+    "confirmDisable": "确认禁用"
+  },
+  "shellLayout": {
+    "inputBarAttach": "添加附件",
+    "sidebar": "侧边栏",
+    "deleteConversation": "删除对话",
+    "workspaceSettings": "工作区设置",
+    "accountMenu": "账号菜单",
+    "signOut": "退出登录"
   }
 }


### PR DESCRIPTION
## Summary

Audit found ~200 hardcoded English/Chinese strings across **57 files** in `frontend/packages/web` that were never wired through `next-intl`. This PR migrates them to `useTranslations` and adds matching `messages/{en,zh}.json` entries — so flipping `NEXT_LOCALE=zh` actually localizes the whole app, not just the bits that already used `t()`.

Major areas covered:

- **MCP** (admin + workspace): forms, server list/detail, credential panel, bindings grid, promote dialog, scope badge, secret input, tools table — was almost entirely English-only before
- **Workspace settings**: persona editor, skills panel, settings nav, workspace-skill card / detail / toolbar / upload modal
- **Tool / artifact panels**: PanelHeader, AttachmentPreview, FileRead, SearchResult, GenericTool, SkillView, ArtifactPanel, FallbackPreview, PdfPreview
- **Pages**: `admin/{layout,sandbox,web-tools,ext,mcp/*}`, `(app)/workspaces`, conversation page error states, workspace `/integrations/mcp/*`
- **Misc chat**: ArtifactCard, ArtifactGallery, ImageLightbox, CitationMarker, UploadDropzone
- **Layout aria-labels**: Sidebar, InputBar, AvatarPopover, AdminSubNav, AdminAvatarMenu — these used to be hardcoded English even in zh mode
- **Workspace creation**: WorkspaceCreateForm, WorkspaceList, workspaces page

The i18n e2e was updated where it relied on aria-labels that are now (correctly) localized.

## Test plan

- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web build`
- [x] `vitest` unit suite — 34 passed
- [x] Playwright E2E (worktree, slot 87): `i18n.spec.ts`, `auth-flow.spec.ts`, `workspace-settings.spec.ts`, `mcp/`, `chat-flow.spec.ts`, `skills/` — 22 specs, all passed
- [x] Manual `NEXT_LOCALE=zh` cookie smoke test on `/login`
- [ ] Manual zh smoke through MCP forms / workspace settings on review

🤖 Generated with [Claude Code](https://claude.com/claude-code)