### PR TITLE
fix(llm): persist provider api type through DB seed and load

### DIFF
--- a/backend/cubebox/llm/factory.py
+++ b/backend/cubebox/llm/factory.py
@@ -21,6 +21,21 @@ from cubebox.llm.openai_compatible import ChatOpenAICompatible
 
 logger = logging.getLogger(__name__)
 
+_PROVIDER_TYPE_TO_API: dict[str, str] = {
+    "openai_compat": "openai-completions",
+    "anthropic": "anthropic",
+}
+
+_API_TO_PROVIDER_TYPE: dict[str, str] = {v: k for k, v in _PROVIDER_TYPE_TO_API.items()}
+
+
+def _provider_type_to_api(provider_type: str) -> str:
+    return _PROVIDER_TYPE_TO_API.get(provider_type, "openai-completions")
+
+
+def api_to_provider_type(api: str) -> str:
+    return _API_TO_PROVIDER_TYPE.get(api, "openai_compat")
+
 
 def _wrap_with_cache_markers(model: BaseChatModel, *, provider_kind: ProviderKind) -> BaseChatModel:
     """Patch the model so every async generation pass-through inserts
@@ -144,7 +159,7 @@ class LLMFactory:
             db_configs[p.name] = {
                 "base_url": p.base_url,
                 "api_key": api_key,
-                "api": "openai-completions",
+                "api": _provider_type_to_api(p.provider_type),
                 "extra_body": p.extra_body,
                 "extra_headers": p.extra_headers,
                 "models": [

--- a/backend/cubebox/seeders/provider_seeder.py
+++ b/backend/cubebox/seeders/provider_seeder.py
@@ -102,8 +102,10 @@ async def seed_system_providers_from_config(
         )
         provider: Provider | None = existing.scalar_one_or_none()
 
+        from cubebox.llm.factory import api_to_provider_type
+
         base_url: str = str(cfg_dict.get("base_url", ""))
-        provider_type: str = "openai_compat"
+        provider_type: str = api_to_provider_type(str(cfg_dict.get("api", "openai-completions")))
 
         if provider is None:
             provider = Provider(

--- a/backend/cubebox/services/provider_service.py
+++ b/backend/cubebox/services/provider_service.py
@@ -315,20 +315,34 @@ class ProviderService:
         """Test reachability of a specific model on a provider using stored credentials."""
         start = time.monotonic()
         provider = await self.get_provider(provider_id)
-        if provider.provider_type != "openai_compat":
-            return TestResultOut(
-                ok=False,
-                error=f"Unsupported provider_type: {provider.provider_type}",
-                latency_ms=0,
-            )
         api_key = await self._resolve_api_key(provider)
         try:
-            llm = ChatOpenAICompatible(
-                base_url=provider.base_url,
-                api_key=api_key or "placeholder",  # type: ignore[arg-type]
-                model=model_id,
-                timeout=15,
-            )
+            from langchain_core.language_models import BaseChatModel
+
+            llm: BaseChatModel
+            if provider.provider_type == "anthropic":
+                from langchain_anthropic import ChatAnthropic
+
+                llm = ChatAnthropic(
+                    model=model_id,  # type: ignore[call-arg]
+                    base_url=provider.base_url,
+                    api_key=api_key or "placeholder",  # type: ignore[arg-type]
+                    max_tokens=32,
+                    timeout=15,
+                )
+            elif provider.provider_type == "openai_compat":
+                llm = ChatOpenAICompatible(
+                    base_url=provider.base_url,
+                    api_key=api_key or "placeholder",  # type: ignore[arg-type]
+                    model=model_id,
+                    timeout=15,
+                )
+            else:
+                return TestResultOut(
+                    ok=False,
+                    error=f"Unsupported provider_type: {provider.provider_type}",
+                    latency_ms=0,
+                )
             await llm.ainvoke([HumanMessage(content="ping")])
             latency_ms = int((time.monotonic() - start) * 1000)
             return TestResultOut(ok=True, error=None, latency_ms=latency_ms)


### PR DESCRIPTION
## Summary
- Seeder now reads config `api` field and maps to `provider_type` (e.g. `api: anthropic` → `provider_type: "anthropic"`) instead of hardcoding `"openai_compat"`
- Factory `_load_db_provider_configs` maps `provider_type` back to the `api` field for dispatch, instead of hardcoding `"openai-completions"`
- Without this, providers configured as `api: anthropic` in config were seeded as `openai_compat` and routed to chat/completions instead of the Anthropic Messages API

This commit was part of #70 but the PR was merged before it was pushed.

## Test plan
- [x] `test_seed_idempotent` passes (default providers still seed as `openai_compat`)
- [x] All 419 unit tests pass
- [x] After re-seed, deepseek `provider_type` becomes `"anthropic"` in DB