### PR TITLE
Drop wire convert layer; cubepi.Message is the wire shape

### DIFF
--- a/backend/cubebox/agents/convert.py
+++ b/backend/cubebox/agents/convert.py
@@ -1,84 +1,17 @@
-"""cubepi.Message ↔ cubebox API wire format conversion.
+"""cubebox request DTO → cubepi.UserMessage builder.
 
-Converts between cubepi's typed message objects
-(``UserMessage`` / ``AssistantMessage`` / ``ToolResultMessage`` and their
-content blocks) and the JSON-serializable shape the cubebox API exposes
-over SSE and the conversations REST endpoints.
+The API response side returns cubepi's native message shape directly
+(``Message.model_dump(mode="json")``) — there is no cubebox-specific wire
+format. This module only handles the request-body → cubepi conversion,
+which has a meaningfully different shape (text + attachment ids) from
+the persisted message.
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import Any
 
-from cubepi.providers.base import (
-    AssistantMessage,
-    Message,
-    TextContent,
-    ToolCall,
-    ToolResultMessage,
-    UserMessage,
-)
-
-
-def _join_text(content: Sequence[Any]) -> str:
-    """Concatenate all TextContent text values; ignore non-text blocks."""
-    parts = [c.text for c in content if isinstance(c, TextContent)]
-    return "".join(parts)
-
-
-def cubepi_message_to_wire(msg: Message) -> dict[str, Any]:
-    """Convert a cubepi.Message into cubebox's API response dict shape."""
-    if isinstance(msg, UserMessage):
-        meta = dict(msg.metadata)
-        attachments = meta.pop("attachments", None)
-        wire: dict[str, Any] = {
-            "role": "user",
-            "content": _join_text(msg.content),
-            "metadata": meta,
-        }
-        if attachments:
-            # The persisted metadata uses ``file_id`` (set by the content-block
-            # builder in run_manager); the wire contract surfaces it as ``id``
-            # to match the frontend ``AttachmentDto`` shape.
-            wire["attachments"] = [
-                {**{k: v for k, v in att.items() if k != "file_id"}, "id": att["file_id"]}
-                if isinstance(att, dict) and "file_id" in att
-                else att
-                for att in attachments
-            ]
-        return wire
-
-    if isinstance(msg, AssistantMessage):
-        tool_calls = [
-            {"id": c.id, "name": c.name, "arguments": c.arguments}
-            for c in msg.content
-            if isinstance(c, ToolCall)
-        ]
-        meta = dict(msg.metadata)
-        if tool_calls:
-            meta["tool_calls"] = tool_calls
-        meta["usage"] = {
-            "input_tokens": msg.usage.input_tokens if msg.usage else 0,
-            "output_tokens": msg.usage.output_tokens if msg.usage else 0,
-        }
-        return {
-            "role": "assistant",
-            "content": _join_text(msg.content),
-            "metadata": meta,
-        }
-
-    if isinstance(msg, ToolResultMessage):
-        meta = dict(msg.metadata)
-        meta["tool_call_id"] = msg.tool_call_id
-        meta["tool_name"] = msg.tool_name
-        return {
-            "role": "tool",
-            "content": _join_text(msg.content),
-            "metadata": meta,
-        }
-
-    raise TypeError(f"unknown cubepi Message type: {type(msg).__name__}")
+from cubepi.providers.base import TextContent, UserMessage
 
 
 def wire_input_to_cubepi_user_message(

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -2,6 +2,7 @@
 
 import json
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -593,16 +594,20 @@ async def send_message(
 
 
 async def _get_history_messages(raw_request: Request, conversation_id: str) -> dict[str, object]:
-    """Read cubepi-runtime conversation history."""
+    """Read cubepi-runtime conversation history.
+
+    Messages are returned in cubepi's native shape (UserMessage / AssistantMessage /
+    ToolResultMessage as pydantic dumps). The frontend consumes this shape directly;
+    no cubebox-specific wire conversion layer.
+    """
     from cubebox.agents.checkpointer import init_checkpointer
-    from cubebox.agents.convert import cubepi_message_to_wire
 
     del raw_request  # checkpointer factory override hook (unused; preserved for future use)
     async with init_checkpointer() as cp:
         data = await cp.load(conversation_id)
     if data is None:
         return {"messages": [], "total": 0}
-    messages = [cubepi_message_to_wire(m) for m in data.messages]
+    messages = [m.model_dump(mode="json") for m in data.messages]
     return {"messages": messages, "total": len(messages)}
 
 
@@ -690,7 +695,9 @@ async def get_conversation_bootstrap(
     last_user_ts: str | None = None
     for msg in reversed(msgs):
         if isinstance(msg, dict) and msg.get("role") == "user":
-            last_user_ts = msg.get("created_at")
+            ts = msg.get("timestamp")
+            if isinstance(ts, (int, float)):
+                last_user_ts = datetime.fromtimestamp(ts, tz=UTC).isoformat()
             break
 
     from cubebox.services.usage import build_usage_summary

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pillow>=10.4.0",
     "pyjwt>=2.12.1",
     "click>=8.3.1",
-    "cubepi[mcp,postgres]==0.3.0",
+    "cubepi[mcp,postgres]",
     "orjson>=3.11.9",
 ]
 
@@ -157,7 +157,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", tag = "v0.3.0" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "50c7c1871af3899a7c6b62a4e4b6726ceb920cd5" }
 
 [dependency-groups]
 dev = [

--- a/backend/tests/e2e/test_cubepi_history_round_trip.py
+++ b/backend/tests/e2e/test_cubepi_history_round_trip.py
@@ -42,3 +42,17 @@ async def test_cubepi_history_round_trip(member_client) -> None:
     roles = [m.get("role") for m in messages]
     assert "user" in roles, f"no user message in history: {roles}"
     assert "assistant" in roles, f"no assistant message in history: {roles}"
+
+    # 4. Wire-shape contract: every message uses cubepi's native pydantic dump.
+    # `content` is a list of typed blocks, not a flat string; assistant carries
+    # `usage` and `stop_reason` at the top level.
+    for msg in messages:
+        assert isinstance(msg.get("content"), list), (
+            f"content must be a block list, got {type(msg.get('content')).__name__}: {msg!r}"
+        )
+        for block in msg["content"]:
+            assert "type" in block, f"content block missing type discriminator: {block!r}"
+
+    assistant_msg = next(m for m in messages if m["role"] == "assistant")
+    assert "usage" in assistant_msg, f"assistant message missing usage: {assistant_msg!r}"
+    assert "stop_reason" in assistant_msg, f"assistant missing stop_reason: {assistant_msg!r}"

--- a/backend/tests/e2e/test_send_with_attachments.py
+++ b/backend/tests/e2e/test_send_with_attachments.py
@@ -99,8 +99,9 @@ async def test_send_with_image_attachment_marks_attached_and_returns_history(
     user_msgs = [m for m in history["messages"] if m.get("role") == "user"]
     assert user_msgs, history
     last = user_msgs[-1]
-    assert "attachments" in last
-    assert any(a.get("id") == fid for a in last["attachments"])
+    attachments = last.get("metadata", {}).get("attachments") or []
+    assert attachments, last
+    assert any(a.get("file_id") == fid for a in attachments)
 
 
 async def test_send_rejects_attachment_from_other_conversation(

--- a/backend/tests/unit/test_convert.py
+++ b/backend/tests/unit/test_convert.py
@@ -1,73 +1,23 @@
-"""convert tests — cubepi.Message ↔ cubebox wire format (M1.2)."""
+"""Tests for the request-body → cubepi.UserMessage builder.
 
-from cubepi.providers.base import (
-    AssistantMessage,
-    TextContent,
-    ToolCall,
-    ToolResultMessage,
-    Usage,
-    UserMessage,
-)
+Outbound wire conversion was removed when cubebox aligned to cubepi's
+native message shape; only the request side still has a meaningful DTO
+translation (text + attachment ids → UserMessage with file_attachment
+metadata + memory_snapshot).
+"""
 
-from cubebox.agents.convert import (
-    cubepi_message_to_wire,
-    wire_input_to_cubepi_user_message,
-)
+from cubepi.providers.base import UserMessage
 
-
-def test_user_message_to_wire_text_only() -> None:
-    msg = UserMessage(content=[TextContent(text="hello")])
-    out = cubepi_message_to_wire(msg)
-    assert out["role"] == "user"
-    assert out["content"] == "hello"
-
-
-def test_assistant_message_to_wire_text_only() -> None:
-    msg = AssistantMessage(content=[TextContent(text="hi back")], usage=Usage())
-    out = cubepi_message_to_wire(msg)
-    assert out["role"] == "assistant"
-    assert out["content"] == "hi back"
-
-
-def test_assistant_message_to_wire_with_tool_call() -> None:
-    """tool_calls land in metadata.tool_calls as cubebox-shaped dicts."""
-    tc = ToolCall(id="tc1", name="search", arguments={"q": "x"})
-    msg = AssistantMessage(
-        content=[TextContent(text="calling tool"), tc],
-        usage=Usage(input_tokens=10, output_tokens=5),
-    )
-    out = cubepi_message_to_wire(msg)
-    assert out["role"] == "assistant"
-    assert out["content"] == "calling tool"
-    assert out["metadata"]["tool_calls"] == [
-        {"id": "tc1", "name": "search", "arguments": {"q": "x"}}
-    ]
-    assert out["metadata"]["usage"]["input_tokens"] == 10
-    assert out["metadata"]["usage"]["output_tokens"] == 5
-
-
-def test_tool_result_message_to_wire() -> None:
-    msg = ToolResultMessage(
-        content=[TextContent(text="result text")],
-        tool_call_id="tc1",
-        tool_name="search",
-    )
-    out = cubepi_message_to_wire(msg)
-    assert out["role"] == "tool"
-    assert out["content"] == "result text"
-    assert out["metadata"]["tool_call_id"] == "tc1"
-    assert out["metadata"]["tool_name"] == "search"
+from cubebox.agents.convert import wire_input_to_cubepi_user_message
 
 
 def test_wire_input_to_user_message_simple_text() -> None:
-    """API request body's user-input text → cubepi.UserMessage."""
     msg = wire_input_to_cubepi_user_message("hello world")
     assert isinstance(msg, UserMessage)
     assert msg.content[0].text == "hello world"
 
 
 def test_wire_input_carries_attachments_in_metadata() -> None:
-    """Attachment blocks (file_attachment dicts) land in metadata for M3 to render."""
     attachments = [
         {"kind": "image", "filename": "a.png", "size_bytes": 100, "sandbox_path": "/x/a.png"}
     ]
@@ -76,11 +26,7 @@ def test_wire_input_carries_attachments_in_metadata() -> None:
     assert msg.metadata["attachments"] == attachments
 
 
-def test_user_message_passthrough_preserves_metadata() -> None:
-    """If a UserMessage has metadata (memory snapshots etc.), to_wire preserves it."""
-    msg = UserMessage(
-        content=[TextContent(text="hi")],
-        metadata={"memory_snapshot": {"id": "m1"}},
-    )
-    out = cubepi_message_to_wire(msg)
-    assert out["metadata"]["memory_snapshot"] == {"id": "m1"}
+def test_wire_input_carries_memory_snapshot() -> None:
+    snap = {"id": "m1", "items": []}
+    msg = wire_input_to_cubepi_user_message("hi", memory_snapshot=snap)
+    assert msg.metadata["memory_snapshot"] == snap

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -767,7 +767,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres"], git = "https://github.com/cubeplexai/cubepi.git?tag=v0.3.0" },
+    { name = "cubepi", extras = ["mcp", "postgres"], git = "https://github.com/cubeplexai/cubepi.git?rev=50c7c1871af3899a7c6b62a4e4b6726ceb920cd5" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -810,7 +810,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.3.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?tag=v0.3.0#f90839a111fb908835c35b7cf8c40f9bb316f74c" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=50c7c1871af3899a7c6b62a4e4b6726ceb920cd5#50c7c1871af3899a7c6b62a4e4b6726ceb920cd5" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -1,8 +1,15 @@
 // frontend/packages/core/src/stores/messageStore.ts
+//
+// All persisted Message values mirror cubepi's pydantic dump shape — content is
+// always a list of typed blocks (text / thinking / tool_call), and cubebox-
+// specific extras (attachments, memory snapshots, citations, subagent_events)
+// ride inside `metadata`. The store builds the same shape on the streaming
+// path so the in-memory view matches what bootstrap returns.
 import { create } from 'zustand'
 import type {
   AgentEvent,
   ArtifactEventData,
+  AssistantMessage as AssistantMessageType,
   ContentBlock,
   Message,
   ReasoningEvent,
@@ -11,7 +18,10 @@ import type {
   ToolCallDeltaEvent,
   ToolCallEvent,
   ToolResultEvent,
+  ToolResultMessage as ToolResultMessageType,
+  UserMessage as UserMessageType,
 } from '../types'
+import { getTextContent } from '../types'
 import type { ApiClient } from '../api'
 import { getConversationBootstrap, streamMessages, streamRun } from '../api'
 import { useCitationStore } from './citationStore'
@@ -21,14 +31,14 @@ export interface AgentStream {
   text: string
   toolCalls: ToolCallEvent[]
   toolResults: ToolResultEvent[]
-  reasoning: string
+  thinking: string
   blocks: ContentBlock[]
   name: string | null
 }
 
 export interface MessageStore {
   messages: Record<string, Message[]>
-  streamAgents: Record<string, AgentStream> // "main" or "task:xxx"
+  streamAgents: Record<string, AgentStream> // "main" or "subagent:xxx"
   isStreaming: boolean
   streamingConversationId: string | null
   currentRunId: string | null
@@ -61,7 +71,7 @@ export interface MessageStore {
 const MAIN_AGENT_KEY = 'main'
 
 function emptyStream(name: string | null = null): AgentStream {
-  return { text: '', toolCalls: [], toolResults: [], reasoning: '', blocks: [], name }
+  return { text: '', toolCalls: [], toolResults: [], thinking: '', blocks: [], name }
 }
 
 function timestampToMs(timestamp?: string): number {
@@ -81,10 +91,45 @@ function nextEventId(current: string | null, next?: string): string | null {
   return compareEventIds(next, current) > 0 ? next : current
 }
 
-/** Finalize the last reasoning block's duration if switching to a different block type */
-function finalizeLastReasoning(blocks: ContentBlock[]): ContentBlock[] {
+let _idCounter = 0
+function nextMessageId(prefix: string): string {
+  _idCounter += 1
+  return `${prefix}-${Date.now()}-${_idCounter}`
+}
+
+/**
+ * cubepi stores thinking timing as `started_at` in epoch seconds + `duration_ms`.
+ * In-memory we normalize started_at to milliseconds so the renderer's
+ * Date.now() math works without unit gymnastics. Idempotent: already-ms values
+ * (anything > 1e12) pass through.
+ */
+function normalizeThinkingTiming(blocks: ContentBlock[]): ContentBlock[] {
+  return blocks.map((b) => {
+    if (b.type !== 'thinking' || b.started_at == null) return b
+    const ms = b.started_at < 1e12 ? b.started_at * 1000 : b.started_at
+    return { ...b, started_at: ms }
+  })
+}
+
+function normalizeMessages(messages: Message[]): Message[] {
+  return messages.map((msg) => {
+    // Some legacy fixtures may omit `id`; synthesize one for React keys.
+    const withId = msg.id ? msg : { ...msg, id: nextMessageId(msg.role) }
+    if (
+      withId.role !== 'tool' &&
+      Array.isArray(withId.content) &&
+      withId.content.some((b) => b.type === 'thinking')
+    ) {
+      return { ...withId, content: normalizeThinkingTiming(withId.content) } as Message
+    }
+    return withId
+  })
+}
+
+/** Finalize the last thinking block's duration if switching to a different block type */
+function finalizeLastThinking(blocks: ContentBlock[]): ContentBlock[] {
   const last = blocks[blocks.length - 1]
-  if (last?.type === 'reasoning' && last.started_at && !last.duration_ms) {
+  if (last?.type === 'thinking' && last.started_at && !last.duration_ms) {
     const updated = [...blocks]
     updated[updated.length - 1] = { ...last, duration_ms: Date.now() - last.started_at }
     return updated
@@ -92,24 +137,32 @@ function finalizeLastReasoning(blocks: ContentBlock[]): ContentBlock[] {
   return blocks
 }
 
-/** Append content to blocks, merging with the last block if same type, or creating new block */
-function appendBlock(
+/** Append content to blocks, merging with the last block of the same type. */
+function appendThinkingBlock(
   blocks: ContentBlock[],
-  type: 'reasoning' | 'text',
-  content: string,
-  timestampMs?: number,
+  delta: string,
+  startedAt: number,
 ): ContentBlock[] {
   const last = blocks[blocks.length - 1]
-  if (last && last.type === type) {
+  if (last && last.type === 'thinking') {
     const updated = [...blocks]
-    updated[updated.length - 1] = { ...last, content: last.content + content }
+    updated[updated.length - 1] = { ...last, thinking: last.thinking + delta }
     return updated
   }
-  const finalized = finalizeLastReasoning(blocks)
-  if (type === 'reasoning') {
-    return [...finalized, { type, content, started_at: timestampMs ?? Date.now() }]
+  return [
+    ...finalizeLastThinking(blocks),
+    { type: 'thinking', thinking: delta, started_at: startedAt },
+  ]
+}
+
+function appendTextBlock(blocks: ContentBlock[], delta: string): ContentBlock[] {
+  const last = blocks[blocks.length - 1]
+  if (last && last.type === 'text') {
+    const updated = [...blocks]
+    updated[updated.length - 1] = { ...last, text: last.text + delta }
+    return updated
   }
-  return [...finalized, { type, content }]
+  return [...finalizeLastThinking(blocks), { type: 'text', text: delta }]
 }
 
 function appendToolCallBlock(
@@ -118,7 +171,7 @@ function appendToolCallBlock(
   args: Record<string, unknown>,
   toolCallId: string,
 ): ContentBlock[] {
-  const finalized = finalizeLastReasoning(blocks)
+  const finalized = finalizeLastThinking(blocks)
   const exactMatchIndex = finalized.findIndex(
     (block) => block.type === 'tool_call_streaming' && block.tool_call_id === toolCallId,
   )
@@ -138,7 +191,7 @@ function appendToolCallBlock(
   const nextBlocks =
     matchIndex >= 0 ? finalized.filter((_, index) => index !== matchIndex) : finalized
 
-  return [...nextBlocks, { type: 'tool_call', name, arguments: args, tool_call_id: toolCallId }]
+  return [...nextBlocks, { type: 'tool_call', id: toolCallId, name, arguments: args }]
 }
 
 function normalizeTodoStatus(status: unknown): TodoItem['status'] {
@@ -164,28 +217,26 @@ function parseTodosFromToolCall(args: Record<string, unknown>): TodoItem[] {
   return todos
 }
 
-function buildPendingUserMessage(runId: string, content: string): Message {
+function buildPendingUserMessage(runId: string, content: string): UserMessageType {
   return {
     id: `pending-${runId}`,
     role: 'user',
-    content,
-    created_at: new Date().toISOString(),
+    content: [{ type: 'text', text: content }],
+    timestamp: Date.now() / 1000,
+    metadata: {},
   }
 }
 
 /**
- * History returned by `/bootstrap` may contain checkpoints from the active run
- * (e.g. an AIMessage with tool calls saved between LangGraph nodes). The stream
- * replay re-emits all of that content, so anything after the active run's user
- * message would render twice. Trim history to end at that user message — or
- * append a pending placeholder if the run is so early that the user message
- * has not been checkpointed yet.
+ * History returned by `/bootstrap` may contain checkpoints from the active run.
+ * The stream replay re-emits all of that content, so anything after the active
+ * run's user message would render twice. Trim history to end at that user
+ * message — or append a pending placeholder if the run is so early that the
+ * user message has not been checkpointed yet.
  *
- * `startedAt` disambiguates a same-content user message from a prior turn:
- * only consider history entries created at or after the run was claimed.
- * Without it, a repeated prompt + a refresh during the brief window before
- * the new user message lands in the checkpoint would bind to the prior
- * turn's user message and silently drop the previous assistant reply.
+ * `startedAt` (ISO from the run record) disambiguates a same-content user
+ * message from a prior turn; we only bind to a history entry created at or
+ * after the run was claimed.
  */
 function trimHistoryForActiveRun(
   messages: Message[],
@@ -197,15 +248,11 @@ function trimHistoryForActiveRun(
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i]
     if (msg.role !== 'user') continue
-    const msgMs = msg.created_at ? Date.parse(msg.created_at) : NaN
+    const msgMs = msg.timestamp != null ? msg.timestamp * 1000 : NaN
     if (Number.isFinite(startedAtMs) && Number.isFinite(msgMs) && msgMs < startedAtMs) {
-      // This user message predates the active run — it belongs to a prior
-      // completed turn. Keep walking back? No: every earlier user message
-      // is also older. Bail out and treat the active run's user message
-      // as not-yet-checkpointed.
       break
     }
-    if (msg.content === content) return messages.slice(0, i + 1)
+    if (getTextContent(msg) === content) return messages.slice(0, i + 1)
     break
   }
   return [...messages, buildPendingUserMessage(runId, content)]
@@ -214,17 +261,22 @@ function trimHistoryForActiveRun(
 function restoreTodosFromHistory(messages: Message[]): TodoItem[] {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i]
-    if (msg.role !== 'assistant' || !msg.tool_calls) continue
-    const tc = msg.tool_calls.find((toolCall) => toolCall.name === 'write_todos')
-    if (tc) return parseTodosFromToolCall(tc.arguments)
+    if (msg.role !== 'assistant') continue
+    for (const block of msg.content) {
+      if (block.type === 'tool_call' && block.name === 'write_todos') {
+        return parseTodosFromToolCall(block.arguments)
+      }
+    }
   }
   return []
 }
 
 function hydrateCitationsFromHistory(conversationId: string, messages: Message[]): void {
   for (const msg of messages) {
-    if (msg.role === 'tool' && msg.citations?.length) {
-      useCitationStore.getState().loadCitations(conversationId, msg.citations)
+    if (msg.role !== 'tool') continue
+    const citations = msg.metadata?.citations
+    if (citations && citations.length > 0) {
+      useCitationStore.getState().loadCitations(conversationId, citations)
     }
   }
 }
@@ -287,12 +339,14 @@ function applyStreamEvent(state: MessageStore, event: AgentEvent): Partial<Messa
         [agentKey]: {
           ...prev,
           text: prev.text + e.data.content,
-          blocks: appendBlock(prev.blocks, 'text', e.data.content, timestampToMs(event.timestamp)),
+          blocks: appendTextBlock(prev.blocks, e.data.content),
         },
       },
     }
   }
 
+  // SSE event name stays `reasoning` for backend protocol compatibility; we map
+  // it into a `thinking` block to match cubepi's ThinkingContent.
   if (event.type === 'reasoning') {
     const e = event as ReasoningEvent
     const prev = state.streamAgents[agentKey] ?? emptyStream(event.agent_name)
@@ -302,13 +356,8 @@ function applyStreamEvent(state: MessageStore, event: AgentEvent): Partial<Messa
         ...state.streamAgents,
         [agentKey]: {
           ...prev,
-          reasoning: prev.reasoning + e.data.content,
-          blocks: appendBlock(
-            prev.blocks,
-            'reasoning',
-            e.data.content,
-            timestampToMs(event.timestamp),
-          ),
+          thinking: prev.thinking + e.data.content,
+          blocks: appendThinkingBlock(prev.blocks, e.data.content, timestampToMs(event.timestamp)),
         },
       },
     }
@@ -380,7 +429,7 @@ function applyStreamEvent(state: MessageStore, event: AgentEvent): Partial<Messa
       }
     }
 
-    const finalized = finalizeLastReasoning(blocks)
+    const finalized = finalizeLastThinking(blocks)
     finalized.push({
       type: 'tool_call_streaming',
       name: e.data.name ?? '',
@@ -458,67 +507,57 @@ async function finalizeCompletedStream(
     return
   }
 
-  const finalBlocks = finalizeLastReasoning(mainStream.blocks)
-    .filter((block) => block.type !== 'tool_call_streaming')
-    .map((block) => {
-      if (block.type === 'reasoning') {
-        const { started_at: _startedAt, ...rest } = block
-        return rest
-      }
-      return block
-    })
+  const finalBlocks = finalizeLastThinking(mainStream.blocks).filter(
+    (block) => block.type !== 'tool_call_streaming',
+  )
 
-  const assistantMessage: Message = {
-    id: `assistant-${Date.now()}`,
+  const usage = get().turnUsage[conversationId]
+  const assistantMessage: AssistantMessageType = {
+    id: nextMessageId('assistant'),
     role: 'assistant',
-    content: mainStream.text || null,
-    tool_calls:
-      mainStream.toolCalls.length > 0
-        ? mainStream.toolCalls.map((tc) => ({
-            name: tc.data.name,
-            arguments: tc.data.arguments,
-            tool_call_id: tc.data.tool_call_id,
-            started_at: tc.data.started_at ?? null,
-          }))
-        : null,
-    reasoning: mainStream.reasoning || null,
-    blocks: finalBlocks.length > 0 ? finalBlocks : null,
-    created_at: new Date().toISOString(),
+    content: finalBlocks,
+    stop_reason: 'stop',
+    usage: usage
+      ? {
+          input_tokens: usage.input_tokens,
+          output_tokens: usage.output_tokens,
+          cache_read_tokens: usage.cache_read_tokens,
+          cache_write_tokens: usage.cache_write_tokens,
+        }
+      : null,
+    timestamp: Date.now() / 1000,
+    metadata: {},
   }
 
-  const toolMessages: Message[] = []
+  const toolMessages: ToolResultMessageType[] = []
+
+  // Collect subagent args so we can attach role/task to each subagent tool message.
   const subagentArgs: Record<string, { role?: string; task?: string }> = {}
   for (const block of finalBlocks) {
     if (block.type === 'tool_call' && block.name === 'subagent') {
       const args = block.arguments as { role?: string; task?: string }
-      subagentArgs[`subagent:${block.tool_call_id}`] = args
+      subagentArgs[`subagent:${block.id}`] = args
     }
   }
 
   // Persist main-agent tool results into history so the just-finished message
-  // remains interactive after streamingConversationId clears. Without this,
-  // useMessages drops the in-memory toolResultMap and the historical builder
-  // finds no role='tool' rows for top-level tool calls, so cards turn dead
-  // until the next page refresh repopulates from the backend.
-  // Skip subagent tool results — those get richer messages from the loop below.
+  // remains interactive after streamingConversationId clears. Skip subagent
+  // tool results — those get richer messages from the loop below.
   const mainToolResultMap = get().toolResultMap
   for (const tr of mainStream.toolResults) {
     const tcId = tr.data.tool_call_id
     if (!tcId || tr.data.tool_name === 'subagent') continue
     const mapEntry = mainToolResultMap[tcId]
-    const startedAtIso =
-      tr.data.started_at ??
-      (mapEntry?.startedAt ? new Date(mapEntry.startedAt).toISOString() : null)
     const receivedAtMs =
       mapEntry?.receivedAt ?? (tr.timestamp ? new Date(tr.timestamp).getTime() : Date.now())
     toolMessages.push({
-      id: `tool-${tcId}-${Date.now()}`,
+      id: nextMessageId('tool'),
       role: 'tool',
-      content: tr.data.content ?? mapEntry?.content ?? '',
-      name: tr.data.tool_name ?? null,
+      content: [{ type: 'text', text: tr.data.content ?? mapEntry?.content ?? '' }],
       tool_call_id: tcId,
-      started_at: startedAtIso,
-      created_at: new Date(receivedAtMs).toISOString(),
+      tool_name: tr.data.tool_name ?? '',
+      timestamp: receivedAtMs / 1000,
+      metadata: {},
     })
   }
 
@@ -528,37 +567,39 @@ async function finalizeCompletedStream(
     const args = subagentArgs[key]
     const currentToolResultMap = get().toolResultMap
     toolMessages.push({
-      id: `tool-${toolCallId}-${Date.now()}`,
+      id: nextMessageId('tool'),
       role: 'tool',
-      content: agentStream.text || null,
-      name: 'subagent',
+      content: [{ type: 'text', text: agentStream.text || '' }],
       tool_call_id: toolCallId,
-      subagent_events: {
-        text: agentStream.text,
-        tool_calls: agentStream.toolCalls.map((tc) => ({
-          name: tc.data.name,
-          arguments: tc.data.arguments,
-          tool_call_id: tc.data.tool_call_id,
-          started_at: tc.data.started_at ?? (tc.timestamp || null),
-        })),
-        tool_results: agentStream.toolResults
-          .map((tr) => {
-            const mapEntry = currentToolResultMap[tr.data.tool_call_id ?? '']
-            return {
-              tool_name: tr.data.tool_name ?? '',
-              tool_call_id: tr.data.tool_call_id ?? '',
-              content: tr.data.content ?? '',
-              content_type: tr.data.content_type ?? mapEntry?.contentType ?? null,
-              started_at: tr.data.started_at ?? null,
-              completed_at: tr.timestamp || null,
-            }
-          })
-          .filter((tr) => tr.tool_call_id),
-        reasoning: agentStream.reasoning,
-        role: args?.role,
-        task: args?.task,
+      tool_name: 'subagent',
+      timestamp: Date.now() / 1000,
+      metadata: {
+        subagent_events: {
+          text: agentStream.text,
+          tool_calls: agentStream.toolCalls.map((tc) => ({
+            name: tc.data.name,
+            arguments: tc.data.arguments,
+            id: tc.data.tool_call_id,
+            started_at: tc.data.started_at ?? (tc.timestamp || null),
+          })),
+          tool_results: agentStream.toolResults
+            .map((tr) => {
+              const mapEntry = currentToolResultMap[tr.data.tool_call_id ?? '']
+              return {
+                tool_name: tr.data.tool_name ?? '',
+                tool_call_id: tr.data.tool_call_id ?? '',
+                content: tr.data.content ?? '',
+                content_type: tr.data.content_type ?? mapEntry?.contentType ?? null,
+                started_at: tr.data.started_at ?? null,
+                completed_at: tr.timestamp || null,
+              }
+            })
+            .filter((tr) => tr.tool_call_id),
+          thinking: agentStream.thinking,
+          role: args?.role,
+          task: args?.task,
+        },
       },
-      created_at: new Date().toISOString(),
     })
   }
 
@@ -683,7 +724,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       const current = get()
       if (current.isStreaming && current.streamingConversationId === conversationId) return
 
-      let messages = bootstrap.messages ?? []
+      let messages = normalizeMessages(bootstrap.messages ?? [])
       if (bootstrap.active_run?.user_message) {
         messages = trimHistoryForActiveRun(
           messages,
@@ -759,12 +800,12 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       void useConversationStore.getState().generateTitle(client, conversationId, content)
     }
 
-    const userMessage: Message = {
-      id: `temp-${Date.now()}`,
+    const userMessage: UserMessageType = {
+      id: nextMessageId('user-temp'),
       role: 'user',
-      content,
-      created_at: new Date().toISOString(),
-      attachments: attachments && attachments.length > 0 ? attachments : null,
+      content: [{ type: 'text', text: content }],
+      timestamp: Date.now() / 1000,
+      metadata: attachments && attachments.length > 0 ? { attachments } : {},
     }
 
     set((state) => ({

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -274,7 +274,14 @@ function restoreTodosFromHistory(messages: Message[]): TodoItem[] {
 function hydrateCitationsFromHistory(conversationId: string, messages: Message[]): void {
   for (const msg of messages) {
     if (msg.role !== 'tool_result') continue
-    const citations = msg.metadata?.citations
+    // CitationMiddleware persists citations on ToolResultMessage.details
+    // (cubebox/middleware/citation.py:169 — AfterToolCallResult(details={"citations": [...]})).
+    // metadata.citations only exists for in-memory finalized messages.
+    const details = msg.details as
+      | { citations?: import('../types').CitationData[] }
+      | null
+      | undefined
+    const citations = details?.citations ?? msg.metadata?.citations
     if (citations && citations.length > 0) {
       useCitationStore.getState().loadCitations(conversationId, citations)
     }

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -116,7 +116,7 @@ function normalizeMessages(messages: Message[]): Message[] {
     // Some legacy fixtures may omit `id`; synthesize one for React keys.
     const withId = msg.id ? msg : { ...msg, id: nextMessageId(msg.role) }
     if (
-      withId.role !== 'tool' &&
+      withId.role !== 'tool_result' &&
       Array.isArray(withId.content) &&
       withId.content.some((b) => b.type === 'thinking')
     ) {
@@ -273,7 +273,7 @@ function restoreTodosFromHistory(messages: Message[]): TodoItem[] {
 
 function hydrateCitationsFromHistory(conversationId: string, messages: Message[]): void {
   for (const msg of messages) {
-    if (msg.role !== 'tool') continue
+    if (msg.role !== 'tool_result') continue
     const citations = msg.metadata?.citations
     if (citations && citations.length > 0) {
       useCitationStore.getState().loadCitations(conversationId, citations)
@@ -552,7 +552,7 @@ async function finalizeCompletedStream(
       mapEntry?.receivedAt ?? (tr.timestamp ? new Date(tr.timestamp).getTime() : Date.now())
     toolMessages.push({
       id: nextMessageId('tool'),
-      role: 'tool',
+      role: 'tool_result',
       content: [{ type: 'text', text: tr.data.content ?? mapEntry?.content ?? '' }],
       tool_call_id: tcId,
       tool_name: tr.data.tool_name ?? '',
@@ -568,7 +568,7 @@ async function finalizeCompletedStream(
     const currentToolResultMap = get().toolResultMap
     toolMessages.push({
       id: nextMessageId('tool'),
-      role: 'tool',
+      role: 'tool_result',
       content: [{ type: 'text', text: agentStream.text || '' }],
       tool_call_id: toolCallId,
       tool_name: 'subagent',

--- a/frontend/packages/core/src/types/events.ts
+++ b/frontend/packages/core/src/types/events.ts
@@ -1,18 +1,21 @@
 // frontend/packages/core/src/types/events.ts
 import type { CitationData } from './citation'
+// Mirrors cubepi's content-block union (cubepi/providers/base.py): TextContent,
+// ThinkingContent, ToolCall. `tool_call_streaming` is a frontend-only block used
+// during live SSE to render partial tool-call args before the full call lands.
 export type ContentBlock =
+  | { type: 'text'; text: string }
   | {
-      type: 'reasoning'
-      content: string
-      started_at?: number
+      type: 'thinking'
+      thinking: string
+      started_at?: number // milliseconds since epoch (live) / cubepi seconds * 1000 (bootstrap)
       duration_ms?: number
     }
-  | { type: 'text'; content: string }
   | {
       type: 'tool_call'
+      id: string
       name: string
       arguments: Record<string, unknown>
-      tool_call_id: string
     }
   | {
       type: 'tool_call_streaming'

--- a/frontend/packages/core/src/types/index.ts
+++ b/frontend/packages/core/src/types/index.ts
@@ -5,7 +5,7 @@ export type * from './conversation'
 export type * from './events'
 export type * from './mcp'
 export type * from './memory'
-export type * from './message'
+export * from './message'
 export type * from './skills'
 export type * from './workspace-settings'
 export type {

--- a/frontend/packages/core/src/types/message.ts
+++ b/frontend/packages/core/src/types/message.ts
@@ -1,4 +1,12 @@
 // frontend/packages/core/src/types/message.ts
+//
+// Messages mirror cubepi's wire shape (cubepi/providers/base.py:Message). The
+// backend returns `m.model_dump(mode="json")` directly; no cubebox-specific
+// conversion layer.
+//
+// cubebox-specific data (attachments, memory snapshots, citations, subagent
+// payloads) lives inside `metadata` — cubepi treats metadata as opaque and
+// round-trips it through the checkpointer unchanged.
 import type { CitationData } from './citation'
 import type { ContentBlock } from './events'
 
@@ -16,46 +24,93 @@ export interface SubagentSummary {
   tool_calls: {
     name: string
     arguments: Record<string, unknown>
-    tool_call_id?: string
+    id?: string
     started_at?: string | null
   }[]
   tool_results?: SubagentToolResult[]
-  reasoning: string
+  thinking: string
   role?: string
   task?: string
 }
 
 export interface MessageAttachment {
-  id: string
+  // Persisted as `file_id` in cubepi UserMessage.metadata.attachments.
+  file_id: string
   filename: string
   kind: 'image' | 'document' | 'other'
   size_bytes: number
   width?: number | null
   height?: number | null
   thumbnail_url?: string | null
-  download_url: string
+  download_url?: string | null
 }
 
-export interface Message {
+// Usage matches cubepi.providers.base.Usage.
+export interface MessageUsage {
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens?: number
+  cache_write_tokens?: number
+}
+
+interface MessageBase {
+  // Synthesized client-side for React keys; never sent to the backend.
   id: string
-  role: 'user' | 'assistant' | 'tool'
-  content: string | null
-  tool_calls?:
-    | {
-        name: string
-        arguments: Record<string, unknown>
-        tool_call_id?: string
-        started_at?: string | null
-      }[]
-    | null
-  reasoning?: string | null
-  reasoning_duration_ms?: number | null // from backend: estimated reasoning duration
-  blocks?: ContentBlock[] | null // ordered content blocks preserving temporal order
-  name?: string | null // for tool messages
-  tool_call_id?: string | null // for tool messages: which tool_call this responds to
-  started_at?: string | null
-  citations?: CitationData[] | null // for tool messages: citation data from this tool result
-  subagent_events?: SubagentSummary | null // consolidated subagent data for tool messages
-  created_at?: string
-  attachments?: MessageAttachment[] | null // for user messages: uploaded file attachments
+  timestamp?: number | null // epoch seconds (cubepi convention)
+  metadata?: Record<string, unknown> & {
+    attachments?: MessageAttachment[]
+    memory_snapshot?: unknown
+    citations?: CitationData[]
+    subagent_events?: SubagentSummary
+  }
+}
+
+export interface UserMessage extends MessageBase {
+  role: 'user'
+  content: ContentBlock[]
+}
+
+export interface AssistantMessage extends MessageBase {
+  role: 'assistant'
+  content: ContentBlock[]
+  stop_reason?: string
+  error_message?: string | null
+  usage?: MessageUsage | null
+  provider_id?: string
+  model_id?: string
+  response_id?: string | null
+}
+
+export interface ToolResultMessage extends MessageBase {
+  role: 'tool'
+  tool_call_id: string
+  tool_name: string
+  content: ContentBlock[]
+  is_error?: boolean
+}
+
+export type Message = UserMessage | AssistantMessage | ToolResultMessage
+
+// --- Helpers (frontend ergonomics over the block-list shape) ---
+
+export function getTextContent(msg: Message): string {
+  return msg.content
+    .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
+    .map((b) => b.text)
+    .join('')
+}
+
+export function getThinking(msg: AssistantMessage): string {
+  return msg.content
+    .filter((b): b is Extract<ContentBlock, { type: 'thinking' }> => b.type === 'thinking')
+    .map((b) => b.thinking)
+    .join('')
+}
+
+export function getToolCalls(
+  msg: AssistantMessage,
+): Extract<ContentBlock, { type: 'tool_call' }>[] {
+  return msg.content.filter(
+    (b): b is Extract<ContentBlock, { type: 'tool_call' }> => b.type === 'tool_call',
+  )
 }

--- a/frontend/packages/core/src/types/message.ts
+++ b/frontend/packages/core/src/types/message.ts
@@ -87,6 +87,9 @@ export interface ToolResultMessage extends MessageBase {
   tool_name: string
   content: ContentBlock[]
   is_error?: boolean
+  // cubepi.ToolResultMessage.details: middleware-attached payload (e.g. the
+  // raw SSE event array a subagent tool result carries). Shape is per-tool.
+  details?: unknown
 }
 
 export type Message = UserMessage | AssistantMessage | ToolResultMessage
@@ -113,4 +116,57 @@ export function getToolCalls(
   return msg.content.filter(
     (b): b is Extract<ContentBlock, { type: 'tool_call' }> => b.type === 'tool_call',
   )
+}
+
+/**
+ * Extract a SubagentSummary for a tool result message, handling both shapes:
+ *
+ *   - in-memory after live finalization: `metadata.subagent_events` already
+ *     holds a normalized `SubagentSummary`
+ *   - reloaded from cubepi: `details.subagent_events` holds the raw SSE event
+ *     list collected by `SubAgentMiddleware` — we replay it into a summary
+ *
+ * Returns null when neither shape is present.
+ */
+export function getSubagentSummary(msg: ToolResultMessage): SubagentSummary | null {
+  const fromMeta = msg.metadata?.subagent_events
+  if (fromMeta && !Array.isArray(fromMeta)) return fromMeta as SubagentSummary
+
+  const details = msg.details as { subagent_events?: unknown } | null | undefined
+  const events = details?.subagent_events
+  if (!Array.isArray(events)) return null
+
+  const summary: SubagentSummary = {
+    text: '',
+    tool_calls: [],
+    tool_results: [],
+    thinking: '',
+  }
+  for (const evt of events) {
+    if (!evt || typeof evt !== 'object') continue
+    const e = evt as Record<string, unknown>
+    switch (e.type) {
+      case 'text_delta':
+        summary.text += typeof e.delta === 'string' ? e.delta : ''
+        break
+      case 'reasoning':
+        summary.thinking += typeof e.delta === 'string' ? e.delta : ''
+        break
+      case 'tool_call':
+        summary.tool_calls.push({
+          id: typeof e.id === 'string' ? e.id : undefined,
+          name: typeof e.name === 'string' ? e.name : '',
+          arguments: (e.arguments as Record<string, unknown>) ?? {},
+        })
+        break
+      case 'tool_result':
+        summary.tool_results!.push({
+          tool_name: typeof e.name === 'string' ? e.name : '',
+          tool_call_id: typeof e.tool_call_id === 'string' ? e.tool_call_id : '',
+          content: typeof e.result === 'string' ? e.result : String(e.result ?? ''),
+        })
+        break
+    }
+  }
+  return summary
 }

--- a/frontend/packages/core/src/types/message.ts
+++ b/frontend/packages/core/src/types/message.ts
@@ -82,7 +82,8 @@ export interface AssistantMessage extends MessageBase {
 }
 
 export interface ToolResultMessage extends MessageBase {
-  role: 'tool'
+  // Mirrors cubepi.ToolResultMessage.role (= "tool_result"). Not "tool".
+  role: 'tool_result'
   tool_call_id: string
   tool_name: string
   content: ContentBlock[]

--- a/frontend/packages/web/__tests__/hooks/useMessages.test.ts
+++ b/frontend/packages/web/__tests__/hooks/useMessages.test.ts
@@ -1,5 +1,5 @@
 import { act } from '@testing-library/react'
-import { useMessageStore } from '@cubebox/core/stores'
+import { useMessageStore, getTextContent } from '@cubebox/core'
 
 const CONV_ID = 'conv-1'
 
@@ -57,7 +57,7 @@ describe('messageStore.send', () => {
     })
 
     const msgs = useMessageStore.getState().messages[CONV_ID] ?? []
-    expect(msgs.some((m) => m.role === 'user' && m.content === 'hello')).toBe(true)
+    expect(msgs.some((m) => m.role === 'user' && getTextContent(m) === 'hello')).toBe(true)
   })
 
   it('accumulates text_delta events into assistant message', async () => {
@@ -90,7 +90,7 @@ describe('messageStore.send', () => {
 
     const msgs = useMessageStore.getState().messages[CONV_ID] ?? []
     const assistantMsg = msgs.find((m) => m.role === 'assistant')
-    expect(assistantMsg?.content).toBe('Hello world')
+    expect(assistantMsg && getTextContent(assistantMsg)).toBe('Hello world')
   })
 
   it('sets error on error event', async () => {
@@ -198,7 +198,8 @@ describe('messageStore.send', () => {
     const state = useMessageStore.getState()
     const msgs = state.messages[CONV_ID] ?? []
     expect(msgs).toHaveLength(1)
-    expect(msgs[0]).toMatchObject({ role: 'user', content: 'resume me' })
+    expect(msgs[0].role).toBe('user')
+    expect(msgs[0] && getTextContent(msgs[0])).toBe('resume me')
     expect(msgs.some((m) => m.role === 'assistant')).toBe(false)
     expect(state.currentRunId).toBe('run-1')
     expect(state.isStreaming).toBe(true)
@@ -213,17 +214,19 @@ describe('messageStore.send', () => {
             {
               id: 'user-1',
               role: 'user',
-              content: 'resume me',
-              created_at: '2026-04-25T00:00:00Z',
+              content: [{ type: 'text', text: 'resume me' }],
+              timestamp: Date.parse('2026-04-25T00:00:00Z') / 1000,
+              metadata: {},
             },
             {
               id: 'assistant-1',
               role: 'assistant',
-              content: 'partial...',
-              tool_calls: [
-                { name: 'read_file', arguments: {}, tool_call_id: 'tc-1', started_at: null },
+              content: [
+                { type: 'text', text: 'partial...' },
+                { type: 'tool_call', id: 'tc-1', name: 'read_file', arguments: {} },
               ],
-              created_at: '2026-04-25T00:00:01Z',
+              timestamp: Date.parse('2026-04-25T00:00:01Z') / 1000,
+              metadata: {},
             },
           ],
           total: 2,
@@ -252,7 +255,8 @@ describe('messageStore.send', () => {
     const msgs = useMessageStore.getState().messages[CONV_ID] ?? []
     const userMsgs = msgs.filter((m) => m.role === 'user')
     expect(userMsgs).toHaveLength(1)
-    expect(userMsgs[0]).toMatchObject({ id: 'user-1', content: 'resume me' })
+    expect(userMsgs[0].id).toBe('user-1')
+    expect(getTextContent(userMsgs[0])).toBe('resume me')
     // Partial assistant checkpoint must be trimmed — the stream replay will
     // re-emit it, so leaving it in history would render the response twice.
     expect(msgs.some((m) => m.role === 'assistant')).toBe(false)
@@ -271,14 +275,16 @@ describe('messageStore.send', () => {
             {
               id: 'user-1',
               role: 'user',
-              content: 'hi',
-              created_at: '2026-04-25T00:00:00Z',
+              content: [{ type: 'text', text: 'hi' }],
+              timestamp: Date.parse('2026-04-25T00:00:00Z') / 1000,
+              metadata: {},
             },
             {
               id: 'assistant-1',
               role: 'assistant',
-              content: 'hello',
-              created_at: '2026-04-25T00:00:01Z',
+              content: [{ type: 'text', text: 'hello' }],
+              timestamp: Date.parse('2026-04-25T00:00:01Z') / 1000,
+              metadata: {},
             },
           ],
           total: 2,
@@ -310,11 +316,9 @@ describe('messageStore.send', () => {
     expect(msgs.some((m) => m.id === 'assistant-1')).toBe(true)
     // A pending placeholder is appended for the active run since its user
     // message has not been checkpointed yet.
-    expect(msgs[msgs.length - 1]).toMatchObject({
-      id: 'pending-run-2',
-      role: 'user',
-      content: 'hi',
-    })
+    expect(msgs[msgs.length - 1].id).toBe('pending-run-2')
+    expect(msgs[msgs.length - 1].role).toBe('user')
+    expect(getTextContent(msgs[msgs.length - 1])).toBe('hi')
   })
 
   it('renders todos from write_todos batch payload', async () => {
@@ -460,12 +464,12 @@ describe('messageStore.send', () => {
 
     const msgs = useMessageStore.getState().messages[CONV_ID] ?? []
     const assistantMsg = msgs.find((m) => m.role === 'assistant')
-    expect(assistantMsg?.blocks).toEqual([
+    expect(assistantMsg?.content).toEqual([
       {
         type: 'tool_call',
+        id: 'call-1',
         name: 'execute',
         arguments: { cmd: 'echo hello' },
-        tool_call_id: 'call-1',
       },
     ])
   })
@@ -498,7 +502,8 @@ describe('messageStore.send', () => {
 
     const msgs = useMessageStore.getState().messages[CONV_ID] ?? []
     const assistantMsg = msgs.find((m) => m.role === 'assistant')
-    expect(assistantMsg?.blocks).toBeNull()
+    // tool_call_streaming blocks are filtered out; no finalized tool_call arrives.
+    expect(assistantMsg?.content).toEqual([])
   })
 
   // TODO(#ci-baseline): flaky — actual Date.now() call count diverged from the mock's

--- a/frontend/packages/web/app/(app)/w/[wsId]/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/page.tsx
@@ -52,7 +52,7 @@ export default function WorkspaceHomePage({
         .map((u) => {
           const f = u.serverFile!
           return {
-            id: f.id,
+            file_id: f.id,
             filename: f.filename,
             kind: f.kind,
             size_bytes: f.size_bytes,

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -2,7 +2,12 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { useTranslations } from 'next-intl'
-import type { Message, ContentBlock, SubagentSummary, TodoItem } from '@cubebox/core'
+import type {
+  AssistantMessage as AssistantMessageType,
+  ContentBlock,
+  SubagentSummary,
+  TodoItem,
+} from '@cubebox/core'
 import type { AgentStream } from '@cubebox/core'
 import { useArtifactStore } from '@cubebox/core'
 import { Bot, ChevronDown, ChevronRight, Brain } from 'lucide-react'
@@ -16,7 +21,7 @@ import { getWriteFileSummary } from '@/lib/writeFilePreview'
 import { MarkdownWithCitations } from '@/components/shared/MarkdownWithCitations'
 
 interface ReasoningBlockProps {
-  reasoning: string
+  thinking: string
   isStreaming: boolean
   startedAt?: number
   durationMs?: number
@@ -31,7 +36,7 @@ function formatDuration(ms: number): string {
   return s > 0 ? `${m}m${s}s` : `${m}m`
 }
 
-function ReasoningBlock({ reasoning, isStreaming, startedAt, durationMs }: ReasoningBlockProps) {
+function ReasoningBlock({ thinking, isStreaming, startedAt, durationMs }: ReasoningBlockProps) {
   const t = useTranslations('chat')
   const [isExpanded, setIsExpanded] = useState(false)
   const [elapsed, setElapsed] = useState(0)
@@ -60,7 +65,7 @@ function ReasoningBlock({ reasoning, isStreaming, startedAt, durationMs }: Reaso
     if (isStreaming && scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
     }
-  }, [reasoning, isStreaming])
+  }, [thinking, isStreaming])
 
   const displayTime = durationMs ?? (isStreaming && startedAt ? elapsed : null)
 
@@ -115,7 +120,7 @@ function ReasoningBlock({ reasoning, isStreaming, startedAt, durationMs }: Reaso
                 ' rgba(0,0,0,0.45) 85%, transparent 100%)',
             }}
           >
-            <span className="text-muted-foreground/70">{reasoning}</span>
+            <span className="text-muted-foreground/70">{thinking}</span>
           </div>
         </div>
       )}
@@ -127,7 +132,7 @@ function ReasoningBlock({ reasoning, isStreaming, startedAt, durationMs }: Reaso
             className="text-xs text-muted-foreground/70 leading-relaxed whitespace-pre-wrap
             italic"
           >
-            {reasoning}
+            {thinking}
           </p>
         </div>
       )}
@@ -136,7 +141,7 @@ function ReasoningBlock({ reasoning, isStreaming, startedAt, durationMs }: Reaso
 }
 
 interface HistoryProps {
-  message: Message
+  message: AssistantMessageType
   subagentDataMap?: Record<string, SubagentSummary>
   toolResultMap: Record<string, { content: string; receivedAt: number }>
   conversationId?: string
@@ -163,30 +168,6 @@ type AssistantMessageProps = HistoryProps | StreamingProps
 
 import { proseClasses } from '@/lib/utils'
 
-/** Build ordered blocks from legacy flat Message fields (for messages without blocks) */
-function blocksFromMessage(msg: Message): ContentBlock[] {
-  const result: ContentBlock[] = []
-  if (msg.reasoning) {
-    result.push({
-      type: 'reasoning',
-      content: msg.reasoning,
-      duration_ms: msg.reasoning_duration_ms ?? undefined,
-    })
-  }
-  if (msg.tool_calls) {
-    for (const tc of msg.tool_calls) {
-      result.push({
-        type: 'tool_call',
-        name: tc.name,
-        arguments: tc.arguments,
-        tool_call_id: tc.tool_call_id ?? '',
-      })
-    }
-  }
-  if (msg.content) result.push({ type: 'text', content: msg.content })
-  return result
-}
-
 /** Convert a consolidated SubagentSummary to an AgentStream for SubAgentCard */
 function subagentSummaryToStream(summary: SubagentSummary): AgentStream {
   return {
@@ -195,7 +176,7 @@ function subagentSummaryToStream(summary: SubagentSummary): AgentStream {
       type: 'tool_call' as const,
       timestamp: '',
       data: {
-        tool_call_id: tc.tool_call_id ?? `hist-${i}`,
+        tool_call_id: tc.id ?? `hist-${i}`,
         name: tc.name,
         arguments: tc.arguments,
       },
@@ -203,7 +184,7 @@ function subagentSummaryToStream(summary: SubagentSummary): AgentStream {
       agent_name: null,
     })),
     toolResults: [],
-    reasoning: summary.reasoning,
+    thinking: summary.thinking,
     blocks: [],
     name: null,
   }
@@ -234,11 +215,11 @@ function ContentBlockRenderer({
   agentId?: string | null
   conversationId?: string
 }) {
-  if (block.type === 'reasoning') {
+  if (block.type === 'thinking') {
     return (
       <div className="bg-card border border-border rounded-xl px-3 py-2.5">
         <ReasoningBlock
-          reasoning={block.content}
+          thinking={block.thinking}
           isStreaming={isStreaming && isLast}
           startedAt={block.started_at}
           durationMs={block.duration_ms}
@@ -247,7 +228,7 @@ function ContentBlockRenderer({
     )
   }
   if (block.type === 'tool_call' && block.name === 'subagent') {
-    const agentKey = `subagent:${block.tool_call_id}`
+    const agentKey = `subagent:${block.id}`
     const stream = subAgentStreams?.[agentKey]
     const historicalStream =
       !stream && subagentDataMap?.[agentKey]
@@ -266,7 +247,7 @@ function ContentBlockRenderer({
         index={subagentIndex ?? 1}
         agentId={agentKey}
         stream={stream ?? historicalStream}
-        isRunning={isStreaming && !!stream && !toolResultMap[block.tool_call_id]}
+        isRunning={isStreaming && !!stream && !toolResultMap[block.id]}
         toolResultMap={toolResultMap}
         conversationId={conversationId}
       />
@@ -275,7 +256,7 @@ function ContentBlockRenderer({
   if (block.type === 'tool_call' && block.name === 'save_artifact') {
     const args = block.arguments as { name?: string; artifact_id?: string }
     // Look up artifact from store by parsing the tool result
-    const toolResult = toolResultMap[block.tool_call_id]
+    const toolResult = toolResultMap[block.id]
     let artifact = null
     if (toolResult?.content) {
       try {
@@ -367,7 +348,7 @@ function ContentBlockRenderer({
   if (block.type === 'text') {
     return (
       <MarkdownWithCitations className={proseClasses} conversationId={conversationId}>
-        {block.content}
+        {block.text}
       </MarkdownWithCitations>
     )
   }
@@ -405,9 +386,11 @@ function groupBlocks(blocks: ContentBlock[]): (ContentBlock | ContentBlock[])[] 
   return result
 }
 
-function extractTodosFromMessage(msg: Message): TodoItem[] {
-  if (!msg.tool_calls) return []
-  const tc = msg.tool_calls.findLast((c) => c.name === 'write_todos')
+function extractTodosFromMessage(msg: AssistantMessageType): TodoItem[] {
+  const toolCalls = msg.content.filter(
+    (b): b is Extract<ContentBlock, { type: 'tool_call' }> => b.type === 'tool_call',
+  )
+  const tc = toolCalls.findLast((c) => c.name === 'write_todos')
   if (!tc) return []
   const raw = Array.isArray(tc.arguments.todos) ? tc.arguments.todos : []
   const result: TodoItem[] = []
@@ -435,13 +418,13 @@ export function AssistantMessage({
 }: AssistantMessageProps) {
   const t = useTranslations('chat')
   const streamAgentId = stream ? 'main' : undefined
-  const blocks: ContentBlock[] = stream
-    ? stream.blocks
-    : (message!.blocks ?? blocksFromMessage(message!))
+  const blocks: ContentBlock[] = stream ? stream.blocks : message!.content
 
   const historyTodos = message ? extractTodosFromMessage(message) : []
 
-  const msgCreatedAt = message?.created_at
+  const msgCreatedAt = message?.timestamp
+    ? new Date(message.timestamp * 1000).toISOString()
+    : undefined
 
   const _hasContent = blocks.length > 0
   const grouped = groupBlocks(blocks)

--- a/frontend/packages/web/components/chat/CitationMarker.tsx
+++ b/frontend/packages/web/components/chat/CitationMarker.tsx
@@ -296,7 +296,7 @@ export function CitationMarker({ citationId, chunkIndex, conversationId }: Citat
       // Find tool result from history messages (top-level or inside subagent_events)
       outer: for (const msgs of Object.values(state.messages)) {
         for (const m of msgs) {
-          if (m.role === 'tool' && m.tool_call_id === citation.tool_call_id) {
+          if (m.role === 'tool_result' && m.tool_call_id === citation.tool_call_id) {
             toolName = m.tool_name || 'web_search'
             content = m.content
               .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
@@ -306,7 +306,7 @@ export function CitationMarker({ citationId, chunkIndex, conversationId }: Citat
           }
           // Search subagent inner tool results
           const subagent =
-            m.role === 'tool' && m.tool_name === 'subagent' ? getSubagentSummary(m) : null
+            m.role === 'tool_result' && m.tool_name === 'subagent' ? getSubagentSummary(m) : null
           if (subagent?.tool_results) {
             const inner = subagent.tool_results.find(
               (tr: { tool_call_id: string }) => tr.tool_call_id === citation.tool_call_id,
@@ -335,7 +335,7 @@ export function CitationMarker({ citationId, chunkIndex, conversationId }: Citat
           }
         }
         const subagent =
-          m.role === 'tool' && m.tool_name === 'subagent' ? getSubagentSummary(m) : null
+          m.role === 'tool_result' && m.tool_name === 'subagent' ? getSubagentSummary(m) : null
         if (subagent?.tool_calls) {
           const tc = subagent.tool_calls.find(
             (t: { id?: string }) => t.id === citation.tool_call_id,

--- a/frontend/packages/web/components/chat/CitationMarker.tsx
+++ b/frontend/packages/web/components/chat/CitationMarker.tsx
@@ -291,14 +291,18 @@ export function CitationMarker({ citationId, chunkIndex, conversationId }: Citat
       outer: for (const msgs of Object.values(state.messages)) {
         for (const m of msgs) {
           if (m.role === 'tool' && m.tool_call_id === citation.tool_call_id) {
-            toolName = m.name ?? 'web_search'
+            toolName = m.tool_name || 'web_search'
             content = m.content
+              .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+              .map((b) => b.text)
+              .join('')
             break outer
           }
           // Search subagent inner tool results
-          if (m.role === 'tool' && m.name === 'subagent' && m.subagent_events?.tool_results) {
-            const inner = m.subagent_events.tool_results.find(
-              (tr) => tr.tool_call_id === citation.tool_call_id,
+          const subagent = m.role === 'tool' ? m.metadata?.subagent_events : undefined
+          if (m.role === 'tool' && m.tool_name === 'subagent' && subagent?.tool_results) {
+            const inner = subagent.tool_results.find(
+              (tr: { tool_call_id: string }) => tr.tool_call_id === citation.tool_call_id,
             )
             if (inner) {
               toolName = inner.tool_name || 'web_search'
@@ -314,19 +318,19 @@ export function CitationMarker({ citationId, chunkIndex, conversationId }: Citat
     // Find tool call arguments (url, etc.) from assistant messages or streaming blocks
     outer2: for (const msgs of Object.values(state.messages)) {
       for (const m of msgs) {
-        // Check assistant tool_calls
-        if (m.role === 'assistant' && m.tool_calls) {
-          const tc = m.tool_calls.find((t) => t.tool_call_id === citation.tool_call_id)
-          if (tc) {
-            toolName = tc.name
-            toolArgs = tc.arguments
-            break outer2
+        if (m.role === 'assistant') {
+          for (const block of m.content) {
+            if (block.type === 'tool_call' && block.id === citation.tool_call_id) {
+              toolName = block.name
+              toolArgs = block.arguments
+              break outer2
+            }
           }
         }
-        // Check subagent inner tool calls
-        if (m.role === 'tool' && m.name === 'subagent' && m.subagent_events?.tool_calls) {
-          const tc = m.subagent_events.tool_calls.find(
-            (t) => t.tool_call_id === citation.tool_call_id,
+        const subagent = m.role === 'tool' ? m.metadata?.subagent_events : undefined
+        if (m.role === 'tool' && m.tool_name === 'subagent' && subagent?.tool_calls) {
+          const tc = subagent.tool_calls.find(
+            (t: { id?: string }) => t.id === citation.tool_call_id,
           )
           if (tc) {
             toolName = tc.name
@@ -340,7 +344,7 @@ export function CitationMarker({ citationId, chunkIndex, conversationId }: Citat
     if (Object.keys(toolArgs).length === 0) {
       for (const agent of Object.values(state.streamAgents)) {
         for (const block of agent.blocks) {
-          if (block.type === 'tool_call' && block.tool_call_id === citation.tool_call_id) {
+          if (block.type === 'tool_call' && block.id === citation.tool_call_id) {
             toolName = block.name
             toolArgs = block.arguments
             break

--- a/frontend/packages/web/components/chat/CitationMarker.tsx
+++ b/frontend/packages/web/components/chat/CitationMarker.tsx
@@ -2,7 +2,13 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { Globe, Calendar } from 'lucide-react'
-import { useCitationStore, usePanelStore, useMessageStore, bareToolName } from '@cubebox/core'
+import {
+  useCitationStore,
+  usePanelStore,
+  useMessageStore,
+  bareToolName,
+  getSubagentSummary,
+} from '@cubebox/core'
 import type { CitationData } from '@cubebox/core'
 import { useTranslations } from 'next-intl'
 
@@ -299,8 +305,9 @@ export function CitationMarker({ citationId, chunkIndex, conversationId }: Citat
             break outer
           }
           // Search subagent inner tool results
-          const subagent = m.role === 'tool' ? m.metadata?.subagent_events : undefined
-          if (m.role === 'tool' && m.tool_name === 'subagent' && subagent?.tool_results) {
+          const subagent =
+            m.role === 'tool' && m.tool_name === 'subagent' ? getSubagentSummary(m) : null
+          if (subagent?.tool_results) {
             const inner = subagent.tool_results.find(
               (tr: { tool_call_id: string }) => tr.tool_call_id === citation.tool_call_id,
             )
@@ -327,8 +334,9 @@ export function CitationMarker({ citationId, chunkIndex, conversationId }: Citat
             }
           }
         }
-        const subagent = m.role === 'tool' ? m.metadata?.subagent_events : undefined
-        if (m.role === 'tool' && m.tool_name === 'subagent' && subagent?.tool_calls) {
+        const subagent =
+          m.role === 'tool' && m.tool_name === 'subagent' ? getSubagentSummary(m) : null
+        if (subagent?.tool_calls) {
           const tc = subagent.tool_calls.find(
             (t: { id?: string }) => t.id === citation.tool_call_id,
           )

--- a/frontend/packages/web/components/chat/MessageAttachments.tsx
+++ b/frontend/packages/web/components/chat/MessageAttachments.tsx
@@ -7,7 +7,7 @@ import { ImageLightbox } from './ImageLightbox'
 import { MessageFileChip } from './MessageFileChip'
 
 export interface MessageAttachmentDto {
-  id: string
+  file_id: string
   filename: string
   kind: 'image' | 'document' | 'other'
   mime_type?: string
@@ -15,7 +15,7 @@ export interface MessageAttachmentDto {
   width?: number | null
   height?: number | null
   thumbnail_url?: string | null
-  download_url: string
+  download_url?: string | null
 }
 
 interface Props {
@@ -45,7 +45,7 @@ export function MessageAttachments({
     return attachments.map((a) => ({
       ...a,
       thumbnail_url: a.thumbnail_url ? fix(a.thumbnail_url) : null,
-      download_url: fix(a.download_url),
+      download_url: fix(a.download_url ?? `./attachments/${a.file_id}`),
     }))
   }, [attachments, conversationId, workspaceId])
 
@@ -60,7 +60,7 @@ export function MessageAttachments({
         if (a.kind === 'image' && a.thumbnail_url) {
           return (
             <button
-              key={a.id}
+              key={a.file_id}
               type="button"
               onClick={() => setOpenSrc({ src: a.download_url, alt: a.filename })}
               className="group relative overflow-hidden rounded-lg border border-border"
@@ -79,8 +79,8 @@ export function MessageAttachments({
         }
         return (
           <MessageFileChip
-            key={a.id}
-            attachmentId={a.id}
+            key={a.file_id}
+            attachmentId={a.file_id}
             filename={a.filename}
             mimeType={a.mime_type ?? ''}
             sizeBytes={a.size_bytes}

--- a/frontend/packages/web/components/chat/MessageAttachments.tsx
+++ b/frontend/packages/web/components/chat/MessageAttachments.tsx
@@ -45,7 +45,10 @@ export function MessageAttachments({
     return attachments.map((a) => ({
       ...a,
       thumbnail_url: a.thumbnail_url ? fix(a.thumbnail_url) : null,
-      download_url: fix(a.download_url ?? `./attachments/${a.file_id}`),
+      // /attachments/{id} is the metadata endpoint; bytes live under /content.
+      // Historical messages reloaded from cubepi only carry file_id, so we
+      // build the URL ourselves when download_url isn't pre-filled.
+      download_url: fix(a.download_url ?? `./attachments/${a.file_id}/content`),
     }))
   }, [attachments, conversationId, workspaceId])
 

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useCallback, useMemo } from 'react'
 import { useTranslations } from 'next-intl'
-import { useMessageStore, createApiClient } from '@cubebox/core'
+import { useMessageStore, createApiClient, getTextContent } from '@cubebox/core'
 import type { Message, SubagentSummary } from '@cubebox/core'
 import { AlertCircle } from 'lucide-react'
 import { UserMessage } from './UserMessage'
@@ -17,15 +17,21 @@ interface MessageListProps {
   conversationId: string
 }
 
+function msgTimestampMs(msg: Message): number {
+  return msg.timestamp != null ? msg.timestamp * 1000 : 0
+}
+
 /**
  * Build a map from tool_call_id -> SubagentSummary by scanning tool messages
- * that follow each assistant message.
+ * with tool_name === 'subagent'. Subagent summaries ride inside metadata.
  */
 function buildSubagentDataMap(messages: Message[]): Record<string, SubagentSummary> {
   const map: Record<string, SubagentSummary> = {}
   for (const msg of messages) {
-    if (msg.role === 'tool' && msg.name === 'subagent' && msg.tool_call_id && msg.subagent_events) {
-      map[`subagent:${msg.tool_call_id}`] = msg.subagent_events
+    if (msg.role !== 'tool') continue
+    const summary = msg.metadata?.subagent_events
+    if (msg.tool_name === 'subagent' && msg.tool_call_id && summary) {
+      map[`subagent:${msg.tool_call_id}`] = summary
     }
   }
   return map
@@ -47,48 +53,47 @@ function buildHistoricalToolResultMap(
       contentType?: string
     }
   > = {}
-  // Build a map of tool_call_id → authoritative tool start time from history.
+  // Build a map of tool_call_id → authoritative tool start time from the
+  // assistant message that issued the call (its timestamp is our best proxy).
   const toolCallStartMap: Record<string, number> = {}
   for (const msg of messages) {
-    if (msg.role === 'assistant' && msg.tool_calls) {
-      for (const tc of msg.tool_calls) {
-        if (!tc.tool_call_id) continue
-        const rawStart = tc.started_at ?? msg.created_at
-        if (!rawStart) continue
-        toolCallStartMap[tc.tool_call_id] = new Date(rawStart).getTime()
+    if (msg.role !== 'assistant') continue
+    const ts = msgTimestampMs(msg)
+    if (!ts) continue
+    for (const block of msg.content) {
+      if (block.type === 'tool_call') {
+        toolCallStartMap[block.id] = ts
       }
     }
   }
+
   for (const msg of messages) {
-    if (msg.role === 'tool' && msg.tool_call_id) {
-      const fallbackStartedAt = msg.started_at ? new Date(msg.started_at).getTime() : undefined
-      map[msg.tool_call_id] = {
-        content: msg.content ?? '',
-        receivedAt: new Date(msg.created_at ?? 0).getTime(),
-        startedAt: toolCallStartMap[msg.tool_call_id] ?? fallbackStartedAt,
-      }
-      // Also index subagent inner tool results so their previews/citations work
-      if (msg.name === 'subagent' && msg.subagent_events?.tool_results) {
-        // Build a started_at map from subagent tool_calls
-        const saToolCallStartMap: Record<string, number> = {}
-        for (const tc of msg.subagent_events.tool_calls ?? []) {
-          if (tc.tool_call_id && tc.started_at) {
-            saToolCallStartMap[tc.tool_call_id] = new Date(tc.started_at).getTime()
-          }
+    if (msg.role !== 'tool' || !msg.tool_call_id) continue
+    const receivedAt = msgTimestampMs(msg)
+    map[msg.tool_call_id] = {
+      content: getTextContent(msg),
+      receivedAt: receivedAt || Date.now(),
+      startedAt: toolCallStartMap[msg.tool_call_id],
+    }
+    // Index subagent inner tool results so their previews/citations work
+    const summary = msg.metadata?.subagent_events
+    if (msg.tool_name === 'subagent' && summary?.tool_results) {
+      const saToolCallStartMap: Record<string, number> = {}
+      for (const tc of summary.tool_calls ?? []) {
+        if (tc.id && tc.started_at) {
+          saToolCallStartMap[tc.id] = new Date(tc.started_at).getTime()
         }
-        const fallbackTs = new Date(msg.created_at ?? 0).getTime()
-        for (const tr of msg.subagent_events.tool_results) {
-          if (tr.tool_call_id) {
-            const startedAt = tr.started_at
-              ? new Date(tr.started_at).getTime()
-              : (saToolCallStartMap[tr.tool_call_id] ?? undefined)
-            map[tr.tool_call_id] = {
-              content: tr.content,
-              receivedAt: tr.completed_at ? new Date(tr.completed_at).getTime() : fallbackTs,
-              startedAt,
-              contentType: tr.content_type ?? undefined,
-            }
-          }
+      }
+      for (const tr of summary.tool_results) {
+        if (!tr.tool_call_id) continue
+        const startedAt = tr.started_at
+          ? new Date(tr.started_at).getTime()
+          : saToolCallStartMap[tr.tool_call_id]
+        map[tr.tool_call_id] = {
+          content: tr.content,
+          receivedAt: tr.completed_at ? new Date(tr.completed_at).getTime() : receivedAt,
+          startedAt,
+          contentType: tr.content_type ?? undefined,
         }
       }
     }
@@ -195,13 +200,13 @@ export function MessageList({ conversationId }: MessageListProps) {
           <div key={msg.id}>
             {msg.role === 'user' && (
               <>
-                {msg.attachments && msg.attachments.length > 0 && (
+                {msg.metadata?.attachments && msg.metadata.attachments.length > 0 && (
                   <MessageAttachments
-                    attachments={msg.attachments}
+                    attachments={msg.metadata.attachments}
                     conversationId={conversationId}
                   />
                 )}
-                <UserMessage content={msg.content ?? ''} />
+                <UserMessage content={getTextContent(msg)} />
               </>
             )}
             {msg.role === 'assistant' && msg.id !== lastAssistantId && (

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -28,7 +28,7 @@ function msgTimestampMs(msg: Message): number {
 function buildSubagentDataMap(messages: Message[]): Record<string, SubagentSummary> {
   const map: Record<string, SubagentSummary> = {}
   for (const msg of messages) {
-    if (msg.role !== 'tool' || msg.tool_name !== 'subagent' || !msg.tool_call_id) continue
+    if (msg.role !== 'tool_result' || msg.tool_name !== 'subagent' || !msg.tool_call_id) continue
     const summary = getSubagentSummary(msg)
     if (summary) map[`subagent:${msg.tool_call_id}`] = summary
   }
@@ -66,7 +66,7 @@ function buildHistoricalToolResultMap(
   }
 
   for (const msg of messages) {
-    if (msg.role !== 'tool' || !msg.tool_call_id) continue
+    if (msg.role !== 'tool_result' || !msg.tool_call_id) continue
     const receivedAt = msgTimestampMs(msg)
     map[msg.tool_call_id] = {
       content: getTextContent(msg),

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useCallback, useMemo } from 'react'
 import { useTranslations } from 'next-intl'
-import { useMessageStore, createApiClient, getTextContent } from '@cubebox/core'
+import { useMessageStore, createApiClient, getTextContent, getSubagentSummary } from '@cubebox/core'
 import type { Message, SubagentSummary } from '@cubebox/core'
 import { AlertCircle } from 'lucide-react'
 import { UserMessage } from './UserMessage'
@@ -28,11 +28,9 @@ function msgTimestampMs(msg: Message): number {
 function buildSubagentDataMap(messages: Message[]): Record<string, SubagentSummary> {
   const map: Record<string, SubagentSummary> = {}
   for (const msg of messages) {
-    if (msg.role !== 'tool') continue
-    const summary = msg.metadata?.subagent_events
-    if (msg.tool_name === 'subagent' && msg.tool_call_id && summary) {
-      map[`subagent:${msg.tool_call_id}`] = summary
-    }
+    if (msg.role !== 'tool' || msg.tool_name !== 'subagent' || !msg.tool_call_id) continue
+    const summary = getSubagentSummary(msg)
+    if (summary) map[`subagent:${msg.tool_call_id}`] = summary
   }
   return map
 }
@@ -76,8 +74,8 @@ function buildHistoricalToolResultMap(
       startedAt: toolCallStartMap[msg.tool_call_id],
     }
     // Index subagent inner tool results so their previews/citations work
-    const summary = msg.metadata?.subagent_events
-    if (msg.tool_name === 'subagent' && summary?.tool_results) {
+    const summary = msg.tool_name === 'subagent' ? getSubagentSummary(msg) : null
+    if (summary?.tool_results) {
       const saToolCallStartMap: Record<string, number> = {}
       for (const tc of summary.tool_calls ?? []) {
         if (tc.id && tc.started_at) {

--- a/frontend/packages/web/components/chat/SubAgentCard.tsx
+++ b/frontend/packages/web/components/chat/SubAgentCard.tsx
@@ -86,7 +86,7 @@ export const SubAgentCard = memo(function SubAgentCard({
           type: 'tool_call' as const,
           name: tc.data.name,
           arguments: tc.data.arguments,
-          tool_call_id: tc.data.tool_call_id,
+          id: tc.data.tool_call_id,
         }))
   const completedCount = toolCalls.filter((tc) => toolResultMap[tc.data.tool_call_id]).length
   const pendingTc = toolCalls.find((tc) => !toolResultMap[tc.data.tool_call_id])
@@ -124,19 +124,19 @@ export const SubAgentCard = memo(function SubAgentCard({
       )
     }
 
-    const result = toolResultMap[block.tool_call_id] ?? null
+    const result = toolResultMap[block.id] ?? null
     return (
       <ToolCallItem
-        key={block.tool_call_id || i}
+        key={block.id || i}
         name={block.name}
         arguments={block.arguments}
-        toolCallId={block.tool_call_id}
+        toolCallId={block.id}
         contentTypeOverride={block.name === 'write_file' ? 'write_file' : undefined}
         toolRef={
           block.name === 'write_file'
             ? ({
                 agent_id: agentId ?? null,
-                tool_call_id: block.tool_call_id,
+                tool_call_id: block.id,
                 index: null,
               } satisfies ToolCallRef)
             : undefined

--- a/frontend/packages/web/components/chat/ToolCallGroup.tsx
+++ b/frontend/packages/web/components/chat/ToolCallGroup.tsx
@@ -26,20 +26,20 @@ export function ToolCallGroup({
         border-l-muted-foreground/20"
     >
       {blocks.map((block, i) => {
-        const result = toolResultMap[block.tool_call_id] ?? null
+        const result = toolResultMap[block.id] ?? null
         const isPending = isStreaming && !result
         return (
           <ToolCallItem
-            key={block.tool_call_id || i}
+            key={block.id || i}
             name={block.name}
             arguments={block.arguments}
-            toolCallId={block.tool_call_id}
+            toolCallId={block.id}
             contentTypeOverride={block.name === 'write_file' ? 'write_file' : undefined}
             toolRef={
               block.name === 'write_file'
                 ? ({
                     agent_id: agentId ?? null,
-                    tool_call_id: block.tool_call_id,
+                    tool_call_id: block.id,
                     index: null,
                   } satisfies ToolCallRef)
                 : undefined

--- a/frontend/packages/web/components/layout/InputBar.tsx
+++ b/frontend/packages/web/components/layout/InputBar.tsx
@@ -87,7 +87,7 @@ export function InputBar({
         .map((u) => {
           const f = u.serverFile!
           return {
-            id: f.id,
+            file_id: f.id,
             filename: f.filename,
             kind: f.kind,
             size_bytes: f.size_bytes,

--- a/frontend/packages/web/lib/writeFilePreview.ts
+++ b/frontend/packages/web/lib/writeFilePreview.ts
@@ -103,7 +103,7 @@ export function resolveLiveWriteFile(
   for (let i = blocks.length - 1; i >= 0; i--) {
     const block = blocks[i]
     if (block.type === 'tool_call' && block.name === 'write_file') {
-      if (toolRef.tool_call_id && block.tool_call_id === toolRef.tool_call_id) {
+      if (toolRef.tool_call_id && block.id === toolRef.tool_call_id) {
         return {
           filePath: readFilePath(block.arguments),
           content: readStringArg(block.arguments, 'content'),


### PR DESCRIPTION
## Summary

- Drops the `cubepi_message_to_wire` adapter — the backend now returns `m.model_dump(mode=\"json\")` directly from `/conversations/{id}/bootstrap` and `/messages`. The frontend consumes cubepi's pydantic shape as-is: `content` is a list of typed blocks (text / thinking / tool_call), and cubebox extras (attachments, memory snapshots, citations, subagent payloads) live in `metadata`.
- Thinking timing now survives reload. cubepi gained `started_at` / `duration_ms` on `ThinkingContent` (pinned at `50c7c18` on the `feat/thinking-timing` branch of cubepi; tag a v0.4.0 once this lands); providers capture timing at `thinking_start`/`_end` and `merge_thinking_timing` propagates it to the final result.
- Frontend `ContentBlock` renamed `reasoning` → `thinking`, `tool_call.tool_call_id` → `id` to match cubepi. SSE event names on the wire are unchanged.
- The `blocksFromMessage()` adapter is gone — the renderer iterates `message.content` directly.

Commits:
- `de787f8f` refactor(backend): cubepi.Message is the wire shape
- `25006210` refactor(frontend): consume cubepi-shape messages directly
- `aab72a67` fix(test): align attachments e2e to cubepi wire shape

Companion cubepi branch: <https://github.com/cubeplexai/cubepi/tree/feat/thinking-timing>

## Test plan

- [x] cubepi: `pytest tests/` — 517 passed, 1 skipped
- [x] backend `make check`: format + lint + mypy + 612 unit tests
- [x] backend e2e: 286 passed / 11 skipped (after attachments fixture fix)
- [x] frontend `pnpm type-check`: clean
- [x] frontend `pnpm test`: 46 passed
- [x] frontend `pnpm test:e2e` chat-flow + attachments: 3 passed, 2 flaky-but-passed
- [ ] Reviewer to confirm cubepi pin (`50c7c18`) is acceptable; tag v0.4.0 + bump cubebox to that tag before merge
- [ ] Manual smoke: send a message with a thinking-capable model, reload, verify thinking text + timer survive