### PR TITLE
feat(llm): fix Anthropic API provider integration

### DIFF
--- a/backend/cubebox/agents/stream.py
+++ b/backend/cubebox/agents/stream.py
@@ -71,7 +71,7 @@ def convert_messages_chunk(
         content = getattr(msg, "content", "") or ""
         additional_kwargs = getattr(msg, "additional_kwargs", {}) or {}
 
-    # Reasoning content
+    # Reasoning content — OpenAI-compatible path puts it in additional_kwargs
     reasoning_content = (additional_kwargs or {}).get("reasoning_content", "")
     if reasoning_content:
         events.append(
@@ -82,6 +82,29 @@ def convert_messages_chunk(
                 "agent_id": agent_id,
             }
         )
+
+    # ChatAnthropic returns content as a list of typed blocks:
+    #   [{"type": "thinking", "thinking": "..."}, {"type": "text", "text": "..."}]
+    # Split into reasoning and text parts before emitting events.
+    text_content: str = ""
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+            if btype == "thinking" and block.get("thinking"):
+                events.append(
+                    {
+                        "type": "reasoning",
+                        "timestamp": timestamp,
+                        "data": {"content": block["thinking"]},
+                        "agent_id": agent_id,
+                    }
+                )
+            elif btype == "text" and block.get("text"):
+                text_content += block["text"]
+    elif isinstance(content, str):
+        text_content = content
 
     # Determine message type so we only emit text from AI responses.
     # SystemMessages injected by middleware (e.g. guard corrections) and
@@ -99,13 +122,13 @@ def convert_messages_chunk(
     ) or {}
 
     # Text content (only AI messages — skip system/tool/human)
-    if content and msg_type in ("ai", "AIMessageChunk"):
+    if text_content and msg_type in ("ai", "AIMessageChunk"):
         events.append(
             {
                 "type": "text_delta",
                 "timestamp": timestamp,
                 "data": {
-                    "content": content,
+                    "content": text_content,
                     "usage": {
                         "input_tokens": usage_metadata.get("input_tokens", 0),
                         "output_tokens": usage_metadata.get("output_tokens", 0),

--- a/backend/cubebox/llm/factory.py
+++ b/backend/cubebox/llm/factory.py
@@ -489,13 +489,20 @@ class LLMFactory:
                 anthropic_kwargs["base_url"] = provider_config.base_url
             if extra_headers:
                 anthropic_kwargs["default_headers"] = extra_headers
-            if model_config.reasoning and not reasoning_config:
+
+            enable_thinking = False
+            if reasoning_config:
+                anthropic_kwargs["thinking"] = reasoning_config
+                enable_thinking = True
+            elif model_config.reasoning and final_max > 1024:
                 anthropic_kwargs["thinking"] = {
                     "type": "enabled",
-                    "budget_tokens": max(1024, final_max - 1),
+                    "budget_tokens": final_max - 1,
                 }
-            elif reasoning_config:
-                anthropic_kwargs["thinking"] = reasoning_config
+                enable_thinking = True
+
+            if enable_thinking:
+                anthropic_kwargs.pop("temperature", None)
             if extra_body:
                 anthropic_kwargs["model_kwargs"] = {"extra_body": extra_body}
 

--- a/backend/cubebox/llm/factory.py
+++ b/backend/cubebox/llm/factory.py
@@ -476,19 +476,30 @@ class LLMFactory:
         if provider_config.api == "anthropic":
             from langchain_anthropic import ChatAnthropic
 
+            final_max = max_tokens or model_config.max_tokens or 4096
             anthropic_kwargs: dict[str, Any] = {
                 "model": model_config.id,
                 "api_key": provider_config.api_key,
                 "streaming": True,
                 "stream_usage": True,
-                "temperature": kwargs.get("temperature", 0.0),
-                "max_tokens": kwargs.get("max_tokens", model_config.max_tokens or 4096),
+                "temperature": temperature,
+                "max_tokens": final_max,
             }
             if provider_config.base_url:
                 anthropic_kwargs["base_url"] = provider_config.base_url
             if extra_headers:
                 anthropic_kwargs["default_headers"] = extra_headers
+            if model_config.reasoning and not reasoning_config:
+                anthropic_kwargs["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": max(1024, final_max - 1),
+                }
+            elif reasoning_config:
+                anthropic_kwargs["thinking"] = reasoning_config
+            if extra_body:
+                anthropic_kwargs["model_kwargs"] = {"extra_body": extra_body}
 
+            anthropic_kwargs.update(kwargs)
             anthropic_llm = ChatAnthropic(**anthropic_kwargs)
 
             # Attach cubebox metadata for CostMiddleware to read.

--- a/backend/tests/unit/llm/test_factory_anthropic.py
+++ b/backend/tests/unit/llm/test_factory_anthropic.py
@@ -16,8 +16,7 @@ from cubebox.llm.config import LLMConfig, ModelConfig, ModelCost, ProviderConfig
 from cubebox.llm.factory import LLMFactory
 
 
-def _build_config() -> LLMConfig:
-    """Minimal LLMConfig with a single Anthropic provider."""
+def _build_config(*, reasoning: bool = False, max_tokens: int = 4096) -> LLMConfig:
     return LLMConfig(
         default_model="anthropic-test/claude-test",
         providers={
@@ -29,8 +28,9 @@ def _build_config() -> LLMConfig:
                     ModelConfig(
                         id="claude-test",
                         name="Claude Test",
+                        reasoning=reasoning,
                         context_window=200000,
-                        max_tokens=4096,
+                        max_tokens=max_tokens,
                         cost=ModelCost(
                             input=3.0,
                             output=15.0,
@@ -50,7 +50,6 @@ async def test_factory_builds_chat_anthropic_for_anthropic_api() -> None:
     llm = factory.create("claude-test", provider_name="anthropic-test")
 
     assert isinstance(llm, ChatAnthropic)
-    # Cubebox metadata must round-trip for CostMiddleware
     assert getattr(llm, "_cubebox_provider", None) == "anthropic-test"
     assert getattr(llm, "_cubebox_model_id", None) == "claude-test"
     assert getattr(llm, "_cubebox_model_cost", None) is not None
@@ -61,23 +60,52 @@ async def test_factory_passes_base_url_and_api_key() -> None:
     factory = LLMFactory(llm_config=_build_config())
     llm = factory.create("claude-test", provider_name="anthropic-test")
 
-    # ChatAnthropic stores base_url under different attr names depending on
-    # version; check both.
     base_url: Any = getattr(llm, "anthropic_api_url", None) or getattr(llm, "base_url", None)
     assert base_url and "example.invalid" in str(base_url)
 
 
 @pytest.mark.asyncio
+async def test_factory_forwards_temperature() -> None:
+    factory = LLMFactory(llm_config=_build_config())
+    llm = factory.create("claude-test", provider_name="anthropic-test", temperature=0.5)
+    assert isinstance(llm, ChatAnthropic)
+    assert llm.temperature == 0.5
+
+
+@pytest.mark.asyncio
+async def test_factory_forwards_max_tokens() -> None:
+    factory = LLMFactory(llm_config=_build_config(max_tokens=8192))
+    llm = factory.create("claude-test", provider_name="anthropic-test", max_tokens=2048)
+    assert isinstance(llm, ChatAnthropic)
+    assert llm.max_tokens == 2048
+
+
+@pytest.mark.asyncio
+async def test_factory_enables_thinking_for_reasoning_model() -> None:
+    factory = LLMFactory(llm_config=_build_config(reasoning=True, max_tokens=12000))
+    llm = factory.create("claude-test", provider_name="anthropic-test")
+
+    assert isinstance(llm, ChatAnthropic)
+    assert llm.thinking is not None
+    assert llm.thinking["type"] == "enabled"
+    assert llm.thinking["budget_tokens"] == 11999
+
+
+@pytest.mark.asyncio
+async def test_factory_reasoning_config_overrides_auto_thinking() -> None:
+    factory = LLMFactory(llm_config=_build_config(reasoning=True))
+    custom = {"type": "enabled", "budget_tokens": 500}
+    llm = factory.create("claude-test", provider_name="anthropic-test", reasoning_config=custom)
+    assert isinstance(llm, ChatAnthropic)
+    assert llm.thinking == custom
+
+
+@pytest.mark.asyncio
 async def test_factory_wraps_anthropic_with_cache_markers() -> None:
-    """The Anthropic branch must apply cache_control via _wrap_with_cache_markers."""
     factory = LLMFactory(llm_config=_build_config())
     llm = factory.create("claude-test", provider_name="anthropic-test")
 
-    # _wrap_with_cache_markers patches `_agenerate` in-place. The patched
-    # method's qualname includes "patched_agenerate" or has been replaced.
     agenerate = llm._agenerate  # type: ignore[attr-defined]
-    assert agenerate.__name__ in {"patched_agenerate", "_agenerate"}
-    # If it's still _agenerate, cache markers were not applied.
     assert agenerate.__name__ == "patched_agenerate", (
         "factory must wrap Anthropic models with _wrap_with_cache_markers"
     )

--- a/backend/tests/unit/llm/test_factory_anthropic.py
+++ b/backend/tests/unit/llm/test_factory_anthropic.py
@@ -92,6 +92,25 @@ async def test_factory_enables_thinking_for_reasoning_model() -> None:
 
 
 @pytest.mark.asyncio
+async def test_factory_drops_temperature_when_thinking_enabled() -> None:
+    factory = LLMFactory(llm_config=_build_config(reasoning=True, max_tokens=12000))
+    llm = factory.create("claude-test", provider_name="anthropic-test", temperature=0.7)
+    assert isinstance(llm, ChatAnthropic)
+    assert llm.thinking is not None
+    # Anthropic requires temperature unset (defaults to 1) with thinking
+    assert llm.temperature is None or llm.temperature == 1
+
+
+@pytest.mark.asyncio
+async def test_factory_skips_thinking_when_max_tokens_too_small() -> None:
+    factory = LLMFactory(llm_config=_build_config(reasoning=True, max_tokens=1024))
+    llm = factory.create("claude-test", provider_name="anthropic-test")
+
+    assert isinstance(llm, ChatAnthropic)
+    assert llm.thinking is None
+
+
+@pytest.mark.asyncio
 async def test_factory_reasoning_config_overrides_auto_thinking() -> None:
     factory = LLMFactory(llm_config=_build_config(reasoning=True))
     custom = {"type": "enabled", "budget_tokens": 500}

--- a/backend/tests/unit/test_stream_converter.py
+++ b/backend/tests/unit/test_stream_converter.py
@@ -87,6 +87,47 @@ def test_system_message_not_emitted_as_text_delta() -> None:
     assert len(text_events) == 0
 
 
+def test_anthropic_thinking_block_emits_reasoning_event() -> None:
+    """ChatAnthropic thinking blocks (list content) produce reasoning events."""
+    msg = AIMessageChunk(
+        content=[{"type": "thinking", "thinking": "Let me think...", "index": 0}],
+    )
+    events = convert_messages_chunk((msg, {}))
+    reasoning = [e for e in events if e["type"] == "reasoning"]
+    text = [e for e in events if e["type"] == "text_delta"]
+    assert len(reasoning) == 1
+    assert reasoning[0]["data"]["content"] == "Let me think..."
+    assert len(text) == 0
+
+
+def test_anthropic_text_block_emits_text_delta() -> None:
+    """ChatAnthropic text blocks (list content) produce text_delta events."""
+    msg = AIMessageChunk(
+        content=[{"type": "text", "text": "Hello!", "index": 1}],
+    )
+    events = convert_messages_chunk((msg, {}))
+    text = [e for e in events if e["type"] == "text_delta"]
+    assert len(text) == 1
+    assert text[0]["data"]["content"] == "Hello!"
+
+
+def test_anthropic_mixed_thinking_and_text_blocks() -> None:
+    """Both thinking and text blocks in one chunk are split correctly."""
+    msg = AIMessageChunk(
+        content=[
+            {"type": "thinking", "thinking": "step 1", "index": 0},
+            {"type": "text", "text": "answer", "index": 1},
+        ],
+    )
+    events = convert_messages_chunk((msg, {}))
+    reasoning = [e for e in events if e["type"] == "reasoning"]
+    text = [e for e in events if e["type"] == "text_delta"]
+    assert len(reasoning) == 1
+    assert reasoning[0]["data"]["content"] == "step 1"
+    assert len(text) == 1
+    assert text[0]["data"]["content"] == "answer"
+
+
 def test_convert_updates_chunk_includes_tool_call_started_at() -> None:
     msg = AIMessage(
         content="",


### PR DESCRIPTION
## Summary
- Fix temperature/max_tokens not being forwarded to `ChatAnthropic` (temperature always defaulted to 0.0, max_tokens always fell back to model config)
- Auto-enable `thinking` for reasoning models (`model_config.reasoning=True`) with `budget_tokens = max_tokens - 1`
- Support `reasoning_config` override and `extra_body` passthrough for the anthropic branch
- Handle `ChatAnthropic`'s list-of-dicts content blocks in stream converter: `{type: "thinking"}` blocks emit as `reasoning` events, `{type: "text"}` blocks emit as `text_delta` events

## Test plan
- [x] Unit tests: 7 factory tests (builds ChatAnthropic, forwards base_url/api_key, temperature, max_tokens, auto-thinking, reasoning_config override, cache markers)
- [x] Unit tests: 3 new stream converter tests (thinking block → reasoning event, text block → text_delta, mixed blocks)
- [x] Live-tested with DeepSeek V4 Pro via `https://api.deepseek.com/anthropic` — reasoning streams correctly, text answers come through
- [x] All 419 unit tests pass, lint/mypy clean