### PR TITLE
feat: token usage info panel in chat UI

### DIFF
--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
+from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.pool import NullPool
@@ -640,42 +641,76 @@ async def get_conversation_bootstrap(
             "started_at": active_run.started_at,
         }
 
-    # --- Session-level token usage for the usage panel ---
+    # --- Token usage for the usage panel ---
     usage_summary: dict[str, object] = {
         "session": {"total_input_tokens": 0, "total_output_tokens": 0},
         "context_window": 0,
     }
     try:
-        from sqlalchemy import func, select
+        from sqlalchemy import func as sa_func
+        from sqlalchemy import select as sa_select
 
         from cubebox.models.billing import BillingEvent, LlmBillingEvent
 
-        stmt = (
-            select(
-                func.coalesce(func.sum(LlmBillingEvent.input_tokens), 0),
-                func.coalesce(func.sum(LlmBillingEvent.output_tokens), 0),
+        session_stmt = (
+            sa_select(
+                sa_func.coalesce(sa_func.sum(LlmBillingEvent.input_tokens), 0),
+                sa_func.coalesce(sa_func.sum(LlmBillingEvent.output_tokens), 0),
             )
-            .select_from(BillingEvent)
             .join(
-                LlmBillingEvent,
+                BillingEvent,
                 LlmBillingEvent.billing_event_id == BillingEvent.id,  # type: ignore[arg-type]
             )
             .where(BillingEvent.conversation_id == conversation_id)  # type: ignore[arg-type]
         )
-        row = (await session.execute(stmt)).one()
+        row = (await session.execute(session_stmt)).one()
         usage_summary["session"] = {
             "total_input_tokens": int(row[0]),
             "total_output_tokens": int(row[1]),
         }
 
+        # Last turn usage: billing events after the last user message
+        msgs: list[dict[str, Any]] = history["messages"]  # type: ignore[assignment]
+        last_user_ts: str | None = None
+        for msg in reversed(msgs):
+            if isinstance(msg, dict) and msg.get("role") == "user":
+                last_user_ts = msg.get("created_at")
+                break
+        if last_user_ts:
+            from datetime import datetime
+
+            ts_dt = datetime.fromisoformat(last_user_ts)
+            turn_stmt = (
+                sa_select(
+                    sa_func.coalesce(sa_func.sum(LlmBillingEvent.input_tokens), 0),
+                    sa_func.coalesce(sa_func.sum(LlmBillingEvent.output_tokens), 0),
+                    sa_func.coalesce(sa_func.sum(LlmBillingEvent.cache_read_tokens), 0),
+                    sa_func.coalesce(sa_func.sum(LlmBillingEvent.cache_write_tokens), 0),
+                )
+                .join(
+                    BillingEvent,
+                    LlmBillingEvent.billing_event_id == BillingEvent.id,  # type: ignore[arg-type]
+                )
+                .where(
+                    BillingEvent.conversation_id == conversation_id,  # type: ignore[arg-type]
+                    BillingEvent.started_at >= ts_dt,  # type: ignore[arg-type]
+                )
+            )
+            turn_row = (await session.execute(turn_stmt)).one()
+            usage_summary["turn"] = {
+                "input_tokens": int(turn_row[0]),
+                "output_tokens": int(turn_row[1]),
+                "cache_read_tokens": int(turn_row[2]),
+                "cache_write_tokens": int(turn_row[3]),
+            }
+
         from cubebox.llm.factory import LLMFactory
 
         factory = LLMFactory(session=session, org_id=ctx.org_id)
-        provider_name, model_id = await factory.get_default_model()
-        model_cfg = factory.get_model_config(provider_name, model_id)
+        model_cfg = await factory.get_default_model_config()
         usage_summary["context_window"] = model_cfg.context_window
     except Exception:
-        pass  # Non-critical; frontend degrades gracefully
+        logger.warning("Failed to load usage_summary for bootstrap", exc_info=True)
 
     return {
         "messages": history["messages"],

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -640,11 +640,49 @@ async def get_conversation_bootstrap(
             "started_at": active_run.started_at,
         }
 
+    # --- Session-level token usage for the usage panel ---
+    usage_summary: dict[str, object] = {
+        "session": {"total_input_tokens": 0, "total_output_tokens": 0},
+        "context_window": 0,
+    }
+    try:
+        from sqlalchemy import func, select
+
+        from cubebox.models.billing import BillingEvent, LlmBillingEvent
+
+        stmt = (
+            select(
+                func.coalesce(func.sum(LlmBillingEvent.input_tokens), 0),
+                func.coalesce(func.sum(LlmBillingEvent.output_tokens), 0),
+            )
+            .select_from(BillingEvent)
+            .join(
+                LlmBillingEvent,
+                LlmBillingEvent.billing_event_id == BillingEvent.id,  # type: ignore[arg-type]
+            )
+            .where(BillingEvent.conversation_id == conversation_id)  # type: ignore[arg-type]
+        )
+        row = (await session.execute(stmt)).one()
+        usage_summary["session"] = {
+            "total_input_tokens": int(row[0]),
+            "total_output_tokens": int(row[1]),
+        }
+
+        from cubebox.llm.factory import LLMFactory
+
+        factory = LLMFactory(session=session, org_id=ctx.org_id)
+        provider_name, model_id = await factory.get_default_model()
+        model_cfg = factory.get_model_config(provider_name, model_id)
+        usage_summary["context_window"] = model_cfg.context_window
+    except Exception:
+        pass  # Non-critical; frontend degrades gracefully
+
     return {
         "messages": history["messages"],
         "total": history["total"],
         "active_run": active_run_payload,
         "last_run_status": last_run_status,
+        "usage_summary": usage_summary,
     }
 
 

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -6,7 +6,6 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
-from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.pool import NullPool
@@ -642,75 +641,21 @@ async def get_conversation_bootstrap(
         }
 
     # --- Token usage for the usage panel ---
-    usage_summary: dict[str, object] = {
-        "session": {"total_input_tokens": 0, "total_output_tokens": 0},
-        "context_window": 0,
-    }
-    try:
-        from sqlalchemy import func as sa_func
-        from sqlalchemy import select as sa_select
+    msgs: list[dict[str, Any]] = history["messages"]  # type: ignore[assignment]
+    last_user_ts: str | None = None
+    for msg in reversed(msgs):
+        if isinstance(msg, dict) and msg.get("role") == "user":
+            last_user_ts = msg.get("created_at")
+            break
 
-        from cubebox.models.billing import BillingEvent, LlmBillingEvent
+    from cubebox.services.usage import build_usage_summary
 
-        session_stmt = (
-            sa_select(
-                sa_func.coalesce(sa_func.sum(LlmBillingEvent.input_tokens), 0),
-                sa_func.coalesce(sa_func.sum(LlmBillingEvent.output_tokens), 0),
-            )
-            .join(
-                BillingEvent,
-                LlmBillingEvent.billing_event_id == BillingEvent.id,  # type: ignore[arg-type]
-            )
-            .where(BillingEvent.conversation_id == conversation_id)  # type: ignore[arg-type]
-        )
-        row = (await session.execute(session_stmt)).one()
-        usage_summary["session"] = {
-            "total_input_tokens": int(row[0]),
-            "total_output_tokens": int(row[1]),
-        }
-
-        # Last turn usage: billing events after the last user message
-        msgs: list[dict[str, Any]] = history["messages"]  # type: ignore[assignment]
-        last_user_ts: str | None = None
-        for msg in reversed(msgs):
-            if isinstance(msg, dict) and msg.get("role") == "user":
-                last_user_ts = msg.get("created_at")
-                break
-        if last_user_ts:
-            from datetime import datetime
-
-            ts_dt = datetime.fromisoformat(last_user_ts)
-            turn_stmt = (
-                sa_select(
-                    sa_func.coalesce(sa_func.sum(LlmBillingEvent.input_tokens), 0),
-                    sa_func.coalesce(sa_func.sum(LlmBillingEvent.output_tokens), 0),
-                    sa_func.coalesce(sa_func.sum(LlmBillingEvent.cache_read_tokens), 0),
-                    sa_func.coalesce(sa_func.sum(LlmBillingEvent.cache_write_tokens), 0),
-                )
-                .join(
-                    BillingEvent,
-                    LlmBillingEvent.billing_event_id == BillingEvent.id,  # type: ignore[arg-type]
-                )
-                .where(
-                    BillingEvent.conversation_id == conversation_id,  # type: ignore[arg-type]
-                    BillingEvent.started_at >= ts_dt,  # type: ignore[arg-type]
-                )
-            )
-            turn_row = (await session.execute(turn_stmt)).one()
-            usage_summary["turn"] = {
-                "input_tokens": int(turn_row[0]),
-                "output_tokens": int(turn_row[1]),
-                "cache_read_tokens": int(turn_row[2]),
-                "cache_write_tokens": int(turn_row[3]),
-            }
-
-        from cubebox.llm.factory import LLMFactory
-
-        factory = LLMFactory(session=session, org_id=ctx.org_id)
-        model_cfg = await factory.get_default_model_config()
-        usage_summary["context_window"] = model_cfg.context_window
-    except Exception:
-        logger.warning("Failed to load usage_summary for bootstrap", exc_info=True)
+    usage_summary = await build_usage_summary(
+        session,
+        conversation_id,
+        org_id=ctx.org_id,
+        last_user_message_ts=last_user_ts,
+    )
 
     return {
         "messages": history["messages"],

--- a/backend/cubebox/llm/factory.py
+++ b/backend/cubebox/llm/factory.py
@@ -481,6 +481,7 @@ class LLMFactory:
             llm._cubebox_provider = provider_name  # type: ignore[attr-defined]
             llm._cubebox_model_id = model_config.id  # type: ignore[attr-defined]
             llm._cubebox_model_cost = model_config.cost  # type: ignore[attr-defined]
+            llm._cubebox_context_window = model_config.context_window  # type: ignore[attr-defined]
 
             # Memory system: insert Anthropic cache_control markers when applicable.
             # `provider_config.api` is the authoritative kind (set in config.yaml /
@@ -528,6 +529,7 @@ class LLMFactory:
             anthropic_llm._cubebox_provider = provider_name  # type: ignore[attr-defined]
             anthropic_llm._cubebox_model_id = model_config.id  # type: ignore[attr-defined]
             anthropic_llm._cubebox_model_cost = model_config.cost  # type: ignore[attr-defined]
+            anthropic_llm._cubebox_context_window = model_config.context_window  # type: ignore[attr-defined]
 
             provider_kind = provider_kind_from_api(provider_config.api)
             return _wrap_with_cache_markers(anthropic_llm, provider_kind=provider_kind)

--- a/backend/cubebox/llm/factory.py
+++ b/backend/cubebox/llm/factory.py
@@ -284,6 +284,14 @@ class LLMFactory:
             raise ValueError("No default_model configured")
         return self._parse_model_ref(model_ref)
 
+    async def get_default_model_config(self) -> ModelConfig:
+        """Resolve the default model's ModelConfig, merging DB configs if available."""
+        if self._session and self._org_id:
+            db_cfgs, db_names = await self._load_db_provider_configs()
+            self.llm_config = self._build_merged_config(db_cfgs, db_names)
+        provider_name, model_id = await self.get_default_model()
+        return self.get_model_config(provider_name, model_id)
+
     async def create_default(self, **kwargs: Any) -> Any:
         """
         Create an LLM instance using the configured default_model,

--- a/backend/cubebox/services/usage.py
+++ b/backend/cubebox/services/usage.py
@@ -1,0 +1,138 @@
+"""Usage aggregation service — centralises billing queries for token usage."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TypedDict
+
+from loguru import logger
+from sqlalchemy import func as sa_func
+from sqlalchemy import select as sa_select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.models.billing import BillingEvent, LlmBillingEvent
+
+
+class TurnUsage(TypedDict):
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_write_tokens: int
+
+
+class SessionUsage(TypedDict):
+    total_input_tokens: int
+    total_output_tokens: int
+    total_cache_read_tokens: int
+    total_cache_write_tokens: int
+
+
+class UsageSummary(TypedDict, total=False):
+    turn: TurnUsage
+    session: SessionUsage
+    context_window: int
+
+
+_ZERO_SESSION: SessionUsage = {
+    "total_input_tokens": 0,
+    "total_output_tokens": 0,
+    "total_cache_read_tokens": 0,
+    "total_cache_write_tokens": 0,
+}
+
+
+async def get_session_usage(
+    session: AsyncSession,
+    conversation_id: str,
+) -> SessionUsage:
+    """Sum all billing tokens for a conversation."""
+    stmt = (
+        sa_select(
+            sa_func.coalesce(sa_func.sum(LlmBillingEvent.input_tokens), 0),
+            sa_func.coalesce(sa_func.sum(LlmBillingEvent.output_tokens), 0),
+            sa_func.coalesce(sa_func.sum(LlmBillingEvent.cache_read_tokens), 0),
+            sa_func.coalesce(sa_func.sum(LlmBillingEvent.cache_write_tokens), 0),
+        )
+        .join(
+            BillingEvent,
+            LlmBillingEvent.billing_event_id == BillingEvent.id,  # type: ignore[arg-type]
+        )
+        .where(
+            BillingEvent.conversation_id == conversation_id,  # type: ignore[arg-type]
+        )
+    )
+    row = (await session.execute(stmt)).one()
+    return {
+        "total_input_tokens": int(row[0]),
+        "total_output_tokens": int(row[1]),
+        "total_cache_read_tokens": int(row[2]),
+        "total_cache_write_tokens": int(row[3]),
+    }
+
+
+async def get_turn_usage(
+    session: AsyncSession,
+    conversation_id: str,
+    *,
+    after: datetime,
+) -> TurnUsage:
+    """Sum billing tokens for one turn (events started at or after *after*)."""
+    stmt = (
+        sa_select(
+            sa_func.coalesce(sa_func.sum(LlmBillingEvent.input_tokens), 0),
+            sa_func.coalesce(sa_func.sum(LlmBillingEvent.output_tokens), 0),
+            sa_func.coalesce(sa_func.sum(LlmBillingEvent.cache_read_tokens), 0),
+            sa_func.coalesce(sa_func.sum(LlmBillingEvent.cache_write_tokens), 0),
+        )
+        .join(
+            BillingEvent,
+            LlmBillingEvent.billing_event_id == BillingEvent.id,  # type: ignore[arg-type]
+        )
+        .where(
+            BillingEvent.conversation_id == conversation_id,  # type: ignore[arg-type]
+            BillingEvent.started_at >= after,  # type: ignore[arg-type]
+        )
+    )
+    row = (await session.execute(stmt)).one()
+    return {
+        "input_tokens": int(row[0]),
+        "output_tokens": int(row[1]),
+        "cache_read_tokens": int(row[2]),
+        "cache_write_tokens": int(row[3]),
+    }
+
+
+async def build_usage_summary(
+    session: AsyncSession,
+    conversation_id: str,
+    *,
+    org_id: str,
+    last_user_message_ts: str | None = None,
+) -> UsageSummary:
+    """Build a complete usage summary for the usage panel.
+
+    Called from both the bootstrap endpoint and RunManager done event.
+    """
+    summary: UsageSummary = {
+        "session": dict(_ZERO_SESSION),  # type: ignore[typeddict-item]
+        "context_window": 0,
+    }
+    try:
+        summary["session"] = await get_session_usage(session, conversation_id)
+
+        if last_user_message_ts:
+            ts_dt = datetime.fromisoformat(last_user_message_ts)
+            summary["turn"] = await get_turn_usage(session, conversation_id, after=ts_dt)
+
+        from cubebox.llm.factory import LLMFactory
+
+        factory = LLMFactory(session=session, org_id=org_id)
+        model_cfg = await factory.get_default_model_config()
+        summary["context_window"] = model_cfg.context_window
+    except Exception:
+        logger.warning(
+            "Failed to build usage summary for conversation %s",
+            conversation_id,
+            exc_info=True,
+        )
+    return summary

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -446,6 +446,12 @@ class RunManager:
 
         tool_delta_context: dict[tuple[str | None, int], dict[str, Any]] = {}
         citation_buffers: dict[str | None, str] = {}
+        turn_usage: dict[str, int] = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        }
 
         async def emit_status(phase: str, detail: str | None = None) -> None:
             data: dict[str, str] = {"phase": phase}
@@ -500,6 +506,9 @@ class RunManager:
                 return
 
             await flush_citation_buffer(agent_key, sse_event.agent_id)
+            if sse_event.type == "usage":
+                for key in turn_usage:
+                    turn_usage[key] += sse_event.data.get(key, 0)
             await publish_event(sse_event)
 
         try:
@@ -576,6 +585,8 @@ class RunManager:
             except Exception:
                 logger.warning("LLMFactory DB load failed, falling back to config-only")
                 llm = await LLMFactory().create_default()
+            _inner = getattr(llm, "runnable", llm)
+            context_window: int = getattr(_inner, "_cubebox_context_window", 0)
             tools = get_registry().list_tools()
             try:
                 from cubebox.credentials.dependencies import build_credential_service
@@ -854,10 +865,49 @@ class RunManager:
                 run_id=run_id,
                 status="completed",
             )
+            # --- Aggregate session-level token totals ---
+            session_usage = {"total_input_tokens": 0, "total_output_tokens": 0}
+            try:
+                from sqlalchemy import func as sa_func
+                from sqlalchemy import select as sa_select
+
+                from cubebox.db.engine import async_session_maker
+                from cubebox.models.billing import BillingEvent, LlmBillingEvent
+
+                async with async_session_maker() as billing_session:
+                    row = (
+                        await billing_session.execute(
+                            sa_select(
+                                sa_func.coalesce(sa_func.sum(LlmBillingEvent.input_tokens), 0),
+                                sa_func.coalesce(sa_func.sum(LlmBillingEvent.output_tokens), 0),
+                            )
+                            .join(
+                                BillingEvent,
+                                LlmBillingEvent.billing_event_id == BillingEvent.id,  # type: ignore[arg-type]
+                            )
+                            .where(
+                                BillingEvent.conversation_id == conversation_id,  # type: ignore[arg-type]
+                            )
+                        )
+                    ).one()
+                    session_usage["total_input_tokens"] = int(row[0])
+                    session_usage["total_output_tokens"] = int(row[1])
+            except Exception:
+                logger.warning("Failed to query session usage for done event")
+
             await self._append_event(
                 run_id,
                 conversation_id,
-                DoneEvent(timestamp=datetime.now(UTC).isoformat()),
+                DoneEvent(
+                    timestamp=datetime.now(UTC).isoformat(),
+                    data={
+                        "usage": {
+                            "turn": dict(turn_usage),
+                            "session": session_usage,
+                            "context_window": context_window,
+                        }
+                    },
+                ),
             )
         except asyncio.CancelledError:
             await update_run_meta(

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -866,32 +866,19 @@ class RunManager:
                 status="completed",
             )
             # --- Aggregate session-level token totals ---
-            session_usage = {"total_input_tokens": 0, "total_output_tokens": 0}
-            try:
-                from sqlalchemy import func as sa_func
-                from sqlalchemy import select as sa_select
+            from cubebox.services.usage import SessionUsage, get_session_usage
 
+            session_usage: SessionUsage = {
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "total_cache_read_tokens": 0,
+                "total_cache_write_tokens": 0,
+            }
+            try:
                 from cubebox.db.engine import async_session_maker
-                from cubebox.models.billing import BillingEvent, LlmBillingEvent
 
                 async with async_session_maker() as billing_session:
-                    row = (
-                        await billing_session.execute(
-                            sa_select(
-                                sa_func.coalesce(sa_func.sum(LlmBillingEvent.input_tokens), 0),
-                                sa_func.coalesce(sa_func.sum(LlmBillingEvent.output_tokens), 0),
-                            )
-                            .join(
-                                BillingEvent,
-                                LlmBillingEvent.billing_event_id == BillingEvent.id,  # type: ignore[arg-type]
-                            )
-                            .where(
-                                BillingEvent.conversation_id == conversation_id,  # type: ignore[arg-type]
-                            )
-                        )
-                    ).one()
-                    session_usage["total_input_tokens"] = int(row[0])
-                    session_usage["total_output_tokens"] = int(row[1])
+                    session_usage = await get_session_usage(billing_session, conversation_id)
             except Exception:
                 logger.warning("Failed to query session usage for done event")
 

--- a/backend/tests/unit/streams/test_done_usage.py
+++ b/backend/tests/unit/streams/test_done_usage.py
@@ -1,0 +1,67 @@
+"""DoneEvent carries accumulated turn usage."""
+
+from cubebox.agents.schemas import DoneEvent, UsageEvent
+
+
+def test_done_event_accepts_usage_payload() -> None:
+    """DoneEvent.data can carry a usage dict."""
+    done = DoneEvent(
+        timestamp="2026-05-11T00:00:00Z",
+        data={
+            "usage": {
+                "turn": {
+                    "input_tokens": 200,
+                    "output_tokens": 50,
+                    "cache_read_tokens": 150,
+                    "cache_write_tokens": 30,
+                },
+                "session": {
+                    "total_input_tokens": 1000,
+                    "total_output_tokens": 400,
+                },
+                "context_window": 128000,
+            }
+        },
+    )
+    assert done.data["usage"]["turn"]["input_tokens"] == 200
+    assert done.data["usage"]["context_window"] == 128000
+
+
+def test_usage_event_accumulation() -> None:
+    """Verify that multiple UsageEvent payloads can be summed."""
+    events = [
+        UsageEvent(
+            timestamp="t1",
+            data={
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_tokens": 80,
+                "cache_write_tokens": 10,
+            },
+        ),
+        UsageEvent(
+            timestamp="t2",
+            data={
+                "input_tokens": 50,
+                "output_tokens": 30,
+                "cache_read_tokens": 40,
+                "cache_write_tokens": 5,
+            },
+        ),
+    ]
+    totals = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+    for e in events:
+        for key in totals:
+            totals[key] += e.data.get(key, 0)
+
+    assert totals == {
+        "input_tokens": 150,
+        "output_tokens": 50,
+        "cache_read_tokens": 120,
+        "cache_write_tokens": 15,
+    }

--- a/docs/superpowers/plans/2026-05-11-token-usage-panel.md
+++ b/docs/superpowers/plans/2026-05-11-token-usage-panel.md
@@ -790,7 +790,9 @@ Destructure new fields from `useMessages`:
 Add the `TokenUsageBar` after the streaming `AssistantMessage` block (after line 225, after `</AssistantMessage>`), inside the same conditional:
 
 ```tsx
-        {!isStreaming && (turnUsage || sessionUsage) && (
+        {!isStreaming &&
+          (turnUsage || sessionUsage) &&
+          (messages ?? []).some((m) => m.role === 'assistant') && (
           <div className="flex justify-start gap-2.5">
             <div className="shrink-0 w-6 h-6" />
             <div className="flex-1 max-w-[75%]">
@@ -804,7 +806,7 @@ Add the `TokenUsageBar` after the streaming `AssistantMessage` block (after line
         )}
 ```
 
-This renders the bar only when streaming is done and there is usage data, aligned with the assistant message's content column (the `w-6` spacer matches the bot icon width).
+This renders the bar only when streaming is done, there is usage data, **and** at least one assistant message exists in history (prevents phantom zero panel on empty conversations after bootstrap). Aligned with the assistant message's content column (the `w-6` spacer matches the bot icon width).
 
 - [ ] **Step 5: Build and type-check**
 

--- a/docs/superpowers/plans/2026-05-11-token-usage-panel.md
+++ b/docs/superpowers/plans/2026-05-11-token-usage-panel.md
@@ -1,0 +1,875 @@
+# Token Usage Info Panel — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show per-turn and session-level token usage (input/output tokens, cache hit rate, context window %) in a collapsible panel below the last assistant message.
+
+**Architecture:** Backend accumulates per-run usage in RunManager and attaches a summary to the `done` SSE event. Bootstrap endpoint also returns session-level totals. Frontend stores usage from `done` event and renders a collapsible `TokenUsageBar` component at the bottom of the last assistant message.
+
+**Tech Stack:** Python/FastAPI (backend), TypeScript/React/Zustand/Tailwind (frontend), SQLAlchemy for session aggregation query.
+
+**Worktree:** `/home/chris/cubebox/.worktrees/feat/token-usage-panel` (ports 8031/3031)
+
+---
+
+### Task 1: Attach `_cubebox_context_window` to LLM instances
+
+Add context window size to the metadata already attached to LLM instances by `LLMFactory.create()`, so downstream code (RunManager) can read it without re-resolving model config.
+
+**Files:**
+- Modify: `backend/cubebox/llm/factory.py:481-483` (openai-completions path) and `:528-530` (anthropic path)
+
+- [ ] **Step 1: Add `_cubebox_context_window` after existing metadata lines**
+
+In `backend/cubebox/llm/factory.py`, after line 483 (`llm._cubebox_model_cost = ...`), add:
+
+```python
+llm._cubebox_context_window = model_config.context_window  # type: ignore[attr-defined]
+```
+
+And after line 530 (`anthropic_llm._cubebox_model_cost = ...`), add:
+
+```python
+anthropic_llm._cubebox_context_window = model_config.context_window  # type: ignore[attr-defined]
+```
+
+- [ ] **Step 2: Verify type-check passes**
+
+Run: `cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/backend && uv run mypy cubebox/llm/factory.py`
+Expected: `Success: no issues found`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cubebox/llm/factory.py
+git commit -m "feat(llm): attach _cubebox_context_window to LLM instances"
+```
+
+---
+
+### Task 2: Accumulate turn usage and enrich DoneEvent in RunManager
+
+Intercept `UsageEvent`s during streaming to build a turn-level accumulator, then attach the summary (turn + session + context_window) to the `DoneEvent`.
+
+**Files:**
+- Modify: `backend/cubebox/streams/run_manager.py:487-503` (`publish_stream_event`) and `:845-861` (done event emission)
+- Test: `backend/tests/unit/streams/test_done_usage.py` (create)
+
+- [ ] **Step 1: Write test for done event usage payload**
+
+Create `backend/tests/unit/streams/__init__.py` (empty) and `backend/tests/unit/streams/test_done_usage.py`:
+
+```python
+"""DoneEvent carries accumulated turn usage."""
+
+from cubebox.agents.schemas import DoneEvent, UsageEvent
+
+
+def test_done_event_accepts_usage_payload() -> None:
+    """DoneEvent.data can carry a usage dict."""
+    done = DoneEvent(
+        timestamp="2026-05-11T00:00:00Z",
+        data={
+            "usage": {
+                "turn": {
+                    "input_tokens": 200,
+                    "output_tokens": 50,
+                    "cache_read_tokens": 150,
+                    "cache_write_tokens": 30,
+                },
+                "session": {
+                    "total_input_tokens": 1000,
+                    "total_output_tokens": 400,
+                },
+                "context_window": 128000,
+            }
+        },
+    )
+    assert done.data["usage"]["turn"]["input_tokens"] == 200
+    assert done.data["usage"]["context_window"] == 128000
+
+
+def test_usage_event_accumulation() -> None:
+    """Verify that multiple UsageEvent payloads can be summed."""
+    events = [
+        UsageEvent(
+            timestamp="t1",
+            data={
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_tokens": 80,
+                "cache_write_tokens": 10,
+            },
+        ),
+        UsageEvent(
+            timestamp="t2",
+            data={
+                "input_tokens": 50,
+                "output_tokens": 30,
+                "cache_read_tokens": 40,
+                "cache_write_tokens": 5,
+            },
+        ),
+    ]
+    totals = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+    for e in events:
+        for key in totals:
+            totals[key] += e.data.get(key, 0)
+
+    assert totals == {
+        "input_tokens": 150,
+        "output_tokens": 50,
+        "cache_read_tokens": 120,
+        "cache_write_tokens": 15,
+    }
+```
+
+- [ ] **Step 2: Run test to verify it passes** (these are schema/logic tests, no impl change needed)
+
+Run: `cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/backend && uv run pytest tests/unit/streams/test_done_usage.py -v`
+Expected: PASS (DoneEvent already accepts arbitrary `data` dicts)
+
+- [ ] **Step 3: Add turn usage accumulator and context_window extraction in `_execute_run`**
+
+In `backend/cubebox/streams/run_manager.py`, add a turn accumulator dict and context_window variable at the top of the `try` block inside `_execute_run` (right after `tool_delta_context` on line 447):
+
+```python
+        turn_usage: dict[str, int] = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        }
+```
+
+Then modify `publish_stream_event` (around line 487) to intercept usage events and accumulate:
+
+After the existing `publish_stream_event` function definition (which ends around line 503), wrap it so that `UsageEvent`s also accumulate. The cleanest approach: add accumulation logic inside `publish_stream_event` before the existing `publish_event` call. Since `publish_stream_event` currently only handles `text_delta` and falls through to `publish_event`, add a new branch:
+
+In `publish_stream_event`, before the final `await publish_event(sse_event)` line (line 503), add:
+
+```python
+            if sse_event.type == "usage":
+                for key in turn_usage:
+                    turn_usage[key] += sse_event.data.get(key, 0)
+```
+
+Then extract context_window from the LLM after it's created. After line 578 (`llm = await LLMFactory(...).create_default()`), add:
+
+```python
+            context_window: int = getattr(llm, "_cubebox_context_window", 0)
+```
+
+Note: `create_default()` may return a `RunnableWithFallbacks` wrapper. The `_cubebox_context_window` attribute is on the inner model. Handle this:
+
+```python
+            _inner = getattr(llm, "runnable", llm)
+            context_window: int = getattr(_inner, "_cubebox_context_window", 0)
+```
+
+- [ ] **Step 4: Query session totals and build enriched DoneEvent**
+
+Replace the DoneEvent emission block (lines 857-861) with:
+
+```python
+            # --- Aggregate session-level token totals ---
+            session_usage = {"total_input_tokens": 0, "total_output_tokens": 0}
+            try:
+                from sqlalchemy import func as sa_func
+                from sqlalchemy import select as sa_select
+
+                from cubebox.db.engine import async_session_maker
+                from cubebox.models.billing import BillingEvent, LlmBillingEvent
+
+                async with async_session_maker() as billing_session:
+                    row = (
+                        await billing_session.execute(
+                            sa_select(
+                                sa_func.coalesce(
+                                    sa_func.sum(LlmBillingEvent.input_tokens), 0
+                                ),
+                                sa_func.coalesce(
+                                    sa_func.sum(LlmBillingEvent.output_tokens), 0
+                                ),
+                            ).join(
+                                BillingEvent,
+                                LlmBillingEvent.billing_event_id == BillingEvent.id,
+                            ).where(
+                                BillingEvent.conversation_id == conversation_id,
+                            )
+                        )
+                    ).one()
+                    session_usage["total_input_tokens"] = int(row[0])
+                    session_usage["total_output_tokens"] = int(row[1])
+            except Exception:
+                logger.warning("Failed to query session usage for done event")
+
+            await self._append_event(
+                run_id,
+                conversation_id,
+                DoneEvent(
+                    timestamp=datetime.now(UTC).isoformat(),
+                    data={
+                        "usage": {
+                            "turn": dict(turn_usage),
+                            "session": session_usage,
+                            "context_window": context_window,
+                        }
+                    },
+                ),
+            )
+```
+
+- [ ] **Step 5: Run existing tests to verify nothing breaks**
+
+Run: `cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/backend && uv run pytest tests/unit/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cubebox/streams/run_manager.py cubebox/llm/factory.py tests/unit/streams/
+git commit -m "feat(stream): accumulate turn usage and enrich DoneEvent with usage summary"
+```
+
+---
+
+### Task 3: Add `usage_summary` to bootstrap endpoint
+
+Return session-level token totals and context_window in the bootstrap response so the frontend can show stats after a page refresh.
+
+**Files:**
+- Modify: `backend/cubebox/api/routes/v1/conversations.py:588-648`
+
+- [ ] **Step 1: Add session usage query to bootstrap handler**
+
+In `backend/cubebox/api/routes/v1/conversations.py`, inside `get_conversation_bootstrap`, before the `return` statement (line 643), add:
+
+```python
+    # --- Session-level token usage for the usage panel ---
+    usage_summary: dict[str, object] = {
+        "session": {"total_input_tokens": 0, "total_output_tokens": 0},
+        "context_window": 0,
+    }
+    try:
+        from sqlalchemy import func as sa_func
+        from sqlalchemy import select as sa_select
+
+        from cubebox.models.billing import BillingEvent, LlmBillingEvent
+
+        row = (
+            await session.execute(
+                sa_select(
+                    sa_func.coalesce(sa_func.sum(LlmBillingEvent.input_tokens), 0),
+                    sa_func.coalesce(sa_func.sum(LlmBillingEvent.output_tokens), 0),
+                )
+                .join(
+                    BillingEvent,
+                    LlmBillingEvent.billing_event_id == BillingEvent.id,
+                )
+                .where(BillingEvent.conversation_id == conversation_id)
+            )
+        ).one()
+        usage_summary["session"] = {
+            "total_input_tokens": int(row[0]),
+            "total_output_tokens": int(row[1]),
+        }
+
+        # Resolve context_window from the default model config
+        from cubebox.llm.config import LLMConfig
+        from cubebox.llm.factory import LLMFactory
+
+        factory = LLMFactory(session=session, org_id=ctx.org_id)
+        provider_name, model_id = await factory.get_default_model()
+        model_cfg = factory.get_model_config(provider_name, model_id)
+        usage_summary["context_window"] = model_cfg.context_window
+    except Exception:
+        pass  # Non-critical; frontend degrades gracefully
+```
+
+Then add `"usage_summary": usage_summary` to the return dict (line 643):
+
+```python
+    return {
+        "messages": history["messages"],
+        "total": history["total"],
+        "active_run": active_run_payload,
+        "last_run_status": last_run_status,
+        "usage_summary": usage_summary,
+    }
+```
+
+- [ ] **Step 2: Run type-check**
+
+Run: `cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/backend && uv run mypy cubebox/api/routes/v1/conversations.py`
+Expected: `Success`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cubebox/api/routes/v1/conversations.py
+git commit -m "feat(api): add usage_summary to conversation bootstrap response"
+```
+
+---
+
+### Task 4: Frontend types — extend DoneEvent and add usage types
+
+Add TypeScript types for usage data in the core package.
+
+**Files:**
+- Modify: `frontend/packages/core/src/types/events.ts:48-58` (AgentEventType) and `:152-155` (DoneEvent)
+- Modify: `frontend/packages/core/src/api/runStreams.ts:17-22` (ConversationBootstrap)
+
+- [ ] **Step 1: Add `'usage'` to AgentEventType and add usage interfaces**
+
+In `frontend/packages/core/src/types/events.ts`:
+
+Add `| 'usage'` to `AgentEventType` (line 58):
+
+```typescript
+export type AgentEventType =
+  | 'text_delta'
+  | 'reasoning'
+  | 'tool_call'
+  | 'tool_call_delta'
+  | 'tool_result'
+  | 'artifact'
+  | 'error'
+  | 'done'
+  | 'citation'
+  | 'status'
+  | 'usage'
+```
+
+Add usage type definitions after the `StatusEvent` interface (after line 162):
+
+```typescript
+export interface TurnUsage {
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_write_tokens: number
+}
+
+export interface SessionUsage {
+  total_input_tokens: number
+  total_output_tokens: number
+}
+
+export interface UsageSummary {
+  turn: TurnUsage
+  session: SessionUsage
+  context_window: number
+}
+```
+
+- [ ] **Step 2: Extend ConversationBootstrap in runStreams.ts**
+
+In `frontend/packages/core/src/api/runStreams.ts`, add `usage_summary` to the `ConversationBootstrap` interface:
+
+```typescript
+export interface ConversationBootstrap {
+  messages: Message[]
+  total: number
+  active_run: ActiveRunBootstrap | null
+  last_run_status: 'stale' | null
+  usage_summary?: {
+    session: { total_input_tokens: number; total_output_tokens: number }
+    context_window: number
+  }
+}
+```
+
+- [ ] **Step 3: Export new types from core index**
+
+Check `frontend/packages/core/src/index.ts` and ensure `TurnUsage`, `SessionUsage`, `UsageSummary` are re-exported from `'./types'`. If types are barrel-exported via `export * from './types'`, no change needed.
+
+- [ ] **Step 4: Build core and type-check**
+
+Run: `cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/frontend && pnpm --filter @cubebox/core build && pnpm type-check`
+Expected: No type errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/frontend
+git add packages/core/src/types/events.ts packages/core/src/api/runStreams.ts
+git commit -m "feat(core): add token usage types and extend DoneEvent/bootstrap"
+```
+
+---
+
+### Task 5: Store usage state in messageStore
+
+Handle `done` event usage payload and bootstrap `usage_summary` in the Zustand store.
+
+**Files:**
+- Modify: `frontend/packages/core/src/stores/messageStore.ts`
+
+- [ ] **Step 1: Add usage state fields to the store interface**
+
+In `frontend/packages/core/src/stores/messageStore.ts`, add to `MessageStore` interface (after `toolResultMap`):
+
+```typescript
+  turnUsage: Record<string, import('../types').TurnUsage | null>
+  sessionUsage: Record<string, import('../types').SessionUsage | null>
+  contextWindow: Record<string, number | null>
+```
+
+- [ ] **Step 2: Initialize these fields in the store creation**
+
+In the `create<MessageStore>` call (line 638), add initial values after `toolResultMap: {}`:
+
+```typescript
+  turnUsage: {},
+  sessionUsage: {},
+  contextWindow: {},
+```
+
+- [ ] **Step 3: Handle usage in the `done` event branch of `send()`**
+
+In the `send()` method, in the `else if (event.type === 'done')` block (line 769), replace:
+
+```typescript
+        } else if (event.type === 'done') {
+          set({
+            lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
+          })
+          sawDone = true
+          break
+        }
+```
+
+with:
+
+```typescript
+        } else if (event.type === 'done') {
+          const usage = (event.data as Record<string, unknown>).usage as
+            | import('../types').UsageSummary
+            | undefined
+          const usageUpdate: Partial<MessageStore> = {
+            lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
+          }
+          if (usage) {
+            usageUpdate.turnUsage = {
+              ...get().turnUsage,
+              [conversationId]: usage.turn,
+            }
+            usageUpdate.sessionUsage = {
+              ...get().sessionUsage,
+              [conversationId]: usage.session,
+            }
+            usageUpdate.contextWindow = {
+              ...get().contextWindow,
+              [conversationId]: usage.context_window,
+            }
+          }
+          set(usageUpdate)
+          sawDone = true
+          break
+        }
+```
+
+- [ ] **Step 4: Do the same for the `consumeRunStream` done branch**
+
+In `consumeRunStream` (the `done` branch around line 618), apply the same pattern:
+
+```typescript
+      } else if (event.type === 'done') {
+        const usage = (event.data as Record<string, unknown>).usage as
+          | import('../types').UsageSummary
+          | undefined
+        const usageUpdate: Partial<MessageStore> = {
+          lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
+        }
+        if (usage) {
+          usageUpdate.turnUsage = {
+            ...get().turnUsage,
+            [conversationId]: usage.turn,
+          }
+          usageUpdate.sessionUsage = {
+            ...get().sessionUsage,
+            [conversationId]: usage.session,
+          }
+          usageUpdate.contextWindow = {
+            ...get().contextWindow,
+            [conversationId]: usage.context_window,
+          }
+        }
+        set(usageUpdate)
+        sawDone = true
+        break
+      }
+```
+
+- [ ] **Step 5: Populate from bootstrap in `loadMessages()`**
+
+In `loadMessages()`, after loading the bootstrap (line 657), extract `usage_summary` and populate:
+
+After `hydrateCitationsFromHistory(conversationId, messages)` (line 672), add:
+
+```typescript
+      const usageSummary = bootstrap.usage_summary
+      const newTurnUsage = { ...get().turnUsage }
+      const newSessionUsage = { ...get().sessionUsage, [conversationId]: null as import('../types').SessionUsage | null }
+      const newContextWindow = { ...get().contextWindow, [conversationId]: null as number | null }
+      if (usageSummary) {
+        newSessionUsage[conversationId] = usageSummary.session
+        newContextWindow[conversationId] = usageSummary.context_window
+      }
+```
+
+Then in the `set()` call (line 677), add:
+
+```typescript
+        turnUsage: newTurnUsage,
+        sessionUsage: newSessionUsage,
+        contextWindow: newContextWindow,
+```
+
+- [ ] **Step 6: Clear turnUsage on new `send()`**
+
+In `send()`, inside the initial `set()` call (line 724), add:
+
+```typescript
+      turnUsage: { ...get().turnUsage, [conversationId]: null },
+```
+
+- [ ] **Step 7: Build and type-check**
+
+Run: `cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/frontend && pnpm --filter @cubebox/core build && pnpm type-check`
+Expected: No type errors
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/frontend
+git add packages/core/src/stores/messageStore.ts
+git commit -m "feat(store): handle token usage from done event and bootstrap"
+```
+
+---
+
+### Task 6: Create TokenUsageBar component
+
+Build the collapsible token usage panel and wire it into the message list.
+
+**Files:**
+- Create: `frontend/packages/web/components/chat/TokenUsageBar.tsx`
+- Modify: `frontend/packages/web/components/chat/MessageList.tsx`
+- Modify: `frontend/packages/web/hooks/useMessages.ts`
+- Modify: `frontend/packages/web/messages/en.json` and `zh.json`
+
+- [ ] **Step 1: Add i18n keys**
+
+In `frontend/packages/web/messages/en.json`, add to the `"chat"` section:
+
+```json
+    "tokenUsage": "Token Usage",
+    "turnLabel": "This Turn",
+    "sessionLabel": "Session Total",
+    "inputTokens": "Input",
+    "outputTokens": "Output",
+    "cacheHitRate": "Cache Hit",
+    "totalTokens": "Total Tokens",
+    "contextWindow": "Context"
+```
+
+In `frontend/packages/web/messages/zh.json`, add to the `"chat"` section:
+
+```json
+    "tokenUsage": "Token 用量",
+    "turnLabel": "本轮",
+    "sessionLabel": "会话累计",
+    "inputTokens": "输入",
+    "outputTokens": "输出",
+    "cacheHitRate": "缓存命中",
+    "totalTokens": "总 Token",
+    "contextWindow": "Context"
+```
+
+- [ ] **Step 2: Expose usage from useMessages hook**
+
+In `frontend/packages/web/hooks/useMessages.ts`, add selectors for usage state:
+
+```typescript
+  const turnUsage = useMessageStore((s) => s.turnUsage[conversationId] ?? null)
+  const sessionUsage = useMessageStore((s) => s.sessionUsage[conversationId] ?? null)
+  const contextWindow = useMessageStore((s) => s.contextWindow[conversationId] ?? null)
+```
+
+Add them to the return object:
+
+```typescript
+  return {
+    messages,
+    isStreaming: isStreamingThis,
+    statusPhase,
+    mainStream,
+    subAgentStreams,
+    todos,
+    error,
+    toolResultMap,
+    turnUsage,
+    sessionUsage,
+    contextWindow,
+  }
+```
+
+- [ ] **Step 3: Create TokenUsageBar component**
+
+Create `frontend/packages/web/components/chat/TokenUsageBar.tsx`:
+
+```tsx
+'use client'
+
+import { useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { ChevronDown, ChevronRight, BarChart3 } from 'lucide-react'
+import type { TurnUsage, SessionUsage } from '@cubebox/core'
+
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
+function progressColor(pct: number): string {
+  if (pct >= 80) return 'bg-red-500'
+  if (pct >= 50) return 'bg-amber-500'
+  return 'bg-emerald-500'
+}
+
+interface TokenUsageBarProps {
+  turnUsage: TurnUsage | null
+  sessionUsage: SessionUsage | null
+  contextWindow: number | null
+}
+
+export function TokenUsageBar({
+  turnUsage,
+  sessionUsage,
+  contextWindow,
+}: TokenUsageBarProps) {
+  const t = useTranslations('chat')
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  if (!turnUsage && !sessionUsage) return null
+
+  const cacheHitRate =
+    turnUsage && turnUsage.input_tokens > 0
+      ? (turnUsage.cache_read_tokens / turnUsage.input_tokens) * 100
+      : null
+
+  const sessionTotal = sessionUsage
+    ? sessionUsage.total_input_tokens + sessionUsage.total_output_tokens
+    : null
+
+  const ctxPct =
+    sessionUsage && contextWindow && contextWindow > 0
+      ? ((sessionUsage.total_input_tokens + sessionUsage.total_output_tokens) /
+          contextWindow) *
+        100
+      : null
+
+  return (
+    <div className="mt-1">
+      <button
+        type="button"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        className="flex items-center gap-1.5 text-xs text-muted-foreground/60
+          hover:text-muted-foreground transition-colors cursor-pointer"
+      >
+        <span className="text-muted-foreground/40">
+          {isExpanded ? (
+            <ChevronDown className="size-3" />
+          ) : (
+            <ChevronRight className="size-3" />
+          )}
+        </span>
+        <BarChart3 className="size-3" />
+        <span>{t('tokenUsage')}</span>
+      </button>
+
+      {isExpanded && (
+        <div
+          className="mt-2 text-xs text-muted-foreground bg-muted/30
+            border border-border/50 rounded-lg px-3 py-2.5 space-y-3
+            max-w-xs"
+        >
+          {turnUsage && (
+            <div>
+              <div className="font-medium text-foreground/70 mb-1">
+                {t('turnLabel')}
+              </div>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
+                <span>{t('inputTokens')}</span>
+                <span className="text-right font-mono">
+                  {formatTokenCount(turnUsage.input_tokens)}
+                </span>
+                <span>{t('outputTokens')}</span>
+                <span className="text-right font-mono">
+                  {formatTokenCount(turnUsage.output_tokens)}
+                </span>
+                <span>{t('cacheHitRate')}</span>
+                <span className="text-right font-mono">
+                  {cacheHitRate !== null ? `${cacheHitRate.toFixed(1)}%` : '—'}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {sessionUsage && (
+            <div>
+              <div className="font-medium text-foreground/70 mb-1">
+                {t('sessionLabel')}
+              </div>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
+                <span>{t('totalTokens')}</span>
+                <span className="text-right font-mono">
+                  {sessionTotal !== null ? formatTokenCount(sessionTotal) : '—'}
+                </span>
+              </div>
+              {ctxPct !== null && (
+                <div className="mt-1.5">
+                  <div className="flex items-center justify-between mb-0.5">
+                    <span>{t('contextWindow')}</span>
+                    <span className="font-mono">{ctxPct.toFixed(1)}%</span>
+                  </div>
+                  <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all ${progressColor(ctxPct)}`}
+                      style={{ width: `${Math.min(ctxPct, 100)}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Wire TokenUsageBar into MessageList**
+
+In `frontend/packages/web/components/chat/MessageList.tsx`:
+
+Add import:
+
+```typescript
+import { TokenUsageBar } from './TokenUsageBar'
+```
+
+Destructure new fields from `useMessages`:
+
+```typescript
+  const {
+    messages,
+    isStreaming,
+    statusPhase,
+    mainStream,
+    subAgentStreams,
+    todos,
+    error,
+    toolResultMap,
+    turnUsage,
+    sessionUsage,
+    contextWindow,
+  } = useMessages(conversationId)
+```
+
+Add the `TokenUsageBar` after the streaming `AssistantMessage` block (after line 225, after `</AssistantMessage>`), inside the same conditional:
+
+```tsx
+        {!isStreaming && (turnUsage || sessionUsage) && (
+          <div className="flex justify-start gap-2.5">
+            <div className="shrink-0 w-6 h-6" />
+            <div className="flex-1 max-w-[75%]">
+              <TokenUsageBar
+                turnUsage={turnUsage}
+                sessionUsage={sessionUsage}
+                contextWindow={contextWindow}
+              />
+            </div>
+          </div>
+        )}
+```
+
+This renders the bar only when streaming is done and there is usage data, aligned with the assistant message's content column (the `w-6` spacer matches the bot icon width).
+
+- [ ] **Step 5: Build and type-check**
+
+Run: `cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/frontend && pnpm --filter @cubebox/core build && pnpm type-check`
+Expected: No type errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/frontend
+git add packages/web/components/chat/TokenUsageBar.tsx \
+       packages/web/components/chat/MessageList.tsx \
+       packages/web/hooks/useMessages.ts \
+       packages/web/messages/en.json \
+       packages/web/messages/zh.json
+git commit -m "feat(ui): add TokenUsageBar component with collapsible token usage panel"
+```
+
+---
+
+### Task 7: Visual verification and polish
+
+Start both servers in the worktree, send a message, and verify the token usage panel renders correctly.
+
+**Files:** None (manual testing)
+
+- [ ] **Step 1: Start backend**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/backend
+python main.py
+```
+
+Confirm it starts on port 8031 (from `.worktree.env`).
+
+- [ ] **Step 2: Start frontend**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/frontend
+pnpm dev
+```
+
+Confirm it starts on port 3031.
+
+- [ ] **Step 3: Test in browser**
+
+Open `http://localhost:3031`. Send a message in a conversation. After the AI responds:
+
+1. Verify the `▸ Token 用量` button appears below the last assistant message (bottom-left).
+2. Click it — verify the panel expands showing:
+   - This Turn: input tokens, output tokens, cache hit rate
+   - Session Total: total tokens, context window progress bar
+3. Click again — verify it collapses.
+4. Send another message — verify the panel updates with new values.
+5. Refresh the page — verify session totals persist (from bootstrap).
+
+- [ ] **Step 4: Run full type-check and lint**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/backend && make check
+cd /home/chris/cubebox/.worktrees/feat/token-usage-panel/frontend && pnpm type-check
+```
+
+- [ ] **Step 5: Final commit if any polish needed**
+
+```bash
+git add -A && git commit -m "fix(ui): polish token usage panel"
+```

--- a/docs/superpowers/specs/2026-05-11-token-usage-panel-design.md
+++ b/docs/superpowers/specs/2026-05-11-token-usage-panel-design.md
@@ -1,0 +1,134 @@
+# Token Usage Info Panel
+
+Show per-turn and session-level token usage in the chat UI so users can
+monitor cost, cache efficiency, and context window consumption.
+
+## Behavior
+
+- A small button appears at the **bottom-left** of each assistant message,
+  but **only after streaming completes** (not during) and **only on the
+  last assistant message** in the conversation.
+- Click to expand an inline panel with two sections:
+  1. **This turn** — input tokens, output tokens, cache hit rate.
+  2. **Session totals** — cumulative input+output tokens and a context
+     window progress bar (ratio of cumulative input tokens to model's
+     context window size).
+- Click again (or click the header) to collapse.
+
+## Data flow
+
+### Backend: `done` event carries usage summary
+
+The `DoneEvent` gains a `data.usage` payload assembled by `RunManager`
+just before the event is emitted:
+
+```json
+{
+  "turn": {
+    "input_tokens": 1234,
+    "output_tokens": 856,
+    "cache_read_tokens": 830,
+    "cache_write_tokens": 200
+  },
+  "session": {
+    "total_input_tokens": 12456,
+    "total_output_tokens": 8900
+  },
+  "context_window": 128000
+}
+```
+
+| Field | Source |
+|---|---|
+| `turn.*` | Sum of all `UsageEvent` payloads within the current run (RunManager already processes these during streaming). |
+| `session.*` | `SELECT SUM(input_tokens), SUM(output_tokens) FROM billing_llm_events WHERE conversation_id = ?` — aggregated once when the run completes. |
+| `context_window` | `ModelConfig.context_window` from the model used for this run. |
+
+### Backend: bootstrap includes session usage
+
+`GET /api/v1/ws/{wsId}/conversations/{id}/bootstrap` already returns
+`messages` and `active_run`. Add a `usage_summary` field:
+
+```json
+{
+  "messages": [...],
+  "active_run": null,
+  "usage_summary": {
+    "session": {
+      "total_input_tokens": 12456,
+      "total_output_tokens": 8900
+    },
+    "context_window": 128000
+  }
+}
+```
+
+This lets the frontend show session-level stats after a page refresh
+without replaying all historical usage events.
+
+### Frontend: store and render
+
+1. **`events.ts`** — extend `DoneEvent.data` to include the `usage` shape.
+2. **`messageStore.ts`** — add state:
+   - `turnUsage: Record<conversationId, TurnUsage | null>` — populated
+     from `done` event, cleared on next `send()`.
+   - `sessionUsage: Record<conversationId, SessionUsage | null>` —
+     populated from `done` event or bootstrap.
+   - `contextWindow: Record<conversationId, number | null>` — from
+     `done` event or bootstrap.
+3. **`TokenUsageBar.tsx`** (new component in `components/chat/`) —
+   renders the collapsible panel below the last assistant message.
+
+## Formulas
+
+**Cache hit rate:**
+```
+cache_hit_rate = cache_read_tokens / input_tokens * 100
+```
+Show `—` if `input_tokens == 0`.
+
+**Context window usage:**
+```
+usage_pct = (session.total_input_tokens + session.total_output_tokens) / context_window * 100
+```
+
+Progress bar color thresholds:
+- Green: < 50%
+- Yellow: 50–80%
+- Red: > 80%
+
+## UI sketch
+
+Collapsed (bottom-left of last assistant message):
+```
+▸ Token 用量
+```
+
+Expanded:
+```
+▾ Token 用量
+────────────────────────────
+本轮
+  输入: 1,234    输出: 856
+  缓存命中: 67.2%
+
+会话累计
+  总 token: 21,356
+  Context: ██████░░░░ 16.7%
+```
+
+## Scope
+
+- Backend: modify `RunManager._execute_run` to accumulate turn usage
+  and query session totals; extend `DoneEvent`; extend bootstrap
+  response.
+- Frontend core: new types, store fields, event handling.
+- Frontend web: one new component (`TokenUsageBar`), mount it in
+  `AssistantMessage` conditionally.
+- No new API endpoints. No new DB tables or migrations.
+
+## Non-goals
+
+- Per-message historical usage (only the latest turn is shown).
+- Cost in currency (this is a token counter, not a billing dashboard).
+- Real-time token counter during streaming.

--- a/frontend/packages/core/src/api/runStreams.ts
+++ b/frontend/packages/core/src/api/runStreams.ts
@@ -19,6 +19,10 @@ export interface ConversationBootstrap {
   total: number
   active_run: ActiveRunBootstrap | null
   last_run_status: 'stale' | null
+  usage_summary?: {
+    session: { total_input_tokens: number; total_output_tokens: number }
+    context_window: number
+  }
 }
 
 export interface StartRunResponse {

--- a/frontend/packages/core/src/api/runStreams.ts
+++ b/frontend/packages/core/src/api/runStreams.ts
@@ -20,6 +20,12 @@ export interface ConversationBootstrap {
   active_run: ActiveRunBootstrap | null
   last_run_status: 'stale' | null
   usage_summary?: {
+    turn?: {
+      input_tokens: number
+      output_tokens: number
+      cache_read_tokens: number
+      cache_write_tokens: number
+    }
     session: { total_input_tokens: number; total_output_tokens: number }
     context_window: number
   }

--- a/frontend/packages/core/src/api/runStreams.ts
+++ b/frontend/packages/core/src/api/runStreams.ts
@@ -26,7 +26,12 @@ export interface ConversationBootstrap {
       cache_read_tokens: number
       cache_write_tokens: number
     }
-    session: { total_input_tokens: number; total_output_tokens: number }
+    session: {
+      total_input_tokens: number
+      total_output_tokens: number
+      total_cache_read_tokens: number
+      total_cache_write_tokens: number
+    }
     context_window: number
   }
 }

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -41,6 +41,9 @@ export interface MessageStore {
     string,
     { content: string; receivedAt: number; startedAt?: number; contentType?: string }
   >
+  turnUsage: Record<string, import('../types').TurnUsage | null>
+  sessionUsage: Record<string, import('../types').SessionUsage | null>
+  contextWindow: Record<string, number | null>
 
   loadMessages(client: ApiClient, conversationId: string): Promise<void>
   send(
@@ -616,9 +619,27 @@ async function consumeRunStream(
         })
         break
       } else if (event.type === 'done') {
-        set({
+        const usage = (event.data as Record<string, unknown>).usage as
+          | import('../types').UsageSummary
+          | undefined
+        const usageUpdate: Partial<MessageStore> = {
           lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
-        })
+        }
+        if (usage) {
+          usageUpdate.turnUsage = {
+            ...get().turnUsage,
+            [conversationId]: usage.turn,
+          }
+          usageUpdate.sessionUsage = {
+            ...get().sessionUsage,
+            [conversationId]: usage.session,
+          }
+          usageUpdate.contextWindow = {
+            ...get().contextWindow,
+            [conversationId]: usage.context_window,
+          }
+        }
+        set(usageUpdate)
         sawDone = true
         break
       }
@@ -648,6 +669,9 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
   todos: [],
   toolStartedMap: {},
   toolResultMap: {},
+  turnUsage: {},
+  sessionUsage: {},
+  contextWindow: {},
 
   async loadMessages(client: ApiClient, conversationId: string) {
     const state = get()
@@ -670,6 +694,20 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
 
       const restoredTodos = restoreTodosFromHistory(messages)
       hydrateCitationsFromHistory(conversationId, messages)
+      const usageSummary = bootstrap.usage_summary
+      const newTurnUsage = { ...get().turnUsage }
+      const newSessionUsage = {
+        ...get().sessionUsage,
+        [conversationId]: null as import('../types').SessionUsage | null,
+      }
+      const newContextWindow = {
+        ...get().contextWindow,
+        [conversationId]: null as number | null,
+      }
+      if (usageSummary) {
+        newSessionUsage[conversationId] = usageSummary.session
+        newContextWindow[conversationId] = usageSummary.context_window
+      }
       const nextStreamAgents: Record<string, AgentStream> = bootstrap.active_run
         ? { [MAIN_AGENT_KEY]: emptyStream() }
         : {}
@@ -687,6 +725,9 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
         currentRunId: bootstrap.active_run?.run_id ?? null,
         lastAppliedEventId: null,
         statusPhase: null,
+        turnUsage: newTurnUsage,
+        sessionUsage: newSessionUsage,
+        contextWindow: newContextWindow,
       }))
 
       if (bootstrap.active_run) {
@@ -737,6 +778,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       todos: [],
       toolStartedMap: {},
       toolResultMap: {},
+      turnUsage: { ...state.turnUsage, [conversationId]: null },
     }))
 
     const { batchedSet, flush } = createBatcher(
@@ -767,9 +809,27 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
           })
           break
         } else if (event.type === 'done') {
-          set({
+          const usage = (event.data as Record<string, unknown>).usage as
+            | import('../types').UsageSummary
+            | undefined
+          const usageUpdate: Partial<MessageStore> = {
             lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
-          })
+          }
+          if (usage) {
+            usageUpdate.turnUsage = {
+              ...get().turnUsage,
+              [conversationId]: usage.turn,
+            }
+            usageUpdate.sessionUsage = {
+              ...get().sessionUsage,
+              [conversationId]: usage.session,
+            }
+            usageUpdate.contextWindow = {
+              ...get().contextWindow,
+              [conversationId]: usage.context_window,
+            }
+          }
+          set(usageUpdate)
           sawDone = true
           break
         }

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -695,18 +695,17 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       const restoredTodos = restoreTodosFromHistory(messages)
       hydrateCitationsFromHistory(conversationId, messages)
       const usageSummary = bootstrap.usage_summary
-      const newTurnUsage = { ...get().turnUsage }
+      const newTurnUsage = {
+        ...get().turnUsage,
+        [conversationId]: (usageSummary?.turn ?? null) as import('../types').TurnUsage | null,
+      }
       const newSessionUsage = {
         ...get().sessionUsage,
-        [conversationId]: null as import('../types').SessionUsage | null,
+        [conversationId]: (usageSummary?.session ?? null) as import('../types').SessionUsage | null,
       }
       const newContextWindow = {
         ...get().contextWindow,
-        [conversationId]: null as number | null,
-      }
-      if (usageSummary) {
-        newSessionUsage[conversationId] = usageSummary.session
-        newContextWindow[conversationId] = usageSummary.context_window
+        [conversationId]: usageSummary?.context_window ?? null,
       }
       const nextStreamAgents: Record<string, AgentStream> = bootstrap.active_run
         ? { [MAIN_AGENT_KEY]: emptyStream() }

--- a/frontend/packages/core/src/types/events.ts
+++ b/frontend/packages/core/src/types/events.ts
@@ -56,6 +56,7 @@ export type AgentEventType =
   | 'done'
   | 'citation'
   | 'status'
+  | 'usage'
 
 export interface AgentEvent {
   type: AgentEventType
@@ -159,4 +160,22 @@ export type StatusPhase = 'sandbox_creating' | 'sandbox_ready' | 'sandbox_failed
 export interface StatusEvent extends AgentEvent {
   type: 'status'
   data: { phase: StatusPhase; detail?: string }
+}
+
+export interface TurnUsage {
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_write_tokens: number
+}
+
+export interface SessionUsage {
+  total_input_tokens: number
+  total_output_tokens: number
+}
+
+export interface UsageSummary {
+  turn: TurnUsage
+  session: SessionUsage
+  context_window: number
 }

--- a/frontend/packages/core/src/types/events.ts
+++ b/frontend/packages/core/src/types/events.ts
@@ -172,6 +172,8 @@ export interface TurnUsage {
 export interface SessionUsage {
   total_input_tokens: number
   total_output_tokens: number
+  total_cache_read_tokens: number
+  total_cache_write_tokens: number
 }
 
 export interface UsageSummary {

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -9,6 +9,7 @@ import { UserMessage } from './UserMessage'
 import { AssistantMessage } from './AssistantMessage'
 import { MessageAttachments } from './MessageAttachments'
 import { TaskProgressCard } from './TaskProgressCard'
+import { TokenUsageBar } from './TokenUsageBar'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useMessages } from '@/hooks/useMessages'
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
@@ -107,6 +108,9 @@ export function MessageList({ conversationId }: MessageListProps) {
     todos,
     error,
     toolResultMap,
+    turnUsage,
+    sessionUsage,
+    contextWindow,
   } = useMessages(conversationId)
   const loadMessages = useMessageStore((s) => s.loadMessages)
   const lastRunStatus = useMessageStore((s) => s.lastRunStatus)
@@ -223,6 +227,21 @@ export function MessageList({ conversationId }: MessageListProps) {
             conversationId={conversationId}
           />
         )}
+
+        {!isStreaming &&
+          (turnUsage || sessionUsage) &&
+          (messages ?? []).some((m) => m.role === 'assistant') && (
+            <div className="flex justify-start gap-2.5">
+              <div className="shrink-0 w-6 h-6" />
+              <div className="flex-1 max-w-[75%]">
+                <TokenUsageBar
+                  turnUsage={turnUsage}
+                  sessionUsage={sessionUsage}
+                  contextWindow={contextWindow}
+                />
+              </div>
+            </div>
+          )}
 
         {!isStreaming && todos.length > 0 && (
           <div className="flex justify-start gap-2.5">

--- a/frontend/packages/web/components/chat/TokenUsageBar.tsx
+++ b/frontend/packages/web/components/chat/TokenUsageBar.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { ChevronDown, ChevronRight, BarChart3 } from 'lucide-react'
+import type { TurnUsage, SessionUsage } from '@cubebox/core'
+
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
+function progressColor(pct: number): string {
+  if (pct >= 80) return 'bg-red-500'
+  if (pct >= 50) return 'bg-amber-500'
+  return 'bg-emerald-500'
+}
+
+interface TokenUsageBarProps {
+  turnUsage: TurnUsage | null
+  sessionUsage: SessionUsage | null
+  contextWindow: number | null
+}
+
+export function TokenUsageBar({ turnUsage, sessionUsage, contextWindow }: TokenUsageBarProps) {
+  const t = useTranslations('chat')
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  if (!turnUsage && !sessionUsage) return null
+
+  const cacheHitRate =
+    turnUsage && turnUsage.input_tokens > 0
+      ? (turnUsage.cache_read_tokens / turnUsage.input_tokens) * 100
+      : null
+
+  const sessionTotal = sessionUsage
+    ? sessionUsage.total_input_tokens + sessionUsage.total_output_tokens
+    : null
+
+  const ctxPct =
+    sessionUsage && contextWindow && contextWindow > 0
+      ? ((sessionUsage.total_input_tokens + sessionUsage.total_output_tokens) / contextWindow) * 100
+      : null
+
+  return (
+    <div className="mt-1">
+      <button
+        type="button"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        className="flex items-center gap-1.5 text-xs text-muted-foreground/60
+          hover:text-muted-foreground transition-colors cursor-pointer"
+      >
+        <span className="text-muted-foreground/40">
+          {isExpanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+        </span>
+        <BarChart3 className="size-3" />
+        <span>{t('tokenUsage')}</span>
+      </button>
+
+      {isExpanded && (
+        <div
+          className="mt-2 text-xs text-muted-foreground bg-muted/30
+            border border-border/50 rounded-lg px-3 py-2.5 space-y-3
+            max-w-xs"
+        >
+          {turnUsage && (
+            <div>
+              <div className="font-medium text-foreground/70 mb-1">{t('turnLabel')}</div>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
+                <span>{t('inputTokens')}</span>
+                <span className="text-right font-mono">
+                  {formatTokenCount(turnUsage.input_tokens)}
+                </span>
+                <span>{t('outputTokens')}</span>
+                <span className="text-right font-mono">
+                  {formatTokenCount(turnUsage.output_tokens)}
+                </span>
+                <span>{t('cacheHitRate')}</span>
+                <span className="text-right font-mono">
+                  {cacheHitRate !== null ? `${cacheHitRate.toFixed(1)}%` : '—'}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {sessionUsage && (
+            <div>
+              <div className="font-medium text-foreground/70 mb-1">{t('sessionLabel')}</div>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
+                <span>{t('totalTokens')}</span>
+                <span className="text-right font-mono">
+                  {sessionTotal !== null ? formatTokenCount(sessionTotal) : '—'}
+                </span>
+              </div>
+              {ctxPct !== null && (
+                <div className="mt-1.5">
+                  <div className="flex items-center justify-between mb-0.5">
+                    <span>{t('contextWindow')}</span>
+                    <span className="font-mono">{ctxPct.toFixed(1)}%</span>
+                  </div>
+                  <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all ${progressColor(ctxPct)}`}
+                      style={{ width: `${Math.min(ctxPct, 100)}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/packages/web/components/chat/TokenUsageBar.tsx
+++ b/frontend/packages/web/components/chat/TokenUsageBar.tsx
@@ -90,6 +90,12 @@ export function TokenUsageBar({ turnUsage, sessionUsage, contextWindow }: TokenU
                     sessionUsage.total_input_tokens + sessionUsage.total_output_tokens,
                   )}
                 </span>
+                <span>{t('cacheHitRate')}</span>
+                <span className="text-right font-mono">
+                  {sessionUsage.total_input_tokens > 0
+                    ? `${((sessionUsage.total_cache_read_tokens / sessionUsage.total_input_tokens) * 100).toFixed(1)}%`
+                    : '—'}
+                </span>
               </div>
               {ctxPct !== null && (
                 <div className="mt-1.5">

--- a/frontend/packages/web/components/chat/TokenUsageBar.tsx
+++ b/frontend/packages/web/components/chat/TokenUsageBar.tsx
@@ -34,10 +34,6 @@ export function TokenUsageBar({ turnUsage, sessionUsage, contextWindow }: TokenU
       ? (turnUsage.cache_read_tokens / turnUsage.input_tokens) * 100
       : null
 
-  const sessionTotal = sessionUsage
-    ? sessionUsage.total_input_tokens + sessionUsage.total_output_tokens
-    : null
-
   const ctxPct =
     sessionUsage && contextWindow && contextWindow > 0
       ? ((sessionUsage.total_input_tokens + sessionUsage.total_output_tokens) / contextWindow) * 100
@@ -90,7 +86,9 @@ export function TokenUsageBar({ turnUsage, sessionUsage, contextWindow }: TokenU
               <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
                 <span>{t('totalTokens')}</span>
                 <span className="text-right font-mono">
-                  {sessionTotal !== null ? formatTokenCount(sessionTotal) : '—'}
+                  {formatTokenCount(
+                    sessionUsage.total_input_tokens + sessionUsage.total_output_tokens,
+                  )}
                 </span>
               </div>
               {ctxPct !== null && (

--- a/frontend/packages/web/hooks/useMessages.ts
+++ b/frontend/packages/web/hooks/useMessages.ts
@@ -40,6 +40,9 @@ export function useMessages(conversationId: string) {
   const toolResultMap = useMessageStore((s) =>
     s.streamingConversationId === conversationId ? s.toolResultMap : {},
   )
+  const turnUsage = useMessageStore((s) => s.turnUsage[conversationId] ?? null)
+  const sessionUsage = useMessageStore((s) => s.sessionUsage[conversationId] ?? null)
+  const contextWindow = useMessageStore((s) => s.contextWindow[conversationId] ?? null)
 
   // Derive subagent streams with stable reference — only for the streaming conversation
   const rawSubAgents = useMessageStore((s) => {
@@ -62,5 +65,8 @@ export function useMessages(conversationId: string) {
     todos,
     error,
     toolResultMap,
+    turnUsage,
+    sessionUsage,
+    contextWindow,
   }
 }

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -66,7 +66,15 @@
     "artifacts": "Artifacts",
     "expand": "Expand",
     "collapse": "Collapse",
-    "executing": "Executing..."
+    "executing": "Executing...",
+    "tokenUsage": "Token Usage",
+    "turnLabel": "This Turn",
+    "sessionLabel": "Session Total",
+    "inputTokens": "Input",
+    "outputTokens": "Output",
+    "cacheHitRate": "Cache Hit",
+    "totalTokens": "Total Tokens",
+    "contextWindow": "Context"
   },
   "subagent": {
     "cluster": "Agent cluster",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -66,7 +66,15 @@
     "artifacts": "产出物",
     "expand": "展开",
     "collapse": "收起",
-    "executing": "正在执行..."
+    "executing": "正在执行...",
+    "tokenUsage": "Token 用量",
+    "turnLabel": "本轮",
+    "sessionLabel": "会话累计",
+    "inputTokens": "输入",
+    "outputTokens": "输出",
+    "cacheHitRate": "缓存命中",
+    "totalTokens": "总 Token",
+    "contextWindow": "Context"
   },
   "subagent": {
     "cluster": "Agent 集群",


### PR DESCRIPTION
## Summary

- Add a collapsible **Token Usage** panel below the last assistant message in chat, visible after streaming completes
- Shows **per-turn** stats (input/output tokens, cache hit rate) and **session totals** (cumulative tokens, context window progress bar with green/yellow/red thresholds)
- Backend: `RunManager` accumulates turn usage from `UsageEvent` SSE payloads and enriches `DoneEvent` with usage summary; bootstrap endpoint returns session + turn usage from billing DB
- Frontend: new `TokenUsageBar` component, Zustand store handling, i18n (en/zh)
- Also includes: `LLMFactory.get_default_model_config()` to correctly resolve `context_window` for DB-seeded providers

## Data flow

```
UsageEvent (per LLM call) → RunManager accumulates → DoneEvent.data.usage
                                                       ↓
Bootstrap endpoint → billing_llm_events query → usage_summary
                                                       ↓
Frontend messageStore → TokenUsageBar component
```

## Test plan

- [x] Send message → after streaming, "Token Usage" button appears below last assistant message
- [x] Click to expand → shows This Turn (input/output/cache hit) + Session Total (total tokens, context %)
- [x] Click again → collapses
- [x] Send second message → values update, cache hit rate increases
- [x] Refresh page → session totals + last turn usage persist via bootstrap
- [x] Empty conversation → no phantom panel
- [x] `pnpm type-check` passes (frontend)
- [x] `make check` passes (backend: format + lint + mypy + tests)