### PR TITLE
fix(auth): resolve_current_org_id picks highest-role org membership

### DIFF
--- a/backend/cubebox/auth/dependencies.py
+++ b/backend/cubebox/auth/dependencies.py
@@ -4,12 +4,12 @@ from collections.abc import Awaitable, Callable
 from typing import Annotated, cast
 
 from fastapi import Depends, HTTPException, Path, Request, status
-from sqlalchemy import select
+from sqlalchemy import case, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.auth.context import RequestContext
 from cubebox.db import get_session
-from cubebox.models import Membership, Role, User, Workspace
+from cubebox.models import Membership, OrganizationMembership, OrgRole, Role, User, Workspace
 from cubebox.plugins import PermissionChecker, PermissionResource, get_registry
 from cubebox.plugins.defaults.permissions import DefaultPermissionChecker
 from cubebox.repositories import MembershipRepository, WorkspaceRepository
@@ -105,24 +105,38 @@ require_member = require_role(Role.ADMIN, Role.MEMBER)
 
 
 async def resolve_current_org_id(user: User, session: AsyncSession) -> str:
-    """Resolve the user's current org (v1: first workspace's org).
+    """Resolve the user's current org from `organization_memberships`.
 
-    v1 is single-org-per-user (register bootstrap creates one personal org).
-    When multi-org ships, this reads a cookie-set current_org_id and validates
-    that the user is a member of a workspace in that org.
+    A user may belong to multiple orgs once cross-org workspace membership is
+    in play. We prefer the org where the user has the highest role
+    (owner > admin > member), then the oldest membership as a stable tiebreaker.
 
-    Raises 403 if the user has no workspace memberships at all — shouldn't
-    happen for a registered user but guards against edge cases.
+    Falls back to the user's oldest workspace's org (for legacy data where the
+    org_memberships row may be missing) before giving up with 403.
     """
-    stmt = (
+    role_priority = case(
+        (OrganizationMembership.role == OrgRole.OWNER.value, 0),  # type: ignore[arg-type]
+        (OrganizationMembership.role == OrgRole.ADMIN.value, 1),  # type: ignore[arg-type]
+        else_=2,
+    )
+    om_stmt = (
+        select(OrganizationMembership)
+        .where(OrganizationMembership.user_id == user.id)  # type: ignore[arg-type]
+        .order_by(role_priority, OrganizationMembership.created_at)  # type: ignore[arg-type]
+        .limit(1)
+    )
+    om = (await session.execute(om_stmt)).scalars().first()
+    if om is not None:
+        return om.org_id
+
+    ws_stmt = (
         select(Workspace)
         .join(Membership, Membership.workspace_id == Workspace.id)  # type: ignore[arg-type]
         .where(Membership.user_id == user.id)  # type: ignore[arg-type]
         .order_by(Workspace.created_at)  # type: ignore[arg-type]
         .limit(1)
     )
-    result = await session.execute(stmt)
-    workspace = result.scalars().first()
+    workspace = (await session.execute(ws_stmt)).scalars().first()
     if workspace is None:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -355,6 +355,30 @@ async def _ensure_test_user_membership(
     user_db = SQLAlchemyUserDatabase(session, User)
     manager = UserManager(user_db)
     user = await manager.create(BaseUserCreate(email=email, password=password), safe=False)
+
+    # multi_tenant bootstrap auto-creates a personal org/workspace for the user
+    # and grants them OrgRole.OWNER + workspace-admin there. Tests want the user
+    # scoped to exactly the explicit `org`/`ws` created above, so wipe any
+    # bootstrap-created memberships in other orgs.
+    from sqlalchemy import delete
+
+    from cubebox.models import Membership as MembershipModel
+    from cubebox.models import OrganizationMembership
+
+    await session.execute(
+        delete(OrganizationMembership).where(
+            OrganizationMembership.user_id == user.id,  # type: ignore[arg-type]
+            OrganizationMembership.org_id != org.id,  # type: ignore[arg-type]
+        )
+    )
+    await session.execute(
+        delete(MembershipModel).where(
+            MembershipModel.user_id == user.id,  # type: ignore[arg-type]
+            MembershipModel.workspace_id != ws.id,  # type: ignore[arg-type]
+        )
+    )
+    await session.commit()
+
     await mem_repo.grant(user_id=user.id, workspace_id=ws.id, role=role)
     org_role = OrgRole.OWNER if role == Role.ADMIN else OrgRole.MEMBER
     await OrganizationMembershipRepository(session).grant(

--- a/backend/tests/e2e/test_admin_me.py
+++ b/backend/tests/e2e/test_admin_me.py
@@ -29,6 +29,69 @@ async def test_unauthenticated_returns_401(unauthenticated_memory_client):
     assert resp.status_code == 401, resp.text
 
 
+async def test_admin_me_picks_own_org_when_added_to_older_foreign_workspace(
+    admin_client, session_factory
+):
+    """A user who joined an older foreign workspace must still resolve to their own org.
+
+    Regression: `resolve_current_org_id` previously picked the user's first
+    joined workspace's org, which broke once cross-org workspace membership
+    landed — a user added to another org's older workspace was reported as
+    `is_admin=false` of THAT org instead of owner of their own.
+    """
+    import secrets
+
+    from fastapi_users.db import SQLAlchemyUserDatabase
+    from fastapi_users.schemas import BaseUserCreate
+    from sqlalchemy import select
+
+    from cubebox.auth.users import UserManager
+    from cubebox.models import Role, User, Workspace
+    from cubebox.models.organization_membership import OrgRole
+    from cubebox.repositories import MembershipRepository, OrganizationMembershipRepository
+
+    client, ws_a = admin_client
+    me_a = (await client.get("/api/v1/auth/me")).json()
+    a_user_id: str = me_a["id"]
+
+    async with session_factory() as session:
+        ws_a_row = (
+            await session.execute(select(Workspace).where(Workspace.id == ws_a))
+        ).scalar_one()
+        org_a = ws_a_row.org_id
+
+        email_b = f"new-owner-{secrets.token_hex(4)}@example.com"
+        manager = UserManager(SQLAlchemyUserDatabase(session, User))
+        b = await manager.create(BaseUserCreate(email=email_b, password="test12345"), safe=False)
+        b_id = b.id
+
+        # B is added to A's org (and A's workspace) by A. B was registered LATER
+        # so the bootstrap might or might not have created an own org; we don't
+        # care for this test — what matters is the foreign membership comes
+        # first by created_at-of-workspace.
+        await OrganizationMembershipRepository(session).grant(
+            user_id=b_id, org_id=org_a, role=OrgRole.MEMBER
+        )
+        await MembershipRepository(session).grant(user_id=b_id, workspace_id=ws_a, role=Role.MEMBER)
+
+    # Login as B
+    resp = await client.post(
+        "/api/v1/auth/login",
+        data={"username": email_b, "password": "test12345"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code in (200, 204), resp.text
+
+    me_resp = await client.get("/api/v1/admin/me")
+    assert me_resp.status_code == 200, me_resp.text
+    body = me_resp.json()
+    # B is owner of their own org, not A's — even though A's workspace is older.
+    assert body["org_id"] != org_a, body
+    assert body["is_admin"] is True, body
+    # cleanup: avoid touching A's user assertions in this client
+    assert a_user_id != b_id
+
+
 async def test_admin_me_uses_org_membership_not_workspace_admin(member_client, session_factory):
     """A workspace-admin who is NOT an org admin reports is_admin=false."""
     client, workspace_id = member_client


### PR DESCRIPTION
## Summary

After member management landed, a user can be a workspace-member of another org's older workspace. The previous `resolve_current_org_id` walked workspaces in `created_at` order and returned the first joined workspace's `org_id` — so any user added to a foreign older workspace was treated as "currently in that org" and got `is_admin=false` on their own `/admin/me`, `/admin/members` operated on the wrong org, etc.

Switch to reading `organization_memberships` directly, ordered by role priority (owner > admin > member) with `created_at` as a stable tiebreaker. Falls back to the previous workspace-based resolution only for legacy users with no `organization_memberships` row.

## Reproduction (against current live `cubebox` DB)

1. Register user A → A has personal org + Personal workspace
2. Register user B → B has personal org + Personal workspace
3. A adds B as `member` of A's org via `/admin/members`
4. A adds B as `member` of A's Personal workspace via `/ws/{wsA}/members`
5. Login as B and hit `/api/v1/admin/me`

Before this fix, B sees `{"is_admin": false, "org_id": "<A's org>", "org_name": "<A's org>"}` — B's own org is hidden behind A's older workspace.

After this fix, B sees `{"is_admin": true, "org_id": "<B's own org>", "org_name": "<B's own org>"}`.

Same problem affected `/admin/members`, `/admin/skills`, MCP admin routes, and cost/insights routes — they all use `resolve_current_org_id`.

## Test plan

- [x] `pytest tests/e2e/test_admin_me.py tests/e2e/test_admin_members.py tests/e2e/test_ws_members.py` — 27 passed
- [x] New `test_admin_me_picks_own_org_when_added_to_older_foreign_workspace` regression test
- [x] `make backend-check-ci` and `make frontend-check-ci` pass (pre-commit hooks green on push)
- [ ] Manual smoke: log in as a user with cross-org workspace membership and verify `/admin/*` operates on the correct org