### PR TITLE
feat(sidebar): rename, pin, auto-title, compact actions for conversation list

### DIFF
--- a/backend/alembic/versions/4be6ed892e02_add_conversation_is_pinned.py
+++ b/backend/alembic/versions/4be6ed892e02_add_conversation_is_pinned.py
@@ -1,0 +1,31 @@
+"""add conversation is_pinned
+
+Revision ID: 4be6ed892e02
+Revises: 94c1f2c164da
+Create Date: 2026-05-12 18:48:08.425250
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4be6ed892e02'
+down_revision: Union[str, Sequence[str], None] = '94c1f2c164da'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'conversations',
+        sa.Column('is_pinned', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('conversations', 'is_pinned')

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -17,6 +17,7 @@ from cubebox.auth.dependencies import require_member
 from cubebox.cache import RedisHandle, redis_dep
 from cubebox.db import get_session
 from cubebox.db.engine import _build_database_url, async_session_maker
+from cubebox.models import Conversation
 from cubebox.repositories import ConversationRepository
 from cubebox.streams.run_events import (
     get_active_run,
@@ -31,6 +32,16 @@ from cubebox.streams.run_manager import RunContext
 from cubebox.utils.time import utc_isoformat
 
 router = APIRouter(prefix="/ws/{workspace_id}/conversations", tags=["conversations"])
+
+
+def _serialize_conversation(c: Conversation) -> dict[str, object]:
+    return {
+        "id": c.id,
+        "title": c.title,
+        "is_pinned": c.is_pinned,
+        "created_at": utc_isoformat(c.created_at),
+        "updated_at": utc_isoformat(c.updated_at),
+    }
 
 
 async def _update_conversation_timestamp(
@@ -82,12 +93,7 @@ async def create_conversation(
         user_id=ctx.user.id,
     )
     conversation = await repo.create(title=title, draft=draft)
-    return {
-        "id": conversation.id,
-        "title": conversation.title,
-        "created_at": utc_isoformat(conversation.created_at),
-        "updated_at": utc_isoformat(conversation.updated_at),
-    }
+    return _serialize_conversation(conversation)
 
 
 @router.get("/{conversation_id}")
@@ -109,12 +115,7 @@ async def get_conversation(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Conversation {conversation_id} not found",
         )
-    return {
-        "id": conversation.id,
-        "title": conversation.title,
-        "created_at": utc_isoformat(conversation.created_at),
-        "updated_at": utc_isoformat(conversation.updated_at),
-    }
+    return _serialize_conversation(conversation)
 
 
 @router.get("")
@@ -133,15 +134,7 @@ async def list_conversations(
     )
     conversations, total = await repo.list_all(limit=limit, offset=offset)
     return {
-        "conversations": [
-            {
-                "id": c.id,
-                "title": c.title,
-                "created_at": utc_isoformat(c.created_at),
-                "updated_at": utc_isoformat(c.updated_at),
-            }
-            for c in conversations
-        ],
+        "conversations": [_serialize_conversation(c) for c in conversations],
         "total": total,
         "limit": limit,
         "offset": offset,
@@ -168,12 +161,36 @@ async def update_conversation(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Conversation {conversation_id} not found",
         )
-    return {
-        "id": conversation.id,
-        "title": conversation.title,
-        "created_at": utc_isoformat(conversation.created_at),
-        "updated_at": utc_isoformat(conversation.updated_at),
-    }
+    return _serialize_conversation(conversation)
+
+
+class PinRequest(BaseModel):
+    """Request body for pin endpoint."""
+
+    is_pinned: bool
+
+
+@router.patch("/{conversation_id}/pin")
+async def set_pin(
+    conversation_id: str,
+    body: PinRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    ctx: Annotated[RequestContext, Depends(require_member)],
+) -> dict[str, object]:
+    """Set the pinned state of a conversation (idempotent)."""
+    repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
+    conversation = await repo.set_pin(conversation_id, body.is_pinned)
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Conversation {conversation_id} not found",
+        )
+    return _serialize_conversation(conversation)
 
 
 @router.delete("/{conversation_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -208,6 +225,107 @@ async def delete_conversation(
     if not deleted:
         # Race condition: someone else deleted it between get and delete; treat as success
         pass
+
+
+class GenerateTitleRequest(BaseModel):
+    """Request body for generate-title endpoint."""
+
+    content: str
+
+
+@router.post("/{conversation_id}/generate-title")
+async def generate_title(
+    conversation_id: str,
+    body: GenerateTitleRequest,
+    raw_request: Request,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    ctx: Annotated[RequestContext, Depends(require_member)],
+) -> dict[str, object]:
+    """Generate a short title from the user's first message.
+
+    Called by the frontend at the start of the first turn, in parallel with
+    the main agent stream. Best-effort and idempotent:
+
+    - Skipped server-side once the conversation already has any messages, so a
+      retried/late call after the first turn cannot retitle an active chat.
+    - Only writes when the row's current title still equals what we read at
+      request start, so a concurrent manual rename is never clobbered.
+    """
+    repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
+    conversation = await repo.get_by_id(conversation_id)
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Conversation {conversation_id} not found",
+        )
+
+    # Server-side first-turn guard: once the conversation has any messages,
+    # we never auto-retitle (a manual `PATCH /{id}?title=…` is the way).
+    if conversation.has_messages:
+        return _serialize_conversation(conversation)
+
+    snippet = (body.content or "").strip()[:1000]
+    if not snippet:
+        return _serialize_conversation(conversation)
+
+    original_title = conversation.title
+
+    from cubebox.llm.factory import LLMFactory
+
+    backend = getattr(raw_request.app.state, "encryption_backend", None)
+    factory = LLMFactory(
+        session=session,
+        org_id=ctx.org_id,
+        encryption_backend=backend,
+    )
+    try:
+        llm = await factory.create_default(temperature=0, max_tokens=60)
+    except Exception:
+        # No usable provider/credential — leave the title alone.
+        return _serialize_conversation(conversation)
+
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    try:
+        result = await llm.ainvoke(
+            [
+                SystemMessage(
+                    content=(
+                        "Write a conversation title for a sidebar list. "
+                        "Strict rules:\n"
+                        "- Match the user's language exactly (Chinese in, "
+                        "  Chinese out; English in, English out).\n"
+                        "- 4-6 English words, OR 6-10 Chinese characters. "
+                        "  Never longer.\n"
+                        "- Front-load the core topic: the first 2-3 words "
+                        "  (first 4-6 Chinese characters) must be enough to "
+                        "  recognise the conversation if the rest is "
+                        "  truncated with an ellipsis.\n"
+                        "- Use a noun phrase. No leading verb like "
+                        "  '帮我'/'询问'/'how to'/'help with'. No punctuation. "
+                        "  No quotes. No trailing period.\n"
+                        "Return ONLY the title text."
+                    ),
+                ),
+                HumanMessage(content=snippet),
+            ]
+        )
+    except Exception:
+        return _serialize_conversation(conversation)
+
+    title = str(result.content).strip().strip('"').strip("'").strip("。 .,").strip()
+    title = title[:255]
+    if title:
+        updated = await repo.update_title_if_current(conversation_id, title, original_title)
+        if updated:
+            conversation = updated
+
+    return _serialize_conversation(conversation)
 
 
 class SendMessageRequest(BaseModel):

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -243,14 +243,11 @@ async def generate_title(
 ) -> dict[str, object]:
     """Generate a short title from the user's first message.
 
-    Called by the frontend at the start of the first turn, in parallel with
-    the main agent stream. Best-effort and idempotent:
-
-    - Skipped server-side once the conversation already has any messages, so a
-      retried/late call after the first turn cannot retitle an active chat.
-    - Only writes when the row's current title still equals what we read at
-      request start, so a concurrent manual rename is never clobbered.
+    Thin wrapper — gating, LLM invocation, and atomic compare-and-set live
+    in :mod:`cubebox.services.conversation_title`.
     """
+    from cubebox.services.conversation_title import generate_and_apply_title
+
     repo = ConversationRepository(
         session,
         org_id=ctx.org_id,
@@ -264,67 +261,15 @@ async def generate_title(
             detail=f"Conversation {conversation_id} not found",
         )
 
-    # Server-side first-turn guard: once the conversation has any messages,
-    # we never auto-retitle (a manual `PATCH /{id}?title=…` is the way).
-    if conversation.has_messages:
-        return _serialize_conversation(conversation)
-
-    snippet = (body.content or "").strip()[:1000]
-    if not snippet:
-        return _serialize_conversation(conversation)
-
-    original_title = conversation.title
-
-    from cubebox.llm.factory import LLMFactory
-
     backend = getattr(raw_request.app.state, "encryption_backend", None)
-    factory = LLMFactory(
+    conversation = await generate_and_apply_title(
+        repo=repo,
         session=session,
         org_id=ctx.org_id,
         encryption_backend=backend,
+        conversation=conversation,
+        content=body.content,
     )
-    try:
-        llm = await factory.create_default(temperature=0, max_tokens=60)
-    except Exception:
-        # No usable provider/credential — leave the title alone.
-        return _serialize_conversation(conversation)
-
-    from langchain_core.messages import HumanMessage, SystemMessage
-
-    try:
-        result = await llm.ainvoke(
-            [
-                SystemMessage(
-                    content=(
-                        "Write a conversation title for a sidebar list. "
-                        "Strict rules:\n"
-                        "- Match the user's language exactly (Chinese in, "
-                        "  Chinese out; English in, English out).\n"
-                        "- 4-6 English words, OR 6-10 Chinese characters. "
-                        "  Never longer.\n"
-                        "- Front-load the core topic: the first 2-3 words "
-                        "  (first 4-6 Chinese characters) must be enough to "
-                        "  recognise the conversation if the rest is "
-                        "  truncated with an ellipsis.\n"
-                        "- Use a noun phrase. No leading verb like "
-                        "  '帮我'/'询问'/'how to'/'help with'. No punctuation. "
-                        "  No quotes. No trailing period.\n"
-                        "Return ONLY the title text."
-                    ),
-                ),
-                HumanMessage(content=snippet),
-            ]
-        )
-    except Exception:
-        return _serialize_conversation(conversation)
-
-    title = str(result.content).strip().strip('"').strip("'").strip("。 .,").strip()
-    title = title[:255]
-    if title:
-        updated = await repo.update_title_if_current(conversation_id, title, original_title)
-        if updated:
-            conversation = updated
-
     return _serialize_conversation(conversation)
 
 

--- a/backend/cubebox/models/conversation.py
+++ b/backend/cubebox/models/conversation.py
@@ -18,3 +18,4 @@ class Conversation(CubeboxBase, OrgScopedMixin, table=True):
     creator_user_id: str = Field(foreign_key="users.id", max_length=20)
     title: str = Field(max_length=255)
     has_messages: bool = Field(default=False, index=True)
+    is_pinned: bool = Field(default=False)

--- a/backend/cubebox/models/mcp.py
+++ b/backend/cubebox/models/mcp.py
@@ -62,6 +62,14 @@ class MCPServer(CubeboxBase, table=True):
             "org_id", "owner_workspace_id", "server_url_hash", name="uq_mcp_server_url"
         ),
         UniqueConstraint("org_id", "owner_workspace_id", "name", name="uq_mcp_server_name"),
+        Index(
+            "uq_mcp_install_per_catalog",
+            "org_id",
+            text("COALESCE(owner_workspace_id, '_org')"),
+            "catalog_connector_id",
+            unique=True,
+            postgresql_where=text("catalog_connector_id IS NOT NULL"),
+        ),
     )
 
     org_id: str = Field(foreign_key="organizations.id", max_length=20, index=True)

--- a/backend/cubebox/models/organization_membership.py
+++ b/backend/cubebox/models/organization_membership.py
@@ -1,12 +1,12 @@
 """OrganizationMembership — User × Organization × org-level role.
 
 Distinct from workspace `Membership`. One owner per org enforced by a
-partial unique index (see alembic migration). Workspace-level admin
-status is orthogonal to org role.
+partial unique index. Workspace-level admin status is orthogonal to org role.
 """
 
 from enum import StrEnum
 
+from sqlalchemy import ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
 
 from cubebox.models.mixins import TimestampMixin
@@ -22,7 +22,28 @@ class OrganizationMembership(SQLModel, TimestampMixin, table=True):
     """Links a User to an Organization with an OrgRole; composite PK."""
 
     __tablename__ = "organization_memberships"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="organization_memberships_user_id_fkey",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["org_id"],
+            ["organizations.id"],
+            name="organization_memberships_org_id_fkey",
+            ondelete="CASCADE",
+        ),
+        Index("ix_org_memberships_org_id", "org_id"),
+        Index(
+            "uq_org_membership_owner",
+            "org_id",
+            unique=True,
+            postgresql_where=text("role = 'owner'"),
+        ),
+    )
 
-    user_id: str = Field(primary_key=True, foreign_key="users.id", max_length=20)
-    org_id: str = Field(primary_key=True, foreign_key="organizations.id", max_length=20)
+    user_id: str = Field(primary_key=True, max_length=20)
+    org_id: str = Field(primary_key=True, max_length=20)
     role: str = Field(max_length=32)  # values from OrgRole enum

--- a/backend/cubebox/prompts/title.py
+++ b/backend/cubebox/prompts/title.py
@@ -1,0 +1,18 @@
+"""System prompt for conversation auto-title generation.
+
+Used by ``cubebox.services.conversation_title`` when the frontend asks the
+backend to label a brand-new conversation from its first user message.
+"""
+
+TITLE_GENERATION_SYSTEM_PROMPT: str = """\
+Write a conversation title for a sidebar list. Strict rules:
+- Match the user's language exactly (Chinese in, Chinese out; English in,
+  English out).
+- 4-6 English words, OR 6-10 Chinese characters. Never longer.
+- Front-load the core topic: the first 2-3 words (first 4-6 Chinese
+  characters) must be enough to recognise the conversation if the rest is
+  truncated with an ellipsis.
+- Use a noun phrase. No leading verb like '帮我'/'询问'/'how to'/'help
+  with'. No punctuation. No quotes. No trailing period.
+Return ONLY the title text.
+"""

--- a/backend/cubebox/repositories/conversation.py
+++ b/backend/cubebox/repositories/conversation.py
@@ -8,7 +8,7 @@ the primary access check is ``creator_user_id``.
 from datetime import UTC, datetime
 from typing import Any, cast
 
-from sqlalchemy import case, desc, func, select
+from sqlalchemy import case, desc, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.models import Conversation
@@ -93,22 +93,32 @@ class ConversationRepository(ScopedRepository[Conversation]):
     async def update_title_if_current(
         self, conversation_id: str, new_title: str, expected_title: str
     ) -> Conversation | None:
-        """Update title only if it still equals expected_title.
+        """Update title atomically only if it still equals expected_title.
 
         Used by auto-title generation to avoid clobbering a concurrent manual
-        rename: if the title has changed between request start and response,
-        leave it alone and return the current row.
+        rename. Compare-and-set happens in SQL (``UPDATE … WHERE title = ?``)
+        so a stale identity-map copy in this session cannot pass the guard
+        after another transaction has already committed a rename.
+
+        Returns the current row (with whatever title now lives in the DB),
+        or ``None`` if the conversation no longer exists.
         """
-        conv = await self.get(conversation_id)
-        if not conv:
-            return None
-        if conv.title != expected_title:
-            return conv
-        conv.title = new_title
-        conv.updated_at = datetime.now(UTC)
+        now = datetime.now(UTC)
+        stmt = (
+            update(Conversation)
+            .where(
+                Conversation.id == conversation_id,  # type: ignore[arg-type]
+                Conversation.creator_user_id == self.user_id,  # type: ignore[arg-type]
+                Conversation.title == expected_title,  # type: ignore[arg-type]
+            )
+            .values(title=new_title, updated_at=now)
+        )
+        await self.session.execute(stmt)
         await self.session.commit()
-        await self.session.refresh(conv)
-        return conv
+        # Drop any stale identity-map state so the follow-up read reflects
+        # whichever writer won the race.
+        self.session.expire_all()
+        return await self.get(conversation_id)
 
     async def update_timestamp(self, conversation_id: str) -> None:
         conv = await self.get(conversation_id)

--- a/backend/cubebox/repositories/conversation.py
+++ b/backend/cubebox/repositories/conversation.py
@@ -8,7 +8,7 @@ the primary access check is ``creator_user_id``.
 from datetime import UTC, datetime
 from typing import Any, cast
 
-from sqlalchemy import desc, func, select
+from sqlalchemy import case, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.models import Conversation
@@ -55,7 +55,13 @@ class ConversationRepository(ScopedRepository[Conversation]):
         stmt = (
             self._scoped_select()
             .where(cast(Any, Conversation.has_messages).is_(True))
-            .order_by(desc(Conversation.updated_at))  # type: ignore[arg-type]
+            .order_by(
+                case(
+                    (cast(Any, Conversation.is_pinned).is_(True), 0),
+                    else_=1,
+                ),
+                desc(Conversation.updated_at),  # type: ignore[arg-type]
+            )
             .limit(limit)
             .offset(offset)
         )
@@ -84,6 +90,26 @@ class ConversationRepository(ScopedRepository[Conversation]):
         await self.session.refresh(conv)
         return conv
 
+    async def update_title_if_current(
+        self, conversation_id: str, new_title: str, expected_title: str
+    ) -> Conversation | None:
+        """Update title only if it still equals expected_title.
+
+        Used by auto-title generation to avoid clobbering a concurrent manual
+        rename: if the title has changed between request start and response,
+        leave it alone and return the current row.
+        """
+        conv = await self.get(conversation_id)
+        if not conv:
+            return None
+        if conv.title != expected_title:
+            return conv
+        conv.title = new_title
+        conv.updated_at = datetime.now(UTC)
+        await self.session.commit()
+        await self.session.refresh(conv)
+        return conv
+
     async def update_timestamp(self, conversation_id: str) -> None:
         conv = await self.get(conversation_id)
         if conv:
@@ -105,6 +131,15 @@ class ConversationRepository(ScopedRepository[Conversation]):
         conv.has_messages = True
         conv.updated_at = datetime.now(UTC)
         await self.session.commit()
+
+    async def set_pin(self, conversation_id: str, is_pinned: bool) -> Conversation | None:
+        conv = await self.get(conversation_id)
+        if not conv:
+            return None
+        conv.is_pinned = is_pinned
+        await self.session.commit()
+        await self.session.refresh(conv)
+        return conv
 
     async def delete_conversation(self, conversation_id: str) -> bool:
         return await self.delete(conversation_id)

--- a/backend/cubebox/services/conversation_title.py
+++ b/backend/cubebox/services/conversation_title.py
@@ -1,0 +1,96 @@
+"""Conversation auto-title generation service.
+
+The frontend calls ``POST /conversations/{id}/generate-title`` in parallel
+with the first user message. This service:
+
+- Skips when the conversation already has a title (durable first-turn gate
+  that is immune to ordering races against ``send_message``'s synchronous
+  ``mark_active`` write — once any title exists, auto or manual, further
+  calls are no-ops).
+- Calls the default LLM with the prompt in ``cubebox.prompts.title``.
+- Persists the new title via an atomic SQL compare-and-set so a concurrent
+  manual rename is never clobbered.
+- Swallows LLM/provider errors and returns the conversation unchanged.
+"""
+
+import logging
+from typing import Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.credentials.encryption import EncryptionBackend
+from cubebox.llm.factory import LLMFactory
+from cubebox.models import Conversation
+from cubebox.prompts.title import TITLE_GENERATION_SYSTEM_PROMPT
+from cubebox.repositories import ConversationRepository
+
+logger = logging.getLogger(__name__)
+
+MAX_SNIPPET_CHARS: int = 1000
+MAX_TITLE_CHARS: int = 255
+LLM_MAX_TOKENS: int = 60
+
+
+def _clean_title(raw: Any) -> str:
+    """Strip whitespace, surrounding quotes, and trailing punctuation."""
+    text = str(raw).strip().strip('"').strip("'").strip("。 .,").strip()
+    return text[:MAX_TITLE_CHARS]
+
+
+async def generate_and_apply_title(
+    *,
+    repo: ConversationRepository,
+    session: AsyncSession,
+    org_id: str,
+    encryption_backend: EncryptionBackend | None,
+    conversation: Conversation,
+    content: str,
+) -> Conversation:
+    """Generate and persist an auto-title for ``conversation``.
+
+    Best-effort and idempotent. Returns the (possibly updated) conversation.
+    """
+    original_title = conversation.title
+
+    # Durable first-turn gate. The frontend already restricts the call to
+    # the first turn, but a retry, a direct API call, or a race against
+    # ``send_message``'s ``mark_active`` could still arrive late. Gating on
+    # the title state — rather than ``has_messages`` — avoids that race
+    # while still preventing repeated auto-retitles of an already-named
+    # conversation.
+    if original_title != "":
+        return conversation
+
+    snippet = (content or "").strip()[:MAX_SNIPPET_CHARS]
+    if not snippet:
+        return conversation
+
+    factory = LLMFactory(
+        session=session,
+        org_id=org_id,
+        encryption_backend=encryption_backend,
+    )
+    try:
+        llm = await factory.create_default(temperature=0, max_tokens=LLM_MAX_TOKENS)
+    except Exception:
+        logger.warning("Auto-title skipped: no usable LLM provider")
+        return conversation
+
+    try:
+        result = await llm.ainvoke(
+            [
+                SystemMessage(content=TITLE_GENERATION_SYSTEM_PROMPT),
+                HumanMessage(content=snippet),
+            ]
+        )
+    except Exception:
+        logger.warning("Auto-title skipped: LLM call failed", exc_info=True)
+        return conversation
+
+    title = _clean_title(result.content)
+    if not title:
+        return conversation
+
+    updated = await repo.update_title_if_current(conversation.id, title, original_title)
+    return updated or conversation

--- a/frontend/packages/core/src/api/conversations.ts
+++ b/frontend/packages/core/src/api/conversations.ts
@@ -57,6 +57,28 @@ export async function renameConversation(
   return res.json() as Promise<Conversation>
 }
 
+export async function setPinConversation(
+  client: ApiClient,
+  id: string,
+  isPinned: boolean,
+): Promise<Conversation> {
+  const res = await client.patch(`/api/v1/conversations/${id}/pin`, {
+    is_pinned: isPinned,
+  })
+  if (!res.ok) throw await toApiError(res)
+  return res.json() as Promise<Conversation>
+}
+
+export async function generateConversationTitle(
+  client: ApiClient,
+  id: string,
+  content: string,
+): Promise<Conversation> {
+  const res = await client.post(`/api/v1/conversations/${id}/generate-title`, { content })
+  if (!res.ok) throw await toApiError(res)
+  return res.json() as Promise<Conversation>
+}
+
 export async function listMessages(
   client: ApiClient,
   conversationId: string,

--- a/frontend/packages/core/src/stores/conversationStore.ts
+++ b/frontend/packages/core/src/stores/conversationStore.ts
@@ -6,7 +6,17 @@ import {
   listConversations,
   deleteConversation,
   renameConversation,
+  setPinConversation,
+  generateConversationTitle,
 } from '../api'
+
+/** Pinned first, then recency desc — same invariant the backend uses. */
+function sortPinnedFirst(list: Conversation[]): Conversation[] {
+  return [...list].sort((a, b) => {
+    if (a.is_pinned !== b.is_pinned) return a.is_pinned ? -1 : 1
+    return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+  })
+}
 
 export interface ConversationStore {
   conversations: Conversation[]
@@ -14,10 +24,14 @@ export interface ConversationStore {
   isLoading: boolean
   isFetchingList: boolean
   error: string | null
+  /** ids currently mid-pin-request — UI uses this to disable the button. */
+  pinPending: Record<string, true>
   fetchList(client: ApiClient): Promise<void>
   create(client: ApiClient, title?: string, opts?: { draft?: boolean }): Promise<Conversation>
   remove(client: ApiClient, id: string): Promise<void>
   rename(client: ApiClient, id: string, title: string): Promise<void>
+  setPin(client: ApiClient, id: string, isPinned: boolean): Promise<void>
+  generateTitle(client: ApiClient, id: string, content: string): Promise<void>
   setActive(id: string | null): void
 }
 
@@ -27,6 +41,7 @@ export const useConversationStore = create<ConversationStore>((set, get) => ({
   isLoading: false,
   isFetchingList: false,
   error: null,
+  pinPending: {},
 
   async fetchList(client: ApiClient) {
     if (get().isFetchingList) return
@@ -45,7 +60,7 @@ export const useConversationStore = create<ConversationStore>((set, get) => ({
     set({ isLoading: true, error: null })
     try {
       const convo = await createConversation(client, title, opts)
-      set((s) => ({ conversations: [convo, ...s.conversations] }))
+      set((s) => ({ conversations: sortPinnedFirst([convo, ...s.conversations]) }))
       return convo
     } catch (err) {
       set({ error: (err as Error).message })
@@ -72,11 +87,44 @@ export const useConversationStore = create<ConversationStore>((set, get) => ({
     try {
       const updated = await renameConversation(client, id, title)
       set((s) => ({
-        conversations: s.conversations.map((c) => (c.id === id ? updated : c)),
+        conversations: sortPinnedFirst(s.conversations.map((c) => (c.id === id ? updated : c))),
       }))
     } catch (err) {
       set({ error: (err as Error).message })
       throw err
+    }
+  },
+
+  async setPin(client: ApiClient, id: string, isPinned: boolean) {
+    // Drop the call if one is already in-flight for this id, so rapid
+    // double-clicks can't race the server.
+    if (get().pinPending[id]) return
+    set((s) => ({ pinPending: { ...s.pinPending, [id]: true as const } }))
+    try {
+      const updated = await setPinConversation(client, id, isPinned)
+      set((s) => ({
+        conversations: sortPinnedFirst(s.conversations.map((c) => (c.id === id ? updated : c))),
+      }))
+    } catch (err) {
+      set({ error: (err as Error).message })
+      throw err
+    } finally {
+      set((s) => {
+        const next = { ...s.pinPending }
+        delete next[id]
+        return { pinPending: next }
+      })
+    }
+  },
+
+  async generateTitle(client: ApiClient, id: string, content: string) {
+    try {
+      const updated = await generateConversationTitle(client, id, content)
+      set((s) => ({
+        conversations: sortPinnedFirst(s.conversations.map((c) => (c.id === id ? updated : c))),
+      }))
+    } catch {
+      // Auto-title is best-effort; swallow errors
     }
   },
 

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -15,6 +15,7 @@ import type {
 import type { ApiClient } from '../api'
 import { getConversationBootstrap, streamMessages, streamRun } from '../api'
 import { useCitationStore } from './citationStore'
+import { useConversationStore } from './conversationStore'
 
 export interface AgentStream {
   text: string
@@ -753,6 +754,11 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
     attachmentIds?: string[],
     attachments?: import('../types').MessageAttachment[],
   ) {
+    const isFirstTurn = (get().messages[conversationId] ?? []).length === 0
+    if (isFirstTurn && content.trim()) {
+      void useConversationStore.getState().generateTitle(client, conversationId, content)
+    }
+
     const userMessage: Message = {
       id: `temp-${Date.now()}`,
       role: 'user',

--- a/frontend/packages/core/src/types/conversation.ts
+++ b/frontend/packages/core/src/types/conversation.ts
@@ -1,6 +1,7 @@
 export interface Conversation {
   id: string
   title: string
+  is_pinned: boolean
   created_at: string
   updated_at: string
 }

--- a/frontend/packages/web/components/layout/Sidebar.tsx
+++ b/frontend/packages/web/components/layout/Sidebar.tsx
@@ -1,39 +1,207 @@
 'use client'
 
 import Link from 'next/link'
-import { Suspense } from 'react'
+import { Suspense, useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { useTranslations } from 'next-intl'
-import { createApiClient, useConversationStore } from '@cubebox/core'
+import { type Conversation, createApiClient, useConversationStore } from '@cubebox/core'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { AvatarPopover } from '@/components/sidebar/AvatarPopover'
 import { WorkspacesSection } from '@/components/sidebar/WorkspacesSection'
 import { SettingsNav } from '@/components/workspace-settings/SettingsNav'
-import { Box, Brain, Plus, Settings, Trash2 } from 'lucide-react'
+import {
+  Box,
+  Brain,
+  MoreHorizontal,
+  Pencil,
+  Pin,
+  PinOff,
+  Plus,
+  Settings,
+  Trash2,
+} from 'lucide-react'
 
-function formatRelativeTime(
-  dateStr: string,
-  t: ReturnType<typeof useTranslations<'time'>>,
-): string {
-  const date = new Date(dateStr)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-  const diffHours = Math.floor(diffMs / 3600000)
-  const diffDays = Math.floor(diffMs / 86400000)
+type ApiClient = ReturnType<typeof createApiClient>
 
-  if (diffMins < 1) return t('justNow')
-  if (diffMins < 60) return t('minutesAgo', { n: diffMins })
-  if (diffHours < 24) return t('hoursAgo', { n: diffHours })
-  return t('daysAgo', { n: diffDays })
+function buildClient(currentWsId: string | null): ApiClient {
+  const client = createApiClient('')
+  if (currentWsId) client.setWorkspaceId(currentWsId)
+  return client
 }
 
-export function Sidebar() {
+function ConversationRow({
+  convo,
+  isActive,
+  currentWsId,
+}: {
+  convo: Conversation
+  isActive: boolean
+  currentWsId: string | null
+}): React.ReactElement {
   const tSidebar = useTranslations('sidebar')
-  const tTime = useTranslations('time')
   const tShell = useTranslations('shellLayout')
-  const { conversations, activeId, remove, setActive } = useConversationStore()
+  const { remove, rename, setPin, setActive, pinPending } = useConversationStore()
+  const isPinPending = !!pinPending[convo.id]
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState(convo.title)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!isEditing) setDraft(convo.title)
+  }, [convo.title, isEditing])
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }
+  }, [isEditing])
+
+  const commitEdit = async (): Promise<void> => {
+    const next = draft.trim()
+    setIsEditing(false)
+    if (!next || next === convo.title) return
+    try {
+      await rename(buildClient(currentWsId), convo.id, next)
+    } catch (err) {
+      console.error('Failed to rename conversation:', err)
+    }
+  }
+
+  const cancelEdit = (): void => {
+    setIsEditing(false)
+    setDraft(convo.title)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      void commitEdit()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      cancelEdit()
+    }
+  }
+
+  const stateClass = isActive
+    ? 'text-foreground bg-primary/8'
+    : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'
+  const baseRowClasses =
+    'group relative flex items-center gap-1 pl-2 pr-1 py-1.5 ' +
+    `rounded-md transition-colors ${stateClass}`
+
+  if (isEditing) {
+    return (
+      <li>
+        <div className={baseRowClasses}>
+          {convo.is_pinned && <Pin className="size-3 shrink-0 text-primary/70 fill-primary/30" />}
+          <input
+            ref={inputRef}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={() => void commitEdit()}
+            className={
+              'flex-1 min-w-0 bg-background/80 border border-border rounded ' +
+              'px-1.5 py-0.5 text-[12.5px] font-medium leading-none outline-none ' +
+              'focus:border-primary'
+            }
+          />
+        </div>
+      </li>
+    )
+  }
+
+  return (
+    <li>
+      <Link
+        href={currentWsId ? `/w/${currentWsId}/conversations/${convo.id}` : '/'}
+        onClick={() => setActive(convo.id)}
+        className={baseRowClasses}
+      >
+        {isActive && (
+          <div className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-primary rounded-r-full" />
+        )}
+        {convo.is_pinned && <Pin className="size-3 shrink-0 text-primary/70 fill-primary/30" />}
+        <div className="flex-1 min-w-0 truncate text-[12.5px] font-medium leading-tight">
+          {convo.title || tSidebar('untitledChat')}
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+            }}
+            className={
+              'p-1 rounded hover:bg-accent text-muted-foreground ' +
+              'hover:text-foreground shrink-0 opacity-0 ' +
+              'group-hover:opacity-100 data-[popup-open]:opacity-100 ' +
+              'transition-opacity'
+            }
+            aria-label={tSidebar('moreActions')}
+            title={tSidebar('moreActions')}
+          >
+            <MoreHorizontal className="size-3.5" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            side="right"
+            sideOffset={4}
+            className="w-36"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <DropdownMenuItem
+              onSelect={() => {
+                setDraft(convo.title)
+                setIsEditing(true)
+              }}
+            >
+              <Pencil className="size-3.5" />
+              {tSidebar('renameConversation')}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={isPinPending}
+              onSelect={() => {
+                void setPin(buildClient(currentWsId), convo.id, !convo.is_pinned).catch((err) =>
+                  console.error('Failed to toggle pin:', err),
+                )
+              }}
+            >
+              {convo.is_pinned ? <PinOff className="size-3.5" /> : <Pin className="size-3.5" />}
+              {convo.is_pinned ? tSidebar('unpinConversation') : tSidebar('pinConversation')}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              variant="destructive"
+              onSelect={() => {
+                void remove(buildClient(currentWsId), convo.id).catch((err) =>
+                  console.error('Failed to delete conversation:', err),
+                )
+              }}
+            >
+              <Trash2 className="size-3.5" />
+              {tShell('deleteConversation')}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </Link>
+    </li>
+  )
+}
+
+export function Sidebar(): React.ReactElement {
+  const tSidebar = useTranslations('sidebar')
+  const tShell = useTranslations('shellLayout')
+  const { conversations, activeId } = useConversationStore()
   const pathname = usePathname()
 
   // Current workspace inferred from URL (no WorkspaceContext dependency).
@@ -43,17 +211,6 @@ export function Sidebar() {
   const isSettingsRoute = currentWsId
     ? (pathname?.startsWith('/w/' + currentWsId + '/settings') ?? false)
     : false
-
-  const handleDeleteClick = async (e: React.MouseEvent, id: string) => {
-    e.preventDefault()
-    const client = createApiClient('')
-    if (currentWsId) client.setWorkspaceId(currentWsId)
-    try {
-      await remove(client, id)
-    } catch (err) {
-      console.error('Failed to delete conversation:', err)
-    }
-  }
 
   return (
     <aside
@@ -107,36 +264,12 @@ export function Sidebar() {
         <ScrollArea className="flex-1 px-2">
           <ul className="space-y-0.5">
             {conversations.map((convo) => (
-              <li key={convo.id}>
-                <Link
-                  href={currentWsId ? `/w/${currentWsId}/conversations/${convo.id}` : '/'}
-                  onClick={() => setActive(convo.id)}
-                  className={`group relative flex items-center gap-2 px-2 py-2 rounded-md transition-colors ${
-                    activeId === convo.id
-                      ? 'text-foreground bg-primary/8'
-                      : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'
-                  }`}
-                >
-                  {activeId === convo.id && (
-                    <div className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-primary rounded-r-full" />
-                  )}
-                  <div className="flex-1 min-w-0 pl-1">
-                    <div className="truncate text-[12.5px] font-medium leading-none mb-1">
-                      {convo.title || tSidebar('untitledChat')}
-                    </div>
-                    <div className="text-[10px] text-muted-foreground/50">
-                      {formatRelativeTime(convo.created_at, tTime)}
-                    </div>
-                  </div>
-                  <button
-                    onClick={(e) => handleDeleteClick(e, convo.id)}
-                    className="opacity-0 group-hover:opacity-40 hover:!opacity-80 transition-opacity shrink-0 p-0.5"
-                    aria-label={tShell('deleteConversation')}
-                  >
-                    <Trash2 className="size-3" />
-                  </button>
-                </Link>
-              </li>
+              <ConversationRow
+                key={convo.id}
+                convo={convo}
+                isActive={activeId === convo.id}
+                currentWsId={currentWsId}
+              />
             ))}
           </ul>
         </ScrollArea>

--- a/frontend/packages/web/components/ui/dropdown-menu.tsx
+++ b/frontend/packages/web/components/ui/dropdown-menu.tsx
@@ -1,0 +1,258 @@
+'use client'
+
+import * as React from 'react'
+import { Menu as MenuPrimitive } from '@base-ui/react/menu'
+
+import { cn } from '@/lib/utils'
+import { ChevronRightIcon, CheckIcon } from 'lucide-react'
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuContent({
+  align = 'start',
+  alignOffset = 0,
+  side = 'bottom',
+  sideOffset = 4,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<MenuPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset'>) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+            'z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95',
+            className,
+          )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        'px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: 'default' | 'destructive'
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  align = 'start',
+  alignOffset = -3,
+  side = 'right',
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        'w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+        className,
+      )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return <MenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSeparator({ className, ...props }: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        'ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -15,7 +15,11 @@
   "sidebar": {
     "newChat": "New chat",
     "recentChats": "Recent chats",
-    "untitledChat": "New conversation"
+    "untitledChat": "New conversation",
+    "renameConversation": "Rename",
+    "pinConversation": "Pin",
+    "unpinConversation": "Unpin",
+    "moreActions": "More"
   },
   "time": {
     "justNow": "Just now",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -15,7 +15,11 @@
   "sidebar": {
     "newChat": "新建对话",
     "recentChats": "最近会话",
-    "untitledChat": "新对话"
+    "untitledChat": "新对话",
+    "renameConversation": "重命名",
+    "pinConversation": "置顶",
+    "unpinConversation": "取消置顶",
+    "moreActions": "更多"
   },
   "time": {
     "justNow": "刚刚",


### PR DESCRIPTION
## Summary

Four user-facing changes to the **Recent Chats** sidebar, plus a small backend cleanup that silences `alembic autogenerate` noise.

- **Inline rename** — `Pencil` action in the per-row menu swaps the title for an editable input. Enter / blur commits, Escape cancels.
- **Pin / unpin** — new `is_pinned` column on conversations (default `false`). `PATCH /conversations/{id}/pin` with `{is_pinned: bool}` is an **idempotent set**, not a toggle, so rapid double-clicks can't race the server. The store de-dupes in-flight requests per id and disables the menu item while pending. `list_all` orders pinned rows first then by recency, and the frontend re-sorts after every local mutation (`create` / `rename` / `setPin` / `generateTitle`) so the invariant holds without a refetch.
- **Auto-titled chats** — `POST /conversations/{id}/generate-title` with the first user message generates a 4-6 word / 6-10 Chinese-character title via the default LLM. Triggered from the frontend in parallel with the first send, **only on the first turn**. The backend also refuses to retitle once `has_messages=True`, and only writes when the row's current title still equals what we read at request start, so a concurrent manual rename is never clobbered. LLM/provider failures silently leave the title alone. Prompt front-loads the core topic so the first 2-3 words remain useful after pixel-based ellipsis truncation.
- **Compact actions** — the timestamp is gone, and the three per-row buttons collapse into a single `MoreHorizontal` trigger that opens a shadcn DropdownMenu (Rename / Pin / Delete). Reclaims roughly two icons' worth of horizontal room for the title.
- **Bonus** (separate commit): declare DB-only constraints (`ondelete=CASCADE` FKs, `ix_org_memberships_org_id`, `uq_org_membership_owner` partial unique, `uq_mcp_install_per_catalog` functional partial unique) in the `OrganizationMembership` and `MCPServer` SQLModels so `alembic check` no longer prints spurious drop/recreate diffs.

## Schema

- `4be6ed892e02_add_conversation_is_pinned` — adds `conversations.is_pinned BOOLEAN NOT NULL DEFAULT FALSE`. No backfill needed (default safe for existing rows).

## API surface

| Method | Path | Body | Notes |
|---|---|---|---|
| `PATCH` | `/conversations/{id}/pin` | `{"is_pinned": bool}` | Idempotent set. |
| `POST` | `/conversations/{id}/generate-title` | `{"content": str}` | Best-effort; no-op once `has_messages=True` or on concurrent rename. |

All existing conversation responses now include `is_pinned: bool` in their JSON shape.

## Test plan

- [x] Backend lint / type-check / unit + e2e (`make check`, `make lint`, `make type-check`, `pytest tests/e2e`) — **255 passed, 11 skipped**
- [x] Frontend type-check (`pnpm type-check` across both packages) — **Done**
- [x] Frontend Playwright e2e (`pnpm test:e2e`) — **42 passed, 3 flaky (preexisting MCP/M2), 1 preexisting flake in `chat-flow.spec.ts:36` reproduced on `main` with these changes stashed**
- [x] `alembic check` — no diff
- [ ] Manual: create a fresh conversation, see auto-title appear within ~1s of the first response; verify it is **not** re-generated on the second turn
- [ ] Manual: pin a conversation, refresh — still at the top above unpinned recent ones
- [ ] Manual: double-click pin rapidly — final state matches last user intent (no flicker), button disabled mid-request
- [ ] Manual: rename a conversation during auto-title generation; the manual rename wins (auto-title leaves it alone)
- [ ] Manual: long Chinese + long English titles both ellipsis at the same pixel width
- [ ] Codex review applied (high/medium findings #1–#3 incorporated; #4 conventions addressed)