### PR TITLE
feat(chat): add stop button to cancel streaming runs

### DIFF
--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -778,3 +778,38 @@ async def stream_run(
         run_id=run_id,
         redis_handle=rds,
     )
+
+
+@router.post("/{conversation_id}/cancel", status_code=status.HTTP_202_ACCEPTED)
+async def cancel_active_run(
+    conversation_id: str,
+    raw_request: Request,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    ctx: Annotated[RequestContext, Depends(require_member)],
+    rds: Annotated[RedisHandle, Depends(redis_dep)],
+) -> dict[str, object]:
+    """Cancel the conversation's active run, if any."""
+    conv_repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
+    conversation = await conv_repo.get_by_id(conversation_id)
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Conversation {conversation_id} not found",
+        )
+
+    active_run = await get_active_run(
+        rds.client,
+        prefix=rds.key_prefix,
+        conversation_id=conversation_id,
+    )
+    if active_run is None or active_run.status != "running":
+        return {"cancelled": False, "run_id": None}
+
+    run_manager = raw_request.app.state.run_manager
+    cancelled = await run_manager.cancel_run(active_run.run_id)
+    return {"cancelled": cancelled, "run_id": active_run.run_id}

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -386,6 +386,14 @@ class RunManager:
             with suppress(asyncio.CancelledError):
                 await task
 
+    async def cancel_run(self, run_id: str) -> bool:
+        """Cancel a single in-flight run. Returns True if the task was found."""
+        task = self._tasks.get(run_id)
+        if task is None or task.done():
+            return False
+        task.cancel()
+        return True
+
     async def drain(self, timeout_seconds: float) -> None:
         """Wait for in-flight runs to finish, then return.
 

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -387,11 +387,19 @@ class RunManager:
                 await task
 
     async def cancel_run(self, run_id: str) -> bool:
-        """Cancel a single in-flight run. Returns True if the task was found."""
+        """Cancel a single in-flight run and wait for cleanup to finish.
+
+        Awaiting the task keeps the caller blocked until ``_execute_run``'s
+        finally block has cleared the Redis active-run key. Without this, a
+        client that clicks Stop and immediately re-sends would race against
+        cleanup and get a 409 from ``start_run``.
+        """
         task = self._tasks.get(run_id)
         if task is None or task.done():
             return False
         task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
         return True
 
     async def drain(self, timeout_seconds: float) -> None:

--- a/frontend/packages/core/src/api/runStreams.ts
+++ b/frontend/packages/core/src/api/runStreams.ts
@@ -89,6 +89,7 @@ export async function* streamRun(
   conversationId: string,
   runId: string,
   lastEventId?: string,
+  signal?: AbortSignal,
 ): AsyncGenerator<AgentEvent> {
   const headers: Record<string, string> = {
     Accept: 'text/event-stream',
@@ -99,12 +100,19 @@ export async function* streamRun(
   if (csrf) headers['X-CSRF-Token'] = csrf
 
   const path = client.resolvePath(`/api/v1/conversations/${conversationId}/runs/${runId}/stream`)
-  const res = await fetch(`${client.baseUrl}${path}`, {
-    method: 'GET',
-    credentials: 'include',
-    headers,
-    cache: 'no-store',
-  })
+  let res: Response
+  try {
+    res = await fetch(`${client.baseUrl}${path}`, {
+      method: 'GET',
+      credentials: 'include',
+      headers,
+      cache: 'no-store',
+      signal,
+    })
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return
+    throw err
+  }
 
   if (!res.ok || !res.body) {
     throw await toApiError(res)
@@ -120,6 +128,8 @@ export async function* streamRun(
         // Ignore malformed lines and keep the stream alive.
       }
     }
+  } catch (err) {
+    if ((err as Error).name !== 'AbortError') throw err
   } finally {
     reader.releaseLock()
   }

--- a/frontend/packages/core/src/api/stream.ts
+++ b/frontend/packages/core/src/api/stream.ts
@@ -101,7 +101,7 @@ export async function* streamMessages(
     }
 
     const body = (await res.json()) as { run_id: string }
-    for await (const event of streamRun(client, conversationId, body.run_id)) {
+    for await (const event of streamRun(client, conversationId, body.run_id, undefined, signal)) {
       yield event
     }
   } catch (err) {

--- a/frontend/packages/core/src/api/stream.ts
+++ b/frontend/packages/core/src/api/stream.ts
@@ -3,6 +3,22 @@ import type { ApiClient } from './client'
 import { CSRF_COOKIE_NAME } from './cookieNames'
 import { streamRun } from './runStreams'
 
+export interface CancelRunResponse {
+  cancelled: boolean
+  run_id: string | null
+}
+
+export async function cancelActiveRun(
+  client: ApiClient,
+  conversationId: string,
+): Promise<CancelRunResponse> {
+  const res = await client.post(`/api/v1/conversations/${conversationId}/cancel`, {})
+  if (!res.ok) {
+    throw new Error(`Failed to cancel run: HTTP ${res.status}`)
+  }
+  return (await res.json()) as CancelRunResponse
+}
+
 async function* readLines(reader: ReadableStreamDefaultReader<Uint8Array>): AsyncGenerator<string> {
   let buffer = ''
   const decoder = new TextDecoder()
@@ -30,6 +46,7 @@ export async function* streamMessages(
   conversationId: string,
   content: string,
   attachmentIds?: string[],
+  signal?: AbortSignal,
 ): AsyncGenerator<AgentEvent> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -49,6 +66,7 @@ export async function* streamMessages(
       headers,
       cache: 'no-store',
       body: JSON.stringify(requestBody),
+      signal,
     })
 
     if (!res.ok) {
@@ -86,7 +104,8 @@ export async function* streamMessages(
     for await (const event of streamRun(client, conversationId, body.run_id)) {
       yield event
     }
-  } catch {
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return
     yield {
       type: 'error',
       timestamp: new Date().toISOString(),

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -13,7 +13,7 @@ import type {
   ToolResultEvent,
 } from '../types'
 import type { ApiClient } from '../api'
-import { getConversationBootstrap, streamMessages, streamRun } from '../api'
+import { cancelActiveRun, getConversationBootstrap, streamMessages, streamRun } from '../api'
 import { useCitationStore } from './citationStore'
 import { useConversationStore } from './conversationStore'
 
@@ -54,9 +54,12 @@ export interface MessageStore {
     attachmentIds?: string[],
     attachments?: import('../types').MessageAttachment[],
   ): Promise<void>
+  cancelStream(client: ApiClient, conversationId: string): Promise<void>
   clearStream(): void
   clearLastRunStatus(): void
 }
+
+let activeStreamController: AbortController | null = null
 
 const MAIN_AGENT_KEY = 'main'
 
@@ -790,9 +793,18 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       set as (updater: (s: MessageStore) => Partial<MessageStore>) => void,
     )
     let sawDone = false
+    activeStreamController?.abort()
+    const controller = new AbortController()
+    activeStreamController = controller
 
     try {
-      for await (const event of streamMessages(client, conversationId, content, attachmentIds)) {
+      for await (const event of streamMessages(
+        client,
+        conversationId,
+        content,
+        attachmentIds,
+        controller.signal,
+      )) {
         if (event.event_id && get().lastAppliedEventId) {
           if (compareEventIds(event.event_id, get().lastAppliedEventId!) <= 0) continue
         }
@@ -810,6 +822,10 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
           const errData = event.data as { message: string; details?: string }
           set({
             error: errData.details || errData.message,
+            isStreaming: false,
+            streamingConversationId: null,
+            currentRunId: null,
+            statusPhase: null,
             lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
           })
           break
@@ -851,6 +867,9 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       return
     } finally {
       flush()
+      if (activeStreamController === controller) {
+        activeStreamController = null
+      }
     }
 
     if (sawDone) {
@@ -858,6 +877,27 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       if (!lastState.error) {
         await finalizeCompletedStream(get, set, conversationId)
       }
+    }
+  },
+
+  async cancelStream(client, conversationId) {
+    const state = get()
+    if (!state.isStreaming || state.streamingConversationId !== conversationId) return
+
+    set({
+      isStreaming: false,
+      streamingConversationId: null,
+      currentRunId: null,
+      statusPhase: null,
+    })
+
+    activeStreamController?.abort()
+    activeStreamController = null
+
+    try {
+      await cancelActiveRun(client, conversationId)
+    } catch (err) {
+      console.error('Failed to cancel run:', err)
     }
   },
 

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -588,6 +588,7 @@ async function consumeRunStream(
   lastEventId: string | undefined,
   set: (partial: Partial<MessageStore> | ((state: MessageStore) => Partial<MessageStore>)) => void,
   get: () => MessageStore,
+  signal?: AbortSignal,
 ): Promise<void> {
   const { batchedSet, flush } = createBatcher(
     set as (updater: (s: MessageStore) => Partial<MessageStore>) => void,
@@ -596,7 +597,7 @@ async function consumeRunStream(
   let sawDone = false
 
   try {
-    for await (const event of streamRun(client, conversationId, runId, lastEventId)) {
+    for await (const event of streamRun(client, conversationId, runId, lastEventId, signal)) {
       const state = get()
       if (state.currentRunId !== runId) {
         shouldFinalize = false
@@ -619,6 +620,10 @@ async function consumeRunStream(
         const errData = event.data as { message: string; details?: string }
         set({
           error: errData.details || errData.message,
+          isStreaming: false,
+          streamingConversationId: null,
+          currentRunId: null,
+          statusPhase: null,
           lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
         })
         break
@@ -734,15 +739,24 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       }))
 
       if (bootstrap.active_run) {
+        activeStreamController?.abort()
+        const controller = new AbortController()
+        activeStreamController = controller
+        const runId = bootstrap.active_run.run_id
         queueMicrotask(() => {
           void consumeRunStream(
             client,
             conversationId,
-            bootstrap.active_run!.run_id,
+            runId,
             undefined,
             set,
             get,
-          )
+            controller.signal,
+          ).finally(() => {
+            if (activeStreamController === controller) {
+              activeStreamController = null
+            }
+          })
         })
       }
     } catch (err) {

--- a/frontend/packages/web/__tests__/hooks/useMessages.test.ts
+++ b/frontend/packages/web/__tests__/hooks/useMessages.test.ts
@@ -116,7 +116,8 @@ describe('messageStore.send', () => {
     expect(useMessageStore.getState().error).toBe('Something failed')
     const msgs = useMessageStore.getState().messages[CONV_ID] ?? []
     expect(msgs.some((m) => m.role === 'assistant')).toBe(false)
-    expect(useMessageStore.getState().isStreaming).toBe(true)
+    expect(useMessageStore.getState().isStreaming).toBe(false)
+    expect(useMessageStore.getState().streamingConversationId).toBe(null)
   })
 
   it('updates statusPhase on status events', async () => {

--- a/frontend/packages/web/components/layout/InputBar.tsx
+++ b/frontend/packages/web/components/layout/InputBar.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
 import { useMessageStore, useAttachmentStore, createApiClient } from '@cubebox/core'
 import { ArrowUp, Loader2, Paperclip, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
 import { AttachmentChips } from '@/components/chat/AttachmentChips'
 import { UploadDropzone } from '@/components/chat/UploadDropzone'
@@ -32,6 +33,7 @@ export function InputBar({
   const [pendingFiles, setPendingFiles] = useState<File[]>([])
   const [isHandlingSubmit, setIsHandlingSubmit] = useState(false)
   const send = useMessageStore((s) => s.send)
+  const cancelStream = useMessageStore((s) => s.cancelStream)
   const { workspaceId } = useWorkspaceContext()
   const messageIsStreaming =
     useMessageStore((s) =>
@@ -158,6 +160,14 @@ export function InputBar({
   }
 
   const canAttach = Boolean(conversationId || onSubmit) && !isSubmitting
+  const canCancel = messageIsStreaming && Boolean(conversationId)
+
+  const handleCancel = async (): Promise<void> => {
+    if (!conversationId) return
+    const client = createApiClient('')
+    if (workspaceId) client.setWorkspaceId(workspaceId)
+    await cancelStream(client, conversationId)
+  }
 
   return (
     <div className="w-full max-w-3xl mx-auto">
@@ -222,18 +232,34 @@ export function InputBar({
           className="flex-1 bg-transparent resize-none outline-none text-sm text-foreground placeholder:text-muted-foreground/40 leading-relaxed min-h-7 max-h-[180px] overflow-y-auto py-0.5"
           disabled={isSubmitting}
         />
-        <button
-          data-testid="send-button"
-          onClick={() => void handleSubmit()}
-          disabled={(!content.trim() && stagedFileCount === 0) || isSubmitting || uploadInFlight}
-          className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary text-white transition-all hover:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-25"
-        >
-          {isSubmitting ? (
-            <Loader2 className="size-3.5 animate-spin" />
-          ) : (
-            <ArrowUp className="size-3.5" />
-          )}
-        </button>
+        {canCancel ? (
+          <button
+            data-testid="stop-button"
+            type="button"
+            onClick={() => void handleCancel()}
+            aria-label={tShell('inputBarStop')}
+            className="group relative flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary text-white transition-all hover:bg-primary/80"
+          >
+            <Loader2 className="absolute inset-0 m-auto size-5 animate-spin opacity-90" />
+            <span className="relative size-2 rounded-[2px] bg-white transition-transform group-hover:scale-110" />
+          </button>
+        ) : (
+          <button
+            data-testid="send-button"
+            onClick={() => void handleSubmit()}
+            disabled={(!content.trim() && stagedFileCount === 0) || isSubmitting || uploadInFlight}
+            className={cn(
+              'flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary text-white transition-all hover:bg-primary/80',
+              'disabled:cursor-not-allowed disabled:opacity-25',
+            )}
+          >
+            {isSubmitting ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <ArrowUp className="size-3.5" />
+            )}
+          </button>
+        )}
       </div>
       <p className="text-center mt-1 text-[10px] text-muted-foreground/35">{t('hint')}</p>
     </div>

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -953,6 +953,7 @@
   },
   "shellLayout": {
     "inputBarAttach": "Attach files",
+    "inputBarStop": "Stop generating",
     "sidebar": "Sidebar",
     "deleteConversation": "Delete conversation",
     "workspaceSettings": "Workspace settings",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -953,6 +953,7 @@
   },
   "shellLayout": {
     "inputBarAttach": "添加附件",
+    "inputBarStop": "停止生成",
     "sidebar": "侧边栏",
     "deleteConversation": "删除对话",
     "workspaceSettings": "工作区设置",


### PR DESCRIPTION
## Summary
- Replaces the spinner-only loading button in the chat input with a stop button (spinning ring + center square). Clicking it halts the active run instead of waiting for the agent to finish.
- Wires the click through to the existing RunManager cancellation flow end-to-end so the backend task actually stops consuming tokens.

## Changes
- **Backend**: new `POST /api/v1/ws/{ws}/conversations/{cid}/cancel` route that looks up the active run via Redis and calls `RunManager.cancel_run(run_id)` (new helper). The existing `_execute_run` cancel path already emits a `Run cancelled` error event and marks status=cancelled, so nothing else needs to change on the server.
- **Core**: `cancelActiveRun()` API; `streamMessages` accepts an optional `AbortSignal` and silently returns on `AbortError` instead of yielding "Connection lost". New `messageStore.cancelStream(client, conversationId)` aborts the in-flight SSE, clears streaming state immediately for snappy UX, then fires the cancel API.
- **Web**: `InputBar` toggles to the new stop button (`Loader2` + 2×2 rounded square) while `messageIsStreaming`; testid `stop-button`; aria-label translated in en/zh.
- **Drive-by fix**: on a streamed `error` event, `messageStore.send` now also clears `isStreaming/streamingConversationId/currentRunId/statusPhase`. The previous behavior left the send button spinning forever whenever the run ended on an error. Updated the corresponding unit test (`useMessages.test.ts`) to assert the new state.

## Test plan
- [ ] `pnpm --filter @cubebox/core type-check && pnpm --filter @cubebox/core build && pnpm --filter web type-check`
- [ ] `pnpm --filter web test` (unit, passes locally)
- [ ] `cd backend && uv run ruff check cubebox/streams/run_manager.py cubebox/api/routes/v1/conversations.py && uv run mypy cubebox/streams/run_manager.py cubebox/api/routes/v1/conversations.py`
- [ ] Manual: start an agent reply, click the stop button mid-stream — verify (1) the input becomes responsive again immediately, (2) the backend run row is `cancelled` and no further events appear, (3) the next send works normally.