### PR TITLE
fix(subagents): handle Anthropic list-type content blocks

### DIFF
--- a/backend/cubebox/middleware/subagents.py
+++ b/backend/cubebox/middleware/subagents.py
@@ -27,6 +27,19 @@ subagent_event_queue: ContextVar[asyncio.Queue[Any] | None] = ContextVar(
 )
 
 
+def _content_to_text(content: Any) -> str:
+    """Extract text from message content (str or Anthropic-style content blocks)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+        return "\n".join(parts) if parts else ""
+    return str(content)
+
+
 class SubAgent(TypedDict, total=False):
     """Specification for a subagent.
 
@@ -172,7 +185,7 @@ def _create_subagent_tool(
                                 c = getattr(msg, "content", "") or ""
                                 msg_name = getattr(msg, "name", None)
                                 if c and not msg_name:
-                                    last_ai_content.append(c)
+                                    last_ai_content.append(_content_to_text(c))
                         elif mode == "updates":
                             evts = convert_updates_chunk(data, agent_id=sa_agent_id)
                             subagent_events.extend(evts)
@@ -191,7 +204,7 @@ def _create_subagent_tool(
                 last = messages[-1] if messages else None
                 if last and hasattr(last, "content"):
                     content = last.content
-                    last_ai_content.append(content if isinstance(content, str) else str(content))
+                    last_ai_content.append(_content_to_text(content))
 
             final_content = "".join(last_ai_content) or "[subagent produced no output]"
 


### PR DESCRIPTION
## Summary
- Anthropic API returns `AIMessage.content` as a list of typed content blocks (`[{"type": "thinking", ...}, {"type": "text", ...}]`) instead of a plain string
- The subagent result collector was passing these lists directly into `"".join()`, causing `sequence item 0: expected str instance, list found`
- Added `_content_to_text()` to extract only `type == "text"` blocks, consistent with `stream.py` and `memory.py` patterns
- Thinking blocks are already streamed to the UI via the SSE queue — the `ToolMessage` returned to the parent agent only needs the text answer

## Test plan
- [ ] Trigger a subagent call using an Anthropic model with extended thinking enabled
- [ ] Verify subagent returns text result without errors
- [ ] Verify thinking/reasoning still displays in the UI during subagent execution