### PR TITLE
fix(mcp): upsert OAuth credentials on callback so re-auth doesn't 500

### DIFF
--- a/backend/cubebox/mcp/oauth/callback.py
+++ b/backend/cubebox/mcp/oauth/callback.py
@@ -270,14 +270,18 @@ class OAuthCallbackHandler:
         expires_at_iso: str,
     ) -> None:
         cred_service = self._cred_service_factory(server.org_id, actor_user_id)
-        access_id = await cred_service.create(
+        # Upsert: re-OAuth (admin Re-authenticate, refresh_token expiry) hits
+        # this path with the same (kind, name) tuple, and the unique index
+        # ``uq_credential_org_kind_name`` would 500 the callback if we always
+        # created a new row.
+        access_id = await cred_service.upsert_by_kind_name(
             kind=CREDENTIAL_KIND_MCP_OAUTH_ACCESS_TOKEN,
             name=f"mcp:{server.name}:org:access",
             plaintext=access_token,
         )
         refresh_id: str | None = None
         if refresh_token is not None:
-            refresh_id = await cred_service.create(
+            refresh_id = await cred_service.upsert_by_kind_name(
                 kind=CREDENTIAL_KIND_MCP_OAUTH_REFRESH_TOKEN,
                 name=f"mcp:{server.name}:org:refresh",
                 plaintext=refresh_token,
@@ -287,6 +291,11 @@ class OAuthCallbackHandler:
         client_config["expires_at"] = expires_at_iso
         if refresh_id is not None:
             client_config["refresh_token_credential_id"] = refresh_id
+        else:
+            # AS dropped the refresh_token this round — clear any stale
+            # pointer so the runtime doesn't try to use a credential whose
+            # ciphertext no longer matches what the AS will accept.
+            client_config.pop("refresh_token_credential_id", None)
         server.oauth_client_config = client_config
         server.authed = True
         server.last_error = None
@@ -302,14 +311,15 @@ class OAuthCallbackHandler:
         expires_at: Any,
     ) -> None:
         cred_service = self._cred_service_factory(server.org_id, actor_user_id)
-        access_id = await cred_service.create(
+        # Upsert mirrors the org path — see _persist_org for the rationale.
+        access_id = await cred_service.upsert_by_kind_name(
             kind=CREDENTIAL_KIND_MCP_OAUTH_ACCESS_TOKEN,
             name=f"mcp:{server.name}:user:{actor_user_id}:access",
             plaintext=access_token,
         )
         refresh_id: str | None = None
         if refresh_token is not None:
-            refresh_id = await cred_service.create(
+            refresh_id = await cred_service.upsert_by_kind_name(
                 kind=CREDENTIAL_KIND_MCP_OAUTH_REFRESH_TOKEN,
                 name=f"mcp:{server.name}:user:{actor_user_id}:refresh",
                 plaintext=refresh_token,

--- a/backend/cubebox/mcp/oauth/callback.py
+++ b/backend/cubebox/mcp/oauth/callback.py
@@ -291,11 +291,11 @@ class OAuthCallbackHandler:
         client_config["expires_at"] = expires_at_iso
         if refresh_id is not None:
             client_config["refresh_token_credential_id"] = refresh_id
-        else:
-            # AS dropped the refresh_token this round — clear any stale
-            # pointer so the runtime doesn't try to use a credential whose
-            # ciphertext no longer matches what the AS will accept.
-            client_config.pop("refresh_token_credential_id", None)
+        # If refresh_id is None the AS chose not to rotate the refresh token
+        # this round. Per RFC 6749 §6 the previously issued refresh token
+        # remains valid, so leave the existing pointer alone — clearing it
+        # would orphan a still-usable credential row and force the next
+        # refresh to raise OAuthInvalidServerState.
         server.oauth_client_config = client_config
         server.authed = True
         server.last_error = None
@@ -342,7 +342,12 @@ class OAuthCallbackHandler:
             )
         else:
             existing.credential_id = access_id
-            existing.oauth_refresh_token_credential_id = refresh_id
+            # Same RFC 6749 §6 invariant as _persist_org: only overwrite the
+            # refresh pointer when the AS actually issued a new refresh token
+            # this round. ``refresh_id is None`` means rotation was skipped,
+            # not that the prior refresh token has been invalidated.
+            if refresh_id is not None:
+                existing.oauth_refresh_token_credential_id = refresh_id
             existing.oauth_expires_at = expires_at
             await self._user_cred_repo.session.commit()
             await self._user_cred_repo.session.refresh(existing)

--- a/backend/cubebox/services/credential.py
+++ b/backend/cubebox/services/credential.py
@@ -78,6 +78,32 @@ class CredentialService:
             cred.cred_metadata = metadata
         await self._repo.update(cred)
 
+    async def upsert_by_kind_name(
+        self,
+        *,
+        kind: str,
+        name: str,
+        plaintext: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """Rotate an existing ``(kind, name)`` row in scope, or create one.
+
+        The credentials table has a partial unique constraint on
+        ``(org_id, kind, name)``; on re-OAuth, blindly calling ``create``
+        with the same name a second time hits ``uq_credential_org_kind_name``
+        and the whole callback fails. Callers that legitimately re-issue a
+        named credential (OAuth access/refresh rotation) should use this
+        method instead of ``create``.
+        """
+        existing = await self._repo.get_by_kind_name(kind=kind, name=name)
+        if existing is None:
+            return await self.create(kind=kind, name=name, plaintext=plaintext, metadata=metadata)
+        existing.value_encrypted = await self._backend.encrypt(plaintext.encode("utf-8"))
+        if metadata is not None:
+            existing.cred_metadata = metadata
+        await self._repo.update(existing)
+        return existing.id
+
     async def delete(self, *, credential_id: str) -> None:
         cred = await self._repo.get(credential_id)
         if cred is None:

--- a/backend/tests/unit/mcp/test_oauth_callback.py
+++ b/backend/tests/unit/mcp/test_oauth_callback.py
@@ -355,6 +355,72 @@ async def test_handle_callback_org_scope_re_oauth_rotates_existing_credentials(
     assert (await encryption_backend.decrypt(refresh_cred.value_encrypted)).decode() == "refresh-v2"
 
 
+async def test_handle_callback_preserves_existing_refresh_token_when_as_omits_it(
+    session: AsyncSession,
+    fake_redis: fakeredis.aioredis.FakeRedis,
+    encryption_backend: FernetBackend,
+) -> None:
+    """RFC 6749 §6: when the token response omits ``refresh_token``, the
+    previously issued refresh token remains valid. The callback must not
+    drop ``refresh_token_credential_id`` from ``oauth_client_config`` —
+    otherwise the next access-token expiry raises ``OAuthInvalidServerState``
+    instead of refreshing.
+    """
+    server = await _seed_oauth_install(
+        session,
+        credential_scope="org",
+        owner_workspace_id=None,
+    )
+
+    async def _fake_discover(
+        _server: MCPServer, *, credential_or_token: str | None
+    ) -> tuple[bool, list[dict[str, Any]] | None, str | None]:
+        return True, [], None
+
+    async def _run_callback(token_payload: dict[str, Any]) -> None:
+        state_store = OAuthStateStore(redis=fake_redis, secret_key=STATE_SECRET, ttl_seconds=300)
+        state = await state_store.issue(install_id=server.id, actor_user_id=USER_ID)
+        await fake_redis.set(PKCE_REDIS_KEY_PREFIX + server.id, "verifier-x")
+        handler = _Handler(
+            _metadata_responses(),
+            token_responses=[httpx.Response(200, json=token_payload)],
+        )
+        http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        cb_handler = _make_handler(session, fake_redis, encryption_backend, http)
+        try:
+            with patch("cubebox.mcp.runtime.discover_tools", _fake_discover):
+                await cb_handler.handle_callback(state=state, code="code")
+        finally:
+            await http.aclose()
+
+    # First callback: AS returns both tokens, refresh credential row is created.
+    await _run_callback(
+        {"access_token": "access-v1", "refresh_token": "refresh-v1", "expires_in": 3600}
+    )
+    server_repo = MCPServerRepository(session, org_id=ORG_ID)
+    after_first = await server_repo.get(server.id)
+    assert after_first is not None
+    first_refresh_id = after_first.oauth_client_config["refresh_token_credential_id"]
+    assert first_refresh_id is not None
+
+    # Second callback: AS rotates access_token only — RFC 6749 §6 permits
+    # omitting refresh_token, in which case the previous one stays valid.
+    await _run_callback({"access_token": "access-v2", "expires_in": 3600})
+
+    after_second = await server_repo.get(server.id)
+    assert after_second is not None
+    assert (
+        after_second.oauth_client_config.get("refresh_token_credential_id") == first_refresh_id
+    ), "must preserve refresh_token_credential_id when AS omits refresh_token"
+
+    cred_repo = CredentialRepository(session, org_id=ORG_ID)
+    refresh_cred = await cred_repo.get(first_refresh_id)
+    assert refresh_cred is not None
+    assert (
+        await encryption_backend.decrypt(refresh_cred.value_encrypted)
+    ).decode() == "refresh-v1", "underlying refresh credential row must be untouched"
+
+
 async def test_handle_callback_user_scope_writes_user_credential_row(
     session: AsyncSession,
     fake_redis: fakeredis.aioredis.FakeRedis,

--- a/backend/tests/unit/mcp/test_oauth_callback.py
+++ b/backend/tests/unit/mcp/test_oauth_callback.py
@@ -272,6 +272,89 @@ async def test_handle_callback_org_scope_writes_vault_and_flips_authed(
     ).decode() == "fresh-refresh"
 
 
+async def test_handle_callback_org_scope_re_oauth_rotates_existing_credentials(
+    session: AsyncSession,
+    fake_redis: fakeredis.aioredis.FakeRedis,
+    encryption_backend: FernetBackend,
+) -> None:
+    """A second OAuth callback for an already-authorized install must
+    rotate the vault rows in place, not insert duplicates.
+
+    Regression: before the fix, ``_persist_org`` always called
+    ``cred_service.create`` with a fixed ``(kind, name)``, and the
+    second callback crashed with ``UniqueViolation`` on
+    ``uq_credential_org_kind_name``. The admin Re-authenticate flow
+    landed exactly on this path.
+    """
+    server = await _seed_oauth_install(
+        session,
+        credential_scope="org",
+        owner_workspace_id=None,
+    )
+
+    async def _fake_discover(
+        _server: MCPServer, *, credential_or_token: str | None
+    ) -> tuple[bool, list[dict[str, Any]] | None, str | None]:
+        return True, [], None
+
+    async def _run_callback(token_payload: dict[str, Any]) -> CallbackResult:
+        state_store = OAuthStateStore(redis=fake_redis, secret_key=STATE_SECRET, ttl_seconds=300)
+        state = await state_store.issue(install_id=server.id, actor_user_id=USER_ID)
+        await fake_redis.set(PKCE_REDIS_KEY_PREFIX + server.id, "verifier-x")
+        handler = _Handler(
+            _metadata_responses(), token_responses=[httpx.Response(200, json=token_payload)]
+        )
+        http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        cb_handler = _make_handler(session, fake_redis, encryption_backend, http)
+        try:
+            with patch("cubebox.mcp.runtime.discover_tools", _fake_discover):
+                return await cb_handler.handle_callback(state=state, code="code")
+        finally:
+            await http.aclose()
+
+    await _run_callback(
+        {
+            "access_token": "access-v1",
+            "refresh_token": "refresh-v1",
+            "expires_in": 3600,
+        }
+    )
+
+    server_repo = MCPServerRepository(session, org_id=ORG_ID)
+    after_first = await server_repo.get(server.id)
+    assert after_first is not None
+    first_access_id = after_first.credential_id
+    first_refresh_id = after_first.oauth_client_config["refresh_token_credential_id"]
+    assert first_access_id is not None
+    assert first_refresh_id is not None
+
+    # Re-authenticate. The AS issues new tokens; the callback runs again.
+    result = await _run_callback(
+        {
+            "access_token": "access-v2",
+            "refresh_token": "refresh-v2",
+            "expires_in": 3600,
+        }
+    )
+    assert result.authed is True
+
+    after_second = await server_repo.get(server.id)
+    assert after_second is not None
+    assert after_second.credential_id == first_access_id, (
+        "access credential row must be rotated, not duplicated"
+    )
+    assert after_second.oauth_client_config["refresh_token_credential_id"] == first_refresh_id, (
+        "refresh credential row must be rotated, not duplicated"
+    )
+
+    cred_repo = CredentialRepository(session, org_id=ORG_ID)
+    access_cred = await cred_repo.get(first_access_id)
+    refresh_cred = await cred_repo.get(first_refresh_id)
+    assert access_cred is not None and refresh_cred is not None
+    assert (await encryption_backend.decrypt(access_cred.value_encrypted)).decode() == "access-v2"
+    assert (await encryption_backend.decrypt(refresh_cred.value_encrypted)).decode() == "refresh-v2"
+
+
 async def test_handle_callback_user_scope_writes_user_credential_row(
     session: AsyncSession,
     fake_redis: fakeredis.aioredis.FakeRedis,

--- a/backend/tests/unit/test_credential_service.py
+++ b/backend/tests/unit/test_credential_service.py
@@ -105,3 +105,52 @@ async def test_credential_service_update_and_delete(
 
     with pytest.raises(CredentialNotFound):
         await service.get_decrypted(credential_id=credential_id, requesting_kind="mcp_server")
+
+
+async def test_credential_service_upsert_by_kind_name_rotates_existing(
+    session: AsyncSession, backend: FernetBackend
+) -> None:
+    """Re-OAuth must rotate the existing (org, kind, name) row in place
+    rather than insert a duplicate that violates ``uq_credential_org_kind_name``.
+
+    Regression for the bug where ``OAuthCallbackHandler._persist_org``
+    blindly called ``create`` on every callback, so re-authorizing an
+    install whose tokens were already in the vault crashed with a
+    psycopg ``UniqueViolation``.
+    """
+    from cubebox.services.credential import CredentialService
+
+    service = CredentialService(
+        CredentialRepository(session, org_id="org-1"),
+        backend,
+        org_id="org-1",
+        actor_user_id="user-1",
+    )
+
+    first_id = await service.upsert_by_kind_name(
+        kind="mcp_oauth_access_token",
+        name="mcp:catalog:notion:org:access",
+        plaintext="token-v1",
+    )
+    second_id = await service.upsert_by_kind_name(
+        kind="mcp_oauth_access_token",
+        name="mcp:catalog:notion:org:access",
+        plaintext="token-v2",
+    )
+
+    assert first_id == second_id, "upsert must rotate the same row, not insert a duplicate"
+    assert (
+        await service.get_decrypted(
+            credential_id=first_id,
+            requesting_kind="mcp_oauth_access_token",
+        )
+        == "token-v2"
+    )
+
+    # A different (kind, name) tuple is a separate row.
+    other_id = await service.upsert_by_kind_name(
+        kind="mcp_oauth_refresh_token",
+        name="mcp:catalog:notion:org:refresh",
+        plaintext="refresh-v1",
+    )
+    assert other_id != first_id


### PR DESCRIPTION
## Summary

After PR #93 shipped the admin Re-authenticate button, the second OAuth roundtrip against an already-authorized install crashed in the callback with:

```
sqlalchemy.exc.IntegrityError: (psycopg.errors.UniqueViolation)
duplicate key value violates unique constraint "uq_credential_org_kind_name"
```

`OAuthCallbackHandler._persist_org` / `_persist_user` always called `cred_service.create(kind=..., name=f"mcp:{server.name}:org:access", ...)` on every successful token exchange. The `credentials` table has a partial unique index `uq_credential_org_kind_name` on `(org_id, kind, name) WHERE org_id IS NOT NULL` — the first OAuth installed fine; the second one (Re-authenticate, or any future re-entry through the callback) hit the constraint, the callback errored out, and the install stayed stuck.

## Fix

- `CredentialService.upsert_by_kind_name(kind, name, plaintext, metadata=None)` — looks up `(kind, name)` in scope via `repo.get_by_kind_name`; if found, rotates ciphertext + metadata in place and returns the existing id; otherwise falls back to `create`.
- `_persist_org` and `_persist_user` both switched from `create` to `upsert_by_kind_name`. Same credential row gets re-used on re-auth — no duplicate insert, no 500.
- `_persist_org` also `pop`s `refresh_token_credential_id` from `oauth_client_config` when the AS this round didn't return a refresh_token, so the runtime doesn't follow a stale pointer next time.

## Tests

- `test_credential_service_upsert_by_kind_name_rotates_existing` — service-level invariant: second upsert returns the same id and rotates ciphertext.
- `test_handle_callback_org_scope_re_oauth_rotates_existing_credentials` — runs the full callback handler twice against the same install, asserts the access + refresh credential ids are stable across re-auth and that the ciphertext was rotated. This is the literal repro for the UniqueViolation that bit you.

## Test plan

- [x] make check-ci (649 backend tests pass)
- [ ] Click Re-authenticate on Notion, complete OAuth, confirm no 500 and tools repopulate
- [ ] Confirm existing credential rows are rotated in place (same ids, fresh ciphertext, authed=true)