### PR TITLE
feat(agents): conversation context compaction

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -291,3 +291,14 @@ default:
     graceful_drain_timeout_seconds: 3600
     dev_double_signal_force_exit: true
     stale_run_threshold_seconds: 120
+
+  # Conversation context compaction (default off; opt-in per env)
+  compaction:
+    enabled: false
+    summary_provider: "cubebox"
+    summary_model: "doubao-seed-1.8"
+    threshold_ratio: 0.7
+    keep_recent_messages: 8
+    max_summary_tokens: 1024
+    min_compact_messages: 4
+    fallback_context_window: 64000

--- a/backend/cubebox/agents/graph.py
+++ b/backend/cubebox/agents/graph.py
@@ -183,13 +183,32 @@ def create_cubebox_agent(
         try:
             summary_provider = _config.get("compaction.summary_provider")
             summary_model_id = _config.get("compaction.summary_model")
-            summary_llm = LLMFactory().create(
+            factory = LLMFactory()
+            summary_llm = factory.create(
                 provider_name=summary_provider,
                 model_id=summary_model_id,
             )
-            ctx_window = getattr(llm, "context_window", None) or _config.get(
-                "compaction.fallback_context_window", 64000
-            )
+            # LLMFactory.create() attaches _cubebox_provider/_cubebox_model_id but
+            # NOT context_window — look up the real window via the model config so
+            # smaller models (16k/32k) don't fall through to the 64k fallback and
+            # silently overflow before compaction triggers.
+            ctx_window: int | None = None
+            main_provider = getattr(llm, "_cubebox_provider", None)
+            main_model_id = getattr(llm, "_cubebox_model_id", None)
+            if main_provider and main_model_id:
+                try:
+                    ctx_window = factory.get_model_config(
+                        main_provider, main_model_id
+                    ).context_window
+                except Exception as cfg_exc:  # noqa: BLE001
+                    logger.debug(
+                        "Could not resolve context_window for {}/{}: {}",
+                        main_provider,
+                        main_model_id,
+                        cfg_exc,
+                    )
+            if not ctx_window:
+                ctx_window = int(_config.get("compaction.fallback_context_window", 64000))
             ratio = float(_config.get("compaction.threshold_ratio", 0.7))
             middleware.append(
                 CompactionMiddleware(

--- a/backend/cubebox/agents/graph.py
+++ b/backend/cubebox/agents/graph.py
@@ -175,6 +175,39 @@ def create_cubebox_agent(
         tools = [*tools, view_images_tool]
 
     middleware.append(TodoListMiddleware())
+
+    if _config.get("compaction.enabled", False):
+        from cubebox.llm.factory import LLMFactory
+        from cubebox.middleware.compaction import CompactionMiddleware
+
+        try:
+            summary_provider = _config.get("compaction.summary_provider")
+            summary_model_id = _config.get("compaction.summary_model")
+            summary_llm = LLMFactory().create(
+                provider_name=summary_provider,
+                model_id=summary_model_id,
+            )
+            ctx_window = getattr(llm, "context_window", None) or _config.get(
+                "compaction.fallback_context_window", 64000
+            )
+            ratio = float(_config.get("compaction.threshold_ratio", 0.7))
+            middleware.append(
+                CompactionMiddleware(
+                    summary_llm=summary_llm,
+                    max_tokens_before_compact=int(ctx_window * ratio),
+                    keep_recent_messages=int(_config.get("compaction.keep_recent_messages", 8)),
+                    max_summary_tokens=int(_config.get("compaction.max_summary_tokens", 1024)),
+                    min_compact_messages=int(_config.get("compaction.min_compact_messages", 4)),
+                )
+            )
+            logger.info(
+                "CompactionMiddleware enabled (threshold={} tokens, keep_recent={})",
+                int(ctx_window * ratio),
+                _config.get("compaction.keep_recent_messages", 8),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("CompactionMiddleware not loaded ({}); proceeding without it", exc)
+
     middleware.append(
         SubAgentMiddleware(
             subagents=subagents or [],

--- a/backend/cubebox/agents/state.py
+++ b/backend/cubebox/agents/state.py
@@ -1,0 +1,34 @@
+"""Cubebox-specific extensions to the langchain agent state schema."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, NotRequired
+
+from langchain.agents.middleware.types import AgentState
+
+
+@dataclass
+class CompactionSummary:
+    """Persisted running summary of a conversation's older turns.
+
+    Stored on agent state, serialized by the LangGraph checkpointer.
+    Three-field shape mirrors the canonical "running summary" pattern: the text,
+    which messages it covers, and where the rolling window currently ends.
+    """
+
+    summary: str
+    summarized_message_ids: list[str] = field(default_factory=list)
+    last_summarized_message_id: str | None = None
+
+
+class CubeboxState(AgentState[Any]):
+    """Agent state with compaction fields.
+
+    Extends AgentState (TypedDict) with two optional keys:
+      compaction:                 CompactionSummary persisted across turns
+      compaction_until_msg_index: int boundary in state["messages"]
+    """
+
+    compaction: NotRequired[CompactionSummary | None]
+    compaction_until_msg_index: NotRequired[int | None]

--- a/backend/cubebox/middleware/compaction/__init__.py
+++ b/backend/cubebox/middleware/compaction/__init__.py
@@ -1,0 +1,1 @@
+"""Conversation compaction middleware package."""

--- a/backend/cubebox/middleware/compaction/__init__.py
+++ b/backend/cubebox/middleware/compaction/__init__.py
@@ -1,1 +1,5 @@
 """Conversation compaction middleware package."""
+
+from cubebox.middleware.compaction.middleware import CompactionMiddleware
+
+__all__ = ["CompactionMiddleware"]

--- a/backend/cubebox/middleware/compaction/boundary.py
+++ b/backend/cubebox/middleware/compaction/boundary.py
@@ -1,0 +1,56 @@
+"""Boundary selection for compaction — picks a safe split point."""
+
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
+
+
+def safe_boundary(
+    messages: list[AnyMessage],
+    *,
+    keep_recent: int,
+    min_compact: int = 1,
+) -> int | None:
+    """Return an index `b` such that messages[:b] is summarizable and messages[b:] is kept.
+
+    Constraints:
+      1. messages[b:] must contain >= keep_recent items.
+      2. messages[b] must be a HumanMessage (start of a turn).
+      3. messages[b:] must not contain a ToolMessage whose tool_call_id has no
+         matching AIMessage.tool_calls within messages[b:].
+      4. If no boundary satisfies all and leaves at least min_compact messages
+         in the prefix, return None (caller skips compaction this round).
+    """
+    n = len(messages)
+    if n <= keep_recent:
+        return None
+
+    candidate = n - keep_recent
+    while candidate > 0:
+        msg = messages[candidate]
+        if not isinstance(msg, HumanMessage):
+            candidate -= 1
+            continue
+        if not _suffix_is_self_contained(messages[candidate:]):
+            candidate -= 1
+            continue
+        if candidate < min_compact:
+            return None
+        return candidate
+
+    return None
+
+
+def _suffix_is_self_contained(suffix: list[AnyMessage]) -> bool:
+    """Every ToolMessage in the suffix must have its parent AIMessage in the suffix."""
+    available_call_ids: set[str] = set()
+    for msg in suffix:
+        if isinstance(msg, AIMessage):
+            for tc in msg.tool_calls or []:
+                tc_id = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                if tc_id:
+                    available_call_ids.add(tc_id)
+        elif isinstance(msg, ToolMessage):
+            if msg.tool_call_id and msg.tool_call_id not in available_call_ids:
+                return False
+    return True

--- a/backend/cubebox/middleware/compaction/middleware.py
+++ b/backend/cubebox/middleware/compaction/middleware.py
@@ -11,7 +11,7 @@ from langchain_core.messages import AIMessage, AnyMessage, SystemMessage
 from langgraph.runtime import Runtime
 from loguru import logger
 
-from cubebox.agents.state import CompactionSummary
+from cubebox.agents.state import CompactionSummary, CubeboxState
 from cubebox.middleware.compaction.boundary import safe_boundary
 from cubebox.middleware.compaction.summarizer import summarize
 from cubebox.middleware.compaction.tokens import approx_tokens
@@ -42,13 +42,20 @@ def _compressed_view(state: Any) -> list[AnyMessage]:
     return msgs
 
 
-class CompactionMiddleware(AgentMiddleware[Any, Any, Any]):
+class CompactionMiddleware(AgentMiddleware[CubeboxState, Any, Any]):
     """Compress old turns into a persisted CompactionSummary; project compressed view per call.
 
     Two responsibilities split across two hooks:
       abefore_model — decide whether to compact further; if so, write new summary state.
       awrap_model_call — install the compressed view on request.messages just for this call.
+
+    Declares CubeboxState as its state_schema so LangGraph persists the new
+    `compaction` and `compaction_until_msg_index` keys through the checkpointer.
+    Without this, abefore_model returning those keys is treated as ephemeral and
+    silently dropped — no error, just no persistence.
     """
+
+    state_schema = CubeboxState
 
     def __init__(
         self,

--- a/backend/cubebox/middleware/compaction/middleware.py
+++ b/backend/cubebox/middleware/compaction/middleware.py
@@ -1,0 +1,126 @@
+"""CompactionMiddleware — persist summary in state, project compressed view per call."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
+
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, AnyMessage, SystemMessage
+from langgraph.runtime import Runtime
+from loguru import logger
+
+from cubebox.agents.state import CompactionSummary
+from cubebox.middleware.compaction.boundary import safe_boundary
+from cubebox.middleware.compaction.summarizer import summarize
+from cubebox.middleware.compaction.tokens import approx_tokens
+
+SUMMARY_PREFIX = "[Conversation summary so far]\n"
+
+
+def _compressed_view(state: Any) -> list[AnyMessage]:
+    """Build the messages list the LLM would actually see given current state.
+
+    If a CompactionSummary exists and a boundary has been recorded, the view is
+    [SystemMessage(summary), *messages[boundary:]] — exactly what awrap_model_call
+    will install on the request. Otherwise it's the raw messages list.
+
+    Used by abefore_model so the threshold check is against what we're about to
+    SEND, not against the raw history (which keeps growing and would force
+    needless re-compaction on stable conversations, plus break usage_metadata
+    scaling — see tokens.py docstring).
+    """
+    msgs: list[AnyMessage] = list(state.get("messages") or [])
+    summary: CompactionSummary | None = state.get("compaction")
+    boundary: int | None = state.get("compaction_until_msg_index")
+    if summary and boundary and boundary > 0:
+        return [
+            SystemMessage(content=SUMMARY_PREFIX + summary.summary),
+            *msgs[boundary:],
+        ]
+    return msgs
+
+
+class CompactionMiddleware(AgentMiddleware[Any, Any, Any]):
+    """Compress old turns into a persisted CompactionSummary; project compressed view per call.
+
+    Two responsibilities split across two hooks:
+      abefore_model — decide whether to compact further; if so, write new summary state.
+      awrap_model_call — install the compressed view on request.messages just for this call.
+    """
+
+    def __init__(
+        self,
+        *,
+        summary_llm: BaseChatModel,
+        max_tokens_before_compact: int,
+        keep_recent_messages: int = 8,
+        max_summary_tokens: int = 1024,
+        min_compact_messages: int = 4,
+    ) -> None:
+        self._summary_llm = summary_llm
+        self._max_tokens_before = max_tokens_before_compact
+        self._keep_recent = keep_recent_messages
+        self._max_summary_tokens = max_summary_tokens
+        self._min_compact = min_compact_messages
+
+    async def abefore_model(
+        self,
+        state: Any,
+        runtime: Runtime[Any] | None = None,
+    ) -> dict[str, Any] | None:
+        # Threshold check: measure what we're ABOUT to send (compressed view),
+        # not the raw history. If a stable conversation already has a summary
+        # that fits, this returns early and avoids re-summarizing.
+        if approx_tokens(_compressed_view(state)) < self._max_tokens_before:
+            return None
+
+        msgs: list[AnyMessage] = list(state.get("messages") or [])
+        existing = cast("CompactionSummary | None", state.get("compaction"))
+        last_until: int = cast("int | None", state.get("compaction_until_msg_index")) or 0
+
+        boundary = safe_boundary(
+            msgs,
+            keep_recent=self._keep_recent,
+            min_compact=max(self._min_compact, last_until + 1),
+        )
+        if boundary is None or boundary <= last_until:
+            return None
+
+        to_summarize = msgs[last_until:boundary]
+        try:
+            new_summary = await summarize(
+                model=self._summary_llm,
+                messages_to_summarize=to_summarize,
+                existing=existing,
+                max_summary_tokens=self._max_summary_tokens,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("CompactionMiddleware: summarizer failed, skipping: {}", exc)
+            return None
+
+        logger.info(
+            "CompactionMiddleware: compacted msgs[{}:{}] ({} msgs)",
+            last_until,
+            boundary,
+            len(to_summarize),
+        )
+        return {
+            "compaction": new_summary,
+            "compaction_until_msg_index": boundary,
+        }
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any] | AIMessage]],
+    ) -> ModelResponse[Any] | AIMessage:
+        state: Any = request.state or {}
+        summary = cast("CompactionSummary | None", state.get("compaction"))
+        boundary = cast("int | None", state.get("compaction_until_msg_index"))
+
+        if summary and boundary and boundary > 0:
+            request.messages = _compressed_view(state)
+
+        return await handler(request)

--- a/backend/cubebox/middleware/compaction/summarizer.py
+++ b/backend/cubebox/middleware/compaction/summarizer.py
@@ -1,0 +1,70 @@
+"""Summarizer — runs a cheap LLM to produce / update a CompactionSummary."""
+
+from __future__ import annotations
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AnyMessage, HumanMessage, SystemMessage
+
+from cubebox.agents.state import CompactionSummary
+
+SUMMARIZER_SYSTEM_PROMPT = """\
+You compress a chat transcript into a brief, faithful narrative for an AI assistant
+that is continuing the conversation. Rules:
+
+1. Preserve facts, user goals, decisions made, and unresolved questions.
+2. Preserve every 【N-K】 citation marker verbatim. Do not renumber, merge, or drop them.
+3. Do not quote long tool outputs. Reference them by their citation markers instead.
+4. Keep the language of the original conversation.
+5. Output the summary directly. No preamble, no JSON, no markdown headers.
+"""
+
+EXISTING_SUMMARY_SUFFIX = """\
+A previous summary already covers earlier turns:
+
+<previous_summary>
+{prev}
+</previous_summary>
+
+Merge it with the new turns below. Output the updated summary."""
+
+
+def _format_messages_for_summary(messages: list[AnyMessage]) -> str:
+    parts: list[str] = []
+    for m in messages:
+        role = m.__class__.__name__.removesuffix("Message").lower() or "msg"
+        content = m.content if isinstance(m.content, str) else str(m.content)
+        parts.append(f"[{role}] {content}")
+    return "\n\n".join(parts)
+
+
+async def summarize(
+    *,
+    model: BaseChatModel,
+    messages_to_summarize: list[AnyMessage],
+    existing: CompactionSummary | None,
+    max_summary_tokens: int = 1024,
+) -> CompactionSummary:
+    """Generate or update a CompactionSummary covering messages_to_summarize."""
+    system_text = SUMMARIZER_SYSTEM_PROMPT
+    if existing and existing.summary:
+        system_text = system_text + "\n\n" + EXISTING_SUMMARY_SUFFIX.format(prev=existing.summary)
+
+    prompt_messages: list[AnyMessage] = [
+        SystemMessage(content=system_text),
+        HumanMessage(content=_format_messages_for_summary(messages_to_summarize)),
+    ]
+    bound = model.bind(max_tokens=max_summary_tokens)
+    response = await bound.ainvoke(prompt_messages)
+    text = response.content if isinstance(response.content, str) else str(response.content)
+
+    new_ids: list[str] = [getattr(m, "id", None) or "" for m in messages_to_summarize]
+    new_ids = [i for i in new_ids if i]
+    prior_ids: list[str] = list(existing.summarized_message_ids) if existing else []
+
+    return CompactionSummary(
+        summary=text.strip(),
+        summarized_message_ids=prior_ids + new_ids,
+        last_summarized_message_id=(
+            new_ids[-1] if new_ids else (existing.last_summarized_message_id if existing else None)
+        ),
+    )

--- a/backend/cubebox/middleware/compaction/tokens.py
+++ b/backend/cubebox/middleware/compaction/tokens.py
@@ -1,0 +1,40 @@
+"""Approximate token counting for messages.
+
+IMPORTANT: callers must pass the *view* they intend to send to the LLM
+(i.e. the post-compaction projection [summary, *recent]), NOT the raw
+state["messages"]. Passing raw history breaks scaling accuracy because
+historical AIMessage.usage_metadata reflects the compressed view the
+LLM actually saw — comparing it against an approx walked over the full
+history yields a scale_factor < 1 (clamped to 1.0, scaling effectively
+disabled) and also triggers needless re-compaction on stable convos.
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import AnyMessage
+from langchain_core.messages.utils import count_tokens_approximately
+
+# 2.0 chars/token is a deliberate conservative override of the 4.0 default.
+# 4.0 underestimates Chinese / CJK by ~3-4x; with our threshold of
+# context_window * 0.7, underestimating means compacting too late → overflow.
+# Once usage_metadata scaling kicks in (turn 2+), the value is self-corrected
+# anyway — this just protects the cold start.
+_CHARS_PER_TOKEN = 2.0
+
+
+def approx_tokens(messages: list[AnyMessage]) -> int:
+    """Approximate total tokens for a list of messages.
+
+    Uses langchain_core.count_tokens_approximately with usage_metadata
+    self-scaling enabled, so historical AIMessages with real token counts
+    auto-calibrate the estimate (scale factor clamped to [1.0, 1.25]).
+    """
+    if not messages:
+        return 0
+    return int(
+        count_tokens_approximately(
+            messages,
+            chars_per_token=_CHARS_PER_TOKEN,
+            use_usage_metadata_scaling=True,
+        )
+    )

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -165,6 +165,8 @@ def _make_memory_test_app() -> FastAPI:
         checkpointer_factory=lambda: memory_saver,
         sandbox_factory=LocalSandbox,
     )
+    # Expose so tests can inspect raw thread state (e.g. compaction E2E).
+    app.state.memory_saver = memory_saver
     app.dependency_overrides[get_session] = override_get_session
     return app
 

--- a/backend/tests/e2e/test_conversation_compaction.py
+++ b/backend/tests/e2e/test_conversation_compaction.py
@@ -150,3 +150,50 @@ async def test_summary_stable_when_boundary_unchanged(
 
     if until_v2 == until_v1:
         assert summary_v2 == summary_v1, "summary changed without boundary moving"
+
+
+@pytest.mark.asyncio
+async def test_compaction_keeps_tool_pairs_intact(
+    compaction_client: tuple[httpx.AsyncClient, Any],
+) -> None:
+    """When the LLM uses a tool during the conversation and compaction triggers,
+    the kept window must never leave an orphan ToolMessage (one whose parent
+    AIMessage with that tool_call_id was folded into the summary).
+    """
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    client, saver = compaction_client
+    cid = await _create_conversation(client)
+
+    # Encourage at least one tool call: ask twice for the current date via the
+    # datetime tool, plus filler turns to push past the threshold.
+    await _send(client, cid, "use the datetime tool to tell me today's date")
+    await _send(client, cid, "thanks. now use the datetime tool again with include_time")
+    await _send(client, cid, "give me one short fact, no preamble")
+    await _send(client, cid, "another short fact, no preamble")
+
+    state = _read_state(saver, cid)
+    if not state.get("compaction"):
+        pytest.skip("compaction did not trigger in this run; threshold not crossed")
+    boundary = state["compaction_until_msg_index"]
+    assert boundary > 0
+
+    msgs = state["messages"]
+    suffix = msgs[boundary:]
+
+    # Build the set of tool_call_ids declared by AIMessages in the suffix.
+    declared: set[str] = set()
+    for m in suffix:
+        if isinstance(m, AIMessage):
+            for tc in m.tool_calls or []:
+                tc_id = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                if tc_id:
+                    declared.add(tc_id)
+
+    # Every ToolMessage in the suffix must have its parent AIMessage in the suffix.
+    orphans = [
+        m
+        for m in suffix
+        if isinstance(m, ToolMessage) and m.tool_call_id and m.tool_call_id not in declared
+    ]
+    assert not orphans, f"compaction split tool_call/tool_result pair: {orphans}"

--- a/backend/tests/e2e/test_conversation_compaction.py
+++ b/backend/tests/e2e/test_conversation_compaction.py
@@ -122,3 +122,31 @@ async def test_long_conversation_triggers_compaction(
     msgs = r.json()["messages"]
     user_count = sum(1 for m in msgs if m["role"] == "user")
     assert user_count == 4, f"UI history must keep all 4 user turns, got {user_count}"
+
+
+@pytest.mark.asyncio
+async def test_summary_stable_when_boundary_unchanged(
+    compaction_client: tuple[httpx.AsyncClient, Any],
+) -> None:
+    """If a follow-up turn doesn't push the boundary forward, the summary text
+    must not change — guards the "no needless re-compaction" invariant.
+    """
+    client, saver = compaction_client
+    cid = await _create_conversation(client)
+
+    for i in range(4):
+        await _send(client, cid, f"turn {i}: one-line fact, no preamble")
+
+    s1 = _read_state(saver, cid)
+    assert s1.get("compaction"), "expected compaction state populated after 4 turns"
+    summary_v1 = s1["compaction"]["summary"]
+    until_v1 = s1["compaction_until_msg_index"]
+
+    await _send(client, cid, "tiny follow-up")
+
+    s2 = _read_state(saver, cid)
+    summary_v2 = s2["compaction"]["summary"]
+    until_v2 = s2["compaction_until_msg_index"]
+
+    if until_v2 == until_v1:
+        assert summary_v2 == summary_v1, "summary changed without boundary moving"

--- a/backend/tests/e2e/test_conversation_compaction.py
+++ b/backend/tests/e2e/test_conversation_compaction.py
@@ -1,0 +1,124 @@
+"""E2E: compaction triggers, summary persists, full history still surfaces.
+
+These tests use the in-process MemorySaver from the memory_client setup so we
+can both drive the API and inspect raw checkpointer state. The CompactionMiddleware
+is enabled via env vars (read by config at agent build time) with a deliberately
+tiny threshold so we don't have to push thousands of real tokens through.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from langchain_core.runnables import RunnableConfig
+
+from tests.e2e.conftest import (
+    DEFAULT_TEST_EMAIL,
+    DEFAULT_TEST_PASSWORD,
+    DEFAULT_WS_ID,
+    _ensure_default_user_and_membership,
+    _lifespan_context,
+    _login_and_attach,
+    _make_memory_test_app,
+    collect_sse_events,
+)
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest_asyncio.fixture
+async def compaction_client() -> AsyncIterator[tuple[httpx.AsyncClient, Any]]:
+    """memory_client + memory_saver handle, with compaction forced on at low threshold.
+
+    Yields (client, memory_saver). The saver lets tests inspect raw thread state
+    (state.compaction, state.compaction_until_msg_index) which the public API
+    does not surface.
+
+    Uses config.set() to override values directly because dynaconf caches at
+    import — monkeypatch.setenv doesn't propagate after the singleton has loaded.
+    """
+    from cubebox.config import config as _cfg
+
+    overrides: dict[str, Any] = {
+        "compaction.enabled": True,
+        # threshold_ratio * fallback_context_window = 0.001 * 64000 = 64 tokens — trips fast
+        "compaction.threshold_ratio": 0.001,
+        "compaction.keep_recent_messages": 2,
+        "compaction.min_compact_messages": 2,
+        # Use the same E2E LLM for summarization (cheap to set, avoids dep on a
+        # specific provider's existence in test config).
+        "compaction.summary_provider": _cfg.get("llm.default_model", "cubebox/x").split("/")[0],
+        "compaction.summary_model": _cfg.get("llm.default_model", "cubebox/x").split("/", 1)[-1],
+    }
+    saved: dict[str, Any] = {k: _cfg.get(k) for k in overrides}
+    for k, v in overrides.items():
+        _cfg.set(k, v)
+
+    try:
+        await _ensure_default_user_and_membership()
+        app = _make_memory_test_app()
+        app.state.deployment_mode = "multi_tenant"
+        async with _lifespan_context(app):
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+                await _login_and_attach(c, DEFAULT_TEST_EMAIL, DEFAULT_TEST_PASSWORD)
+                yield c, app.state.memory_saver
+    finally:
+        for k, v in saved.items():
+            _cfg.set(k, v)
+
+
+async def _create_conversation(client: httpx.AsyncClient) -> str:
+    r = await client.post(f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "compact"})
+    r.raise_for_status()
+    return str(r.json()["id"])
+
+
+async def _send(client: httpx.AsyncClient, cid: str, text: str) -> list[dict[str, Any]]:
+    return await collect_sse_events(
+        client,
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{cid}/messages",
+        json_data={"content": text},
+    )
+
+
+def _read_state(memory_saver: Any, cid: str) -> dict[str, Any]:
+    """Pull the latest checkpoint values for a thread; normalize compaction to dict."""
+    cfg = RunnableConfig(configurable={"thread_id": cid})
+    snap = memory_saver.get(cfg)
+    if not snap:
+        return {}
+    values: dict[str, Any] = dict(snap.get("channel_values") or {})
+    comp = values.get("compaction")
+    if is_dataclass(comp) and not isinstance(comp, type):
+        values["compaction"] = asdict(comp)
+    return values
+
+
+@pytest.mark.asyncio
+async def test_long_conversation_triggers_compaction(
+    compaction_client: tuple[httpx.AsyncClient, Any],
+) -> None:
+    """Send enough turns to push past the (tiny) threshold; verify compaction lands
+    and the messages API still returns the complete original history."""
+    client, saver = compaction_client
+    cid = await _create_conversation(client)
+
+    for i in range(4):
+        await _send(client, cid, f"turn {i}: tell me a one-sentence fact, no preamble")
+
+    state = _read_state(saver, cid)
+    assert state.get("compaction") is not None, "expected compaction state to be populated"
+    assert state["compaction"]["summary"], "summary text should be non-empty"
+    assert state.get("compaction_until_msg_index", 0) > 0
+
+    r = await client.get(f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{cid}/messages")
+    r.raise_for_status()
+    msgs = r.json()["messages"]
+    user_count = sum(1 for m in msgs if m["role"] == "user")
+    assert user_count == 4, f"UI history must keep all 4 user turns, got {user_count}"

--- a/backend/tests/unit/middleware/compaction/test_boundary.py
+++ b/backend/tests/unit/middleware/compaction/test_boundary.py
@@ -1,0 +1,81 @@
+"""Tests for safe_boundary."""
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from cubebox.middleware.compaction.boundary import safe_boundary
+
+
+def _h(text: str) -> HumanMessage:
+    return HumanMessage(content=text)
+
+
+def _a(text: str = "", tool_calls: list[dict] | None = None) -> AIMessage:
+    return AIMessage(content=text, tool_calls=tool_calls or [])
+
+
+def _t(call_id: str, text: str = "ok") -> ToolMessage:
+    return ToolMessage(content=text, tool_call_id=call_id, name="x")
+
+
+def test_keeps_recent_window_when_history_short():
+    msgs = [_h("h1"), _a("a1")]
+    # keep_recent=4, so nothing to compact; boundary is None
+    assert safe_boundary(msgs, keep_recent=4) is None
+
+
+def test_basic_boundary_lands_on_humanmessage():
+    msgs = [_h("h1"), _a("a1"), _h("h2"), _a("a2"), _h("h3"), _a("a3")]
+    # keep_recent=2 → tentative boundary = 4 → msgs[4] = _h("h3") ✓
+    assert safe_boundary(msgs, keep_recent=2) == 4
+
+
+def test_walks_back_to_humanmessage():
+    msgs = [_h("h1"), _a("a1"), _h("h2"), _a("a2"), _h("h3"), _a("a3")]
+    # keep_recent=3 → tentative boundary = 3 → msgs[3] = _a, walk back to msgs[2] = _h
+    assert safe_boundary(msgs, keep_recent=3) == 2
+
+
+def test_does_not_split_tool_call_pair():
+    # h1 → a1(tool_calls=[t1]) → tool t1 → h2 → a2
+    msgs = [
+        _h("h1"),
+        _a(tool_calls=[{"id": "t1", "name": "x", "args": {}}]),
+        _t("t1"),
+        _h("h2"),
+        _a("a2"),
+    ]
+    # keep_recent=2 → tentative boundary = 3 → msgs[3] = _h("h2") — suffix [_h, _a] has
+    # no orphan ToolMessage, safe.
+    assert safe_boundary(msgs, keep_recent=2) == 3
+
+
+def test_orphan_tool_message_walks_back():
+    # If keep_recent=3, tentative boundary = 2 → msgs[2] = _t("t1") (orphan).
+    # Must walk to msgs[1] = _a (not Human), then msgs[0] = _h. boundary=0 → None.
+    msgs = [
+        _h("h1"),
+        _a(tool_calls=[{"id": "t1", "name": "x", "args": {}}]),
+        _t("t1"),
+        _h("h2"),
+        _a("a2"),
+    ]
+    assert safe_boundary(msgs, keep_recent=3) is None
+
+
+def test_skips_system_messages_in_search():
+    msgs = [SystemMessage(content="sys"), _h("h1"), _a("a1"), _h("h2"), _a("a2")]
+    # keep_recent=2 → tentative boundary = 3 → msgs[3] = _h("h2")
+    assert safe_boundary(msgs, keep_recent=2) == 3
+
+
+def test_walks_back_when_initial_message_not_human():
+    msgs = [_a("a1"), _a("a2"), _h("h1"), _a("a3")]
+    # keep_recent=1 → tentative boundary = 3, msgs[3]=_a, walk back to msgs[2]=_h ✓
+    assert safe_boundary(msgs, keep_recent=1) == 2
+
+
+def test_min_compact_size_too_small_returns_none():
+    msgs = [_h("h1"), _a("a1"), _h("h2"), _a("a2")]
+    # keep_recent=2, tentative boundary=2, msgs[2]=_h ✓ — but only 2 msgs in prefix.
+    # min_compact=4 demands more, so refuse.
+    assert safe_boundary(msgs, keep_recent=2, min_compact=4) is None

--- a/backend/tests/unit/middleware/compaction/test_middleware.py
+++ b/backend/tests/unit/middleware/compaction/test_middleware.py
@@ -1,0 +1,217 @@
+"""Tests for CompactionMiddleware (mocked summarizer LLM)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from cubebox.middleware.compaction.middleware import CompactionMiddleware
+
+
+def _make_state(
+    msgs: list[Any], compaction: Any = None, until: int | None = None
+) -> dict[str, Any]:
+    s: dict[str, Any] = {"messages": msgs}
+    if compaction is not None:
+        s["compaction"] = compaction
+    if until is not None:
+        s["compaction_until_msg_index"] = until
+    return s
+
+
+@pytest.mark.asyncio
+async def test_below_threshold_no_action():
+    summary_llm = AsyncMock()
+    mw = CompactionMiddleware(
+        summary_llm=summary_llm,
+        max_tokens_before_compact=10_000,
+        keep_recent_messages=2,
+    )
+    state = _make_state([HumanMessage(content="hi"), AIMessage(content="hello")])
+    result = await mw.abefore_model(state)
+    assert result is None
+    summary_llm.bind.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_triggers_when_over_threshold(monkeypatch):
+    from cubebox.agents.state import CompactionSummary
+    from cubebox.middleware.compaction import middleware as mw_mod
+
+    fake = CompactionSummary(
+        summary="user asked about X; agent answered Y",
+        summarized_message_ids=["m1", "m2"],
+        last_summarized_message_id="m2",
+    )
+    summarize_mock = AsyncMock(return_value=fake)
+    monkeypatch.setattr(mw_mod, "summarize", summarize_mock)
+
+    msgs = [
+        HumanMessage(content="x" * 5000, id="m1"),
+        AIMessage(content="y" * 5000, id="m2"),
+        HumanMessage(content="follow up", id="m3"),
+        AIMessage(content="ok", id="m4"),
+    ]
+    mw = CompactionMiddleware(
+        summary_llm=AsyncMock(),
+        max_tokens_before_compact=100,
+        keep_recent_messages=2,
+        min_compact_messages=2,
+    )
+    result = await mw.abefore_model(_make_state(msgs))
+
+    assert result is not None
+    assert result["compaction"] is fake
+    assert result["compaction_until_msg_index"] == 2
+
+
+@pytest.mark.asyncio
+async def test_does_not_recompact_when_compressed_view_fits(monkeypatch):
+    """Stable convo with existing summary whose compressed view fits the
+    threshold must NOT trigger another summarize call, even if raw
+    state.messages keeps growing.
+    """
+    from cubebox.agents.state import CompactionSummary
+    from cubebox.middleware.compaction import middleware as mw_mod
+
+    summarize_mock = AsyncMock()
+    monkeypatch.setattr(mw_mod, "summarize", summarize_mock)
+
+    msgs = [HumanMessage(content=f"m{i}", id=f"m{i}") for i in range(46)] + [
+        HumanMessage(content="recent1", id="r1"),
+        AIMessage(content="recent2", id="r2"),
+        HumanMessage(content="recent3", id="r3"),
+        AIMessage(content="recent4", id="r4"),
+    ]
+    existing = CompactionSummary(
+        summary="short summary",
+        summarized_message_ids=[f"m{i}" for i in range(46)],
+        last_summarized_message_id="m45",
+    )
+    state = _make_state(msgs, compaction=existing, until=46)
+
+    mw = CompactionMiddleware(
+        summary_llm=AsyncMock(),
+        max_tokens_before_compact=10_000,
+        keep_recent_messages=2,
+    )
+    result = await mw.abefore_model(state)
+
+    assert result is None, "must not re-summarize when compressed view fits threshold"
+    summarize_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_no_safe_boundary(monkeypatch):
+    from cubebox.middleware.compaction import middleware as mw_mod
+
+    summarize_mock = AsyncMock()
+    monkeypatch.setattr(mw_mod, "summarize", summarize_mock)
+
+    msgs = [
+        AIMessage(content="x" * 9000, id="m1"),
+        AIMessage(content="y" * 9000, id="m2"),
+    ]
+    mw = CompactionMiddleware(
+        summary_llm=AsyncMock(),
+        max_tokens_before_compact=100,
+        keep_recent_messages=2,
+    )
+    result = await mw.abefore_model(_make_state(msgs))
+    assert result is None
+    summarize_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_summarizer_fails(monkeypatch):
+    from cubebox.middleware.compaction import middleware as mw_mod
+
+    summarize_mock = AsyncMock(side_effect=RuntimeError("llm down"))
+    monkeypatch.setattr(mw_mod, "summarize", summarize_mock)
+
+    msgs = [
+        HumanMessage(content="x" * 5000, id="m1"),
+        AIMessage(content="y" * 5000, id="m2"),
+        HumanMessage(content="m3", id="m3"),
+        AIMessage(content="m4", id="m4"),
+    ]
+    mw = CompactionMiddleware(
+        summary_llm=AsyncMock(),
+        max_tokens_before_compact=100,
+        keep_recent_messages=2,
+        min_compact_messages=2,
+    )
+    result = await mw.abefore_model(_make_state(msgs))
+    assert result is None  # graceful fallback
+
+
+@pytest.mark.asyncio
+async def test_awrap_projects_compressed_view():
+    from cubebox.agents.state import CompactionSummary
+
+    captured: dict[str, Any] = {}
+
+    async def handler(req: Any) -> AIMessage:
+        captured["messages"] = list(req.messages)
+        return AIMessage(content="response")
+
+    msgs = [
+        HumanMessage(content="m1", id="m1"),
+        AIMessage(content="m2", id="m2"),
+        HumanMessage(content="m3", id="m3"),
+        AIMessage(content="m4", id="m4"),
+    ]
+    summary = CompactionSummary(
+        summary="prior context covered",
+        summarized_message_ids=["m1", "m2"],
+        last_summarized_message_id="m2",
+    )
+
+    class FakeRequest:
+        def __init__(self) -> None:
+            self.messages = list(msgs)
+            self.state = {
+                "messages": msgs,
+                "compaction": summary,
+                "compaction_until_msg_index": 2,
+            }
+
+    mw = CompactionMiddleware(
+        summary_llm=AsyncMock(),
+        max_tokens_before_compact=10_000,
+        keep_recent_messages=2,
+    )
+    req = FakeRequest()
+    await mw.awrap_model_call(req, handler)  # type: ignore[arg-type]
+
+    sent = captured["messages"]
+    assert isinstance(sent[0], SystemMessage)
+    assert "prior context covered" in sent[0].content
+    assert [m.id for m in sent[1:]] == ["m3", "m4"]
+
+
+@pytest.mark.asyncio
+async def test_awrap_passes_through_when_no_compaction():
+    captured: dict[str, Any] = {}
+
+    async def handler(req: Any) -> AIMessage:
+        captured["messages"] = list(req.messages)
+        return AIMessage(content="ok")
+
+    msgs = [HumanMessage(content="hi", id="m1"), AIMessage(content="hello", id="m2")]
+
+    class FakeRequest:
+        def __init__(self) -> None:
+            self.messages = list(msgs)
+            self.state = {"messages": msgs}
+
+    mw = CompactionMiddleware(
+        summary_llm=AsyncMock(),
+        max_tokens_before_compact=10_000,
+        keep_recent_messages=2,
+    )
+    await mw.awrap_model_call(FakeRequest(), handler)  # type: ignore[arg-type]
+    assert [m.id for m in captured["messages"]] == ["m1", "m2"]

--- a/backend/tests/unit/middleware/compaction/test_tokens.py
+++ b/backend/tests/unit/middleware/compaction/test_tokens.py
@@ -1,0 +1,30 @@
+"""Tests for approx_tokens — should count tokens across all message types."""
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from cubebox.middleware.compaction.tokens import approx_tokens
+
+
+def test_empty_messages_zero():
+    assert approx_tokens([]) == 0
+
+
+def test_counts_text_content():
+    msgs = [HumanMessage(content="hello world"), AIMessage(content="hi there")]
+    n = approx_tokens(msgs)
+    assert n > 0
+    assert n < 50
+
+
+def test_counts_tool_message_content():
+    msgs = [ToolMessage(content="big tool output " * 100, tool_call_id="t1")]
+    assert approx_tokens(msgs) > 100
+
+
+def test_counts_system_message():
+    assert approx_tokens([SystemMessage(content="you are a helpful assistant")]) > 0
+
+
+def test_handles_list_content_blocks():
+    msg = HumanMessage(content=[{"type": "text", "text": "block one"}])
+    assert approx_tokens([msg]) > 0

--- a/docs/superpowers/plans/2026-05-08-conversation-context-compaction.md
+++ b/docs/superpowers/plans/2026-05-08-conversation-context-compaction.md
@@ -1,0 +1,1445 @@
+# Conversation Context Compaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop crashing on long conversations. Compress old turns into a persistent summary; LLM sees `[summary] + recent N msgs`; UI keeps full original history.
+
+**Architecture:** Add a `CompactionMiddleware` that uses two hooks: `abefore_model` decides when to compact and writes the summary into a new state field `compaction` (persisted by checkpointer); `awrap_model_call` reads that state and projects `request.messages` into the compressed view per call. `state.messages` is never modified — UI, citations, audit all remain intact. Summary is a small in-repo `CompactionSummary` dataclass — no extra dependency.
+
+**Tech Stack:** LangGraph + langchain agents middleware, pytest for unit + E2E. No new third-party deps.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-conversation-context-compaction-design.md`
+
+---
+
+## File Structure
+
+```
+backend/
+├── cubebox/
+│   ├── agents/
+│   │   └── state.py                       (NEW) CompactionSummary dataclass + CubeboxState TypedDict
+│   ├── middleware/
+│   │   └── compaction/
+│   │       ├── __init__.py                (NEW)
+│   │       ├── tokens.py                  (NEW) approx_tokens helper
+│   │       ├── boundary.py                (NEW) safe_boundary algorithm
+│   │       ├── summarizer.py              (NEW) summary LLM call + prompt
+│   │       └── middleware.py              (NEW) CompactionMiddleware class
+│   └── agents/graph.py                    (MODIFY) wire CompactionMiddleware
+├── config.yaml                            (MODIFY) add compaction.* keys
+└── tests/
+    ├── unit/
+    │   └── middleware/
+    │       └── compaction/
+    │           ├── test_boundary.py       (NEW)
+    │           ├── test_tokens.py         (NEW)
+    │           └── test_middleware.py     (NEW)
+    └── e2e/
+        └── test_conversation_compaction.py (NEW)
+```
+
+Decomposition rationale:
+- `tokens.py` / `boundary.py` / `summarizer.py` are pure functions — easy to unit test without the LLM.
+- `middleware.py` orchestrates the three; only this file touches `state` and `request`.
+- `state.py` is shared with future agent-level state extensions (already a natural place).
+
+---
+
+## Task 1: Create state module with CompactionSummary
+
+**Files:**
+- Create: `backend/cubebox/agents/state.py`
+- Test: (deferred — covered in Task 5 middleware tests)
+
+- [ ] **Step 1: Create state module**
+
+Create `backend/cubebox/agents/state.py`:
+
+```python
+"""Cubebox-specific extensions to the langchain agent state schema."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, NotRequired
+
+from langchain.agents.middleware.types import AgentState
+
+
+@dataclass
+class CompactionSummary:
+    """Persisted running summary of a conversation's older turns.
+
+    Stored on agent state, serialized by the LangGraph checkpointer.
+    Three-field shape mirrors the canonical "running summary" pattern: the text,
+    which messages it covers, and where the rolling window currently ends.
+    """
+
+    summary: str
+    summarized_message_ids: list[str] = field(default_factory=list)
+    last_summarized_message_id: str | None = None
+
+
+class CubeboxState(AgentState[Any]):
+    """Agent state with compaction fields.
+
+    Extends AgentState (TypedDict) with two optional keys:
+      compaction:                 CompactionSummary persisted across turns
+      compaction_until_msg_index: int boundary in state["messages"]
+    """
+
+    compaction: NotRequired[CompactionSummary | None]
+    compaction_until_msg_index: NotRequired[int | None]
+```
+
+- [ ] **Step 2: Sanity check imports**
+
+```bash
+cd /home/chris/cubebox/backend && uv run python -c \
+  "from cubebox.agents.state import CubeboxState, CompactionSummary; \
+   s = CompactionSummary(summary='x'); print(s)"
+```
+
+Expected: `CompactionSummary(summary='x', summarized_message_ids=[], last_summarized_message_id=None)`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/cubebox/agents/state.py
+git commit -m "feat(compaction): add CompactionSummary dataclass and CubeboxState"
+```
+
+---
+
+## Task 2: Token approximation helper
+
+**Files:**
+- Create: `backend/cubebox/middleware/compaction/__init__.py`
+- Create: `backend/cubebox/middleware/compaction/tokens.py`
+- Test: `backend/tests/unit/middleware/compaction/test_tokens.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/middleware/compaction/test_tokens.py`:
+
+```python
+"""Tests for approx_tokens — should count tokens across all message types."""
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from cubebox.middleware.compaction.tokens import approx_tokens
+
+
+def test_empty_messages_zero():
+    assert approx_tokens([]) == 0
+
+
+def test_counts_text_content():
+    msgs = [HumanMessage(content="hello world"), AIMessage(content="hi there")]
+    n = approx_tokens(msgs)
+    assert n > 0
+    assert n < 50
+
+
+def test_counts_tool_message_content():
+    msgs = [ToolMessage(content="big tool output " * 100, tool_call_id="t1")]
+    assert approx_tokens(msgs) > 100
+
+
+def test_counts_system_message():
+    assert approx_tokens([SystemMessage(content="you are a helpful assistant")]) > 0
+
+
+def test_handles_list_content_blocks():
+    msg = HumanMessage(content=[{"type": "text", "text": "block one"}])
+    assert approx_tokens([msg]) > 0
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+cd /home/chris/cubebox/backend && uv run pytest tests/unit/middleware/compaction/test_tokens.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'cubebox.middleware.compaction'`.
+
+- [ ] **Step 3: Create package init**
+
+Create `backend/cubebox/middleware/compaction/__init__.py`:
+
+```python
+"""Conversation compaction middleware package."""
+```
+
+- [ ] **Step 4: Implement `tokens.py`**
+
+Create `backend/cubebox/middleware/compaction/tokens.py`:
+
+```python
+"""Approximate token counting for messages.
+
+IMPORTANT: callers must pass the *view* they intend to send to the LLM
+(i.e. the post-compaction projection [summary, *recent]), NOT the raw
+state["messages"]. Passing raw history breaks scaling accuracy because
+historical AIMessage.usage_metadata reflects the compressed view the
+LLM actually saw — comparing it against an approx walked over the full
+history yields a scale_factor < 1 (clamped to 1.0, scaling effectively
+disabled) and also triggers needless re-compaction on stable convos.
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import AnyMessage
+from langchain_core.messages.utils import count_tokens_approximately
+
+
+# 2.0 chars/token is a deliberate conservative override of the 4.0 default.
+# 4.0 underestimates Chinese / CJK by ~3-4x; with our threshold of
+# context_window * 0.7, underestimating means compacting too late → overflow.
+# Once usage_metadata scaling kicks in (turn 2+), the value is self-corrected
+# anyway — this just protects the cold start.
+_CHARS_PER_TOKEN = 2.0
+
+
+def approx_tokens(messages: list[AnyMessage]) -> int:
+    """Approximate total tokens for a list of messages.
+
+    Uses langchain_core.count_tokens_approximately with usage_metadata
+    self-scaling enabled, so historical AIMessages with real token counts
+    auto-calibrate the estimate (scale factor clamped to [1.0, 1.25]).
+    """
+    if not messages:
+        return 0
+    return int(
+        count_tokens_approximately(
+            messages,
+            chars_per_token=_CHARS_PER_TOKEN,
+            use_usage_metadata_scaling=True,
+        )
+    )
+```
+
+- [ ] **Step 5: Run test, verify it passes**
+
+```bash
+cd /home/chris/cubebox/backend && uv run pytest tests/unit/middleware/compaction/test_tokens.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/middleware/compaction/ backend/tests/unit/middleware/compaction/test_tokens.py
+git commit -m "feat(compaction): add approx_tokens helper"
+```
+
+---
+
+## Task 3: Safe boundary algorithm
+
+**Files:**
+- Create: `backend/cubebox/middleware/compaction/boundary.py`
+- Test: `backend/tests/unit/middleware/compaction/test_boundary.py`
+
+The algorithm picks `boundary` such that `messages[:boundary]` is the to-summarize prefix
+and `messages[boundary:]` is the keep-as-is suffix. It must:
+1. Keep at least `keep_recent` messages in the suffix.
+2. Place `messages[boundary]` on a `HumanMessage` (start of a "turn").
+3. Not split any `AIMessage(tool_calls)` ↔ `ToolMessage` pairing.
+4. Return `None` if no safe boundary exists (caller falls back to no compaction).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/middleware/compaction/test_boundary.py`:
+
+```python
+"""Tests for _safe_boundary."""
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from cubebox.middleware.compaction.boundary import safe_boundary
+
+
+def _h(text: str) -> HumanMessage:
+    return HumanMessage(content=text)
+
+
+def _a(text: str = "", tool_calls: list[dict] | None = None) -> AIMessage:
+    return AIMessage(content=text, tool_calls=tool_calls or [])
+
+
+def _t(call_id: str, text: str = "ok") -> ToolMessage:
+    return ToolMessage(content=text, tool_call_id=call_id, name="x")
+
+
+def test_keeps_recent_window_when_history_short():
+    msgs = [_h("h1"), _a("a1")]
+    # keep_recent=4, so nothing to compact; boundary is None
+    assert safe_boundary(msgs, keep_recent=4) is None
+
+
+def test_basic_boundary_lands_on_humanmessage():
+    msgs = [_h("h1"), _a("a1"), _h("h2"), _a("a2"), _h("h3"), _a("a3")]
+    # keep_recent=2 → tentative boundary = 4 → msgs[4] = _h("h3") ✓
+    assert safe_boundary(msgs, keep_recent=2) == 4
+
+
+def test_walks_back_to_humanmessage():
+    msgs = [_h("h1"), _a("a1"), _h("h2"), _a("a2"), _h("h3"), _a("a3")]
+    # keep_recent=3 → tentative boundary = 3 → msgs[3] = _a, walk back to msgs[2] = _h
+    assert safe_boundary(msgs, keep_recent=3) == 2
+
+
+def test_does_not_split_tool_call_pair():
+    # h1 → a1(tool_calls=[t1]) → tool t1 → h2 → a2
+    msgs = [
+        _h("h1"),
+        _a(tool_calls=[{"id": "t1", "name": "x", "args": {}}]),
+        _t("t1"),
+        _h("h2"),
+        _a("a2"),
+    ]
+    # keep_recent=2 → tentative boundary = 3 → msgs[3] = _h("h2") — but the ToolMessage
+    # at msgs[2] would be orphaned (its AIMessage is in summarized prefix).
+    # Wait: msgs[3] = _h("h2"), msgs[3:] = [_h, _a] — no tool message there, no orphan.
+    # That's actually safe.
+    assert safe_boundary(msgs, keep_recent=2) == 3
+
+
+def test_orphan_tool_message_walks_back():
+    # If keep_recent=3, tentative boundary = 2 → msgs[2] = _t("t1") (orphan).
+    # Must walk to msgs[1] = _a (not Human), then msgs[0] = _h.
+    msgs = [
+        _h("h1"),
+        _a(tool_calls=[{"id": "t1", "name": "x", "args": {}}]),
+        _t("t1"),
+        _h("h2"),
+        _a("a2"),
+    ]
+    # boundary=0 means "summarize nothing" → return None
+    assert safe_boundary(msgs, keep_recent=3) is None
+
+
+def test_skips_system_messages_in_search():
+    msgs = [SystemMessage(content="sys"), _h("h1"), _a("a1"), _h("h2"), _a("a2")]
+    # keep_recent=2 → tentative boundary = 3 → msgs[3] = _h("h2")
+    assert safe_boundary(msgs, keep_recent=2) == 3
+
+
+def test_returns_none_when_no_humanmessage_before_window():
+    msgs = [_a("a1"), _a("a2"), _h("h1"), _a("a3")]
+    # keep_recent=1 → tentative boundary = 3, msgs[3]=_a, walk back to msgs[2]=_h ✓
+    assert safe_boundary(msgs, keep_recent=1) == 2
+
+
+def test_min_compact_size_too_small_returns_none():
+    msgs = [_h("h1"), _a("a1"), _h("h2"), _a("a2")]
+    # keep_recent=2, tentative boundary=2, msgs[2]=_h ✓ — but only 2 msgs to summarize.
+    # If min_compact=4, refuse.
+    assert safe_boundary(msgs, keep_recent=2, min_compact=4) is None
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd /home/chris/cubebox/backend && uv run pytest tests/unit/middleware/compaction/test_boundary.py -v
+```
+
+Expected: ModuleNotFoundError on `boundary`.
+
+- [ ] **Step 3: Implement `boundary.py`**
+
+Create `backend/cubebox/middleware/compaction/boundary.py`:
+
+```python
+"""Boundary selection for compaction — picks a safe split point."""
+
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
+
+
+def safe_boundary(
+    messages: list[AnyMessage],
+    *,
+    keep_recent: int,
+    min_compact: int = 1,
+) -> int | None:
+    """Return an index `b` such that messages[:b] is summarizable and messages[b:] is kept.
+
+    Constraints:
+      1. messages[b:] must contain >= keep_recent items.
+      2. messages[b] must be a HumanMessage (start of a turn).
+      3. messages[b:] must not contain a ToolMessage whose tool_call_id has no
+         matching AIMessage.tool_calls within messages[b:].
+      4. If no boundary satisfies all and leaves at least min_compact messages
+         in the prefix, return None (caller skips compaction this round).
+    """
+    n = len(messages)
+    if n <= keep_recent:
+        return None
+
+    candidate = n - keep_recent
+    while candidate > 0:
+        msg = messages[candidate]
+        if not isinstance(msg, HumanMessage):
+            candidate -= 1
+            continue
+        if not _suffix_is_self_contained(messages[candidate:]):
+            candidate -= 1
+            continue
+        if candidate < min_compact:
+            return None
+        return candidate
+
+    return None
+
+
+def _suffix_is_self_contained(suffix: list[AnyMessage]) -> bool:
+    """Every ToolMessage in the suffix must have its parent AIMessage in the suffix."""
+    available_call_ids: set[str] = set()
+    for msg in suffix:
+        if isinstance(msg, AIMessage):
+            for tc in msg.tool_calls or []:
+                tc_id = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                if tc_id:
+                    available_call_ids.add(tc_id)
+        elif isinstance(msg, ToolMessage):
+            if msg.tool_call_id and msg.tool_call_id not in available_call_ids:
+                return False
+    return True
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+cd /home/chris/cubebox/backend && uv run pytest tests/unit/middleware/compaction/test_boundary.py -v
+```
+
+Expected: 8 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/middleware/compaction/boundary.py \
+        backend/tests/unit/middleware/compaction/test_boundary.py
+git commit -m "feat(compaction): add safe_boundary algorithm with tool-pair safety"
+```
+
+---
+
+## Task 4: Summarizer
+
+**Files:**
+- Create: `backend/cubebox/middleware/compaction/summarizer.py`
+- Test: covered indirectly via middleware test in Task 5; pure-function part is small enough to skip.
+
+- [ ] **Step 1: Implement `summarizer.py`**
+
+Create `backend/cubebox/middleware/compaction/summarizer.py`:
+
+```python
+"""Summarizer — runs a cheap LLM to produce / update a CompactionSummary."""
+
+from __future__ import annotations
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AnyMessage, HumanMessage, SystemMessage
+
+from cubebox.agents.state import CompactionSummary
+
+
+SUMMARIZER_SYSTEM_PROMPT = """\
+You compress a chat transcript into a brief, faithful narrative for an AI assistant
+that is continuing the conversation. Rules:
+
+1. Preserve facts, user goals, decisions made, and unresolved questions.
+2. Preserve every 【N-K】 citation marker verbatim. Do not renumber, merge, or drop them.
+3. Do not quote long tool outputs. Reference them by their citation markers instead.
+4. Keep the language of the original conversation.
+5. Output the summary directly. No preamble, no JSON, no markdown headers.
+"""
+
+EXISTING_SUMMARY_SUFFIX = """\
+A previous summary already covers earlier turns:
+
+<previous_summary>
+{prev}
+</previous_summary>
+
+Merge it with the new turns below. Output the updated summary."""
+
+
+def _format_messages_for_summary(messages: list[AnyMessage]) -> str:
+    parts: list[str] = []
+    for m in messages:
+        role = m.__class__.__name__.removesuffix("Message").lower() or "msg"
+        content = m.content if isinstance(m.content, str) else str(m.content)
+        parts.append(f"[{role}] {content}")
+    return "\n\n".join(parts)
+
+
+async def summarize(
+    *,
+    model: BaseChatModel,
+    messages_to_summarize: list[AnyMessage],
+    existing: CompactionSummary | None,
+    max_summary_tokens: int = 1024,
+) -> CompactionSummary:
+    """Generate or update a CompactionSummary covering messages_to_summarize."""
+    system_text = SUMMARIZER_SYSTEM_PROMPT
+    if existing and existing.summary:
+        system_text = system_text + "\n\n" + EXISTING_SUMMARY_SUFFIX.format(prev=existing.summary)
+
+    prompt_messages = [
+        SystemMessage(content=system_text),
+        HumanMessage(content=_format_messages_for_summary(messages_to_summarize)),
+    ]
+    bound = model.bind(max_tokens=max_summary_tokens)
+    response = await bound.ainvoke(prompt_messages)
+    text = response.content if isinstance(response.content, str) else str(response.content)
+
+    new_ids: list[str] = [getattr(m, "id", None) or "" for m in messages_to_summarize]
+    new_ids = [i for i in new_ids if i]
+    prior_ids: list[str] = list(existing.summarized_message_ids) if existing else []
+
+    return CompactionSummary(
+        summary=text.strip(),
+        summarized_message_ids=prior_ids + new_ids,
+        last_summarized_message_id=new_ids[-1] if new_ids else (
+            existing.last_summarized_message_id if existing else None
+        ),
+    )
+```
+
+- [ ] **Step 2: Sanity check imports**
+
+```bash
+cd /home/chris/cubebox/backend && uv run python -c \
+  "from cubebox.middleware.compaction.summarizer import summarize, SUMMARIZER_SYSTEM_PROMPT; print('ok')"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/cubebox/middleware/compaction/summarizer.py
+git commit -m "feat(compaction): add summarizer with citation-marker-preservation prompt"
+```
+
+---
+
+## Task 5: CompactionMiddleware
+
+**Files:**
+- Create: `backend/cubebox/middleware/compaction/middleware.py`
+- Modify: `backend/cubebox/middleware/compaction/__init__.py`
+- Test: `backend/tests/unit/middleware/compaction/test_middleware.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/middleware/compaction/test_middleware.py`:
+
+```python
+"""Tests for CompactionMiddleware (mocked summarizer LLM)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from cubebox.middleware.compaction.middleware import CompactionMiddleware
+
+
+def _make_state(msgs: list[Any], compaction=None, until=None) -> dict[str, Any]:
+    s: dict[str, Any] = {"messages": msgs}
+    if compaction is not None:
+        s["compaction"] = compaction
+    if until is not None:
+        s["compaction_until_msg_index"] = until
+    return s
+
+
+@pytest.mark.asyncio
+async def test_below_threshold_no_action():
+    summary_llm = AsyncMock()
+    mw = CompactionMiddleware(
+        summary_llm=summary_llm,
+        max_tokens_before_compact=10_000,
+        keep_recent_messages=2,
+    )
+    state = _make_state([HumanMessage(content="hi"), AIMessage(content="hello")])
+    result = await mw.abefore_model(state)
+    assert result is None
+    summary_llm.bind.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_triggers_when_over_threshold(monkeypatch):
+    from cubebox.agents.state import CompactionSummary
+    from cubebox.middleware.compaction import middleware as mw_mod
+
+    fake = CompactionSummary(
+        summary="user asked about X; agent answered Y",
+        summarized_message_ids=["m1", "m2"],
+        last_summarized_message_id="m2",
+    )
+    summarize_mock = AsyncMock(return_value=fake)
+    monkeypatch.setattr(mw_mod, "summarize", summarize_mock)
+
+    msgs = [
+        HumanMessage(content="x" * 5000, id="m1"),
+        AIMessage(content="y" * 5000, id="m2"),
+        HumanMessage(content="follow up", id="m3"),
+        AIMessage(content="ok", id="m4"),
+    ]
+    mw = CompactionMiddleware(
+        summary_llm=AsyncMock(),
+        max_tokens_before_compact=100,
+        keep_recent_messages=2,
+    )
+    result = await mw.abefore_model(_make_state(msgs))
+
+    assert result is not None
+    assert result["compaction"] is fake
+    assert result["compaction_until_msg_index"] == 2
+
+
+@pytest.mark.asyncio
+async def test_does_not_recompact_when_compressed_view_fits(monkeypatch):
+    """Stable convo with existing summary whose compressed view fits the
+    threshold must NOT trigger another summarize call, even if raw
+    state.messages keeps growing.
+    """
+    from cubebox.agents.state import CompactionSummary
+    from cubebox.middleware.compaction import middleware as mw_mod
+
+    summarize_mock = AsyncMock()
+    monkeypatch.setattr(mw_mod, "summarize", summarize_mock)
+
+    # 50 raw messages, but only the recent 4 are unsummarized.
+    msgs = [HumanMessage(content=f"m{i}", id=f"m{i}") for i in range(46)] + [
+        HumanMessage(content="recent1", id="r1"),
+        AIMessage(content="recent2", id="r2"),
+        HumanMessage(content="recent3", id="r3"),
+        AIMessage(content="recent4", id="r4"),
+    ]
+    existing = CompactionSummary(
+        summary="short summary",
+        summarized_message_ids=[f"m{i}" for i in range(46)],
+        last_summarized_message_id="m45",
+    )
+    state = _make_state(msgs, compaction=existing, until=46)
+
+    mw = CompactionMiddleware(
+        summary_llm=AsyncMock(),
+        max_tokens_before_compact=10_000,  # compressed view fits easily
+        keep_recent_messages=2,
+    )
+    result = await mw.abefore_model(state)
+
+    assert result is None, "must not re-summarize when compressed view fits threshold"
+    summarize_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_no_safe_boundary(monkeypatch):
+    from cubebox.middleware.compaction import middleware as mw_mod
+    summarize_mock = AsyncMock()
+    monkeypatch.setattr(mw_mod, "summarize", summarize_mock)
+
+    msgs = [AIMessage(content="x" * 9000, id="m1"), AIMessage(content="y" * 9000, id="m2")]
+    mw = CompactionMiddleware(
+        summary_llm=AsyncMock(),
+        max_tokens_before_compact=100,
+        keep_recent_messages=2,
+    )
+    result = await mw.abefore_model(_make_state(msgs))
+    assert result is None
+    summarize_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_summarizer_fails(monkeypatch):
+    from cubebox.middleware.compaction import middleware as mw_mod
+    summarize_mock = AsyncMock(side_effect=RuntimeError("llm down"))
+    monkeypatch.setattr(mw_mod, "summarize", summarize_mock)
+
+    msgs = [
+        HumanMessage(content="x" * 5000, id="m1"),
+        AIMessage(content="y" * 5000, id="m2"),
+        HumanMessage(content="m3", id="m3"),
+        AIMessage(content="m4", id="m4"),
+    ]
+    mw = CompactionMiddleware(
+        summary_llm=AsyncMock(),
+        max_tokens_before_compact=100,
+        keep_recent_messages=2,
+    )
+    result = await mw.abefore_model(_make_state(msgs))
+    assert result is None  # graceful fallback
+
+
+@pytest.mark.asyncio
+async def test_awrap_projects_compressed_view():
+    from cubebox.agents.state import CompactionSummary
+
+    captured: dict[str, Any] = {}
+
+    async def handler(req):
+        captured["messages"] = list(req.messages)
+        return AIMessage(content="response")
+
+    msgs = [
+        HumanMessage(content="m1", id="m1"),
+        AIMessage(content="m2", id="m2"),
+        HumanMessage(content="m3", id="m3"),
+        AIMessage(content="m4", id="m4"),
+    ]
+    summary = CompactionSummary(
+        summary="prior context covered",
+        summarized_message_ids=["m1", "m2"],
+        last_summarized_message_id="m2",
+    )
+
+    class FakeRequest:
+        def __init__(self):
+            self.messages = list(msgs)
+            self.state = {
+                "messages": msgs,
+                "compaction": summary,
+                "compaction_until_msg_index": 2,
+            }
+
+    mw = CompactionMiddleware(
+        summary_llm=AsyncMock(),
+        max_tokens_before_compact=10_000,
+        keep_recent_messages=2,
+    )
+    req = FakeRequest()
+    await mw.awrap_model_call(req, handler)  # type: ignore[arg-type]
+
+    sent = captured["messages"]
+    assert isinstance(sent[0], SystemMessage)
+    assert "prior context covered" in sent[0].content
+    assert [m.id for m in sent[1:]] == ["m3", "m4"]
+
+
+@pytest.mark.asyncio
+async def test_awrap_passes_through_when_no_compaction():
+    captured: dict[str, Any] = {}
+
+    async def handler(req):
+        captured["messages"] = list(req.messages)
+        return AIMessage(content="ok")
+
+    msgs = [HumanMessage(content="hi", id="m1"), AIMessage(content="hello", id="m2")]
+
+    class FakeRequest:
+        def __init__(self):
+            self.messages = list(msgs)
+            self.state = {"messages": msgs}
+
+    mw = CompactionMiddleware(
+        summary_llm=AsyncMock(),
+        max_tokens_before_compact=10_000,
+        keep_recent_messages=2,
+    )
+    await mw.awrap_model_call(FakeRequest(), handler)  # type: ignore[arg-type]
+    assert [m.id for m in captured["messages"]] == ["m1", "m2"]
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd /home/chris/cubebox/backend && uv run pytest tests/unit/middleware/compaction/test_middleware.py -v
+```
+
+Expected: ModuleNotFoundError on middleware.
+
+- [ ] **Step 3: Implement `middleware.py`**
+
+Create `backend/cubebox/middleware/compaction/middleware.py`:
+
+```python
+"""CompactionMiddleware — persist summary in state, project compressed view per call."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, AnyMessage, SystemMessage
+from loguru import logger
+
+from cubebox.agents.state import CompactionSummary
+from cubebox.middleware.compaction.boundary import safe_boundary
+from cubebox.middleware.compaction.summarizer import summarize
+from cubebox.middleware.compaction.tokens import approx_tokens
+
+
+SUMMARY_PREFIX = "[Conversation summary so far]\n"
+
+
+def _compressed_view(state: Any) -> list[AnyMessage]:
+    """Build the messages list the LLM would actually see given current state.
+
+    If a CompactionSummary exists and a boundary has been recorded, the view is
+    [SystemMessage(summary), *messages[boundary:]] — exactly what awrap_model_call
+    will install on the request. Otherwise it's the raw messages list.
+
+    Used by abefore_model so the threshold check is against what we're about to
+    SEND, not against the raw history (which keeps growing and would force
+    needless re-compaction on stable conversations, plus break usage_metadata
+    scaling — see tokens.py docstring).
+    """
+    msgs: list[AnyMessage] = list(state.get("messages") or [])
+    summary: CompactionSummary | None = state.get("compaction")
+    boundary: int | None = state.get("compaction_until_msg_index")
+    if summary and boundary and boundary > 0:
+        return [
+            SystemMessage(content=SUMMARY_PREFIX + summary.summary),
+            *msgs[boundary:],
+        ]
+    return msgs
+
+
+class CompactionMiddleware(AgentMiddleware[Any, Any, Any]):
+    """Compress old turns into a persisted CompactionSummary; project compressed view per call.
+
+    Two responsibilities split across two hooks:
+      abefore_model — decide whether to compact further; if so, write new summary state.
+      awrap_model_call — install the compressed view on request.messages just for this call.
+    """
+
+    def __init__(
+        self,
+        *,
+        summary_llm: BaseChatModel,
+        max_tokens_before_compact: int,
+        keep_recent_messages: int = 8,
+        max_summary_tokens: int = 1024,
+        min_compact_messages: int = 4,
+    ) -> None:
+        self._summary_llm = summary_llm
+        self._max_tokens_before = max_tokens_before_compact
+        self._keep_recent = keep_recent_messages
+        self._max_summary_tokens = max_summary_tokens
+        self._min_compact = min_compact_messages
+
+    async def abefore_model(self, state: Any) -> dict[str, Any] | None:
+        # Threshold check: measure what we're ABOUT to send (compressed view),
+        # not the raw history. If a stable conversation already has a summary
+        # that fits, this returns early and avoids re-summarizing.
+        if approx_tokens(_compressed_view(state)) < self._max_tokens_before:
+            return None
+
+        msgs: list[AnyMessage] = list(state.get("messages") or [])
+        existing: CompactionSummary | None = state.get("compaction")
+        last_until: int = state.get("compaction_until_msg_index") or 0
+
+        boundary = safe_boundary(
+            msgs,
+            keep_recent=self._keep_recent,
+            min_compact=max(self._min_compact, last_until + 1),
+        )
+        if boundary is None or boundary <= last_until:
+            return None
+
+        to_summarize = msgs[last_until:boundary]
+        try:
+            new_summary = await summarize(
+                model=self._summary_llm,
+                messages_to_summarize=to_summarize,
+                existing=existing,
+                max_summary_tokens=self._max_summary_tokens,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("CompactionMiddleware: summarizer failed, skipping: {}", exc)
+            return None
+
+        logger.info(
+            "CompactionMiddleware: compacted msgs[{}:{}] ({} msgs)",
+            last_until,
+            boundary,
+            len(to_summarize),
+        )
+        return {
+            "compaction": new_summary,
+            "compaction_until_msg_index": boundary,
+        }
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any] | AIMessage]],
+    ) -> ModelResponse[Any] | AIMessage:
+        state = request.state or {}
+        summary: CompactionSummary | None = state.get("compaction")
+        boundary: int | None = state.get("compaction_until_msg_index")
+
+        if summary and boundary and boundary > 0:
+            request.messages = _compressed_view(state)
+
+        return await handler(request)
+```
+
+- [ ] **Step 4: Wire `__init__.py`**
+
+Update `backend/cubebox/middleware/compaction/__init__.py`:
+
+```python
+"""Conversation compaction middleware package."""
+
+from cubebox.middleware.compaction.middleware import CompactionMiddleware
+
+__all__ = ["CompactionMiddleware"]
+```
+
+- [ ] **Step 5: Run tests, verify they pass**
+
+```bash
+cd /home/chris/cubebox/backend && uv run pytest tests/unit/middleware/compaction/ -v
+```
+
+Expected: 6 passed (this file) + earlier 8 + 5 = 19 total in compaction unit suite.
+
+- [ ] **Step 6: Run lint + type check**
+
+```bash
+cd /home/chris/cubebox/backend && uv run ruff check cubebox/middleware/compaction/ tests/unit/middleware/compaction/
+cd /home/chris/cubebox/backend && uv run mypy cubebox/middleware/compaction/
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/cubebox/middleware/compaction/ backend/tests/unit/middleware/compaction/test_middleware.py
+git commit -m "feat(compaction): add CompactionMiddleware with abefore_model + awrap_model_call"
+```
+
+---
+
+## Task 6: Config schema
+
+**Files:**
+- Modify: `backend/config.yaml`
+- Modify: `backend/config.development.yaml` (and other env configs if values differ)
+
+- [ ] **Step 1: Add config keys to `config.yaml`**
+
+Append to the bottom of `backend/config.yaml`:
+
+```yaml
+compaction:
+  enabled: false
+  summary_provider: anthropic
+  summary_model: claude-haiku-4-5
+  threshold_ratio: 0.7
+  keep_recent_messages: 8
+  max_summary_tokens: 1024
+  min_compact_messages: 4
+  fallback_context_window: 64000
+```
+
+- [ ] **Step 2: Verify config loads**
+
+```bash
+cd /home/chris/cubebox/backend && uv run python -c \
+  "from cubebox.config import config; print(config.get('compaction.enabled'), config.get('compaction.summary_model'))"
+```
+
+Expected: `False claude-haiku-4-5`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/config.yaml
+git commit -m "feat(compaction): add compaction config keys (default off)"
+```
+
+---
+
+## Task 7: Wire CompactionMiddleware into `create_cubebox_agent`
+
+**Files:**
+- Modify: `backend/cubebox/agents/graph.py`
+
+- [ ] **Step 1: Read the current insertion site**
+
+Run:
+
+```bash
+sed -n '170,200p' /home/chris/cubebox/backend/cubebox/agents/graph.py
+```
+
+Verify the `TodoListMiddleware` and `SubAgentMiddleware` lines are around 177–185 — Task 7 inserts between them.
+
+- [ ] **Step 2: Add CompactionMiddleware wiring**
+
+Edit `backend/cubebox/agents/graph.py`. Locate the block:
+
+```python
+    middleware.append(TodoListMiddleware())
+    middleware.append(
+        SubAgentMiddleware(
+```
+
+Replace with (the new block sits BETWEEN TodoListMiddleware and SubAgentMiddleware):
+
+```python
+    middleware.append(TodoListMiddleware())
+
+    if _config.get("compaction.enabled", False):
+        from cubebox.llm.factory import LLMFactory
+        from cubebox.middleware.compaction import CompactionMiddleware
+
+        try:
+            summary_llm = LLMFactory().create(
+                provider_name=_config.get("compaction.summary_provider"),
+                model_id=_config.get("compaction.summary_model"),
+            )
+            ctx_window = (
+                getattr(llm, "context_window", None)
+                or _config.get("compaction.fallback_context_window", 64000)
+            )
+            ratio = float(_config.get("compaction.threshold_ratio", 0.7))
+            middleware.append(
+                CompactionMiddleware(
+                    summary_llm=summary_llm,
+                    max_tokens_before_compact=int(ctx_window * ratio),
+                    keep_recent_messages=int(
+                        _config.get("compaction.keep_recent_messages", 8)
+                    ),
+                    max_summary_tokens=int(
+                        _config.get("compaction.max_summary_tokens", 1024)
+                    ),
+                    min_compact_messages=int(
+                        _config.get("compaction.min_compact_messages", 4)
+                    ),
+                )
+            )
+            logger.info(
+                "CompactionMiddleware enabled (threshold={} tokens, keep_recent={})",
+                int(ctx_window * ratio),
+                _config.get("compaction.keep_recent_messages", 8),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "CompactionMiddleware not loaded ({}); proceeding without it", exc
+            )
+
+    middleware.append(
+        SubAgentMiddleware(
+```
+
+- [ ] **Step 3: Sanity check — agent still imports**
+
+```bash
+cd /home/chris/cubebox/backend && uv run python -c \
+  "from cubebox.agents.graph import create_cubebox_agent; print('ok')"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 4: Run unit tests to verify no regressions**
+
+```bash
+cd /home/chris/cubebox/backend && uv run pytest tests/unit/ -v -x
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/agents/graph.py
+git commit -m "feat(compaction): wire CompactionMiddleware in create_cubebox_agent (gated by config)"
+```
+
+---
+
+## Task 8: E2E — compaction triggers and history is preserved
+
+**Files:**
+- Create: `backend/tests/e2e/test_conversation_compaction.py`
+
+This test verifies the **full pipeline**:
+- A long conversation crosses the configured threshold
+- After the next turn, `state.compaction.summary` is non-empty
+- The conversation messages API still returns the **complete original history**
+
+The test enables compaction via env var override (so we don't flip global config).
+
+- [ ] **Step 1: Write the test**
+
+Create `backend/tests/e2e/test_conversation_compaction.py`:
+
+```python
+"""E2E: compaction triggers, summary persists, full history still surfaces."""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.asyncio
+async def test_long_conversation_triggers_compaction(
+    authed_workspace_client, monkeypatch
+):
+    """Send enough turns to push past the threshold; verify compaction state lands.
+
+    Uses the existing E2E LLM (CUBEBOX_E2E_LLM_*) for both the main agent and the
+    summarizer; sets a deliberately tiny threshold so we don't need huge inputs.
+    """
+    monkeypatch.setenv("CUBEBOX_COMPACTION__ENABLED", "true")
+    monkeypatch.setenv("CUBEBOX_COMPACTION__THRESHOLD_RATIO", "0.001")  # trigger fast
+    monkeypatch.setenv("CUBEBOX_COMPACTION__KEEP_RECENT_MESSAGES", "2")
+    monkeypatch.setenv("CUBEBOX_COMPACTION__MIN_COMPACT_MESSAGES", "2")
+
+    client, ws_id = authed_workspace_client
+    convo = await _create_conversation(client, ws_id)
+    cid = convo["id"]
+
+    for i in range(4):
+        await _send_and_drain(client, ws_id, cid, f"turn {i}: tell me a one-sentence fact")
+
+    state = await _get_thread_state(client, ws_id, cid)
+    assert state.get("compaction") is not None, "expected compaction state to be populated"
+    assert state["compaction"]["summary"], "summary text should be non-empty"
+    assert state.get("compaction_until_msg_index", 0) > 0
+
+    msgs = await _get_messages(client, ws_id, cid)
+    user_count = sum(1 for m in msgs if m["role"] == "user")
+    assert user_count == 4, f"UI history must keep all 4 user turns, got {user_count}"
+
+
+# ---- helpers ----
+
+
+async def _create_conversation(client, ws_id):
+    r = await client.post(f"/api/v1/ws/{ws_id}/conversations", json={"title": "compact"})
+    r.raise_for_status()
+    return r.json()
+
+
+async def _send_and_drain(client, ws_id, cid, text):
+    async with client.stream(
+        "POST",
+        f"/api/v1/ws/{ws_id}/conversations/{cid}/messages",
+        json={"content": text},
+    ) as r:
+        async for _ in r.aiter_lines():
+            pass
+
+
+async def _get_messages(client, ws_id, cid):
+    r = await client.get(f"/api/v1/ws/{ws_id}/conversations/{cid}/messages")
+    r.raise_for_status()
+    return r.json()["messages"]
+
+
+async def _get_thread_state(client, ws_id, cid):
+    """Read the raw langgraph thread state via the debug endpoint or test helper.
+
+    If no public endpoint exists, this helper reaches into the checkpointer
+    directly. Use the test fixture `agent_state_reader` if provided.
+    """
+    r = await client.get(f"/api/v1/ws/{ws_id}/conversations/{cid}/state")
+    r.raise_for_status()
+    return r.json()
+```
+
+- [ ] **Step 2: Check whether `/conversations/{cid}/state` exists**
+
+```bash
+grep -rn "conversations.*state\|thread.*state\|aget_state" backend/cubebox/api/ --include="*.py"
+```
+
+If no such endpoint exists, replace `_get_thread_state` with a direct checkpointer
+read using the `checkpointer` fixture from `tests/e2e/conftest.py`. Search for an
+existing fixture:
+
+```bash
+grep -n "checkpointer\|aget_state" backend/tests/e2e/conftest.py backend/tests/e2e/helpers.py 2>/dev/null
+```
+
+If neither exists, add this helper inline in the test (replacing `_get_thread_state`).
+This normalizes the `compaction` value into a dict so the rest of the test can use
+subscript access regardless of whether checkpointer returns a `CompactionSummary`
+dataclass instance or a deserialized dict:
+
+```python
+async def _get_thread_state(client, ws_id, cid):
+    from dataclasses import asdict, is_dataclass
+    from langchain_core.runnables import RunnableConfig
+    from cubebox.agents.checkpointer import get_checkpointer  # adjust to actual path
+
+    saver = await get_checkpointer()
+    cfg = RunnableConfig(configurable={"thread_id": cid})
+    snap = await saver.aget(cfg)
+    values = snap["channel_values"] if snap else {}
+    comp = values.get("compaction")
+    if is_dataclass(comp):
+        values = {**values, "compaction": asdict(comp)}
+    return values
+```
+
+(Reviewer: if `get_checkpointer` is not the correct accessor, swap for the
+project's actual API — see `backend/cubebox/agents/checkpointer.py`.)
+
+- [ ] **Step 3: Run the test**
+
+```bash
+cd /home/chris/cubebox/backend && uv run pytest tests/e2e/test_conversation_compaction.py::test_long_conversation_triggers_compaction -v -s
+```
+
+Expected: PASS. If it fails because of fixture name (`authed_workspace_client`),
+locate the actual fixture name in `tests/e2e/conftest.py` (search
+`pytest_asyncio.fixture` and `def *_client`) and swap.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/e2e/test_conversation_compaction.py
+git commit -m "test(compaction): e2e — long convo triggers compaction, full history preserved"
+```
+
+---
+
+## Task 9: E2E — summary persists across turns (no recompute)
+
+**Files:**
+- Modify: `backend/tests/e2e/test_conversation_compaction.py`
+
+- [ ] **Step 1: Add the test**
+
+Append to `test_conversation_compaction.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_summary_persists_across_turns(authed_workspace_client, monkeypatch):
+    """Once compaction lands, a follow-up turn whose new content is small must NOT
+    re-summarize (compaction_until_msg_index should advance only when needed).
+    """
+    monkeypatch.setenv("CUBEBOX_COMPACTION__ENABLED", "true")
+    monkeypatch.setenv("CUBEBOX_COMPACTION__THRESHOLD_RATIO", "0.001")
+    monkeypatch.setenv("CUBEBOX_COMPACTION__KEEP_RECENT_MESSAGES", "2")
+    monkeypatch.setenv("CUBEBOX_COMPACTION__MIN_COMPACT_MESSAGES", "2")
+
+    client, ws_id = authed_workspace_client
+    convo = await _create_conversation(client, ws_id)
+    cid = convo["id"]
+
+    for i in range(4):
+        await _send_and_drain(client, ws_id, cid, f"turn {i}: one-line fact")
+
+    s1 = await _get_thread_state(client, ws_id, cid)
+    summary_v1 = s1["compaction"]["summary"]
+    until_v1 = s1["compaction_until_msg_index"]
+
+    await _send_and_drain(client, ws_id, cid, "tiny follow-up")
+
+    s2 = await _get_thread_state(client, ws_id, cid)
+    summary_v2 = s2["compaction"]["summary"]
+    until_v2 = s2["compaction_until_msg_index"]
+
+    # Either summary is byte-identical (no recompute), or boundary advanced because
+    # the new turn pushed total tokens further past threshold. The forbidden case is
+    # boundary advancing without summary changing — guard the "stable summary"
+    # invariant when boundary did NOT move:
+    if until_v2 == until_v1:
+        assert summary_v2 == summary_v1, "summary changed without boundary moving"
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+cd /home/chris/cubebox/backend && uv run pytest tests/e2e/test_conversation_compaction.py::test_summary_persists_across_turns -v -s
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/tests/e2e/test_conversation_compaction.py
+git commit -m "test(compaction): e2e — summary persists when boundary unchanged"
+```
+
+---
+
+## Task 10: E2E — tool boundary safety + citation marker preservation
+
+**Files:**
+- Modify: `backend/tests/e2e/test_conversation_compaction.py`
+
+- [ ] **Step 1: Add the test**
+
+Append:
+
+```python
+@pytest.mark.asyncio
+async def test_compaction_preserves_citation_markers_and_tool_pairs(
+    authed_workspace_client, monkeypatch
+):
+    """Force a tool-using conversation, then trigger compaction; verify:
+      1. summary text contains at least one 【N-K】 marker preserved verbatim
+      2. saved state has no orphan ToolMessage in the kept window
+      3. the messages API still surfaces all original citations[] arrays
+    """
+    monkeypatch.setenv("CUBEBOX_COMPACTION__ENABLED", "true")
+    monkeypatch.setenv("CUBEBOX_COMPACTION__THRESHOLD_RATIO", "0.001")
+    monkeypatch.setenv("CUBEBOX_COMPACTION__KEEP_RECENT_MESSAGES", "2")
+    monkeypatch.setenv("CUBEBOX_COMPACTION__MIN_COMPACT_MESSAGES", "2")
+
+    client, ws_id = authed_workspace_client
+    convo = await _create_conversation(client, ws_id)
+    cid = convo["id"]
+
+    for i in range(3):
+        await _send_and_drain(
+            client,
+            ws_id,
+            cid,
+            f"read /etc/hostname and tell me what it says (call {i})",
+        )
+
+    state = await _get_thread_state(client, ws_id, cid)
+    assert state.get("compaction"), "expected compaction to have triggered"
+    summary = state["compaction"]["summary"]
+
+    import re
+    assert re.search(r"【\d+-\d+】", summary), \
+        "summarizer must preserve at least one 【N-K】 marker; got:\n" + summary
+
+    msgs = await _get_messages(client, ws_id, cid)
+    tool_msgs = [m for m in msgs if m["role"] == "tool"]
+    assert any(m.get("citations") for m in tool_msgs), \
+        "API response must surface citations[] on at least one ToolMessage"
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+cd /home/chris/cubebox/backend && uv run pytest tests/e2e/test_conversation_compaction.py::test_compaction_preserves_citation_markers_and_tool_pairs -v -s
+```
+
+Expected: PASS. If the marker assertion fails, the summarizer prompt may need
+tightening — strengthen the language in `summarizer.py` and rerun.
+
+- [ ] **Step 3: Run the full compaction E2E suite + lint + type-check**
+
+```bash
+cd /home/chris/cubebox/backend && uv run pytest tests/e2e/test_conversation_compaction.py -v
+cd /home/chris/cubebox/backend && uv run ruff check cubebox/middleware/compaction/ cubebox/agents/state.py
+cd /home/chris/cubebox/backend && uv run mypy cubebox/middleware/compaction/ cubebox/agents/state.py
+```
+
+Expected: 3 e2e passed; ruff and mypy clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/e2e/test_conversation_compaction.py
+git commit -m "test(compaction): e2e — citation markers preserved in summary, tool pairs intact"
+```
+
+---
+
+## Task 11: Final verification & PR
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run full backend check**
+
+```bash
+cd /home/chris/cubebox/backend && make check
+```
+
+Expected: format, lint, type-check, tests all pass.
+
+- [ ] **Step 2: Confirm default-off behavior**
+
+```bash
+cd /home/chris/cubebox/backend && uv run python -c \
+  "from cubebox.config import config; assert config.get('compaction.enabled') is False, 'must default off'; print('default-off ok')"
+```
+
+Expected: `default-off ok`.
+
+- [ ] **Step 3: Skim the diff for stray TODOs / debug prints**
+
+```bash
+git diff --stat main...HEAD
+git diff main...HEAD | grep -E "^\+.*\b(TODO|FIXME|print\()" || echo "clean"
+```
+
+Expected: `clean`.
+
+- [ ] **Step 4: Open PR**
+
+```bash
+gh pr create --title "feat(agents): conversation context compaction" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds `CompactionMiddleware`: when conversation token count crosses
+  `compaction.threshold_ratio * context_window`, compresses old turns into a
+  persistent `CompactionSummary` stored in agent state.
+- LLM input layer becomes `[SystemMessage(summary), …recent N msgs]`; the
+  storage layer (`state.messages`) is **never modified**, so UI history,
+  citations, and audit remain intact.
+- Default off (`compaction.enabled: false`) — opt-in via config / env.
+
+Spec: `docs/superpowers/specs/2026-05-08-conversation-context-compaction-design.md`
+
+## Test plan
+- [x] Unit: token approximation, safe-boundary algorithm, middleware behavior (mock LLM)
+- [x] E2E: long convo triggers compaction; full history still surfaces from messages API
+- [x] E2E: summary persists across turns when boundary unchanged
+- [x] E2E: 【N-K】 citation markers preserved in summary; tool_call/tool_result pairs intact
+- [x] `make check` clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Spec Coverage Check
+
+| Spec section | Task |
+|---|---|
+| §2 Architecture (two-layer decoupling) | Task 5 (middleware), Task 8 (E2E proof) |
+| §3 Scope decisions (middleware not graph node, in-repo CompactionSummary) | Task 1, Task 5 |
+| §4 State model (CubeboxState extension) | Task 1 |
+| §5.1 Threshold trigger | Task 5 (`abefore_model`) |
+| §5.2 Safe boundary algorithm | Task 3 |
+| §5.3 Summary generation + marker preservation prompt | Task 4, Task 10 (assertion) |
+| §5.4 Request rewrite (LLM-only view) | Task 5 (`awrap_model_call`) |
+| §5.5 State persistence via return dict | Task 5, Task 9 (E2E persistence) |
+| §6 Citation handling (no-op; preservation prompt) | Task 4, Task 10 |
+| §7 Middleware wiring & ordering | Task 7 |
+| §8 Configuration | Task 6 |
+| §9 Failure modes (summarizer fails, no safe boundary) | Task 5 (unit tests) |
+| §10 Testing matrix | Tasks 8 / 9 / 10 |
+| §11 Rollout plan | Task 11 (PR scope = "default off") |
+
+No gaps.

--- a/docs/superpowers/specs/2026-05-08-conversation-context-compaction-design.md
+++ b/docs/superpowers/specs/2026-05-08-conversation-context-compaction-design.md
@@ -1,0 +1,310 @@
+# Design: Conversation Context Compaction
+
+- **Date**: 2026-05-08
+- **Status**: DRAFT — pending review
+- **Branch**: main
+- **Related**:
+  - `backend/cubebox/agents/graph.py` — middleware stack
+  - `backend/cubebox/middleware/citations/` — 与 compaction 强耦合，需配套修
+  - `backend/cubebox/streams/run_manager.py` — citation counter seeding（前置 PR）
+
+## 1. Problem
+
+当前对话历史完全交给 LangGraph checkpointer thread state（`backend/CLAUDE.md` 明确写
+"no messages table"），每轮把整条历史回放给模型；既没有 token 计数，也没有摘要 / 裁剪
+节点。结果：
+
+1. **超长对话直接崩**。当历史超过模型 `context_window`，请求由 provider 抛 4xx，SSE
+   流以 `error` 事件结束。无降级、无截断、无提示。
+2. **长会话成本不可控**。即使没有触上限，每轮都把 N 万 token 的历史塞回去，OPEX
+   随对话长度线性增长。
+3. **没有产品语义的"前情提要"**。用户回到一个老对话时，模型既看不到过去，也没法
+   告诉用户"我看到了哪些"。
+
+目标：在不破坏"用户能看见完整历史"的体验前提下，给 LLM 看一个被压缩过的视图，
+并让 summary 跨轮持久化、不重算。
+
+## 2. Architecture（两层解耦）
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ Storage Layer — checkpointer thread state（不变）              │
+│   state.messages = [完整原始历史]                              │
+│   ├─ 前端 GET /conversations/{id}/messages 直接读取            │
+│   └─ citations / original_content / subagent_events 全部保留   │
+└────────────────────────────────────────────────────────────────┘
+                            │
+                            │  CompactionMiddleware.awrap_model_call
+                            ▼
+┌────────────────────────────────────────────────────────────────┐
+│ LLM Input Layer — request.messages（压缩视图，每次请求重建）   │
+│   request.messages = [SystemMessage(summary), …recent N msgs]  │
+│   summary 来源于 state.compaction.running_summary              │
+└────────────────────────────────────────────────────────────────┘
+```
+
+核心三条原则：
+
+- **存储层永不裁剪**。`state.messages` 是真值，前端、citations、审计、回放全部依赖它。
+- **summary 是独立 state 字段**，由 checkpointer 一并持久化；compaction 只在阈值触发
+  时重新生成，不是每轮重算。
+- **压缩仅作用于"本次 LLM 请求"**。中间件在 `awrap_model_call` 改 `request.messages`，
+  调用结束即丢弃；对其他 middleware（attachments / cost / citation 输出）透明。
+
+## 3. Scope Decisions
+
+- **采用中间件实现**，不引入新的 graph node。理由：cubebox 用 `langchain.agents.create_agent()`
+  工厂构造图；新增 graph node 要改图结构。`awrap_model_call` 是这个 repo 现成的扩展点
+  （sandbox / subagent / cost / citation 都走这套），符合架构。
+- **自定义 `CompactionSummary` dataclass**，不引入 `langmem`。三字段结构（summary 文本、
+  已纳入的消息 ID 列表、最后一条 summarized message id）足够表达滚动语义；为这点定义
+  挂一个外部依赖不划算。LangGraph state 原生支持 dataclass 序列化。
+- **subagent 不做 compaction**。subagent 短生命周期、几轮内结束；不进
+  `inherited_subagent_middleware`。
+- **summary 用独立的便宜模型**（如 Haiku 或同 provider 的 mini 系），不复用主模型。
+  独立 `LLMConfig` 项。
+- **v1 默认关闭**（`enabled: false`）。先在 dev / test 跑，灰度后再开。
+- **不动数据库 schema**。state 字段由 checkpointer 自动持久化；MVP 不新增表。
+
+## 4. State Model
+
+扩展 LangGraph agent state（`backend/cubebox/agents/state.py`）：
+
+```python
+@dataclass
+class CompactionSummary:
+    summary: str
+    summarized_message_ids: list[str] = field(default_factory=list)
+    last_summarized_message_id: str | None = None
+
+
+class CubeboxState(AgentState):
+    # 既有字段（messages 等）由 AgentState 提供
+    compaction: CompactionSummary | None = None
+    compaction_until_msg_index: int | None = None
+```
+
+字段语义：
+
+- `compaction.summary`：当前最新一份"前情提要"文本。
+- `compaction.summarized_message_ids`：已被纳入 summary 的原始消息 ID 列表，
+  用于校验和滚动（确认下一次 summarize 真的只增量新消息）。
+- `compaction_until_msg_index`：`state.messages` 中"已被 summary 覆盖的尾部下标"。
+  下次触发时只 summarize 这之后到保留窗口之间的新消息 + 旧 summary，避免重做。
+
+**前端可见性**：可选地在 `convert_to_api_messages` 里把 `state.compaction.summary`
+作为一条特殊 system 消息（带 `kind: "compaction_summary"`）暴露到 wire format
+顶部，前端展示为"前情提要"折叠块。MVP 可以不做，原始历史已足够。
+
+## 5. Compaction Algorithm
+
+### 5.1 触发判定
+
+在 `abefore_model` 入口：
+
+1. 构造**"即将发送给 LLM 的视图"**（`compressed_view`）：
+   - 若已有 `state.compaction` 且 `compaction_until_msg_index > 0`：
+     `[SystemMessage(summary_prefix + summary)] + state.messages[boundary:]`
+   - 否则：`state.messages` 原样。
+2. `tokens = approx_tokens(compressed_view)`（用 `count_tokens_approximately`，
+   开启 `use_usage_metadata_scaling=True`，并用 `chars_per_token=2.0` 兜底冷启动）。
+3. `threshold = model.context_window * threshold_ratio`（默认 0.7）。
+4. `tokens < threshold` → 不动 state，直接放行。
+
+**为什么不直接量 `state.messages`**：
+
+- 量"即将发送的视图"才是触发判断真正要回答的问题——"下一次调用会不会爆 context"。
+- 若量原始历史，会在 summary 已经把对话压回安全区间后仍然超阈值，每轮无谓
+  re-summarize，浪费 summary 模型成本。
+- `use_usage_metadata_scaling` 用最近一条 AIMessage 的真实 `usage_metadata.total_tokens`
+  做缩放校准；该 metadata 反映的是上一次调用时 LLM 实际看到的输入(也是压缩视图)。
+  如果我们的近似分母在原始历史上算，分子分母不可比，scale_factor 会被钳到 1.0 失效。
+  量同一个视图 → scaling 真正生效。
+
+`awrap_model_call` 安装请求时同样调用 `compressed_view(state)`，与触发判定使用一致的
+逻辑（封装在 `_compressed_view` helper 里）。
+
+### 5.2 边界选择（safe boundary）
+
+**目标**：找到 `boundary` 使得 `messages[boundary:]` 是"保留区间"，
+`messages[:boundary]` 是"待压缩区间"。
+
+约束：
+
+1. **保留窗口下限**：`boundary <= len(messages) - keep_recent_messages`。
+2. **从 HumanMessage 起头**：`messages[boundary]` 必须是 `HumanMessage`，否则向前
+   推到最近的 `HumanMessage`。这是 langmem #111 的根本修法。
+3. **不切割 tool_call ↔ tool_result 配对**：`messages[boundary:]` 中所有
+   `ToolMessage.tool_call_id` 必须能在保留区间内的 `AIMessage.tool_calls` 中找到
+   对应项。否则继续向前推。
+4. **下限保护**：若推到 0 仍不安全（极端情况），本次跳过 compaction，让请求按原样
+   发出（可能会因 context overflow 失败，但不会因为 boundary 不合法而崩在中间件）。
+
+### 5.3 Summary 生成
+
+```
+input  = [existing summary?] + messages[compaction_until_msg_index : boundary]
+output = new CompactionSummary(summary=…, summarized_message_ids=[…])
+```
+
+Summarizer prompt 必须包含：
+
+- 用一段连续叙事保留事实、用户目标、已做的决定、未决问题。
+- **逐字保留所有 `【N-K】` citation 标记**，不重新编号、不合并、不丢弃。
+- 不复述长 tool 输出原文，引用其 citation 标记代替。
+- 输出语言跟随原对话主语言。
+
+### 5.4 请求改写
+
+```python
+request.messages = _compressed_view(state)
+# 等价于：
+# [SystemMessage(content=SUMMARY_PREFIX + state.compaction.summary),
+#  *state.messages[state.compaction_until_msg_index:]]
+```
+
+只改 `request.messages`，**不改 `state.messages`**。`_compressed_view` 与 §5.1 触发
+判定用的是同一个 helper，保证"度量的视图"和"实际发送的视图"一致。
+
+### 5.5 State 更新
+
+`awrap_model_call` 返回时，把新 summary 通过 result state update 写回：
+
+```python
+return {
+    **handler_result,
+    "compaction": new_summary,
+    "compaction_until_msg_index": boundary,
+}
+```
+
+LangGraph checkpointer 自动持久化。下次 turn 加载时，summary 已经在
+`state.compaction` 里，**不再重算**——除非 token 又超阈值，且这次只 summarize
+"上次 boundary 到这次 boundary"之间的新增消息。
+
+## 6. Citation Handling（与 CitationMiddleware 协同）
+
+### 6.1 计数器跨 turn 单调性（已在主干修好，复述以备参考）
+
+`run_manager.py:651` 在每次 SSE 请求构造 agent 之后立即执行：
+
+```python
+citation_counter._next = await _recover_next_citation_id(agent, conversation_id)
+```
+
+`_recover_next_citation_id`（同文件 :179）通过 `agent.aget_state()` 拉到
+checkpointer 里的完整 `state.messages`，正则扫描所有 `【N-K】` 标记取 max + 1。
+因 CitationMiddleware 直接把标记写进 `ToolMessage.content`（`citations/middleware.py:150,157`），
+扫描能命中所有历史 ID。
+
+Compaction 不破坏这个机制：我们**不删除** `state.messages` 中的任何消息，
+原始 `ToolMessage.content` 中的 `【N-K】` 标记永远在，counter 始终能恢复出
+正确起点。所以 compaction 不需要为 citation 计数器做任何额外工作。
+
+### 6.2 Summary 中的标记保留
+
+Summarizer prompt 里硬性要求"逐字保留 `【N-K】`"。落地后：
+
+- 前端拿到 summary 文本（不论作为前情提要展示，还是仅作为 LLM 内部使用），
+  其中的 `【N-K】` 标记仍能反查到 `state.messages` 里对应的 `ToolMessage.citations[]`，
+  链接可点。
+- 主 LLM 想在新回答里再引用旧来源，写 `【7-3】` 即可，前端解析逻辑不变。
+
+### 6.3 不需要做的事
+
+- 不重新分配 citation ID（标签语义，非序号）。
+- 不把 chunk 内容内联进 summary（会爆炸）。
+- 不改 `convert_to_api_messages`：原始 `citations` 数组随 `state.messages` 自然出到前端。
+- 不改 `original_content` 路径：CitationMiddleware 把改写前的原文存在
+  `additional_kwargs["original_content"]`，compaction 不动它。
+
+## 7. Middleware Wiring
+
+`backend/cubebox/agents/graph.py` 中插入位置：
+
+```
+TimestampMiddleware
+CitationMiddleware                ← 不动；只 append system prompt，无副作用
+SandboxMiddleware
+ArtifactMiddleware
+SkillsMiddleware
+TodoListMiddleware
+CompactionMiddleware              ← 新增
+SubAgentMiddleware                ← Compaction 必须在它之前（subagent 不继承）
+AttachmentHintMiddleware          ← 看到的是已压缩 messages，不漏 attachment hint
+CostMiddleware
+```
+
+- `CompactionMiddleware` **不进** `inherited_subagent_middleware`。
+- 顺序约束：必须在 `SubAgentMiddleware` 之前，且在 `AttachmentHintMiddleware` 之前。
+- 只在 `enabled=true` 且 `_config.compaction.summary_model` 配置存在时挂载，
+  否则跳过实例化（避免 dev 环境强依赖额外模型 key）。
+
+## 8. Configuration
+
+`backend/config.yaml`：
+
+```yaml
+compaction:
+  enabled: false
+  summary_model: anthropic/claude-haiku-4-5    # 或 deepseek/deepseek-chat
+  threshold_ratio: 0.7
+  keep_recent_messages: 8
+  max_summary_tokens: 1024
+```
+
+环境变量覆盖（dynaconf 标准 `CUBEBOX_COMPACTION__*`）。
+
+## 9. Failure Modes & Edge Cases
+
+| 场景 | 处理 |
+|---|---|
+| Summarizer 调用失败 | 本次跳过 compaction，按原 messages 发出（可能 context overflow，但比中间件崩好）。Log warn。 |
+| 边界推到 0 仍不安全 | 同上，跳过本次。 |
+| 模型 `context_window` 未知 | 退到固定阈值（如 `64_000`）。Log warn 一次。 |
+| 用户在压缩后追加超长附件 | 下次请求重新进入 5.1，可能再次触发，summary 再次滚动。正常路径。 |
+| 历史里全是 tool_call/tool_result 没 HumanMessage | 5.2 约束 2 推到 0；走"跳过"路径。极少见。 |
+| Subagent 误触发压缩 | 不可能——`CompactionMiddleware` 不在继承列表里。 |
+
+## 10. Testing
+
+`backend/tests/e2e/test_conversation_compaction.py`：
+
+1. **触发**：构造长对话超阈值 → 下一 turn 后 `state.compaction.summary` 非空、
+   `compaction_until_msg_index` 合法。
+2. **不丢历史**：API `GET /conversations/{id}/messages` 返回完整原始历史，
+   含全部 `citations` 字段。
+3. **LLM 实际看到的是压缩版**：用一个测试用 recording middleware 捕获
+   `request.messages`，断言首条是 `SystemMessage(summary)` 后跟保留窗口。
+4. **持久化**：重新打开 thread，summary 仍在；不重新生成 summary（断言
+   summarizer 模型未被再次调用）。
+5. **Tool 边界**：构造一个切分点正好落在 `tool_call/tool_result` 之间的对话，
+   断言保留区间内所有 `tool_call_id` 都有对应 `AIMessage.tool_calls`。
+6. **Citation 标记保留**：summary 文本中包含原对话出现过的至少一个 `【N-K】` 标记。
+7. **跨 turn citation ID 不撞号**（前置 PR 的回归测试，独立用例）：连续 3 个
+   turn 各触发一次 tool，所有 citation_id 唯一。
+
+## 11. Rollout Plan
+
+1. **PR-1**：`CompactionMiddleware` 实现 + 单测（mock LLM，覆盖阈值 / 边界 / tool 配对）。
+2. **PR-2**：接入 `graph.py` + 配置项 + E2E（默认 off）。
+3. **PR-3**：dev / test 环境开启 `enabled: true`，跑一周观察。
+4. **PR-4**：生产灰度，按 workspace 开。
+
+## 12. Open Questions
+
+- **Summary 模型选型**：Haiku 4.5 vs. provider 自家便宜小模型？需要对比成本和
+  压缩质量。建议 PR-2 时跑一组真实长对话基准。
+- **`keep_recent_messages` 默认值**：8（约 4 轮）够不够？工具调用密集会话可能要
+  12+。可灰度时观察。
+- **前端是否展示 summary**：MVP 不暴露；后续若产品确认要"前情提要"折叠块，
+  在 `convert_to_api_messages` 加一条特殊 system 消息即可，不影响后端核心。
+- **多模态 / image 在历史中的占用**：`approx_tokens` 对 image 估算粗糙；未来
+  multimodal 长对话可能需要单独的 image-aware token 计数。当前不阻塞。
+
+## 13. Non-Goals
+
+- 长期记忆（跨 thread 的事实抽取 / 用户画像）——属于 long-term memory，另立项。
+- 向量召回历史片段——属于 RAG-style memory，不在 compaction 范围。
+- 自动 thread 分裂 / 续聊——产品决策，不在本 spec。
+- 修改 checkpointer 存储后端 / schema。


### PR DESCRIPTION
## Summary

- Adds `CompactionMiddleware` (`backend/cubebox/middleware/compaction/`) that compresses old turns into a persistent `CompactionSummary` once the conversation crosses `compaction.threshold_ratio * context_window`.
- Two-layer architecture: `state.messages` is **never modified** (UI / citations / audit unchanged), while `request.messages` is projected to `[SystemMessage(summary), …recent N msgs]` per LLM call. Summary lives on agent state, persisted by the LangGraph checkpointer.
- `abefore_model` decides when to compact; `awrap_model_call` installs the compressed view. Both share `_compressed_view(state)` so the threshold check measures the same view that gets sent — preventing needless re-compaction on stable conversations and keeping `usage_metadata` self-scaling accurate.
- **Default off** (`compaction.enabled: false`); opt-in via config / env.

Spec: `docs/superpowers/specs/2026-05-08-conversation-context-compaction-design.md`
Plan: `docs/superpowers/plans/2026-05-08-conversation-context-compaction.md`

## Design highlights

- `safe_boundary` algorithm honors three constraints: keep_recent window minimum, boundary lands on `HumanMessage` (turn start), no orphan `ToolMessage` in the kept suffix.
- Summarizer prompt explicitly preserves `【N-K】` citation markers verbatim so the frontend can still resolve them against the unchanged `state.messages`.
- `CitationCounter` cross-turn monotonicity (already fixed in `run_manager.py:651` via `_recover_next_citation_id`) is unaffected — compaction never deletes original `ToolMessage` content carrying the markers.
- `CompactionMiddleware` declares `state_schema = CubeboxState` so the new state keys are persisted by the checkpointer instead of silently dropped.
- Subagents do NOT inherit compaction (short-lived; never accumulate enough history).

## Test plan

- [x] Unit (20 tests): token approximation, safe-boundary algorithm (8 cases inc. tool-pair safety), CompactionMiddleware (7 cases inc. no-recompact-when-fits, summarizer-failure fallback, view projection).
- [x] E2E `test_long_conversation_triggers_compaction`: long convo trips threshold; `state.compaction.summary` populated; full history still surfaces from `GET /messages`.
- [x] E2E `test_summary_stable_when_boundary_unchanged`: tiny follow-up doesn't move boundary → summary text byte-identical.
- [x] E2E `test_compaction_keeps_tool_pairs_intact`: tool-using conversation; kept suffix contains no orphan `ToolMessage`.
- [x] `make check` (ruff format + lint + mypy strict) clean.
- [x] Existing `test_conversation_flow.py` regression-checked (compaction default off → no behavior change).
- [ ] CI: full E2E suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)