### PR TITLE
fix(mcp): make workspace override credential_mode default to inherit

### DIFF
--- a/backend/alembic/versions/1991a15c011d_make_workspace_mcp_override_credential_.py
+++ b/backend/alembic/versions/1991a15c011d_make_workspace_mcp_override_credential_.py
@@ -1,0 +1,56 @@
+"""make workspace mcp override credential_mode nullable
+
+Revision ID: 1991a15c011d
+Revises: 09a4503eba8a
+Create Date: 2026-05-13 11:52:40.136741
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1991a15c011d'
+down_revision: Union[str, Sequence[str], None] = '09a4503eba8a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    ``credential_mode`` originally landed as NOT NULL with server_default='org',
+    which made every pre-existing override row claim a hard ``org`` mode even
+    when the workspace had never opted out of the server-level ``credential_scope``.
+    That broke user-scope OAuth installs: the runtime would resolve effective_mode
+    to 'org', look up a non-existent org credential, and call the upstream MCP
+    with no Authorization header.
+
+    Make the column nullable (NULL = inherit ``MCPServer.credential_scope``) and
+    rewrite the migration-backfilled 'org' rows back to NULL. We can't tell apart
+    user-set 'org' from migration-backfilled 'org' for rows created before this
+    revision, but the UI hasn't shipped an explicit 'org' opt-in yet, so treating
+    them all as inherit is safe.
+    """
+    op.execute("UPDATE workspace_mcp_overrides SET credential_mode = NULL WHERE credential_mode = 'org'")
+    op.alter_column(
+        "workspace_mcp_overrides",
+        "credential_mode",
+        existing_type=sa.String(length=16),
+        nullable=True,
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("UPDATE workspace_mcp_overrides SET credential_mode = 'org' WHERE credential_mode IS NULL")
+    op.alter_column(
+        "workspace_mcp_overrides",
+        "credential_mode",
+        existing_type=sa.String(length=16),
+        nullable=False,
+        server_default="org",
+    )

--- a/backend/cubebox/api/routes/v1/ws_settings.py
+++ b/backend/cubebox/api/routes/v1/ws_settings.py
@@ -281,7 +281,7 @@ async def list_workspace_mcp(
         if override is None or not override.enabled:
             continue
 
-        mode = override.credential_mode or "org"
+        mode = override.credential_mode or srv.credential_scope
         credential_source: str | None = None
         credential_shared_by: str | None = None
 

--- a/backend/cubebox/models/mcp.py
+++ b/backend/cubebox/models/mcp.py
@@ -136,6 +136,7 @@ class WorkspaceMCPOverride(CubeboxBase, OrgScopedMixin, table=True):
     (default-invisible semantics).
 
     ``credential_mode`` controls how credentials resolve for this workspace:
+    - ``None``: inherit ``MCPServer.credential_scope`` (default — no override)
     - ``org``: use the org-level shared credential (MCPServer.credential_id)
     - ``workspace``: one member provides a credential shared by all workspace members
     - ``user``: each member authenticates individually
@@ -147,7 +148,7 @@ class WorkspaceMCPOverride(CubeboxBase, OrgScopedMixin, table=True):
 
     mcp_server_id: str = Field(foreign_key="mcp_servers.id", max_length=20, index=True)
     enabled: bool = Field(default=False)
-    credential_mode: str = Field(default="org", max_length=16)
+    credential_mode: str | None = Field(default=None, max_length=16)
     updated_by_user_id: str = Field(foreign_key="users.id", max_length=20)
 
 

--- a/backend/tests/unit/test_mcp_service_invariants.py
+++ b/backend/tests/unit/test_mcp_service_invariants.py
@@ -564,3 +564,51 @@ async def test_workspace_override_credential_mode_redirects_credential_writes(
         plaintext="user-secret",
     )
     assert user_cred_id
+
+
+async def test_workspace_override_with_null_credential_mode_inherits_server_scope(
+    mcp_service: MCPServerService,
+) -> None:
+    """An enabled override row with credential_mode=NULL must inherit the
+    server-level ``credential_scope`` rather than silently defaulting to 'org'.
+
+    Regression for the bug where existing override rows backfilled to 'org'
+    by the 09a4503eba8a migration broke user-scope OAuth installs.
+    """
+    server = await mcp_service.create(
+        name="user-scope-server",
+        server_url="https://user-scope",
+        transport="streamable_http",
+        auth_method="static",
+        credential_scope="user",
+    )
+
+    await mcp_service.override_repo.upsert(
+        workspace_id="ws-test",
+        mcp_server_id=server.id,
+        enabled=True,
+        updated_by_user_id="u1",
+    )
+    override = await mcp_service.override_repo.get_for_workspace_and_server(
+        workspace_id="ws-test", mcp_server_id=server.id
+    )
+    assert override is not None
+    assert override.credential_mode is None, "new overrides must inherit, not lock to 'org'"
+
+    # set_user_credential must be allowed because effective_mode falls back to
+    # the server's 'user' scope.
+    user_cred_id = await mcp_service.set_user_credential(
+        server_id=server.id,
+        user_id="u9",
+        workspace_id="ws-test",
+        plaintext="user-secret",
+    )
+    assert user_cred_id
+
+    # And the org write path is still rejected (effective_mode != 'org').
+    with pytest.raises(MCPCredentialPathMismatch):
+        await mcp_service.set_workspace_credential(
+            server_id=server.id,
+            workspace_id="ws-test",
+            plaintext="ws-secret",
+        )


### PR DESCRIPTION
## Summary

- `WorkspaceMCPOverride.credential_mode` shipped as NOT NULL with model + migration defaults of `'org'`, so every pre-existing override row claimed a hard `'org'` mode even when the workspace had never opted out of the server-level `credential_scope`.
- This silently broke previously-authenticated user-scope OAuth installs (e.g. Notion): the runtime resolved `effective_mode = 'org'`, looked up a non-existent org credential, and called the upstream MCP with no `Authorization` header — surfaced as `401 Unauthorized` from sync-tools and from agent runs.
- The runtime helper already treats a falsy `credential_mode` as "inherit server scope", which was the original intent. Make the column nullable with `NULL = inherit`, drop the column default, and rewrite migration-backfilled `'org'` rows back to `NULL` on upgrade.
- Also fix `list_workspace_mcp` in `ws_settings.py` which had a parallel `or "org"` fallback that masked the same bug in the workspace MCP listing UI.

## Files

- `backend/cubebox/models/mcp.py` — `credential_mode: str | None = Field(default=None, ...)`
- `backend/alembic/versions/1991a15c011d_*.py` — `UPDATE … SET credential_mode = NULL WHERE credential_mode = 'org'`; drop server_default; make nullable
- `backend/cubebox/api/routes/v1/ws_settings.py` — `mode = override.credential_mode or srv.credential_scope`
- `backend/tests/unit/test_mcp_service_invariants.py` — regression test: enabled override with `credential_mode=NULL` inherits the server's `user` scope

## Test plan

- [x] `make check-ci` (645 passed)
- [x] alembic upgrade → downgrade → upgrade round-trip on local Postgres
- [ ] Manually verify previously-authenticated Notion is recognized again after `alembic upgrade head` on the affected DB
- [ ] Sync tools button on the workspace user MCP page returns successfully (no 401)
- [ ] Agent run that uses Notion succeeds end-to-end