### PR TITLE
fix(mcp): refresh OAuth tokens on admin sync-tools + add Re-authenticate button

### DIFF
--- a/backend/cubebox/mcp/dependencies.py
+++ b/backend/cubebox/mcp/dependencies.py
@@ -23,8 +23,10 @@ from cubebox.mcp.oauth.dcr import DCRClient
 from cubebox.mcp.oauth.metadata import OAuthMetadataDiscovery
 from cubebox.mcp.oauth.start import OAuthStartService
 from cubebox.mcp.oauth.state import OAuthStateStore
+from cubebox.mcp.oauth.token_manager import OAuthTokenManager
 from cubebox.mcp.user_token import HS256Signer, MCPUserTokenSigner
 from cubebox.models import Role, User
+from cubebox.repositories.credential import CredentialRepository
 from cubebox.repositories.mcp import (
     MCPServerRepository,
     UserMCPCredentialRepository,
@@ -52,11 +54,94 @@ async def get_audit_sink(request: Request) -> AuditSink:
     return cast(AuditSink, request.app.state.audit_sink)
 
 
+# ---------------- OAuth wiring (must precede services that depend on it) ---------------- #
+
+
+async def get_redis(request: Request) -> Redis:
+    """Return the shared async Redis client established at lifespan."""
+    return cast(Redis, request.app.state.redis)
+
+
+_HTTP_CLIENT_KEY = "_mcp_oauth_http_client"
+_OAUTH_METADATA_DISCOVERY_KEY = "_mcp_oauth_metadata_discovery"
+
+
+async def get_oauth_http_client(request: Request) -> httpx.AsyncClient:
+    """Lazy-initialize a shared ``httpx.AsyncClient`` for OAuth IO.
+
+    We don't open a global pool from app lifespan — only routes that
+    actually need it pay for the connection. The client is cached on
+    ``app.state`` so subsequent requests reuse a single pool.
+    """
+    client = getattr(request.app.state, _HTTP_CLIENT_KEY, None)
+    if client is None:
+        client = httpx.AsyncClient(timeout=30.0)
+        setattr(request.app.state, _HTTP_CLIENT_KEY, client)
+    return cast(httpx.AsyncClient, client)
+
+
+async def get_oauth_metadata_discovery(
+    request: Request,
+    http_client: httpx.AsyncClient = Depends(get_oauth_http_client),
+) -> OAuthMetadataDiscovery:
+    """Return the app-lifetime ``OAuthMetadataDiscovery`` instance.
+
+    The discovery client carries an in-memory TTL cache for AS / PR
+    well-known documents. Constructing a new instance per request would
+    reset that cache on every call, defeating the cache entirely. We
+    stash a single instance on ``app.state`` (mirroring the
+    ``_HTTP_CLIENT_KEY`` pattern above) so the cache survives across
+    requests for the lifetime of the process.
+    """
+    cached = getattr(request.app.state, _OAUTH_METADATA_DISCOVERY_KEY, None)
+    if cached is None:
+        cached = OAuthMetadataDiscovery(http_client)
+        setattr(request.app.state, _OAUTH_METADATA_DISCOVERY_KEY, cached)
+    return cast(OAuthMetadataDiscovery, cached)
+
+
+def _build_token_manager_for_org(
+    *,
+    session: AsyncSession,
+    backend: EncryptionBackend,
+    redis: Redis,
+    http_client: httpx.AsyncClient,
+    metadata: OAuthMetadataDiscovery,
+    org_id: str,
+) -> OAuthTokenManager:
+    """Construct an ``OAuthTokenManager`` scoped to ``org_id``.
+
+    Mirrors the wiring in ``streams.run_manager._build_oauth_token_manager``
+    so admin sync-tools and agent runtime use the same refresh logic.
+    """
+    return OAuthTokenManager(
+        http_client=http_client,
+        redis=redis,
+        encryption_backend=backend,
+        credential_repo=CredentialRepository(session, org_id=org_id),
+        server_repo=MCPServerRepository(session, org_id=org_id),
+        user_cred_repo=UserMCPCredentialRepository(session, org_id=org_id),
+        metadata=metadata,
+    )
+
+
 async def get_mcp_service(
     session: AsyncSession = Depends(get_session),
+    backend: EncryptionBackend = Depends(get_encryption_backend),
     cred_service: CredentialService = Depends(get_credential_service),
+    redis: Redis = Depends(get_redis),
+    http_client: httpx.AsyncClient = Depends(get_oauth_http_client),
+    metadata: OAuthMetadataDiscovery = Depends(get_oauth_metadata_discovery),
     ctx: RequestContext = Depends(require_member),
 ) -> MCPServerService:
+    token_manager = _build_token_manager_for_org(
+        session=session,
+        backend=backend,
+        redis=redis,
+        http_client=http_client,
+        metadata=metadata,
+        org_id=ctx.org_id,
+    )
     return MCPServerService(
         server_repo=MCPServerRepository(session, org_id=ctx.org_id),
         ws_cred_repo=WorkspaceMCPCredentialRepository(session, org_id=ctx.org_id),
@@ -64,6 +149,7 @@ async def get_mcp_service(
         override_repo=WorkspaceMCPOverrideRepository(session, org_id=ctx.org_id),
         cred_service=cred_service,
         request_context=ctx,
+        token_manager=token_manager,
     )
 
 
@@ -78,6 +164,9 @@ async def get_admin_request_context(
 async def get_admin_mcp_service(
     session: AsyncSession = Depends(get_session),
     backend: EncryptionBackend = Depends(get_encryption_backend),
+    redis: Redis = Depends(get_redis),
+    http_client: httpx.AsyncClient = Depends(get_oauth_http_client),
+    metadata: OAuthMetadataDiscovery = Depends(get_oauth_metadata_discovery),
     ctx: RequestContext = Depends(get_admin_request_context),
 ) -> MCPServerService:
     cred_service = build_credential_service(
@@ -86,6 +175,14 @@ async def get_admin_mcp_service(
         org_id=ctx.org_id,
         actor_user_id=ctx.user.id,
     )
+    token_manager = _build_token_manager_for_org(
+        session=session,
+        backend=backend,
+        redis=redis,
+        http_client=http_client,
+        metadata=metadata,
+        org_id=ctx.org_id,
+    )
     return MCPServerService(
         server_repo=MCPServerRepository(session, org_id=ctx.org_id),
         ws_cred_repo=WorkspaceMCPCredentialRepository(session, org_id=ctx.org_id),
@@ -93,6 +190,7 @@ async def get_admin_mcp_service(
         override_repo=WorkspaceMCPOverrideRepository(session, org_id=ctx.org_id),
         cred_service=cred_service,
         request_context=ctx,
+        token_manager=token_manager,
     )
 
 
@@ -136,12 +234,7 @@ async def get_admin_catalog_service(
     )
 
 
-# ---------------- OAuth wiring ---------------- #
-
-
-async def get_redis(request: Request) -> Redis:
-    """Return the shared async Redis client established at lifespan."""
-    return cast(Redis, request.app.state.redis)
+# ---------------- OAuth start/callback wiring ---------------- #
 
 
 def _oauth_redirect_uri() -> str:
@@ -162,48 +255,10 @@ def _state_secret_key() -> bytes:
     return str(secret).encode("utf-8")
 
 
-_HTTP_CLIENT_KEY = "_mcp_oauth_http_client"
-_OAUTH_METADATA_DISCOVERY_KEY = "_mcp_oauth_metadata_discovery"
-
-
-async def get_oauth_http_client(request: Request) -> httpx.AsyncClient:
-    """Lazy-initialize a shared ``httpx.AsyncClient`` for OAuth IO.
-
-    We don't open a global pool from app lifespan — only routes that
-    actually need it pay for the connection. The client is cached on
-    ``app.state`` so subsequent requests reuse a single pool.
-    """
-    client = getattr(request.app.state, _HTTP_CLIENT_KEY, None)
-    if client is None:
-        client = httpx.AsyncClient(timeout=30.0)
-        setattr(request.app.state, _HTTP_CLIENT_KEY, client)
-    return cast(httpx.AsyncClient, client)
-
-
 async def get_oauth_state_store(
     redis: Redis = Depends(get_redis),
 ) -> OAuthStateStore:
     return OAuthStateStore(redis=redis, secret_key=_state_secret_key())
-
-
-async def get_oauth_metadata_discovery(
-    request: Request,
-    http_client: httpx.AsyncClient = Depends(get_oauth_http_client),
-) -> OAuthMetadataDiscovery:
-    """Return the app-lifetime ``OAuthMetadataDiscovery`` instance.
-
-    The discovery client carries an in-memory TTL cache for AS / PR
-    well-known documents. Constructing a new instance per request would
-    reset that cache on every call, defeating the cache entirely. We
-    stash a single instance on ``app.state`` (mirroring the
-    ``_HTTP_CLIENT_KEY`` pattern above) so the cache survives across
-    requests for the lifetime of the process.
-    """
-    cached = getattr(request.app.state, _OAUTH_METADATA_DISCOVERY_KEY, None)
-    if cached is None:
-        cached = OAuthMetadataDiscovery(http_client)
-        setattr(request.app.state, _OAUTH_METADATA_DISCOVERY_KEY, cached)
-    return cast(OAuthMetadataDiscovery, cached)
 
 
 async def get_oauth_dcr_client(

--- a/backend/cubebox/services/mcp.py
+++ b/backend/cubebox/services/mcp.py
@@ -21,6 +21,7 @@ from cubebox.mcp.exceptions import (
     MCPShareCredentialOnlyForWorkspaceScope,
     MCPUserScopeCredentialForbidden,
     MCPWorkspaceOwnedNoOverride,
+    OAuthInvalidServerState,
     OAuthRefreshContention,
     OAuthRefreshFailed,
 )
@@ -637,6 +638,16 @@ class MCPServerService:
                 return
             except OAuthRefreshContention:
                 # Another worker is mid-refresh; let them finish.
+                return
+            except OAuthInvalidServerState as exc:
+                # Access token expired but no refresh_token metadata to rotate
+                # with — e.g. AS never returned a refresh_token on install, or
+                # the refresh credential row was purged. Token manager doesn't
+                # touch ``authed`` in that case, so we flip it here so the UI
+                # surfaces the Re-authenticate button instead of a 500.
+                server.authed = False
+                server.last_error = f"OAuth re-authentication required: {exc}"[:2048]
+                await self.server_repo.update(server)
                 return
             await self._refresh_tools_for_server_with_token(server, credential_or_token=refreshed)
             return

--- a/backend/cubebox/services/mcp.py
+++ b/backend/cubebox/services/mcp.py
@@ -21,7 +21,10 @@ from cubebox.mcp.exceptions import (
     MCPShareCredentialOnlyForWorkspaceScope,
     MCPUserScopeCredentialForbidden,
     MCPWorkspaceOwnedNoOverride,
+    OAuthRefreshContention,
+    OAuthRefreshFailed,
 )
+from cubebox.mcp.oauth.token_manager import OAuthTokenManager
 from cubebox.models import (
     MCPServer,
     UserMCPCredential,
@@ -52,6 +55,7 @@ class MCPServerService:
         override_repo: WorkspaceMCPOverrideRepository,
         cred_service: CredentialService,
         request_context: RequestContext,
+        token_manager: OAuthTokenManager | None = None,
     ) -> None:
         self.server_repo = server_repo
         self.ws_cred_repo = ws_cred_repo
@@ -59,6 +63,7 @@ class MCPServerService:
         self.override_repo = override_repo
         self.cred_service = cred_service
         self._ctx = request_context
+        self._token_manager = token_manager
 
     async def create(
         self,
@@ -617,6 +622,23 @@ class MCPServerService:
         # OAuth installs have no credential at create-time — the callback
         # handler writes one and triggers discovery itself. Skip silently.
         if server.auth_method == "oauth" and server.credential_id is None:
+            return
+
+        # OAuth tokens have short TTLs (Notion: 1h). Reading the stored
+        # access token directly here would let it go stale and surface as
+        # a 401 even when a refresh_token is sitting in the vault. Route
+        # OAuth through OAuthTokenManager so it auto-refreshes on the
+        # admin sync-tools path the same way the agent runtime does.
+        if server.auth_method == "oauth" and self._token_manager is not None:
+            try:
+                refreshed = await self._token_manager.get_valid_access_token(server)
+            except OAuthRefreshFailed:
+                # Token manager already wrote authed=False + last_error.
+                return
+            except OAuthRefreshContention:
+                # Another worker is mid-refresh; let them finish.
+                return
+            await self._refresh_tools_for_server_with_token(server, credential_or_token=refreshed)
             return
 
         cred_kind = (

--- a/backend/tests/unit/test_mcp_service_invariants.py
+++ b/backend/tests/unit/test_mcp_service_invariants.py
@@ -689,3 +689,74 @@ async def test_refresh_tools_for_oauth_server_uses_token_manager(
     assert captured["token"] == "fresh-access-token", (
         "discovery must receive the refreshed token, not the stored stale one"
     )
+
+
+async def test_refresh_tools_marks_unauthed_when_oauth_state_unusable(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+    cred_service: CredentialService,
+    request_context: RequestContext,
+) -> None:
+    """If the token manager raises ``OAuthInvalidServerState`` (e.g. expired
+    access token + missing refresh_token metadata), the service must flip
+    ``authed=False`` and write a descriptive ``last_error`` so the admin UI
+    can show the Re-authenticate button. Letting the exception propagate
+    would surface as a 500 and leave the server stuck in its old
+    ``authed=true`` state.
+    """
+    from cubebox.mcp._constants import server_url_hash
+    from cubebox.mcp.exceptions import OAuthInvalidServerState
+    from cubebox.models import MCPServer
+
+    async def _discover_should_not_run(
+        _server: object, *, credential_or_token: str | None
+    ) -> tuple[bool, list, None]:
+        raise AssertionError("discovery must not run when refresh is impossible")
+
+    monkeypatch.setattr("cubebox.services.mcp.discover_tools", _discover_should_not_run)
+    monkeypatch.setattr("cubebox.mcp.runtime.discover_tools", _discover_should_not_run)
+
+    class StubTokenManager:
+        async def get_valid_access_token(self, server: object, **_kwargs: object) -> str:
+            raise OAuthInvalidServerState(
+                f"server {getattr(server, 'id', '?')} has no refresh_token_credential_id"
+            )
+
+    svc = MCPServerService(
+        server_repo=MCPServerRepository(session, org_id=request_context.org_id),
+        ws_cred_repo=WorkspaceMCPCredentialRepository(session, org_id=request_context.org_id),
+        user_cred_repo=UserMCPCredentialRepository(session, org_id=request_context.org_id),
+        override_repo=WorkspaceMCPOverrideRepository(session, org_id=request_context.org_id),
+        cred_service=cred_service,
+        request_context=request_context,
+        token_manager=StubTokenManager(),  # type: ignore[arg-type]
+    )
+
+    cred_id = await cred_service.create(
+        kind="mcp_oauth_access_token",
+        name="mcp:notion:org:access",
+        plaintext="stale-token",
+    )
+    saved = await svc.server_repo.add(
+        MCPServer(
+            org_id=request_context.org_id,
+            name="catalog:notion",
+            server_url="https://mcp.notion.com/mcp",
+            server_url_hash=server_url_hash("https://mcp.notion.com/mcp"),
+            transport="streamable_http",
+            auth_method="oauth",
+            credential_scope="org",
+            credential_id=cred_id,
+            authed=True,  # was previously usable; now refresh impossible
+            created_by_user_id=request_context.user.id,
+        )
+    )
+
+    # Must NOT raise — service translates the exception into a soft failure.
+    await svc.refresh_tools(server_id=saved.id)
+
+    refreshed = await svc.server_repo.get(saved.id)
+    assert refreshed is not None
+    assert refreshed.authed is False, "must flip authed=False so UI shows Re-authenticate"
+    assert refreshed.last_error is not None
+    assert "OAuth re-authentication required" in refreshed.last_error

--- a/backend/tests/unit/test_mcp_service_invariants.py
+++ b/backend/tests/unit/test_mcp_service_invariants.py
@@ -612,3 +612,80 @@ async def test_workspace_override_with_null_credential_mode_inherits_server_scop
             workspace_id="ws-test",
             plaintext="ws-secret",
         )
+
+
+async def test_refresh_tools_for_oauth_server_uses_token_manager(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+    cred_service: CredentialService,
+    request_context: RequestContext,
+) -> None:
+    """``refresh_tools`` on an OAuth server must route through the token
+    manager so an expired access token gets refreshed before discovery
+    rather than blindly producing a 401.
+
+    Regression for the case where Notion's stored access_token expired
+    overnight, sync-tools kept feeding the dead token into discovery,
+    and the UI showed ``Error / Not authenticated`` even though a usable
+    refresh_token was sitting in the vault.
+    """
+    captured: dict[str, object] = {}
+
+    async def _discover_success(
+        _server: object, *, credential_or_token: str | None
+    ) -> tuple[bool, list, None]:
+        captured["token"] = credential_or_token
+        return True, [], None
+
+    monkeypatch.setattr("cubebox.services.mcp.discover_tools", _discover_success)
+    monkeypatch.setattr("cubebox.mcp.runtime.discover_tools", _discover_success)
+
+    class StubTokenManager:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def get_valid_access_token(self, server: object, **_kwargs: object) -> str:
+            self.calls.append(getattr(server, "id", "?"))
+            return "fresh-access-token"
+
+    stub = StubTokenManager()
+
+    svc = MCPServerService(
+        server_repo=MCPServerRepository(session, org_id=request_context.org_id),
+        ws_cred_repo=WorkspaceMCPCredentialRepository(session, org_id=request_context.org_id),
+        user_cred_repo=UserMCPCredentialRepository(session, org_id=request_context.org_id),
+        override_repo=WorkspaceMCPOverrideRepository(session, org_id=request_context.org_id),
+        cred_service=cred_service,
+        request_context=request_context,
+        token_manager=stub,  # type: ignore[arg-type]
+    )
+
+    # Seed an OAuth+org server with a stale-looking access_token credential.
+    cred_id = await cred_service.create(
+        kind="mcp_oauth_access_token",
+        name="mcp:notion:org:access",
+        plaintext="stale-token",
+    )
+    from cubebox.mcp._constants import server_url_hash
+    from cubebox.models import MCPServer
+
+    server_repo = svc.server_repo
+    server = MCPServer(
+        org_id=request_context.org_id,
+        name="catalog:notion",
+        server_url="https://mcp.notion.com/mcp",
+        server_url_hash=server_url_hash("https://mcp.notion.com/mcp"),
+        transport="streamable_http",
+        auth_method="oauth",
+        credential_scope="org",
+        credential_id=cred_id,
+        created_by_user_id=request_context.user.id,
+    )
+    saved = await server_repo.add(server)
+
+    await svc.refresh_tools(server_id=saved.id)
+
+    assert stub.calls == [saved.id], "token manager must be consulted for OAuth servers"
+    assert captured["token"] == "fresh-access-token", (
+        "discovery must receive the refreshed token, not the stored stale one"
+    )

--- a/frontend/packages/web/components/mcp/MCPAdminDetailPanel.tsx
+++ b/frontend/packages/web/components/mcp/MCPAdminDetailPanel.tsx
@@ -2,8 +2,19 @@
 
 import { useState } from 'react'
 import { useTranslations } from 'next-intl'
-import { Check, FileText, Loader2, Network, RefreshCw, Trash2, Wrench, X } from 'lucide-react'
+import {
+  Check,
+  FileText,
+  KeyRound,
+  Loader2,
+  Network,
+  RefreshCw,
+  Trash2,
+  Wrench,
+  X,
+} from 'lucide-react'
 import type { ApiClient, MCPAdminConnector } from '@cubebox/core'
+import { useMcpStore } from '@cubebox/core'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -13,6 +24,20 @@ import { MCPCatalogInstallPanel } from './MCPCatalogInstallPanel'
 import { MCPCustomCreatePanel } from './MCPCustomCreatePanel'
 import { MCPToolsTable } from './MCPToolsTable'
 import { MCPWorkspacesTab } from './MCPWorkspacesTab'
+
+const OAUTH_ORIGIN_KEY = 'mcp_oauth_origin'
+
+function persistOAuthOrigin(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(
+      OAUTH_ORIGIN_KEY,
+      window.location.pathname + window.location.search,
+    )
+  } catch {
+    // sessionStorage may be unavailable; non-fatal.
+  }
+}
 
 interface MCPAdminDetailPanelProps {
   connector: MCPAdminConnector | null
@@ -52,7 +77,9 @@ export function MCPAdminDetailPanel({
   const [refreshing, setRefreshing] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [reauthorizing, setReauthorizing] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
+  const startOAuth = useMcpStore((s) => s.startOAuth)
 
   // ── Placeholder states ──────────────────────────────────────────────
 
@@ -135,6 +162,21 @@ export function MCPAdminDetailPanel({
     }
   }
 
+  async function handleReauthorize(): Promise<void> {
+    setReauthorizing(true)
+    setActionError(null)
+    try {
+      const result = await startOAuth(client, server!.id)
+      persistOAuthOrigin()
+      window.location.href = result.authorize_url
+    } catch (err) {
+      setActionError((err as Error).message)
+      setReauthorizing(false)
+    }
+  }
+
+  const needsReauth = server.auth_method === 'oauth' && !c.authed
+
   return (
     <div className="flex w-full flex-col gap-4 p-6" data-testid="mcp-admin-detail-panel">
       {/* ── Header ─────────────────────────────────────────────────── */}
@@ -166,11 +208,28 @@ export function MCPAdminDetailPanel({
 
           {/* Spacer + action buttons */}
           <div className="ml-auto flex items-center gap-2">
+            {needsReauth && (
+              <Button
+                type="button"
+                variant="default"
+                size="sm"
+                disabled={refreshing || deleting || reauthorizing}
+                onClick={() => void handleReauthorize()}
+                data-testid="mcp-admin-reauthorize-button"
+              >
+                {reauthorizing ? (
+                  <Loader2 data-icon="inline-start" className="animate-spin" />
+                ) : (
+                  <KeyRound data-icon="inline-start" />
+                )}
+                {t('reauthorize')}
+              </Button>
+            )}
             <Button
               type="button"
               variant="outline"
               size="sm"
-              disabled={refreshing || deleting}
+              disabled={refreshing || deleting || reauthorizing}
               onClick={() => void handleRefresh()}
             >
               {refreshing ? (
@@ -188,7 +247,7 @@ export function MCPAdminDetailPanel({
                 size="sm"
                 className="text-destructive hover:bg-destructive/10
                   hover:text-destructive"
-                disabled={refreshing || deleting}
+                disabled={refreshing || deleting || reauthorizing}
                 onClick={() => setConfirmDelete(true)}
               >
                 <Trash2 data-icon="inline-start" />

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -903,6 +903,7 @@
     "notAuthenticated": "Not authenticated",
     "customBadge": "Custom",
     "refreshTools": "Refresh Tools",
+    "reauthorize": "Re-authenticate",
     "deleteButton": "Delete",
     "confirmDeleteLabel": "Delete?",
 

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -903,6 +903,7 @@
     "notAuthenticated": "未认证",
     "customBadge": "自定义",
     "refreshTools": "刷新工具",
+    "reauthorize": "重新认证",
     "deleteButton": "删除",
     "confirmDeleteLabel": "确认删除?",
 


### PR DESCRIPTION
## Summary

**Root cause of "Error / Not authenticated" on admin MCP page after OAuth tokens age out:**

`MCPServerService._refresh_tools_for_server` was reading the stored access_token credential directly for OAuth servers. Notion's access tokens have ~1h TTL — once the cached token aged out, sync-tools kept feeding the dead token into discovery, the upstream MCP returned 401, and the admin UI persistently showed `Error` even though a usable `refresh_token` was sitting in the vault. The agent runtime had already been doing the right thing by routing OAuth servers through `OAuthTokenManager.get_valid_access_token` (RFC 6749 refresh under a redis lock), so live agent calls did silently auto-refresh — but the explicit admin sync-tools button never benefited from that path.

**Fix:**

- Inject `OAuthTokenManager` into `MCPServerService` (optional kwarg → unit tests still work without it).
- On the OAuth branch of `_refresh_tools_for_server`, call `token_manager.get_valid_access_token(server)` and pass the result into discovery. Terminal `OAuthRefreshFailed` is swallowed — the token manager has already written `authed=False` + `last_error`, which the UI can render.
- New DI helper `_build_token_manager_for_org` builds the manager from the existing `httpx` / redis / metadata / encryption-backend deps; both `get_mcp_service` (member) and `get_admin_mcp_service` (org admin) now provide it.

**UX gap:**

Once refresh fails terminally (refresh_token revoked / vault-purged), there was no UI to retrigger OAuth. Added a `Re-authenticate` button on `MCPAdminDetailPanel` shown for `auth_method=oauth && !authed`. It reuses the existing `startOAuth` store action and redirects to the authorize URL, mirroring the first-install flow in `MCPCatalogInstallPanel`.

## Files

- `backend/cubebox/services/mcp.py` — `MCPServerService` accepts an optional `token_manager`; `_refresh_tools_for_server` routes OAuth through it
- `backend/cubebox/mcp/dependencies.py` — `_build_token_manager_for_org` helper; both DI factories provide a token manager
- `backend/tests/unit/test_mcp_service_invariants.py` — regression: OAuth server's `refresh_tools` must consult the token manager and feed the refreshed token into discovery
- `frontend/packages/web/components/mcp/MCPAdminDetailPanel.tsx` — `Re-authenticate` button + `handleReauthorize`
- `frontend/packages/web/messages/{en,zh}.json` — `reauthorize` key

## Test plan

- [x] `make check-ci` (646 backend tests pass, including new regression)
- [x] frontend `pnpm build` / `type-check` / lint pass
- [ ] On the affected DB: click Re-authenticate on the Notion server, complete OAuth, then sync tools and confirm `authed=true` and tools list populates
- [ ] Click Refresh Tools on a recently-OAuth'd server whose access token has just expired (within refresh window) — must succeed silently without surfacing 401

## Notes

- Workspace credential_scope OAuth is invalid at create-time, so the OAuth branch only matters for `org` scope. `credential_scope=user` OAuth still returns early from the admin path — refreshing per-user tokens from an admin context is out of scope here (admin has no `user_id`).
- The token manager's locking semantics are unchanged; concurrent sync-tools / agent calls collapse to a single token endpoint hit.