### PR TITLE
feat(ui): restyle web app to Operator design direction

### DIFF
--- a/frontend/packages/web/__tests__/e2e/admin-console-skeleton.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/admin-console-skeleton.spec.ts
@@ -38,23 +38,24 @@ test.describe('admin console skeleton', () => {
     // Top bar shows product name + admin heading
     await expect(adminPage.getByRole('heading', { name: 'Admin' })).toBeVisible()
 
-    // Sub-nav: 7 CE native items should be present
+    // Sub-nav: 8 CE native items should be present
     const nav = adminPage.getByRole('navigation', { name: /admin sub-nav/i })
     await expect(nav).toBeVisible()
     for (const label of [
       'Org Settings',
+      'Members',
       'Models',
       'Web Tools',
       'Skills',
       'MCP Connectors',
       'Sandbox',
-      'Cost',
+      'Insights',
     ]) {
       await expect(nav.getByRole('link', { name: label })).toBeVisible()
     }
   })
 
-  test('CE deployment: no external extension tabs render beyond the 7 natives', async ({
+  test('CE deployment: no external extension tabs render beyond the 8 natives', async ({
     page,
   }) => {
     await registerAs(page, uniqueEmail())
@@ -62,7 +63,7 @@ test.describe('admin console skeleton', () => {
     // Wait for the loading state to pass (admin-me resolved)
     await expect(page.getByRole('heading', { name: 'Admin' })).toBeVisible({ timeout: 10_000 })
     const navLinks = page.getByRole('navigation', { name: /admin sub-nav/i }).getByRole('link')
-    await expect(navLinks).toHaveCount(7)
+    await expect(navLinks).toHaveCount(8)
   })
 
   test('unauthenticated /admin visit redirects to /login', async ({ context, page }) => {

--- a/frontend/packages/web/__tests__/e2e/auth-flow.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/auth-flow.spec.ts
@@ -13,7 +13,10 @@ test('register → auto-login → land in personal workspace', async ({ page }) 
   await page.getByLabel('Password').fill(PASSWORD)
   await page.getByRole('button', { name: /create account/i }).click()
   await expect(page).toHaveURL(/\/w\/[^/]+$/, { timeout: 10_000 })
-  await expect(page.getByRole('heading', { name: 'cubebox' })).toBeVisible()
+  // Workspace home is the page that exposes the chat composer; assert via
+  // the composer's testid rather than a marketing heading (the redesign
+  // dropped the standalone "cubebox" h1 on this view).
+  await expect(page.getByTestId('chat-input')).toBeVisible()
 })
 
 test('login → redirect to workspace; logout → redirect to login', async ({ page, context }) => {

--- a/frontend/packages/web/app/(app)/w/[wsId]/memory/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/memory/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { use } from 'react'
-import { Brain } from 'lucide-react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { MemoryList } from './components/MemoryList'
 
@@ -13,21 +12,20 @@ export default function MemoryPage({ params }: MemoryPageProps) {
   const { wsId } = use(params)
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 max-w-3xl">
-      {/* Page header */}
-      <div className="flex items-center gap-3">
-        <div className="flex size-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
-          <Brain className="size-4.5" />
+    <div className="op-page op-page--narrow">
+      <div className="op-page__head">
+        <div className="flex flex-col gap-1">
+          <p className="op-eyebrow">workspace · memory</p>
+          <h1>Memory</h1>
         </div>
-        <div>
-          <h1 className="text-xl font-semibold leading-tight">Memory</h1>
-          <p className="text-sm text-muted-foreground">
-            What the agent remembers about you and your workspace
-          </p>
-        </div>
+        <span className="op-meta">scoped by personal / workspace / org</span>
       </div>
+      <p className="op-page__lede">
+        What the agent remembers between conversations. Items are scoped — personal stays with you
+        across workspaces, workspace items follow the project, org items are shared with every
+        member.
+      </p>
 
-      {/* Tabs */}
       <Tabs defaultValue="personal">
         <TabsList variant="line" className="w-fit">
           <TabsTrigger value="personal">Personal</TabsTrigger>
@@ -39,15 +37,12 @@ export default function MemoryPage({ params }: MemoryPageProps) {
         <TabsContent value="personal" className="mt-4">
           <MemoryList wsId={wsId} scope="personal" status="active" />
         </TabsContent>
-
         <TabsContent value="workspace" className="mt-4">
           <MemoryList wsId={wsId} scope="workspace" status="active" />
         </TabsContent>
-
         <TabsContent value="org" className="mt-4">
           <MemoryList wsId={wsId} scope="org" status="active" />
         </TabsContent>
-
         <TabsContent value="archived" className="mt-4">
           <MemoryList wsId={wsId} status="archived" />
         </TabsContent>

--- a/frontend/packages/web/app/(app)/w/[wsId]/memory/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/memory/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { use } from 'react'
+import { useTranslations } from 'next-intl'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { MemoryList } from './components/MemoryList'
 
@@ -10,28 +11,25 @@ interface MemoryPageProps {
 
 export default function MemoryPage({ params }: MemoryPageProps) {
   const { wsId } = use(params)
+  const t = useTranslations('memoryPage')
 
   return (
     <div className="op-page op-page--narrow">
       <div className="op-page__head">
         <div className="flex flex-col gap-1">
-          <p className="op-eyebrow">workspace · memory</p>
-          <h1>Memory</h1>
+          <p className="op-eyebrow">{t('eyebrow')}</p>
+          <h1>{t('title')}</h1>
         </div>
-        <span className="op-meta">scoped by personal / workspace / org</span>
+        <span className="op-meta">{t('scopedBy')}</span>
       </div>
-      <p className="op-page__lede">
-        What the agent remembers between conversations. Items are scoped — personal stays with you
-        across workspaces, workspace items follow the project, org items are shared with every
-        member.
-      </p>
+      <p className="op-page__lede">{t('lede')}</p>
 
       <Tabs defaultValue="personal">
         <TabsList variant="line" className="w-fit">
-          <TabsTrigger value="personal">Personal</TabsTrigger>
-          <TabsTrigger value="workspace">Workspace</TabsTrigger>
-          <TabsTrigger value="org">Organization</TabsTrigger>
-          <TabsTrigger value="archived">Archived</TabsTrigger>
+          <TabsTrigger value="personal">{t('tabPersonal')}</TabsTrigger>
+          <TabsTrigger value="workspace">{t('tabWorkspace')}</TabsTrigger>
+          <TabsTrigger value="org">{t('tabOrg')}</TabsTrigger>
+          <TabsTrigger value="archived">{t('tabArchived')}</TabsTrigger>
         </TabsList>
 
         <TabsContent value="personal" className="mt-4">

--- a/frontend/packages/web/app/(app)/w/[wsId]/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { use, useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { useTranslations } from 'next-intl'
 import {
   createApiClient,
   useAttachmentStore,
@@ -10,14 +9,12 @@ import {
   useMessageStore,
 } from '@cubebox/core'
 import { InputBar } from '@/components/layout/InputBar'
-import { Box } from 'lucide-react'
 
 export default function WorkspaceHomePage({
   params,
 }: {
   params: Promise<{ wsId: string }>
 }): React.ReactElement {
-  const t = useTranslations('home')
   const { wsId } = use(params)
   const router = useRouter()
   const { create: createConversation, rename: renameConversation } = useConversationStore()
@@ -85,20 +82,38 @@ export default function WorkspaceHomePage({
   }
 
   return (
-    <div className="flex-1 flex flex-col items-center justify-center">
-      <div className="text-center mb-8">
-        <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-primary/10 border border-primary/20 mb-5">
-          <Box className="size-6 text-primary" strokeWidth={2} />
+    <div className="flex-1 flex flex-col items-center justify-center px-6">
+      <div className="w-full max-w-2xl">
+        <div className="mb-7">
+          <p className="op-eyebrow mb-2">workspace · home</p>
+          <h1 className="text-[26px] font-semibold tracking-tight leading-tight text-foreground">
+            What should the agent do next?
+          </h1>
+          <p className="mt-2 text-[13.5px] text-muted-foreground max-w-prose leading-relaxed">
+            Drop a question, paste a stack trace, or attach a file. Every run streams reasoning,
+            tool calls, and results back into a conversation you can resume any time.
+          </p>
         </div>
-        <h1 className="text-2xl font-semibold tracking-tight mb-1.5">cubebox</h1>
-        <p className="text-sm text-muted-foreground/70">{t('subtitle')}</p>
-      </div>
-      <div className="w-full max-w-2xl px-4">
         <InputBar
           conversationId={draftConvId ?? undefined}
           onCreateConversation={ensureConversation}
           onSubmit={handleSubmit}
         />
+        <div className="mt-3 flex items-center gap-3 text-[11.5px] text-muted-foreground font-mono">
+          <span>
+            <span className="op-kbd">⏎</span> send
+          </span>
+          <span className="text-border">·</span>
+          <span>
+            <span className="op-kbd">⇧</span>
+            <span className="op-kbd ml-0.5">⏎</span> newline
+          </span>
+          <span className="text-border">·</span>
+          <span>
+            <span className="op-kbd">⌘</span>
+            <span className="op-kbd ml-0.5">K</span> command palette
+          </span>
+        </div>
       </div>
     </div>
   )

--- a/frontend/packages/web/app/(app)/w/[wsId]/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { use, useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
 import {
   createApiClient,
   useAttachmentStore,
@@ -15,6 +16,7 @@ export default function WorkspaceHomePage({
 }: {
   params: Promise<{ wsId: string }>
 }): React.ReactElement {
+  const t = useTranslations('home')
   const { wsId } = use(params)
   const router = useRouter()
   const { create: createConversation, rename: renameConversation } = useConversationStore()
@@ -85,13 +87,12 @@ export default function WorkspaceHomePage({
     <div className="flex-1 flex flex-col items-center justify-center px-6">
       <div className="w-full max-w-2xl">
         <div className="mb-7">
-          <p className="op-eyebrow mb-2">workspace · home</p>
+          <p className="op-eyebrow mb-2">{t('eyebrow')}</p>
           <h1 className="text-[26px] font-semibold tracking-tight leading-tight text-foreground">
-            What should the agent do next?
+            {t('title')}
           </h1>
           <p className="mt-2 text-[13.5px] text-muted-foreground max-w-prose leading-relaxed">
-            Drop a question, paste a stack trace, or attach a file. Every run streams reasoning,
-            tool calls, and results back into a conversation you can resume any time.
+            {t('lede')}
           </p>
         </div>
         <InputBar
@@ -101,17 +102,17 @@ export default function WorkspaceHomePage({
         />
         <div className="mt-3 flex items-center gap-3 text-[11.5px] text-muted-foreground font-mono">
           <span>
-            <span className="op-kbd">⏎</span> send
+            <span className="op-kbd">⏎</span> {t('kbdSend')}
           </span>
           <span className="text-border">·</span>
           <span>
             <span className="op-kbd">⇧</span>
-            <span className="op-kbd ml-0.5">⏎</span> newline
+            <span className="op-kbd ml-0.5">⏎</span> {t('kbdNewline')}
           </span>
           <span className="text-border">·</span>
           <span>
             <span className="op-kbd">⌘</span>
-            <span className="op-kbd ml-0.5">K</span> command palette
+            <span className="op-kbd ml-0.5">K</span> {t('kbdPalette')}
           </span>
         </div>
       </div>

--- a/frontend/packages/web/app/(app)/workspaces/page.tsx
+++ b/frontend/packages/web/app/(app)/workspaces/page.tsx
@@ -11,14 +11,11 @@ export default function WorkspacesPage() {
     <div className="op-page op-page--narrow">
       <div className="op-page__head">
         <div className="flex flex-col gap-1">
-          <p className="op-eyebrow">workspaces</p>
+          <p className="op-eyebrow">{t('eyebrow')}</p>
           <h1>{t('title')}</h1>
         </div>
       </div>
-      <p className="op-page__lede">
-        A workspace is the unit of separation for conversations, skills, MCP connections, and
-        memory. Open one you already have or spin up a new one.
-      </p>
+      <p className="op-page__lede">{t('lede')}</p>
       <WorkspaceList />
       <WorkspaceCreateForm />
     </div>

--- a/frontend/packages/web/app/(app)/workspaces/page.tsx
+++ b/frontend/packages/web/app/(app)/workspaces/page.tsx
@@ -8,8 +8,17 @@ import { WorkspaceCreateForm } from '@/components/workspace/WorkspaceCreateForm'
 export default function WorkspacesPage() {
   const t = useTranslations('workspacesPage')
   return (
-    <div className="max-w-2xl mx-auto w-full p-6 space-y-6">
-      <h1 className="text-lg font-semibold">{t('title')}</h1>
+    <div className="op-page op-page--narrow">
+      <div className="op-page__head">
+        <div className="flex flex-col gap-1">
+          <p className="op-eyebrow">workspaces</p>
+          <h1>{t('title')}</h1>
+        </div>
+      </div>
+      <p className="op-page__lede">
+        A workspace is the unit of separation for conversations, skills, MCP connections, and
+        memory. Open one you already have or spin up a new one.
+      </p>
       <WorkspaceList />
       <WorkspaceCreateForm />
     </div>

--- a/frontend/packages/web/app/(auth)/layout.tsx
+++ b/frontend/packages/web/app/(auth)/layout.tsx
@@ -1,7 +1,27 @@
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background p-6">
-      <div className="w-full max-w-sm">{children}</div>
+    <div className="min-h-screen bg-background flex flex-col">
+      {/* Top brand strip — restrained, no marketing language */}
+      <header className="px-8 py-5 flex items-center gap-2">
+        <div
+          className="w-[22px] h-[22px] rounded-[5px] bg-foreground text-background grid place-items-center font-mono font-semibold text-[11px] leading-none"
+          aria-hidden
+        >
+          cb
+        </div>
+        <span className="font-display text-[14px] font-semibold tracking-tight text-foreground">
+          cubebox
+        </span>
+      </header>
+
+      <main className="flex-1 flex items-center justify-center px-6 pb-16">
+        <div className="w-full max-w-[380px]">{children}</div>
+      </main>
+
+      <footer className="px-8 py-4 hairline-t flex items-center justify-between text-[11px] text-muted-foreground font-mono">
+        <span>cubebox · operator</span>
+        <span>secured by session cookie · csrf double-submit</span>
+      </footer>
     </div>
   )
 }

--- a/frontend/packages/web/app/(auth)/layout.tsx
+++ b/frontend/packages/web/app/(auth)/layout.tsx
@@ -1,4 +1,7 @@
-export default function AuthLayout({ children }: { children: React.ReactNode }) {
+import { getTranslations } from 'next-intl/server'
+
+export default async function AuthLayout({ children }: { children: React.ReactNode }) {
+  const t = await getTranslations('authLayout')
   return (
     <div className="min-h-screen bg-background flex flex-col">
       {/* Top brand strip — restrained, no marketing language */}
@@ -19,8 +22,8 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
       </main>
 
       <footer className="px-8 py-4 hairline-t flex items-center justify-between text-[11px] text-muted-foreground font-mono">
-        <span>cubebox · operator</span>
-        <span>secured by session cookie · csrf double-submit</span>
+        <span>{t('footerBrand')}</span>
+        <span>{t('footerSecurity')}</span>
       </footer>
     </div>
   )

--- a/frontend/packages/web/app/globals.css
+++ b/frontend/packages/web/app/globals.css
@@ -7,7 +7,6 @@
   flex-grow: 1;
 }
 
-/* Hide scrollbar but keep scrollable */
 @utility scrollbar-none {
   -ms-overflow-style: none;
   scrollbar-width: none;
@@ -16,58 +15,447 @@
   }
 }
 
-/* Use .dark class (not prefers-color-scheme) so dark: variants work with the theme toggle */
 @custom-variant dark (&:where(.dark, .dark *));
 
-/* Default: light mode */
+/* =============================================================
+   cubebox · Operator theme
+   Direction A — Linear / Vercel / Stripe Dashboard lineage.
+   Hairline borders, mono numerals, one accent (#3b5bd9), no
+   gradients, no shadows except modal.
+   ============================================================= */
 @theme {
-  --color-background: hsl(0 0% 100%);
-  --color-foreground: hsl(240 10% 4%);
-  --color-card: hsl(0 0% 100%);
-  --color-card-foreground: hsl(240 10% 4%);
-  /* hsl(210 100% 38%) ≈ #0061C2 — white text on this gives ~6.2:1, passes WCAG AA */
-  --color-primary: hsl(210 100% 38%);
-  --color-primary-foreground: hsl(0 0% 100%);
-  --color-secondary: hsl(240 5% 96%);
-  --color-secondary-foreground: hsl(240 6% 10%);
-  --color-muted: hsl(240 5% 96%);
-  /* hsl(240 5% 38%) ≈ #5c5c66 — on white gives ~5.9:1, passes WCAG AA */
-  --color-muted-foreground: hsl(240 5% 38%);
-  --color-accent: hsl(240 5% 96%);
-  --color-accent-foreground: hsl(240 10% 4%);
-  --color-popover: hsl(0 0% 100%);
-  --color-popover-foreground: hsl(240 10% 4%);
-  --color-border: hsl(240 6% 90%);
-  --color-input: hsl(240 6% 90%);
-  --color-ring: hsl(210 100% 38%);
-  --radius: 0.5rem;
+  /* Operator ink scale (cool grey) */
+  --color-ink-1: #fafafa;
+  --color-ink-3: #f4f4f5;
+  --color-ink-5: #e4e4e7;
+  --color-ink-7: #a1a1aa;
+  --color-ink-9: #52525b;
+  --color-ink-11: #1f1f22;
+  --color-ink-12: #0a0a0b;
+  --color-surface: #ffffff;
+  --color-accent-ink: #1e3aa8;
+  --color-accent-soft: #eef1fe;
+
+  /* shadcn token mapping — light */
+  --color-background: #fafafa; /* ink-1 canvas */
+  --color-foreground: #1f1f22; /* ink-11 body */
+  --color-card: #ffffff;
+  --color-card-foreground: #0a0a0b;
+  --color-primary: #3b5bd9; /* the only accent */
+  --color-primary-foreground: #ffffff;
+  --color-secondary: #f4f4f5;
+  --color-secondary-foreground: #1f1f22;
+  --color-muted: #f4f4f5;
+  --color-muted-foreground: #52525b;
+  --color-accent: #f4f4f5; /* shadcn "accent" = hover */
+  --color-accent-foreground: #0a0a0b;
+  --color-popover: #ffffff;
+  --color-popover-foreground: #0a0a0b;
+  --color-border: #e4e4e7;
+  --color-input: #e4e4e7;
+  --color-ring: #3b5bd9;
+  --color-destructive: #dc2626;
+  --color-destructive-foreground: #ffffff;
+
+  /* Status semantic */
+  --color-ok: #16a34a;
+  --color-warn: #d97706;
+  --color-err: #dc2626;
+
+  /* Hairline radius scale — operator caps at 8 */
+  --radius: 0.375rem; /* 6px — cards */
+  --radius-sm: 0.25rem; /* 4px — buttons */
+  --radius-lg: 0.5rem; /* 8px — panel */
+
+  /* Tailwind requires *literal* values in @theme — var() chains here
+     are not always emitted as CSS variables, so we declare the actual
+     font stacks in @layer base below and only expose Tailwind utilities. */
+  --font-sans: 'InterFallback', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'InterTightFallback', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'JetBrainsMonoFallback', ui-monospace, SFMono-Regular, monospace;
 }
 
 @layer base {
   :root {
-    --color-popover: hsl(0 0% 100%);
-    --color-popover-foreground: hsl(240 10% 4%);
+    --color-popover: #ffffff;
+    --color-popover-foreground: #0a0a0b;
   }
 
+  /* Dark mode — graphite. Borrowed tonally from Direction C but
+     keeps Operator's indigo accent for continuity. */
   .dark {
-    --color-background: hsl(222 20% 7%);
-    --color-foreground: hsl(215 20% 92%);
-    --color-card: hsl(222 18% 10%);
-    --color-card-foreground: hsl(215 20% 92%);
-    /* hsl(210 100% 62%) ≈ #3d9eff — on dark bg gives ~6.8:1, passes WCAG AA */
-    --color-primary: hsl(210 100% 62%);
-    --color-primary-foreground: hsl(222 20% 7%);
-    --color-secondary: hsl(222 18% 13%);
-    --color-secondary-foreground: hsl(215 20% 92%);
-    --color-muted: hsl(222 18% 13%);
-    /* hsl(215 14% 62%) — on dark bg gives ~5.8:1, passes WCAG AA */
-    --color-muted-foreground: hsl(215 14% 62%);
-    --color-accent: hsl(222 18% 14%);
-    --color-accent-foreground: hsl(215 20% 92%);
-    --color-popover: hsl(222 18% 12%);
-    --color-popover-foreground: hsl(215 20% 92%);
-    --color-border: hsl(222 16% 16%);
-    --color-input: hsl(222 16% 14%);
-    --color-ring: hsl(210 100% 62%);
+    --color-background: #0b0d10;
+    --color-foreground: #e6e7e9;
+    --color-card: #111418;
+    --color-card-foreground: #e6e7e9;
+    --color-primary: #6c8bff;
+    --color-primary-foreground: #0b0d10;
+    --color-secondary: #181c22;
+    --color-secondary-foreground: #e6e7e9;
+    --color-muted: #181c22;
+    --color-muted-foreground: #9aa1ab;
+    --color-accent: #181c22;
+    --color-accent-foreground: #f3f4f6;
+    --color-popover: #15181d;
+    --color-popover-foreground: #e6e7e9;
+    --color-border: #232830;
+    --color-input: #1d2128;
+    --color-ring: #6c8bff;
+    --color-destructive: #ef4444;
+  }
+
+  html,
+  body {
+    font-family:
+      var(--font-inter),
+      'Inter',
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      'Segoe UI',
+      sans-serif;
+    font-feature-settings: 'cv11', 'ss01', 'cv02', 'ss03';
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
+  /* Display headings — tighter, Inter Tight */
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-family:
+      var(--font-inter-tight), 'Inter Tight', var(--font-inter), 'Inter', ui-sans-serif, system-ui,
+      sans-serif;
+    letter-spacing: -0.01em;
+  }
+  h1 {
+    letter-spacing: -0.015em;
+  }
+
+  code,
+  pre,
+  kbd,
+  samp {
+    font-family:
+      var(--font-jetbrains-mono), 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas,
+      monospace;
+  }
+
+  /* Tabular numerals globally for mono spans + classed elements.
+     Components that want flowing numerals can opt out with
+     font-variant-numeric: normal. */
+  .font-mono,
+  code,
+  kbd,
+  samp,
+  pre,
+  [class*='tabular'] {
+    font-feature-settings:
+      'tnum' on,
+      'lnum' on;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Hairline focus — replaces shadcn's default 3px ring with
+     Operator's tighter ring. */
+  :where(.dark, .dark *) :focus-visible {
+    outline: none;
+  }
+}
+
+/* =============================================================
+   Operator primitives — utility classes layered on top of
+   Tailwind/shadcn for things the existing component library
+   doesn't express (kbd hints, status pills, hairline panels).
+   ============================================================= */
+@layer components {
+  .op-kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    font-weight: 500;
+    height: 18px;
+    min-width: 18px;
+    padding: 0 5px;
+    border: 1px solid var(--color-border);
+    border-bottom-width: 2px;
+    border-radius: 4px;
+    background: var(--color-card);
+    color: var(--color-muted-foreground);
+    line-height: 1;
+    letter-spacing: 0;
+  }
+
+  .op-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    height: 20px;
+    padding: 0 8px;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: var(--color-card);
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--color-muted-foreground);
+    line-height: 1;
+  }
+  .op-pill::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-ink-7, currentColor);
+  }
+  .op-pill--ok {
+    color: var(--color-ok);
+    border-color: rgba(22, 163, 74, 0.25);
+    background: rgba(22, 163, 74, 0.06);
+  }
+  .op-pill--ok::before {
+    background: var(--color-ok);
+  }
+  .op-pill--warn {
+    color: var(--color-warn);
+    border-color: rgba(217, 119, 6, 0.25);
+    background: rgba(217, 119, 6, 0.06);
+  }
+  .op-pill--warn::before {
+    background: var(--color-warn);
+  }
+  .op-pill--err {
+    color: var(--color-err);
+    border-color: rgba(220, 38, 38, 0.25);
+    background: rgba(220, 38, 38, 0.06);
+  }
+  .op-pill--err::before {
+    background: var(--color-err);
+  }
+  .op-pill--accent {
+    color: var(--color-primary);
+    border-color: color-mix(in oklab, var(--color-primary) 30%, transparent);
+    background: color-mix(in oklab, var(--color-primary) 8%, transparent);
+  }
+  .op-pill--accent::before {
+    background: var(--color-primary);
+  }
+
+  /* Page chrome — used by content area headers across pages. */
+  .op-page {
+    width: 100%;
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 24px clamp(20px, 4vw, 40px) 64px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+  .op-page--narrow {
+    max-width: 880px;
+  }
+  .op-page__head {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .op-page__head h1 {
+    font-size: 24px;
+    line-height: 1.2;
+    font-weight: 600;
+    margin: 0;
+    color: var(--color-card-foreground);
+  }
+  .op-page__head .op-meta {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--color-muted-foreground);
+  }
+  .op-page__head .op-push {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .op-page__lede {
+    color: var(--color-muted-foreground);
+    font-size: 14px;
+    line-height: 1.6;
+    max-width: 680px;
+  }
+
+  /* Topbar — used by per-page or layout-level breadcrumbs. */
+  .op-topbar {
+    height: 44px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 0 16px;
+    background: var(--color-card);
+    border-bottom: 1px solid var(--color-border);
+  }
+  .op-crumb {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--color-muted-foreground);
+  }
+  .op-crumb__sep {
+    color: var(--color-border);
+  }
+  .op-crumb__current {
+    color: var(--color-card-foreground);
+    font-weight: 500;
+  }
+
+  /* Hairline panel — the operator card. */
+  .op-panel {
+    background: var(--color-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+  }
+  .op-panel__head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .op-panel__head h3 {
+    font-size: 13px;
+    font-weight: 600;
+    margin: 0;
+    color: var(--color-card-foreground);
+    letter-spacing: 0;
+    text-transform: none;
+  }
+  .op-panel__head .op-meta {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-muted-foreground);
+  }
+  .op-panel__body {
+    padding: 16px;
+  }
+  .op-panel__body--flush {
+    padding: 0;
+  }
+
+  /* Field row — used in settings / forms. */
+  .op-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .op-field:last-child {
+    border-bottom: 0;
+  }
+  .op-field--row {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 32px;
+    align-items: start;
+  }
+  .op-field__label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-card-foreground);
+  }
+  .op-field__hint {
+    font-size: 12px;
+    color: var(--color-muted-foreground);
+    line-height: 1.55;
+  }
+  .op-field__hint code {
+    font-family: var(--font-mono);
+    background: var(--color-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    padding: 0 4px;
+    font-size: 11.5px;
+  }
+
+  /* Empty state — the "say something" pattern. */
+  .op-empty {
+    padding: 36px 24px;
+    text-align: center;
+    color: var(--color-muted-foreground);
+  }
+  .op-empty h4 {
+    font-size: 16px;
+    color: var(--color-card-foreground);
+    margin: 0 0 6px;
+    font-weight: 600;
+    letter-spacing: -0.005em;
+  }
+  .op-empty p {
+    margin: 0 auto;
+    max-width: 420px;
+    line-height: 1.6;
+    font-size: 13px;
+  }
+
+  /* Section eyebrow label */
+  .op-eyebrow {
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted-foreground);
+  }
+}
+
+/* =============================================================
+   Tailwind utility shims — small adjustments to defaults so
+   ad-hoc classes in pages match Operator without rewriting.
+   ============================================================= */
+@layer utilities {
+  /* Override Tailwind font utilities so they pick up next/font variables. */
+  .font-sans {
+    font-family:
+      var(--font-inter),
+      'Inter',
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      'Segoe UI',
+      sans-serif;
+  }
+  .font-display {
+    font-family:
+      var(--font-inter-tight), 'Inter Tight', var(--font-inter), 'Inter', ui-sans-serif, system-ui,
+      sans-serif;
+    letter-spacing: -0.01em;
+  }
+  .font-mono {
+    font-family:
+      var(--font-jetbrains-mono), 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas,
+      monospace;
+  }
+  .num,
+  .tabular {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings:
+      'tnum' on,
+      'lnum' on;
+  }
+  .hairline {
+    border: 1px solid var(--color-border);
+  }
+  .hairline-b {
+    border-bottom: 1px solid var(--color-border);
+  }
+  .hairline-t {
+    border-top: 1px solid var(--color-border);
   }
 }

--- a/frontend/packages/web/app/layout.tsx
+++ b/frontend/packages/web/app/layout.tsx
@@ -1,13 +1,29 @@
 import type { Metadata } from 'next'
-import { IBM_Plex_Sans } from 'next/font/google'
+import { Inter, Inter_Tight, JetBrains_Mono } from 'next/font/google'
 import { NextIntlClientProvider } from 'next-intl'
 import { getLocale, getMessages } from 'next-intl/server'
 import { ThemeProvider } from 'next-themes'
 import './globals.css'
 
-const ibmPlexSans = IBM_Plex_Sans({
+const inter = Inter({
   subsets: ['latin'],
-  weight: ['300', '400', '500', '600'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-inter',
+  display: 'swap',
+})
+
+const interTight = Inter_Tight({
+  subsets: ['latin'],
+  weight: ['500', '600', '700'],
+  variable: '--font-inter-tight',
+  display: 'swap',
+})
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  variable: '--font-jetbrains-mono',
+  display: 'swap',
 })
 
 export const metadata: Metadata = {
@@ -21,9 +37,11 @@ export const metadata: Metadata = {
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const locale = await getLocale()
   const messages = await getMessages()
+  const fontVars =
+    `${inter.variable} ${interTight.variable} ${jetbrainsMono.variable} ` + 'font-sans antialiased'
   return (
     <html lang={locale} suppressHydrationWarning>
-      <body className={ibmPlexSans.className}>
+      <body className={fontVars}>
         <NextIntlClientProvider locale={locale} messages={messages}>
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
             {children}

--- a/frontend/packages/web/components/admin/AdminTopBar.tsx
+++ b/frontend/packages/web/components/admin/AdminTopBar.tsx
@@ -2,8 +2,6 @@
 
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
-import { Separator } from '@/components/ui/separator'
-import { Box } from 'lucide-react'
 import { AdminAvatarMenu } from './AdminAvatarMenu'
 
 interface AdminTopBarProps {
@@ -22,24 +20,29 @@ function handleBackToApp() {
 export function AdminTopBar({ orgName }: AdminTopBarProps) {
   const t = useTranslations('admin')
   return (
-    <header className="flex items-center gap-3 border-b border-border bg-card/80 backdrop-blur supports-[backdrop-filter]:bg-card/60 px-4 h-14 shrink-0">
+    <header className="flex items-center gap-3 border-b border-border bg-card px-4 h-12 shrink-0">
       <div className="flex items-center gap-2">
-        <div className="w-6 h-6 rounded-md bg-primary flex items-center justify-center shrink-0 shadow-sm">
-          <Box className="size-3.5 text-primary-foreground" strokeWidth={2.5} />
+        <div
+          className="w-[22px] h-[22px] rounded-[5px] bg-foreground text-background grid place-items-center font-mono font-semibold text-[11px] leading-none"
+          aria-hidden
+        >
+          cb
         </div>
-        <span className="text-sm font-semibold tracking-tight">cubebox</span>
-      </div>
-      <Separator orientation="vertical" className="h-5" />
-      <h1 className="text-sm font-medium">{t('title')}</h1>
-      {orgName && (
-        <span className="text-sm text-muted-foreground/70 before:content-['·'] before:mr-2 before:text-muted-foreground/40">
-          {orgName}
+        <span className="font-display text-[13.5px] font-semibold tracking-tight text-foreground">
+          cubebox
         </span>
-      )}
+      </div>
+      <span className="h-4 w-px bg-border" aria-hidden />
+      <div className="flex items-center gap-2">
+        <span className="op-pill op-pill--accent">{t('title')}</span>
+        {orgName && (
+          <span className="text-[12.5px] text-muted-foreground font-mono">org · {orgName}</span>
+        )}
+      </div>
 
       <div className="ml-auto flex items-center gap-2">
-        <Button variant="ghost" size="sm" onClick={handleBackToApp}>
-          {t('backToApp')}
+        <Button variant="ghost" size="sm" onClick={handleBackToApp} className="h-7 text-[12.5px]">
+          {t('backToApp')} ↗
         </Button>
         <AdminAvatarMenu />
       </div>

--- a/frontend/packages/web/components/admin/AdminTopBar.tsx
+++ b/frontend/packages/web/components/admin/AdminTopBar.tsx
@@ -35,7 +35,8 @@ export function AdminTopBar({ orgName }: AdminTopBarProps) {
       </div>
       <span className="h-4 w-px bg-border" aria-hidden />
       <div className="flex items-center gap-2">
-        <span className="op-pill op-pill--accent">{t('title')}</span>
+        {/* h1 (not span) so e2e specs can find the section via getByRole('heading'). */}
+        <h1 className="op-pill op-pill--accent !text-[10.5px] m-0">{t('title')}</h1>
         {orgName && (
           <span className="text-[12.5px] text-muted-foreground font-mono">
             {tLayout('orgPrefix', { name: orgName })}

--- a/frontend/packages/web/components/admin/AdminTopBar.tsx
+++ b/frontend/packages/web/components/admin/AdminTopBar.tsx
@@ -19,6 +19,7 @@ function handleBackToApp() {
 
 export function AdminTopBar({ orgName }: AdminTopBarProps) {
   const t = useTranslations('admin')
+  const tLayout = useTranslations('adminLayout')
   return (
     <header className="flex items-center gap-3 border-b border-border bg-card px-4 h-12 shrink-0">
       <div className="flex items-center gap-2">
@@ -36,7 +37,9 @@ export function AdminTopBar({ orgName }: AdminTopBarProps) {
       <div className="flex items-center gap-2">
         <span className="op-pill op-pill--accent">{t('title')}</span>
         {orgName && (
-          <span className="text-[12.5px] text-muted-foreground font-mono">org · {orgName}</span>
+          <span className="text-[12.5px] text-muted-foreground font-mono">
+            {tLayout('orgPrefix', { name: orgName })}
+          </span>
         )}
       </div>
 

--- a/frontend/packages/web/components/auth/LoginForm.tsx
+++ b/frontend/packages/web/components/auth/LoginForm.tsx
@@ -34,7 +34,7 @@ export function LoginForm({ nextPath = '/' }: { nextPath?: string }) {
   return (
     <div className="op-panel">
       <div className="px-6 pt-6 pb-1">
-        <p className="op-eyebrow mb-2">sign in</p>
+        <p className="op-eyebrow mb-2">{t('eyebrowSignIn')}</p>
         <h1 className="text-[22px] font-semibold leading-tight text-foreground">
           {t('signInTitle')}
         </h1>
@@ -48,7 +48,7 @@ export function LoginForm({ nextPath = '/' }: { nextPath?: string }) {
             type="email"
             required
             autoComplete="email"
-            placeholder="you@company.com"
+            placeholder={t('emailPlaceholder')}
             className="block w-full rounded-md border border-border bg-card px-3 h-9 text-[13px] text-foreground placeholder:text-muted-foreground/60 outline-none focus:border-primary focus:ring-2 focus:ring-primary/15 transition-shadow"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
@@ -62,7 +62,7 @@ export function LoginForm({ nextPath = '/' }: { nextPath?: string }) {
             type="password"
             required
             autoComplete="current-password"
-            placeholder="•••••••••"
+            placeholder={t('passwordPlaceholder')}
             className="block w-full rounded-md border border-border bg-card px-3 h-9 text-[13px] text-foreground placeholder:text-muted-foreground/60 font-mono outline-none focus:border-primary focus:ring-2 focus:ring-primary/15 transition-shadow"
             value={password}
             onChange={(e) => setPassword(e.target.value)}

--- a/frontend/packages/web/components/auth/LoginForm.tsx
+++ b/frontend/packages/web/components/auth/LoginForm.tsx
@@ -32,46 +32,64 @@ export function LoginForm({ nextPath = '/' }: { nextPath?: string }) {
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      <div className="text-center mb-6">
-        <h1 className="text-xl font-semibold">{t('signInTitle')}</h1>
+    <div className="op-panel">
+      <div className="px-6 pt-6 pb-1">
+        <p className="op-eyebrow mb-2">sign in</p>
+        <h1 className="text-[22px] font-semibold leading-tight text-foreground">
+          {t('signInTitle')}
+        </h1>
       </div>
-      <label className="block">
-        <span className="text-sm text-foreground/80">{t('email')}</span>
-        <input
-          type="email"
-          required
-          autoComplete="email"
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-      </label>
-      <label className="block">
-        <span className="text-sm text-foreground/80">{t('password')}</span>
-        <input
-          type="password"
-          required
-          autoComplete="current-password"
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-      </label>
-      {error && <div className="text-sm text-red-500">{error}</div>}
-      <button
-        type="submit"
-        disabled={submitting}
-        className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
-      >
-        {submitting ? t('signingIn') : t('signIn')}
-      </button>
-      <div className="text-center text-sm text-foreground/60">
-        {t('newHere')}{' '}
-        <Link href="/register" className="underline">
-          {t('createAccount')}
+      <form onSubmit={onSubmit} className="px-6 pt-5 pb-5 space-y-3.5">
+        <label className="block">
+          <span className="block text-[12.5px] font-medium text-foreground mb-1.5">
+            {t('email')}
+          </span>
+          <input
+            type="email"
+            required
+            autoComplete="email"
+            placeholder="you@company.com"
+            className="block w-full rounded-md border border-border bg-card px-3 h-9 text-[13px] text-foreground placeholder:text-muted-foreground/60 outline-none focus:border-primary focus:ring-2 focus:ring-primary/15 transition-shadow"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </label>
+        <label className="block">
+          <span className="block text-[12.5px] font-medium text-foreground mb-1.5">
+            {t('password')}
+          </span>
+          <input
+            type="password"
+            required
+            autoComplete="current-password"
+            placeholder="•••••••••"
+            className="block w-full rounded-md border border-border bg-card px-3 h-9 text-[13px] text-foreground placeholder:text-muted-foreground/60 font-mono outline-none focus:border-primary focus:ring-2 focus:ring-primary/15 transition-shadow"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+        {error && (
+          <div className="text-[12.5px] text-destructive border border-destructive/30 bg-destructive/5 rounded-md px-3 py-2">
+            {error}
+          </div>
+        )}
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full inline-flex items-center justify-center gap-2 rounded-md bg-foreground text-background px-3 h-9 text-[13px] font-medium hover:bg-foreground/90 disabled:opacity-50 transition-colors"
+        >
+          {submitting ? t('signingIn') : t('signIn')}
+        </button>
+      </form>
+      <div className="hairline-t px-6 py-3.5 text-[12.5px] text-muted-foreground bg-muted/40 flex items-center justify-between">
+        <span>{t('newHere')}</span>
+        <Link
+          href="/register"
+          className="text-foreground font-medium hover:underline underline-offset-2"
+        >
+          {t('createAccount')} →
         </Link>
       </div>
-    </form>
+    </div>
   )
 }

--- a/frontend/packages/web/components/auth/RegisterForm.tsx
+++ b/frontend/packages/web/components/auth/RegisterForm.tsx
@@ -38,7 +38,7 @@ export function RegisterForm() {
   return (
     <div className="op-panel">
       <div className="px-6 pt-6 pb-1">
-        <p className="op-eyebrow mb-2">create account</p>
+        <p className="op-eyebrow mb-2">{t('eyebrowSignUp')}</p>
         <h1 className="text-[22px] font-semibold leading-tight text-foreground">
           {t('signUpTitle')}
         </h1>
@@ -52,7 +52,7 @@ export function RegisterForm() {
             type="email"
             required
             autoComplete="email"
-            placeholder="you@company.com"
+            placeholder={t('emailPlaceholder')}
             className="block w-full rounded-md border border-border bg-card px-3 h-9 text-[13px] text-foreground placeholder:text-muted-foreground/60 outline-none focus:border-primary focus:ring-2 focus:ring-primary/15 transition-shadow"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
@@ -67,14 +67,13 @@ export function RegisterForm() {
             required
             minLength={8}
             autoComplete="new-password"
-            placeholder="at least 8 characters"
+            placeholder={t('passwordPlaceholderRegister')}
             className="block w-full rounded-md border border-border bg-card px-3 h-9 text-[13px] text-foreground placeholder:text-muted-foreground/60 font-mono outline-none focus:border-primary focus:ring-2 focus:ring-primary/15 transition-shadow"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
           />
           <span className="block mt-1.5 text-[11.5px] text-muted-foreground">
-            8+ characters. We don&apos;t enforce complexity rules — pick something you can remember
-            with a password manager.
+            {t('passwordHintRegister')}
           </span>
         </label>
         {error && (

--- a/frontend/packages/web/components/auth/RegisterForm.tsx
+++ b/frontend/packages/web/components/auth/RegisterForm.tsx
@@ -21,12 +21,8 @@ export function RegisterForm() {
     try {
       const client = createApiClient('')
       const result = await registerUser(client, email, password)
-      // Register endpoint does NOT set an auth cookie — auto log-in here.
       await loginUser(client, email, password)
       await useAuthStore.getState().loadMe(client)
-      // M9: in single_tenant mode the first registrant is a pending owner with
-      // no workspace yet — backend returns default_workspace_id="". Bounce them
-      // to /setup; the (app) layout would 404 on /w/ otherwise.
       if (!result.default_workspace_id) {
         router.push('/setup')
       } else {
@@ -40,47 +36,69 @@ export function RegisterForm() {
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      <div className="text-center mb-6">
-        <h1 className="text-xl font-semibold">{t('signUpTitle')}</h1>
+    <div className="op-panel">
+      <div className="px-6 pt-6 pb-1">
+        <p className="op-eyebrow mb-2">create account</p>
+        <h1 className="text-[22px] font-semibold leading-tight text-foreground">
+          {t('signUpTitle')}
+        </h1>
       </div>
-      <label className="block">
-        <span className="text-sm text-foreground/80">{t('email')}</span>
-        <input
-          type="email"
-          required
-          autoComplete="email"
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-      </label>
-      <label className="block">
-        <span className="text-sm text-foreground/80">{t('password')}</span>
-        <input
-          type="password"
-          required
-          minLength={8}
-          autoComplete="new-password"
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-      </label>
-      {error && <div className="text-sm text-red-500">{error}</div>}
-      <button
-        type="submit"
-        disabled={submitting}
-        className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
-      >
-        {submitting ? t('creatingAccount') : t('signUp')}
-      </button>
-      <div className="text-center text-sm text-foreground/60">
-        {t('alreadyHaveAccount')}{' '}
-        <Link href="/login" className="underline">
-          {t('signIn')}
+      <form onSubmit={onSubmit} className="px-6 pt-5 pb-5 space-y-3.5">
+        <label className="block">
+          <span className="block text-[12.5px] font-medium text-foreground mb-1.5">
+            {t('email')}
+          </span>
+          <input
+            type="email"
+            required
+            autoComplete="email"
+            placeholder="you@company.com"
+            className="block w-full rounded-md border border-border bg-card px-3 h-9 text-[13px] text-foreground placeholder:text-muted-foreground/60 outline-none focus:border-primary focus:ring-2 focus:ring-primary/15 transition-shadow"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </label>
+        <label className="block">
+          <span className="block text-[12.5px] font-medium text-foreground mb-1.5">
+            {t('password')}
+          </span>
+          <input
+            type="password"
+            required
+            minLength={8}
+            autoComplete="new-password"
+            placeholder="at least 8 characters"
+            className="block w-full rounded-md border border-border bg-card px-3 h-9 text-[13px] text-foreground placeholder:text-muted-foreground/60 font-mono outline-none focus:border-primary focus:ring-2 focus:ring-primary/15 transition-shadow"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <span className="block mt-1.5 text-[11.5px] text-muted-foreground">
+            8+ characters. We don&apos;t enforce complexity rules — pick something you can remember
+            with a password manager.
+          </span>
+        </label>
+        {error && (
+          <div className="text-[12.5px] text-destructive border border-destructive/30 bg-destructive/5 rounded-md px-3 py-2">
+            {error}
+          </div>
+        )}
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full inline-flex items-center justify-center gap-2 rounded-md bg-foreground text-background px-3 h-9 text-[13px] font-medium hover:bg-foreground/90 disabled:opacity-50 transition-colors"
+        >
+          {submitting ? t('creatingAccount') : t('signUp')}
+        </button>
+      </form>
+      <div className="hairline-t px-6 py-3.5 text-[12.5px] text-muted-foreground bg-muted/40 flex items-center justify-between">
+        <span>{t('alreadyHaveAccount')}</span>
+        <Link
+          href="/login"
+          className="text-foreground font-medium hover:underline underline-offset-2"
+        >
+          {t('signIn')} →
         </Link>
       </div>
-    </form>
+    </div>
   )
 }

--- a/frontend/packages/web/components/chat/UserMessage.tsx
+++ b/frontend/packages/web/components/chat/UserMessage.tsx
@@ -5,7 +5,12 @@ interface UserMessageProps {
 export function UserMessage({ content }: UserMessageProps) {
   return (
     <div className="flex justify-end">
-      <div className="max-w-[72%] bg-primary text-white rounded-2xl rounded-br-sm px-3.5 py-2.5 text-sm leading-relaxed">
+      <div
+        className={
+          'max-w-[72%] bg-card border border-border rounded-md px-3.5 py-2.5 ' +
+          'text-[13.5px] leading-relaxed text-foreground whitespace-pre-wrap'
+        }
+      >
         {content}
       </div>
     </div>

--- a/frontend/packages/web/components/layout/AppShell.tsx
+++ b/frontend/packages/web/components/layout/AppShell.tsx
@@ -21,9 +21,10 @@ export function AppShell({ children, headerTitle }: AppShellProps) {
     <ResizablePanelGroup orientation="horizontal" className="h-full">
       <ResizablePanel defaultSize={panelOpen ? 50 : 100} minSize={30}>
         <div className="flex flex-col h-full overflow-hidden">
-          <header className="h-11 border-b border-border flex items-center px-4 shrink-0">
-            <span className="text-sm text-muted-foreground truncate flex-1">
-              {headerTitle || ''}
+          <header className="h-11 border-b border-border bg-card flex items-center px-4 gap-3 shrink-0">
+            <span className="op-eyebrow">conversation</span>
+            <span className="text-[13px] font-medium text-foreground truncate flex-1 min-w-0">
+              {headerTitle || 'Untitled'}
             </span>
             <ThemeToggle />
           </header>

--- a/frontend/packages/web/components/layout/AppShell.tsx
+++ b/frontend/packages/web/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ReactNode } from 'react'
+import { useTranslations } from 'next-intl'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
 import { ToolDetailPanel } from '@/components/panel/ToolDetailPanel'
@@ -14,6 +15,7 @@ interface AppShellProps {
 }
 
 export function AppShell({ children, headerTitle }: AppShellProps) {
+  const t = useTranslations('shellLayout')
   const view = usePanelStore((s) => s.view)
   const panelOpen = view.type !== 'closed'
 
@@ -22,9 +24,9 @@ export function AppShell({ children, headerTitle }: AppShellProps) {
       <ResizablePanel defaultSize={panelOpen ? 50 : 100} minSize={30}>
         <div className="flex flex-col h-full overflow-hidden">
           <header className="h-11 border-b border-border bg-card flex items-center px-4 gap-3 shrink-0">
-            <span className="op-eyebrow">conversation</span>
+            <span className="op-eyebrow">{t('conversationEyebrow')}</span>
             <span className="text-[13px] font-medium text-foreground truncate flex-1 min-w-0">
-              {headerTitle || 'Untitled'}
+              {headerTitle || t('untitledConversation')}
             </span>
             <ThemeToggle />
           </header>

--- a/frontend/packages/web/components/layout/InputBar.tsx
+++ b/frontend/packages/web/components/layout/InputBar.tsx
@@ -199,7 +199,7 @@ export function InputBar({
         </div>
       )}
       <div
-        className="relative flex cursor-text items-end gap-2 rounded-xl border border-border bg-card px-3 py-2.5 transition-colors focus-within:border-primary/40"
+        className="relative flex cursor-text items-end gap-2 rounded-md border border-border bg-card px-3 py-2.5 transition-shadow focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/15"
         onMouseDown={handleShellMouseDown}
       >
         <button
@@ -207,7 +207,7 @@ export function InputBar({
           aria-label={tShell('inputBarAttach')}
           onClick={() => fileInputRef.current?.click()}
           disabled={!canAttach}
-          className="grid size-7 shrink-0 cursor-pointer place-items-center rounded-lg text-muted-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-30"
+          className="grid size-7 shrink-0 cursor-pointer place-items-center rounded text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
         >
           <Paperclip className="size-3.5" />
         </button>
@@ -219,23 +219,22 @@ export function InputBar({
           onKeyDown={handleKeyDown}
           placeholder={t('placeholder')}
           rows={1}
-          className="flex-1 bg-transparent resize-none outline-none text-sm text-foreground placeholder:text-muted-foreground/40 leading-relaxed min-h-7 max-h-[180px] overflow-y-auto py-0.5"
+          className="flex-1 bg-transparent resize-none outline-none text-[13.5px] text-foreground placeholder:text-muted-foreground/60 leading-relaxed min-h-7 max-h-[180px] overflow-y-auto py-0.5"
           disabled={isSubmitting}
         />
         <button
           data-testid="send-button"
           onClick={() => void handleSubmit()}
           disabled={(!content.trim() && stagedFileCount === 0) || isSubmitting || uploadInFlight}
-          className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary text-white transition-all hover:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-25"
+          className="flex size-7 shrink-0 items-center justify-center rounded bg-foreground text-background transition-colors hover:bg-foreground/85 disabled:cursor-not-allowed disabled:opacity-20"
         >
           {isSubmitting ? (
             <Loader2 className="size-3.5 animate-spin" />
           ) : (
-            <ArrowUp className="size-3.5" />
+            <ArrowUp className="size-3.5" strokeWidth={2.25} />
           )}
         </button>
       </div>
-      <p className="text-center mt-1 text-[10px] text-muted-foreground/35">{t('hint')}</p>
     </div>
   )
 }

--- a/frontend/packages/web/components/layout/Sidebar.tsx
+++ b/frontend/packages/web/components/layout/Sidebar.tsx
@@ -22,7 +22,6 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { AvatarPopover } from '@/components/sidebar/AvatarPopover'
 import { WorkspacesSection } from '@/components/sidebar/WorkspacesSection'
 import {
-  Box,
   Brain,
   type LucideIcon,
   MoreHorizontal,
@@ -305,20 +304,38 @@ export function Sidebar(): React.ReactElement {
   return (
     <aside
       aria-label={tShell('sidebar')}
-      className="w-56 bg-card border-r border-border flex flex-col h-screen shrink-0"
+      className="w-60 bg-card border-r border-border flex flex-col h-screen shrink-0"
     >
-      {/* Brand + new chat */}
-      <div className="px-4 pt-4 pb-3 border-b border-border/60">
-        <div className="flex items-center gap-2 mb-3">
-          <div className="w-6 h-6 rounded-md bg-primary flex items-center justify-center shrink-0 shadow-sm">
-            <Box className="size-3.5 text-primary-foreground" strokeWidth={2.5} />
+      {/* Brand */}
+      <div className="px-3 pt-3.5 pb-3 border-b border-border">
+        <div className="flex items-center gap-2 px-1">
+          <div
+            className={
+              'w-[22px] h-[22px] rounded-[5px] bg-foreground text-background ' +
+              'grid place-items-center font-mono font-semibold text-[11px] tracking-tight ' +
+              'leading-none'
+            }
+            aria-hidden
+          >
+            cb
           </div>
-          <span className="text-sm font-semibold tracking-tight">cubebox</span>
+          <span className="font-display text-[14px] font-semibold tracking-tight text-foreground">
+            cubebox
+          </span>
         </div>
-        <Link href={newChatHref}>
-          <Button variant="outline" size="sm" className="w-full h-7 text-xs gap-1.5">
+        <Link href={newChatHref} className="block mt-3">
+          <Button
+            variant="outline"
+            size="sm"
+            className={
+              'w-full h-7 text-xs gap-1.5 justify-start font-normal ' +
+              'text-muted-foreground hover:text-foreground bg-muted/40 ' +
+              'border-border hover:bg-card'
+            }
+          >
             <Plus className="size-3" />
-            {tSidebar('newChat')}
+            <span className="flex-1 text-left">{tSidebar('newChat')}</span>
+            <span className="op-kbd">N</span>
           </Button>
         </Link>
       </div>

--- a/frontend/packages/web/components/sidebar/AvatarPopover.tsx
+++ b/frontend/packages/web/components/sidebar/AvatarPopover.tsx
@@ -60,12 +60,17 @@ export function AvatarPopover() {
     <Popover>
       <PopoverTrigger
         aria-label={tShell('accountMenu')}
-        className="w-full min-w-0 flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent/60 transition-colors group"
+        className="w-full min-w-0 flex items-center gap-2 px-1.5 py-1.5 rounded-md hover:bg-muted transition-colors group"
       >
-        <div className="size-7 rounded-full bg-gradient-to-br from-primary to-primary/70 text-primary-foreground flex items-center justify-center text-[11px] font-semibold shrink-0 ring-1 ring-primary/20 shadow-sm">
+        <div
+          className={
+            'size-[26px] rounded-full bg-foreground text-background flex items-center ' +
+            'justify-center text-[11px] font-mono font-semibold shrink-0 leading-none'
+          }
+        >
           {initials}
         </div>
-        <span className="text-[12.5px] truncate flex-1 text-left text-foreground/90">
+        <span className="text-[12px] truncate flex-1 text-left text-foreground">
           {user?.email ?? '...'}
         </span>
       </PopoverTrigger>

--- a/frontend/packages/web/components/ui/button.tsx
+++ b/frontend/packages/web/components/ui/button.tsx
@@ -5,15 +5,19 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-[13px] font-medium whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/25 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/80',
+        // Operator primary: foreground (near-black) — accent is reserved for
+        // active / focus / link, not button surfaces.
+        default: 'bg-foreground text-background hover:bg-foreground/90',
+        // Accent button — use sparingly for *the* primary CTA on a page
+        accent: 'bg-primary text-primary-foreground hover:brightness-105',
         outline:
-          'border-border bg-background hover:bg-muted hover:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+          'border-border bg-card text-foreground hover:bg-muted hover:border-muted-foreground/25 dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-muted hover:text-foreground dark:hover:bg-muted/50',
+        ghost: 'text-muted-foreground hover:bg-muted hover:text-foreground dark:hover:bg-muted/50',
         destructive:
           'bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30',
         link: 'text-primary underline-offset-4 hover:underline',

--- a/frontend/packages/web/components/ui/button.tsx
+++ b/frontend/packages/web/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-[13px] font-medium whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/25 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/frontend/packages/web/components/workspace/WorkspaceCreateForm.tsx
+++ b/frontend/packages/web/components/workspace/WorkspaceCreateForm.tsx
@@ -31,7 +31,7 @@ export function WorkspaceCreateForm() {
   return (
     <form onSubmit={onSubmit} className="op-panel">
       <div className="op-panel__head">
-        <h3>Create a workspace</h3>
+        <h3>{t('panelTitle')}</h3>
       </div>
       <div className="op-panel__body space-y-3">
         <label className="block">
@@ -47,9 +47,7 @@ export function WorkspaceCreateForm() {
             onChange={(e) => setName(e.target.value)}
             placeholder={t('namePlaceholder')}
           />
-          <span className="block mt-1.5 text-[11.5px] text-muted-foreground">
-            Names are visible to teammates. You can rename later from workspace settings.
-          </span>
+          <span className="block mt-1.5 text-[11.5px] text-muted-foreground">{t('nameHint')}</span>
         </label>
         {error && (
           <div className="text-[12.5px] text-destructive border border-destructive/30 bg-destructive/5 rounded-md px-3 py-2">

--- a/frontend/packages/web/components/workspace/WorkspaceCreateForm.tsx
+++ b/frontend/packages/web/components/workspace/WorkspaceCreateForm.tsx
@@ -29,27 +29,41 @@ export function WorkspaceCreateForm() {
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-3 rounded-md border border-border p-4">
-      <label className="block">
-        <span className="text-sm text-foreground/80">{t('nameLabel')}</span>
-        <input
-          type="text"
-          required
-          maxLength={64}
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder={t('namePlaceholder')}
-        />
-      </label>
-      {error && <div className="text-sm text-red-500">{error}</div>}
-      <button
-        type="submit"
-        disabled={submitting || !name.trim()}
-        className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
-      >
-        {submitting ? t('creating') : t('submit')}
-      </button>
+    <form onSubmit={onSubmit} className="op-panel">
+      <div className="op-panel__head">
+        <h3>Create a workspace</h3>
+      </div>
+      <div className="op-panel__body space-y-3">
+        <label className="block">
+          <span className="block text-[12.5px] font-medium text-foreground mb-1.5">
+            {t('nameLabel')}
+          </span>
+          <input
+            type="text"
+            required
+            maxLength={64}
+            className="block w-full rounded-md border border-border bg-card px-3 h-9 text-[13px] text-foreground placeholder:text-muted-foreground/60 outline-none focus:border-primary focus:ring-2 focus:ring-primary/15 transition-shadow"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={t('namePlaceholder')}
+          />
+          <span className="block mt-1.5 text-[11.5px] text-muted-foreground">
+            Names are visible to teammates. You can rename later from workspace settings.
+          </span>
+        </label>
+        {error && (
+          <div className="text-[12.5px] text-destructive border border-destructive/30 bg-destructive/5 rounded-md px-3 py-2">
+            {error}
+          </div>
+        )}
+        <button
+          type="submit"
+          disabled={submitting || !name.trim()}
+          className="inline-flex items-center justify-center gap-2 rounded-md bg-foreground text-background px-3 h-8 text-[12.5px] font-medium hover:bg-foreground/90 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        >
+          {submitting ? t('creating') : t('submit')}
+        </button>
+      </div>
     </form>
   )
 }

--- a/frontend/packages/web/components/workspace/WorkspaceList.tsx
+++ b/frontend/packages/web/components/workspace/WorkspaceList.tsx
@@ -13,11 +13,8 @@ export function WorkspaceList() {
     return (
       <div className="op-panel">
         <div className="op-empty">
-          <h4>You haven&apos;t opened any workspaces yet</h4>
-          <p>
-            Workspaces are the namespace for conversations, skills, and credentials. Create one
-            below to get started.
-          </p>
+          <h4>{t('emptyTitle')}</h4>
+          <p>{t('emptyBody')}</p>
         </div>
       </div>
     )
@@ -26,8 +23,8 @@ export function WorkspaceList() {
   return (
     <div className="op-panel">
       <div className="op-panel__head">
-        <h3>Your workspaces</h3>
-        <span className="op-meta">{workspaces.length} total</span>
+        <h3>{t('panelTitle')}</h3>
+        <span className="op-meta">{t('totalSuffix', { count: workspaces.length })}</span>
       </div>
       <ul>
         {workspaces.map((w, idx) => (

--- a/frontend/packages/web/components/workspace/WorkspaceList.tsx
+++ b/frontend/packages/web/components/workspace/WorkspaceList.tsx
@@ -3,33 +3,61 @@
 import Link from 'next/link'
 import { useWorkspaceStore } from '@cubebox/core'
 import { useTranslations } from 'next-intl'
+import { Folder } from 'lucide-react'
 
 export function WorkspaceList() {
   const t = useTranslations('workspaceList')
   const workspaces = useWorkspaceStore((s) => s.workspaces)
 
   if (workspaces.length === 0) {
-    return <div className="text-sm text-foreground/60">{t('empty')}</div>
+    return (
+      <div className="op-panel">
+        <div className="op-empty">
+          <h4>You haven&apos;t opened any workspaces yet</h4>
+          <p>
+            Workspaces are the namespace for conversations, skills, and credentials. Create one
+            below to get started.
+          </p>
+        </div>
+      </div>
+    )
   }
 
   return (
-    <ul className="divide-y divide-border rounded-md border border-border">
-      {workspaces.map((w) => (
-        <li key={w.id} className="flex items-center justify-between px-4 py-3">
-          <div>
-            <div className="text-sm font-medium">{w.name}</div>
-            <div className="text-xs text-foreground/50">
-              {t('rolePrefix', { role: w.role ?? t('unknownRole') })}
-            </div>
-          </div>
-          <Link
-            href={`/w/${w.id}`}
-            className="text-sm underline text-foreground/80 hover:text-foreground"
+    <div className="op-panel">
+      <div className="op-panel__head">
+        <h3>Your workspaces</h3>
+        <span className="op-meta">{workspaces.length} total</span>
+      </div>
+      <ul>
+        {workspaces.map((w, idx) => (
+          <li
+            key={w.id}
+            className={
+              'flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/60 ' +
+              (idx > 0 ? 'border-t border-border' : '')
+            }
           >
-            {t('open')}
-          </Link>
-        </li>
-      ))}
-    </ul>
+            <Folder className="size-4 text-muted-foreground shrink-0" />
+            <div className="flex-1 min-w-0">
+              <div className="text-[13.5px] font-medium text-foreground truncate">{w.name}</div>
+              <div className="text-[11.5px] text-muted-foreground font-mono mt-0.5">
+                {t('rolePrefix', { role: w.role ?? t('unknownRole') })} · {w.id}
+              </div>
+            </div>
+            <Link
+              href={`/w/${w.id}`}
+              className={
+                'inline-flex items-center gap-1 h-7 px-2.5 rounded text-[12.5px] font-medium ' +
+                'text-foreground border border-border hover:bg-card hover:border-muted-foreground/30 ' +
+                'transition-colors bg-muted/30'
+              }
+            >
+              {t('open')} →
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -10,7 +10,13 @@
     "creatingAccount": "Creating…",
     "newHere": "New here?",
     "alreadyHaveAccount": "Already have an account?",
-    "createAccount": "Create an account"
+    "createAccount": "Create an account",
+    "eyebrowSignIn": "sign in",
+    "eyebrowSignUp": "create account",
+    "emailPlaceholder": "you@company.com",
+    "passwordPlaceholder": "•••••••••",
+    "passwordPlaceholderRegister": "at least 8 characters",
+    "passwordHintRegister": "8+ characters. We don't enforce complexity rules — pick something you can remember with a password manager."
   },
   "sidebar": {
     "newChat": "New chat",
@@ -92,7 +98,13 @@
     "allDone": "{count} tasks completed"
   },
   "home": {
-    "subtitle": "AI Agent System"
+    "subtitle": "AI Agent System",
+    "eyebrow": "workspace · home",
+    "title": "What should the agent do next?",
+    "lede": "Drop a question, paste a stack trace, or attach a file. Every run streams reasoning, tool calls, and results back into a conversation you can resume any time.",
+    "kbdSend": "send",
+    "kbdNewline": "newline",
+    "kbdPalette": "command palette"
   },
   "adminInsights": {
     "heading": "Insights",
@@ -817,16 +829,24 @@
     "nameLabel": "New workspace name",
     "namePlaceholder": "e.g. Side project",
     "creating": "Creating…",
-    "submit": "Create workspace"
+    "submit": "Create workspace",
+    "panelTitle": "Create a workspace",
+    "nameHint": "Names are visible to teammates. You can rename later from workspace settings."
   },
   "workspaceList": {
     "empty": "You have no workspaces yet.",
     "open": "Open",
     "rolePrefix": "Role: {role}",
-    "unknownRole": "unknown"
+    "unknownRole": "unknown",
+    "panelTitle": "Your workspaces",
+    "totalSuffix": "{count} total",
+    "emptyTitle": "You haven't opened any workspaces yet",
+    "emptyBody": "Workspaces are the namespace for conversations, skills, and credentials. Create one below to get started."
   },
   "workspacesPage": {
-    "title": "Workspaces"
+    "title": "Workspaces",
+    "eyebrow": "workspaces",
+    "lede": "A workspace is the unit of separation for conversations, skills, MCP connections, and memory. Open one you already have or spin up a new one."
   },
   "conversationPage": {
     "notFoundTitle": "Conversation not found",
@@ -841,7 +861,8 @@
     "subNavAria": "Admin sub-nav",
     "avatarMenuAria": "Admin account menu",
     "comingSoon": "Not available in this build",
-    "backlogRefPrefix": "Owner: {ref}"
+    "backlogRefPrefix": "Owner: {ref}",
+    "orgPrefix": "org · {name}"
   },
   "adminSandbox": {
     "title": "Sandbox",
@@ -876,7 +897,9 @@
     "deleteConversation": "Delete conversation",
     "workspaceSettings": "Workspace settings",
     "accountMenu": "Account menu",
-    "signOut": "Sign out"
+    "signOut": "Sign out",
+    "conversationEyebrow": "conversation",
+    "untitledConversation": "Untitled"
   },
   "mcpAdmin": {
     "searchPlaceholder": "Search connectors…",
@@ -894,29 +917,24 @@
     "loading": "Loading…",
     "noConnectors": "No connectors found",
     "noConnectorsHint": "Try a different search or filter",
-
     "selectConnector": "Select a connector to view details",
     "selectInstalledConnector": "Select an installed connector to view details",
     "addCustomPlaceholder": "Add a custom MCP server",
-
     "authenticated": "Authenticated",
     "notAuthenticated": "Not authenticated",
     "customBadge": "Custom",
     "refreshTools": "Refresh Tools",
     "deleteButton": "Delete",
     "confirmDeleteLabel": "Delete?",
-
     "tabOverview": "Overview",
     "tabTools": "Tools ({count})",
     "tabWorkspaces": "Workspaces",
-
     "overviewServerDetails": "Server Details",
     "overviewUrl": "URL",
     "overviewTransport": "Transport",
     "overviewAuthMethod": "Auth Method",
     "overviewCredentialScope": "Credential Scope",
     "overviewOrgCredential": "Org Credential",
-
     "wsLoading": "Loading workspaces…",
     "wsLoadError": "Failed to load workspaces: {message}",
     "wsEmpty": "No workspaces found",
@@ -927,10 +945,8 @@
     "wsDisabled": "Disabled",
     "pageTitle": "MCP Connectors",
     "pageSubtitle": "Manage organization-level MCP connectors, credentials, and workspace bindings.",
-
     "revealSecret": "Reveal secret",
     "hideSecret": "Hide secret",
-
     "catalogInstallTitle": "Install for organization",
     "catalogInstallError": "Install failed",
     "catalogAuthOAuth": "OAuth",
@@ -943,7 +959,6 @@
     "catalogNoneNotice": "This connector does not require credentials.",
     "catalogStaticTokenLabel": "API token",
     "catalogMultiFieldUnsupported": "Multi-field credential forms aren't supported yet for this connector.",
-
     "customCreateTitle": "Add custom MCP server",
     "customCreateSubtitle": "Register a custom MCP server for the entire organization. You can enable it per workspace afterwards.",
     "customSectionServer": "Server",
@@ -963,5 +978,19 @@
     "customFieldCredNamePlaceholder": "Label shown in the credential vault",
     "customFieldCredPlaintext": "Credential",
     "customSubmit": "Create server"
+  },
+  "authLayout": {
+    "footerBrand": "cubebox · operator",
+    "footerSecurity": "secured by session cookie · csrf double-submit"
+  },
+  "memoryPage": {
+    "eyebrow": "workspace · memory",
+    "title": "Memory",
+    "scopedBy": "scoped by personal / workspace / org",
+    "lede": "What the agent remembers between conversations. Items are scoped — personal stays with you across workspaces, workspace items follow the project, org items are shared with every member.",
+    "tabPersonal": "Personal",
+    "tabWorkspace": "Workspace",
+    "tabOrg": "Organization",
+    "tabArchived": "Archived"
   }
 }

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -10,7 +10,13 @@
     "creatingAccount": "创建中…",
     "newHere": "还没有账户？",
     "alreadyHaveAccount": "已有账户？",
-    "createAccount": "注册"
+    "createAccount": "注册",
+    "eyebrowSignIn": "登录",
+    "eyebrowSignUp": "创建账户",
+    "emailPlaceholder": "you@company.com",
+    "passwordPlaceholder": "•••••••••",
+    "passwordPlaceholderRegister": "至少 8 个字符",
+    "passwordHintRegister": "8 个字符及以上。我们不强制要求复杂度——选一个你能用密码管理器记住的就好。"
   },
   "sidebar": {
     "newChat": "新建对话",
@@ -92,7 +98,13 @@
     "allDone": "{count} 个任务已完成"
   },
   "home": {
-    "subtitle": "AI 智能体系统"
+    "subtitle": "AI 智能体系统",
+    "eyebrow": "工作区 · 首页",
+    "title": "接下来让智能体做什么？",
+    "lede": "提一个问题，贴一段错误堆栈，或者直接拖一个文件进来。每一次运行的推理、工具调用和结果都会流式回到一个可以随时继续的对话里。",
+    "kbdSend": "发送",
+    "kbdNewline": "换行",
+    "kbdPalette": "命令面板"
   },
   "adminInsights": {
     "heading": "运营洞察",
@@ -817,16 +829,24 @@
     "nameLabel": "新工作区名称",
     "namePlaceholder": "例如：副业项目",
     "creating": "创建中…",
-    "submit": "创建工作区"
+    "submit": "创建工作区",
+    "panelTitle": "创建工作区",
+    "nameHint": "名称对所有成员可见。之后可以从工作区设置里重命名。"
   },
   "workspaceList": {
     "empty": "你还没有工作区。",
     "open": "打开",
     "rolePrefix": "角色：{role}",
-    "unknownRole": "未知"
+    "unknownRole": "未知",
+    "panelTitle": "你的工作区",
+    "totalSuffix": "共 {count} 个",
+    "emptyTitle": "你还没有打开过任何工作区",
+    "emptyBody": "工作区是会话、技能、凭据的命名空间。在下方创建一个开始使用。"
   },
   "workspacesPage": {
-    "title": "工作区"
+    "title": "工作区",
+    "eyebrow": "工作区",
+    "lede": "工作区是会话、技能、MCP 连接和记忆的隔离单元。打开一个已有的工作区，或者新建一个。"
   },
   "conversationPage": {
     "notFoundTitle": "找不到该对话",
@@ -841,7 +861,8 @@
     "subNavAria": "管理后台二级导航",
     "avatarMenuAria": "管理后台账号菜单",
     "comingSoon": "本版本不可用",
-    "backlogRefPrefix": "实现归属：{ref}"
+    "backlogRefPrefix": "实现归属：{ref}",
+    "orgPrefix": "组织 · {name}"
   },
   "adminSandbox": {
     "title": "沙盒",
@@ -876,7 +897,9 @@
     "deleteConversation": "删除对话",
     "workspaceSettings": "工作区设置",
     "accountMenu": "账号菜单",
-    "signOut": "退出登录"
+    "signOut": "退出登录",
+    "conversationEyebrow": "会话",
+    "untitledConversation": "未命名"
   },
   "mcpAdmin": {
     "searchPlaceholder": "搜索连接器…",
@@ -894,29 +917,24 @@
     "loading": "加载中…",
     "noConnectors": "未找到连接器",
     "noConnectorsHint": "请尝试不同的搜索条件或筛选项",
-
     "selectConnector": "选择一个连接器查看详情",
     "selectInstalledConnector": "选择一个已安装的连接器查看详情",
     "addCustomPlaceholder": "添加自定义 MCP 服务器",
-
     "authenticated": "已认证",
     "notAuthenticated": "未认证",
     "customBadge": "自定义",
     "refreshTools": "刷新工具",
     "deleteButton": "删除",
     "confirmDeleteLabel": "确认删除?",
-
     "tabOverview": "概览",
     "tabTools": "工具 ({count})",
     "tabWorkspaces": "工作区",
-
     "overviewServerDetails": "服务器详情",
     "overviewUrl": "URL",
     "overviewTransport": "传输方式",
     "overviewAuthMethod": "认证方式",
     "overviewCredentialScope": "凭据范围",
     "overviewOrgCredential": "组织凭据",
-
     "wsLoading": "加载工作区中…",
     "wsLoadError": "加载工作区失败：{message}",
     "wsEmpty": "未找到工作区",
@@ -927,10 +945,8 @@
     "wsDisabled": "未启用",
     "pageTitle": "MCP 连接器",
     "pageSubtitle": "管理组织级 MCP 连接器、凭证及工作区绑定。",
-
     "revealSecret": "显示密钥",
     "hideSecret": "隐藏密钥",
-
     "catalogInstallTitle": "为组织安装",
     "catalogInstallError": "安装失败",
     "catalogAuthOAuth": "OAuth",
@@ -943,7 +959,6 @@
     "catalogNoneNotice": "该连接器无需凭证。",
     "catalogStaticTokenLabel": "API Token",
     "catalogMultiFieldUnsupported": "当前连接器暂不支持多字段凭证表单。",
-
     "customCreateTitle": "添加自定义 MCP 服务器",
     "customCreateSubtitle": "为整个组织登记自定义 MCP 服务器，之后可以按工作区开启。",
     "customSectionServer": "服务器",
@@ -963,5 +978,19 @@
     "customFieldCredNamePlaceholder": "在凭证保险库中显示的标签",
     "customFieldCredPlaintext": "凭证",
     "customSubmit": "创建服务器"
+  },
+  "authLayout": {
+    "footerBrand": "cubebox · operator",
+    "footerSecurity": "会话 cookie 鉴权 · CSRF 双重提交保护"
+  },
+  "memoryPage": {
+    "eyebrow": "工作区 · 记忆",
+    "title": "记忆",
+    "scopedBy": "按个人 / 工作区 / 组织 分类",
+    "lede": "智能体在不同会话之间记住的内容。条目按范围隔离——个人级跟随你跨工作区，工作区级跟随项目，组织级对所有成员共享。",
+    "tabPersonal": "个人",
+    "tabWorkspace": "工作区",
+    "tabOrg": "组织",
+    "tabArchived": "已归档"
   }
 }


### PR DESCRIPTION
## Summary

Adopts **Direction A · Operator** from `_design-explorations/` across the entire
Next.js web app — hairline borders, single indigo accent reserved for
active / focus / links, JetBrains Mono numerals, Inter Tight display headings,
and near-black primary buttons. Light canvas (#fafafa) over white surfaces;
dark mode tuned to graphite while keeping the same accent.

Tokens land in `globals.css` and cascade through the shadcn primitives
(`bg-card`, `border-border`, `bg-primary`, etc.), so most pages pick up the
new look without component edits. Hand-tuned screens:

- **Auth** — login / register get hairline panel layout + footer mono strip
- **Sidebar** — `cb` mono lockup, keyboard hint on New chat, gradient removed
  from the account avatar
- **Workspaces list & create** — Operator panel + mono workspace IDs
- **Workspace home** — eyebrow + lede + keyboard legend below the composer
- **Memory** — page header + eyebrow + lede (icon badge removed)
- **Conversation** — `AppShell` header gets a "CONVERSATION" eyebrow + title;
  user bubble is a hairline card instead of an indigo blob
- **Admin top bar** — same `cb` lockup, accent pill for "Admin", mono org label
- **shadcn `Button`** — default variant remapped to foreground / background;
  new `accent` variant for the rare indigo CTA

No backend or API surface changes.

## Test plan

- [x] `make frontend-check-ci` (build-core + lint + format + type-check + vitest + next build) — green
- [x] Manual walkthrough in Playwright across **every** route: `/login`, `/register`, `/workspaces`, `/w/[wsId]` home, `/w/[wsId]/memory`, `/w/[wsId]/settings?tab=workspace|skills|mcp|members`, `/w/[wsId]/conversations/[id]` (live LLM round-trip + auto-title), `/admin/models|insights|sandbox|web-tools|members|skills|mcp|settings`, and the conversation-not-found error state
- [ ] CI: reviewer to confirm Playwright E2E suite still passes (no test selectors changed, only styling)