### PR TITLE
fix(sandbox): keep sandbox alive during long turns + silence third-party DEBUG

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -3,6 +3,16 @@ default:
   env: default
   debug: false
 
+  # Logging Configuration
+  # When `debug: true` the root level is DEBUG, which captures every chatty
+  # third-party logger (botocore/aiobotocore/httpcore/...) via the stdlib
+  # intercept. `third_party_level` caps a known-noisy list at a higher level
+  # by default. Per-module overrides go in `verbose_modules` (full or partial
+  # logger names) for selectively re-enabling DEBUG.
+  logging:
+    third_party_level: "WARNING"
+    verbose_modules: []
+
   # Deployment Configuration
   deployment:
     mode: single_tenant
@@ -111,7 +121,11 @@ default:
     # ttl: Sandbox idle timeout (time since last activity before cleanup)
     #   SandboxManager's background cleanup task periodically checks for sandboxes
     #   that have been inactive (no commands) for this duration and terminates them.
-    ttl: 600 # 10 minutes in seconds
+    #   Activity is refreshed at turn start (get_or_create reuse), turn end (release),
+    #   and during the turn whenever LazySandbox is exercised — throttled by
+    #   `touch_interval` so chatty execute/upload loops don't hammer the DB.
+    ttl: 1800 # 30 minutes in seconds
+    touch_interval: 60 # Min seconds between activity touches from LazySandbox
     cleanup_interval: 60 # Cleanup task interval in seconds
     workdir: "/workspace" # Default working directory for command execution
     # resource: CPU and memory limits for sandbox containers

--- a/backend/cubebox/sandbox/lazy.py
+++ b/backend/cubebox/sandbox/lazy.py
@@ -140,7 +140,6 @@ class LazySandbox(Sandbox):
         """Ensure sandbox, retrying once if the existing one is broken."""
         try:
             sandbox = await self._ensure()
-            return sandbox
         except Exception:
             # First attempt failed — reset and try creating a fresh one
             async with self._lock:
@@ -149,7 +148,19 @@ class LazySandbox(Sandbox):
                 "Lazy sandbox: first attempt failed for user {}, retrying",
                 self._user_id,
             )
-            return await self._ensure()
+            sandbox = await self._ensure()
+
+        # Refresh last_activity so cleanup_expired won't kill an in-use
+        # sandbox mid-turn. Throttled inside the manager.
+        try:
+            await self._manager.touch(
+                sandbox.id,
+                org_id=self._org_id,
+                workspace_id=self._workspace_id,
+            )
+        except Exception:
+            logger.exception("Lazy sandbox: touch failed (non-fatal)")
+        return sandbox
 
     # ------------------------------------------------------------------
     # Sandbox interface

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -14,7 +14,7 @@ versioned paths under ``/.skills/<name>/<version>/``.
 
 import hashlib
 import re
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
 import opensandbox
 from loguru import logger
@@ -40,8 +40,13 @@ class SandboxManager:
         self._api_key: str | None = config.get("sandbox.api_key", None)
         self._request_timeout: int = config.get("sandbox.request_timeout", 60)
         self._ttl: int = config.get("sandbox.ttl", 600)
+        self._touch_interval: int = config.get("sandbox.touch_interval", 60)
         self._ready_timeout: int = config.get("sandbox.ready_timeout", 60)
         self._use_server_proxy: bool = config.get("sandbox.use_server_proxy", False)
+
+        # In-process cache of (sandbox_id -> last_touch_at) used to throttle
+        # mid-turn activity bumps so chatty tool loops don't hammer the DB.
+        self._touch_cache: dict[str, datetime] = {}
 
         # Sandbox workdir
         self._workdir: str = config.get("sandbox.workdir", "/workspace")
@@ -197,6 +202,30 @@ class SandboxManager:
             repo = UserSandboxRepository(session, org_id=org_id, workspace_id=workspace_id)
             await repo.update_activity_by_sandbox_id(sandbox_id)
             logger.debug("Released sandbox {}", sandbox_id)
+
+    async def touch(
+        self,
+        sandbox_id: str,
+        *,
+        org_id: str,
+        workspace_id: str,
+    ) -> None:
+        """Refresh `last_activity_at` for an in-use sandbox.
+
+        Called from `LazySandbox` before each tool invocation so that
+        cleanup_expired won't kill a sandbox in active use mid-turn.
+        Throttled by `sandbox.touch_interval` to avoid one DB write per
+        execute call.
+        """
+        now = datetime.now(UTC)
+        last = self._touch_cache.get(sandbox_id)
+        if last is not None and (now - last).total_seconds() < self._touch_interval:
+            return
+        self._touch_cache[sandbox_id] = now
+
+        async with self._session_factory() as session:
+            repo = UserSandboxRepository(session, org_id=org_id, workspace_id=workspace_id)
+            await repo.update_activity_by_sandbox_id(sandbox_id)
 
     async def cleanup_expired(self) -> None:
         """Find and terminate sandboxes that exceeded their TTL.

--- a/backend/cubebox/utils/log.py
+++ b/backend/cubebox/utils/log.py
@@ -78,6 +78,45 @@ def json_formatter(record: dict[str, Any]) -> str:
     return formatting
 
 
+# Third-party libraries that emit large volumes of DEBUG output when the root
+# logger is at DEBUG. Capped to `logging.third_party_level` by default; opt
+# back into DEBUG via `logging.verbose_modules`.
+_NOISY_THIRD_PARTY_LOGGERS = (
+    "botocore",
+    "aiobotocore",
+    "boto3",
+    "s3transfer",
+    "urllib3",
+    "httpcore",
+    "httpx",
+    "anthropic",
+    "openai",
+    "opensandbox",
+)
+
+
+def _apply_third_party_log_levels(root_level: int) -> None:
+    """Silence chatty third-party loggers, then re-enable any opted-in modules.
+
+    If `root_level` is already INFO or higher, the silence cap is a no-op
+    (third-party loggers already inherit INFO from root). The opt-in
+    `verbose_modules` list still works at any root level.
+    """
+    third_party_name = str(config.get("logging.third_party_level", "WARNING")).upper()
+    third_party_level = logging.getLevelName(third_party_name)
+    if not isinstance(third_party_level, int):
+        third_party_level = logging.WARNING
+
+    # Only raise the floor — never lower a logger below its natural level.
+    if third_party_level > root_level:
+        for name in _NOISY_THIRD_PARTY_LOGGERS:
+            logging.getLogger(name).setLevel(third_party_level)
+
+    verbose_modules = config.get("logging.verbose_modules", []) or []
+    for name in verbose_modules:
+        logging.getLogger(name).setLevel(logging.DEBUG)
+
+
 class InterceptHandler(logging.Handler):
     """
     Intercept standard logging and redirect to loguru.
@@ -134,6 +173,8 @@ def init(log_path: str | None = None, debug: bool | None = None) -> None:
     logging.basicConfig(handlers=[intercept_handler], level=level, force=True)
     logging.getLogger("uvicorn.access").handlers = [intercept_handler]
     logging.getLogger("uvicorn").handlers = [intercept_handler]
+
+    _apply_third_party_log_levels(level)
 
     diagnose = bool(debug)
     logger.configure(


### PR DESCRIPTION
## Summary

Two fixes prompted by today's log review:

**1. Sandbox lifecycle (`fix(sandbox)`)**
- `last_activity_at` was only refreshed at turn start and turn end. A long-running turn could be killed mid-flight by `cleanup_expired`, and any think-pause >10min between turns forced a full sandbox re-create + skill re-init. Today's log: between 16:22–17:11 a single user burned through 5 fresh sandboxes (lifetime 11–13 min each, zero reuses); once their cadence tightened, sandbox E lived ~51min and was reused 10×.
- Bump `sandbox.ttl` 600 → 1800 (30 min).
- Add `SandboxManager.touch(sandbox_id, *, org_id, workspace_id)` with an in-process throttle (`sandbox.touch_interval`, default 60 s) so chatty execute/upload loops don't hammer the DB.
- `LazySandbox._ensure_with_retry` now calls `touch()` after every ensure — covers `execute` / `upload` / `download` / `file_read`.

**2. Third-party DEBUG noise (`chore(logging)`)**
- With `debug: true`, root logger is DEBUG and stdlib intercept forwards everything to loguru. Today's log was 91% DEBUG, dominated by `aiobotocore.hooks` (40%), `httpcore._trace` (29%), `botocore.*` (15%).
- Hardcoded silence list capped to `logging.third_party_level` (default `WARNING`). The cap only raises — if root is already INFO+ it's a no-op.
- To re-enable DEBUG for a specific module: `logging.verbose_modules: ["httpcore"]` in YAML or `CUBEBOX_LOGGING__VERBOSE_MODULES='["httpcore"]'`.

## Test plan

- [ ] `make check` (ruff + mypy + tests) — pre-commit + pre-push hooks already green
- [ ] Long-running turn (>30 min of model time or many `execute` calls) does not get its sandbox killed by `cleanup_expired`
- [ ] After a 20-min think-pause between turns, the same sandbox is reused (no "Creating new sandbox" log)
- [ ] Backend logs default to INFO for `botocore` / `httpcore` / `aiobotocore` etc.; adding one to `logging.verbose_modules` brings it back to DEBUG