### PR TITLE
test(backend): agent middleware E2E coverage under real LLM

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -57,7 +57,7 @@ test:
 
 test-real-llm:
 	@echo "Running real-LLM tests..."
-	uv run pytest -s -v -m real_llm tests/e2e/memory/
+	uv run pytest -s -v -m real_llm tests/e2e/memory/ tests/e2e/middleware/
 	@echo "✓ Real-LLM tests passed"
 
 test-cov:

--- a/backend/tests/e2e/middleware/_helpers.py
+++ b/backend/tests/e2e/middleware/_helpers.py
@@ -18,9 +18,13 @@ from tests.e2e.conftest import collect_sse_events
 TOOL_CALCULATOR = "calculator"
 # cubebox/middleware/todo.py:418
 TOOL_TODO = "write_todos"
-# memory middleware does not register an AgentTool; it is a prompt-injection
-# middleware only (transform_system_prompt / transform_context). No write tool.
-TOOL_MEMORY_WRITE: str | None = None
+# MemoryMiddleware itself is prompt-injection only (transform_system_prompt /
+# transform_context). The memory *tools* live separately in
+# cubebox/tools/builtin/memory.py and are registered into every cubepi run's
+# tool list via run_manager.py (lines 594-600). Three tools are exposed:
+TOOL_MEMORY_SAVE = "memory_save"
+TOOL_MEMORY_SEARCH = "memory_search"
+TOOL_MEMORY_UPDATE = "memory_update"
 # cubebox/middleware/sandbox.py:154 — primary code-execution tool
 TOOL_SANDBOX = "execute"
 # cubebox/middleware/subagents.py:256

--- a/backend/tests/e2e/middleware/_helpers.py
+++ b/backend/tests/e2e/middleware/_helpers.py
@@ -1,0 +1,110 @@
+"""Shared scaffolding for the agent-middleware-coverage E2E suite.
+
+Constants and tiny helpers consumed by test_journey.py, test_subagent.py,
+and test_compaction.py. See
+docs/superpowers/specs/2026-05-15-agent-middleware-e2e-design.md.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from tests.e2e.conftest import collect_sse_events
+
+# --- Tool names (verified against middleware source in Task 2) ---------------
+# cubebox/tools/registry.py — built-in tool
+TOOL_CALCULATOR = "calculator"
+# cubebox/middleware/todo.py:418
+TOOL_TODO = "write_todos"
+# memory middleware does not register an AgentTool; it is a prompt-injection
+# middleware only (transform_system_prompt / transform_context). No write tool.
+TOOL_MEMORY_WRITE: str | None = None
+# cubebox/middleware/sandbox.py:154 — primary code-execution tool
+TOOL_SANDBOX = "execute"
+# cubebox/middleware/subagents.py:256
+TOOL_SUBAGENT_SPAWN = "subagent"
+
+# --- SSE event types (verified against cubebox/streams/run_manager.py) -------
+EVT_TEXT_DELTA = "text_delta"
+EVT_TOOL_CALL = "tool_call"
+EVT_TOOL_RESULT = "tool_result"
+EVT_USAGE = "usage"
+EVT_ERROR = "error"
+EVT_DONE = "done"
+
+# --- Compaction note (informational; no test asserts on this) ----------------
+# Trigger: approx_tokens(compressed_history) >= context_window * threshold_ratio
+# Defaults: fallback_context_window=64000, threshold_ratio=0.7 → ~44800 tokens.
+# Both values are overridable via config keys "compaction.fallback_context_window"
+# and "compaction.threshold_ratio" (cubebox/streams/run_manager.py lines 770-771).
+COMPACTION_NOTE = (
+    "Compact when approx_tokens(compressed_history) >= context_window * 0.7 "
+    "(default fallback_context_window=64000, giving ~44800 token threshold)"
+)
+
+
+# ---------------------------------------------------------------------------
+# Event filtering helpers
+# ---------------------------------------------------------------------------
+
+
+def events_of_type(events: list[dict[str, Any]], type_name: str) -> list[dict[str, Any]]:
+    """Return all events whose 'type' field equals type_name."""
+    return [e for e in events if e.get("type") == type_name]
+
+
+def tool_call_names(events: list[dict[str, Any]]) -> list[str]:
+    """Return the tool name from every tool_call event in the stream.
+
+    The cubebox SSE envelope nests tool identity under a 'data' sub-dict:
+      {'type': 'tool_call', 'data': {'name': 'calculator', ...}, ...}
+    Falls back to top-level 'name' for forward-compatibility.
+    """
+    names: list[str] = []
+    for e in events_of_type(events, EVT_TOOL_CALL):
+        data = e.get("data") or {}
+        n = data.get("name") or e.get("name")
+        if isinstance(n, str):
+            names.append(n)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers — mirror test_cubepi_path_tools.py exactly
+# ---------------------------------------------------------------------------
+
+
+async def create_conversation(client: httpx.AsyncClient, ws_id: str, title: str) -> str:
+    """Create a conversation and return its id.
+
+    Body shape mirrors test_cubepi_path_tools.py: title is a query param,
+    not a JSON body field (matches POST /api/v1/ws/{ws_id}/conversations).
+    """
+    resp = await client.post(
+        f"/api/v1/ws/{ws_id}/conversations",
+        params={"title": title},
+    )
+    assert resp.status_code == 201, f"conversation creation failed: {resp.text}"
+    return str(resp.json()["id"])
+
+
+async def post_turn(
+    client: httpx.AsyncClient,
+    ws_id: str,
+    conv_id: str,
+    content: str,
+) -> list[dict[str, Any]]:
+    """POST a user message and collect all SSE events.
+
+    Mirrors the streaming pattern in test_cubepi_path_tools.py:
+      collect_sse_events(client, url, json_data={"content": ...})
+    which opens client.stream("POST", url, json=...) and parses
+    each "data: ..." line as JSON.
+    """
+    return await collect_sse_events(
+        client,
+        f"/api/v1/ws/{ws_id}/conversations/{conv_id}/messages",
+        json_data={"content": content},
+    )

--- a/backend/tests/e2e/middleware/_helpers.py
+++ b/backend/tests/e2e/middleware/_helpers.py
@@ -71,6 +71,54 @@ def tool_call_names(events: list[dict[str, Any]]) -> list[str]:
     return names
 
 
+def _flatten_content(evt: dict[str, Any]) -> str:
+    """Extract plain text from a tool_result/text_delta event.
+
+    The SSE envelope nests content under 'data.content' (or 'data.result'
+    for tool_result). Handles structured list-of-blocks shapes returned by
+    some providers. Mirrors the helper in test_cubepi_path_tools.py.
+    """
+
+    def _from_value(c: object) -> str | None:
+        if isinstance(c, str):
+            return c
+        if isinstance(c, list):
+            parts: list[str] = []
+            for block in c:
+                if isinstance(block, dict) and "text" in block:
+                    parts.append(str(block["text"]))
+                elif isinstance(block, str):
+                    parts.append(block)
+            return "".join(parts)
+        return None
+
+    data = evt.get("data")
+    if isinstance(data, dict):
+        v = _from_value(data.get("content"))
+        if v is not None:
+            return v
+        v = _from_value(data.get("result"))
+        if v is not None:
+            return v
+    v = _from_value(evt.get("content"))
+    if v is not None:
+        return v
+    v = _from_value(evt.get("result"))
+    if v is not None:
+        return v
+    return ""
+
+
+def tool_result_contents(events: list[dict[str, Any]]) -> list[str]:
+    """Return flattened content strings for every tool_result event."""
+    return [_flatten_content(e) for e in events_of_type(events, EVT_TOOL_RESULT)]
+
+
+def assistant_text(events: list[dict[str, Any]]) -> str:
+    """Concatenate the content of every text_delta event into the full reply."""
+    return "".join(_flatten_content(e) for e in events_of_type(events, EVT_TEXT_DELTA))
+
+
 # ---------------------------------------------------------------------------
 # HTTP helpers — mirror test_cubepi_path_tools.py exactly
 # ---------------------------------------------------------------------------

--- a/backend/tests/e2e/middleware/test_compaction.py
+++ b/backend/tests/e2e/middleware/test_compaction.py
@@ -1,0 +1,67 @@
+"""E2E: compaction middleware participation.
+
+Compaction's strong path (history trim) only fires above ~44,800 tokens
+of history (fallback_context_window=64000 * threshold_ratio=0.7 per
+COMPACTION_NOTE in _helpers.py). Hitting that threshold via real-LLM
+filler is impractical for this suite, so this test verifies only that
+the compaction middleware participates in the stack without crashing
+streams under multi-turn load — the weak-fallback path documented in
+the plan.
+
+Track B chosen because: the app is created inside the fixture and the
+config object is loaded at module import time, so monkeypatch.setenv
+cannot override the already-initialized compaction thresholds per-test
+without modifying conftest (out of scope).
+
+See plan: docs/superpowers/plans/2026-05-15-agent-middleware-e2e.md
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.middleware._helpers import (
+    EVT_DONE,
+    EVT_ERROR,
+    create_conversation,
+    events_of_type,
+    post_turn,
+)
+
+pytestmark = pytest.mark.real_llm
+
+
+@pytest.mark.asyncio
+async def test_compaction_middleware_does_not_crash_stream(
+    member_client: tuple,  # type: ignore[type-arg]
+) -> None:
+    """Compaction middleware participates in the stack without crashing streams.
+
+    Sends 4 filler turns to put content in history, then a final summary
+    turn. Asserts every turn completes with a ``done`` event and no ``error``
+    events — proving the middleware path is wired and does not blow up under
+    multi-turn load, even when the compaction threshold is never reached at
+    this token volume.
+    """
+    client, ws_id = member_client
+    conv_id = await create_conversation(client, ws_id, "compaction")
+
+    filler = ("背景资料段落，仅用于撑大上下文。" * 60) + "请简短回复 ok。"
+
+    for i in range(4):
+        evts = await post_turn(client, ws_id, conv_id, f"[{i}] {filler}")
+        assert events_of_type(evts, EVT_ERROR) == [], f"errors in filler turn {i}: {evts}"
+        assert evts[-1].get("type") == EVT_DONE, (
+            f"filler turn {i} did not terminate cleanly; last event: {evts[-1]}"
+        )
+
+    final = await post_turn(
+        client,
+        ws_id,
+        conv_id,
+        "用一句话总结上面对话的主题。",
+    )
+    assert events_of_type(final, EVT_ERROR) == [], f"errors in final turn: {final}"
+    assert final[-1].get("type") == EVT_DONE, (
+        f"final turn did not terminate cleanly; last event: {final[-1]}"
+    )

--- a/backend/tests/e2e/middleware/test_compaction.py
+++ b/backend/tests/e2e/middleware/test_compaction.py
@@ -23,6 +23,7 @@ import pytest
 from tests.e2e.middleware._helpers import (
     EVT_DONE,
     EVT_ERROR,
+    assistant_text,
     create_conversation,
     events_of_type,
     post_turn,
@@ -54,6 +55,8 @@ async def test_compaction_middleware_does_not_crash_stream(
         assert evts[-1].get("type") == EVT_DONE, (
             f"filler turn {i} did not terminate cleanly; last event: {evts[-1]}"
         )
+        text = assistant_text(evts)
+        assert text.strip() != "", f"filler turn {i} produced empty reply"
 
     final = await post_turn(
         client,
@@ -65,3 +68,6 @@ async def test_compaction_middleware_does_not_crash_stream(
     assert final[-1].get("type") == EVT_DONE, (
         f"final turn did not terminate cleanly; last event: {final[-1]}"
     )
+    final_text = assistant_text(final)
+    assert final_text.strip() != "", "final summary turn produced empty reply"
+    assert len(final_text.strip()) >= 5, f"final reply too short to be a summary: {final_text!r}"

--- a/backend/tests/e2e/middleware/test_journey.py
+++ b/backend/tests/e2e/middleware/test_journey.py
@@ -21,10 +21,12 @@ from tests.e2e.middleware._helpers import (
     TOOL_CALCULATOR,
     TOOL_SANDBOX,
     TOOL_TODO,
+    assistant_text,
     create_conversation,
     events_of_type,
     post_turn,
     tool_call_names,
+    tool_result_contents,
 )
 
 pytestmark = pytest.mark.real_llm
@@ -47,6 +49,12 @@ async def test_full_middleware_journey(member_client: tuple) -> None:  # type: i
     assert events_of_type(t1, EVT_USAGE), "no usage event (cost middleware silent)"
     t1_tools = tool_call_names(t1)
     assert TOOL_CALCULATOR in t1_tools, f"expected calculator call, got {t1_tools}"
+    t1_results = tool_result_contents(t1)
+    assert any("304" in c for c in t1_results), (
+        f"expected '304' in calculator tool_result; got: {t1_results}"
+    )
+    t1_text = assistant_text(t1)
+    assert "304" in t1_text, f"expected '304' in assistant reply; got: {t1_text!r}"
 
     # Turn 2: todo list → write_todos
     t2 = await post_turn(
@@ -59,6 +67,13 @@ async def test_full_middleware_journey(member_client: tuple) -> None:  # type: i
     assert t2[-1].get("type") == EVT_DONE
     t2_tools = tool_call_names(t2)
     assert TOOL_TODO in t2_tools, f"expected {TOOL_TODO} call, got {t2_tools}"
+    t2_results = tool_result_contents(t2)
+    assert len(t2_results) >= 1, f"expected at least one tool_result in t2; got: {t2_results}"
+    assert any(c.strip() for c in t2_results), (
+        f"expected non-empty tool_result content in t2; got: {t2_results}"
+    )
+    t2_text = assistant_text(t2)
+    assert t2_text.strip() != "", f"expected non-empty assistant reply in t2; got: {t2_text!r}"
 
     # Turn 3: sandbox → execute
     t3 = await post_turn(
@@ -71,6 +86,12 @@ async def test_full_middleware_journey(member_client: tuple) -> None:  # type: i
     assert t3[-1].get("type") == EVT_DONE
     t3_tools = tool_call_names(t3)
     assert TOOL_SANDBOX in t3_tools, f"expected {TOOL_SANDBOX} call, got {t3_tools}"
+    t3_results = tool_result_contents(t3)
+    assert any("55" in c for c in t3_results), (
+        f"expected '55' in execute tool_result; got: {t3_results}"
+    )
+    t3_text = assistant_text(t3)
+    assert "55" in t3_text, f"expected '55' in assistant reply; got: {t3_text!r}"
 
     # Whole-conversation union check
     all_types = {e.get("type") for e in (t1 + t2 + t3)}

--- a/backend/tests/e2e/middleware/test_journey.py
+++ b/backend/tests/e2e/middleware/test_journey.py
@@ -1,0 +1,77 @@
+"""E2E: a single conversation that walks through the full middleware stack.
+
+Turn 1 → timestamps, cost, calculator (builtin tool).
+Turn 2 → todo (write_todos tool).
+Turn 3 → sandbox (execute tool).
+Loaded-but-quiet middleware (memory/skills/citation/attachments/artifacts)
+covered by zero-error assertions. See design doc 2026-05-15.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.middleware._helpers import (
+    EVT_DONE,
+    EVT_ERROR,
+    EVT_TEXT_DELTA,
+    EVT_TOOL_CALL,
+    EVT_TOOL_RESULT,
+    EVT_USAGE,
+    TOOL_CALCULATOR,
+    TOOL_SANDBOX,
+    TOOL_TODO,
+    create_conversation,
+    events_of_type,
+    post_turn,
+    tool_call_names,
+)
+
+pytestmark = pytest.mark.real_llm
+
+
+@pytest.mark.asyncio
+async def test_full_middleware_journey(member_client: tuple) -> None:  # type: ignore[type-arg]
+    client, ws_id = member_client
+    conv_id = await create_conversation(client, ws_id, "middleware journey")
+
+    # Turn 1: time + arithmetic → calculator, timestamps, cost
+    t1 = await post_turn(
+        client,
+        ws_id,
+        conv_id,
+        "现在几点？顺便你必须先调用 calculator 工具算 (2025 - 1949) * 4。",
+    )
+    assert events_of_type(t1, EVT_ERROR) == [], f"errors in t1: {t1}"
+    assert t1[-1].get("type") == EVT_DONE
+    assert events_of_type(t1, EVT_USAGE), "no usage event (cost middleware silent)"
+    t1_tools = tool_call_names(t1)
+    assert TOOL_CALCULATOR in t1_tools, f"expected calculator call, got {t1_tools}"
+
+    # Turn 2: todo list → write_todos
+    t2 = await post_turn(
+        client,
+        ws_id,
+        conv_id,
+        "把刚才解题的步骤你必须用 write_todos 工具整理成一个列表，每个步骤一条。",
+    )
+    assert events_of_type(t2, EVT_ERROR) == []
+    assert t2[-1].get("type") == EVT_DONE
+    t2_tools = tool_call_names(t2)
+    assert TOOL_TODO in t2_tools, f"expected {TOOL_TODO} call, got {t2_tools}"
+
+    # Turn 3: sandbox → execute
+    t3 = await post_turn(
+        client,
+        ws_id,
+        conv_id,
+        "你必须用 execute 工具运行一段 Python：print(sum(range(11)))，告诉我结果。",
+    )
+    assert events_of_type(t3, EVT_ERROR) == []
+    assert t3[-1].get("type") == EVT_DONE
+    t3_tools = tool_call_names(t3)
+    assert TOOL_SANDBOX in t3_tools, f"expected {TOOL_SANDBOX} call, got {t3_tools}"
+
+    # Whole-conversation union check
+    all_types = {e.get("type") for e in (t1 + t2 + t3)}
+    assert {EVT_TEXT_DELTA, EVT_TOOL_CALL, EVT_TOOL_RESULT, EVT_USAGE, EVT_DONE} <= all_types

--- a/backend/tests/e2e/middleware/test_journey.py
+++ b/backend/tests/e2e/middleware/test_journey.py
@@ -3,8 +3,10 @@
 Turn 1 → timestamps, cost, calculator (builtin tool).
 Turn 2 → todo (write_todos tool).
 Turn 3 → sandbox (execute tool).
-Loaded-but-quiet middleware (memory/skills/citation/attachments/artifacts)
-covered by zero-error assertions. See design doc 2026-05-15.
+Turn 4 → memory_save (builtin tool backed by MemoryService).
+Loaded-but-quiet middleware (skills/citation/attachments/artifacts) covered
+by zero-error assertions. MemoryMiddleware's read path (transform_context
+injection) runs implicitly on every turn. See design doc 2026-05-15.
 """
 
 from __future__ import annotations
@@ -19,6 +21,7 @@ from tests.e2e.middleware._helpers import (
     EVT_TOOL_RESULT,
     EVT_USAGE,
     TOOL_CALCULATOR,
+    TOOL_MEMORY_SAVE,
     TOOL_SANDBOX,
     TOOL_TODO,
     assistant_text,
@@ -93,6 +96,27 @@ async def test_full_middleware_journey(member_client: tuple) -> None:  # type: i
     t3_text = assistant_text(t3)
     assert "55" in t3_text, f"expected '55' in assistant reply; got: {t3_text!r}"
 
+    # Turn 4: memory_save → builtin memory tool
+    t4 = await post_turn(
+        client,
+        ws_id,
+        conv_id,
+        "你必须用 memory_save 工具把我的偏好记下来。参数：scope='personal'，"
+        "type='preference'，content='我做数据处理偏好用 Python + pandas'。"
+        "保存成功后用一句话确认。",
+    )
+    assert events_of_type(t4, EVT_ERROR) == [], f"errors in t4: {t4}"
+    assert t4[-1].get("type") == EVT_DONE
+    t4_tools = tool_call_names(t4)
+    assert TOOL_MEMORY_SAVE in t4_tools, f"expected {TOOL_MEMORY_SAVE} call, got {t4_tools}"
+    # memory_save returns JSON like {"status": "saved", "memory_id": "..."}
+    t4_results = tool_result_contents(t4)
+    assert any("saved" in c for c in t4_results), (
+        f"expected 'saved' in memory_save tool_result; got: {t4_results}"
+    )
+    t4_text = assistant_text(t4)
+    assert t4_text.strip() != "", f"expected non-empty assistant reply in t4; got: {t4_text!r}"
+
     # Whole-conversation union check
-    all_types = {e.get("type") for e in (t1 + t2 + t3)}
+    all_types = {e.get("type") for e in (t1 + t2 + t3 + t4)}
     assert {EVT_TEXT_DELTA, EVT_TOOL_CALL, EVT_TOOL_RESULT, EVT_USAGE, EVT_DONE} <= all_types

--- a/backend/tests/e2e/middleware/test_subagent.py
+++ b/backend/tests/e2e/middleware/test_subagent.py
@@ -12,10 +12,12 @@ from tests.e2e.middleware._helpers import (
     EVT_DONE,
     EVT_ERROR,
     TOOL_SUBAGENT_SPAWN,
+    assistant_text,
     create_conversation,
     events_of_type,
     post_turn,
     tool_call_names,
+    tool_result_contents,
 )
 
 pytestmark = pytest.mark.real_llm
@@ -42,3 +44,14 @@ async def test_subagent_dispatch_real_llm(member_client: tuple) -> None:  # type
     assert events[-1].get("type") == EVT_DONE
     tools = tool_call_names(events)
     assert TOOL_SUBAGENT_SPAWN in tools, f"expected {TOOL_SUBAGENT_SPAWN} call, got {tools}"
+
+    results = tool_result_contents(events)
+    assert any(r.strip() for r in results), f"all tool_result contents empty: {results!r}"
+    assert any("cubebox" in r.lower() for r in results), (
+        f"expected 'cubebox' in some tool_result; got: {results!r}"
+    )
+    outer_text = assistant_text(events)
+    assert outer_text.strip() != "", "outer agent produced no text reply"
+    assert "cubebox" in outer_text.lower(), (
+        f"expected 'cubebox' in outer reply; got: {outer_text!r}"
+    )

--- a/backend/tests/e2e/middleware/test_subagent.py
+++ b/backend/tests/e2e/middleware/test_subagent.py
@@ -1,0 +1,44 @@
+"""E2E: explicit subagent dispatch.
+
+Confirms the subagents middleware registers a `subagent` spawn tool and
+the agent actually calls it under a real LLM. See design doc 2026-05-15.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.middleware._helpers import (
+    EVT_DONE,
+    EVT_ERROR,
+    TOOL_SUBAGENT_SPAWN,
+    create_conversation,
+    events_of_type,
+    post_turn,
+    tool_call_names,
+)
+
+pytestmark = pytest.mark.real_llm
+
+
+@pytest.mark.asyncio
+async def test_subagent_dispatch_real_llm(member_client: tuple) -> None:  # type: ignore[type-arg]
+    """If qwen3.6-flash consistently refuses to spawn, convert to
+    @pytest.mark.xfail(strict=False, reason=...). Do not soften the
+    assertion to 'any tool'. We want visibility, not green-but-uncovered.
+    """
+    client, ws_id = member_client
+    conv_id = await create_conversation(client, ws_id, "subagent dispatch")
+
+    events = await post_turn(
+        client,
+        ws_id,
+        conv_id,
+        "请用 subagent 工具派一个子代理去帮我总结一句话：'cubebox 是什么'，"
+        "你只负责派单和汇总，不要自己回答。",
+    )
+
+    assert events_of_type(events, EVT_ERROR) == [], f"errors: {events}"
+    assert events[-1].get("type") == EVT_DONE
+    tools = tool_call_names(events)
+    assert TOOL_SUBAGENT_SPAWN in tools, f"expected {TOOL_SUBAGENT_SPAWN} call, got {tools}"


### PR DESCRIPTION
## Summary

- Add `backend/tests/e2e/middleware/` — three real-LLM E2E tests that drive the cubepi agent through the full cubebox middleware stack and assert on SSE event streams (no DB / checkpointer reads).
- `test_journey.py` walks one conversation through 4 turns exercising calculator → write_todos → execute → memory_save tool calls; asserts each tool_result content and the assistant's final reply content match the expected values (304, "saved" status, 55, etc.).
- `test_subagent.py` confirms the subagents middleware's `subagent` spawn tool fires and the outer reply includes the topic keyword.
- `test_compaction.py` runs multi-turn filler against the compaction middleware and verifies the stack survives multi-turn load with non-empty replies (weak-fallback only — strong-signal trim requires lowering the 44.8k-token threshold, which is out of scope here).

## Coverage notes

- Loaded-but-quiet middleware (skills/citation/attachments/artifacts/timestamps) is covered by the zero-error / `usage` event assertions; not all expose visible tool_calls.
- Memory middleware: read path runs implicitly every turn via `transform_context`; write path covered explicitly in Turn 4 of `test_journey.py` via the `memory_save` builtin tool.
- See `docs/superpowers/specs/2026-05-15-agent-middleware-e2e-design.md` and `docs/superpowers/plans/2026-05-15-agent-middleware-e2e.md` for design & plan.

## Test plan

- [x] `uv run pytest tests/e2e/middleware/ -v -m real_llm` — 3 passed (~42s)
- [x] `uv run pytest tests/e2e/test_cubepi_path_tools.py tests/e2e/test_cubepi_path_conversation.py -v -m real_llm` — 2 passed, no regression
- [x] `make lint` / `make type-check` — clean
- [x] Pre-push hook (ruff + mypy + pytest unit, frontend build-core + lint + format + type-check + vitest + next build) — all green