### PR TITLE
MCP: admin auto_enable_workspaces flag + workspace catalog self-install

### DIFF
--- a/backend/alembic/versions/be0ae034a240_add_auto_enroll_new_workspaces_to_mcp_.py
+++ b/backend/alembic/versions/be0ae034a240_add_auto_enroll_new_workspaces_to_mcp_.py
@@ -1,0 +1,33 @@
+"""add auto_enroll_new_workspaces to mcp_servers
+
+Revision ID: be0ae034a240
+Revises: 94630a9e13b4
+Create Date: 2026-05-15 15:17:08.740842
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'be0ae034a240'
+down_revision: Union[str, Sequence[str], None] = '94630a9e13b4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "mcp_servers",
+        sa.Column(
+            "auto_enroll_new_workspaces",
+            sa.Boolean(),
+            server_default=sa.text("true"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("mcp_servers", "auto_enroll_new_workspaces")

--- a/backend/cubebox/api/routes/v1/workspaces.py
+++ b/backend/cubebox/api/routes/v1/workspaces.py
@@ -106,12 +106,17 @@ async def create_workspace(
                 detail="not a member of this org",
             )
 
+    from cubebox.mcp.workspace_bootstrap import enroll_workspace_in_org_wide_mcp
+
     ws_repo = WorkspaceRepository(session)
     mem_repo = MembershipRepository(session)
     ws = await ws_repo.create(org_id=org_id, name=body.name)
     await mem_repo.grant(user_id=user.id, workspace_id=ws.id, role=Role.ADMIN)
     agent_cfg = AgentConfig(org_id=org_id, workspace_id=ws.id)
     session.add(agent_cfg)
+    await enroll_workspace_in_org_wide_mcp(
+        session, org_id=org_id, workspace_id=ws.id, actor_user_id=user.id
+    )
     await session.commit()
     return {"id": ws.id, "name": ws.name, "org_id": ws.org_id}
 

--- a/backend/cubebox/auth/users.py
+++ b/backend/cubebox/auth/users.py
@@ -145,10 +145,14 @@ class UserManager(BaseUserManager[User, str]):
             await MembershipRepository(session).grant(
                 user_id=user.id, workspace_id=ws.id, role=Role.ADMIN
             )
+            from cubebox.mcp.workspace_bootstrap import enroll_workspace_in_org_wide_mcp
             from cubebox.models.agent_config import AgentConfig
 
             agent_cfg = AgentConfig(org_id=org.id, workspace_id=ws.id)
             session.add(agent_cfg)
+            await enroll_workspace_in_org_wide_mcp(
+                session, org_id=org.id, workspace_id=ws.id, actor_user_id=user.id
+            )
             await session.flush()
         except Exception as exc:
             logger.exception(
@@ -236,10 +240,17 @@ class UserManager(BaseUserManager[User, str]):
             await MembershipRepository(session).grant(
                 user_id=user.id, workspace_id=ws.id, role=Role.ADMIN
             )
+            from cubebox.mcp.workspace_bootstrap import enroll_workspace_in_org_wide_mcp
             from cubebox.models.agent_config import AgentConfig
 
             agent_cfg = AgentConfig(org_id=singleton_org_id, workspace_id=ws.id)
             session.add(agent_cfg)
+            await enroll_workspace_in_org_wide_mcp(
+                session,
+                org_id=singleton_org_id,
+                workspace_id=ws.id,
+                actor_user_id=user.id,
+            )
             await session.flush()
         except Exception as exc:
             await self._best_effort_cleanup_register(user=user, org=None, session=session)

--- a/backend/cubebox/mcp/workspace_bootstrap.py
+++ b/backend/cubebox/mcp/workspace_bootstrap.py
@@ -1,0 +1,52 @@
+"""Bootstrap helpers for inheriting org-wide MCP installs into new workspaces.
+
+When a workspace is created, any org-wide MCP server in the same org whose
+``auto_enroll_new_workspaces`` flag is True gets a ``WorkspaceMCPOverride``
+row with ``enabled=True`` so the new workspace can see the connector out of
+the box.
+
+Called from workspace-creation paths (register bootstrap + ``POST /workspaces``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.models import MCPServer
+from cubebox.repositories.mcp import WorkspaceMCPOverrideRepository
+
+
+async def enroll_workspace_in_org_wide_mcp(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    workspace_id: str,
+    actor_user_id: str,
+) -> None:
+    """Upsert enabled overrides for every auto-enroll org-wide install.
+
+    Iterates org-wide ``mcp_servers`` rows (``owner_workspace_id IS NULL``)
+    whose ``auto_enroll_new_workspaces`` is True; idempotent against repeat
+    invocation (the override repo's upsert flips an existing row rather than
+    duplicating it).
+    """
+    stmt = select(MCPServer).where(
+        MCPServer.org_id == org_id,  # type: ignore[arg-type]
+        MCPServer.owner_workspace_id.is_(None),  # type: ignore[union-attr]
+        cast(Any, MCPServer.auto_enroll_new_workspaces).is_(True),
+    )
+    servers = list((await session.execute(stmt)).scalars().all())
+    if not servers:
+        return
+
+    override_repo = WorkspaceMCPOverrideRepository(session, org_id=org_id)
+    for server in servers:
+        await override_repo.upsert(
+            workspace_id=workspace_id,
+            mcp_server_id=server.id,
+            enabled=True,
+            updated_by_user_id=actor_user_id,
+        )

--- a/backend/cubebox/mcp/workspace_bootstrap.py
+++ b/backend/cubebox/mcp/workspace_bootstrap.py
@@ -1,9 +1,20 @@
 """Bootstrap helpers for inheriting org-wide MCP installs into new workspaces.
 
 When a workspace is created, any org-wide MCP server in the same org whose
-``auto_enroll_new_workspaces`` flag is True gets a ``WorkspaceMCPOverride``
-row with ``enabled=True`` so the new workspace can see the connector out of
-the box.
+``auto_enroll_new_workspaces`` flag is True **and** whose ``authed`` is True
+gets a ``WorkspaceMCPOverride`` row with ``enabled=True`` so the new
+workspace can see the connector out of the box.
+
+The ``authed`` filter matters: ``delete_install`` is a soft delete that
+flips ``authed`` to False but leaves ``auto_enroll_new_workspaces``
+untouched (the flag captures the admin's policy intent, not the install's
+live state). Without this filter, soft-deleted installs would zombie back
+into every newly created workspace as "needs_setup" entries. Pending-OAuth
+installs (authed=False, never completed) are also skipped here — those
+get backfilled at install time on workspaces that exist *at* install time,
+which is the only moment we have a fresh "spread to all workspaces" signal
+from the admin. A workspace created during the brief OAuth window can opt
+in manually via the override toggle once the install lands.
 
 Called from workspace-creation paths (register bootstrap + ``POST /workspaces``).
 """
@@ -26,17 +37,18 @@ async def enroll_workspace_in_org_wide_mcp(
     workspace_id: str,
     actor_user_id: str,
 ) -> None:
-    """Upsert enabled overrides for every auto-enroll org-wide install.
+    """Upsert enabled overrides for every authed auto-enroll org-wide install.
 
     Iterates org-wide ``mcp_servers`` rows (``owner_workspace_id IS NULL``)
-    whose ``auto_enroll_new_workspaces`` is True; idempotent against repeat
-    invocation (the override repo's upsert flips an existing row rather than
-    duplicating it).
+    whose ``auto_enroll_new_workspaces`` AND ``authed`` are both True;
+    idempotent against repeat invocation (the override repo's upsert flips
+    an existing row rather than duplicating it).
     """
     stmt = select(MCPServer).where(
         MCPServer.org_id == org_id,  # type: ignore[arg-type]
         MCPServer.owner_workspace_id.is_(None),  # type: ignore[union-attr]
         cast(Any, MCPServer.auto_enroll_new_workspaces).is_(True),
+        cast(Any, MCPServer.authed).is_(True),
     )
     servers = list((await session.execute(stmt)).scalars().all())
     if not servers:

--- a/backend/cubebox/models/mcp.py
+++ b/backend/cubebox/models/mcp.py
@@ -98,6 +98,11 @@ class MCPServer(CubeboxBase, table=True):
         sa_column=Column(JSON, nullable=False, server_default=text("'{}'")),
     )
     authed: bool = Field(default=False)
+    # Org-wide installs only: when True, new workspaces auto-inherit an enabled
+    # WorkspaceMCPOverride. Ignored for workspace-private installs.
+    auto_enroll_new_workspaces: bool = Field(
+        default=True, sa_column_kwargs={"server_default": text("true")}
+    )
     last_error: str | None = Field(default=None, max_length=2048)
     last_discovered_at: datetime | None = None
     timeout: float = Field(default=30.0)

--- a/backend/cubebox/services/mcp_catalog.py
+++ b/backend/cubebox/services/mcp_catalog.py
@@ -54,6 +54,7 @@ from cubebox.repositories.mcp import (
     WorkspaceMCPOverrideRepository,
 )
 from cubebox.repositories.mcp_catalog import MCPCatalogConnectorRepository
+from cubebox.repositories.workspace import WorkspaceRepository
 from cubebox.services.credential import CredentialService
 
 _VALID_AUTH_METHODS = {"static", "oauth", "none"}
@@ -90,6 +91,7 @@ class MCPCatalogService:
         override_repo: WorkspaceMCPOverrideRepository,
         cred_service: CredentialService,
         request_context: RequestContext,
+        workspace_repo: WorkspaceRepository | None = None,
     ) -> None:
         self.catalog_repo = catalog_repo
         self.server_repo = server_repo
@@ -98,6 +100,7 @@ class MCPCatalogService:
         self.override_repo = override_repo
         self.cred_service = cred_service
         self._ctx = request_context
+        self.workspace_repo = workspace_repo or WorkspaceRepository(server_repo.session)
 
     # ---------------- read path ---------------- #
 
@@ -190,18 +193,22 @@ class MCPCatalogService:
         connector = await self._get_connector_or_raise(catalog_id)
         self._assert_auth_method_supported(connector, auth_method)
 
-        # NOTE: With inverted semantics (no override row = invisible),
-        # ``auto_enable_workspaces`` would need to create explicit enabled
-        # override rows for each workspace. Deferred to a follow-up task;
-        # for now the flag is accepted but not acted on.
-        del auto_enable_workspaces
-
-        return await self._install_org_wide(
+        result = await self._install_org_wide(
             connector=connector,
             auth_method=auth_method,
             credential_plaintext=credential_plaintext,
             credential_name=credential_name,
+            auto_enroll_new_workspaces=auto_enable_workspaces,
         )
+
+        # Backfill enabled overrides for every existing workspace in the org.
+        # Eager: we do this regardless of authed state — workspace UIs surface
+        # an explicit "needs setup" state, which is more useful than hiding the
+        # connector entirely while OAuth is mid-flight.
+        if auto_enable_workspaces:
+            await self._enable_for_existing_workspaces(server_id=result.install_id)
+
+        return result
 
     async def install_for_workspace(
         self,
@@ -382,6 +389,7 @@ class MCPCatalogService:
         auth_method: str,
         credential_plaintext: str | None,
         credential_name: str | None,
+        auto_enroll_new_workspaces: bool = True,
     ) -> InstallResult:
         await self._reject_duplicate(
             connector_id=connector.id,
@@ -412,6 +420,7 @@ class MCPCatalogService:
                 timeout=30.0,
                 sse_read_timeout=300.0,
                 tool_citations=copy.deepcopy(connector.tool_citations or {}),
+                auto_enroll_new_workspaces=auto_enroll_new_workspaces,
                 created_by_user_id=self._ctx.user.id,
             )
         )
@@ -421,6 +430,22 @@ class MCPCatalogService:
             auth_method=auth_method,
             credential_plaintext=credential_plaintext,
         )
+
+    async def _enable_for_existing_workspaces(self, *, server_id: str) -> None:
+        """Upsert enabled overrides for every workspace in the org.
+
+        Idempotent: workspaces that already have an enabled override get a
+        no-op flip; disabled overrides get re-enabled (admin install intent
+        wins over a prior per-workspace opt-out).
+        """
+        workspaces = await self.workspace_repo.list_for_org(self._ctx.org_id)
+        for ws in workspaces:
+            await self.override_repo.upsert(
+                workspace_id=ws.id,
+                mcp_server_id=server_id,
+                enabled=True,
+                updated_by_user_id=self._ctx.user.id,
+            )
 
     async def _install_workspace_user(
         self,

--- a/backend/cubebox/services/mcp_catalog.py
+++ b/backend/cubebox/services/mcp_catalog.py
@@ -230,11 +230,21 @@ class MCPCatalogService:
             credential_name=credential_name,
         )
 
-    async def delete_install(self, install_id: str) -> None:
+    async def delete_install(
+        self, install_id: str, *, purge_workspace_overrides: bool = True
+    ) -> None:
         """Soft disable: clear credentials, mark unauthed, keep the row.
 
         Does NOT call OAuth revoke — that's a Phase 5 concern. The TODO
         notes the entry point so the OAuth route can wire it in later.
+
+        ``purge_workspace_overrides`` (default True) controls whether any
+        ``WorkspaceMCPOverride`` rows pointing at this install get deleted.
+        The admin "Delete install" path wants the purge — it mirrors the
+        ``auto_enable_workspaces`` backfill on install (all-on ↔ all-off).
+        Callers that delete-install only to clear credentials before rewriting
+        them (``switch_auth_method``) pass ``False`` so workspace visibility
+        survives the rekey.
         """
         server = await self.server_repo.get(install_id)
         if server is None:
@@ -280,6 +290,21 @@ class MCPCatalogService:
         server.last_discovered_at = datetime.now(UTC)
         await self.server_repo.update(server)
 
+        # Drop every workspace override pointing at this install. Mirrors the
+        # auto_enable_workspaces backfill on install: admin install ≈ "all
+        # workspaces on by default", admin delete ≈ "all workspaces off". Stale
+        # enabled-overrides on top of an unauthed server otherwise show as
+        # "needs_setup" in workspace settings and as "Available" in the
+        # workspace catalog page — both misleading. Workspaces that genuinely
+        # want it back must re-enable via the override endpoint after the admin
+        # rekeys the install.
+        if purge_workspace_overrides and server.owner_workspace_id is None:
+            for override in await self.override_repo.list_for_server(server.id):
+                await self.override_repo.delete(
+                    workspace_id=override.workspace_id,
+                    mcp_server_id=server.id,
+                )
+
     async def switch_auth_method(
         self,
         *,
@@ -304,7 +329,8 @@ class MCPCatalogService:
         self._assert_auth_method_supported(connector, new_auth_method)
 
         # Clear out existing creds first (best-effort; mirror delete_install).
-        await self.delete_install(install_id)
+        # Re-key is "same install, different auth" — workspace overrides survive.
+        await self.delete_install(install_id, purge_workspace_overrides=False)
         # delete_install set authed=False; refresh server reference.
         server = await self.server_repo.get(install_id)
         assert server is not None  # re-fetched above

--- a/backend/tests/e2e/test_mcp_auto_enroll.py
+++ b/backend/tests/e2e/test_mcp_auto_enroll.py
@@ -1,0 +1,174 @@
+"""E2E: admin install ``auto_enable_workspaces`` flag + new-workspace inheritance.
+
+Covers:
+
+- Default ``auto_enable_workspaces=True`` upserts an enabled
+  ``WorkspaceMCPOverride`` for every existing workspace in the org → catalog
+  list reports ``workspace_visible=True`` right after install.
+- ``auto_enable_workspaces=False`` leaves overrides untouched →
+  ``workspace_visible=False`` until each workspace explicitly enables.
+- New workspaces created (via ``POST /api/v1/workspaces``) after an install
+  inherit an enabled override iff that install's
+  ``auto_enroll_new_workspaces`` column is True.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.models import MCPCatalogConnector
+from cubebox.repositories.mcp_catalog import MCPCatalogConnectorRepository
+
+pytestmark = pytest.mark.usefixtures("stub_discover_tools")
+
+
+async def _seed_simple_connector(
+    session: AsyncSession,
+    *,
+    slug: str = "github-ae",
+    name: str = "GitHub AE",
+) -> MCPCatalogConnector:
+    repo = MCPCatalogConnectorRepository(session)
+    row = await repo.upsert_by_slug(
+        slug=slug,
+        name=name,
+        description=f"{name} test connector.",
+        provider="GitHub",
+        server_url=f"https://{slug}.example.com/mcp",
+        transport="streamable_http",
+        supported_auth_methods=["static"],
+        default_credential_scope="org",
+        static_form_fields=[{"name": "token", "label": "API token", "secret": True}],
+        static_auth_header_template="Bearer {token}",
+        cred_metadata=None,
+        status="active",
+    )
+    await session.commit()
+    return row
+
+
+@pytest_asyncio.fixture
+async def catalog_one(db_session: AsyncSession) -> AsyncIterator[str]:
+    row = await _seed_simple_connector(db_session)
+    yield row.id
+
+
+async def _org_id_for(client: httpx.AsyncClient, workspace_id: str) -> str:
+    resp = await client.get("/api/v1/workspaces")
+    assert resp.status_code == 200, resp.text
+    for ws in resp.json():
+        if ws["id"] == workspace_id:
+            return ws["org_id"]
+    raise AssertionError(f"workspace {workspace_id} not in listing")
+
+
+async def _catalog_item(client: httpx.AsyncClient, workspace_id: str, slug: str) -> dict[str, Any]:
+    resp = await client.get(f"/api/v1/ws/{workspace_id}/mcp/catalog")
+    assert resp.status_code == 200, resp.text
+    for item in resp.json()["items"]:
+        if item["slug"] == slug:
+            return item
+    raise AssertionError(f"connector {slug} not in catalog response")
+
+
+async def test_install_auto_enable_default_makes_existing_workspace_visible(
+    admin_client: tuple[httpx.AsyncClient, str],
+    catalog_one: str,
+) -> None:
+    client, workspace_id = admin_client
+
+    resp = await client.post(
+        f"/api/v1/admin/mcp/catalog/{catalog_one}/install",
+        json={"auth_method": "static", "credential_plaintext": "ghp_test"},
+    )
+    assert resp.status_code == 201, resp.text
+
+    item = await _catalog_item(client, workspace_id, "github-ae")
+    assert item["org_install_id"] is not None
+    assert item["workspace_visible"] is True
+
+
+async def test_install_auto_enable_false_keeps_existing_workspace_invisible(
+    admin_client: tuple[httpx.AsyncClient, str],
+    catalog_one: str,
+) -> None:
+    client, workspace_id = admin_client
+
+    resp = await client.post(
+        f"/api/v1/admin/mcp/catalog/{catalog_one}/install",
+        json={
+            "auth_method": "static",
+            "credential_plaintext": "ghp_test",
+            "auto_enable_workspaces": False,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+
+    item = await _catalog_item(client, workspace_id, "github-ae")
+    assert item["org_install_id"] is not None
+    assert item["workspace_visible"] is False
+
+
+async def test_new_workspace_inherits_when_auto_enroll_true(
+    admin_client: tuple[httpx.AsyncClient, str],
+    catalog_one: str,
+) -> None:
+    client, original_ws_id = admin_client
+
+    # Install with default auto_enable=true.
+    install_resp = await client.post(
+        f"/api/v1/admin/mcp/catalog/{catalog_one}/install",
+        json={"auth_method": "static", "credential_plaintext": "ghp_test"},
+    )
+    assert install_resp.status_code == 201, install_resp.text
+
+    org_id = await _org_id_for(client, original_ws_id)
+
+    create_resp = await client.post(
+        "/api/v1/workspaces",
+        json={"name": "second-ws", "org_id": org_id},
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    new_ws_id = create_resp.json()["id"]
+
+    item = await _catalog_item(client, new_ws_id, "github-ae")
+    assert item["workspace_visible"] is True, (
+        "new workspace should inherit enabled override when auto_enroll=true"
+    )
+
+
+async def test_new_workspace_does_not_inherit_when_auto_enroll_false(
+    admin_client: tuple[httpx.AsyncClient, str],
+    catalog_one: str,
+) -> None:
+    client, original_ws_id = admin_client
+
+    install_resp = await client.post(
+        f"/api/v1/admin/mcp/catalog/{catalog_one}/install",
+        json={
+            "auth_method": "static",
+            "credential_plaintext": "ghp_test",
+            "auto_enable_workspaces": False,
+        },
+    )
+    assert install_resp.status_code == 201, install_resp.text
+
+    org_id = await _org_id_for(client, original_ws_id)
+
+    create_resp = await client.post(
+        "/api/v1/workspaces",
+        json={"name": "third-ws", "org_id": org_id},
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    new_ws_id = create_resp.json()["id"]
+
+    item = await _catalog_item(client, new_ws_id, "github-ae")
+    assert item["workspace_visible"] is False, (
+        "new workspace must not inherit enabled override when auto_enroll=false"
+    )

--- a/backend/tests/e2e/test_mcp_auto_enroll.py
+++ b/backend/tests/e2e/test_mcp_auto_enroll.py
@@ -172,3 +172,61 @@ async def test_new_workspace_does_not_inherit_when_auto_enroll_false(
     assert item["workspace_visible"] is False, (
         "new workspace must not inherit enabled override when auto_enroll=false"
     )
+
+
+async def test_delete_install_clears_workspace_overrides(
+    admin_client: tuple[httpx.AsyncClient, str],
+    catalog_one: str,
+) -> None:
+    """Admin delete-install mirrors the auto_enable backfill: wipe overrides."""
+    client, workspace_id = admin_client
+
+    install_resp = await client.post(
+        f"/api/v1/admin/mcp/catalog/{catalog_one}/install",
+        json={"auth_method": "static", "credential_plaintext": "ghp_test"},
+    )
+    assert install_resp.status_code == 201, install_resp.text
+    install_id = install_resp.json()["install_id"]
+
+    # Workspace inherits the auto-enable override.
+    item = await _catalog_item(client, workspace_id, "github-ae")
+    assert item["workspace_visible"] is True
+
+    delete_resp = await client.delete(f"/api/v1/admin/mcp/installs/{install_id}")
+    assert delete_resp.status_code == 204, delete_resp.text
+
+    # After delete: install row survives but unauthed, and the override is gone
+    # so workspace surfaces don't show a misleading "needs_setup" entry.
+    item = await _catalog_item(client, workspace_id, "github-ae")
+    assert item["org_install_id"] == install_id
+    assert item["workspace_visible"] is False
+
+
+async def test_switch_auth_method_preserves_workspace_overrides(
+    admin_client: tuple[httpx.AsyncClient, str],
+    catalog_one: str,
+) -> None:
+    """Rekey calls delete_install internally but must keep workspace visibility."""
+    client, workspace_id = admin_client
+
+    install_resp = await client.post(
+        f"/api/v1/admin/mcp/catalog/{catalog_one}/install",
+        json={"auth_method": "static", "credential_plaintext": "ghp_test"},
+    )
+    assert install_resp.status_code == 201, install_resp.text
+    install_id = install_resp.json()["install_id"]
+
+    item = await _catalog_item(client, workspace_id, "github-ae")
+    assert item["workspace_visible"] is True
+
+    patch_resp = await client.patch(
+        f"/api/v1/admin/mcp/installs/{install_id}",
+        json={"auth_method": "static", "credential_plaintext": "ghp_rekeyed"},
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+
+    # Override survives the rekey.
+    item = await _catalog_item(client, workspace_id, "github-ae")
+    assert item["workspace_visible"] is True, (
+        "switch_auth_method must not revoke workspace visibility"
+    )

--- a/backend/tests/e2e/test_mcp_auto_enroll.py
+++ b/backend/tests/e2e/test_mcp_auto_enroll.py
@@ -202,6 +202,45 @@ async def test_delete_install_clears_workspace_overrides(
     assert item["workspace_visible"] is False
 
 
+async def test_deleted_install_does_not_zombie_into_new_workspaces(
+    admin_client: tuple[httpx.AsyncClient, str],
+    catalog_one: str,
+) -> None:
+    """Soft-deleted org install must not seep into workspaces created after delete.
+
+    ``delete_install`` clears authed but keeps ``auto_enroll_new_workspaces=true``
+    on the row (the flag is policy intent, not live state). The bootstrap helper
+    therefore must gate by ``authed=true`` as well; otherwise the deleted
+    install zombies back as a ``needs_setup`` entry in every fresh workspace.
+    """
+    client, original_ws_id = admin_client
+
+    install_resp = await client.post(
+        f"/api/v1/admin/mcp/catalog/{catalog_one}/install",
+        json={"auth_method": "static", "credential_plaintext": "ghp_test"},
+    )
+    assert install_resp.status_code == 201, install_resp.text
+    install_id = install_resp.json()["install_id"]
+
+    # Soft-delete the install.
+    delete_resp = await client.delete(f"/api/v1/admin/mcp/installs/{install_id}")
+    assert delete_resp.status_code == 204, delete_resp.text
+
+    org_id = await _org_id_for(client, original_ws_id)
+
+    create_resp = await client.post(
+        "/api/v1/workspaces",
+        json={"name": "fourth-ws", "org_id": org_id},
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    new_ws_id = create_resp.json()["id"]
+
+    item = await _catalog_item(client, new_ws_id, "github-ae")
+    assert item["workspace_visible"] is False, (
+        "deleted-then-bootstrapped install must not appear as visible"
+    )
+
+
 async def test_switch_auth_method_preserves_workspace_overrides(
     admin_client: tuple[httpx.AsyncClient, str],
     catalog_one: str,

--- a/backend/tests/e2e/test_mcp_catalog_override.py
+++ b/backend/tests/e2e/test_mcp_catalog_override.py
@@ -47,17 +47,20 @@ async def test_workspace_override_enable_then_disable(
 ) -> None:
     client, workspace_id = admin_client
 
+    # auto_enable_workspaces=False so this test can exercise the explicit
+    # enable/disable transition without the install's auto-backfill noise.
     install_resp = await client.post(
         f"/api/v1/admin/mcp/catalog/{catalog_id}/install",
         json={
             "auth_method": "static",
             "credential_plaintext": "ghp_test",
+            "auto_enable_workspaces": False,
         },
     )
     assert install_resp.status_code == 201, install_resp.text
     install_id = install_resp.json()["install_id"]
 
-    # Default: workspace does NOT inherit org-wide install (invisible by default).
+    # With auto_enable=false the workspace starts without an override.
     list_resp = await client.get(f"/api/v1/ws/{workspace_id}/mcp/servers")
     assert list_resp.status_code == 200
     inherited_ids = {item["id"] for item in list_resp.json()["inherited"]}

--- a/backend/tests/e2e/test_mcp_catalog_routes.py
+++ b/backend/tests/e2e/test_mcp_catalog_routes.py
@@ -231,12 +231,13 @@ async def test_admin_install_static_succeeds(
     assert body["authed"] is True
     install_id = body["install_id"]
 
-    # Catalog list: org_install_id is set, but workspace_visible=False
-    # (org installs are invisible by default until explicitly enabled).
+    # Catalog list: org_install_id is set, and workspace_visible=True
+    # because admin installs default to auto_enable_workspaces=True, which
+    # upserts enabled overrides for every existing workspace in the org.
     list_resp = await client.get(f"/api/v1/ws/{workspace_id}/mcp/catalog")
     items = {item["slug"]: item for item in list_resp.json()["items"]}
     assert items["github"]["org_install_id"] == install_id
-    assert items["github"]["workspace_visible"] is False
+    assert items["github"]["workspace_visible"] is True
 
 
 async def test_admin_install_duplicate_returns_409(

--- a/backend/tests/e2e/test_mcp_catalog_runtime.py
+++ b/backend/tests/e2e/test_mcp_catalog_runtime.py
@@ -137,7 +137,9 @@ async def test_org_install_appears_in_workspace_runtime_with_tools_cache(
     assert body["authed"] is True
     install_id = body["install_id"]
 
-    # New semantics: org install is invisible by default. Enable it first.
+    # auto_enable defaults to True so an enabled override is created at install
+    # time — re-PATCHing here is idempotent and asserts the canonical override
+    # surface still works regardless of how the row got there.
     enable_resp = await client.patch(
         f"/api/v1/ws/{workspace_id}/mcp/org-installs/{install_id}/override",
         json={"enabled": True},
@@ -305,7 +307,8 @@ async def test_workspace_override_disable_does_not_affect_other_workspace(
     assert install_resp.status_code == 201, install_resp.text
     install_id = install_resp.json()["install_id"]
 
-    # 3) Enable for both workspaces (org installs are invisible by default).
+    # 3) Both workspaces already have enabled overrides from auto_enable=true
+    #    backfill; PATCH again is idempotent and asserts the canonical surface.
     for ws_id in (workspace_a, workspace_b):
         enable_resp = await client.patch(
             f"/api/v1/ws/{ws_id}/mcp/org-installs/{install_id}/override",

--- a/frontend/packages/core/src/stores/index.ts
+++ b/frontend/packages/core/src/stores/index.ts
@@ -18,4 +18,8 @@ export { useProvidersStore } from './providersStore'
 export { useModelsStore } from './modelsStore'
 export { useOrgModelSettingsStore } from './orgModelSettingsStore'
 export { useWorkspaceSettingsStore, type WorkspaceSettingsStore } from './workspaceSettingsStore'
+export {
+  useWorkspaceMcpCatalogStore,
+  type WorkspaceMcpCatalogStore,
+} from './workspaceMcpCatalogStore'
 export { useMemberStore } from './memberStore'

--- a/frontend/packages/core/src/stores/workspaceMcpCatalogStore.ts
+++ b/frontend/packages/core/src/stores/workspaceMcpCatalogStore.ts
@@ -1,0 +1,86 @@
+/**
+ * Workspace-scoped MCP catalog state.
+ *
+ * Powers the workspace settings MCP panel: lists every active catalog
+ * connector with per-(workspace, user) status (visible / installed-org-wide /
+ * installed-workspace-private / available-to-install) and exposes the four
+ * write actions a workspace member can take:
+ *
+ *   - install a catalog connector workspace-private (POST /ws/.../mcp/catalog/.../install)
+ *   - uninstall a workspace-private install (DELETE /ws/.../mcp/installs/...)
+ *   - enable an org-wide install for this workspace (PATCH .../override enabled=true)
+ *   - disable an org-wide install for this workspace (PATCH .../override enabled=false)
+ *
+ * Distinct from `useMcpStore` (admin-scoped) — both read the same backend
+ * surfaces but the admin store deals in org-wide installs + workspace
+ * override matrices, while this one deals in a single workspace's view.
+ */
+
+import { create } from 'zustand'
+
+import type { ApiClient } from '../api/client'
+import * as api from '../api/mcp'
+import type { MCPCatalogConnector, MCPCatalogInstallWsRequest } from '../types/mcp'
+
+export interface WorkspaceMcpCatalogStore {
+  connectors: MCPCatalogConnector[]
+  loading: boolean
+  error: string | null
+  selectedSlug: string | null
+
+  load: (client: ApiClient, wsId: string) => Promise<void>
+  selectSlug: (slug: string | null) => void
+
+  installForWorkspace: (
+    client: ApiClient,
+    wsId: string,
+    catalogId: string,
+    body: MCPCatalogInstallWsRequest,
+  ) => Promise<void>
+
+  uninstallWorkspacePrivate: (client: ApiClient, wsId: string, installId: string) => Promise<void>
+
+  enableOrgInstall: (client: ApiClient, wsId: string, installId: string) => Promise<void>
+  disableOrgInstall: (client: ApiClient, wsId: string, installId: string) => Promise<void>
+}
+
+export const useWorkspaceMcpCatalogStore = create<WorkspaceMcpCatalogStore>((set, get) => ({
+  connectors: [],
+  loading: false,
+  error: null,
+  selectedSlug: null,
+
+  async load(client, wsId) {
+    set({ loading: true, error: null })
+    try {
+      const items = await api.wsCatalogList(client, wsId)
+      set({ connectors: items, loading: false })
+    } catch (err) {
+      set({ loading: false, error: String(err) })
+    }
+  },
+
+  selectSlug(slug) {
+    set({ selectedSlug: slug })
+  },
+
+  async installForWorkspace(client, wsId, catalogId, body) {
+    await api.wsCatalogInstall(client, wsId, catalogId, body)
+    await get().load(client, wsId)
+  },
+
+  async uninstallWorkspacePrivate(client, wsId, installId) {
+    await api.wsCatalogDeleteInstall(client, wsId, installId)
+    await get().load(client, wsId)
+  },
+
+  async enableOrgInstall(client, wsId, installId) {
+    await api.wsCatalogOverrideOrgInstall(client, wsId, installId, { enabled: true })
+    await get().load(client, wsId)
+  },
+
+  async disableOrgInstall(client, wsId, installId) {
+    await api.wsCatalogOverrideOrgInstall(client, wsId, installId, { enabled: false })
+    await get().load(client, wsId)
+  },
+}))

--- a/frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx
+++ b/frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx
@@ -14,6 +14,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -132,11 +133,18 @@ export function MCPCatalogInstallPanel({
   const [values, setValues] = useState<Record<string, string>>(() =>
     Object.fromEntries(staticFields.map((f) => [f.name, ''])),
   )
+  // auto_enable_workspaces: controls whether the install (a) backfills enabled
+  // overrides for every existing workspace in the org now, and (b) persists
+  // ``auto_enroll_new_workspaces=True`` on the install so future workspaces
+  // inherit by default. Defaults checked — opt-out for connectors the admin
+  // wants to gate workspace-by-workspace.
+  const [autoEnable, setAutoEnable] = useState(true)
 
   useEffect(() => {
     setActiveMethod(defaultAuthMethod(supported))
     setValues(Object.fromEntries(staticFields.map((f) => [f.name, ''])))
     setError(null)
+    setAutoEnable(true)
   }, [connector.id, supported, staticFields])
 
   const allStaticFilled = staticFields.every((f) => (values[f.name] ?? '').trim().length > 0)
@@ -149,6 +157,7 @@ export function MCPCatalogInstallPanel({
     try {
       const result = await installFromCatalog(client, wsId, connector.catalog_id, {
         auth_method: 'oauth',
+        auto_enable_workspaces: autoEnable,
       })
       persistOAuthOrigin()
       const oauth = await startOAuth(client, result.install_id)
@@ -176,6 +185,7 @@ export function MCPCatalogInstallPanel({
       const result = await installFromCatalog(client, wsId, connector.catalog_id, {
         auth_method: 'static',
         credential_plaintext: credentialPlaintext,
+        auto_enable_workspaces: autoEnable,
       })
       onInstalled(result.install_id)
     } catch (err) {
@@ -192,6 +202,7 @@ export function MCPCatalogInstallPanel({
     try {
       const result = await installFromCatalog(client, wsId, connector.catalog_id, {
         auth_method: 'none',
+        auto_enable_workspaces: autoEnable,
       })
       onInstalled(result.install_id)
     } catch (err) {
@@ -331,6 +342,23 @@ export function MCPCatalogInstallPanel({
               </TabsContent>
             )}
           </Tabs>
+
+          <div className="mt-4 flex items-start gap-2 border-t border-border/70 pt-4">
+            <Checkbox
+              id="catalog-install-auto-enable"
+              checked={autoEnable}
+              onCheckedChange={(v: boolean | 'indeterminate') => setAutoEnable(v === true)}
+              disabled={submitting}
+              className="mt-0.5"
+            />
+            <Label
+              htmlFor="catalog-install-auto-enable"
+              className="flex flex-col gap-0.5 text-sm font-normal"
+            >
+              <span>{t('catalogAutoEnableLabel')}</span>
+              <span className="text-xs text-muted-foreground">{t('catalogAutoEnableHelp')}</span>
+            </Label>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx
+++ b/frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx
@@ -240,6 +240,28 @@ export function MCPCatalogInstallPanel({
           <CardTitle>{t('catalogInstallTitle')}</CardTitle>
         </CardHeader>
         <CardContent>
+          <div className="relative mb-4 flex items-start gap-2 rounded-md bg-muted/40 p-3">
+            {/* Wrap the checkbox so shadcn's ``after:absolute`` hit-target
+                (``after:-inset-x-3 after:-inset-y-2``) positions against this
+                wrapper instead of escaping up the DOM and intercepting the
+                Install button below. */}
+            <span className="relative mt-0.5 inline-flex">
+              <Checkbox
+                id="catalog-install-auto-enable"
+                checked={autoEnable}
+                onCheckedChange={(v: boolean | 'indeterminate') => setAutoEnable(v === true)}
+                disabled={submitting}
+              />
+            </span>
+            <Label
+              htmlFor="catalog-install-auto-enable"
+              className="flex flex-col gap-0.5 text-sm font-normal"
+            >
+              <span>{t('catalogAutoEnableLabel')}</span>
+              <span className="text-xs text-muted-foreground">{t('catalogAutoEnableHelp')}</span>
+            </Label>
+          </div>
+
           <Tabs
             value={activeMethod}
             onValueChange={(value: unknown) => setActiveMethod(value as MCPAuthMethod)}
@@ -342,23 +364,6 @@ export function MCPCatalogInstallPanel({
               </TabsContent>
             )}
           </Tabs>
-
-          <div className="mt-4 flex items-start gap-2 border-t border-border/70 pt-4">
-            <Checkbox
-              id="catalog-install-auto-enable"
-              checked={autoEnable}
-              onCheckedChange={(v: boolean | 'indeterminate') => setAutoEnable(v === true)}
-              disabled={submitting}
-              className="mt-0.5"
-            />
-            <Label
-              htmlFor="catalog-install-auto-enable"
-              className="flex flex-col gap-0.5 text-sm font-normal"
-            >
-              <span>{t('catalogAutoEnableLabel')}</span>
-              <span className="text-xs text-muted-foreground">{t('catalogAutoEnableHelp')}</span>
-            </Label>
-          </div>
         </CardContent>
       </Card>
     </div>

--- a/frontend/packages/web/components/workspace-settings/McpPanel.tsx
+++ b/frontend/packages/web/components/workspace-settings/McpPanel.tsx
@@ -11,14 +11,26 @@ import {
   Loader2,
   Plug,
 } from 'lucide-react'
-import { createApiClient, useWorkspaceMcpCatalogStore, wsOAuthStart } from '@cubebox/core'
-import type { MCPAuthMethod, MCPCatalogConnector, MCPCatalogStaticFormField } from '@cubebox/core'
+import {
+  createApiClient,
+  useWorkspaceMcpCatalogStore,
+  useWorkspaceSettingsStore,
+  wsOAuthStart,
+} from '@cubebox/core'
+import type {
+  MCPAuthMethod,
+  MCPCatalogConnector,
+  MCPCatalogStaticFormField,
+  MCPCredentialMode,
+  MCPServerItem,
+} from '@cubebox/core'
 import { useTranslations } from 'next-intl'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { cn } from '@/lib/utils'
 
 const OAUTH_ORIGIN_KEY = 'mcp_oauth_origin'
@@ -355,6 +367,7 @@ function ActionPanel({ connector, wsId }: { connector: MCPCatalogConnector; wsId
   const disableOrgInstall = useWorkspaceMcpCatalogStore((s) => s.disableOrgInstall)
   const uninstallWorkspacePrivate = useWorkspaceMcpCatalogStore((s) => s.uninstallWorkspacePrivate)
   const [busy, setBusy] = useState(false)
+  const [resumeError, setResumeError] = useState<string | null>(null)
 
   const client = useMemo(() => {
     const c = createApiClient('')
@@ -372,31 +385,58 @@ function ActionPanel({ connector, wsId }: { connector: MCPCatalogConnector; wsId
   }
 
   if (connector.user_install_id) {
-    return (
-      <Button
-        variant="destructive"
-        disabled={busy}
-        onClick={() =>
-          withBusy(() =>
-            uninstallWorkspacePrivate(client, wsId, connector.user_install_id as string),
-          )
+    // Workspace-private install. If it's already authed (workspace_visible),
+    // only Uninstall is relevant. If it's unauthed and the catalog supports
+    // OAuth, the user likely hit an interrupted callback — offer Resume so
+    // they don't have to delete+recreate the install to retry the dance.
+    const installId = connector.user_install_id
+    const showResume =
+      !connector.workspace_visible && connector.supported_auth_methods.includes('oauth')
+
+    async function handleResume(): Promise<void> {
+      setResumeError(null)
+      setBusy(true)
+      try {
+        persistOAuthOrigin()
+        const oauth = await wsOAuthStart(client, wsId, installId)
+        if (typeof window !== 'undefined') {
+          window.location.href = oauth.authorize_url
         }
-      >
-        {busy && <Loader2 className="mr-2 size-4 animate-spin" />}
-        {t('actionUninstall')}
-      </Button>
+      } catch (err) {
+        setResumeError((err as Error).message)
+        setBusy(false)
+      }
+    }
+
+    return (
+      <div className="flex flex-col gap-2">
+        {showResume && (
+          <Button disabled={busy} onClick={() => void handleResume()}>
+            {busy && <Loader2 className="mr-2 size-4 animate-spin" />}
+            {t('actionResumeOAuth')}
+          </Button>
+        )}
+        {resumeError && <p className="text-xs text-destructive">{resumeError}</p>}
+        <Button
+          variant={showResume ? 'outline' : 'destructive'}
+          disabled={busy}
+          onClick={() => withBusy(() => uninstallWorkspacePrivate(client, wsId, installId))}
+        >
+          {busy && <Loader2 className="mr-2 size-4 animate-spin" />}
+          {t('actionUninstall')}
+        </Button>
+      </div>
     )
   }
 
   if (connector.org_install_id) {
+    const installId = connector.org_install_id
     if (connector.workspace_visible) {
       return (
         <Button
           variant="outline"
           disabled={busy}
-          onClick={() =>
-            withBusy(() => disableOrgInstall(client, wsId, connector.org_install_id as string))
-          }
+          onClick={() => withBusy(() => disableOrgInstall(client, wsId, installId))}
         >
           {busy && <Loader2 className="mr-2 size-4 animate-spin" />}
           {t('actionDisable')}
@@ -406,9 +446,7 @@ function ActionPanel({ connector, wsId }: { connector: MCPCatalogConnector; wsId
     return (
       <Button
         disabled={busy}
-        onClick={() =>
-          withBusy(() => enableOrgInstall(client, wsId, connector.org_install_id as string))
-        }
+        onClick={() => withBusy(() => enableOrgInstall(client, wsId, installId))}
       >
         {busy && <Loader2 className="mr-2 size-4 animate-spin" />}
         {t('actionEnable')}
@@ -419,7 +457,94 @@ function ActionPanel({ connector, wsId }: { connector: MCPCatalogConnector; wsId
   return <InstallForm connector={connector} wsId={wsId} />
 }
 
-function ConnectorDetail({ connector, wsId }: { connector: MCPCatalogConnector; wsId: string }) {
+const CREDENTIAL_MODES: MCPCredentialMode[] = ['org', 'workspace', 'user']
+
+function CredentialModeSection({ server, wsId }: { server: MCPServerItem; wsId: string }) {
+  const t = useTranslations('mcp.wsPanel')
+  const patchMCPCredentialMode = useWorkspaceSettingsStore((s) => s.patchMCPCredentialMode)
+  const reloadSettings = useWorkspaceSettingsStore((s) => s.loadAll)
+  const [saving, setSaving] = useState(false)
+
+  const client = useMemo(() => {
+    const c = createApiClient('')
+    c.setWorkspaceId(wsId)
+    return c
+  }, [wsId])
+
+  async function handleModeChange(mode: string): Promise<void> {
+    setSaving(true)
+    try {
+      await patchMCPCredentialMode(client, server.server_id, mode as MCPCredentialMode)
+      // Reload so credential_source picks up the new mode's resolved state.
+      await reloadSettings(client)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-border/70 bg-card/40 p-4">
+      <h4 className="mb-3 text-sm font-semibold">{t('credentialModeTitle')}</h4>
+      <RadioGroup
+        value={server.credential_mode}
+        onValueChange={(v) => void handleModeChange(v)}
+        disabled={saving}
+        className="flex flex-col gap-3"
+      >
+        {CREDENTIAL_MODES.map((mode) => (
+          <label
+            key={mode}
+            htmlFor={`cred-mode-${mode}`}
+            className={cn(
+              'flex cursor-pointer items-start gap-3 rounded-lg border p-3',
+              'transition-colors hover:bg-accent/40',
+              server.credential_mode === mode
+                ? 'border-primary/40 bg-primary/5'
+                : 'border-border/70',
+            )}
+          >
+            <RadioGroupItem value={mode} id={`cred-mode-${mode}`} disabled={saving} />
+            <span className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium">{t(`credMode_${mode}_title`)}</span>
+              <span className="text-xs text-muted-foreground">{t(`credMode_${mode}_help`)}</span>
+            </span>
+          </label>
+        ))}
+      </RadioGroup>
+
+      <div className="mt-3 rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+        <CredentialStateDescription server={server} />
+      </div>
+    </div>
+  )
+}
+
+function CredentialStateDescription({ server }: { server: MCPServerItem }) {
+  const t = useTranslations('mcp.wsPanel')
+  switch (server.credential_mode) {
+    case 'org':
+      return <span>{t('credStateOrg')}</span>
+    case 'workspace':
+      if (server.credential_source === 'workspace' && server.credential_shared_by) {
+        return <span>{t('credStateWsActive', { name: server.credential_shared_by })}</span>
+      }
+      return <span>{t('credStateWsNeeded')}</span>
+    case 'user':
+      return <span>{t('credStateUser')}</span>
+    default:
+      return null
+  }
+}
+
+function ConnectorDetail({
+  connector,
+  wsId,
+  orgServerItem,
+}: {
+  connector: MCPCatalogConnector
+  wsId: string
+  orgServerItem: MCPServerItem | null
+}) {
   const t = useTranslations('mcp.wsPanel.catalog')
   const status = statusOf(connector)
 
@@ -461,6 +586,7 @@ function ConnectorDetail({ connector, wsId }: { connector: MCPCatalogConnector; 
       </div>
 
       <ActionPanel connector={connector} wsId={wsId} />
+      {orgServerItem && <CredentialModeSection server={orgServerItem} wsId={wsId} />}
     </div>
   )
 }
@@ -473,6 +599,10 @@ export function McpPanel({ wsId }: McpPanelProps) {
   const selectedSlug = useWorkspaceMcpCatalogStore((s) => s.selectedSlug)
   const selectSlug = useWorkspaceMcpCatalogStore((s) => s.selectSlug)
   const load = useWorkspaceMcpCatalogStore((s) => s.load)
+  // Workspace settings store carries credential_mode/source for each org install,
+  // joined by mcp_server_id; the catalog endpoint doesn't expose those.
+  const settingsMcp = useWorkspaceSettingsStore((s) => s.mcp)
+  const loadSettings = useWorkspaceSettingsStore((s) => s.loadAll)
 
   const [search, setSearch] = useState('')
 
@@ -484,7 +614,8 @@ export function McpPanel({ wsId }: McpPanelProps) {
 
   useEffect(() => {
     void load(client, wsId)
-  }, [client, wsId, load])
+    void loadSettings(client)
+  }, [client, wsId, load, loadSettings])
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase()
@@ -511,6 +642,11 @@ export function McpPanel({ wsId }: McpPanelProps) {
     () => connectors.find((c) => c.slug === selectedSlug) ?? null,
     [connectors, selectedSlug],
   )
+
+  const selectedOrgServerItem = useMemo<MCPServerItem | null>(() => {
+    if (!selected?.org_install_id || !settingsMcp) return null
+    return settingsMcp.org_servers.find((s) => s.server_id === selected.org_install_id) ?? null
+  }, [selected, settingsMcp])
 
   const enabledCount = connectors.filter((c) => c.workspace_visible).length
 
@@ -569,7 +705,11 @@ export function McpPanel({ wsId }: McpPanelProps) {
 
         <section className="flex flex-1 overflow-y-auto">
           {selected ? (
-            <ConnectorDetail connector={selected} wsId={wsId} />
+            <ConnectorDetail
+              connector={selected}
+              wsId={wsId}
+              orgServerItem={selectedOrgServerItem}
+            />
           ) : (
             <div
               className="flex flex-1 items-center justify-center p-8 text-sm

--- a/frontend/packages/web/components/workspace-settings/McpPanel.tsx
+++ b/frontend/packages/web/components/workspace-settings/McpPanel.tsx
@@ -1,393 +1,575 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
-import { CheckCircle2, Globe, Plug, ShieldCheck, Users, User } from 'lucide-react'
-import { createApiClient, useWorkspaceSettingsStore } from '@cubebox/core'
-import type { MCPCredentialMode, MCPServerItem } from '@cubebox/core'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  Globe,
+  Loader2,
+  Plug,
+} from 'lucide-react'
+import { createApiClient, useWorkspaceMcpCatalogStore, wsOAuthStart } from '@cubebox/core'
+import type { MCPAuthMethod, MCPCatalogConnector, MCPCatalogStaticFormField } from '@cubebox/core'
 import { useTranslations } from 'next-intl'
 
 import { Badge } from '@/components/ui/badge'
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
-import { Switch } from '@/components/ui/switch'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
+
+const OAUTH_ORIGIN_KEY = 'mcp_oauth_origin'
 
 interface McpPanelProps {
   wsId: string
 }
 
-function CredentialBadge({ srv }: { srv: MCPServerItem }) {
-  const t = useTranslations('mcp.wsPanel')
-  if (srv.scope !== 'org') return null
+type ConnectorStatus = 'enabled' | 'available' | 'needsSetup' | 'notInstalled'
 
-  switch (srv.credential_source) {
-    case 'org':
-      return (
-        <Badge
-          variant="outline"
-          className="border-blue-500/40 px-1.5 text-[10px] text-blue-600
-            dark:text-blue-400"
-        >
-          <ShieldCheck className="mr-0.5 size-3" />
-          {t('credOrgBadge')}
-        </Badge>
-      )
-    case 'workspace':
-      return (
-        <Badge
-          variant="outline"
-          className="border-blue-500/40 px-1.5 text-[10px] text-blue-600
-            dark:text-blue-400"
-        >
-          <Users className="mr-0.5 size-3" />
-          {srv.credential_shared_by
-            ? t('credSharedByBadge', { name: srv.credential_shared_by })
-            : t('credWorkspaceBadge')}
-        </Badge>
-      )
-    case 'user':
-      return (
-        <Badge
-          variant="outline"
-          className="border-emerald-500/40 px-1.5 text-[10px] text-emerald-600
-            dark:text-emerald-400"
-        >
-          <User className="mr-0.5 size-3" />
-          {t('credUserActiveBadge')}
-        </Badge>
-      )
-    case 'needs_setup':
-      return (
-        <Badge
-          variant="outline"
-          className="border-red-500/40 px-1.5 text-[10px] text-red-600
-            dark:text-red-400"
-        >
-          {t('credNeedsSetupBadge')}
-        </Badge>
-      )
-    default:
-      return null
+function statusOf(c: MCPCatalogConnector): ConnectorStatus {
+  if (c.user_install_id) return c.workspace_visible ? 'enabled' : 'needsSetup'
+  if (c.org_install_id) return c.workspace_visible ? 'enabled' : 'available'
+  return 'notInstalled'
+}
+
+function defaultAuthMethod(supported: MCPAuthMethod[]): MCPAuthMethod {
+  if (supported.includes('oauth')) return 'oauth'
+  if (supported.includes('static')) return 'static'
+  return 'none'
+}
+
+function persistOAuthOrigin(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(
+      OAUTH_ORIGIN_KEY,
+      window.location.pathname + window.location.search,
+    )
+  } catch {
+    // sessionStorage may be unavailable; non-fatal.
   }
 }
 
-function McpItemCard({
-  srv,
+function StatusChip({ status }: { status: ConnectorStatus }) {
+  const t = useTranslations('mcp.wsPanel.catalog')
+
+  if (status === 'enabled') {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10
+          px-1.5 py-0.5 text-[10px] font-medium text-emerald-600
+          dark:text-emerald-400"
+      >
+        <CheckCircle2 className="size-3" />
+        {t('statusEnabled')}
+      </span>
+    )
+  }
+  if (status === 'available') {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-muted
+          px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+      >
+        <Plug className="size-3" />
+        {t('statusAvailable')}
+      </span>
+    )
+  }
+  if (status === 'needsSetup') {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-amber-500/10
+          px-1.5 py-0.5 text-[10px] font-medium text-amber-600
+          dark:text-amber-400"
+      >
+        <AlertTriangle className="size-3" />
+        {t('statusNeedsSetup')}
+      </span>
+    )
+  }
+  return null
+}
+
+function ConnectorCard({
+  connector,
   active,
-  toggling,
   onClick,
-  onToggle,
 }: {
-  srv: MCPServerItem
+  connector: MCPCatalogConnector
   active: boolean
-  toggling: boolean
   onClick: () => void
-  onToggle: (enabled: boolean) => void
 }) {
-  const t = useTranslations('mcp.wsPanel')
-  const SourceIcon = srv.scope === 'workspace' ? Plug : Globe
+  const status = statusOf(connector)
+  const ScopeIcon = connector.org_install_id ? Globe : Plug
   return (
     <button
       type="button"
       onClick={onClick}
       aria-current={active ? 'true' : undefined}
+      data-testid={`ws-catalog-card-${connector.slug}`}
       className={cn(
-        'group flex w-full flex-col gap-1.5 rounded-lg border p-3',
-        'text-left transition-all',
+        'group flex w-full flex-col gap-1.5 rounded-lg border p-3 text-left transition-all',
         active
           ? 'border-primary/40 bg-primary/5 shadow-sm'
           : 'border-border/70 bg-card/40 hover:border-border hover:bg-accent/40',
       )}
     >
       <div className="flex items-center gap-2">
-        <SourceIcon
+        <ScopeIcon
           className={cn(
             'size-3.5 shrink-0',
-            srv.scope === 'workspace' ? 'text-muted-foreground' : 'text-primary',
+            connector.org_install_id ? 'text-primary' : 'text-muted-foreground',
           )}
         />
-        <span className="truncate text-sm font-semibold">{srv.name}</span>
-        {srv.enabled && (
-          <span
-            className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10
-              px-1.5 py-0.5 text-[10px] font-medium text-emerald-600
-              dark:text-emerald-400"
-          >
-            <CheckCircle2 className="size-3" />
-            {t('onBadge')}
-          </span>
-        )}
-        <Switch
-          checked={srv.enabled}
-          disabled={srv.scope === 'workspace' || toggling}
-          onCheckedChange={onToggle}
-          onClick={(e) => e.stopPropagation()}
-          className="ml-auto shrink-0 scale-75"
-        />
+        <span className="truncate text-sm font-semibold">{connector.name}</span>
+        <span className="ml-auto shrink-0">
+          <StatusChip status={status} />
+        </span>
       </div>
-      <p className="line-clamp-1 truncate text-xs text-muted-foreground">{srv.server_url}</p>
+      {connector.provider && (
+        <p className="truncate text-xs text-muted-foreground">{connector.provider}</p>
+      )}
       <div className="flex flex-wrap items-center gap-1 pt-0.5">
         <Badge variant="outline" className="px-1.5 text-[10px]">
-          {srv.transport}
+          {connector.transport === 'streamable_http' ? 'HTTP' : 'SSE'}
         </Badge>
-        <Badge variant="outline" className="px-1.5 text-[10px]">
-          {srv.scope === 'workspace' ? t('workspaceLabel') : t('orgLabel')}
-        </Badge>
-        <CredentialBadge srv={srv} />
+        {connector.supported_auth_methods.map((m) => (
+          <Badge key={m} variant="outline" className="px-1.5 text-[10px]">
+            {m}
+          </Badge>
+        ))}
       </div>
     </button>
   )
 }
 
-const CREDENTIAL_MODES: MCPCredentialMode[] = ['org', 'workspace', 'user']
+function StaticFieldRow({
+  field,
+  value,
+  onChange,
+}: {
+  field: MCPCatalogStaticFormField
+  value: string
+  onChange: (next: string) => void
+}) {
+  const t = useTranslations('mcpCatalog')
+  const [reveal, setReveal] = useState(false)
+  const inputType = field.secret && !reveal ? 'password' : 'text'
 
-function CredentialModeSection({ srv, wsId }: { srv: MCPServerItem; wsId: string }) {
-  const t = useTranslations('mcp.wsPanel')
-  const { patchMCPCredentialMode } = useWorkspaceSettingsStore()
-  const [saving, setSaving] = useState(false)
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={`ws-catalog-static-${field.name}`}>
+        {field.label}
+        <span className="ml-0.5 text-destructive">*</span>
+      </Label>
+      <div className="flex gap-2">
+        <Input
+          id={`ws-catalog-static-${field.name}`}
+          type={inputType}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder}
+          autoComplete={field.secret ? 'new-password' : 'off'}
+          required
+        />
+        {field.secret && (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            onClick={() => setReveal((r) => !r)}
+            aria-label={reveal ? t('hideSecret') : t('showSecret')}
+          >
+            {reveal ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+          </Button>
+        )}
+      </div>
+      {field.helper_url && (
+        <a
+          href={field.helper_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          <ExternalLink className="size-3" />
+          {t('helperLearnMore')}
+        </a>
+      )}
+    </div>
+  )
+}
 
-  const client = useCallback(() => {
+function InstallForm({ connector, wsId }: { connector: MCPCatalogConnector; wsId: string }) {
+  const t = useTranslations('mcp.wsPanel.catalog')
+  const tc = useTranslations('mcpCatalog')
+  const installForWorkspace = useWorkspaceMcpCatalogStore((s) => s.installForWorkspace)
+
+  const supported = useMemo(() => connector.supported_auth_methods, [connector])
+  const staticFields = useMemo(() => connector.static_form_fields ?? [], [connector])
+
+  const [authMethod, setAuthMethod] = useState<MCPAuthMethod>(() => defaultAuthMethod(supported))
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(staticFields.map((f) => [f.name, ''])),
+  )
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setAuthMethod(defaultAuthMethod(supported))
+    setValues(Object.fromEntries(staticFields.map((f) => [f.name, ''])))
+    setError(null)
+  }, [connector.id, supported, staticFields])
+
+  const allStaticFilled = staticFields.every((f) => (values[f.name] ?? '').trim().length > 0)
+  const multiField = staticFields.length > 1
+
+  const client = useMemo(() => {
     const c = createApiClient('')
     c.setWorkspaceId(wsId)
     return c
   }, [wsId])
 
-  if (srv.scope !== 'org') return null
-
-  async function handleModeChange(mode: string): Promise<void> {
-    setSaving(true)
+  async function handleStatic(): Promise<void> {
+    if (multiField) {
+      setError(tc('multiFieldUnsupported'))
+      return
+    }
+    if (!allStaticFilled) return
+    setSubmitting(true)
+    setError(null)
     try {
-      await patchMCPCredentialMode(client(), srv.server_id, mode as MCPCredentialMode)
+      const fieldName = staticFields[0]?.name ?? 'token'
+      await installForWorkspace(client, wsId, connector.id, {
+        auth_method: 'static',
+        credential_plaintext: (values[fieldName] ?? '').trim(),
+      })
+    } catch (err) {
+      setError((err as Error).message)
     } finally {
-      setSaving(false)
+      setSubmitting(false)
+    }
+  }
+
+  async function handleOAuth(): Promise<void> {
+    setSubmitting(true)
+    setError(null)
+    try {
+      await installForWorkspace(client, wsId, connector.id, { auth_method: 'oauth' })
+      // The fresh state may already include the new user_install_id; fetch the
+      // fresh row to get the install id for the OAuth start call.
+      const after = useWorkspaceMcpCatalogStore
+        .getState()
+        .connectors.find((c) => c.id === connector.id)
+      const installId = after?.user_install_id
+      if (!installId) {
+        throw new Error('install id not found after install')
+      }
+      persistOAuthOrigin()
+      const oauth = await wsOAuthStart(client, wsId, installId)
+      if (typeof window !== 'undefined') {
+        window.location.href = oauth.authorize_url
+      }
+    } catch (err) {
+      setError((err as Error).message)
+      setSubmitting(false)
+    }
+  }
+
+  async function handleNone(): Promise<void> {
+    setSubmitting(true)
+    setError(null)
+    try {
+      await installForWorkspace(client, wsId, connector.id, { auth_method: 'none' })
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setSubmitting(false)
     }
   }
 
   return (
-    <div className="rounded-lg border border-border/70 bg-card/40 p-4">
-      <h4 className="mb-3 text-sm font-semibold">{t('credentialModeTitle')}</h4>
-      <RadioGroup
-        value={srv.credential_mode}
-        onValueChange={(v) => void handleModeChange(v)}
-        disabled={saving}
-        className="flex flex-col gap-3"
-      >
-        {CREDENTIAL_MODES.map((mode) => (
-          <label
-            key={mode}
-            htmlFor={`cred-mode-${mode}`}
-            className={cn(
-              'flex cursor-pointer items-start gap-3 rounded-lg border p-3',
-              'transition-colors hover:bg-accent/40',
-              srv.credential_mode === mode ? 'border-primary/40 bg-primary/5' : 'border-border/70',
-            )}
-          >
-            <RadioGroupItem value={mode} id={`cred-mode-${mode}`} disabled={saving} />
-            <span className="flex flex-col gap-0.5">
-              <span className="text-sm font-medium">{t(`credMode_${mode}_title`)}</span>
-              <span className="text-xs text-muted-foreground">{t(`credMode_${mode}_help`)}</span>
-            </span>
-          </label>
-        ))}
-      </RadioGroup>
+    <div className="flex flex-col gap-4 rounded-lg border border-border/70 bg-card/40 p-4">
+      <div className="flex flex-col gap-1">
+        <h4 className="text-sm font-semibold">{t('installTitle')}</h4>
+        <p className="text-xs text-muted-foreground">{tc('workspaceOAuthNotice')}</p>
+      </div>
 
-      <div className="mt-3 rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-        <CredentialStateDescription srv={srv} />
+      {supported.length > 1 && (
+        <div className="flex gap-2">
+          {supported.map((m) => (
+            <Button
+              key={m}
+              type="button"
+              size="sm"
+              variant={authMethod === m ? 'default' : 'outline'}
+              onClick={() => setAuthMethod(m)}
+            >
+              {tc(`auth${m.charAt(0).toUpperCase() + m.slice(1)}` as 'authOAuth')}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {authMethod === 'static' && staticFields.length > 0 && (
+        <div className="flex flex-col gap-3">
+          {staticFields.map((f) => (
+            <StaticFieldRow
+              key={f.name}
+              field={f}
+              value={values[f.name] ?? ''}
+              onChange={(next) => setValues((v) => ({ ...v, [f.name]: next }))}
+            />
+          ))}
+        </div>
+      )}
+
+      {authMethod === 'none' && <p className="text-xs text-muted-foreground">{tc('noneNotice')}</p>}
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          onClick={() => {
+            if (authMethod === 'oauth') void handleOAuth()
+            else if (authMethod === 'static') void handleStatic()
+            else void handleNone()
+          }}
+          disabled={submitting || (authMethod === 'static' && (!allStaticFilled || multiField))}
+        >
+          {submitting && <Loader2 className="mr-2 size-4 animate-spin" />}
+          {authMethod === 'oauth' ? tc('connectWithOAuth') : tc('installButton')}
+        </Button>
       </div>
     </div>
   )
 }
 
-function CredentialStateDescription({ srv }: { srv: MCPServerItem }) {
-  const t = useTranslations('mcp.wsPanel')
+function ActionPanel({ connector, wsId }: { connector: MCPCatalogConnector; wsId: string }) {
+  const t = useTranslations('mcp.wsPanel.catalog')
+  const enableOrgInstall = useWorkspaceMcpCatalogStore((s) => s.enableOrgInstall)
+  const disableOrgInstall = useWorkspaceMcpCatalogStore((s) => s.disableOrgInstall)
+  const uninstallWorkspacePrivate = useWorkspaceMcpCatalogStore((s) => s.uninstallWorkspacePrivate)
+  const [busy, setBusy] = useState(false)
 
-  switch (srv.credential_mode) {
-    case 'org':
-      return <span>{t('credStateOrg')}</span>
-    case 'workspace':
-      if (srv.credential_source === 'workspace' && srv.credential_shared_by) {
-        return <span>{t('credStateWsActive', { name: srv.credential_shared_by })}</span>
-      }
-      return <span>{t('credStateWsNeeded')}</span>
-    case 'user':
-      return <span>{t('credStateUser')}</span>
-    default:
-      return null
+  const client = useMemo(() => {
+    const c = createApiClient('')
+    c.setWorkspaceId(wsId)
+    return c
+  }, [wsId])
+
+  async function withBusy(fn: () => Promise<void>): Promise<void> {
+    setBusy(true)
+    try {
+      await fn()
+    } finally {
+      setBusy(false)
+    }
   }
+
+  if (connector.user_install_id) {
+    return (
+      <Button
+        variant="destructive"
+        disabled={busy}
+        onClick={() =>
+          withBusy(() =>
+            uninstallWorkspacePrivate(client, wsId, connector.user_install_id as string),
+          )
+        }
+      >
+        {busy && <Loader2 className="mr-2 size-4 animate-spin" />}
+        {t('actionUninstall')}
+      </Button>
+    )
+  }
+
+  if (connector.org_install_id) {
+    if (connector.workspace_visible) {
+      return (
+        <Button
+          variant="outline"
+          disabled={busy}
+          onClick={() =>
+            withBusy(() => disableOrgInstall(client, wsId, connector.org_install_id as string))
+          }
+        >
+          {busy && <Loader2 className="mr-2 size-4 animate-spin" />}
+          {t('actionDisable')}
+        </Button>
+      )
+    }
+    return (
+      <Button
+        disabled={busy}
+        onClick={() =>
+          withBusy(() => enableOrgInstall(client, wsId, connector.org_install_id as string))
+        }
+      >
+        {busy && <Loader2 className="mr-2 size-4 animate-spin" />}
+        {t('actionEnable')}
+      </Button>
+    )
+  }
+
+  return <InstallForm connector={connector} wsId={wsId} />
+}
+
+function ConnectorDetail({ connector, wsId }: { connector: MCPCatalogConnector; wsId: string }) {
+  const t = useTranslations('mcp.wsPanel.catalog')
+  const status = statusOf(connector)
+
+  return (
+    <div className="flex w-full flex-col gap-4 p-6">
+      <header className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-xl font-semibold tracking-tight">{connector.name}</h3>
+          <StatusChip status={status} />
+        </div>
+        {connector.description && (
+          <p className="text-sm text-muted-foreground">{connector.description}</p>
+        )}
+      </header>
+
+      <div className="rounded-lg border border-border/70 bg-card/40 p-4">
+        <dl className="grid grid-cols-[140px_1fr] gap-y-2 text-sm">
+          <dt className="text-muted-foreground">{t('provider')}</dt>
+          <dd>{connector.provider || '-'}</dd>
+          <dt className="text-muted-foreground">{t('serverUrl')}</dt>
+          <dd className="break-all font-mono text-xs">{connector.server_url}</dd>
+          <dt className="text-muted-foreground">{t('transport')}</dt>
+          <dd>{connector.transport}</dd>
+          <dt className="text-muted-foreground">{t('authMethods')}</dt>
+          <dd>{connector.supported_auth_methods.join(', ')}</dd>
+          {connector.org_install_id && (
+            <>
+              <dt className="text-muted-foreground">{t('scope')}</dt>
+              <dd>{t('scopeOrgWide')}</dd>
+            </>
+          )}
+          {connector.user_install_id && (
+            <>
+              <dt className="text-muted-foreground">{t('scope')}</dt>
+              <dd>{t('scopeWorkspacePrivate')}</dd>
+            </>
+          )}
+        </dl>
+      </div>
+
+      <ActionPanel connector={connector} wsId={wsId} />
+    </div>
+  )
 }
 
 export function McpPanel({ wsId }: McpPanelProps) {
-  const t = useTranslations('mcp.wsPanel')
-  const { mcp, loading, loadAll, toggleMCP } = useWorkspaceSettingsStore()
-  const [selected, setSelected] = useState<MCPServerItem | null>(null)
-  const [toggling, setToggling] = useState<string | null>(null)
+  const t = useTranslations('mcp.wsPanel.catalog')
+  const connectors = useWorkspaceMcpCatalogStore((s) => s.connectors)
+  const loading = useWorkspaceMcpCatalogStore((s) => s.loading)
+  const error = useWorkspaceMcpCatalogStore((s) => s.error)
+  const selectedSlug = useWorkspaceMcpCatalogStore((s) => s.selectedSlug)
+  const selectSlug = useWorkspaceMcpCatalogStore((s) => s.selectSlug)
+  const load = useWorkspaceMcpCatalogStore((s) => s.load)
 
-  const client = useCallback(() => {
+  const [search, setSearch] = useState('')
+
+  const client = useMemo(() => {
     const c = createApiClient('')
     c.setWorkspaceId(wsId)
     return c
   }, [wsId])
 
   useEffect(() => {
-    if (!mcp) loadAll(client())
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wsId])
+    void load(client, wsId)
+  }, [client, wsId, load])
 
-  // Keep selected item in sync with store updates
-  useEffect(() => {
-    if (!selected || !mcp) return
-    const all = [...(mcp.org_servers ?? []), ...(mcp.workspace_servers ?? [])]
-    const fresh = all.find((s) => s.server_id === selected.server_id)
-    if (fresh) setSelected(fresh)
-  }, [mcp, selected])
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return connectors
+      .filter((c) => {
+        if (!q) return true
+        return `${c.name} ${c.provider} ${c.description}`.toLowerCase().includes(q)
+      })
+      .sort((a, b) => {
+        const order: Record<ConnectorStatus, number> = {
+          enabled: 0,
+          needsSetup: 1,
+          available: 2,
+          notInstalled: 3,
+        }
+        const oa = order[statusOf(a)]
+        const ob = order[statusOf(b)]
+        if (oa !== ob) return oa - ob
+        return a.name.localeCompare(b.name)
+      })
+  }, [connectors, search])
 
-  const orgServers = mcp?.org_servers ?? []
-  const workspaceServers = mcp?.workspace_servers ?? []
-  const allServers = [...orgServers, ...workspaceServers]
-  const enabledCount = allServers.filter((s) => s.enabled).length
+  const selected = useMemo(
+    () => connectors.find((c) => c.slug === selectedSlug) ?? null,
+    [connectors, selectedSlug],
+  )
 
-  async function handleToggle(srv: MCPServerItem, enabled: boolean): Promise<void> {
-    if (srv.scope === 'workspace') return
-    setToggling(srv.server_id)
-    try {
-      await toggleMCP(client(), srv.server_id, enabled)
-    } finally {
-      setToggling(null)
-    }
-  }
+  const enabledCount = connectors.filter((c) => c.workspace_visible).length
 
   return (
     <div className="flex h-full flex-1 flex-col overflow-hidden">
       <header
-        className="flex items-center justify-between gap-2 border-b
-          border-border/70 px-6 py-4"
+        className="flex items-center justify-between gap-2 border-b border-border/70
+          px-6 py-4"
       >
         <div>
           <h2 className="text-lg font-semibold tracking-tight">{t('title')}</h2>
           <p className="mt-0.5 text-xs text-muted-foreground">
-            {t('summary', { enabled: enabledCount, total: allServers.length })}
+            {t('summary', { enabled: enabledCount, total: connectors.length })}
           </p>
         </div>
+        <Input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={t('searchPlaceholder')}
+          className="max-w-xs"
+        />
       </header>
 
       <div className="flex flex-1 overflow-hidden">
         <aside
           aria-label={t('listAria')}
-          className="w-[320px] shrink-0 overflow-y-auto border-r
+          className="w-[340px] shrink-0 overflow-y-auto border-r
             border-border/70 bg-card/20"
         >
-          {loading && !mcp ? (
+          {loading && connectors.length === 0 ? (
             <p className="px-4 py-6 text-center text-xs text-muted-foreground">{t('loading')}</p>
-          ) : allServers.length === 0 ? (
+          ) : error ? (
+            <p className="px-4 py-6 text-center text-xs text-destructive">{error}</p>
+          ) : filtered.length === 0 ? (
             <div
-              className="flex h-full flex-col items-center justify-center
-                gap-1 px-6 text-center"
+              className="flex h-full flex-col items-center justify-center gap-1
+                px-6 text-center"
             >
               <p className="text-sm text-muted-foreground">{t('empty')}</p>
               <p className="text-xs text-muted-foreground/70">{t('emptyHint')}</p>
             </div>
           ) : (
-            <div className="flex flex-col gap-3 p-3">
-              {orgServers.length > 0 && (
-                <section className="flex flex-col gap-1.5">
-                  <p
-                    className="px-1 text-[10px] font-medium uppercase
-                      tracking-widest text-muted-foreground/60"
-                  >
-                    {t('orgWide')}
-                  </p>
-                  <ul className="flex flex-col gap-1.5">
-                    {orgServers.map((srv) => (
-                      <li key={srv.server_id}>
-                        <McpItemCard
-                          srv={srv}
-                          active={selected?.server_id === srv.server_id}
-                          toggling={toggling === srv.server_id}
-                          onClick={() => setSelected(srv)}
-                          onToggle={(v) => void handleToggle(srv, v)}
-                        />
-                      </li>
-                    ))}
-                  </ul>
-                </section>
-              )}
-              {workspaceServers.length > 0 && (
-                <section className="flex flex-col gap-1.5">
-                  <p
-                    className="px-1 text-[10px] font-medium uppercase
-                      tracking-widest text-muted-foreground/60"
-                  >
-                    {t('workspacePrivate')}
-                  </p>
-                  <ul className="flex flex-col gap-1.5">
-                    {workspaceServers.map((srv) => (
-                      <li key={srv.server_id}>
-                        <McpItemCard
-                          srv={srv}
-                          active={selected?.server_id === srv.server_id}
-                          toggling={toggling === srv.server_id}
-                          onClick={() => setSelected(srv)}
-                          onToggle={(v) => void handleToggle(srv, v)}
-                        />
-                      </li>
-                    ))}
-                  </ul>
-                </section>
-              )}
+            <div className="flex flex-col gap-1.5 p-3">
+              {filtered.map((c) => (
+                <ConnectorCard
+                  key={c.slug}
+                  connector={c}
+                  active={c.slug === selectedSlug}
+                  onClick={() => selectSlug(c.slug)}
+                />
+              ))}
             </div>
           )}
         </aside>
 
         <section className="flex flex-1 overflow-y-auto">
           {selected ? (
-            <div className="flex w-full flex-col gap-4 p-6">
-              <header className="flex flex-col gap-2">
-                <div className="flex flex-wrap items-center gap-2">
-                  <h3 className="text-xl font-semibold tracking-tight">{selected.name}</h3>
-                  <Badge variant="outline">{selected.transport}</Badge>
-                  <Badge variant={selected.scope === 'workspace' ? 'secondary' : 'default'}>
-                    {selected.scope === 'workspace' ? t('workspaceLabel') : t('orgLabel')}
-                  </Badge>
-                  <Badge
-                    variant="outline"
-                    className={cn(
-                      selected.enabled
-                        ? 'border-emerald-500/40 text-emerald-600'
-                        : 'text-muted-foreground',
-                    )}
-                  >
-                    {selected.enabled ? t('enabledLabel') : t('disabledLabel')}
-                  </Badge>
-                </div>
-              </header>
-
-              <div className="rounded-lg border border-border/70 bg-card/40 p-4">
-                <dl className="grid grid-cols-[140px_1fr] gap-y-2 text-sm">
-                  <dt className="text-muted-foreground">{t('serverUrl')}</dt>
-                  <dd className="break-all font-mono text-xs">{selected.server_url}</dd>
-                  <dt className="text-muted-foreground">{t('transport')}</dt>
-                  <dd>{selected.transport}</dd>
-                  <dt className="text-muted-foreground">{t('scope')}</dt>
-                  <dd>{selected.scope}</dd>
-                  <dt className="text-muted-foreground">{t('enabled')}</dt>
-                  <dd>{selected.enabled ? t('yes') : t('no')}</dd>
-                  {selected.scope === 'org' && (
-                    <>
-                      <dt className="text-muted-foreground">{t('credentialModeLabel')}</dt>
-                      <dd>{selected.credential_mode}</dd>
-                      <dt className="text-muted-foreground">{t('credentialSourceLabel')}</dt>
-                      <dd>
-                        {selected.credential_source ?? '-'}
-                        {selected.credential_source === 'workspace' &&
-                          selected.credential_shared_by &&
-                          ` (${selected.credential_shared_by})`}
-                      </dd>
-                    </>
-                  )}
-                </dl>
-              </div>
-
-              {selected.scope === 'org' && <CredentialModeSection srv={selected} wsId={wsId} />}
-            </div>
+            <ConnectorDetail connector={selected} wsId={wsId} />
           ) : (
             <div
               className="flex flex-1 items-center justify-center p-8 text-sm

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -575,7 +575,31 @@
       "credStateOrg": "This connector uses the organization-level credential.",
       "credStateWsActive": "Active — shared by {name}",
       "credStateWsNeeded": "A workspace admin needs to provide a credential.",
-      "credStateUser": "Each member authenticates individually."
+      "credStateUser": "Each member authenticates individually.",
+      "catalog": {
+        "title": "MCP Connectors",
+        "summary": "{enabled} of {total} enabled in this workspace",
+        "searchPlaceholder": "Search connectors…",
+        "loading": "Loading…",
+        "empty": "No connectors match",
+        "emptyHint": "Try a different search term.",
+        "listAria": "MCP connector list",
+        "selectConnector": "Select a connector to view details",
+        "statusEnabled": "Enabled",
+        "statusAvailable": "Available",
+        "statusNeedsSetup": "Needs setup",
+        "provider": "Provider",
+        "serverUrl": "Server URL",
+        "transport": "Transport",
+        "authMethods": "Auth methods",
+        "scope": "Scope",
+        "scopeOrgWide": "Org-wide install",
+        "scopeWorkspacePrivate": "Workspace-private install",
+        "installTitle": "Install for this workspace",
+        "actionEnable": "Enable for workspace",
+        "actionDisable": "Disable for workspace",
+        "actionUninstall": "Uninstall"
+      }
     },
     "wsPage": {
       "title": "Workspace MCP connectors",
@@ -1026,6 +1050,8 @@
     "catalogNoneNotice": "This connector does not require credentials.",
     "catalogStaticTokenLabel": "API token",
     "catalogMultiFieldUnsupported": "Multi-field credential forms aren't supported yet for this connector.",
+    "catalogAutoEnableLabel": "Enable for every workspace",
+    "catalogAutoEnableHelp": "Existing workspaces see this connector immediately, and any new workspace created later inherits it too. Uncheck to let each workspace enable manually.",
 
     "customCreateTitle": "Add custom MCP server",
     "customCreateSubtitle": "Register a custom MCP server for the entire organization. You can enable it per workspace afterwards.",

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -598,7 +598,8 @@
         "installTitle": "Install for this workspace",
         "actionEnable": "Enable for workspace",
         "actionDisable": "Disable for workspace",
-        "actionUninstall": "Uninstall"
+        "actionUninstall": "Uninstall",
+        "actionResumeOAuth": "Resume setup"
       }
     },
     "wsPage": {

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -598,7 +598,8 @@
         "installTitle": "为本工作区安装",
         "actionEnable": "在本工作区启用",
         "actionDisable": "在本工作区停用",
-        "actionUninstall": "卸载"
+        "actionUninstall": "卸载",
+        "actionResumeOAuth": "继续设置"
       }
     },
     "wsPage": {

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -575,7 +575,31 @@
       "credStateOrg": "此 connector 使用组织级凭证。",
       "credStateWsActive": "已激活 — 由 {name} 共享",
       "credStateWsNeeded": "需要工作区管理员提供凭证。",
-      "credStateUser": "每位成员各自认证。"
+      "credStateUser": "每位成员各自认证。",
+      "catalog": {
+        "title": "MCP Connectors",
+        "summary": "本工作区已启用 {enabled} / {total}",
+        "searchPlaceholder": "搜索 connector…",
+        "loading": "加载中…",
+        "empty": "未匹配到 connector",
+        "emptyHint": "尝试其他关键词。",
+        "listAria": "MCP connector 列表",
+        "selectConnector": "选择一个 connector 查看详情",
+        "statusEnabled": "已启用",
+        "statusAvailable": "可启用",
+        "statusNeedsSetup": "待配置",
+        "provider": "提供方",
+        "serverUrl": "服务器 URL",
+        "transport": "传输协议",
+        "authMethods": "认证方式",
+        "scope": "范围",
+        "scopeOrgWide": "组织级安装",
+        "scopeWorkspacePrivate": "工作区私有安装",
+        "installTitle": "为本工作区安装",
+        "actionEnable": "在本工作区启用",
+        "actionDisable": "在本工作区停用",
+        "actionUninstall": "卸载"
+      }
     },
     "wsPage": {
       "title": "工作区 MCP connectors",
@@ -1026,6 +1050,8 @@
     "catalogNoneNotice": "该连接器无需凭证。",
     "catalogStaticTokenLabel": "API Token",
     "catalogMultiFieldUnsupported": "当前连接器暂不支持多字段凭证表单。",
+    "catalogAutoEnableLabel": "对所有工作区启用",
+    "catalogAutoEnableHelp": "勾选后，组织内现有工作区立即可见此连接器，之后新建的工作区也会默认继承。取消勾选则每个工作区需手动启用。",
 
     "customCreateTitle": "添加自定义 MCP 服务器",
     "customCreateSubtitle": "为整个组织登记自定义 MCP 服务器，之后可以按工作区开启。",


### PR DESCRIPTION
## Summary

Two related gaps fixed:

1. **Admin install of an org-wide MCP connector now reaches every workspace by default.** The pre-existing `auto_enable_workspaces` body field on `POST /admin/mcp/catalog/{id}/install` had a TODO and was silently discarded (`mcp_catalog.py:193-197`). It now upserts an enabled `WorkspaceMCPOverride` for every existing workspace in the org, and a new `mcp_servers.auto_enroll_new_workspaces` column carries the policy forward so workspaces created later inherit too. Admin install form gains a checkbox (default checked) to opt out.

2. **Workspace settings MCP panel now shows the full catalog, not just installed servers.** It mirrors the admin page structure: every active catalog connector is listed with one of four states (`enabled` / `available` / `needs setup` / `not installed`) and the appropriate primary action — Enable/Disable for org-wide installs, inline Install (auth-method picker + token field + OAuth handoff) for catalog connectors the workspace hasn't installed yet, Uninstall for workspace-private ones. Backed by a new `workspaceMcpCatalogStore` over the existing `/ws/{ws}/mcp/catalog`, `/catalog/{id}/install`, `/installs/{id}`, `/org-installs/{id}/override` endpoints.

Symmetric delete: `delete_install` purges every override pointing at the removed install (admin off ≈ all off), so the workspace UI doesn't show stale "needs_setup" entries on top of an unauthed server. `switch_auth_method` opts out via `purge_workspace_overrides=False` so rekey doesn't revoke visibility.

## Commits
- `03795ab5` Backend: `auto_enable_workspaces` wiring, `auto_enroll_new_workspaces` column + migration, `enroll_workspace_in_org_wide_mcp` from `on_after_register` (both modes) and `POST /workspaces`. 4 new E2E + 3 stale-assertion fixes.
- `362e5049` Frontend: new workspace MCP catalog panel, admin install checkbox, en/zh i18n.
- `1a3a17ad` UX fix: caught by Playwright that shadcn `Checkbox`'s `after:absolute` hit-target was intercepting the Install button — moved checkbox above the Tabs and scoped it with a relative wrapper.
- `b6c95763` `delete_install` clears `workspace_mcp_overrides`; `switch_auth_method` opts out. 2 more E2E.

## Test plan
- [x] `pytest tests/e2e/test_mcp_auto_enroll.py` (6 new tests, all pass)
- [x] `pytest tests/e2e/test_mcp_catalog_routes.py tests/e2e/test_mcp_catalog_override.py tests/e2e/test_mcp_catalog_runtime.py` (23 existing, no regressions)
- [x] `pytest tests/e2e/test_auth.py tests/e2e/test_workspace_create_modes.py tests/e2e/test_auth_needs_org_setup.py` (auth bootstrap, 13 pass)
- [x] `pnpm --filter @cubebox/core build && pnpm --filter web type-check && pnpm --filter web lint`
- [x] Manual browser on slot 51: register → seed catalog → admin install MS Learn (auto_enable on) → both workspaces see "Enabled"; disable in one → flips to "Available"; create new workspace → auto-inherits; admin install WebTools with auto_enable off → no overrides → new workspace doesn't see it.

## Follow-ups out of scope
- The shadcn `Checkbox` primitive ships without `relative` on its root, so its `after:absolute` hit-target escapes — fixed locally at the one call site here. Worth an upstream fix to `components/ui/checkbox.tsx` in a separate PR.