### PR TITLE
fix(conversations): let auto-title service run on first turn

### DIFF
--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -74,9 +74,9 @@ async def _update_conversation_timestamp(
 
 @router.post("", status_code=status.HTTP_201_CREATED)
 async def create_conversation(
-    title: str,
     session: Annotated[AsyncSession, Depends(get_session)],
     ctx: Annotated[RequestContext, Depends(require_member)],
+    title: str = "",
     draft: bool = False,
 ) -> dict[str, object]:
     """Create a new conversation.

--- a/frontend/packages/web/app/(app)/w/[wsId]/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/page.tsx
@@ -28,7 +28,7 @@ export default function WorkspaceHomePage({
     if (draftConvId) return draftConvId
     const client = createApiClient('')
     client.setWorkspaceId(wsId)
-    const convo = await createConversation(client, 'New chat', { draft: true })
+    const convo = await createConversation(client, '', { draft: true })
     useConversationStore.setState({ activeId: convo.id })
     setDraftConvId(convo.id)
     return convo.id
@@ -63,10 +63,16 @@ export default function WorkspaceHomePage({
           }
         })
 
-      const title = content.trim() ? content.trim().slice(0, 30) : 'Files'
-      await renameConversation(client, convId, title).catch((err) => {
-        console.error('Failed to set conversation title:', err)
-      })
+      // Only stamp a placeholder title for files-only submissions. When the
+      // user typed text, leave title empty so the backend's generate-title
+      // service can produce an LLM title — preempting it here would trip
+      // the "already-titled" gate in conversation_title.py and silently
+      // skip auto-generation.
+      if (!content.trim() && attachedIds.length > 0) {
+        await renameConversation(client, convId, 'Files').catch((err) => {
+          console.error('Failed to set conversation title:', err)
+        })
+      }
 
       useAttachmentStore.getState().clear(convId)
       send(client, convId, content, attachedIds, optimisticAttachments).catch((err) => {


### PR DESCRIPTION
## Summary

`POST /conversations/{id}/generate-title` was silently no-op'ing on every first
turn — the sidebar would show "New chat" (or the raw user input) forever, even
though the backend service is in place and the LLM call path is healthy.

Root cause is two writes the frontend made **before** calling `generate-title`,
each of which left a non-empty title in the DB and tripped the durable
`if original_title != "": return` gate in `services/conversation_title.py`:

1. Draft conversation was created with `title="New chat"`.
2. Just before `send`, the home page PATCHed the title to the first 30 chars of
   the user input.

By the time the service ran, `original_title` was already non-empty, so the
gate intentionally bailed (it exists to avoid clobbering a concurrent manual
rename). The LLM call never happened.

## Fix

- **Backend** (`backend/cubebox/api/routes/v1/conversations.py`): `title` on
  `POST /conversations` is now optional with default `""` (parameter order
  shuffled so the non-default `session`/`ctx` come first).
- **Frontend** (`frontend/packages/web/app/(app)/w/[wsId]/page.tsx`):
  - Drafts are created without a title.
  - The pre-`send` `renameConversation` PATCH is gated to files-only
    submissions, where it still sets a `'Files'` placeholder (the backend's
    auto-title service early-returns on empty snippet, so a placeholder is
    still needed there).

The manual-rename gate keeps working: a conversation with a user-set title is
left alone on subsequent `generate-title` calls.

## Test plan

- [x] Manual end-to-end against the local backend (no browser):
  - Draft created with no `title` → row stored with `title=""` ✅
  - `POST .../generate-title` with `"把 'how are you' 翻译成中文"` →
    response title `'英语问候语中译'` ✅ (LLM was actually called)
  - Conversation created with explicit `title=manual%20name` → second
    `generate-title` leaves title untouched ✅ (gate still effective)
- [x] `make check` (ruff format, ruff check, mypy strict) — passes
- [x] `pnpm --filter web type-check` — passes
- [ ] In-browser smoke test on `/(app)/w/{wsId}` home: send a first message,
  confirm sidebar updates from `untitledChat` placeholder to the LLM-generated
  title once the call returns
- [ ] Files-only submission still shows `'Files'` in sidebar