### PR TITLE
docs(mcp): MCP management four-layer spec + revised plan

### DIFF
--- a/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
+++ b/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
@@ -618,7 +618,14 @@ Create `backend/cubebox/services/mcp_installs.py`. The module exposes:
     user_id=None, name=None)` — stores the secret in the vault via
     `CredentialService.create(kind=CREDENTIAL_KIND_MCP, ...)`, then writes the
     grant row pointing at the vault id. Validates scope-vs-fk combination
-    (`workspace` ⇒ `workspace_id`, `user` ⇒ `user_id`).
+    matching the DB check constraint exactly:
+    - `org` ⇒ `workspace_id` and `user_id` MUST both be `None`.
+    - `workspace` ⇒ `workspace_id` MUST be set, `user_id` MUST be `None`.
+    - `user` ⇒ **both** `workspace_id` AND `user_id` MUST be set (user grants
+      are scoped per workspace, so the workspace context is recorded on the
+      grant row to prevent cross-workspace reuse — the `/grants/me` route
+      passes the current `workspace_id` from the path).
+    Wrong shape → `ValueError` before any vault or DB write.
   - `disconnect_grant(*, install_id, grant_scope, workspace_id=None, user_id=None)`
     — deletes the grant row (and OAuth-side revoke when available). Does **not**
     touch install or workspace state.
@@ -633,15 +640,28 @@ not just an absence of code.
 
 - [ ] **Step 4: Add dependency providers**
 
-In `backend/cubebox/mcp/dependencies.py`, add two FastAPI dependency providers
-following the patterns already in that file:
+In `backend/cubebox/mcp/dependencies.py`, add the FastAPI dependency providers
+needed for the workspace and admin route surfaces. The split is necessary
+because admin routes are org-scoped (no `workspace_id` in the path) and use
+`get_admin_request_context` / `require_org_admin`; workspace routes use
+`request_context` / `require_member`. Reusing a member-scoped provider on
+admin routes would either reject the call or scope through an arbitrary
+workspace membership.
 
-- `get_connector_template_service(session) -> MCPConnectorTemplateService` — global,
-  no org scope.
-- `get_connector_install_service(session, cred_service, ctx) ->
-  MCPConnectorInstallService` — `ctx` from the existing `require_member` /
-  `request_context` dependency; instantiate the three repos (install, state, grant)
-  with `org_id=ctx.org_id`, pass `actor_user_id=ctx.user.id`.
+Providers:
+
+- `get_connector_template_service(session) -> MCPConnectorTemplateService` —
+  global, no org scope; used by both admin and workspace routes.
+- `get_ws_install_service(session, cred_service, ctx=Depends(request_context))
+  -> MCPConnectorInstallService` — used by workspace routes. Instantiates the
+  three repos with `org_id=ctx.org_id` from workspace membership, passes
+  `actor_user_id=ctx.user.id`.
+- `get_admin_install_service(session, cred_service,
+  ctx=Depends(get_admin_request_context)) -> MCPConnectorInstallService` —
+  used by admin routes. Same construction but `org_id` comes from the admin
+  context (no workspace), and the underlying calls into the service that
+  involve workspace fan-out get an explicit `workspace_ids` list from the
+  request body, not from `ctx`.
 
 Remove old `get_*catalog*` / `get_*override*` providers from the same module.
 
@@ -1117,16 +1137,21 @@ implementation could pass Step 2a but break the `install_scope="org"` +
 
 - [ ] **Step 3: User-policy scope isolation (spec test #3)**
 
-Two assertions in one test:
+Two assertions in one test (reason strings must be the spec's scope-specific
+values, not the generic `credential_missing` — collapsing reasons here would
+let the implementation pass while regressing the diagnostic matrix Task 5
+protects):
 
 1. Org admin installs static template with `credential_policy="org"` + org-grant
    plaintext. Workspace admin (`admin_client`) flips state to
    `credential_policy="user"`. Without any user grant, both users see
-   `credential_availability="missing"` and `usable=false`. The pre-existing
-   org grant must **not** satisfy a user-policy row.
+   `credential_availability="missing"`, `usable=false`, and
+   `reason="user_needs_connection"`. The pre-existing org grant must **not**
+   satisfy a user-policy row.
 2. User A (`admin_client`'s user) POSTs `/grants/me` with their token. User A
-   then sees `usable=true`; user B (`member_client`) still sees
-   `credential_availability="missing"` and `usable=false` for the same install.
+   then sees `usable=true`, `reason="usable"`; user B (`member_client`) still
+   sees `credential_availability="missing"`, `usable=false`,
+   `reason="user_needs_connection"` for the same install.
 
 - [ ] **Step 4: Policy change drops the previous scope's grant from runtime
   (spec test #4)**
@@ -1134,14 +1159,16 @@ Two assertions in one test:
 - Org install with `credential_policy="org"` and a valid org grant.
 - Workspace flips `credential_policy` to `"workspace"` via PATCH state.
 - GET `/connectors` shows `credential_source` is no longer `org`; without a
-  workspace grant, `usable=false`, reason `credential_missing`.
+  workspace grant, `usable=false`, `reason="missing_workspace_grant"`.
 
 - [ ] **Step 5: Disconnect keeps install/state (spec test #5)**
 
 - After Step 4's setup, DELETE the org grant.
 - Install row still exists with `install_state="active"`; `WorkspaceConnectorState`
   row still has `enabled=true`. Effective state for that workspace returns
-  `usable=false`, reason `credential_missing`. Re-POSTing a grant immediately
+  `usable=false`, `reason="missing_org_grant"` (assuming the original setup was
+  org-policy; replace with `missing_workspace_grant` / `user_needs_connection`
+  if the test variant flipped policy first). Re-POSTing a grant immediately
   flips back to usable without re-install.
 
 - [ ] **Step 6: Uninstall then reinstall same template (spec test #6)**
@@ -1274,13 +1301,16 @@ export async function wsCreateInstall(client: ApiClient, wsId: string, body: unk
   return (await res.json()) as MCPConnectorInstall
 }
 
-export async function wsPatchInstallState(
+export async function wsPatchConnectorState(
   client: ApiClient,
   wsId: string,
   installId: string,
   body: Partial<MCPWorkspaceConnectorState>,
 ) {
-  const res = await client.patch(`/api/v1/ws/${wsId}/mcp/installs/${installId}/state`, body)
+  const res = await client.patch(
+    `/api/v1/ws/${wsId}/mcp/connectors/${installId}/state`,
+    body,
+  )
   if (!res.ok) throw await toApiError(res)
   return (await res.json()) as MCPWorkspaceConnectorState
 }

--- a/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
+++ b/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
@@ -18,6 +18,8 @@
 - Use target table names now:
   `mcp_connector_templates`, `mcp_connector_installs`, `mcp_workspace_connector_states`,
   `mcp_credential_grants`.
+- Use MCP-specific public ID prefixes now:
+  `mctpl`, `mcins`, `mcwcs`, `mcgrn`.
 - Existing local MCP data can be dropped by migration. The product has no released
   external contract.
 - Keep the credential vault table; grant rows point to vault credential ids.
@@ -113,6 +115,10 @@ def test_mcp_four_layer_table_names() -> None:
     assert MCPConnectorInstall.__tablename__ == "mcp_connector_installs"
     assert MCPWorkspaceConnectorState.__tablename__ == "mcp_workspace_connector_states"
     assert MCPCredentialGrant.__tablename__ == "mcp_credential_grants"
+    assert MCPConnectorTemplate._PREFIX == "mctpl"
+    assert MCPConnectorInstall._PREFIX == "mcins"
+    assert MCPWorkspaceConnectorState._PREFIX == "mcwcs"
+    assert MCPCredentialGrant._PREFIX == "mcgrn"
 
 
 def test_no_auth_install_defaults_to_none_policy() -> None:
@@ -165,7 +171,7 @@ from cubebox.models.mixins import CubeboxBase
 
 
 class MCPConnectorTemplate(CubeboxBase, table=True):
-    _PREFIX: ClassVar[str] = "ctpl"
+    _PREFIX: ClassVar[str] = "mctpl"
     __tablename__ = "mcp_connector_templates"
     __table_args__ = (UniqueConstraint("slug", name="uq_mcp_connector_template_slug"),)
 
@@ -205,7 +211,7 @@ class MCPConnectorTemplate(CubeboxBase, table=True):
 
 
 class MCPConnectorInstall(CubeboxBase, table=True):
-    _PREFIX: ClassVar[str] = "cins"
+    _PREFIX: ClassVar[str] = "mcins"
     __tablename__ = "mcp_connector_installs"
     __table_args__ = (
         UniqueConstraint(
@@ -276,7 +282,7 @@ class MCPConnectorInstall(CubeboxBase, table=True):
 
 
 class MCPWorkspaceConnectorState(CubeboxBase, table=True):
-    _PREFIX: ClassVar[str] = "wcst"
+    _PREFIX: ClassVar[str] = "mcwcs"
     __tablename__ = "mcp_workspace_connector_states"
     __table_args__ = (
         UniqueConstraint("workspace_id", "install_id", name="uq_mcp_workspace_connector_state"),
@@ -292,7 +298,7 @@ class MCPWorkspaceConnectorState(CubeboxBase, table=True):
 
 
 class MCPCredentialGrant(CubeboxBase, table=True):
-    _PREFIX: ClassVar[str] = "cgrn"
+    _PREFIX: ClassVar[str] = "mcgrn"
     __tablename__ = "mcp_credential_grants"
     __table_args__ = (
         UniqueConstraint(
@@ -457,7 +463,7 @@ async def test_credential_grant_repository_scopes_user_grants(
     await repo.add(
         MCPCredentialGrant(
             org_id="org-1",
-            install_id="cins-1",
+            install_id="mcins-1",
             grant_scope="user",
             user_id="user-1",
             credential_id="cred-1",
@@ -465,8 +471,8 @@ async def test_credential_grant_repository_scopes_user_grants(
         )
     )
 
-    assert await repo.get_user_grant(install_id="cins-1", user_id="user-1") is not None
-    assert await repo.get_user_grant(install_id="cins-1", user_id="user-2") is None
+    assert await repo.get_user_grant(install_id="mcins-1", user_id="user-1") is not None
+    assert await repo.get_user_grant(install_id="mcins-1", user_id="user-2") is None
 ```
 
 - [ ] **Step 2: Run tests and confirm missing repositories**

--- a/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
+++ b/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace the current MCP catalog/server/override model with the final four-layer model: connector templates, connector installs, workspace connector states, and credential grants.
 
-**Architecture:** Use a direct schema and API replacement because the product has not shipped. Create target tables and model classes, remove old catalog/override routes, make `credential_grants` the single grant table, and make `EffectiveConnectorService` the only source of runtime usability.
+**Architecture:** Use a direct schema and API replacement because the product has not shipped. Create target tables and model classes, remove old catalog/override routes, make `mcp_credential_grants` the single grant table, and make `MCPEffectiveConnectorService` the only source of runtime usability.
 
 **Tech Stack:** FastAPI, SQLModel, Alembic, PostgreSQL, Redis, OAuthTokenManager, Next.js, Zustand, TypeScript, pytest, Playwright.
 
@@ -16,13 +16,13 @@
 - Remove `catalog` and `override` from public API paths, frontend API helpers, UI copy,
   services, repositories, and new tests.
 - Use target table names now:
-  `connector_templates`, `connector_installs`, `workspace_connector_states`,
-  `credential_grants`.
+  `mcp_connector_templates`, `mcp_connector_installs`, `mcp_workspace_connector_states`,
+  `mcp_credential_grants`.
 - Existing local MCP data can be dropped by migration. The product has no released
   external contract.
 - Keep the credential vault table; grant rows point to vault credential ids.
 - Keep `backend/cubebox/models/mcp.py` as the MCP model module, but replace the model
-  classes inside it with the four final nouns.
+  classes inside it with the four final MCP-prefixed nouns.
 
 ---
 
@@ -88,7 +88,7 @@
 
 ---
 
-## Task 1: Target Schema And Model Classes
+## Task 1: Target Prefixed Schema And Model Classes
 
 **Files:**
 
@@ -96,29 +96,29 @@
 - Modify: `backend/cubebox/models/mcp.py`
 - Modify: `backend/tests/unit/test_mcp_models.py`
 
-- [ ] **Step 1: Write model tests for final table names**
+- [ ] **Step 1: Write model tests for final prefixed table names**
 
 Append to `backend/tests/unit/test_mcp_models.py`:
 
 ```python
 def test_mcp_four_layer_table_names() -> None:
     from cubebox.models import (
-        ConnectorInstall,
-        ConnectorTemplate,
-        CredentialGrant,
-        WorkspaceConnectorState,
+        MCPConnectorInstall,
+        MCPConnectorTemplate,
+        MCPCredentialGrant,
+        MCPWorkspaceConnectorState,
     )
 
-    assert ConnectorTemplate.__tablename__ == "connector_templates"
-    assert ConnectorInstall.__tablename__ == "connector_installs"
-    assert WorkspaceConnectorState.__tablename__ == "workspace_connector_states"
-    assert CredentialGrant.__tablename__ == "credential_grants"
+    assert MCPConnectorTemplate.__tablename__ == "mcp_connector_templates"
+    assert MCPConnectorInstall.__tablename__ == "mcp_connector_installs"
+    assert MCPWorkspaceConnectorState.__tablename__ == "mcp_workspace_connector_states"
+    assert MCPCredentialGrant.__tablename__ == "mcp_credential_grants"
 
 
 def test_no_auth_install_defaults_to_none_policy() -> None:
-    from cubebox.models import ConnectorInstall
+    from cubebox.models import MCPConnectorInstall
 
-    row = ConnectorInstall(
+    row = MCPConnectorInstall(
         org_id="org-1",
         name="NoAuth",
         server_url="https://noauth.example.com/mcp",
@@ -164,10 +164,10 @@ from sqlmodel import Field
 from cubebox.models.mixins import CubeboxBase
 
 
-class ConnectorTemplate(CubeboxBase, table=True):
+class MCPConnectorTemplate(CubeboxBase, table=True):
     _PREFIX: ClassVar[str] = "ctpl"
-    __tablename__ = "connector_templates"
-    __table_args__ = (UniqueConstraint("slug", name="uq_connector_template_slug"),)
+    __tablename__ = "mcp_connector_templates"
+    __table_args__ = (UniqueConstraint("slug", name="uq_mcp_connector_template_slug"),)
 
     slug: str = Field(max_length=64, index=True)
     name: str = Field(max_length=128)
@@ -204,24 +204,24 @@ class ConnectorTemplate(CubeboxBase, table=True):
     status: str = Field(default="active", max_length=16)
 
 
-class ConnectorInstall(CubeboxBase, table=True):
+class MCPConnectorInstall(CubeboxBase, table=True):
     _PREFIX: ClassVar[str] = "cins"
-    __tablename__ = "connector_installs"
+    __tablename__ = "mcp_connector_installs"
     __table_args__ = (
         UniqueConstraint(
             "org_id",
             "workspace_id",
             "server_url_hash",
-            name="uq_connector_install_url",
+            name="uq_mcp_connector_install_url",
         ),
         UniqueConstraint(
             "org_id",
             "workspace_id",
             "name",
-            name="uq_connector_install_name",
+            name="uq_mcp_connector_install_name",
         ),
         Index(
-            "uq_connector_install_per_template",
+            "uq_mcp_connector_install_per_template",
             "org_id",
             text("COALESCE(workspace_id, '_org')"),
             "template_id",
@@ -233,7 +233,7 @@ class ConnectorInstall(CubeboxBase, table=True):
     org_id: str = Field(foreign_key="organizations.id", max_length=20, index=True)
     template_id: str | None = Field(
         default=None,
-        foreign_key="connector_templates.id",
+        foreign_key="mcp_connector_templates.id",
         max_length=20,
         index=True,
     )
@@ -275,37 +275,37 @@ class ConnectorInstall(CubeboxBase, table=True):
     created_by_user_id: str = Field(foreign_key="users.id", max_length=20)
 
 
-class WorkspaceConnectorState(CubeboxBase, table=True):
+class MCPWorkspaceConnectorState(CubeboxBase, table=True):
     _PREFIX: ClassVar[str] = "wcst"
-    __tablename__ = "workspace_connector_states"
+    __tablename__ = "mcp_workspace_connector_states"
     __table_args__ = (
-        UniqueConstraint("workspace_id", "install_id", name="uq_workspace_connector_state"),
+        UniqueConstraint("workspace_id", "install_id", name="uq_mcp_workspace_connector_state"),
     )
 
     org_id: str = Field(foreign_key="organizations.id", max_length=20, index=True)
     workspace_id: str = Field(foreign_key="workspaces.id", max_length=20, index=True)
-    install_id: str = Field(foreign_key="connector_installs.id", max_length=20, index=True)
+    install_id: str = Field(foreign_key="mcp_connector_installs.id", max_length=20, index=True)
     enabled: bool = Field(default=True)
     credential_policy: str = Field(max_length=16)
     enablement_source: str = Field(default="workspace_manual", max_length=32)
     updated_by_user_id: str = Field(foreign_key="users.id", max_length=20)
 
 
-class CredentialGrant(CubeboxBase, table=True):
+class MCPCredentialGrant(CubeboxBase, table=True):
     _PREFIX: ClassVar[str] = "cgrn"
-    __tablename__ = "credential_grants"
+    __tablename__ = "mcp_credential_grants"
     __table_args__ = (
         UniqueConstraint(
             "install_id",
             "grant_scope",
             "workspace_id",
             "user_id",
-            name="uq_credential_grant_scope",
+            name="uq_mcp_credential_grant_scope",
         ),
     )
 
     org_id: str = Field(foreign_key="organizations.id", max_length=20, index=True)
-    install_id: str = Field(foreign_key="connector_installs.id", max_length=20, index=True)
+    install_id: str = Field(foreign_key="mcp_connector_installs.id", max_length=20, index=True)
     grant_scope: str = Field(max_length=16)
     workspace_id: str | None = Field(
         default=None,
@@ -344,8 +344,8 @@ def upgrade() -> None:
     op.drop_table("mcp_servers")
     op.drop_table("mcp_catalog_connectors")
 
-    # Create connector_templates, connector_installs,
-    # workspace_connector_states, and credential_grants with the
+    # Create mcp_connector_templates, mcp_connector_installs,
+    # mcp_workspace_connector_states, and mcp_credential_grants with the
     # columns defined in backend/cubebox/models/mcp.py.
 ```
 
@@ -354,23 +354,23 @@ constraints:
 
 ```python
 op.create_check_constraint(
-    "ck_connector_installs_scope",
-    "connector_installs",
+    "ck_mcp_connector_installs_scope",
+    "mcp_connector_installs",
     "install_scope IN ('org', 'workspace')",
 )
 op.create_check_constraint(
-    "ck_connector_installs_auth_method",
-    "connector_installs",
+    "ck_mcp_connector_installs_auth_method",
+    "mcp_connector_installs",
     "auth_method IN ('oauth', 'static', 'none')",
 )
 op.create_check_constraint(
-    "ck_workspace_connector_states_policy",
-    "workspace_connector_states",
+    "ck_mcp_workspace_connector_states_policy",
+    "mcp_workspace_connector_states",
     "credential_policy IN ('org', 'workspace', 'user', 'none')",
 )
 op.create_check_constraint(
-    "ck_credential_grants_scope",
-    "credential_grants",
+    "ck_mcp_credential_grants_scope",
+    "mcp_credential_grants",
     "grant_scope IN ('org', 'workspace', 'user')",
 )
 ```
@@ -429,9 +429,9 @@ Append to `backend/tests/unit/test_mcp_repositories.py`:
 
 ```python
 async def test_connector_template_repository_upserts_by_slug(session: AsyncSession) -> None:
-    from cubebox.repositories.mcp import ConnectorTemplateRepository
+    from cubebox.repositories.mcp import MCPConnectorTemplateRepository
 
-    repo = ConnectorTemplateRepository(session)
+    repo = MCPConnectorTemplateRepository(session)
     row = await repo.upsert_by_slug(
         slug="github",
         name="GitHub",
@@ -450,12 +450,12 @@ async def test_connector_template_repository_upserts_by_slug(session: AsyncSessi
 async def test_credential_grant_repository_scopes_user_grants(
     session: AsyncSession,
 ) -> None:
-    from cubebox.models import CredentialGrant
-    from cubebox.repositories.mcp import CredentialGrantRepository
+    from cubebox.models import MCPCredentialGrant
+    from cubebox.repositories.mcp import MCPCredentialGrantRepository
 
-    repo = CredentialGrantRepository(session, org_id="org-1")
+    repo = MCPCredentialGrantRepository(session, org_id="org-1")
     await repo.add(
-        CredentialGrant(
+        MCPCredentialGrant(
             org_id="org-1",
             install_id="cins-1",
             grant_scope="user",
@@ -485,32 +485,32 @@ Expected: FAIL because the final repositories do not exist.
 
 Edit `backend/cubebox/repositories/mcp.py` so it exports these concrete methods:
 
-- `ConnectorTemplateRepository.get(template_id: str) -> ConnectorTemplate | None`
-- `ConnectorTemplateRepository.get_by_slug(slug: str) -> ConnectorTemplate | None`
-- `ConnectorTemplateRepository.list_active() -> list[ConnectorTemplate]`
-- `ConnectorTemplateRepository.upsert_by_slug(slug: str, name: str, description: str,
+- `MCPConnectorTemplateRepository.get(template_id: str) -> MCPConnectorTemplate | None`
+- `MCPConnectorTemplateRepository.get_by_slug(slug: str) -> MCPConnectorTemplate | None`
+- `MCPConnectorTemplateRepository.list_active() -> list[MCPConnectorTemplate]`
+- `MCPConnectorTemplateRepository.upsert_by_slug(slug: str, name: str, description: str,
   provider: str, server_url: str, transport: str, supported_auth_methods: list[str],
-  default_credential_policy: str) -> ConnectorTemplate`
-- `ConnectorInstallRepository.get(install_id: str) -> ConnectorInstall | None`
-- `ConnectorInstallRepository.list_org_installs() -> list[ConnectorInstall]`
-- `ConnectorInstallRepository.list_workspace_installs(workspace_id: str)
-  -> list[ConnectorInstall]`
-- `ConnectorInstallRepository.add(install: ConnectorInstall) -> ConnectorInstall`
-- `ConnectorInstallRepository.update(install: ConnectorInstall) -> ConnectorInstall`
-- `WorkspaceConnectorStateRepository.get(workspace_id: str, install_id: str)
-  -> WorkspaceConnectorState | None`
-- `WorkspaceConnectorStateRepository.list_for_workspace(workspace_id: str)
-  -> list[WorkspaceConnectorState]`
-- `WorkspaceConnectorStateRepository.upsert(workspace_id: str, install_id: str,
+  default_credential_policy: str) -> MCPConnectorTemplate`
+- `MCPConnectorInstallRepository.get(install_id: str) -> MCPConnectorInstall | None`
+- `MCPConnectorInstallRepository.list_org_installs() -> list[MCPConnectorInstall]`
+- `MCPConnectorInstallRepository.list_workspace_installs(workspace_id: str)
+  -> list[MCPConnectorInstall]`
+- `MCPConnectorInstallRepository.add(install: MCPConnectorInstall) -> MCPConnectorInstall`
+- `MCPConnectorInstallRepository.update(install: MCPConnectorInstall) -> MCPConnectorInstall`
+- `MCPWorkspaceConnectorStateRepository.get(workspace_id: str, install_id: str)
+  -> MCPWorkspaceConnectorState | None`
+- `MCPWorkspaceConnectorStateRepository.list_for_workspace(workspace_id: str)
+  -> list[MCPWorkspaceConnectorState]`
+- `MCPWorkspaceConnectorStateRepository.upsert(workspace_id: str, install_id: str,
   enabled: bool, credential_policy: str, enablement_source: str,
-  updated_by_user_id: str) -> WorkspaceConnectorState`
-- `CredentialGrantRepository.add(grant: CredentialGrant) -> CredentialGrant`
-- `CredentialGrantRepository.get_org_grant(install_id: str) -> CredentialGrant | None`
-- `CredentialGrantRepository.get_workspace_grant(install_id: str, workspace_id: str)
-  -> CredentialGrant | None`
-- `CredentialGrantRepository.get_user_grant(install_id: str, user_id: str)
-  -> CredentialGrant | None`
-- `CredentialGrantRepository.delete_scope(install_id: str, grant_scope: str,
+  updated_by_user_id: str) -> MCPWorkspaceConnectorState`
+- `MCPCredentialGrantRepository.add(grant: MCPCredentialGrant) -> MCPCredentialGrant`
+- `MCPCredentialGrantRepository.get_org_grant(install_id: str) -> MCPCredentialGrant | None`
+- `MCPCredentialGrantRepository.get_workspace_grant(install_id: str, workspace_id: str)
+  -> MCPCredentialGrant | None`
+- `MCPCredentialGrantRepository.get_user_grant(install_id: str, user_id: str)
+  -> MCPCredentialGrant | None`
+- `MCPCredentialGrantRepository.delete_scope(install_id: str, grant_scope: str,
   workspace_id: str | None, user_id: str | None) -> None`
 
 Use the existing org-scoped repository pattern: every non-template repository receives
@@ -523,18 +523,18 @@ Create `backend/cubebox/services/mcp_templates.py`:
 ```python
 """Connector template service."""
 
-from cubebox.models import ConnectorTemplate
-from cubebox.repositories.mcp import ConnectorTemplateRepository
+from cubebox.models import MCPConnectorTemplate
+from cubebox.repositories.mcp import MCPConnectorTemplateRepository
 
 
-class ConnectorTemplateService:
-    def __init__(self, repo: ConnectorTemplateRepository) -> None:
+class MCPConnectorTemplateService:
+    def __init__(self, repo: MCPConnectorTemplateRepository) -> None:
         self._repo = repo
 
-    async def list_active(self) -> list[ConnectorTemplate]:
+    async def list_active(self) -> list[MCPConnectorTemplate]:
         return await self._repo.list_active()
 
-    async def get_active(self, template_id: str) -> ConnectorTemplate:
+    async def get_active(self, template_id: str) -> MCPConnectorTemplate:
         row = await self._repo.get(template_id)
         if row is None or row.status != "active":
             raise ValueError("connector_template_not_found")
@@ -553,7 +553,7 @@ git mv backend/cubebox/cli/seed_mcp_catalog.py backend/cubebox/cli/seed_mcp_temp
 ```
 
 In `backend/cubebox/mcp/template_seed.py`, rename `CatalogSeedEntry` to
-`ConnectorTemplateSeedEntry`. Rename fields:
+`MCPConnectorTemplateSeedEntry`. Rename fields:
 
 ```python
 default_credential_scope -> default_credential_policy
@@ -563,7 +563,7 @@ tool_citations -> tool_citation_defaults
 ```
 
 Update `backend/cubebox/seeders/mcp_template_seeder.py` and
-`backend/cubebox/cli/seed_mcp_templates.py` to call `ConnectorTemplateRepository`.
+`backend/cubebox/cli/seed_mcp_templates.py` to call `MCPConnectorTemplateRepository`.
 
 - [ ] **Step 6: Run repository and seed tests**
 
@@ -656,21 +656,21 @@ from datetime import UTC, datetime
 from cubebox.mcp._constants import CREDENTIAL_KIND_MCP
 from cubebox.mcp._constants import server_url_hash
 from cubebox.models import (
-    ConnectorInstall,
-    ConnectorTemplate,
-    CredentialGrant,
-    WorkspaceConnectorState,
+    MCPConnectorInstall,
+    MCPConnectorTemplate,
+    MCPCredentialGrant,
+    MCPWorkspaceConnectorState,
 )
 from cubebox.repositories.mcp import (
-    ConnectorInstallRepository,
-    CredentialGrantRepository,
-    WorkspaceConnectorStateRepository,
+    MCPConnectorInstallRepository,
+    MCPCredentialGrantRepository,
+    MCPWorkspaceConnectorStateRepository,
 )
 from cubebox.services.credential import CredentialService
 
 
 @dataclass(frozen=True, slots=True)
-class InstallDefaults:
+class MCPInstallDefaults:
     auth_status: str
     credential_policy: str
 
@@ -678,19 +678,19 @@ class InstallDefaults:
 def install_defaults_for_auth_method(
     auth_method: str,
     requested_policy: str,
-) -> InstallDefaults:
+) -> MCPInstallDefaults:
     if auth_method == "none":
-        return InstallDefaults(auth_status="not_required", credential_policy="none")
-    return InstallDefaults(auth_status="pending", credential_policy=requested_policy)
+        return MCPInstallDefaults(auth_status="not_required", credential_policy="none")
+    return MCPInstallDefaults(auth_status="pending", credential_policy=requested_policy)
 
 
-class ConnectorInstallService:
+class MCPConnectorInstallService:
     def __init__(
         self,
         *,
-        install_repo: ConnectorInstallRepository,
-        state_repo: WorkspaceConnectorStateRepository,
-        grant_repo: CredentialGrantRepository,
+        install_repo: MCPConnectorInstallRepository,
+        state_repo: MCPWorkspaceConnectorStateRepository,
+        grant_repo: MCPCredentialGrantRepository,
         cred_service: CredentialService,
         org_id: str,
         actor_user_id: str,
@@ -705,14 +705,14 @@ class ConnectorInstallService:
     async def create_from_template_for_workspace(
         self,
         *,
-        template: ConnectorTemplate,
+        template: MCPConnectorTemplate,
         workspace_id: str,
         auth_method: str,
         credential_policy: str,
-    ) -> ConnectorInstall:
+    ) -> MCPConnectorInstall:
         defaults = install_defaults_for_auth_method(auth_method, credential_policy)
         install = await self._install_repo.add(
-            ConnectorInstall(
+            MCPConnectorInstall(
                 org_id=self._org_id,
                 template_id=template.id,
                 install_scope="workspace",
@@ -748,14 +748,14 @@ class ConnectorInstallService:
         workspace_id: str | None = None,
         user_id: str | None = None,
         name: str | None = None,
-    ) -> CredentialGrant:
+    ) -> MCPCredentialGrant:
         credential_id = await self._cred_service.create(
             kind=CREDENTIAL_KIND_MCP,
             name=name or f"mcp:{install_id}:{grant_scope}",
             plaintext=plaintext,
         )
         return await self._grant_repo.add(
-            CredentialGrant(
+            MCPCredentialGrant(
                 org_id=self._org_id,
                 install_id=install_id,
                 grant_scope=grant_scope,
@@ -767,7 +767,7 @@ class ConnectorInstallService:
             )
         )
 
-    async def uninstall(self, install_id: str) -> ConnectorInstall:
+    async def uninstall(self, install_id: str) -> MCPConnectorInstall:
         install = await self._install_repo.get(install_id)
         if install is None:
             raise ValueError("connector_install_not_found")
@@ -784,19 +784,19 @@ Edit `backend/cubebox/mcp/dependencies.py` and add:
 ```python
 async def get_connector_template_service(
     session: AsyncSession = Depends(get_session),
-) -> ConnectorTemplateService:
-    return ConnectorTemplateService(ConnectorTemplateRepository(session))
+) -> MCPConnectorTemplateService:
+    return MCPConnectorTemplateService(MCPConnectorTemplateRepository(session))
 
 
 async def get_connector_install_service(
     session: AsyncSession = Depends(get_session),
     cred_service: CredentialService = Depends(get_credential_service),
     ctx: RequestContext = Depends(require_member),
-) -> ConnectorInstallService:
-    return ConnectorInstallService(
-        install_repo=ConnectorInstallRepository(session, org_id=ctx.org_id),
-        state_repo=WorkspaceConnectorStateRepository(session, org_id=ctx.org_id),
-        grant_repo=CredentialGrantRepository(session, org_id=ctx.org_id),
+) -> MCPConnectorInstallService:
+    return MCPConnectorInstallService(
+        install_repo=MCPConnectorInstallRepository(session, org_id=ctx.org_id),
+        state_repo=MCPWorkspaceConnectorStateRepository(session, org_id=ctx.org_id),
+        grant_repo=MCPCredentialGrantRepository(session, org_id=ctx.org_id),
         cred_service=cred_service,
         org_id=ctx.org_id,
         actor_user_id=ctx.user.id,
@@ -896,17 +896,17 @@ Use `Literal["org", "workspace", "user", "none"]` for credential policy fields a
 
 The response schemas must include these fields:
 
-- `ConnectorTemplateOut`: `template_id`, `slug`, `name`, `provider`, `description`,
+- `MCPConnectorTemplateOut`: `template_id`, `slug`, `name`, `provider`, `description`,
   `server_url`, `transport`, `supported_auth_methods`, `default_credential_policy`,
   `static_form_schema`, `status`.
-- `ConnectorInstallOut`: `install_id`, `template_id`, `install_scope`, `workspace_id`,
+- `MCPConnectorInstallOut`: `install_id`, `template_id`, `install_scope`, `workspace_id`,
   `name`, `server_url`, `transport`, `auth_method`, `default_credential_policy`,
   `auth_status`, `discovery_status`, `install_state`, `tool_count`, `last_error`.
-- `WorkspaceConnectorStateOut`: `workspace_id`, `install_id`, `enabled`,
+- `MCPWorkspaceConnectorStateOut`: `workspace_id`, `install_id`, `enabled`,
   `credential_policy`, `enablement_source`.
-- `CredentialGrantStatusOut`: `install_id`, `grant_scope`, `workspace_id`, `user_id`,
+- `MCPCredentialGrantStatusOut`: `install_id`, `grant_scope`, `workspace_id`, `user_id`,
   `grant_status`, `has_value`, `expires_at`.
-- `EffectiveConnectorOut`: `template`, `install`, `workspace_state`, `credential_policy`,
+- `MCPEffectiveConnectorOut`: `template`, `install`, `workspace_state`, `credential_policy`,
   `credential_availability`, `credential_source`, `usable`, `reason`.
 
 - [ ] **Step 4: Replace admin routes**
@@ -987,12 +987,12 @@ git commit -m "feat(mcp): replace catalog routes with four-layer API"
 Create `backend/tests/unit/mcp/test_effective_state.py`:
 
 ```python
-from cubebox.mcp.effective import EffectiveInput, GrantInput, compute_effective_state
+from cubebox.mcp.effective import MCPEffectiveInput, MCPGrantInput, compute_effective_state
 
 
 def test_no_auth_connector_is_usable_without_grant() -> None:
     result = compute_effective_state(
-        EffectiveInput(
+        MCPEffectiveInput(
             template_status="active",
             install_state="active",
             workspace_enabled=True,
@@ -1010,7 +1010,7 @@ def test_no_auth_connector_is_usable_without_grant() -> None:
 
 def test_user_policy_requires_user_grant() -> None:
     result = compute_effective_state(
-        EffectiveInput(
+        MCPEffectiveInput(
             template_status="active",
             install_state="active",
             workspace_enabled=True,
@@ -1027,13 +1027,13 @@ def test_user_policy_requires_user_grant() -> None:
 
 def test_valid_user_grant_makes_user_policy_usable() -> None:
     result = compute_effective_state(
-        EffectiveInput(
+        MCPEffectiveInput(
             template_status="active",
             install_state="active",
             workspace_enabled=True,
             auth_method="static",
             credential_policy="user",
-            grant=GrantInput(scope="user", status="valid"),
+            grant=MCPGrantInput(scope="user", status="valid"),
             transport="streamable_http",
         )
     )
@@ -1051,7 +1051,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 CredentialPolicy = Literal["org", "workspace", "user", "none"]
-EffectiveReason = Literal[
+MCPEffectiveReason = Literal[
     "usable",
     "template_inactive",
     "install_uninstalled",
@@ -1063,64 +1063,64 @@ EffectiveReason = Literal[
 
 
 @dataclass(frozen=True, slots=True)
-class GrantInput:
+class MCPGrantInput:
     scope: str
     status: str
 
 
 @dataclass(frozen=True, slots=True)
-class EffectiveInput:
+class MCPEffectiveInput:
     template_status: str | None
     install_state: str
     workspace_enabled: bool
     auth_method: str
     credential_policy: CredentialPolicy
-    grant: GrantInput | None
+    grant: MCPGrantInput | None
     transport: str
 
 
 @dataclass(frozen=True, slots=True)
-class EffectiveResult:
+class MCPEffectiveResult:
     usable: bool
-    reason: EffectiveReason
+    reason: MCPEffectiveReason
     credential_availability: str
 
 
-def compute_effective_state(value: EffectiveInput) -> EffectiveResult:
+def compute_effective_state(value: MCPEffectiveInput) -> MCPEffectiveResult:
     if value.template_status is not None and value.template_status != "active":
-        return EffectiveResult(False, "template_inactive", "missing")
+        return MCPEffectiveResult(False, "template_inactive", "missing")
     if value.install_state != "active":
-        return EffectiveResult(False, "install_uninstalled", "missing")
+        return MCPEffectiveResult(False, "install_uninstalled", "missing")
     if value.transport not in {"streamable_http", "sse"}:
-        return EffectiveResult(False, "unsupported_transport", "missing")
+        return MCPEffectiveResult(False, "unsupported_transport", "missing")
     if not value.workspace_enabled:
-        return EffectiveResult(False, "workspace_disabled", "missing")
+        return MCPEffectiveResult(False, "workspace_disabled", "missing")
     if value.auth_method == "none" or value.credential_policy == "none":
-        return EffectiveResult(True, "usable", "not_required")
+        return MCPEffectiveResult(True, "usable", "not_required")
     if value.grant is None:
-        return EffectiveResult(False, "credential_missing", "missing")
+        return MCPEffectiveResult(False, "credential_missing", "missing")
     if value.grant.status != "valid" or value.grant.scope != value.credential_policy:
-        return EffectiveResult(False, "credential_invalid", "missing")
-    return EffectiveResult(True, "usable", "available")
+        return MCPEffectiveResult(False, "credential_invalid", "missing")
+    return MCPEffectiveResult(True, "usable", "available")
 ```
 
 - [ ] **Step 3: Add DB-backed effective service**
 
-Extend `backend/cubebox/mcp/effective.py` with `EffectiveConnectorService`.
+Extend `backend/cubebox/mcp/effective.py` with `MCPEffectiveConnectorService`.
 
 It should:
 
 - load active org installs plus workspace installs;
-- load `WorkspaceConnectorState` for each install and workspace;
-- load the required grant from `CredentialGrantRepository`;
+- load `MCPWorkspaceConnectorState` for each install and workspace;
+- load the required grant from `MCPCredentialGrantRepository`;
 - return unusable rows when `include_unusable=True`;
 - return only usable rows to runtime.
 
 The service exposes two methods:
 
 - `list_for_workspace_user(workspace_id: str, user_id: str, include_unusable: bool)
-  -> list[EffectiveConnectorDTO]`
-- `list_runtime_specs(workspace_id: str, user_id: str) -> list[RuntimeConnectorSpec]`
+  -> list[MCPEffectiveConnectorDTO]`
+- `list_runtime_specs(workspace_id: str, user_id: str) -> list[MCPRuntimeConnectorSpec]`
 
 - [ ] **Step 4: Wire OAuth refresh in runtime token resolution**
 
@@ -1128,7 +1128,7 @@ Edit `backend/cubebox/mcp/cubepi_runtime.py` so `load_workspace_mcp_tools_for_cu
 accepts:
 
 ```python
-effective_service: EffectiveConnectorService
+effective_service: MCPEffectiveConnectorService
 token_manager: OAuthTokenManager | None
 ```
 
@@ -1148,7 +1148,7 @@ For no-auth connectors, sign the short-lived Cubebox identity token.
 
 - [ ] **Step 5: Wire run manager**
 
-Edit `backend/cubebox/streams/run_manager.py` to construct `EffectiveConnectorService`
+Edit `backend/cubebox/streams/run_manager.py` to construct `MCPEffectiveConnectorService`
 inside the MCP tools block and pass it to `load_workspace_mcp_tools_for_cubepi`.
 Construct `OAuthTokenManager` using the same `_build_token_manager_for_org` helper used by
 admin MCP dependencies.
@@ -1196,9 +1196,9 @@ Append to `backend/tests/e2e/conftest.py`:
 ```python
 @pytest_asyncio.fixture
 async def noauth_template_id(db_session: AsyncSession) -> AsyncIterator[str]:
-    from cubebox.repositories.mcp import ConnectorTemplateRepository
+    from cubebox.repositories.mcp import MCPConnectorTemplateRepository
 
-    row = await ConnectorTemplateRepository(db_session).upsert_by_slug(
+    row = await MCPConnectorTemplateRepository(db_session).upsert_by_slug(
         slug="noauth-e2e",
         name="NoAuth E2E",
         description="No auth connector.",
@@ -1326,7 +1326,7 @@ Remove `MCPCatalogConnector`, `MCPCatalogListResponse`, `MCPOrgInstallOverrideRe
 and old server override types. Add:
 
 ```typescript
-export interface ConnectorTemplate {
+export interface MCPConnectorTemplate {
   template_id: string
   slug: string
   name: string
@@ -1340,7 +1340,7 @@ export interface ConnectorTemplate {
   status: 'active' | 'deprecated' | 'disabled'
 }
 
-export interface ConnectorInstall {
+export interface MCPConnectorInstall {
   install_id: string
   template_id: string | null
   install_scope: 'org' | 'workspace'
@@ -1353,17 +1353,17 @@ export interface ConnectorInstall {
   install_state: 'active' | 'uninstalled'
 }
 
-export interface WorkspaceConnectorState {
+export interface MCPWorkspaceConnectorState {
   workspace_id: string
   install_id: string
   enabled: boolean
   credential_policy: MCPCredentialScope
 }
 
-export interface EffectiveConnector {
-  template: ConnectorTemplate | null
-  install: ConnectorInstall
-  workspace_state: WorkspaceConnectorState
+export interface MCPEffectiveConnector {
+  template: MCPConnectorTemplate | null
+  install: MCPConnectorInstall
+  workspace_state: MCPWorkspaceConnectorState
   credential_policy: MCPCredentialScope
   credential_availability: 'available' | 'missing' | 'not_required'
   credential_source: 'org' | 'workspace' | 'user' | null
@@ -1382,30 +1382,30 @@ Add helpers for final paths:
 export async function wsListTemplates(client: ApiClient, wsId: string) {
   const res = await client.get(`/api/v1/ws/${wsId}/mcp/templates`)
   if (!res.ok) throw await toApiError(res)
-  return (await res.json()) as { items: ConnectorTemplate[] }
+  return (await res.json()) as { items: MCPConnectorTemplate[] }
 }
 
 export async function wsCreateInstall(client: ApiClient, wsId: string, body: unknown) {
   const res = await client.post(`/api/v1/ws/${wsId}/mcp/installs`, body)
   if (!res.ok) throw await toApiError(res)
-  return (await res.json()) as ConnectorInstall
+  return (await res.json()) as MCPConnectorInstall
 }
 
 export async function wsPatchInstallState(
   client: ApiClient,
   wsId: string,
   installId: string,
-  body: Partial<WorkspaceConnectorState>,
+  body: Partial<MCPWorkspaceConnectorState>,
 ) {
   const res = await client.patch(`/api/v1/ws/${wsId}/mcp/installs/${installId}/state`, body)
   if (!res.ok) throw await toApiError(res)
-  return (await res.json()) as WorkspaceConnectorState
+  return (await res.json()) as MCPWorkspaceConnectorState
 }
 
 export async function wsListEffectiveConnectors(client: ApiClient, wsId: string) {
   const res = await client.get(`/api/v1/ws/${wsId}/mcp/connectors`)
   if (!res.ok) throw await toApiError(res)
-  return (await res.json()) as { items: EffectiveConnector[] }
+  return (await res.json()) as { items: MCPEffectiveConnector[] }
 }
 ```
 

--- a/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
+++ b/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
@@ -26,18 +26,28 @@
 - Keep `backend/cubebox/models/mcp.py` as the MCP model module, but replace the model
   classes inside it with the four final MCP-prefixed nouns.
 
+**Plan granularity:**
+
+This plan describes design points, key steps, and core logic — not full source.
+Subagents fill in actual SQLModel definitions, schema bodies, route handlers,
+and service code by following existing patterns in the codebase (cubepi conventions,
+`OrgScopedMixin` style, the `mcp_oauth` module's existing handlers, etc.). Test
+snippets and field/route inventories are **contracts** the implementation must
+satisfy; they are not boilerplate to be pasted verbatim.
+
 ---
 
 ## File Structure
 
 **Backend — create:**
 
-- `backend/alembic/versions/f2a6c7d8e901_normalize_mcp_four_layer_tables.py`
+- `backend/alembic/versions/<autogen-hash>_normalize_mcp_four_layer_tables.py`
+  (produced by `alembic revision --autogenerate`; do not hard-code the hash)
 - `backend/cubebox/mcp/effective.py`
 - `backend/cubebox/services/mcp_templates.py`
 - `backend/cubebox/services/mcp_installs.py`
-- `backend/tests/unit/mcp/test_effective_state.py`
-- `backend/tests/unit/mcp/test_effective_service.py`
+- `backend/tests/unit/test_mcp_effective_state.py`
+- `backend/tests/unit/test_mcp_effective_service.py`
 - `backend/tests/e2e/test_mcp_four_layer_routes.py`
 - `backend/tests/e2e/test_mcp_four_layer_runtime.py`
 
@@ -53,8 +63,11 @@
   `backend/cubebox/cli/seed_mcp_templates.py`.
 - `backend/cubebox/mcp/dependencies.py` — new template/install/effective providers.
 - `backend/cubebox/api/schemas/mcp.py` — template/install/state/grant schemas.
-- `backend/cubebox/api/routes/v1/admin_mcp.py` — admin template/install/grant routes.
+- `backend/cubebox/api/routes/v1/admin_mcp.py` — admin template/install/grant routes
+  (and the public `GET /api/v1/mcp/templates` route, mounted unscoped).
 - `backend/cubebox/api/routes/v1/ws_mcp.py` — workspace template/install/state/grant routes.
+- `backend/cubebox/api/routes/v1/mcp_oauth.py` — align start/callback to new grant table
+  + new oauth/start paths.
 - `backend/cubebox/api/app.py` — stop mounting old catalog router.
 - `backend/cubebox/mcp/cubepi_discovery.py` — use effective runtime specs.
 - `backend/cubebox/mcp/cubepi_runtime.py` — load only usable effective connectors.
@@ -94,7 +107,8 @@
 
 **Files:**
 
-- Create: `backend/alembic/versions/f2a6c7d8e901_normalize_mcp_four_layer_tables.py`
+- Create: `backend/alembic/versions/<autogen-hash>_normalize_mcp_four_layer_tables.py`
+  (via `alembic revision --autogenerate`)
 - Modify: `backend/cubebox/models/mcp.py`
 - Modify: `backend/tests/unit/test_mcp_models.py`
 
@@ -156,238 +170,134 @@ Expected: FAIL because the four final model classes are not exported.
 
 - [ ] **Step 3: Replace MCP model classes**
 
-Edit `backend/cubebox/models/mcp.py` so it defines these final classes:
+Rewrite `backend/cubebox/models/mcp.py` with four SQLModel `table=True` classes.
+Follow existing conventions (`CubeboxBase`, `_PREFIX`, `Field(foreign_key=...)`,
+JSON columns via `sa_column=Column(JSON, ...)`). Do **not** inherit `OrgScopedMixin`
+on any of these — installs/grants have nullable `workspace_id` and grants have
+nullable `user_id`, which `OrgScopedMixin`'s NOT NULL contract forbids. Each model
+declares its own `org_id`/`workspace_id` fields explicitly.
 
-```python
-"""MCP connector management models."""
+Required shape per model:
 
-from datetime import datetime
-from typing import Any, ClassVar
+**`MCPConnectorTemplate`** (`mctpl`, table `mcp_connector_templates`, global — no `org_id`):
 
-from sqlalchemy import JSON, Column, Index, UniqueConstraint, text
-from sqlmodel import Field
+- Identifying: `slug` (unique, indexed), `name`, `description`, `provider`.
+- Runtime defaults: `server_url`, `transport`, `supported_auth_methods` (JSON list),
+  `default_credential_policy`.
+- OAuth metadata (nullable): `oauth_dcr_supported`, `oauth_default_scope`,
+  `oauth_static_client_id`, `oauth_static_client_secret_credential_id`
+  (FK → `credentials.id`; points at a system credential row with `org_id IS NULL`
+  per the existing vault scope-model pattern).
+- Static auth metadata (nullable): `static_form_schema` (JSON), `static_auth_header_template`.
+- Free-form metadata (JSON, non-null, default `{}`): `template_metadata`,
+  `tool_citation_defaults`.
+- Lifecycle: `status` (`active` | `deprecated` | `disabled`, default `active`).
+- Unique constraint on `slug`.
 
-from cubebox.models.mixins import CubeboxBase
+**`MCPConnectorInstall`** (`mcins`, table `mcp_connector_installs`):
 
+- Scope: `org_id` (FK, indexed, required), `workspace_id` (FK, indexed, **nullable** —
+  required iff `install_scope=workspace`), `install_scope` (`org` | `workspace`),
+  `template_id` (FK, nullable — `NULL` means custom install).
+- Identity: `name`, `server_url`, `server_url_hash` (64-char), `transport`.
+- Auth: `auth_method` (`oauth` | `static` | `none`), `default_credential_policy`
+  (`org` | `workspace` | `user` | `none`).
+- State: `auth_status` (`not_required` | `pending` | `authorized` | `disconnected` | `error`),
+  `discovery_status` (`not_run` | `success` | `error`), `install_state`
+  (`active` | `uninstalled`, server_default `'active'`).
+- Caches/config (JSON): `oauth_client_config`, `headers`, `tools_cache`, `tool_citations`.
+- Diagnostics: `last_error`, `last_discovered_at`, `timeout`, `sse_read_timeout`.
+- Distribution: `auto_enroll_new_workspaces` (bool, server_default `true`) —
+  flips `WorkspaceConnectorState` auto-creation when a new workspace lands in the org.
+- Audit: `created_by_user_id` (FK).
+- Constraints:
+  - `UniqueConstraint(org_id, workspace_id, server_url_hash)` — duplicate-URL guard.
+  - `UniqueConstraint(org_id, workspace_id, name)` — name uniqueness inside scope.
+  - Partial unique index `uq_mcp_connector_install_per_template` on
+    `(org_id, COALESCE(workspace_id, '_org'), template_id)` where
+    `template_id IS NOT NULL AND install_state = 'active'` — at most one active
+    install per template per scope, but uninstalled rows must not block reinstall.
+  - Check constraints (`ck_*`): `install_scope IN ('org','workspace')`,
+    `auth_method IN ('oauth','static','none')`.
 
-class MCPConnectorTemplate(CubeboxBase, table=True):
-    _PREFIX: ClassVar[str] = "mctpl"
-    __tablename__ = "mcp_connector_templates"
-    __table_args__ = (UniqueConstraint("slug", name="uq_mcp_connector_template_slug"),)
+**`MCPWorkspaceConnectorState`** (`mcwcs`, table `mcp_workspace_connector_states`):
 
-    slug: str = Field(max_length=64, index=True)
-    name: str = Field(max_length=128)
-    description: str = Field(max_length=2048)
-    provider: str = Field(max_length=64)
-    server_url: str = Field(max_length=2048)
-    transport: str = Field(max_length=16)
-    supported_auth_methods: list[str] = Field(
-        default_factory=list,
-        sa_column=Column(JSON, nullable=False),
-    )
-    default_credential_policy: str = Field(default="user", max_length=16)
-    oauth_dcr_supported: bool | None = Field(default=None)
-    oauth_default_scope: str | None = Field(default=None, max_length=512)
-    oauth_static_client_id: str | None = Field(default=None, max_length=256)
-    oauth_static_client_secret_credential_id: str | None = Field(
-        default=None,
-        foreign_key="credentials.id",
-        max_length=20,
-    )
-    static_form_schema: list[dict[str, Any]] | None = Field(
-        default=None,
-        sa_column=Column(JSON, nullable=True),
-    )
-    static_auth_header_template: str | None = Field(default=None, max_length=256)
-    template_metadata: dict[str, Any] = Field(
-        default_factory=dict,
-        sa_column=Column(JSON, nullable=False, server_default=text("'{}'")),
-    )
-    tool_citation_defaults: dict[str, dict[str, Any]] = Field(
-        default_factory=dict,
-        sa_column=Column(JSON, nullable=False, server_default=text("'{}'")),
-    )
-    status: str = Field(default="active", max_length=16)
+- `org_id` (FK, indexed), `workspace_id` (FK, indexed, required),
+  `install_id` (FK, indexed, required).
+- `enabled` (bool, default `true`), `credential_policy`
+  (`org` | `workspace` | `user` | `none`), `enablement_source`
+  (`admin_auto` | `admin_manual` | `workspace_manual`), `updated_by_user_id` (FK).
+- Unique on `(workspace_id, install_id)`.
+- Check: `credential_policy IN ('org','workspace','user','none')`.
 
+**`MCPCredentialGrant`** (`mcgrn`, table `mcp_credential_grants`):
 
-class MCPConnectorInstall(CubeboxBase, table=True):
-    _PREFIX: ClassVar[str] = "mcins"
-    __tablename__ = "mcp_connector_installs"
-    __table_args__ = (
-        UniqueConstraint(
-            "org_id",
-            "workspace_id",
-            "server_url_hash",
-            name="uq_mcp_connector_install_url",
-        ),
-        UniqueConstraint(
-            "org_id",
-            "workspace_id",
-            "name",
-            name="uq_mcp_connector_install_name",
-        ),
-        Index(
-            "uq_mcp_connector_install_per_template",
-            "org_id",
-            text("COALESCE(workspace_id, '_org')"),
-            "template_id",
-            unique=True,
-            postgresql_where=text("template_id IS NOT NULL AND install_state = 'active'"),
-        ),
-    )
+- `org_id` (FK, indexed), `install_id` (FK, indexed), `grant_scope`
+  (`org` | `workspace` | `user`).
+- `workspace_id` (FK, indexed, nullable — required iff `grant_scope=workspace` or
+  `=user`), `user_id` (FK, indexed, nullable — required iff `grant_scope=user`).
+- `credential_id` (FK → `credentials.id`, required, max_length 20),
+  `refresh_credential_id` (FK → `credentials.id`, nullable, max_length 20).
+- `expires_at` (nullable, OAuth access-token expiry), `grant_status`
+  (`valid` | `missing` | `expired` | `revoked` | `error`, default `valid`),
+  `created_by_user_id` (FK).
+- Unique on `(install_id, grant_scope, workspace_id, user_id)`.
+- Check: `grant_scope IN ('org','workspace','user')`.
 
-    org_id: str = Field(foreign_key="organizations.id", max_length=20, index=True)
-    template_id: str | None = Field(
-        default=None,
-        foreign_key="mcp_connector_templates.id",
-        max_length=20,
-        index=True,
-    )
-    install_scope: str = Field(default="org", max_length=16)
-    workspace_id: str | None = Field(
-        default=None,
-        foreign_key="workspaces.id",
-        max_length=20,
-        index=True,
-    )
-    name: str = Field(max_length=64)
-    server_url: str = Field(max_length=2048)
-    server_url_hash: str = Field(max_length=64)
-    transport: str = Field(max_length=16)
-    auth_method: str = Field(max_length=16)
-    default_credential_policy: str = Field(max_length=16)
-    auth_status: str = Field(default="pending", max_length=16)
-    discovery_status: str = Field(default="not_run", max_length=16)
-    install_state: str = Field(
-        default="active",
-        max_length=16,
-        sa_column_kwargs={"server_default": text("'active'")},
-    )
-    oauth_client_config: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
-    headers: dict[str, str] = Field(default_factory=dict, sa_column=Column(JSON))
-    tools_cache: list[dict[str, Any]] = Field(default_factory=list, sa_column=Column(JSON))
-    tool_citations: dict[str, dict[str, Any]] = Field(
-        default_factory=dict,
-        sa_column=Column(JSON, nullable=False, server_default=text("'{}'")),
-    )
-    last_error: str | None = Field(default=None, max_length=2048)
-    last_discovered_at: datetime | None = None
-    timeout: float = Field(default=30.0)
-    sse_read_timeout: float = Field(default=300.0)
-    auto_enroll_new_workspaces: bool = Field(
-        default=True,
-        sa_column_kwargs={"server_default": text("true")},
-    )
-    created_by_user_id: str = Field(foreign_key="users.id", max_length=20)
+Update `backend/cubebox/models/__init__.py` to export the four classes and remove
+old MCP model exports.
 
+- [ ] **Step 4: Generate the migration via Alembic autogenerate, then patch what autogen can't see**
 
-class MCPWorkspaceConnectorState(CubeboxBase, table=True):
-    _PREFIX: ClassVar[str] = "mcwcs"
-    __tablename__ = "mcp_workspace_connector_states"
-    __table_args__ = (
-        UniqueConstraint("workspace_id", "install_id", name="uq_mcp_workspace_connector_state"),
-    )
+Per repo convention (`backend/CLAUDE.md`, "After modifying SQLModel schemas, use
+auto-generation"), do not hand-write the table create/drop. Run:
 
-    org_id: str = Field(foreign_key="organizations.id", max_length=20, index=True)
-    workspace_id: str = Field(foreign_key="workspaces.id", max_length=20, index=True)
-    install_id: str = Field(foreign_key="mcp_connector_installs.id", max_length=20, index=True)
-    enabled: bool = Field(default=True)
-    credential_policy: str = Field(max_length=16)
-    enablement_source: str = Field(default="workspace_manual", max_length=32)
-    updated_by_user_id: str = Field(foreign_key="users.id", max_length=20)
-
-
-class MCPCredentialGrant(CubeboxBase, table=True):
-    _PREFIX: ClassVar[str] = "mcgrn"
-    __tablename__ = "mcp_credential_grants"
-    __table_args__ = (
-        UniqueConstraint(
-            "install_id",
-            "grant_scope",
-            "workspace_id",
-            "user_id",
-            name="uq_mcp_credential_grant_scope",
-        ),
-    )
-
-    org_id: str = Field(foreign_key="organizations.id", max_length=20, index=True)
-    install_id: str = Field(foreign_key="mcp_connector_installs.id", max_length=20, index=True)
-    grant_scope: str = Field(max_length=16)
-    workspace_id: str | None = Field(
-        default=None,
-        foreign_key="workspaces.id",
-        max_length=20,
-        index=True,
-    )
-    user_id: str | None = Field(
-        default=None,
-        foreign_key="users.id",
-        max_length=20,
-        index=True,
-    )
-    credential_id: str = Field(foreign_key="credentials.id", max_length=20)
-    refresh_credential_id: str | None = Field(default=None, foreign_key="credentials.id")
-    expires_at: datetime | None = None
-    grant_status: str = Field(default="valid", max_length=16)
-    created_by_user_id: str = Field(foreign_key="users.id", max_length=20)
+```bash
+cd backend
+uv run alembic revision --autogenerate -m "normalize mcp four-layer tables"
 ```
 
-Update `backend/cubebox/models/__init__.py` to export the four classes and remove old
-MCP model exports.
+Alembic will emit a new file under `backend/alembic/versions/<hash>_normalize_mcp_four_layer_tables.py`
+containing:
 
-- [ ] **Step 4: Add destructive migration to target tables**
+- `op.drop_table(...)` for `user_mcp_credentials`, `workspace_mcp_credentials`,
+  `workspace_mcp_overrides`, `mcp_servers`, `mcp_catalog_connectors`.
+- `op.create_table(...)` for the four new tables with columns, FKs, plain
+  `UniqueConstraint`s, and indexes reflected off the SQLModel classes.
 
-Create `backend/alembic/versions/f2a6c7d8e901_normalize_mcp_four_layer_tables.py`.
+Then open the generated file and manually add what autogenerate cannot infer:
 
-Use revision id `f2a6c7d8e901` and set `down_revision` to the current head before this
-branch. The migration should:
+1. **Partial unique index** on installs (autogen does not produce `postgresql_where`):
 
-```python
-def upgrade() -> None:
-    op.drop_table("user_mcp_credentials")
-    op.drop_table("workspace_mcp_credentials")
-    op.drop_table("workspace_mcp_overrides")
-    op.drop_table("mcp_servers")
-    op.drop_table("mcp_catalog_connectors")
+   ```python
+   op.create_index(
+       "uq_mcp_connector_install_per_template",
+       "mcp_connector_installs",
+       ["org_id", sa.text("COALESCE(workspace_id, '_org')"), "template_id"],
+       unique=True,
+       postgresql_where=sa.text(
+           "template_id IS NOT NULL AND install_state = 'active'"
+       ),
+   )
+   ```
 
-    # Create mcp_connector_templates, mcp_connector_installs,
-    # mcp_workspace_connector_states, and mcp_credential_grants with the
-    # columns defined in backend/cubebox/models/mcp.py.
-```
+2. **Four `CHECK` constraints** (autogen ignores `CheckConstraint` produced by SQLModel
+   in some versions; verify and add as needed):
 
-Create the four tables with the columns from `backend/cubebox/models/mcp.py`. Keep these
-constraints:
+   - `ck_mcp_connector_installs_scope`: `install_scope IN ('org','workspace')`
+   - `ck_mcp_connector_installs_auth_method`: `auth_method IN ('oauth','static','none')`
+   - `ck_mcp_workspace_connector_states_policy`:
+     `credential_policy IN ('org','workspace','user','none')`
+   - `ck_mcp_credential_grants_scope`: `grant_scope IN ('org','workspace','user')`
 
-```python
-op.create_check_constraint(
-    "ck_mcp_connector_installs_scope",
-    "mcp_connector_installs",
-    "install_scope IN ('org', 'workspace')",
-)
-op.create_check_constraint(
-    "ck_mcp_connector_installs_auth_method",
-    "mcp_connector_installs",
-    "auth_method IN ('oauth', 'static', 'none')",
-)
-op.create_check_constraint(
-    "ck_mcp_workspace_connector_states_policy",
-    "mcp_workspace_connector_states",
-    "credential_policy IN ('org', 'workspace', 'user', 'none')",
-)
-op.create_check_constraint(
-    "ck_mcp_credential_grants_scope",
-    "mcp_credential_grants",
-    "grant_scope IN ('org', 'workspace', 'user')",
-)
-```
+3. **Downgrade**: destructive migration is not reversible. Replace the autogenerated
+   `downgrade()` body with:
 
-For `downgrade()`, drop the four target tables and recreate the old MCP tables only if
-the repository convention requires reversible migrations. If reversible migrations are not
-required for destructive internal changes, raise:
+   ```python
+   raise RuntimeError("Destructive MCP four-layer migration is not reversible")
+   ```
 
-```python
-raise RuntimeError("Destructive MCP four-layer migration is not reversible")
-```
+Do not hard-code the revision hash anywhere; trust whatever Alembic generated.
 
 - [ ] **Step 5: Run migration and model tests**
 
@@ -407,7 +317,7 @@ Expected: migration succeeds and tests pass.
 ```bash
 git add backend/cubebox/models/mcp.py \
         backend/cubebox/models/__init__.py \
-        backend/alembic/versions/f2a6c7d8e901_normalize_mcp_four_layer_tables.py \
+        backend/alembic/versions/*_normalize_mcp_four_layer_tables.py \
         backend/tests/unit/test_mcp_models.py
 git commit -m "feat(mcp): add four-layer connector schema"
 ```
@@ -519,8 +429,14 @@ Edit `backend/cubebox/repositories/mcp.py` so it exports these concrete methods:
 - `MCPCredentialGrantRepository.delete_scope(install_id: str, grant_scope: str,
   workspace_id: str | None, user_id: str | None) -> None`
 
-Use the existing org-scoped repository pattern: every non-template repository receives
-`org_id` in `__init__` and filters by it in every query.
+**Repository scoping note.** The existing `ScopedRepository[T]` (in
+`backend/cubebox/repositories/base.py`) requires `OrgScopedMixin`, which the new MCP
+models cannot use (installs/grants have nullable `workspace_id`; templates have no
+`org_id` at all). Introduce a *new* lightweight org-only base instead — every
+non-template repo takes `org_id` in `__init__`, every query filters by `org_id`,
+and `add()` force-sets `org_id` to defend against cross-org writes. `MCPConnectorTemplate`
+has no org scope. Document the deviation from `ScopedRepository` in a short module
+docstring so future engineers don't try to inherit it.
 
 - [ ] **Step 4: Create template service**
 
@@ -651,163 +567,57 @@ Expected: FAIL because `cubebox.services.mcp_installs` does not exist.
 
 - [ ] **Step 3: Create install service primitives**
 
-Create `backend/cubebox/services/mcp_installs.py`:
+Create `backend/cubebox/services/mcp_installs.py`. The module exposes:
 
-```python
-"""Connector install, workspace state, and grant service."""
+- A frozen dataclass `MCPInstallDefaults(auth_status: str, credential_policy: str)`.
+- A pure function `install_defaults_for_auth_method(auth_method, requested_policy)
+  -> MCPInstallDefaults` with these invariants (the existing unit tests are the contract):
+  - `auth_method=="none"` → `auth_status="not_required"`, `credential_policy="none"`
+    (regardless of what was requested — "none" must never become user-scope).
+  - Otherwise → `auth_status="pending"`, `credential_policy=requested_policy`.
+- A class `MCPConnectorInstallService(install_repo, state_repo, grant_repo,
+  cred_service, *, org_id, actor_user_id)` with these methods:
+  - `create_from_template_for_workspace(*, template, workspace_id, auth_method,
+    credential_policy)` — writes one install with `install_scope="workspace"`,
+    copies `tool_citation_defaults → tool_citations`, hashes the server URL
+    (reuse `cubebox.mcp._constants.server_url_hash`), then upserts a
+    `WorkspaceConnectorState(enabled=True, enablement_source="workspace_manual")`
+    in the same transaction (atomically — failure rolls both back).
+  - `create_from_template_for_org(*, template, auth_method, credential_policy,
+    distribution)` — analogous to above but `install_scope="org"`,
+    `workspace_id=None`; if `distribution.mode == "auto"` (all current workspaces)
+    or `"selected"` (list of `workspace_ids`), create `WorkspaceConnectorState`
+    rows with `enablement_source="admin_auto"`/`"admin_manual"` accordingly.
+  - `create_static_grant(*, install_id, grant_scope, plaintext, workspace_id=None,
+    user_id=None, name=None)` — stores the secret in the vault via
+    `CredentialService.create(kind=CREDENTIAL_KIND_MCP, ...)`, then writes the
+    grant row pointing at the vault id. Validates scope-vs-fk combination
+    (`workspace` ⇒ `workspace_id`, `user` ⇒ `user_id`).
+  - `disconnect_grant(*, install_id, grant_scope, workspace_id=None, user_id=None)`
+    — deletes the grant row (and OAuth-side revoke when available). Does **not**
+    touch install or workspace state.
+  - `uninstall(install_id)` — flips `install_state="uninstalled"`,
+    `auth_status="disconnected"`, bumps `updated_at`. Does not delete workspace
+    state rows (the effective-state service treats `install_state != "active"`
+    as unusable, per the spec's reason matrix).
 
-from dataclasses import dataclass
-from datetime import UTC, datetime
-
-from cubebox.mcp._constants import CREDENTIAL_KIND_MCP
-from cubebox.mcp._constants import server_url_hash
-from cubebox.models import (
-    MCPConnectorInstall,
-    MCPConnectorTemplate,
-    MCPCredentialGrant,
-    MCPWorkspaceConnectorState,
-)
-from cubebox.repositories.mcp import (
-    MCPConnectorInstallRepository,
-    MCPCredentialGrantRepository,
-    MCPWorkspaceConnectorStateRepository,
-)
-from cubebox.services.credential import CredentialService
-
-
-@dataclass(frozen=True, slots=True)
-class MCPInstallDefaults:
-    auth_status: str
-    credential_policy: str
-
-
-def install_defaults_for_auth_method(
-    auth_method: str,
-    requested_policy: str,
-) -> MCPInstallDefaults:
-    if auth_method == "none":
-        return MCPInstallDefaults(auth_status="not_required", credential_policy="none")
-    return MCPInstallDefaults(auth_status="pending", credential_policy=requested_policy)
-
-
-class MCPConnectorInstallService:
-    def __init__(
-        self,
-        *,
-        install_repo: MCPConnectorInstallRepository,
-        state_repo: MCPWorkspaceConnectorStateRepository,
-        grant_repo: MCPCredentialGrantRepository,
-        cred_service: CredentialService,
-        org_id: str,
-        actor_user_id: str,
-    ) -> None:
-        self._install_repo = install_repo
-        self._state_repo = state_repo
-        self._grant_repo = grant_repo
-        self._cred_service = cred_service
-        self._org_id = org_id
-        self._actor_user_id = actor_user_id
-
-    async def create_from_template_for_workspace(
-        self,
-        *,
-        template: MCPConnectorTemplate,
-        workspace_id: str,
-        auth_method: str,
-        credential_policy: str,
-    ) -> MCPConnectorInstall:
-        defaults = install_defaults_for_auth_method(auth_method, credential_policy)
-        install = await self._install_repo.add(
-            MCPConnectorInstall(
-                org_id=self._org_id,
-                template_id=template.id,
-                install_scope="workspace",
-                workspace_id=workspace_id,
-                name=template.name,
-                server_url=template.server_url,
-                server_url_hash=server_url_hash(template.server_url),
-                transport=template.transport,
-                auth_method=auth_method,
-                default_credential_policy=defaults.credential_policy,
-                auth_status=defaults.auth_status,
-                discovery_status="not_run",
-                tool_citations=dict(template.tool_citation_defaults or {}),
-                created_by_user_id=self._actor_user_id,
-            )
-        )
-        await self._state_repo.upsert(
-            workspace_id=workspace_id,
-            install_id=install.id,
-            enabled=True,
-            credential_policy=defaults.credential_policy,
-            enablement_source="workspace_manual",
-            updated_by_user_id=self._actor_user_id,
-        )
-        return install
-
-    async def create_static_grant(
-        self,
-        *,
-        install_id: str,
-        grant_scope: str,
-        plaintext: str,
-        workspace_id: str | None = None,
-        user_id: str | None = None,
-        name: str | None = None,
-    ) -> MCPCredentialGrant:
-        credential_id = await self._cred_service.create(
-            kind=CREDENTIAL_KIND_MCP,
-            name=name or f"mcp:{install_id}:{grant_scope}",
-            plaintext=plaintext,
-        )
-        return await self._grant_repo.add(
-            MCPCredentialGrant(
-                org_id=self._org_id,
-                install_id=install_id,
-                grant_scope=grant_scope,
-                workspace_id=workspace_id,
-                user_id=user_id,
-                credential_id=credential_id,
-                grant_status="valid",
-                created_by_user_id=self._actor_user_id,
-            )
-        )
-
-    async def uninstall(self, install_id: str) -> MCPConnectorInstall:
-        install = await self._install_repo.get(install_id)
-        if install is None:
-            raise ValueError("connector_install_not_found")
-        install.install_state = "uninstalled"
-        install.auth_status = "disconnected"
-        install.updated_at = datetime.now(UTC)
-        return await self._install_repo.update(install)
-```
+No fall-back fan-out: a `credential_policy=user` request must never write or read
+an `org`-scope grant; enforce this at the service boundary as a positive assertion,
+not just an absence of code.
 
 - [ ] **Step 4: Add dependency providers**
 
-Edit `backend/cubebox/mcp/dependencies.py` and add:
+In `backend/cubebox/mcp/dependencies.py`, add two FastAPI dependency providers
+following the patterns already in that file:
 
-```python
-async def get_connector_template_service(
-    session: AsyncSession = Depends(get_session),
-) -> MCPConnectorTemplateService:
-    return MCPConnectorTemplateService(MCPConnectorTemplateRepository(session))
+- `get_connector_template_service(session) -> MCPConnectorTemplateService` — global,
+  no org scope.
+- `get_connector_install_service(session, cred_service, ctx) ->
+  MCPConnectorInstallService` — `ctx` from the existing `require_member` /
+  `request_context` dependency; instantiate the three repos (install, state, grant)
+  with `org_id=ctx.org_id`, pass `actor_user_id=ctx.user.id`.
 
-
-async def get_connector_install_service(
-    session: AsyncSession = Depends(get_session),
-    cred_service: CredentialService = Depends(get_credential_service),
-    ctx: RequestContext = Depends(require_member),
-) -> MCPConnectorInstallService:
-    return MCPConnectorInstallService(
-        install_repo=MCPConnectorInstallRepository(session, org_id=ctx.org_id),
-        state_repo=MCPWorkspaceConnectorStateRepository(session, org_id=ctx.org_id),
-        grant_repo=MCPCredentialGrantRepository(session, org_id=ctx.org_id),
-        cred_service=cred_service,
-        org_id=ctx.org_id,
-        actor_user_id=ctx.user.id,
-    )
-```
+Remove old `get_*catalog*` / `get_*override*` providers from the same module.
 
 - [ ] **Step 5: Run service tests**
 
@@ -831,13 +641,14 @@ git commit -m "feat(mcp): add install state and grant services"
 
 ---
 
-## Task 4: Final API Routes Only
+## Task 4: Final API Routes (Including OAuth Alignment)
 
 **Files:**
 
 - Modify: `backend/cubebox/api/schemas/mcp.py`
 - Modify: `backend/cubebox/api/routes/v1/admin_mcp.py`
 - Modify: `backend/cubebox/api/routes/v1/ws_mcp.py`
+- Modify: `backend/cubebox/api/routes/v1/mcp_oauth.py`
 - Modify: `backend/cubebox/api/app.py`
 - Delete: `backend/cubebox/api/routes/v1/mcp_catalog.py`
 - Modify: `backend/tests/unit/test_admin_mcp_routes.py`
@@ -846,42 +657,51 @@ git commit -m "feat(mcp): add install state and grant services"
 
 - [ ] **Step 1: Add route registration tests**
 
-Replace the MCP route assertions in `backend/tests/unit/test_ws_mcp_routes.py` with:
+Replace the MCP route assertions in `backend/tests/unit/test_ws_mcp_routes.py` with
+the workspace-side contract. The test must assert each of the following is registered:
 
-```python
-def test_workspace_mcp_four_layer_routes_are_registered() -> None:
-    from cubebox.api.app import create_app
+- `GET    /api/v1/ws/{workspace_id}/mcp/templates`
+- `GET    /api/v1/ws/{workspace_id}/mcp/connectors`
+- `POST   /api/v1/ws/{workspace_id}/mcp/installs`
+- `DELETE /api/v1/ws/{workspace_id}/mcp/installs/{install_id}`  (workspace-local uninstall)
+- `PATCH  /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/state`
+- `POST   /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me`
+- `DELETE /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me`
+- `POST   /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me/oauth/start`
+- `POST   /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/workspace`
+- `DELETE /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/workspace`
+- `POST   /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/workspace/oauth/start`
 
-    app = create_app()
-    paths = {route.path for route in app.routes}
+And negative assertions that `/mcp/catalog`, `/mcp/org-installs/.../override`, and
+any `/mcp/servers/...` are absent.
 
-    assert "/api/v1/ws/{workspace_id}/mcp/templates" in paths
-    assert "/api/v1/ws/{workspace_id}/mcp/installs" in paths
-    assert "/api/v1/ws/{workspace_id}/mcp/installs/{install_id}/state" in paths
-    assert "/api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me" in paths
-    assert "/api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/workspace" in paths
-    assert "/api/v1/ws/{workspace_id}/mcp/connectors" in paths
-    assert "/api/v1/ws/{workspace_id}/mcp/catalog" not in paths
-    assert "/api/v1/ws/{workspace_id}/mcp/org-installs/{install_id}/override" not in paths
-```
+Replace the MCP route assertions in `backend/tests/unit/test_admin_mcp_routes.py`
+with the admin-side contract. Required:
 
-Replace the MCP route assertions in `backend/tests/unit/test_admin_mcp_routes.py` with:
+- `GET    /api/v1/admin/mcp/templates`                  (template library)
+- `GET    /api/v1/admin/mcp/installs`                   (list org installs)
+- `POST   /api/v1/admin/mcp/installs`                   (create org install, with optional
+   `template_id` and `auto_enable` distribution payload)
+- `GET    /api/v1/admin/mcp/installs/{install_id}`      (detail)
+- `PATCH  /api/v1/admin/mcp/installs/{install_id}`      (edit default_credential_policy,
+   auto_enroll_new_workspaces, headers, etc.)
+- `DELETE /api/v1/admin/mcp/installs/{install_id}`      (uninstall)
+- `POST   /api/v1/admin/mcp/installs/{install_id}/grants/org`
+- `DELETE /api/v1/admin/mcp/installs/{install_id}/grants/org`
+- `POST   /api/v1/admin/mcp/installs/{install_id}/grants/org/oauth/start`
 
-```python
-def test_admin_mcp_four_layer_routes_are_registered() -> None:
-    from cubebox.api.app import create_app
+Plus a public route:
 
-    app = create_app()
-    paths = {route.path for route in app.routes}
+- `GET    /api/v1/mcp/templates`  (authenticated, but not workspace-scoped — used
+   by the template library / global picker; may attach `install_summary` for the
+   caller's current org when present).
 
-    assert "/api/v1/admin/mcp/templates" in paths
-    assert "/api/v1/admin/mcp/templates/{template_id}/installs" in paths
-    assert "/api/v1/admin/mcp/installs" in paths
-    assert "/api/v1/admin/mcp/installs/{install_id}" in paths
-    assert "/api/v1/admin/mcp/installs/{install_id}/grants/org" in paths
-    assert "/api/v1/admin/mcp/catalog/{catalog_id}/install" not in paths
-    assert "/api/v1/admin/mcp/servers/{server_id}/overrides" not in paths
-```
+And negative assertions: no `/admin/mcp/catalog/...`, no `/admin/mcp/servers/...`,
+no `/admin/mcp/.../overrides`.
+
+Methods are part of the contract: do **not** use `PUT` for grant create. POST creates
+or replaces a scoped grant; DELETE disconnects it. This matches the spec's API
+shape and lets the same body shape be reused for replace-on-rotation.
 
 - [ ] **Step 2: Run route tests and confirm old route names still exist**
 
@@ -896,47 +716,78 @@ Expected: FAIL because current routes still expose old MCP paths.
 
 - [ ] **Step 3: Replace MCP schemas**
 
-Edit `backend/cubebox/api/schemas/mcp.py` so public schemas use final names.
-Use `Literal["org", "workspace", "user", "none"]` for credential policy fields and
-`Literal["oauth", "static", "none"]` for auth method fields.
-
-The response schemas must include these fields:
+Rewrite `backend/cubebox/api/schemas/mcp.py` using final nouns. Use
+`Literal["org","workspace","user","none"]` for credential policies,
+`Literal["oauth","static","none"]` for auth methods. The contracts (one Pydantic
+model per item; subagent decides field order, base class, etc.):
 
 - `MCPConnectorTemplateOut`: `template_id`, `slug`, `name`, `provider`, `description`,
   `server_url`, `transport`, `supported_auth_methods`, `default_credential_policy`,
   `static_form_schema`, `status`.
 - `MCPConnectorInstallOut`: `install_id`, `template_id`, `install_scope`, `workspace_id`,
   `name`, `server_url`, `transport`, `auth_method`, `default_credential_policy`,
-  `auth_status`, `discovery_status`, `install_state`, `tool_count`, `last_error`.
+  `auth_status`, `discovery_status`, `install_state`, `tool_count` (derived: `len(tools_cache)`),
+  `last_error`, `auto_enroll_new_workspaces`.
 - `MCPWorkspaceConnectorStateOut`: `workspace_id`, `install_id`, `enabled`,
   `credential_policy`, `enablement_source`.
 - `MCPCredentialGrantStatusOut`: `install_id`, `grant_scope`, `workspace_id`, `user_id`,
-  `grant_status`, `has_value`, `expires_at`.
-- `MCPEffectiveConnectorOut`: `template`, `install`, `workspace_state`, `credential_policy`,
-  `credential_availability`, `credential_source`, `usable`, `reason`.
+  `grant_status`, `has_value` (true iff vault still holds the credential),
+  `expires_at`.
+- `MCPEffectiveConnectorOut` (per spec §API Shape example): `template` (nullable for
+  custom installs), `install`, `workspace_state`, `credential_policy`,
+  `required_grant_scope`, `credential_availability`
+  (`available` | `missing` | `not_required`), `credential_source` (`org` | `workspace` |
+  `user` | `null`), `usable`, `reason`.
+
+Request schemas should also exist for:
+
+- `AdminCreateInstallIn`: `template_id?`, `install_scope` (`org`),
+  `auth_method`, `default_credential_policy`, `auto_enable?: {mode: "all"|"selected"|"none",
+  workspace_ids?: list[str]}`, optional `server_url`/`transport`/`headers` for custom.
+- `PatchInstallIn`: subset of mutable install fields (`default_credential_policy`,
+  `auto_enroll_new_workspaces`, `headers`, `name`, ...). Reject any unknown key.
+- `PatchWorkspaceStateIn`: `enabled?`, `credential_policy?`.
+- `CreateGrantIn` (three flavors for org / workspace / me): `credential_plaintext`
+  for static, `oauth_callback_state` for OAuth resolution, or empty body for OAuth-start.
 
 - [ ] **Step 4: Replace admin routes**
 
-Edit `backend/cubebox/api/routes/v1/admin_mcp.py` to expose these routes:
+Rewrite `backend/cubebox/api/routes/v1/admin_mcp.py` to expose the admin contract
+from Step 1 (template list, install CRUD, grant POST/DELETE, oauth/start). Each
+handler delegates to `MCPConnectorInstallService` / `MCPConnectorTemplateService`;
+no DB queries inline.
 
-- `GET /api/v1/admin/mcp/templates`
-- `POST /api/v1/admin/mcp/templates/{template_id}/installs`
-- `GET /api/v1/admin/mcp/installs`
-- `DELETE /api/v1/admin/mcp/installs/{install_id}`
-- `PUT /api/v1/admin/mcp/installs/{install_id}/grants/org`
+Also register the public template route:
 
-Remove server/override route handlers from this module.
+- `GET /api/v1/mcp/templates` — authenticated; returns templates plus an optional
+  `install_summary` (count of active installs for the caller's org) for each row.
+
+Existing `mcp_oauth.py` start/callback handlers must be **aligned** in this task:
+
+- The OAuth start endpoints now live at `…/grants/<scope>/oauth/start`; the
+  callback writes an `MCPCredentialGrant` whose `grant_scope`, `workspace_id`,
+  and `user_id` are recovered from the OAuth state token (not from session state).
+- The callback must not write to `mcp_servers` or `workspace_mcp_credentials`
+  (those tables are gone). Update its imports/repositories accordingly.
+- The callback updates the install's `auth_status` from `pending` → `authorized`
+  only when the grant being created has `grant_scope` matching
+  `install.default_credential_policy`'s required scope; otherwise leave
+  `auth_status` alone — the install can have multiple per-user grants without
+  the install itself becoming "authorized".
+
+Remove server/override/catalog handlers from this module.
 
 - [ ] **Step 5: Replace workspace routes**
 
-Edit `backend/cubebox/api/routes/v1/ws_mcp.py` to expose these routes:
+Rewrite `backend/cubebox/api/routes/v1/ws_mcp.py` to expose the workspace contract
+from Step 1. Authorization rules from spec §User Roles And Permissions:
 
-- `GET /api/v1/ws/{workspace_id}/mcp/templates`
-- `POST /api/v1/ws/{workspace_id}/mcp/installs`
-- `PATCH /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/state`
-- `PUT /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me`
-- `PUT /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/workspace`
-- `GET /api/v1/ws/{workspace_id}/mcp/connectors`
+- All routes require workspace membership (`require_member`).
+- `POST /installs`, `DELETE /installs/{id}`, `PATCH /installs/{id}/state`, and
+  the workspace-scope grant routes require `role=admin` on the workspace.
+- `*/grants/me*` routes are open to any member.
+- A workspace member cannot delete a workspace-local install they did not create
+  unless they are workspace admin.
 
 Remove old server/catalog/org-install override handlers from this module.
 
@@ -968,6 +819,7 @@ Expected: all tests pass.
 git add backend/cubebox/api/schemas/mcp.py \
         backend/cubebox/api/routes/v1/admin_mcp.py \
         backend/cubebox/api/routes/v1/ws_mcp.py \
+        backend/cubebox/api/routes/v1/mcp_oauth.py \
         backend/cubebox/api/app.py \
         backend/tests/unit/test_admin_mcp_routes.py \
         backend/tests/unit/test_ws_mcp_routes.py
@@ -984,13 +836,13 @@ git commit -m "feat(mcp): replace catalog routes with four-layer API"
 - Modify: `backend/cubebox/mcp/cubepi_discovery.py`
 - Modify: `backend/cubebox/mcp/cubepi_runtime.py`
 - Modify: `backend/cubebox/streams/run_manager.py`
-- Create: `backend/tests/unit/mcp/test_effective_state.py`
-- Create: `backend/tests/unit/mcp/test_effective_service.py`
+- Create: `backend/tests/unit/test_mcp_effective_state.py`
+- Create: `backend/tests/unit/test_mcp_effective_service.py`
 - Modify: `backend/tests/unit/test_mcp_cubepi_runtime.py`
 
 - [ ] **Step 1: Add effective state tests**
 
-Create `backend/tests/unit/mcp/test_effective_state.py`:
+Create `backend/tests/unit/test_mcp_effective_state.py`:
 
 ```python
 from cubebox.mcp.effective import MCPEffectiveInput, MCPGrantInput, compute_effective_state
@@ -1112,52 +964,81 @@ def compute_effective_state(value: MCPEffectiveInput) -> MCPEffectiveResult:
 
 - [ ] **Step 3: Add DB-backed effective service**
 
-Extend `backend/cubebox/mcp/effective.py` with `MCPEffectiveConnectorService`.
+Extend `backend/cubebox/mcp/effective.py` with `MCPEffectiveConnectorService`. This
+is the **only** place in the codebase that joins template + install + workspace state
++ grant to decide runtime usability. Two public methods:
 
-It should:
+- `list_for_workspace_user(workspace_id, user_id, *, include_unusable: bool=True)
+  -> list[MCPEffectiveConnectorDTO]` — for UI/admin/diagnostics. Returns every
+  install visible to the workspace (org installs that have a `WorkspaceConnectorState`
+  row, plus all workspace-local installs in the same workspace). When
+  `include_unusable=False`, drop rows whose `compute_effective_state` returns
+  `usable=False`.
+- `list_runtime_specs(workspace_id, user_id) -> list[MCPRuntimeConnectorSpec]` —
+  for the agent runtime. Returns only `usable=True` rows with the minimum fields
+  the loader needs (`install_id`, `server_url`, `transport`, `auth_method`,
+  resolved `grant_scope`, `credential_id` reference, `tool_citations`,
+  `tools_cache`).
 
-- load active org installs plus workspace installs;
-- load `MCPWorkspaceConnectorState` for each install and workspace;
-- load the required grant from `MCPCredentialGrantRepository`;
-- return unusable rows when `include_unusable=True`;
-- return only usable rows to runtime.
+Algorithm (sequential reads OK; everything is per-request and small):
 
-The service exposes two methods:
+1. Resolve the caller's `org_id` from workspace membership.
+2. Load active workspace-local installs for this workspace and all active org
+   installs in this org. Skip rows where `install_state != "active"`.
+3. For each install, look up its `WorkspaceConnectorState` for `(workspace_id, install_id)`.
+   Missing state for an org install ⇒ `enabled=False` (don't synthesize a row).
+   Missing state for a workspace install ⇒ defect — log + treat as `enabled=False`.
+4. Resolve the **required grant** by combining `state.credential_policy` (if state
+   exists) else `install.default_credential_policy`:
+   - `none` ⇒ no grant fetch; `credential_availability="not_required"`.
+   - `org` ⇒ fetch `(install_id, grant_scope='org')`.
+   - `workspace` ⇒ fetch `(install_id, 'workspace', workspace_id)`.
+   - `user` ⇒ fetch `(install_id, 'user', workspace_id, user_id)`.
+   No fall-back across scopes. The presence of an org grant must not flip a
+   user-policy row to usable.
+5. Load template by `install.template_id` (if any). Custom installs (template_id
+   `NULL`) get `template_status=None`; `compute_effective_state` must treat
+   `None` as "no template gate" (already implemented in the pure function).
+6. For OAuth grants that look expired (`expires_at < now`), call
+   `OAuthTokenManager.get_access_token(...)` — it refreshes via the
+   `refresh_credential_id` and updates the grant in place. If refresh fails,
+   set `grant_status="expired"` and let `compute_effective_state` mark unusable
+   with reason `grant_expired`.
+7. Hand off to `compute_effective_state` per row and assemble the DTO list.
 
-- `list_for_workspace_user(workspace_id: str, user_id: str, include_unusable: bool)
-  -> list[MCPEffectiveConnectorDTO]`
-- `list_runtime_specs(workspace_id: str, user_id: str) -> list[MCPRuntimeConnectorSpec]`
+Performance: one round-trip per layer (templates, installs, states, grants) using
+`IN (...)` filters keyed by the install id set; do not N+1 per install.
 
-- [ ] **Step 4: Wire OAuth refresh in runtime token resolution**
+- [ ] **Step 4: Wire credential resolution in the runtime loader**
 
-Edit `backend/cubebox/mcp/cubepi_runtime.py` so `load_workspace_mcp_tools_for_cubepi`
-accepts:
+`backend/cubebox/mcp/cubepi_runtime.py::load_workspace_mcp_tools_for_cubepi` should
+take `effective_service: MCPEffectiveConnectorService` and a non-optional
+`token_manager: OAuthTokenManager`. For each `MCPRuntimeConnectorSpec` from
+`list_runtime_specs(...)`, resolve the connection credential by `auth_method`:
 
-```python
-effective_service: MCPEffectiveConnectorService
-token_manager: OAuthTokenManager | None
-```
+- `oauth` → `token_manager.get_access_token(install_id, grant_scope, workspace_id,
+  user_id)`; the token manager handles refresh + persistence already.
+- `static` → fetch the vault row by `spec.credential_id` via `CredentialService`,
+  decrypt, inject into the configured header template.
+- `none` → mint a short-lived cubebox identity token via the existing
+  `cubebox.mcp.user_token` helper (the same one `mcp_oauth` already uses for
+  identity flow); do **not** look for a grant.
 
-For OAuth grants, call:
-
-```python
-token = await token_manager.get_access_token(
-    install_id=spec.install_id,
-    grant_scope=spec.grant_scope,
-    workspace_id=workspace_id,
-    user_id=user_id,
-)
-```
-
-For static grants, decrypt `spec.credential_id` through `CredentialService`.
-For no-auth connectors, sign the short-lived Cubebox identity token.
+Discovery/refresh failures should not crash the loader — log + skip + continue,
+matching the current behavior.
 
 - [ ] **Step 5: Wire run manager**
 
-Edit `backend/cubebox/streams/run_manager.py` to construct `MCPEffectiveConnectorService`
-inside the MCP tools block and pass it to `load_workspace_mcp_tools_for_cubepi`.
-Construct `OAuthTokenManager` using the same `_build_token_manager_for_org` helper used by
-admin MCP dependencies.
+In `backend/cubebox/streams/run_manager.py`, inside the per-run MCP tools block:
+
+- Build `MCPEffectiveConnectorService` for the current `(org_id, workspace_id, user_id)`.
+- Build `OAuthTokenManager` via the existing
+  `cubebox.mcp.dependencies._build_token_manager_for_org` helper (confirmed to
+  exist; if private, expose a thin wrapper rather than reaching into the
+  underscore name).
+- Pass both into `load_workspace_mcp_tools_for_cubepi`.
+
+Remove any references to old install/server tables from this block.
 
 - [ ] **Step 6: Run effective and runtime tests**
 
@@ -1179,8 +1060,8 @@ git add backend/cubebox/mcp/effective.py \
         backend/cubebox/mcp/cubepi_discovery.py \
         backend/cubebox/mcp/cubepi_runtime.py \
         backend/cubebox/streams/run_manager.py \
-        backend/tests/unit/mcp/test_effective_state.py \
-        backend/tests/unit/mcp/test_effective_service.py \
+        backend/tests/unit/test_mcp_effective_state.py \
+        backend/tests/unit/test_mcp_effective_service.py \
         backend/tests/unit/test_mcp_cubepi_runtime.py
 git commit -m "feat(mcp): derive runtime connectors from effective state"
 ```
@@ -1195,114 +1076,103 @@ git commit -m "feat(mcp): derive runtime connectors from effective state"
 - Create: `backend/tests/e2e/test_mcp_four_layer_runtime.py`
 - Modify: `backend/tests/e2e/conftest.py`
 
-- [ ] **Step 1: Add template fixtures**
+**Goal:** every numbered flow in spec §Testing Strategy lands as an E2E test.
 
-Append to `backend/tests/e2e/conftest.py`:
+- [ ] **Step 1: Add fixtures**
 
-```python
-@pytest_asyncio.fixture
-async def noauth_template_id(db_session: AsyncSession) -> AsyncIterator[str]:
-    from cubebox.repositories.mcp import MCPConnectorTemplateRepository
+In `backend/tests/e2e/conftest.py`, add the fixtures the tests below need.
+Reuse the existing E2E plumbing (the auth/client/workspace fixtures already in this
+file — do not invent new auth flow). Required new fixtures:
 
-    row = await MCPConnectorTemplateRepository(db_session).upsert_by_slug(
-        slug="noauth-e2e",
-        name="NoAuth E2E",
-        description="No auth connector.",
-        provider="Cubebox",
-        server_url="https://noauth-e2e.example.com/mcp",
-        transport="streamable_http",
-        supported_auth_methods=["none"],
-        default_credential_policy="none",
-    )
-    await db_session.commit()
-    yield row.id
-```
+- `noauth_template_id` — seeds a `slug="noauth-e2e"` template with
+  `supported_auth_methods=["none"]`, `default_credential_policy="none"`.
+- `static_template_id` — seeds a `slug="static-e2e"` template with
+  `supported_auth_methods=["static"]`, `default_credential_policy="user"`.
+- `oauth_template_id` — seeds a template with `supported_auth_methods=["oauth"]`
+  and minimal OAuth metadata. Used by the OAuth-refresh test.
+- `admin_client` and `member_client` — workspace clients whose membership role
+  is `admin` and `member` respectively, sharing the same workspace. Used by the
+  user-isolation test (one as admin doing the install, the other as a second
+  user member). If a two-user fixture pattern doesn't yet exist in the file,
+  add the minimum scaffolding (register second user, accept invite) reusing the
+  existing helpers.
 
-- [ ] **Step 2: Add no-auth route E2E**
+- [ ] **Step 2: No-auth happy path (spec test #1, #5-no-auth variant)**
 
-Create `backend/tests/e2e/test_mcp_four_layer_routes.py`:
+Test `test_workspace_installs_noauth_template_and_gets_usable_connector` in
+`backend/tests/e2e/test_mcp_four_layer_routes.py`:
 
-```python
-import httpx
-import pytest
+- Workspace admin POSTs `/installs` with the no-auth template id.
+- GET `/connectors` returns a row whose `enabled=true`, `credential_policy="none"`,
+  `credential_availability="not_required"`, `usable=true`.
+- Runtime smoke (in the runtime-side test file): `list_runtime_specs(...)`
+  returns the connector and no grant lookup is performed.
 
+- [ ] **Step 3: User-policy scope isolation (spec test #3)**
 
-@pytest.mark.usefixtures("stub_discover_tools")
-async def test_workspace_installs_noauth_template_and_gets_usable_connector(
-    client: httpx.AsyncClient,
-    workspace_id: str,
-    noauth_template_id: str,
-) -> None:
-    install = await client.post(
-        f"/api/v1/ws/{workspace_id}/mcp/installs",
-        json={"template_id": noauth_template_id, "auth_method": "none"},
-    )
-    assert install.status_code == 201, install.text
+Two assertions in one test:
 
-    connectors = await client.get(f"/api/v1/ws/{workspace_id}/mcp/connectors")
-    assert connectors.status_code == 200, connectors.text
-    row = next(
-        item
-        for item in connectors.json()["items"]
-        if item["install"]["install_id"] == install.json()["install_id"]
-    )
-    assert row["workspace_state"]["enabled"] is True
-    assert row["credential_policy"] == "none"
-    assert row["credential_availability"] == "not_required"
-    assert row["usable"] is True
-```
+1. Org admin installs static template with `credential_policy="org"` + org-grant
+   plaintext. Workspace admin (`admin_client`) flips state to
+   `credential_policy="user"`. Without any user grant, both users see
+   `credential_availability="missing"` and `usable=false`. The pre-existing
+   org grant must **not** satisfy a user-policy row.
+2. User A (`admin_client`'s user) POSTs `/grants/me` with their token. User A
+   then sees `usable=true`; user B (`member_client`) still sees
+   `credential_availability="missing"` and `usable=false` for the same install.
 
-- [ ] **Step 3: Add user grant isolation E2E**
+- [ ] **Step 4: Policy change drops the previous scope's grant from runtime
+  (spec test #4)**
 
-Append to `backend/tests/e2e/test_mcp_four_layer_routes.py`:
+- Org install with `credential_policy="org"` and a valid org grant.
+- Workspace flips `credential_policy` to `"workspace"` via PATCH state.
+- GET `/connectors` shows `credential_source` is no longer `org`; without a
+  workspace grant, `usable=false`, reason `credential_missing`.
 
-```python
-@pytest.mark.usefixtures("stub_discover_tools")
-async def test_user_grant_policy_does_not_fall_back_to_org_grant(
-    admin_client: tuple[httpx.AsyncClient, str],
-    github_template_id: str,
-) -> None:
-    client, workspace_id = admin_client
-    install = await client.post(
-        f"/api/v1/admin/mcp/templates/{github_template_id}/installs",
-        json={
-            "auth_method": "static",
-            "credential_policy": "org",
-            "credential_plaintext": "org-token",
-        },
-    )
-    assert install.status_code == 201, install.text
-    install_id = install.json()["install_id"]
+- [ ] **Step 5: Disconnect keeps install/state (spec test #5)**
 
-    state = await client.patch(
-        f"/api/v1/ws/{workspace_id}/mcp/installs/{install_id}/state",
-        json={"enabled": True, "credential_policy": "user"},
-    )
-    assert state.status_code == 200, state.text
+- After Step 4's setup, DELETE the org grant.
+- Install row still exists with `install_state="active"`; `WorkspaceConnectorState`
+  row still has `enabled=true`. Effective state for that workspace returns
+  `usable=false`, reason `credential_missing`. Re-POSTing a grant immediately
+  flips back to usable without re-install.
 
-    connectors = await client.get(f"/api/v1/ws/{workspace_id}/mcp/connectors")
-    row = next(
-        item
-        for item in connectors.json()["items"]
-        if item["install"]["install_id"] == install_id
-    )
-    assert row["credential_policy"] == "user"
-    assert row["credential_availability"] == "missing"
-    assert row["usable"] is False
-```
+- [ ] **Step 6: Uninstall then reinstall same template (spec test #6)**
 
-- [ ] **Step 4: Run backend E2E tests**
+- DELETE the install. Verify `install_state="uninstalled"`,
+  `WorkspaceConnectorState` rows are no longer returned by `GET /connectors`.
+- POST a new install from the same template — should succeed (partial unique
+  index ignores uninstalled rows).
 
-Run:
+- [ ] **Step 7: OAuth refresh before runtime returns usable (spec test #7)**
+
+In `backend/tests/e2e/test_mcp_four_layer_runtime.py`, stub `OAuthTokenManager`'s
+HTTP refresh call (the existing OAuth tests already monkeypatch the provider
+endpoint — reuse that fixture). Insert a user grant with `expires_at` in the
+past and a fake refresh-credential. `list_runtime_specs(...)` should:
+
+1. Trigger a refresh call (assert the mock got hit exactly once).
+2. Return the connector as usable with the freshly-rotated `credential_id`
+   stored on the grant row.
+3. Leave `grant_status="valid"`.
+
+- [ ] **Step 8: Invalid credential policy is rejected at API boundary
+  (spec test #8)**
+
+POST `/installs` with `credential_policy="bogus"` returns 422 with a field
+error pointing at `credential_policy`; no rows are written.
+
+- [ ] **Step 9: Run backend E2E tests**
 
 ```bash
 cd backend
-uv run pytest -q tests/e2e/test_mcp_four_layer_routes.py
+uv run pytest -q tests/e2e/test_mcp_four_layer_routes.py \
+                 tests/e2e/test_mcp_four_layer_runtime.py
 ```
 
 Expected: all tests pass.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
 git add backend/tests/e2e/conftest.py \
@@ -1514,35 +1384,33 @@ Ready
 
 Remove visible UI copy containing `Catalog`, `Override`, `catalog`, or `override`.
 
-- [ ] **Step 3: Add message keys**
+- [ ] **Step 3: Replace message keys (both locales together — i18n parity check is in CI)**
 
-Add to `frontend/packages/web/messages/en.json` under `mcp`:
+Add the new keys (English / 简体中文) to `frontend/packages/web/messages/en.json` and
+`frontend/packages/web/messages/zh.json` under `mcp`:
 
-```json
-"templates": "Connector templates",
-"installs": "Connector installs",
-"workspaceState": "Workspace state",
-"credentialPolicy": "Credential policy",
-"orgGrant": "Org grant",
-"workspaceGrant": "Workspace grant",
-"myGrant": "My grant",
-"needsCredential": "Needs your credential",
-"ready": "Ready"
+| Key | en | zh |
+| --- | --- | --- |
+| `templates` | Connector templates | 连接器模板 |
+| `installs` | Connector installs | 连接器安装 |
+| `workspaceState` | Workspace state | 工作区状态 |
+| `credentialPolicy` | Credential policy | 凭证策略 |
+| `orgGrant` | Org grant | 组织授权 |
+| `workspaceGrant` | Workspace grant | 工作区授权 |
+| `myGrant` | My grant | 我的授权 |
+| `needsCredential` | Needs your credential | 需要你的凭证 |
+| `ready` | Ready | 可用 |
+
+In the same edit, **remove every key whose path starts with `mcpCatalog.*` or
+`mcpOverride*`** from both files — the i18n parity check (added in commit
+`884920a0`) will fail CI if the two locales diverge. After editing, run:
+
+```bash
+cd frontend
+pnpm --filter @cubebox/web i18n:check  # or whatever the parity script is named
 ```
 
-Add to `frontend/packages/web/messages/zh.json` under `mcp`:
-
-```json
-"templates": "连接器模板",
-"installs": "连接器安装",
-"workspaceState": "工作区状态",
-"credentialPolicy": "凭证策略",
-"orgGrant": "组织授权",
-"workspaceGrant": "工作区授权",
-"myGrant": "我的授权",
-"needsCredential": "需要你的凭证",
-"ready": "可用"
-```
+to confirm no orphan keys remain.
 
 - [ ] **Step 4: Add E2E copy assertions**
 

--- a/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
+++ b/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
@@ -1,1629 +1,957 @@
-# MCP Management Four-Layer Implementation Plan
+# MCP Management Four-Layer Direct Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Implement the four-layer MCP management model so templates, installs, workspace state, and credential grants have separate product and runtime semantics.
+**Goal:** Replace the current MCP catalog/server/override model with the final four-layer model: connector templates, connector installs, workspace connector states, and credential grants.
 
-**Architecture:** Add a backend effective-state service over the current tables first, then move runtime, APIs, and UI to consume that service. Keep legacy `catalog`/`override` URLs as compatibility wrappers while the product language changes to connector templates, installs, workspace state, and grants.
+**Architecture:** Use a direct schema and API replacement because the product has not shipped. Create target tables and model classes, remove old catalog/override routes, make `credential_grants` the single grant table, and make `EffectiveConnectorService` the only source of runtime usability.
 
 **Tech Stack:** FastAPI, SQLModel, Alembic, PostgreSQL, Redis, OAuthTokenManager, Next.js, Zustand, TypeScript, pytest, Playwright.
 
 **Spec:** `docs/superpowers/specs/2026-05-15-mcp-management-four-layer-design.md`
 
-**Conventions:**
+**Implementation Policy:**
 
-- Run backend commands from `backend/`.
-- Run frontend commands from `frontend/`.
-- In this worktree, read `.worktree.env` before manual server checks.
-- Keep one logical commit per task unless a task only updates this plan.
-- Do not physically rename existing DB tables in this implementation pass.
-- Preserve old endpoints until frontend and runtime have migrated.
+- No forward compatibility with old MCP product/API names.
+- Remove `catalog` and `override` from public API paths, frontend API helpers, UI copy,
+  services, repositories, and new tests.
+- Use target table names now:
+  `connector_templates`, `connector_installs`, `workspace_connector_states`,
+  `credential_grants`.
+- Existing local MCP data can be dropped by migration. The product has no released
+  external contract.
+- Keep the credential vault table; grant rows point to vault credential ids.
+- Keep `backend/cubebox/models/mcp.py` as the MCP model module, but replace the model
+  classes inside it with the four final nouns.
 
 ---
 
 ## File Structure
 
-**Backend — new files:**
+**Backend — create:**
 
-- `backend/cubebox/mcp/effective.py` — four-layer domain types, pure state computation,
-  DB-backed effective connector service, and runtime spec conversion.
-- `backend/tests/unit/mcp/test_effective_state.py` — pure decision-table tests.
-- `backend/tests/unit/mcp/test_effective_service.py` — service tests using fake rows/repos.
-- `backend/tests/e2e/test_mcp_effective_connectors.py` — route and runtime-level coverage.
+- `backend/alembic/versions/f2a6c7d8e901_normalize_mcp_four_layer_tables.py`
+- `backend/cubebox/mcp/effective.py`
+- `backend/cubebox/services/mcp_templates.py`
+- `backend/cubebox/services/mcp_installs.py`
+- `backend/tests/unit/mcp/test_effective_state.py`
+- `backend/tests/unit/mcp/test_effective_service.py`
+- `backend/tests/e2e/test_mcp_four_layer_routes.py`
+- `backend/tests/e2e/test_mcp_four_layer_runtime.py`
 
-**Backend — modified files:**
+**Backend — modify:**
 
-- `backend/cubebox/models/mcp.py` — add `install_status` to separate install lifecycle
-  from credential readiness.
-- `backend/cubebox/repositories/mcp.py` — filter active installs and add active-list helpers.
-- `backend/cubebox/services/mcp_catalog.py` — no-auth workspace install fix,
-  `install_status` transitions, and reactivation behavior.
-- `backend/cubebox/mcp/dependencies.py` — add `get_effective_connector_service`.
-- `backend/cubebox/api/schemas/mcp.py` — effective connector response and patch schemas.
-- `backend/cubebox/api/schemas/ws_settings.py` — tighten MCP credential mode literals.
-- `backend/cubebox/api/routes/v1/ws_mcp.py` — add normalized workspace connector routes.
-- `backend/cubebox/api/routes/v1/mcp_catalog.py` — expose template aliases while keeping
-  catalog routes.
-- `backend/cubebox/api/routes/v1/ws_settings.py` — delegate MCP settings to the
-  effective service.
-- `backend/cubebox/mcp/cubepi_discovery.py` — stop duplicating effective-state logic.
-- `backend/cubebox/mcp/cubepi_runtime.py` — load runtime specs from the effective service.
-- `backend/cubebox/streams/run_manager.py` — pass OAuth token manager into MCP runtime load.
+- `backend/cubebox/models/mcp.py` — final four model classes.
+- `backend/cubebox/repositories/mcp.py` — final four repositories.
+- Rename `backend/cubebox/mcp/catalog_seed.py` to
+  `backend/cubebox/mcp/template_seed.py`.
+- Rename `backend/cubebox/seeders/mcp_catalog_seeder.py` to
+  `backend/cubebox/seeders/mcp_template_seeder.py`.
+- Rename `backend/cubebox/cli/seed_mcp_catalog.py` to
+  `backend/cubebox/cli/seed_mcp_templates.py`.
+- `backend/cubebox/mcp/dependencies.py` — new template/install/effective providers.
+- `backend/cubebox/api/schemas/mcp.py` — template/install/state/grant schemas.
+- `backend/cubebox/api/routes/v1/admin_mcp.py` — admin template/install/grant routes.
+- `backend/cubebox/api/routes/v1/ws_mcp.py` — workspace template/install/state/grant routes.
+- `backend/cubebox/api/app.py` — stop mounting old catalog router.
+- `backend/cubebox/mcp/cubepi_discovery.py` — use effective runtime specs.
+- `backend/cubebox/mcp/cubepi_runtime.py` — load only usable effective connectors.
+- `backend/cubebox/streams/run_manager.py` — pass OAuth token manager to runtime.
 
-**Frontend — modified files:**
+**Backend — delete:**
 
-- `frontend/packages/core/src/types/mcp.ts` — add template, install, state, grant,
-  and effective connector types.
-- `frontend/packages/core/src/api/mcp.ts` — add effective connector API helpers.
-- `frontend/packages/core/src/api/workspace-settings.ts` — route MCP settings through
-  the normalized connector endpoints.
-- `frontend/packages/core/src/stores/workspaceSettingsStore.ts` — store effective connector
-  state and update it after workspace-state patches.
-- `frontend/packages/core/__tests__/api/mcp.test.ts` — API path and payload coverage.
-- `frontend/packages/web/components/workspace-settings/McpPanel.tsx` — show four-layer
-  semantics without exposing `override` as product language.
-- `frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx` — present catalog as
-  connector templates.
-- `frontend/packages/web/messages/en.json` and
-  `frontend/packages/web/messages/zh.json` — terminology updates.
+- `backend/cubebox/api/routes/v1/mcp_catalog.py`
+- `backend/cubebox/repositories/mcp_catalog.py`
+- `backend/cubebox/services/mcp_catalog.py`
+
+**Frontend — create or rename:**
+
+- Rename `frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx` to
+  `frontend/packages/web/components/mcp/MCPTemplateInstallPanel.tsx`.
+
+**Frontend — modify:**
+
+- `frontend/packages/core/src/types/mcp.ts`
+- `frontend/packages/core/src/api/mcp.ts`
+- `frontend/packages/core/src/types/workspace-settings.ts`
+- `frontend/packages/core/src/api/workspace-settings.ts`
+- `frontend/packages/core/src/stores/workspaceSettingsStore.ts`
+- `frontend/packages/core/__tests__/api/mcp.test.ts`
+- `frontend/packages/web/components/workspace-settings/McpPanel.tsx`
+- `frontend/packages/web/components/mcp/MCPConnectorList.tsx`
+- `frontend/packages/web/components/mcp/MCPAdminDetailPanel.tsx`
+- `frontend/packages/web/components/mcp/MCPWorkspacesTab.tsx`
+- `frontend/packages/web/messages/en.json`
+- `frontend/packages/web/messages/zh.json`
+- `frontend/packages/web/__tests__/e2e/mcp/ws-mcp.spec.ts`
+- `frontend/packages/web/__tests__/e2e/mcp/admin-mcp.spec.ts`
 
 ---
 
-## Task 1: Effective State Domain Model
+## Task 1: Target Schema And Model Classes
 
 **Files:**
 
-- Create: `backend/cubebox/mcp/effective.py`
-- Create: `backend/tests/unit/mcp/test_effective_state.py`
-
-- [ ] **Step 1: Write the pure state tests**
-
-Create `backend/tests/unit/mcp/test_effective_state.py`:
-
-```python
-from cubebox.mcp.effective import (
-    ConnectorInstallView,
-    ConnectorTemplateView,
-    CredentialGrantView,
-    WorkspaceConnectorStateView,
-    compute_effective_state,
-)
-
-
-def _install(
-    *,
-    auth_method: str = "static",
-    credential_scope: str = "org",
-    install_status: str = "active",
-    origin: str = "org",
-) -> ConnectorInstallView:
-    return ConnectorInstallView(
-        install_id="mcp-1",
-        name="GitHub",
-        server_url="https://github.example.com/mcp",
-        transport="streamable_http",
-        auth_method=auth_method,
-        credential_scope=credential_scope,
-        install_status=install_status,
-        origin=origin,
-        owner_workspace_id=None if origin == "org" else "ws-1",
-        credential_id="cred-1" if credential_scope == "org" else None,
-        headers={},
-        tools_cache=[],
-        tool_citations={},
-    )
-
-
-def _template(status: str = "active") -> ConnectorTemplateView:
-    return ConnectorTemplateView(
-        template_id="mctlg-1",
-        slug="github",
-        name="GitHub",
-        provider="GitHub",
-        status=status,
-    )
-
-
-def test_no_auth_connector_is_usable_without_grant() -> None:
-    state = compute_effective_state(
-        template=_template(),
-        install=_install(auth_method="none", credential_scope="none"),
-        workspace_state=WorkspaceConnectorStateView(enabled=True, credential_policy=None),
-        grant=None,
-    )
-
-    assert state.usable is True
-    assert state.reason == "usable"
-    assert state.credential_policy == "none"
-    assert state.credential_availability == "not_required"
-
-
-def test_user_policy_requires_current_user_grant() -> None:
-    state = compute_effective_state(
-        template=_template(),
-        install=_install(credential_scope="org"),
-        workspace_state=WorkspaceConnectorStateView(enabled=True, credential_policy="user"),
-        grant=None,
-    )
-
-    assert state.usable is False
-    assert state.reason == "credential_missing"
-    assert state.credential_policy == "user"
-    assert state.credential_availability == "missing"
-
-
-def test_available_user_grant_makes_user_policy_usable() -> None:
-    state = compute_effective_state(
-        template=_template(),
-        install=_install(credential_scope="org"),
-        workspace_state=WorkspaceConnectorStateView(enabled=True, credential_policy="user"),
-        grant=CredentialGrantView(policy="user", available=True, source="user"),
-    )
-
-    assert state.usable is True
-    assert state.reason == "usable"
-    assert state.credential_source == "user"
-
-
-def test_disabled_workspace_state_blocks_runtime() -> None:
-    state = compute_effective_state(
-        template=_template(),
-        install=_install(credential_scope="org"),
-        workspace_state=WorkspaceConnectorStateView(enabled=False, credential_policy=None),
-        grant=CredentialGrantView(policy="org", available=True, source="org"),
-    )
-
-    assert state.usable is False
-    assert state.reason == "workspace_disabled"
-
-
-def test_inactive_template_blocks_catalog_backed_install() -> None:
-    state = compute_effective_state(
-        template=_template(status="disabled"),
-        install=_install(credential_scope="org"),
-        workspace_state=WorkspaceConnectorStateView(enabled=True, credential_policy=None),
-        grant=CredentialGrantView(policy="org", available=True, source="org"),
-    )
-
-    assert state.usable is False
-    assert state.reason == "template_inactive"
-
-
-def test_deleted_install_blocks_runtime_before_credentials() -> None:
-    state = compute_effective_state(
-        template=_template(),
-        install=_install(credential_scope="org", install_status="deleted"),
-        workspace_state=WorkspaceConnectorStateView(enabled=True, credential_policy=None),
-        grant=CredentialGrantView(policy="org", available=True, source="org"),
-    )
-
-    assert state.usable is False
-    assert state.reason == "install_deleted"
-```
-
-- [ ] **Step 2: Run tests and confirm the missing module failure**
-
-Run: `cd backend && uv run pytest -q tests/unit/mcp/test_effective_state.py`
-
-Expected: FAIL with `ModuleNotFoundError: No module named 'cubebox.mcp.effective'`.
-
-- [ ] **Step 3: Add the domain model and pure computation**
-
-Create `backend/cubebox/mcp/effective.py`:
-
-```python
-"""Effective MCP connector state.
-
-This module is the semantic boundary for the four-layer MCP model:
-template, install, workspace state, and credential grant.
-"""
-
-from __future__ import annotations
-
-from dataclasses import dataclass, field
-from typing import Any, Literal, cast
-
-AuthMethod = Literal["static", "oauth", "none"]
-ConnectorOrigin = Literal["org", "workspace"]
-CredentialPolicy = Literal["org", "workspace", "user", "none"]
-CredentialAvailability = Literal["available", "missing", "not_required"]
-CredentialSource = Literal["org", "workspace", "user"]
-EffectiveReason = Literal[
-    "usable",
-    "template_inactive",
-    "install_deleted",
-    "workspace_disabled",
-    "credential_missing",
-    "unsupported_transport",
-]
-
-_VALID_CREDENTIAL_POLICIES: frozenset[str] = frozenset({"org", "workspace", "user", "none"})
-_VALID_TRANSPORTS: frozenset[str] = frozenset({"sse", "streamable_http"})
-
-
-@dataclass(frozen=True, slots=True)
-class ConnectorTemplateView:
-    template_id: str | None
-    slug: str | None
-    name: str
-    provider: str | None
-    status: str
-
-
-@dataclass(frozen=True, slots=True)
-class ConnectorInstallView:
-    install_id: str
-    name: str
-    server_url: str
-    transport: str
-    auth_method: str
-    credential_scope: str
-    install_status: str
-    origin: str
-    owner_workspace_id: str | None
-    credential_id: str | None
-    headers: dict[str, str] = field(default_factory=dict)
-    tools_cache: list[dict[str, Any]] = field(default_factory=list)
-    tool_citations: dict[str, dict[str, Any]] = field(default_factory=dict)
-
-
-@dataclass(frozen=True, slots=True)
-class WorkspaceConnectorStateView:
-    enabled: bool
-    credential_policy: str | None
-
-
-@dataclass(frozen=True, slots=True)
-class CredentialGrantView:
-    policy: str
-    available: bool
-    source: str | None = None
-    shared_by: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class EffectiveConnectorState:
-    template: ConnectorTemplateView | None
-    install: ConnectorInstallView
-    workspace_state: WorkspaceConnectorStateView
-    credential_policy: CredentialPolicy
-    credential_availability: CredentialAvailability
-    credential_source: str | None
-    credential_shared_by: str | None
-    usable: bool
-    reason: EffectiveReason
-
-
-def normalize_credential_policy(
-    *,
-    auth_method: str,
-    install_scope: str,
-    workspace_policy: str | None,
-) -> CredentialPolicy:
-    if auth_method == "none":
-        return "none"
-    raw = workspace_policy or install_scope
-    if raw not in _VALID_CREDENTIAL_POLICIES or raw == "none":
-        return "user"
-    return cast(CredentialPolicy, raw)
-
-
-def compute_effective_state(
-    *,
-    template: ConnectorTemplateView | None,
-    install: ConnectorInstallView,
-    workspace_state: WorkspaceConnectorStateView,
-    grant: CredentialGrantView | None,
-) -> EffectiveConnectorState:
-    policy = normalize_credential_policy(
-        auth_method=install.auth_method,
-        install_scope=install.credential_scope,
-        workspace_policy=workspace_state.credential_policy,
-    )
-
-    if policy == "none":
-        availability: CredentialAvailability = "not_required"
-        source: str | None = None
-        shared_by: str | None = None
-    elif grant is not None and grant.available and grant.policy == policy:
-        availability = "available"
-        source = grant.source
-        shared_by = grant.shared_by
-    else:
-        availability = "missing"
-        source = None
-        shared_by = None
-
-    reason: EffectiveReason = "usable"
-    usable = True
-    if template is not None and template.status != "active":
-        reason = "template_inactive"
-        usable = False
-    elif install.install_status != "active":
-        reason = "install_deleted"
-        usable = False
-    elif install.transport not in _VALID_TRANSPORTS:
-        reason = "unsupported_transport"
-        usable = False
-    elif not workspace_state.enabled:
-        reason = "workspace_disabled"
-        usable = False
-    elif availability == "missing":
-        reason = "credential_missing"
-        usable = False
-
-    return EffectiveConnectorState(
-        template=template,
-        install=install,
-        workspace_state=workspace_state,
-        credential_policy=policy,
-        credential_availability=availability,
-        credential_source=source,
-        credential_shared_by=shared_by,
-        usable=usable,
-        reason=reason,
-    )
-```
-
-- [ ] **Step 4: Run the pure tests**
-
-Run: `cd backend && uv run pytest -q tests/unit/mcp/test_effective_state.py`
-
-Expected: 6 passed.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add backend/cubebox/mcp/effective.py backend/tests/unit/mcp/test_effective_state.py
-git commit -m "feat(mcp): add effective connector state model"
-```
-
----
-
-## Task 2: Install Lifecycle and No-Auth Correctness
-
-**Files:**
-
+- Create: `backend/alembic/versions/f2a6c7d8e901_normalize_mcp_four_layer_tables.py`
 - Modify: `backend/cubebox/models/mcp.py`
-- Modify: `backend/cubebox/repositories/mcp.py`
-- Modify: `backend/cubebox/services/mcp_catalog.py`
 - Modify: `backend/tests/unit/test_mcp_models.py`
-- Modify: `backend/tests/e2e/test_mcp_catalog_routes.py`
-- Create: `backend/alembic/versions/<ts>_add_mcp_install_status.py`
 
-- [ ] **Step 1: Add model and route tests for `install_status`**
+- [ ] **Step 1: Write model tests for final table names**
 
 Append to `backend/tests/unit/test_mcp_models.py`:
 
 ```python
-def test_mcp_server_install_status_defaults_active() -> None:
-    from cubebox.models import MCPServer
+def test_mcp_four_layer_table_names() -> None:
+    from cubebox.models import (
+        ConnectorInstall,
+        ConnectorTemplate,
+        CredentialGrant,
+        WorkspaceConnectorState,
+    )
 
-    row = MCPServer(
+    assert ConnectorTemplate.__tablename__ == "connector_templates"
+    assert ConnectorInstall.__tablename__ == "connector_installs"
+    assert WorkspaceConnectorState.__tablename__ == "workspace_connector_states"
+    assert CredentialGrant.__tablename__ == "credential_grants"
+
+
+def test_no_auth_install_defaults_to_none_policy() -> None:
+    from cubebox.models import ConnectorInstall
+
+    row = ConnectorInstall(
         org_id="org-1",
-        name="GitHub",
-        server_url="https://github.example.com/mcp",
+        name="NoAuth",
+        server_url="https://noauth.example.com/mcp",
         server_url_hash="hash",
         transport="streamable_http",
         auth_method="none",
-        credential_scope="none",
+        default_credential_policy="none",
         created_by_user_id="user-1",
     )
 
-    assert row.install_status == "active"
+    assert row.auth_method == "none"
+    assert row.default_credential_policy == "none"
+    assert row.install_state == "active"
+    assert row.auth_status == "not_required"
+    assert row.discovery_status == "not_run"
 ```
 
-Append to `backend/tests/e2e/test_mcp_catalog_routes.py`:
-
-```python
-async def test_workspace_no_auth_catalog_install_uses_none_scope(
-    client: httpx.AsyncClient,
-    workspace_id: str,
-    db_session: AsyncSession,
-) -> None:
-    from cubebox.repositories.mcp_catalog import MCPCatalogConnectorRepository
-
-    row = await MCPCatalogConnectorRepository(db_session).upsert_by_slug(
-        slug="noauth-effective-test",
-        name="NoAuth Effective Test",
-        description="No auth connector.",
-        provider="Cubebox",
-        server_url="https://noauth-effective.example.com/mcp",
-        transport="streamable_http",
-        supported_auth_methods=["none"],
-        default_credential_scope="none",
-    )
-    await db_session.commit()
-
-    resp = await client.post(
-        f"/api/v1/ws/{workspace_id}/mcp/catalog/{row.id}/install",
-        json={"auth_method": "none"},
-    )
-
-    assert resp.status_code == 201, resp.text
-    install_id = resp.json()["install_id"]
-    detail = await client.get(f"/api/v1/ws/{workspace_id}/mcp/servers/{install_id}")
-    assert detail.status_code == 200, detail.text
-    body = detail.json()
-    assert body["auth_method"] == "none"
-    assert body["credential_scope"] == "none"
-    assert body["authed"] is True
-```
-
-- [ ] **Step 2: Run tests and confirm failures**
-
-Run: `cd backend && uv run pytest -q tests/unit/test_mcp_models.py::test_mcp_server_install_status_defaults_active`
-
-Expected: FAIL with `AttributeError: 'MCPServer' object has no attribute 'install_status'`.
-
-Run: `cd backend && uv run pytest -q tests/e2e/test_mcp_catalog_routes.py::test_workspace_no_auth_catalog_install_uses_none_scope`
-
-Expected: FAIL because workspace catalog install currently forces user scope.
-
-- [ ] **Step 3: Add `install_status` to the model**
-
-Edit `backend/cubebox/models/mcp.py` inside `MCPServer`, after `credential_scope`:
-
-```python
-    install_status: str = Field(
-        default="active",
-        max_length=16,
-        sa_column_kwargs={"server_default": text("'active'")},
-    )
-```
-
-- [ ] **Step 4: Add the Alembic migration**
+- [ ] **Step 2: Run the tests and confirm the missing model failure**
 
 Run:
 
 ```bash
 cd backend
-uv run alembic revision --autogenerate -m "add mcp install status"
+uv run pytest -q tests/unit/test_mcp_models.py::test_mcp_four_layer_table_names \
+                 tests/unit/test_mcp_models.py::test_no_auth_install_defaults_to_none_policy
 ```
 
-Edit the generated migration so `upgrade()` contains:
+Expected: FAIL because the four final model classes are not exported.
+
+- [ ] **Step 3: Replace MCP model classes**
+
+Edit `backend/cubebox/models/mcp.py` so it defines these final classes:
 
 ```python
-op.add_column(
-    "mcp_servers",
-    sa.Column(
-        "install_status",
-        sa.String(length=16),
-        server_default=sa.text("'active'"),
-        nullable=False,
-    ),
+"""MCP connector management models."""
+
+from datetime import datetime
+from typing import Any, ClassVar
+
+from sqlalchemy import JSON, Column, Index, UniqueConstraint, text
+from sqlmodel import Field
+
+from cubebox.models.mixins import CubeboxBase
+
+
+class ConnectorTemplate(CubeboxBase, table=True):
+    _PREFIX: ClassVar[str] = "ctpl"
+    __tablename__ = "connector_templates"
+    __table_args__ = (UniqueConstraint("slug", name="uq_connector_template_slug"),)
+
+    slug: str = Field(max_length=64, index=True)
+    name: str = Field(max_length=128)
+    description: str = Field(max_length=2048)
+    provider: str = Field(max_length=64)
+    server_url: str = Field(max_length=2048)
+    transport: str = Field(max_length=16)
+    supported_auth_methods: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(JSON, nullable=False),
+    )
+    default_credential_policy: str = Field(default="user", max_length=16)
+    oauth_dcr_supported: bool | None = Field(default=None)
+    oauth_default_scope: str | None = Field(default=None, max_length=512)
+    oauth_static_client_id: str | None = Field(default=None, max_length=256)
+    oauth_static_client_secret_credential_id: str | None = Field(
+        default=None,
+        foreign_key="credentials.id",
+        max_length=20,
+    )
+    static_form_schema: list[dict[str, Any]] | None = Field(
+        default=None,
+        sa_column=Column(JSON, nullable=True),
+    )
+    static_auth_header_template: str | None = Field(default=None, max_length=256)
+    template_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False, server_default=text("'{}'")),
+    )
+    tool_citation_defaults: dict[str, dict[str, Any]] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False, server_default=text("'{}'")),
+    )
+    status: str = Field(default="active", max_length=16)
+
+
+class ConnectorInstall(CubeboxBase, table=True):
+    _PREFIX: ClassVar[str] = "cins"
+    __tablename__ = "connector_installs"
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id",
+            "workspace_id",
+            "server_url_hash",
+            name="uq_connector_install_url",
+        ),
+        UniqueConstraint(
+            "org_id",
+            "workspace_id",
+            "name",
+            name="uq_connector_install_name",
+        ),
+        Index(
+            "uq_connector_install_per_template",
+            "org_id",
+            text("COALESCE(workspace_id, '_org')"),
+            "template_id",
+            unique=True,
+            postgresql_where=text("template_id IS NOT NULL AND install_state = 'active'"),
+        ),
+    )
+
+    org_id: str = Field(foreign_key="organizations.id", max_length=20, index=True)
+    template_id: str | None = Field(
+        default=None,
+        foreign_key="connector_templates.id",
+        max_length=20,
+        index=True,
+    )
+    install_scope: str = Field(default="org", max_length=16)
+    workspace_id: str | None = Field(
+        default=None,
+        foreign_key="workspaces.id",
+        max_length=20,
+        index=True,
+    )
+    name: str = Field(max_length=64)
+    server_url: str = Field(max_length=2048)
+    server_url_hash: str = Field(max_length=64)
+    transport: str = Field(max_length=16)
+    auth_method: str = Field(max_length=16)
+    default_credential_policy: str = Field(max_length=16)
+    auth_status: str = Field(default="pending", max_length=16)
+    discovery_status: str = Field(default="not_run", max_length=16)
+    install_state: str = Field(
+        default="active",
+        max_length=16,
+        sa_column_kwargs={"server_default": text("'active'")},
+    )
+    oauth_client_config: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    headers: dict[str, str] = Field(default_factory=dict, sa_column=Column(JSON))
+    tools_cache: list[dict[str, Any]] = Field(default_factory=list, sa_column=Column(JSON))
+    tool_citations: dict[str, dict[str, Any]] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False, server_default=text("'{}'")),
+    )
+    last_error: str | None = Field(default=None, max_length=2048)
+    last_discovered_at: datetime | None = None
+    timeout: float = Field(default=30.0)
+    sse_read_timeout: float = Field(default=300.0)
+    auto_enroll_new_workspaces: bool = Field(
+        default=True,
+        sa_column_kwargs={"server_default": text("true")},
+    )
+    created_by_user_id: str = Field(foreign_key="users.id", max_length=20)
+
+
+class WorkspaceConnectorState(CubeboxBase, table=True):
+    _PREFIX: ClassVar[str] = "wcst"
+    __tablename__ = "workspace_connector_states"
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "install_id", name="uq_workspace_connector_state"),
+    )
+
+    org_id: str = Field(foreign_key="organizations.id", max_length=20, index=True)
+    workspace_id: str = Field(foreign_key="workspaces.id", max_length=20, index=True)
+    install_id: str = Field(foreign_key="connector_installs.id", max_length=20, index=True)
+    enabled: bool = Field(default=True)
+    credential_policy: str = Field(max_length=16)
+    enablement_source: str = Field(default="workspace_manual", max_length=32)
+    updated_by_user_id: str = Field(foreign_key="users.id", max_length=20)
+
+
+class CredentialGrant(CubeboxBase, table=True):
+    _PREFIX: ClassVar[str] = "cgrn"
+    __tablename__ = "credential_grants"
+    __table_args__ = (
+        UniqueConstraint(
+            "install_id",
+            "grant_scope",
+            "workspace_id",
+            "user_id",
+            name="uq_credential_grant_scope",
+        ),
+    )
+
+    org_id: str = Field(foreign_key="organizations.id", max_length=20, index=True)
+    install_id: str = Field(foreign_key="connector_installs.id", max_length=20, index=True)
+    grant_scope: str = Field(max_length=16)
+    workspace_id: str | None = Field(
+        default=None,
+        foreign_key="workspaces.id",
+        max_length=20,
+        index=True,
+    )
+    user_id: str | None = Field(
+        default=None,
+        foreign_key="users.id",
+        max_length=20,
+        index=True,
+    )
+    credential_id: str = Field(foreign_key="credentials.id", max_length=20)
+    refresh_credential_id: str | None = Field(default=None, foreign_key="credentials.id")
+    expires_at: datetime | None = None
+    grant_status: str = Field(default="valid", max_length=16)
+    created_by_user_id: str = Field(foreign_key="users.id", max_length=20)
+```
+
+Update `backend/cubebox/models/__init__.py` to export the four classes and remove old
+MCP model exports.
+
+- [ ] **Step 4: Add destructive migration to target tables**
+
+Create `backend/alembic/versions/f2a6c7d8e901_normalize_mcp_four_layer_tables.py`.
+
+Use revision id `f2a6c7d8e901` and set `down_revision` to the current head before this
+branch. The migration should:
+
+```python
+def upgrade() -> None:
+    op.drop_table("user_mcp_credentials")
+    op.drop_table("workspace_mcp_credentials")
+    op.drop_table("workspace_mcp_overrides")
+    op.drop_table("mcp_servers")
+    op.drop_table("mcp_catalog_connectors")
+
+    # Create connector_templates, connector_installs,
+    # workspace_connector_states, and credential_grants with the
+    # columns defined in backend/cubebox/models/mcp.py.
+```
+
+Create the four tables with the columns from `backend/cubebox/models/mcp.py`. Keep these
+constraints:
+
+```python
+op.create_check_constraint(
+    "ck_connector_installs_scope",
+    "connector_installs",
+    "install_scope IN ('org', 'workspace')",
 )
 op.create_check_constraint(
-    "ck_mcp_servers_install_status",
-    "mcp_servers",
-    "install_status IN ('active', 'deleted')",
+    "ck_connector_installs_auth_method",
+    "connector_installs",
+    "auth_method IN ('oauth', 'static', 'none')",
+)
+op.create_check_constraint(
+    "ck_workspace_connector_states_policy",
+    "workspace_connector_states",
+    "credential_policy IN ('org', 'workspace', 'user', 'none')",
+)
+op.create_check_constraint(
+    "ck_credential_grants_scope",
+    "credential_grants",
+    "grant_scope IN ('org', 'workspace', 'user')",
 )
 ```
 
-Ensure `downgrade()` contains:
+For `downgrade()`, drop the four target tables and recreate the old MCP tables only if
+the repository convention requires reversible migrations. If reversible migrations are not
+required for destructive internal changes, raise:
 
 ```python
-op.drop_constraint("ck_mcp_servers_install_status", "mcp_servers", type_="check")
-op.drop_column("mcp_servers", "install_status")
+raise RuntimeError("Destructive MCP four-layer migration is not reversible")
 ```
 
-- [ ] **Step 5: Filter deleted installs in repository list helpers**
-
-Edit `backend/cubebox/repositories/mcp.py`.
-
-In `list_for_org`, add this filter before returning:
-
-```python
-        stmt = stmt.where(MCPServer.install_status == "active")  # type: ignore[arg-type]
-```
-
-In `list_for_workspace`, replace the `MCPServer.authed` filter with:
-
-```python
-            MCPServer.install_status == "active",  # type: ignore[arg-type]
-```
-
-Keep credential readiness out of this repository method. Effective-state code will decide
-whether an active install is usable for a specific user.
-
-In `list_org_wide_with_workspace_override`, add:
-
-```python
-                MCPServer.install_status == "active",  # type: ignore[arg-type]
-```
-
-- [ ] **Step 6: Set lifecycle state during delete and re-key**
-
-Edit `backend/cubebox/services/mcp_catalog.py`.
-
-In `delete_install`, replace the block that sets `server.authed = False` with:
-
-```python
-        server.install_status = "deleted"
-        server.authed = False
-        server.last_error = None
-        server.tools_cache = []
-        server.last_discovered_at = datetime.now(UTC)
-        await self.server_repo.update(server)
-```
-
-In `switch_auth_method`, immediately after `server.auth_method = new_auth_method`, add:
-
-```python
-        server.install_status = "active"
-```
-
-In `_finalize_install`, add this as the first statement:
-
-```python
-        server.install_status = "active"
-```
-
-- [ ] **Step 7: Fix workspace no-auth catalog install scope**
-
-Edit `_install_workspace_user` in `backend/cubebox/services/mcp_catalog.py`.
-
-Replace the server constructor's hard-coded user scope with:
-
-```python
-            credential_scope="none" if auth_method == "none" else "user",
-```
-
-Keep static and OAuth user installs as user-scope because those grants are owned by the
-installing user.
-
-- [ ] **Step 8: Run migration and tests**
+- [ ] **Step 5: Run migration and model tests**
 
 Run:
 
 ```bash
 cd backend
 uv run alembic upgrade head
-uv run pytest -q tests/unit/test_mcp_models.py::test_mcp_server_install_status_defaults_active
-uv run pytest -q tests/e2e/test_mcp_catalog_routes.py::test_workspace_no_auth_catalog_install_uses_none_scope
+uv run pytest -q tests/unit/test_mcp_models.py::test_mcp_four_layer_table_names \
+                 tests/unit/test_mcp_models.py::test_no_auth_install_defaults_to_none_policy
 ```
 
-Expected: all commands pass.
+Expected: migration succeeds and tests pass.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add backend/cubebox/models/mcp.py \
-        backend/cubebox/repositories/mcp.py \
-        backend/cubebox/services/mcp_catalog.py \
-        backend/alembic/versions/*add_mcp_install_status* \
-        backend/tests/unit/test_mcp_models.py \
-        backend/tests/e2e/test_mcp_catalog_routes.py
-git commit -m "feat(mcp): separate install lifecycle from credential readiness"
+        backend/cubebox/models/__init__.py \
+        backend/alembic/versions/f2a6c7d8e901_normalize_mcp_four_layer_tables.py \
+        backend/tests/unit/test_mcp_models.py
+git commit -m "feat(mcp): add four-layer connector schema"
 ```
 
 ---
 
-## Task 3: DB-Backed Effective Connector Service
+## Task 2: Repositories And Template Seeding
 
 **Files:**
 
-- Modify: `backend/cubebox/mcp/effective.py`
-- Modify: `backend/cubebox/mcp/dependencies.py`
-- Create: `backend/tests/unit/mcp/test_effective_service.py`
+- Modify: `backend/cubebox/repositories/mcp.py`
+- Create: `backend/cubebox/services/mcp_templates.py`
+- Rename: `backend/cubebox/mcp/catalog_seed.py` to
+  `backend/cubebox/mcp/template_seed.py`
+- Rename: `backend/cubebox/seeders/mcp_catalog_seeder.py` to
+  `backend/cubebox/seeders/mcp_template_seeder.py`
+- Rename: `backend/cubebox/cli/seed_mcp_catalog.py` to
+  `backend/cubebox/cli/seed_mcp_templates.py`
+- Modify: `backend/tests/unit/test_catalog_seed.py`
+- Modify: `backend/tests/unit/test_mcp_repositories.py`
 
-- [ ] **Step 1: Add service tests with fake dependencies**
+- [ ] **Step 1: Write repository tests for final nouns**
 
-Create `backend/tests/unit/mcp/test_effective_service.py`:
+Append to `backend/tests/unit/test_mcp_repositories.py`:
 
 ```python
-from types import SimpleNamespace
+async def test_connector_template_repository_upserts_by_slug(session: AsyncSession) -> None:
+    from cubebox.repositories.mcp import ConnectorTemplateRepository
 
-import pytest
-
-from cubebox.mcp.effective import EffectiveConnectorService
-
-
-def _server(**overrides: object) -> SimpleNamespace:
-    base = {
-        "id": "mcp-1",
-        "catalog_connector_id": "mctlg-1",
-        "name": "GitHub",
-        "server_url": "https://github.example.com/mcp",
-        "transport": "streamable_http",
-        "auth_method": "static",
-        "credential_scope": "org",
-        "install_status": "active",
-        "owner_workspace_id": None,
-        "credential_id": "cred-1",
-        "headers": {},
-        "tools_cache": [],
-        "tool_citations": {},
-    }
-    base.update(overrides)
-    return SimpleNamespace(**base)
-
-
-def _catalog(**overrides: object) -> SimpleNamespace:
-    base = {
-        "id": "mctlg-1",
-        "slug": "github",
-        "name": "GitHub",
-        "provider": "GitHub",
-        "status": "active",
-    }
-    base.update(overrides)
-    return SimpleNamespace(**base)
-
-
-class _ServerRepo:
-    def __init__(self, rows: list[SimpleNamespace]) -> None:
-        self.rows = rows
-
-    async def list_for_org(self, *, owner_workspace_id: str | None | object = ...) -> list[object]:
-        if owner_workspace_id is ...:
-            return list(self.rows)
-        return [row for row in self.rows if row.owner_workspace_id == owner_workspace_id]
-
-    async def list_org_wide_with_workspace_override(self, workspace_id: str) -> list[tuple[object, object | None]]:
-        return [(row, SimpleNamespace(enabled=True, credential_mode=None)) for row in self.rows]
-
-
-class _CatalogRepo:
-    async def get_by_id(self, catalog_id: str) -> object:
-        assert catalog_id == "mctlg-1"
-        return _catalog()
-
-
-class _WorkspaceCredRepo:
-    async def get(self, *, workspace_id: str, mcp_server_id: str) -> object | None:
-        return None
-
-
-class _UserCredRepo:
-    async def get(self, *, user_id: str, mcp_server_id: str) -> object | None:
-        return None
-
-
-class _Session:
-    async def get(self, model: object, key: str) -> object | None:
-        return None
-
-
-@pytest.mark.asyncio
-async def test_effective_service_lists_active_org_install_with_org_grant() -> None:
-    service = EffectiveConnectorService(
-        session=_Session(),  # type: ignore[arg-type]
-        server_repo=_ServerRepo([_server()]),  # type: ignore[arg-type]
-        catalog_repo=_CatalogRepo(),  # type: ignore[arg-type]
-        ws_cred_repo=_WorkspaceCredRepo(),  # type: ignore[arg-type]
-        user_cred_repo=_UserCredRepo(),  # type: ignore[arg-type]
+    repo = ConnectorTemplateRepository(session)
+    row = await repo.upsert_by_slug(
+        slug="github",
+        name="GitHub",
+        description="GitHub MCP server.",
+        provider="GitHub",
+        server_url="https://github.example.com/mcp",
+        transport="streamable_http",
+        supported_auth_methods=["oauth", "static"],
+        default_credential_policy="user",
     )
 
-    rows = await service.list_for_workspace_user(
-        workspace_id="ws-1",
-        user_id="user-1",
-        include_unusable=True,
+    assert row.slug == "github"
+    assert row.default_credential_policy == "user"
+
+
+async def test_credential_grant_repository_scopes_user_grants(
+    session: AsyncSession,
+) -> None:
+    from cubebox.models import CredentialGrant
+    from cubebox.repositories.mcp import CredentialGrantRepository
+
+    repo = CredentialGrantRepository(session, org_id="org-1")
+    await repo.add(
+        CredentialGrant(
+            org_id="org-1",
+            install_id="cins-1",
+            grant_scope="user",
+            user_id="user-1",
+            credential_id="cred-1",
+            created_by_user_id="user-1",
+        )
     )
 
-    assert len(rows) == 1
-    assert rows[0].usable is True
-    assert rows[0].credential_policy == "org"
-    assert rows[0].credential_source == "org"
-
-
-@pytest.mark.asyncio
-async def test_effective_service_marks_missing_user_grant_unusable() -> None:
-    service = EffectiveConnectorService(
-        session=_Session(),  # type: ignore[arg-type]
-        server_repo=_ServerRepo([_server(credential_scope="user", credential_id=None)]),  # type: ignore[arg-type]
-        catalog_repo=_CatalogRepo(),  # type: ignore[arg-type]
-        ws_cred_repo=_WorkspaceCredRepo(),  # type: ignore[arg-type]
-        user_cred_repo=_UserCredRepo(),  # type: ignore[arg-type]
-    )
-
-    rows = await service.list_for_workspace_user(
-        workspace_id="ws-1",
-        user_id="user-1",
-        include_unusable=True,
-    )
-
-    assert rows[0].usable is False
-    assert rows[0].reason == "credential_missing"
+    assert await repo.get_user_grant(install_id="cins-1", user_id="user-1") is not None
+    assert await repo.get_user_grant(install_id="cins-1", user_id="user-2") is None
 ```
 
-- [ ] **Step 2: Run tests and confirm service is missing**
+- [ ] **Step 2: Run tests and confirm missing repositories**
 
-Run: `cd backend && uv run pytest -q tests/unit/mcp/test_effective_service.py`
+Run:
 
-Expected: FAIL with `ImportError` for `EffectiveConnectorService`.
+```bash
+cd backend
+uv run pytest -q tests/unit/test_mcp_repositories.py::test_connector_template_repository_upserts_by_slug \
+                 tests/unit/test_mcp_repositories.py::test_credential_grant_repository_scopes_user_grants
+```
 
-- [ ] **Step 3: Add service construction and row mapping**
+Expected: FAIL because the final repositories do not exist.
 
-Append to `backend/cubebox/mcp/effective.py`:
+- [ ] **Step 3: Replace repository classes**
+
+Edit `backend/cubebox/repositories/mcp.py` so it exports these concrete methods:
+
+- `ConnectorTemplateRepository.get(template_id: str) -> ConnectorTemplate | None`
+- `ConnectorTemplateRepository.get_by_slug(slug: str) -> ConnectorTemplate | None`
+- `ConnectorTemplateRepository.list_active() -> list[ConnectorTemplate]`
+- `ConnectorTemplateRepository.upsert_by_slug(slug: str, name: str, description: str,
+  provider: str, server_url: str, transport: str, supported_auth_methods: list[str],
+  default_credential_policy: str) -> ConnectorTemplate`
+- `ConnectorInstallRepository.get(install_id: str) -> ConnectorInstall | None`
+- `ConnectorInstallRepository.list_org_installs() -> list[ConnectorInstall]`
+- `ConnectorInstallRepository.list_workspace_installs(workspace_id: str)
+  -> list[ConnectorInstall]`
+- `ConnectorInstallRepository.add(install: ConnectorInstall) -> ConnectorInstall`
+- `ConnectorInstallRepository.update(install: ConnectorInstall) -> ConnectorInstall`
+- `WorkspaceConnectorStateRepository.get(workspace_id: str, install_id: str)
+  -> WorkspaceConnectorState | None`
+- `WorkspaceConnectorStateRepository.list_for_workspace(workspace_id: str)
+  -> list[WorkspaceConnectorState]`
+- `WorkspaceConnectorStateRepository.upsert(workspace_id: str, install_id: str,
+  enabled: bool, credential_policy: str, enablement_source: str,
+  updated_by_user_id: str) -> WorkspaceConnectorState`
+- `CredentialGrantRepository.add(grant: CredentialGrant) -> CredentialGrant`
+- `CredentialGrantRepository.get_org_grant(install_id: str) -> CredentialGrant | None`
+- `CredentialGrantRepository.get_workspace_grant(install_id: str, workspace_id: str)
+  -> CredentialGrant | None`
+- `CredentialGrantRepository.get_user_grant(install_id: str, user_id: str)
+  -> CredentialGrant | None`
+- `CredentialGrantRepository.delete_scope(install_id: str, grant_scope: str,
+  workspace_id: str | None, user_id: str | None) -> None`
+
+Use the existing org-scoped repository pattern: every non-template repository receives
+`org_id` in `__init__` and filters by it in every query.
+
+- [ ] **Step 4: Create template service**
+
+Create `backend/cubebox/services/mcp_templates.py`:
 
 ```python
-from sqlalchemy.ext.asyncio import AsyncSession
+"""Connector template service."""
 
-from cubebox.models import User
-from cubebox.repositories.mcp import (
-    MCPServerRepository,
-    UserMCPCredentialRepository,
-    WorkspaceMCPCredentialRepository,
+from cubebox.models import ConnectorTemplate
+from cubebox.repositories.mcp import ConnectorTemplateRepository
+
+
+class ConnectorTemplateService:
+    def __init__(self, repo: ConnectorTemplateRepository) -> None:
+        self._repo = repo
+
+    async def list_active(self) -> list[ConnectorTemplate]:
+        return await self._repo.list_active()
+
+    async def get_active(self, template_id: str) -> ConnectorTemplate:
+        row = await self._repo.get(template_id)
+        if row is None or row.status != "active":
+            raise ValueError("connector_template_not_found")
+        return row
+```
+
+- [ ] **Step 5: Rename seed concepts to templates**
+
+Run:
+
+```bash
+git mv backend/cubebox/mcp/catalog_seed.py backend/cubebox/mcp/template_seed.py
+git mv backend/cubebox/seeders/mcp_catalog_seeder.py \
+       backend/cubebox/seeders/mcp_template_seeder.py
+git mv backend/cubebox/cli/seed_mcp_catalog.py backend/cubebox/cli/seed_mcp_templates.py
+```
+
+In `backend/cubebox/mcp/template_seed.py`, rename `CatalogSeedEntry` to
+`ConnectorTemplateSeedEntry`. Rename fields:
+
+```python
+default_credential_scope -> default_credential_policy
+static_form_fields -> static_form_schema
+cred_metadata -> template_metadata
+tool_citations -> tool_citation_defaults
+```
+
+Update `backend/cubebox/seeders/mcp_template_seeder.py` and
+`backend/cubebox/cli/seed_mcp_templates.py` to call `ConnectorTemplateRepository`.
+
+- [ ] **Step 6: Run repository and seed tests**
+
+Run:
+
+```bash
+cd backend
+uv run pytest -q tests/unit/test_mcp_repositories.py tests/unit/test_catalog_seed.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Delete old repository/service files**
+
+Run:
+
+```bash
+git rm backend/cubebox/repositories/mcp_catalog.py backend/cubebox/services/mcp_catalog.py
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/cubebox/repositories/mcp.py \
+        backend/cubebox/services/mcp_templates.py \
+        backend/cubebox/mcp/template_seed.py \
+        backend/cubebox/seeders/mcp_template_seeder.py \
+        backend/cubebox/cli/seed_mcp_templates.py \
+        backend/tests/unit/test_catalog_seed.py \
+        backend/tests/unit/test_mcp_repositories.py
+git commit -m "feat(mcp): replace catalog repositories with connector templates"
+```
+
+---
+
+## Task 3: Install, Workspace State, And Grant Services
+
+**Files:**
+
+- Create: `backend/cubebox/services/mcp_installs.py`
+- Modify: `backend/cubebox/mcp/dependencies.py`
+- Modify: `backend/tests/unit/test_mcp_service_invariants.py`
+- Create: `backend/tests/e2e/test_mcp_four_layer_routes.py`
+
+- [ ] **Step 1: Add service invariant tests**
+
+Append to `backend/tests/unit/test_mcp_service_invariants.py`:
+
+```python
+def test_auth_method_none_resolves_not_required_defaults() -> None:
+    from cubebox.services.mcp_installs import install_defaults_for_auth_method
+
+    defaults = install_defaults_for_auth_method("none", "user")
+
+    assert defaults.auth_status == "not_required"
+    assert defaults.credential_policy == "none"
+
+
+def test_static_auth_uses_requested_policy() -> None:
+    from cubebox.services.mcp_installs import install_defaults_for_auth_method
+
+    defaults = install_defaults_for_auth_method("static", "workspace")
+
+    assert defaults.auth_status == "pending"
+    assert defaults.credential_policy == "workspace"
+```
+
+- [ ] **Step 2: Run invariant tests and confirm missing service**
+
+Run:
+
+```bash
+cd backend
+uv run pytest -q tests/unit/test_mcp_service_invariants.py::test_auth_method_none_resolves_not_required_defaults \
+                 tests/unit/test_mcp_service_invariants.py::test_static_auth_uses_requested_policy
+```
+
+Expected: FAIL because `cubebox.services.mcp_installs` does not exist.
+
+- [ ] **Step 3: Create install service primitives**
+
+Create `backend/cubebox/services/mcp_installs.py`:
+
+```python
+"""Connector install, workspace state, and grant service."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from cubebox.mcp._constants import CREDENTIAL_KIND_MCP
+from cubebox.mcp._constants import server_url_hash
+from cubebox.models import (
+    ConnectorInstall,
+    ConnectorTemplate,
+    CredentialGrant,
+    WorkspaceConnectorState,
 )
-from cubebox.repositories.mcp_catalog import MCPCatalogConnectorRepository
+from cubebox.repositories.mcp import (
+    ConnectorInstallRepository,
+    CredentialGrantRepository,
+    WorkspaceConnectorStateRepository,
+)
+from cubebox.services.credential import CredentialService
 
 
-class EffectiveConnectorService:
+@dataclass(frozen=True, slots=True)
+class InstallDefaults:
+    auth_status: str
+    credential_policy: str
+
+
+def install_defaults_for_auth_method(
+    auth_method: str,
+    requested_policy: str,
+) -> InstallDefaults:
+    if auth_method == "none":
+        return InstallDefaults(auth_status="not_required", credential_policy="none")
+    return InstallDefaults(auth_status="pending", credential_policy=requested_policy)
+
+
+class ConnectorInstallService:
     def __init__(
         self,
         *,
-        session: AsyncSession,
-        server_repo: MCPServerRepository,
-        catalog_repo: MCPCatalogConnectorRepository,
-        ws_cred_repo: WorkspaceMCPCredentialRepository,
-        user_cred_repo: UserMCPCredentialRepository,
+        install_repo: ConnectorInstallRepository,
+        state_repo: WorkspaceConnectorStateRepository,
+        grant_repo: CredentialGrantRepository,
+        cred_service: CredentialService,
+        org_id: str,
+        actor_user_id: str,
     ) -> None:
-        self._session = session
-        self._server_repo = server_repo
-        self._catalog_repo = catalog_repo
-        self._ws_cred_repo = ws_cred_repo
-        self._user_cred_repo = user_cred_repo
+        self._install_repo = install_repo
+        self._state_repo = state_repo
+        self._grant_repo = grant_repo
+        self._cred_service = cred_service
+        self._org_id = org_id
+        self._actor_user_id = actor_user_id
 
-    async def list_for_workspace_user(
+    async def create_from_template_for_workspace(
         self,
         *,
+        template: ConnectorTemplate,
         workspace_id: str,
-        user_id: str,
-        include_unusable: bool = True,
-    ) -> list[EffectiveConnectorState]:
-        org_rows = await self._server_repo.list_org_wide_with_workspace_override(workspace_id)
-        workspace_rows = [
-            (row, None)
-            for row in await self._server_repo.list_for_org(owner_workspace_id=workspace_id)
-        ]
-        states: list[EffectiveConnectorState] = []
+        auth_method: str,
+        credential_policy: str,
+    ) -> ConnectorInstall:
+        defaults = install_defaults_for_auth_method(auth_method, credential_policy)
+        install = await self._install_repo.add(
+            ConnectorInstall(
+                org_id=self._org_id,
+                template_id=template.id,
+                install_scope="workspace",
+                workspace_id=workspace_id,
+                name=template.name,
+                server_url=template.server_url,
+                server_url_hash=server_url_hash(template.server_url),
+                transport=template.transport,
+                auth_method=auth_method,
+                default_credential_policy=defaults.credential_policy,
+                auth_status=defaults.auth_status,
+                discovery_status="not_run",
+                tool_citations=dict(template.tool_citation_defaults or {}),
+                created_by_user_id=self._actor_user_id,
+            )
+        )
+        await self._state_repo.upsert(
+            workspace_id=workspace_id,
+            install_id=install.id,
+            enabled=True,
+            credential_policy=defaults.credential_policy,
+            enablement_source="workspace_manual",
+            updated_by_user_id=self._actor_user_id,
+        )
+        return install
 
-        for server, override in [*org_rows, *workspace_rows]:
-            enabled = bool(server.owner_workspace_id == workspace_id)
-            credential_policy: str | None = None
-            if server.owner_workspace_id is None:
-                enabled = bool(override is not None and override.enabled)
-                credential_policy = getattr(override, "credential_mode", None)
-
-            template = await self._template_view(server.catalog_connector_id)
-            install = ConnectorInstallView(
-                install_id=server.id,
-                name=server.name,
-                server_url=server.server_url,
-                transport=server.transport,
-                auth_method=server.auth_method,
-                credential_scope=server.credential_scope,
-                install_status=server.install_status,
-                origin="workspace" if server.owner_workspace_id else "org",
-                owner_workspace_id=server.owner_workspace_id,
-                credential_id=server.credential_id,
-                headers=dict(server.headers or {}),
-                tools_cache=list(server.tools_cache or []),
-                tool_citations=dict(server.tool_citations or {}),
-            )
-            workspace_state = WorkspaceConnectorStateView(
-                enabled=enabled,
-                credential_policy=credential_policy,
-            )
-            policy = normalize_credential_policy(
-                auth_method=server.auth_method,
-                install_scope=server.credential_scope,
-                workspace_policy=credential_policy,
-            )
-            grant = await self._grant_view(
-                policy=policy,
-                server_id=server.id,
-                server_credential_id=server.credential_id,
+    async def create_static_grant(
+        self,
+        *,
+        install_id: str,
+        grant_scope: str,
+        plaintext: str,
+        workspace_id: str | None = None,
+        user_id: str | None = None,
+        name: str | None = None,
+    ) -> CredentialGrant:
+        credential_id = await self._cred_service.create(
+            kind=CREDENTIAL_KIND_MCP,
+            name=name or f"mcp:{install_id}:{grant_scope}",
+            plaintext=plaintext,
+        )
+        return await self._grant_repo.add(
+            CredentialGrant(
+                org_id=self._org_id,
+                install_id=install_id,
+                grant_scope=grant_scope,
                 workspace_id=workspace_id,
                 user_id=user_id,
+                credential_id=credential_id,
+                grant_status="valid",
+                created_by_user_id=self._actor_user_id,
             )
-            state = compute_effective_state(
-                template=template,
-                install=install,
-                workspace_state=workspace_state,
-                grant=grant,
-            )
-            if include_unusable or state.usable:
-                states.append(state)
-
-        return states
-
-    async def _template_view(self, catalog_connector_id: str | None) -> ConnectorTemplateView | None:
-        if catalog_connector_id is None:
-            return None
-        row = await self._catalog_repo.get_by_id(catalog_connector_id)
-        if row is None:
-            return None
-        return ConnectorTemplateView(
-            template_id=row.id,
-            slug=row.slug,
-            name=row.name,
-            provider=row.provider,
-            status=row.status,
         )
 
-    async def _grant_view(
-        self,
-        *,
-        policy: CredentialPolicy,
-        server_id: str,
-        server_credential_id: str | None,
-        workspace_id: str,
-        user_id: str,
-    ) -> CredentialGrantView | None:
-        if policy == "none":
-            return None
-        if policy == "org":
-            return CredentialGrantView(
-                policy="org",
-                available=server_credential_id is not None,
-                source="org" if server_credential_id is not None else None,
-            )
-        if policy == "workspace":
-            row = await self._ws_cred_repo.get(
-                workspace_id=workspace_id,
-                mcp_server_id=server_id,
-            )
-            shared_by = None
-            if row is not None:
-                user = await self._session.get(User, row.created_by_user_id)
-                shared_by = user.email if user is not None else None
-            return CredentialGrantView(
-                policy="workspace",
-                available=row is not None,
-                source="workspace" if row is not None else None,
-                shared_by=shared_by,
-            )
-        row = await self._user_cred_repo.get(user_id=user_id, mcp_server_id=server_id)
-        return CredentialGrantView(
-            policy="user",
-            available=row is not None,
-            source="user" if row is not None else None,
-        )
+    async def uninstall(self, install_id: str) -> ConnectorInstall:
+        install = await self._install_repo.get(install_id)
+        if install is None:
+            raise ValueError("connector_install_not_found")
+        install.install_state = "uninstalled"
+        install.auth_status = "disconnected"
+        install.updated_at = datetime.now(UTC)
+        return await self._install_repo.update(install)
 ```
 
-- [ ] **Step 4: Add the FastAPI dependency**
+- [ ] **Step 4: Add dependency providers**
 
-Edit `backend/cubebox/mcp/dependencies.py`.
-
-Add the import:
+Edit `backend/cubebox/mcp/dependencies.py` and add:
 
 ```python
-from cubebox.mcp.effective import EffectiveConnectorService
-```
-
-Add this provider after `get_member_catalog_service`:
-
-```python
-async def get_effective_connector_service(
+async def get_connector_template_service(
     session: AsyncSession = Depends(get_session),
+) -> ConnectorTemplateService:
+    return ConnectorTemplateService(ConnectorTemplateRepository(session))
+
+
+async def get_connector_install_service(
+    session: AsyncSession = Depends(get_session),
+    cred_service: CredentialService = Depends(get_credential_service),
     ctx: RequestContext = Depends(require_member),
-) -> EffectiveConnectorService:
-    return EffectiveConnectorService(
-        session=session,
-        server_repo=MCPServerRepository(session, org_id=ctx.org_id),
-        catalog_repo=MCPCatalogConnectorRepository(session),
-        ws_cred_repo=WorkspaceMCPCredentialRepository(session, org_id=ctx.org_id),
-        user_cred_repo=UserMCPCredentialRepository(session, org_id=ctx.org_id),
+) -> ConnectorInstallService:
+    return ConnectorInstallService(
+        install_repo=ConnectorInstallRepository(session, org_id=ctx.org_id),
+        state_repo=WorkspaceConnectorStateRepository(session, org_id=ctx.org_id),
+        grant_repo=CredentialGrantRepository(session, org_id=ctx.org_id),
+        cred_service=cred_service,
+        org_id=ctx.org_id,
+        actor_user_id=ctx.user.id,
     )
 ```
 
 - [ ] **Step 5: Run service tests**
 
-Run: `cd backend && uv run pytest -q tests/unit/mcp/test_effective_state.py tests/unit/mcp/test_effective_service.py`
+Run:
+
+```bash
+cd backend
+uv run pytest -q tests/unit/test_mcp_service_invariants.py
+```
 
 Expected: all tests pass.
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add backend/cubebox/mcp/effective.py \
+git add backend/cubebox/services/mcp_installs.py \
         backend/cubebox/mcp/dependencies.py \
-        backend/tests/unit/mcp/test_effective_service.py
-git commit -m "feat(mcp): add effective connector service"
+        backend/tests/unit/test_mcp_service_invariants.py
+git commit -m "feat(mcp): add install state and grant services"
 ```
 
 ---
 
-## Task 4: Normalized Workspace Connector API
+## Task 4: Final API Routes Only
 
 **Files:**
 
 - Modify: `backend/cubebox/api/schemas/mcp.py`
+- Modify: `backend/cubebox/api/routes/v1/admin_mcp.py`
 - Modify: `backend/cubebox/api/routes/v1/ws_mcp.py`
-- Modify: `backend/cubebox/api/schemas/ws_settings.py`
-- Modify: `backend/cubebox/api/routes/v1/ws_settings.py`
-- Modify: `backend/tests/e2e/conftest.py`
-- Create: `backend/tests/e2e/test_mcp_effective_connectors.py`
+- Modify: `backend/cubebox/api/app.py`
+- Delete: `backend/cubebox/api/routes/v1/mcp_catalog.py`
+- Modify: `backend/tests/unit/test_admin_mcp_routes.py`
+- Modify: `backend/tests/unit/test_ws_mcp_routes.py`
+- Modify: `backend/tests/e2e/test_mcp_four_layer_routes.py`
 
-- [ ] **Step 1: Add the no-auth catalog fixture**
+- [ ] **Step 1: Add route registration tests**
 
-Append to `backend/tests/e2e/conftest.py`:
-
-```python
-@pytest_asyncio.fixture
-async def noauth_catalog_id(db_session: AsyncSession) -> AsyncIterator[str]:
-    from cubebox.repositories.mcp_catalog import MCPCatalogConnectorRepository
-
-    row = await MCPCatalogConnectorRepository(db_session).upsert_by_slug(
-        slug="noauth-effective",
-        name="NoAuth Effective",
-        description="No auth connector for effective-state tests.",
-        provider="Cubebox",
-        server_url="https://noauth-effective.example.com/mcp",
-        transport="streamable_http",
-        supported_auth_methods=["none"],
-        default_credential_scope="none",
-    )
-    await db_session.commit()
-    yield row.id
-```
-
-- [ ] **Step 2: Add API tests for effective connector listing and state patching**
-
-Create `backend/tests/e2e/test_mcp_effective_connectors.py`:
+Replace the MCP route assertions in `backend/tests/unit/test_ws_mcp_routes.py` with:
 
 ```python
-import httpx
-import pytest
+def test_workspace_mcp_four_layer_routes_are_registered() -> None:
+    from cubebox.api.app import create_app
 
+    app = create_app()
+    paths = {route.path for route in app.routes}
 
-@pytest.mark.usefixtures("stub_discover_tools")
-async def test_effective_connectors_report_missing_user_grant(
-    admin_client: tuple[httpx.AsyncClient, str],
-    github_catalog_id: str,
-) -> None:
-    client, workspace_id = admin_client
-
-    install = await client.post(
-        f"/api/v1/admin/mcp/catalog/{github_catalog_id}/install",
-        json={"auth_method": "static", "credential_plaintext": "ghp_test"},
-    )
-    assert install.status_code == 201, install.text
-    install_id = install.json()["install_id"]
-
-    patch = await client.patch(
-        f"/api/v1/ws/{workspace_id}/mcp/connectors/{install_id}/state",
-        json={"enabled": True, "credential_policy": "user"},
-    )
-    assert patch.status_code == 200, patch.text
-
-    resp = await client.get(f"/api/v1/ws/{workspace_id}/mcp/connectors")
-    assert resp.status_code == 200, resp.text
-    rows = resp.json()["items"]
-    row = next(item for item in rows if item["install"]["install_id"] == install_id)
-    assert row["workspace_state"]["enabled"] is True
-    assert row["credential_policy"] == "user"
-    assert row["credential_availability"] == "missing"
-    assert row["usable"] is False
-    assert row["reason"] == "credential_missing"
-
-
-@pytest.mark.usefixtures("stub_discover_tools")
-async def test_effective_connectors_report_no_auth_as_usable(
-    client: httpx.AsyncClient,
-    workspace_id: str,
-    noauth_catalog_id: str,
-) -> None:
-    install = await client.post(
-        f"/api/v1/ws/{workspace_id}/mcp/catalog/{noauth_catalog_id}/install",
-        json={"auth_method": "none"},
-    )
-    assert install.status_code == 201, install.text
-
-    resp = await client.get(f"/api/v1/ws/{workspace_id}/mcp/connectors")
-    assert resp.status_code == 200, resp.text
-    row = next(
-        item
-        for item in resp.json()["items"]
-        if item["install"]["install_id"] == install.json()["install_id"]
-    )
-    assert row["credential_policy"] == "none"
-    assert row["credential_availability"] == "not_required"
-    assert row["usable"] is True
+    assert "/api/v1/ws/{workspace_id}/mcp/templates" in paths
+    assert "/api/v1/ws/{workspace_id}/mcp/installs" in paths
+    assert "/api/v1/ws/{workspace_id}/mcp/installs/{install_id}/state" in paths
+    assert "/api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me" in paths
+    assert "/api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/workspace" in paths
+    assert "/api/v1/ws/{workspace_id}/mcp/connectors" in paths
+    assert "/api/v1/ws/{workspace_id}/mcp/catalog" not in paths
+    assert "/api/v1/ws/{workspace_id}/mcp/org-installs/{install_id}/override" not in paths
 ```
 
-- [ ] **Step 3: Run route tests and confirm missing route failure**
-
-Run: `cd backend && uv run pytest -q tests/e2e/test_mcp_effective_connectors.py`
-
-Expected: FAIL with 404 for `/api/v1/ws/{workspace_id}/mcp/connectors`.
-
-- [ ] **Step 4: Add response and patch schemas**
-
-Append to `backend/cubebox/api/schemas/mcp.py`:
+Replace the MCP route assertions in `backend/tests/unit/test_admin_mcp_routes.py` with:
 
 ```python
-class MCPConnectorTemplateOut(BaseModel):
-    template_id: str | None
-    slug: str | None
-    name: str
-    provider: str | None
-    status: str
+def test_admin_mcp_four_layer_routes_are_registered() -> None:
+    from cubebox.api.app import create_app
 
+    app = create_app()
+    paths = {route.path for route in app.routes}
 
-class MCPConnectorInstallOut(BaseModel):
-    install_id: str
-    name: str
-    server_url: str
-    transport: str
-    auth_method: str
-    credential_scope: str
-    install_status: str
-    origin: str
-    owner_workspace_id: str | None
-    tool_count: int
-
-
-class MCPWorkspaceConnectorStateOut(BaseModel):
-    enabled: bool
-    credential_policy: str | None
-
-
-class MCPEffectiveConnectorOut(BaseModel):
-    template: MCPConnectorTemplateOut | None
-    install: MCPConnectorInstallOut
-    workspace_state: MCPWorkspaceConnectorStateOut
-    credential_policy: str
-    credential_availability: str
-    credential_source: str | None
-    credential_shared_by: str | None
-    usable: bool
-    reason: str
-
-
-class MCPEffectiveConnectorListOut(BaseModel):
-    items: list[MCPEffectiveConnectorOut]
-
-
-class MCPWorkspaceConnectorStatePatch(BaseModel):
-    enabled: bool | None = None
-    credential_policy: Literal["org", "workspace", "user", "none"] | None = None
+    assert "/api/v1/admin/mcp/templates" in paths
+    assert "/api/v1/admin/mcp/templates/{template_id}/installs" in paths
+    assert "/api/v1/admin/mcp/installs" in paths
+    assert "/api/v1/admin/mcp/installs/{install_id}" in paths
+    assert "/api/v1/admin/mcp/installs/{install_id}/grants/org" in paths
+    assert "/api/v1/admin/mcp/catalog/{catalog_id}/install" not in paths
+    assert "/api/v1/admin/mcp/servers/{server_id}/overrides" not in paths
 ```
 
-- [ ] **Step 5: Add route mapping helpers and endpoints**
-
-Edit `backend/cubebox/api/routes/v1/ws_mcp.py`.
-
-Add imports:
-
-```python
-from cubebox.api.schemas.mcp import (
-    MCPEffectiveConnectorListOut,
-    MCPEffectiveConnectorOut,
-    MCPConnectorInstallOut,
-    MCPConnectorTemplateOut,
-    MCPWorkspaceConnectorStateOut,
-    MCPWorkspaceConnectorStatePatch,
-)
-from cubebox.mcp.dependencies import get_effective_connector_service
-from cubebox.mcp.effective import EffectiveConnectorService, EffectiveConnectorState
-```
-
-Add helper:
-
-```python
-def _effective_to_out(state: EffectiveConnectorState) -> MCPEffectiveConnectorOut:
-    template = None
-    if state.template is not None:
-        template = MCPConnectorTemplateOut(
-            template_id=state.template.template_id,
-            slug=state.template.slug,
-            name=state.template.name,
-            provider=state.template.provider,
-            status=state.template.status,
-        )
-    return MCPEffectiveConnectorOut(
-        template=template,
-        install=MCPConnectorInstallOut(
-            install_id=state.install.install_id,
-            name=state.install.name,
-            server_url=state.install.server_url,
-            transport=state.install.transport,
-            auth_method=state.install.auth_method,
-            credential_scope=state.install.credential_scope,
-            install_status=state.install.install_status,
-            origin=state.install.origin,
-            owner_workspace_id=state.install.owner_workspace_id,
-            tool_count=len(state.install.tools_cache),
-        ),
-        workspace_state=MCPWorkspaceConnectorStateOut(
-            enabled=state.workspace_state.enabled,
-            credential_policy=state.workspace_state.credential_policy,
-        ),
-        credential_policy=state.credential_policy,
-        credential_availability=state.credential_availability,
-        credential_source=state.credential_source,
-        credential_shared_by=state.credential_shared_by,
-        usable=state.usable,
-        reason=state.reason,
-    )
-```
-
-Add endpoints near the top of the router:
-
-```python
-@router.get("/connectors", response_model=MCPEffectiveConnectorListOut)
-async def list_effective_connectors(
-    workspace_id: str,
-    ctx: RequestContext = Depends(require_member),
-    effective: EffectiveConnectorService = Depends(get_effective_connector_service),
-) -> MCPEffectiveConnectorListOut:
-    rows = await effective.list_for_workspace_user(
-        workspace_id=workspace_id,
-        user_id=ctx.user.id,
-        include_unusable=True,
-    )
-    return MCPEffectiveConnectorListOut(items=[_effective_to_out(row) for row in rows])
-
-
-@router.patch(
-    "/connectors/{install_id}/state",
-    response_model=MCPEffectiveConnectorOut,
-)
-async def patch_effective_connector_state(
-    workspace_id: str,
-    install_id: str,
-    body: MCPWorkspaceConnectorStatePatch,
-    svc: MCPServerService = Depends(get_mcp_service),
-    ctx: RequestContext = Depends(require_member),
-    effective: EffectiveConnectorService = Depends(get_effective_connector_service),
-) -> MCPEffectiveConnectorOut:
-    server = await svc.server_repo.get(install_id)
-    if server is None or server.owner_workspace_id is not None:
-        raise HTTPException(404, detail={"code": "mcp_install_not_found"})
-
-    if body.enabled is not None:
-        if body.enabled:
-            await svc.override_repo.upsert(
-                workspace_id=workspace_id,
-                mcp_server_id=install_id,
-                enabled=True,
-                updated_by_user_id=ctx.user.id,
-            )
-        else:
-            await svc.override_repo.delete(
-                workspace_id=workspace_id,
-                mcp_server_id=install_id,
-            )
-
-    if body.credential_policy is not None:
-        override = await svc.override_repo.get_for_workspace_and_server(
-            workspace_id=workspace_id,
-            mcp_server_id=install_id,
-        )
-        if override is None:
-            raise HTTPException(
-                status.HTTP_409_CONFLICT,
-                detail={"code": "mcp_connector_state_required"},
-            )
-        override.credential_mode = body.credential_policy
-        override.updated_by_user_id = ctx.user.id
-        svc.server_repo.session.add(override)
-        await svc.server_repo.session.commit()
-
-    rows = await effective.list_for_workspace_user(
-        workspace_id=workspace_id,
-        user_id=ctx.user.id,
-        include_unusable=True,
-    )
-    for row in rows:
-        if row.install.install_id == install_id:
-            return _effective_to_out(row)
-    raise HTTPException(404, detail={"code": "mcp_install_not_found"})
-```
-
-- [ ] **Step 6: Tighten workspace settings schema literals**
-
-Edit `backend/cubebox/api/schemas/ws_settings.py`.
-
-Add import:
-
-```python
-from typing import Literal
-```
-
-Replace:
-
-```python
-    credential_mode: str = "org"
-```
-
-with:
-
-```python
-    credential_mode: Literal["org", "workspace", "user", "none"] = "org"
-```
-
-Replace:
-
-```python
-    credential_mode: str | None = None
-```
-
-with:
-
-```python
-    credential_mode: Literal["org", "workspace", "user", "none"] | None = None
-```
-
-- [ ] **Step 7: Delegate settings MCP list to effective service**
-
-Edit `backend/cubebox/api/routes/v1/ws_settings.py`.
-
-Replace `list_workspace_mcp`'s body with:
-
-```python
-    from cubebox.mcp.dependencies import get_effective_connector_service
-
-    effective = await get_effective_connector_service(session=session, ctx=ctx)
-    rows = await effective.list_for_workspace_user(
-        workspace_id=ctx.workspace_id,
-        user_id=ctx.user.id,
-        include_unusable=True,
-    )
-    org_servers: list[MCPServerItem] = []
-    workspace_servers: list[MCPServerItem] = []
-    for row in rows:
-        item = MCPServerItem(
-            server_id=row.install.install_id,
-            name=row.install.name,
-            server_url=row.install.server_url,
-            transport=row.install.transport,
-            enabled=row.workspace_state.enabled,
-            scope=row.install.origin,
-            credential_mode=row.credential_policy,
-            credential_source=(
-                row.credential_source
-                if row.credential_availability == "available"
-                else "needs_setup"
-                if row.credential_availability == "missing"
-                else None
-            ),
-            credential_shared_by=row.credential_shared_by,
-        )
-        if row.install.origin == "org":
-            org_servers.append(item)
-        else:
-            workspace_servers.append(item)
-    return WorkspaceMCPOut(org_servers=org_servers, workspace_servers=workspace_servers)
-```
-
-- [ ] **Step 8: Run API tests**
+- [ ] **Step 2: Run route tests and confirm old route names still exist**
 
 Run:
 
 ```bash
 cd backend
-uv run pytest -q tests/e2e/test_mcp_effective_connectors.py
-uv run pytest -q tests/e2e/test_ws_settings.py
+uv run pytest -q tests/unit/test_ws_mcp_routes.py tests/unit/test_admin_mcp_routes.py
 ```
 
-Expected: all tests pass.
+Expected: FAIL because current routes still expose old MCP paths.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 3: Replace MCP schemas**
+
+Edit `backend/cubebox/api/schemas/mcp.py` so public schemas use final names.
+Use `Literal["org", "workspace", "user", "none"]` for credential policy fields and
+`Literal["oauth", "static", "none"]` for auth method fields.
+
+The response schemas must include these fields:
+
+- `ConnectorTemplateOut`: `template_id`, `slug`, `name`, `provider`, `description`,
+  `server_url`, `transport`, `supported_auth_methods`, `default_credential_policy`,
+  `static_form_schema`, `status`.
+- `ConnectorInstallOut`: `install_id`, `template_id`, `install_scope`, `workspace_id`,
+  `name`, `server_url`, `transport`, `auth_method`, `default_credential_policy`,
+  `auth_status`, `discovery_status`, `install_state`, `tool_count`, `last_error`.
+- `WorkspaceConnectorStateOut`: `workspace_id`, `install_id`, `enabled`,
+  `credential_policy`, `enablement_source`.
+- `CredentialGrantStatusOut`: `install_id`, `grant_scope`, `workspace_id`, `user_id`,
+  `grant_status`, `has_value`, `expires_at`.
+- `EffectiveConnectorOut`: `template`, `install`, `workspace_state`, `credential_policy`,
+  `credential_availability`, `credential_source`, `usable`, `reason`.
+
+- [ ] **Step 4: Replace admin routes**
+
+Edit `backend/cubebox/api/routes/v1/admin_mcp.py` to expose these routes:
+
+- `GET /api/v1/admin/mcp/templates`
+- `POST /api/v1/admin/mcp/templates/{template_id}/installs`
+- `GET /api/v1/admin/mcp/installs`
+- `DELETE /api/v1/admin/mcp/installs/{install_id}`
+- `PUT /api/v1/admin/mcp/installs/{install_id}/grants/org`
+
+Remove server/override route handlers from this module.
+
+- [ ] **Step 5: Replace workspace routes**
+
+Edit `backend/cubebox/api/routes/v1/ws_mcp.py` to expose these routes:
+
+- `GET /api/v1/ws/{workspace_id}/mcp/templates`
+- `POST /api/v1/ws/{workspace_id}/mcp/installs`
+- `PATCH /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/state`
+- `PUT /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me`
+- `PUT /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/workspace`
+- `GET /api/v1/ws/{workspace_id}/mcp/connectors`
+
+Remove old server/catalog/org-install override handlers from this module.
+
+- [ ] **Step 6: Remove old route module from app**
+
+Edit `backend/cubebox/api/app.py` and remove the import/mount for
+`cubebox.api.routes.v1.mcp_catalog`.
+
+Run:
 
 ```bash
-git add backend/cubebox/api/schemas/mcp.py \
-        backend/cubebox/api/routes/v1/ws_mcp.py \
-        backend/cubebox/api/schemas/ws_settings.py \
-        backend/cubebox/api/routes/v1/ws_settings.py \
-        backend/tests/e2e/conftest.py \
-        backend/tests/e2e/test_mcp_effective_connectors.py
-git commit -m "feat(mcp): expose effective workspace connector state"
+git rm backend/cubebox/api/routes/v1/mcp_catalog.py
 ```
 
----
-
-## Task 5: Runtime Uses Effective Service and OAuth Refresh
-
-**Files:**
-
-- Modify: `backend/cubebox/mcp/effective.py`
-- Modify: `backend/cubebox/mcp/cubepi_discovery.py`
-- Modify: `backend/cubebox/mcp/cubepi_runtime.py`
-- Modify: `backend/cubebox/streams/run_manager.py`
-- Modify: `backend/tests/unit/test_mcp_cubepi_runtime.py`
-- Modify: `backend/tests/unit/mcp/test_oauth_token_manager.py`
-
-- [ ] **Step 1: Add runtime token resolver tests**
-
-Append to `backend/tests/unit/test_mcp_cubepi_runtime.py`:
-
-```python
-@pytest.mark.asyncio
-async def test_load_only_discovers_usable_effective_connectors(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from cubebox.mcp.effective import (
-        ConnectorInstallView,
-        EffectiveConnectorState,
-        WorkspaceConnectorStateView,
-    )
-
-    usable = EffectiveConnectorState(
-        template=None,
-        install=ConnectorInstallView(
-            install_id="s1",
-            name="good",
-            server_url="http://good",
-            transport="streamable_http",
-            auth_method="none",
-            credential_scope="none",
-            install_status="active",
-            origin="workspace",
-            owner_workspace_id="ws-1",
-            credential_id=None,
-        ),
-        workspace_state=WorkspaceConnectorStateView(enabled=True, credential_policy=None),
-        credential_policy="none",
-        credential_availability="not_required",
-        credential_source=None,
-        credential_shared_by=None,
-        usable=True,
-        reason="usable",
-    )
-    unusable = dataclasses.replace(usable, usable=False, reason="credential_missing")
-
-    class _Effective:
-        async def list_for_workspace_user(
-            self, *, workspace_id: str, user_id: str, include_unusable: bool
-        ) -> list[EffectiveConnectorState]:
-            return [usable, unusable]
-
-    async def _fake_loader(
-        url: str,
-        *,
-        headers: dict[str, str] | None,
-        timeout: float,
-        transport: str,
-    ) -> list[object]:
-        assert url == "http://good"
-        return [_FakeTool(name="search")]
-
-    monkeypatch.setattr("cubebox.mcp.cubepi_runtime.load_mcp_tools_http", _fake_loader)
-
-    tools, _citation_configs = await load_workspace_mcp_tools_for_cubepi(
-        session=None,  # type: ignore[arg-type]
-        workspace_id="ws-1",
-        org_id="org-1",
-        user_id="user-1",
-        cred_service=None,  # type: ignore[arg-type]
-        signer=None,  # type: ignore[arg-type]
-        effective_service=_Effective(),  # type: ignore[arg-type]
-        token_manager=None,
-    )
-
-    assert [tool.name for tool in tools] == ["good__search"]
-```
-
-- [ ] **Step 2: Run the runtime test and confirm signature failure**
+- [ ] **Step 7: Run route tests**
 
 Run:
 
 ```bash
 cd backend
-uv run pytest -q tests/unit/test_mcp_cubepi_runtime.py::test_load_only_discovers_usable_effective_connectors
-```
-
-Expected: FAIL because `load_workspace_mcp_tools_for_cubepi` does not accept
-`effective_service`.
-
-- [ ] **Step 3: Add runtime spec conversion to effective service**
-
-Append to `backend/cubebox/mcp/effective.py`:
-
-```python
-@dataclass(frozen=True, slots=True)
-class RuntimeConnectorSpec:
-    server_id: str
-    server_name: str
-    url: str
-    transport: str
-    headers: dict[str, str]
-    tool_citations: dict[str, dict[str, Any]]
-    credential_policy: CredentialPolicy
-    auth_method: str
-    credential_id: str | None
-
-
-def effective_state_to_runtime_spec(state: EffectiveConnectorState) -> RuntimeConnectorSpec:
-    return RuntimeConnectorSpec(
-        server_id=state.install.install_id,
-        server_name=state.install.name,
-        url=state.install.server_url,
-        transport=state.install.transport,
-        headers=dict(state.install.headers),
-        tool_citations=dict(state.install.tool_citations),
-        credential_policy=state.credential_policy,
-        auth_method=state.install.auth_method,
-        credential_id=state.install.credential_id,
-    )
-```
-
-- [ ] **Step 4: Change runtime loader signature and filtering**
-
-Edit `backend/cubebox/mcp/cubepi_runtime.py`.
-
-Add imports:
-
-```python
-from cubebox.mcp.effective import (
-    EffectiveConnectorService,
-    RuntimeConnectorSpec,
-    effective_state_to_runtime_spec,
-)
-from cubebox.mcp.oauth.token_manager import OAuthTokenManager
-```
-
-Change `load_workspace_mcp_tools_for_cubepi` signature to include:
-
-```python
-    effective_service: EffectiveConnectorService | None = None,
-    token_manager: OAuthTokenManager | None = None,
-```
-
-Replace the call to `discover_workspace_mcp_servers_for_cubepi` with:
-
-```python
-    if effective_service is None:
-        servers = await discover_workspace_mcp_servers_for_cubepi(
-            session=session,
-            workspace_id=workspace_id,
-            org_id=org_id,
-            user_id=user_id,
-            cred_service=cred_service,
-            signer=signer,
-            token_manager=token_manager,
-        )
-    else:
-        states = await effective_service.list_for_workspace_user(
-            workspace_id=workspace_id,
-            user_id=user_id,
-            include_unusable=False,
-        )
-        servers = [
-            CubepiMCPServerSpec(
-                server_id=spec.server_id,
-                server_name=spec.server_name,
-                url=spec.url,
-                transport=cast(Any, spec.transport),
-                headers=spec.headers,
-                tool_citations=spec.tool_citations,
-            )
-            for spec in [effective_state_to_runtime_spec(state) for state in states]
-        ]
-```
-
-Add `cast` to the typing imports if it is not present.
-
-- [ ] **Step 5: Add OAuth token manager pass-through in discovery**
-
-Edit `backend/cubebox/mcp/cubepi_discovery.py`.
-
-Import:
-
-```python
-from cubebox.mcp.oauth.token_manager import OAuthTokenManager
-```
-
-Add parameter to `discover_workspace_mcp_servers_for_cubepi`:
-
-```python
-    token_manager: OAuthTokenManager | None = None,
-```
-
-Pass it into `_resolve_token_for_cubepi`:
-
-```python
-                token_manager=token_manager,
-```
-
-Add parameter to `_resolve_token_for_cubepi`:
-
-```python
-    token_manager: OAuthTokenManager | None,
-```
-
-At the top of the user-scope branch, before falling back to direct vault decryption:
-
-```python
-        if auth_method == "oauth" and token_manager is not None:
-            return await token_manager.get_access_token(
-                server_id=server_id,
-                user_id=user_id,
-            )
-```
-
-This keeps OAuth refresh in one manager instead of decrypting stale access tokens directly.
-
-- [ ] **Step 6: Wire token manager and effective service in run manager**
-
-Edit `backend/cubebox/streams/run_manager.py`.
-
-Inside the MCP tools block, import:
-
-```python
-import httpx
-
-from cubebox.mcp.dependencies import _build_token_manager_for_org
-from cubebox.mcp.effective import EffectiveConnectorService
-from cubebox.mcp.oauth.metadata import OAuthMetadataDiscovery
-from cubebox.repositories.mcp import (
-    MCPServerRepository,
-    UserMCPCredentialRepository,
-    WorkspaceMCPCredentialRepository,
-)
-from cubebox.repositories.mcp_catalog import MCPCatalogConnectorRepository
-```
-
-Before calling `load_workspace_mcp_tools_for_cubepi`, construct:
-
-```python
-                oauth_http_client = getattr(
-                    self._app.state,
-                    "_mcp_oauth_http_client",
-                    None,
-                )
-                if oauth_http_client is None:
-                    oauth_http_client = httpx.AsyncClient(timeout=30.0)
-                    setattr(
-                        self._app.state,
-                        "_mcp_oauth_http_client",
-                        oauth_http_client,
-                    )
-
-                oauth_metadata = getattr(
-                    self._app.state,
-                    "_mcp_oauth_metadata_discovery",
-                    None,
-                )
-                if oauth_metadata is None:
-                    oauth_metadata = OAuthMetadataDiscovery(oauth_http_client)
-                    setattr(
-                        self._app.state,
-                        "_mcp_oauth_metadata_discovery",
-                        oauth_metadata,
-                    )
-
-                token_manager = _build_token_manager_for_org(
-                    session=mcp_session,
-                    backend=self._app.state.encryption_backend,
-                    redis=self._app.state.redis,
-                    http_client=oauth_http_client,
-                    metadata=oauth_metadata,
-                    org_id=ctx.org_id,
-                )
-```
-
-Then pass:
-
-```python
-                effective_service = EffectiveConnectorService(
-                    session=mcp_session,
-                    server_repo=MCPServerRepository(mcp_session, org_id=ctx.org_id),
-                    catalog_repo=MCPCatalogConnectorRepository(mcp_session),
-                    ws_cred_repo=WorkspaceMCPCredentialRepository(mcp_session, org_id=ctx.org_id),
-                    user_cred_repo=UserMCPCredentialRepository(mcp_session, org_id=ctx.org_id),
-                )
-```
-
-and call the loader with:
-
-```python
-                    effective_service=effective_service,
-                    token_manager=token_manager,
-```
-
-- [ ] **Step 7: Run runtime tests**
-
-Run:
-
-```bash
-cd backend
-uv run pytest -q tests/unit/test_mcp_cubepi_runtime.py
-uv run pytest -q tests/unit/mcp/test_oauth_token_manager.py
+uv run pytest -q tests/unit/test_ws_mcp_routes.py tests/unit/test_admin_mcp_routes.py
 ```
 
 Expected: all tests pass.
@@ -1631,105 +959,339 @@ Expected: all tests pass.
 - [ ] **Step 8: Commit**
 
 ```bash
-git add backend/cubebox/mcp/effective.py \
-        backend/cubebox/mcp/cubepi_discovery.py \
-        backend/cubebox/mcp/cubepi_runtime.py \
-        backend/cubebox/streams/run_manager.py \
-        backend/tests/unit/test_mcp_cubepi_runtime.py \
-        backend/tests/unit/mcp/test_oauth_token_manager.py
-git commit -m "feat(mcp): load runtime tools from effective connector state"
+git add backend/cubebox/api/schemas/mcp.py \
+        backend/cubebox/api/routes/v1/admin_mcp.py \
+        backend/cubebox/api/routes/v1/ws_mcp.py \
+        backend/cubebox/api/app.py \
+        backend/tests/unit/test_admin_mcp_routes.py \
+        backend/tests/unit/test_ws_mcp_routes.py
+git commit -m "feat(mcp): replace catalog routes with four-layer API"
 ```
 
 ---
 
-## Task 6: Template Aliases and Grant-Oriented Compatibility
+## Task 5: Effective State Service And Runtime
 
 **Files:**
 
-- Modify: `backend/cubebox/api/routes/v1/mcp_catalog.py`
-- Modify: `backend/cubebox/api/routes/v1/ws_mcp.py`
-- Modify: `backend/tests/unit/test_ws_mcp_routes.py`
-- Modify: `backend/tests/e2e/test_mcp_effective_connectors.py`
+- Create: `backend/cubebox/mcp/effective.py`
+- Modify: `backend/cubebox/mcp/cubepi_discovery.py`
+- Modify: `backend/cubebox/mcp/cubepi_runtime.py`
+- Modify: `backend/cubebox/streams/run_manager.py`
+- Create: `backend/tests/unit/mcp/test_effective_state.py`
+- Create: `backend/tests/unit/mcp/test_effective_service.py`
+- Modify: `backend/tests/unit/test_mcp_cubepi_runtime.py`
 
-- [ ] **Step 1: Add route registration tests**
+- [ ] **Step 1: Add effective state tests**
 
-Append to `backend/tests/unit/test_ws_mcp_routes.py`:
+Create `backend/tests/unit/mcp/test_effective_state.py`:
 
 ```python
-def test_workspace_mcp_effective_routes_are_registered() -> None:
-    from cubebox.api.app import create_app
+from cubebox.mcp.effective import EffectiveInput, GrantInput, compute_effective_state
 
-    app = create_app()
-    paths = {route.path for route in app.routes}
 
-    assert "/api/v1/ws/{workspace_id}/mcp/connectors" in paths
-    assert "/api/v1/ws/{workspace_id}/mcp/connectors/{install_id}/state" in paths
-    assert "/api/v1/ws/{workspace_id}/mcp/templates" in paths
+def test_no_auth_connector_is_usable_without_grant() -> None:
+    result = compute_effective_state(
+        EffectiveInput(
+            template_status="active",
+            install_state="active",
+            workspace_enabled=True,
+            auth_method="none",
+            credential_policy="none",
+            grant=None,
+            transport="streamable_http",
+        )
+    )
+
+    assert result.usable is True
+    assert result.reason == "usable"
+    assert result.credential_availability == "not_required"
+
+
+def test_user_policy_requires_user_grant() -> None:
+    result = compute_effective_state(
+        EffectiveInput(
+            template_status="active",
+            install_state="active",
+            workspace_enabled=True,
+            auth_method="static",
+            credential_policy="user",
+            grant=None,
+            transport="streamable_http",
+        )
+    )
+
+    assert result.usable is False
+    assert result.reason == "credential_missing"
+
+
+def test_valid_user_grant_makes_user_policy_usable() -> None:
+    result = compute_effective_state(
+        EffectiveInput(
+            template_status="active",
+            install_state="active",
+            workspace_enabled=True,
+            auth_method="static",
+            credential_policy="user",
+            grant=GrantInput(scope="user", status="valid"),
+            transport="streamable_http",
+        )
+    )
+
+    assert result.usable is True
+    assert result.reason == "usable"
 ```
 
-- [ ] **Step 2: Add template alias endpoint**
+- [ ] **Step 2: Implement pure effective-state model**
 
-Edit `backend/cubebox/api/routes/v1/mcp_catalog.py`.
-
-Below `list_catalog`, add:
+Create `backend/cubebox/mcp/effective.py`:
 
 ```python
-@catalog_member_router.get("/templates", response_model=MCPCatalogListOut)
-async def list_templates(
-    workspace_id: str = Path(..., max_length=20),
-    q: str | None = Query(default=None),
-    provider: str | None = Query(default=None),
-    svc: MCPCatalogService = Depends(get_member_catalog_service),
-) -> MCPCatalogListOut:
-    dtos = await svc.list_for_member(workspace_id, q=q, provider=provider)
-    return MCPCatalogListOut(items=[_connector_to_out(dto) for dto in dtos])
+from dataclasses import dataclass
+from typing import Literal
+
+CredentialPolicy = Literal["org", "workspace", "user", "none"]
+EffectiveReason = Literal[
+    "usable",
+    "template_inactive",
+    "install_uninstalled",
+    "workspace_disabled",
+    "credential_missing",
+    "credential_invalid",
+    "unsupported_transport",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class GrantInput:
+    scope: str
+    status: str
+
+
+@dataclass(frozen=True, slots=True)
+class EffectiveInput:
+    template_status: str | None
+    install_state: str
+    workspace_enabled: bool
+    auth_method: str
+    credential_policy: CredentialPolicy
+    grant: GrantInput | None
+    transport: str
+
+
+@dataclass(frozen=True, slots=True)
+class EffectiveResult:
+    usable: bool
+    reason: EffectiveReason
+    credential_availability: str
+
+
+def compute_effective_state(value: EffectiveInput) -> EffectiveResult:
+    if value.template_status is not None and value.template_status != "active":
+        return EffectiveResult(False, "template_inactive", "missing")
+    if value.install_state != "active":
+        return EffectiveResult(False, "install_uninstalled", "missing")
+    if value.transport not in {"streamable_http", "sse"}:
+        return EffectiveResult(False, "unsupported_transport", "missing")
+    if not value.workspace_enabled:
+        return EffectiveResult(False, "workspace_disabled", "missing")
+    if value.auth_method == "none" or value.credential_policy == "none":
+        return EffectiveResult(True, "usable", "not_required")
+    if value.grant is None:
+        return EffectiveResult(False, "credential_missing", "missing")
+    if value.grant.status != "valid" or value.grant.scope != value.credential_policy:
+        return EffectiveResult(False, "credential_invalid", "missing")
+    return EffectiveResult(True, "usable", "available")
 ```
 
-This preserves the existing response shape while moving product language off `catalog`.
+- [ ] **Step 3: Add DB-backed effective service**
 
-- [ ] **Step 3: Add grant alias routes for user and workspace credentials**
+Extend `backend/cubebox/mcp/effective.py` with `EffectiveConnectorService`.
 
-Edit `backend/cubebox/api/routes/v1/ws_mcp.py`.
+It should:
 
-For the existing user credential handlers, add route decorators above the same functions:
+- load active org installs plus workspace installs;
+- load `WorkspaceConnectorState` for each install and workspace;
+- load the required grant from `CredentialGrantRepository`;
+- return unusable rows when `include_unusable=True`;
+- return only usable rows to runtime.
+
+The service exposes two methods:
+
+- `list_for_workspace_user(workspace_id: str, user_id: str, include_unusable: bool)
+  -> list[EffectiveConnectorDTO]`
+- `list_runtime_specs(workspace_id: str, user_id: str) -> list[RuntimeConnectorSpec]`
+
+- [ ] **Step 4: Wire OAuth refresh in runtime token resolution**
+
+Edit `backend/cubebox/mcp/cubepi_runtime.py` so `load_workspace_mcp_tools_for_cubepi`
+accepts:
 
 ```python
-@router.get("/connectors/{server_id}/grants/me", response_model=MCPCredentialStatus)
+effective_service: EffectiveConnectorService
+token_manager: OAuthTokenManager | None
 ```
 
-```python
-@router.put("/connectors/{server_id}/grants/me", response_model=MCPCredentialStatus)
-```
+For OAuth grants, call:
 
 ```python
-@router.delete("/connectors/{server_id}/grants/me", status_code=status.HTTP_204_NO_CONTENT)
-```
-
-For workspace credential handlers, add:
-
-```python
-@router.get("/connectors/{server_id}/grants/workspace", response_model=MCPCredentialStatus)
-```
-
-```python
-@router.put("/connectors/{server_id}/grants/workspace", response_model=MCPCredentialStatus)
-```
-
-```python
-@router.delete(
-    "/connectors/{server_id}/grants/workspace",
-    status_code=status.HTTP_204_NO_CONTENT,
+token = await token_manager.get_access_token(
+    install_id=spec.install_id,
+    grant_scope=spec.grant_scope,
+    workspace_id=workspace_id,
+    user_id=user_id,
 )
 ```
 
-- [ ] **Step 4: Run route registration and E2E tests**
+For static grants, decrypt `spec.credential_id` through `CredentialService`.
+For no-auth connectors, sign the short-lived Cubebox identity token.
+
+- [ ] **Step 5: Wire run manager**
+
+Edit `backend/cubebox/streams/run_manager.py` to construct `EffectiveConnectorService`
+inside the MCP tools block and pass it to `load_workspace_mcp_tools_for_cubepi`.
+Construct `OAuthTokenManager` using the same `_build_token_manager_for_org` helper used by
+admin MCP dependencies.
+
+- [ ] **Step 6: Run effective and runtime tests**
 
 Run:
 
 ```bash
 cd backend
-uv run pytest -q tests/unit/test_ws_mcp_routes.py::test_workspace_mcp_effective_routes_are_registered
-uv run pytest -q tests/e2e/test_mcp_effective_connectors.py
+uv run pytest -q tests/unit/mcp/test_effective_state.py \
+                 tests/unit/mcp/test_effective_service.py \
+                 tests/unit/test_mcp_cubepi_runtime.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/cubebox/mcp/effective.py \
+        backend/cubebox/mcp/cubepi_discovery.py \
+        backend/cubebox/mcp/cubepi_runtime.py \
+        backend/cubebox/streams/run_manager.py \
+        backend/tests/unit/mcp/test_effective_state.py \
+        backend/tests/unit/mcp/test_effective_service.py \
+        backend/tests/unit/test_mcp_cubepi_runtime.py
+git commit -m "feat(mcp): derive runtime connectors from effective state"
+```
+
+---
+
+## Task 6: Backend E2E Coverage
+
+**Files:**
+
+- Create: `backend/tests/e2e/test_mcp_four_layer_routes.py`
+- Create: `backend/tests/e2e/test_mcp_four_layer_runtime.py`
+- Modify: `backend/tests/e2e/conftest.py`
+
+- [ ] **Step 1: Add template fixtures**
+
+Append to `backend/tests/e2e/conftest.py`:
+
+```python
+@pytest_asyncio.fixture
+async def noauth_template_id(db_session: AsyncSession) -> AsyncIterator[str]:
+    from cubebox.repositories.mcp import ConnectorTemplateRepository
+
+    row = await ConnectorTemplateRepository(db_session).upsert_by_slug(
+        slug="noauth-e2e",
+        name="NoAuth E2E",
+        description="No auth connector.",
+        provider="Cubebox",
+        server_url="https://noauth-e2e.example.com/mcp",
+        transport="streamable_http",
+        supported_auth_methods=["none"],
+        default_credential_policy="none",
+    )
+    await db_session.commit()
+    yield row.id
+```
+
+- [ ] **Step 2: Add no-auth route E2E**
+
+Create `backend/tests/e2e/test_mcp_four_layer_routes.py`:
+
+```python
+import httpx
+import pytest
+
+
+@pytest.mark.usefixtures("stub_discover_tools")
+async def test_workspace_installs_noauth_template_and_gets_usable_connector(
+    client: httpx.AsyncClient,
+    workspace_id: str,
+    noauth_template_id: str,
+) -> None:
+    install = await client.post(
+        f"/api/v1/ws/{workspace_id}/mcp/installs",
+        json={"template_id": noauth_template_id, "auth_method": "none"},
+    )
+    assert install.status_code == 201, install.text
+
+    connectors = await client.get(f"/api/v1/ws/{workspace_id}/mcp/connectors")
+    assert connectors.status_code == 200, connectors.text
+    row = next(
+        item
+        for item in connectors.json()["items"]
+        if item["install"]["install_id"] == install.json()["install_id"]
+    )
+    assert row["workspace_state"]["enabled"] is True
+    assert row["credential_policy"] == "none"
+    assert row["credential_availability"] == "not_required"
+    assert row["usable"] is True
+```
+
+- [ ] **Step 3: Add user grant isolation E2E**
+
+Append to `backend/tests/e2e/test_mcp_four_layer_routes.py`:
+
+```python
+@pytest.mark.usefixtures("stub_discover_tools")
+async def test_user_grant_policy_does_not_fall_back_to_org_grant(
+    admin_client: tuple[httpx.AsyncClient, str],
+    github_template_id: str,
+) -> None:
+    client, workspace_id = admin_client
+    install = await client.post(
+        f"/api/v1/admin/mcp/templates/{github_template_id}/installs",
+        json={
+            "auth_method": "static",
+            "credential_policy": "org",
+            "credential_plaintext": "org-token",
+        },
+    )
+    assert install.status_code == 201, install.text
+    install_id = install.json()["install_id"]
+
+    state = await client.patch(
+        f"/api/v1/ws/{workspace_id}/mcp/installs/{install_id}/state",
+        json={"enabled": True, "credential_policy": "user"},
+    )
+    assert state.status_code == 200, state.text
+
+    connectors = await client.get(f"/api/v1/ws/{workspace_id}/mcp/connectors")
+    row = next(
+        item
+        for item in connectors.json()["items"]
+        if item["install"]["install_id"] == install_id
+    )
+    assert row["credential_policy"] == "user"
+    assert row["credential_availability"] == "missing"
+    assert row["usable"] is False
+```
+
+- [ ] **Step 4: Run backend E2E tests**
+
+Run:
+
+```bash
+cd backend
+uv run pytest -q tests/e2e/test_mcp_four_layer_routes.py
 ```
 
 Expected: all tests pass.
@@ -1737,16 +1299,15 @@ Expected: all tests pass.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add backend/cubebox/api/routes/v1/mcp_catalog.py \
-        backend/cubebox/api/routes/v1/ws_mcp.py \
-        backend/tests/unit/test_ws_mcp_routes.py \
-        backend/tests/e2e/test_mcp_effective_connectors.py
-git commit -m "feat(mcp): add template and grant route aliases"
+git add backend/tests/e2e/conftest.py \
+        backend/tests/e2e/test_mcp_four_layer_routes.py \
+        backend/tests/e2e/test_mcp_four_layer_runtime.py
+git commit -m "test(mcp): cover four-layer connector flows"
 ```
 
 ---
 
-## Task 7: Frontend Core API and State Types
+## Task 7: Frontend Core API And Types
 
 **Files:**
 
@@ -1757,210 +1318,124 @@ git commit -m "feat(mcp): add template and grant route aliases"
 - Modify: `frontend/packages/core/src/stores/workspaceSettingsStore.ts`
 - Modify: `frontend/packages/core/__tests__/api/mcp.test.ts`
 
-- [ ] **Step 1: Add API tests**
+- [ ] **Step 1: Replace core type names**
+
+Edit `frontend/packages/core/src/types/mcp.ts`.
+
+Remove `MCPCatalogConnector`, `MCPCatalogListResponse`, `MCPOrgInstallOverrideRequest`,
+and old server override types. Add:
+
+```typescript
+export interface ConnectorTemplate {
+  template_id: string
+  slug: string
+  name: string
+  provider: string
+  description: string
+  server_url: string
+  transport: MCPTransport
+  supported_auth_methods: MCPAuthMethod[]
+  default_credential_policy: MCPCredentialScope
+  static_form_schema: MCPTemplateStaticFormField[] | null
+  status: 'active' | 'deprecated' | 'disabled'
+}
+
+export interface ConnectorInstall {
+  install_id: string
+  template_id: string | null
+  install_scope: 'org' | 'workspace'
+  workspace_id: string | null
+  name: string
+  auth_method: MCPAuthMethod
+  default_credential_policy: MCPCredentialScope
+  auth_status: string
+  discovery_status: string
+  install_state: 'active' | 'uninstalled'
+}
+
+export interface WorkspaceConnectorState {
+  workspace_id: string
+  install_id: string
+  enabled: boolean
+  credential_policy: MCPCredentialScope
+}
+
+export interface EffectiveConnector {
+  template: ConnectorTemplate | null
+  install: ConnectorInstall
+  workspace_state: WorkspaceConnectorState
+  credential_policy: MCPCredentialScope
+  credential_availability: 'available' | 'missing' | 'not_required'
+  credential_source: 'org' | 'workspace' | 'user' | null
+  usable: boolean
+  reason: string
+}
+```
+
+- [ ] **Step 2: Replace API helpers**
+
+Edit `frontend/packages/core/src/api/mcp.ts`.
+
+Add helpers for final paths:
+
+```typescript
+export async function wsListTemplates(client: ApiClient, wsId: string) {
+  const res = await client.get(`/api/v1/ws/${wsId}/mcp/templates`)
+  if (!res.ok) throw await toApiError(res)
+  return (await res.json()) as { items: ConnectorTemplate[] }
+}
+
+export async function wsCreateInstall(client: ApiClient, wsId: string, body: unknown) {
+  const res = await client.post(`/api/v1/ws/${wsId}/mcp/installs`, body)
+  if (!res.ok) throw await toApiError(res)
+  return (await res.json()) as ConnectorInstall
+}
+
+export async function wsPatchInstallState(
+  client: ApiClient,
+  wsId: string,
+  installId: string,
+  body: Partial<WorkspaceConnectorState>,
+) {
+  const res = await client.patch(`/api/v1/ws/${wsId}/mcp/installs/${installId}/state`, body)
+  if (!res.ok) throw await toApiError(res)
+  return (await res.json()) as WorkspaceConnectorState
+}
+
+export async function wsListEffectiveConnectors(client: ApiClient, wsId: string) {
+  const res = await client.get(`/api/v1/ws/${wsId}/mcp/connectors`)
+  if (!res.ok) throw await toApiError(res)
+  return (await res.json()) as { items: EffectiveConnector[] }
+}
+```
+
+Remove helpers whose names include `Catalog` or `Override`.
+
+- [ ] **Step 3: Add API path tests**
 
 Append to `frontend/packages/core/__tests__/api/mcp.test.ts`:
 
 ```typescript
-it('lists effective workspace connectors', async () => {
+it('uses template and install paths for workspace MCP', async () => {
   const { client, fetchMock } = makeClient({
     ok: true,
     json: async () => ({ items: [] }),
   })
 
-  const out = await wsListEffectiveConnectors(client, 'ws-x')
-
-  expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/ws/ws-x/mcp/connectors')
-  expect(out).toEqual({ items: [] })
+  await wsListTemplates(client, 'ws-x')
+  expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/ws/ws-x/mcp/templates')
 })
 
-it('patches effective workspace connector state', async () => {
-  const { client, fetchMock } = makeClient({
-    ok: true,
-    json: async () => ({
-      install: { install_id: 'mcp-1' },
-      workspace_state: { enabled: true, credential_policy: 'user' },
-    }),
-  })
+it('does not use catalog or override paths', async () => {
+  const source = await import('../../src/api/mcp')
+  const exportedNames = Object.keys(source)
 
-  await wsPatchConnectorState(client, 'ws-x', 'mcp-1', {
-    enabled: true,
-    credential_policy: 'user',
-  })
-
-  expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/ws/ws-x/mcp/connectors/mcp-1/state')
-  expect(JSON.parse(fetchMock.mock.calls[0][1]?.body as string)).toEqual({
-    enabled: true,
-    credential_policy: 'user',
-  })
+  expect(exportedNames.some((name) => name.includes('Catalog'))).toBe(false)
+  expect(exportedNames.some((name) => name.includes('Override'))).toBe(false)
 })
 ```
 
-- [ ] **Step 2: Run tests and confirm missing exports**
-
-Run:
-
-```bash
-cd frontend
-pnpm --filter @cubebox/core test -- mcp.test.ts
-```
-
-Expected: FAIL because `wsListEffectiveConnectors` and `wsPatchConnectorState` are
-not exported.
-
-- [ ] **Step 3: Add effective connector types**
-
-Append to `frontend/packages/core/src/types/mcp.ts`:
-
-```typescript
-export type MCPEffectiveReason =
-  | 'usable'
-  | 'template_inactive'
-  | 'install_deleted'
-  | 'workspace_disabled'
-  | 'credential_missing'
-  | 'unsupported_transport'
-
-export type MCPCredentialAvailability = 'available' | 'missing' | 'not_required'
-
-export interface MCPConnectorTemplate {
-  template_id: string | null
-  slug: string | null
-  name: string
-  provider: string | null
-  status: string
-}
-
-export interface MCPConnectorInstall {
-  install_id: string
-  name: string
-  server_url: string
-  transport: MCPTransport
-  auth_method: MCPAuthMethod
-  credential_scope: MCPCredentialScope
-  install_status: 'active' | 'deleted'
-  origin: 'org' | 'workspace'
-  owner_workspace_id: string | null
-  tool_count: number
-}
-
-export interface MCPWorkspaceConnectorState {
-  enabled: boolean
-  credential_policy: MCPCredentialScope | null
-}
-
-export interface MCPEffectiveConnector {
-  template: MCPConnectorTemplate | null
-  install: MCPConnectorInstall
-  workspace_state: MCPWorkspaceConnectorState
-  credential_policy: MCPCredentialScope
-  credential_availability: MCPCredentialAvailability
-  credential_source: 'org' | 'workspace' | 'user' | null
-  credential_shared_by: string | null
-  usable: boolean
-  reason: MCPEffectiveReason
-}
-
-export interface MCPEffectiveConnectorList {
-  items: MCPEffectiveConnector[]
-}
-
-export interface MCPWorkspaceConnectorStatePatch {
-  enabled?: boolean
-  credential_policy?: MCPCredentialScope
-}
-```
-
-- [ ] **Step 4: Add API helpers**
-
-Edit `frontend/packages/core/src/api/mcp.ts`.
-
-Add imports:
-
-```typescript
-  MCPEffectiveConnector,
-  MCPEffectiveConnectorList,
-  MCPWorkspaceConnectorStatePatch,
-```
-
-Add functions:
-
-```typescript
-export async function wsListEffectiveConnectors(
-  client: ApiClient,
-  wsId: string,
-): Promise<MCPEffectiveConnectorList> {
-  const res = await client.get(`/api/v1/ws/${wsId}/mcp/connectors`)
-  if (!res.ok) throw await toApiError(res)
-  return (await res.json()) as MCPEffectiveConnectorList
-}
-
-export async function wsPatchConnectorState(
-  client: ApiClient,
-  wsId: string,
-  installId: string,
-  body: MCPWorkspaceConnectorStatePatch,
-): Promise<MCPEffectiveConnector> {
-  const res = await client.patch(`/api/v1/ws/${wsId}/mcp/connectors/${installId}/state`, body)
-  if (!res.ok) throw await toApiError(res)
-  return (await res.json()) as MCPEffectiveConnector
-}
-```
-
-- [ ] **Step 5: Extend workspace settings types**
-
-Edit `frontend/packages/core/src/types/workspace-settings.ts`.
-
-Change:
-
-```typescript
-export type MCPCredentialMode = 'org' | 'workspace' | 'user'
-```
-
-to:
-
-```typescript
-export type MCPCredentialMode = 'org' | 'workspace' | 'user' | 'none'
-```
-
-Add import:
-
-```typescript
-import type { MCPEffectiveConnector } from './mcp'
-```
-
-Add to `WorkspaceMCP`:
-
-```typescript
-  connectors?: MCPEffectiveConnector[]
-```
-
-- [ ] **Step 6: Route workspace settings store through normalized helpers**
-
-Edit `frontend/packages/core/src/api/workspace-settings.ts`.
-
-Keep existing functions for compatibility, but make `patchWorkspaceMCPCredentialMode`
-call the connector state endpoint when the `ApiClient` has a workspace id in scope:
-
-```typescript
-export async function patchWorkspaceMCPCredentialMode(
-  client: ApiClient,
-  serverId: string,
-  credentialMode: MCPCredentialMode,
-): Promise<{ server_id: string; credential_mode: MCPCredentialMode }> {
-  const res = await client.patch(`/api/v1/mcp/connectors/${serverId}/state`, {
-    credential_policy: credentialMode,
-  })
-  if (!res.ok) throw await toApiError(res)
-  const body = await res.json()
-  return {
-    server_id: body.install.install_id,
-    credential_mode: body.credential_policy,
-  }
-}
-```
-
-- [ ] **Step 7: Run frontend core tests and typecheck**
+- [ ] **Step 4: Run frontend core checks**
 
 Run:
 
@@ -1972,7 +1447,7 @@ pnpm --filter @cubebox/core type-check
 
 Expected: both commands pass.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add frontend/packages/core/src/types/mcp.ts \
@@ -1981,117 +1456,107 @@ git add frontend/packages/core/src/types/mcp.ts \
         frontend/packages/core/src/api/workspace-settings.ts \
         frontend/packages/core/src/stores/workspaceSettingsStore.ts \
         frontend/packages/core/__tests__/api/mcp.test.ts
-git commit -m "feat(mcp): add effective connector types and API client"
+git commit -m "feat(mcp): switch frontend core to four-layer API"
 ```
 
 ---
 
-## Task 8: Workspace UI Uses Four-Layer Semantics
+## Task 8: Frontend UI Terminology And Flows
 
 **Files:**
 
+- Rename: `frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx`
+  to `frontend/packages/web/components/mcp/MCPTemplateInstallPanel.tsx`
 - Modify: `frontend/packages/web/components/workspace-settings/McpPanel.tsx`
-- Modify: `frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx`
+- Modify: `frontend/packages/web/components/mcp/MCPConnectorList.tsx`
+- Modify: `frontend/packages/web/components/mcp/MCPAdminDetailPanel.tsx`
+- Modify: `frontend/packages/web/components/mcp/MCPWorkspacesTab.tsx`
 - Modify: `frontend/packages/web/messages/en.json`
 - Modify: `frontend/packages/web/messages/zh.json`
 - Modify: `frontend/packages/web/__tests__/e2e/mcp/ws-mcp.spec.ts`
+- Modify: `frontend/packages/web/__tests__/e2e/mcp/admin-mcp.spec.ts`
 
-- [ ] **Step 1: Add Playwright assertions for visible semantics**
+- [ ] **Step 1: Rename the install panel file**
 
-Edit `frontend/packages/web/__tests__/e2e/mcp/ws-mcp.spec.ts`.
+Run:
 
-Add a test that navigates to workspace settings and asserts these user-facing strings:
+```bash
+git mv frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx \
+       frontend/packages/web/components/mcp/MCPTemplateInstallPanel.tsx
+```
+
+Update imports that referenced `MCPCatalogInstallPanel`.
+
+- [ ] **Step 2: Replace UI copy**
+
+Use these final product labels:
+
+```text
+Connector templates
+Connector installs
+Workspace state
+Credential policy
+Org grant
+Workspace grant
+My grant
+Connect
+Disconnect
+Uninstall
+Needs your credential
+Ready
+```
+
+Remove visible UI copy containing `Catalog`, `Override`, `catalog`, or `override`.
+
+- [ ] **Step 3: Add message keys**
+
+Add to `frontend/packages/web/messages/en.json` under `mcp`:
+
+```json
+"templates": "Connector templates",
+"installs": "Connector installs",
+"workspaceState": "Workspace state",
+"credentialPolicy": "Credential policy",
+"orgGrant": "Org grant",
+"workspaceGrant": "Workspace grant",
+"myGrant": "My grant",
+"needsCredential": "Needs your credential",
+"ready": "Ready"
+```
+
+Add to `frontend/packages/web/messages/zh.json` under `mcp`:
+
+```json
+"templates": "连接器模板",
+"installs": "连接器安装",
+"workspaceState": "工作区状态",
+"credentialPolicy": "凭证策略",
+"orgGrant": "组织授权",
+"workspaceGrant": "工作区授权",
+"myGrant": "我的授权",
+"needsCredential": "需要你的凭证",
+"ready": "可用"
+```
+
+- [ ] **Step 4: Add E2E copy assertions**
+
+Append to `frontend/packages/web/__tests__/e2e/mcp/ws-mcp.spec.ts`:
 
 ```typescript
 await expect(page.getByText('Connector templates')).toBeVisible()
-await expect(page.getByText('Installed in this workspace')).toBeVisible()
-await expect(page.getByText('Needs your credential')).toBeVisible()
+await expect(page.getByText('Workspace state')).toBeVisible()
+await expect(page.getByText('Credential policy')).toBeVisible()
+await expect(page.getByText('Override')).toHaveCount(0)
+await expect(page.getByText('Catalog')).toHaveCount(0)
 ```
 
-For Chinese locale coverage, add the same assertion pattern using:
+Append to `frontend/packages/web/__tests__/e2e/mcp/admin-mcp.spec.ts`:
 
 ```typescript
-await expect(page.getByText('连接器模板')).toBeVisible()
-await expect(page.getByText('已安装到此工作区')).toBeVisible()
-await expect(page.getByText('需要你的凭证')).toBeVisible()
-```
-
-- [ ] **Step 2: Update workspace panel terminology**
-
-Edit `frontend/packages/web/components/workspace-settings/McpPanel.tsx`.
-
-Use these display labels:
-
-```typescript
-const reasonLabel: Record<string, string> = {
-  usable: t('state.usable'),
-  template_inactive: t('state.templateInactive'),
-  install_deleted: t('state.installDeleted'),
-  workspace_disabled: t('state.workspaceDisabled'),
-  credential_missing: t('state.credentialMissing'),
-  unsupported_transport: t('state.unsupportedTransport'),
-}
-```
-
-Use "Enable for workspace" for workspace state, "Credential policy" for mode,
-and "Disconnect" for deleting a user grant. Do not display the word "override".
-
-- [ ] **Step 3: Present catalog as templates**
-
-Edit `frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx`.
-
-Change the heading and empty state keys to:
-
-```typescript
-const title = t('templates.title')
-const empty = t('templates.empty')
-```
-
-Ensure actions still call the existing install helpers. The endpoint alias will be used by
-core API after compatibility is verified.
-
-- [ ] **Step 4: Add message keys**
-
-Add under `mcp.wsPanel` in `frontend/packages/web/messages/en.json`:
-
-```json
-"templates": {
-  "title": "Connector templates",
-  "empty": "No connector templates match this filter."
-},
-"installedWorkspace": "Installed in this workspace",
-"credentialPolicy": "Credential policy",
-"enableWorkspace": "Enable for workspace",
-"disconnect": "Disconnect",
-"state": {
-  "usable": "Ready",
-  "templateInactive": "Template unavailable",
-  "installDeleted": "Install removed",
-  "workspaceDisabled": "Disabled in this workspace",
-  "credentialMissing": "Needs your credential",
-  "unsupportedTransport": "Unsupported transport"
-}
-```
-
-Add under `mcp.wsPanel` in `frontend/packages/web/messages/zh.json`:
-
-```json
-"templates": {
-  "title": "连接器模板",
-  "empty": "没有匹配的连接器模板。"
-},
-"installedWorkspace": "已安装到此工作区",
-"credentialPolicy": "凭证策略",
-"enableWorkspace": "为工作区启用",
-"disconnect": "断开连接",
-"state": {
-  "usable": "可用",
-  "templateInactive": "模板不可用",
-  "installDeleted": "安装已移除",
-  "workspaceDisabled": "此工作区已停用",
-  "credentialMissing": "需要你的凭证",
-  "unsupportedTransport": "不支持的传输方式"
-}
+await expect(page.getByText('Connector installs')).toBeVisible()
+await expect(page.getByText('Org grant')).toBeVisible()
+await expect(page.getByText('Override')).toHaveCount(0)
+await expect(page.getByText('Catalog')).toHaveCount(0)
 ```
 
 - [ ] **Step 5: Run frontend checks**
@@ -2101,149 +1566,46 @@ Run:
 ```bash
 cd frontend
 pnpm --filter @cubebox/web type-check
-pnpm --filter @cubebox/web test:e2e -- mcp/ws-mcp.spec.ts
+pnpm --filter @cubebox/web test:e2e -- mcp/ws-mcp.spec.ts mcp/admin-mcp.spec.ts
 ```
 
-Expected: typecheck passes and the MCP workspace spec passes.
+Expected: typecheck passes and both MCP E2E specs pass.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 git add frontend/packages/web/components/workspace-settings/McpPanel.tsx \
-        frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx \
-        frontend/packages/web/messages/en.json \
-        frontend/packages/web/messages/zh.json \
-        frontend/packages/web/__tests__/e2e/mcp/ws-mcp.spec.ts
-git commit -m "feat(mcp): clarify workspace connector management UI"
-```
-
----
-
-## Task 9: Admin UI and Compatibility Cleanup
-
-**Files:**
-
-- Modify: `frontend/packages/web/app/admin/mcp/page.tsx`
-- Modify: `frontend/packages/web/components/mcp/MCPConnectorList.tsx`
-- Modify: `frontend/packages/web/components/mcp/MCPWorkspacesTab.tsx`
-- Modify: `frontend/packages/web/components/mcp/MCPCredentialPanel.tsx`
-- Modify: `frontend/packages/web/messages/en.json`
-- Modify: `frontend/packages/web/messages/zh.json`
-- Modify: `frontend/packages/web/__tests__/e2e/mcp/admin-mcp.spec.ts`
-- Modify: `backend/tests/e2e/test_mcp_auto_enroll.py`
-
-- [ ] **Step 1: Add admin E2E assertions for install vs workspace state**
-
-Edit `frontend/packages/web/__tests__/e2e/mcp/admin-mcp.spec.ts`.
-
-Add assertions for these visible labels:
-
-```typescript
-await expect(page.getByText('Connector installs')).toBeVisible()
-await expect(page.getByText('Workspace state')).toBeVisible()
-await expect(page.getByText('Org grant')).toBeVisible()
-```
-
-- [ ] **Step 2: Update admin labels**
-
-In the admin MCP page and components, replace visible "Catalog" labels with
-"Templates" and "Override" labels with "Workspace state".
-
-Use this map for admin badges:
-
-```typescript
-const scopeLabel: Record<string, string> = {
-  org: t('scope.orgInstall'),
-  workspace: t('scope.workspaceInstall'),
-  user: t('scope.userGrant'),
-  none: t('scope.noGrantRequired'),
-}
-```
-
-- [ ] **Step 3: Keep old endpoint names inside API helpers only**
-
-Do not rename functions that still target old backend URLs in UI components. Keep old
-endpoint terminology in `frontend/packages/core/src/api/mcp.ts` until backend compatibility
-metrics show no remaining callers.
-
-- [ ] **Step 4: Verify delete vs disconnect semantics**
-
-Extend `backend/tests/e2e/test_mcp_auto_enroll.py` with:
-
-```python
-async def test_admin_delete_install_removes_workspace_state_not_user_grants(
-    admin_client: tuple[httpx.AsyncClient, str],
-    github_catalog_id: str,
-) -> None:
-    client, workspace_id = admin_client
-    install = await client.post(
-        f"/api/v1/admin/mcp/catalog/{github_catalog_id}/install",
-        json={"auth_method": "static", "credential_plaintext": "ghp_test"},
-    )
-    assert install.status_code == 201, install.text
-    install_id = install.json()["install_id"]
-
-    delete_resp = await client.delete(f"/api/v1/admin/mcp/installs/{install_id}")
-    assert delete_resp.status_code == 204, delete_resp.text
-
-    rows = await client.get(f"/api/v1/ws/{workspace_id}/mcp/connectors")
-    assert rows.status_code == 200, rows.text
-    assert all(item["install"]["install_id"] != install_id for item in rows.json()["items"])
-```
-
-- [ ] **Step 5: Run admin checks**
-
-Run:
-
-```bash
-cd backend
-uv run pytest -q tests/e2e/test_mcp_auto_enroll.py
-cd ../frontend
-pnpm --filter @cubebox/web type-check
-pnpm --filter @cubebox/web test:e2e -- mcp/admin-mcp.spec.ts
-```
-
-Expected: all commands pass.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add frontend/packages/web/app/admin/mcp/page.tsx \
+        frontend/packages/web/components/mcp/MCPTemplateInstallPanel.tsx \
         frontend/packages/web/components/mcp/MCPConnectorList.tsx \
+        frontend/packages/web/components/mcp/MCPAdminDetailPanel.tsx \
         frontend/packages/web/components/mcp/MCPWorkspacesTab.tsx \
-        frontend/packages/web/components/mcp/MCPCredentialPanel.tsx \
         frontend/packages/web/messages/en.json \
         frontend/packages/web/messages/zh.json \
-        frontend/packages/web/__tests__/e2e/mcp/admin-mcp.spec.ts \
-        backend/tests/e2e/test_mcp_auto_enroll.py
-git commit -m "feat(mcp): align admin terminology with connector model"
+        frontend/packages/web/__tests__/e2e/mcp/ws-mcp.spec.ts \
+        frontend/packages/web/__tests__/e2e/mcp/admin-mcp.spec.ts
+git commit -m "feat(mcp): update UI to connector template model"
 ```
 
 ---
 
-## Task 10: Final Verification and Risk Review
+## Task 9: Final Cleanup And Verification
 
 **Files:**
 
-- Modify: this plan only if verification finds command or path drift.
+- Modify files found by the search commands in this task.
 
-- [ ] **Step 1: Run backend MCP slices**
+- [ ] **Step 1: Search for removed public concepts**
 
 Run:
 
 ```bash
-cd backend
-uv run pytest -q tests/unit/mcp tests/unit/test_mcp_*.py
-uv run pytest -q tests/e2e/test_mcp_catalog_routes.py \
-                 tests/e2e/test_mcp_effective_connectors.py \
-                 tests/e2e/test_mcp_catalog_runtime.py \
-                 tests/e2e/test_mcp_auto_enroll.py \
-                 tests/e2e/test_mcp_user_credentials.py \
-                 tests/e2e/test_mcp_bindings.py \
-                 tests/e2e/test_ws_settings.py
+rg -n "Catalog|catalog|Override|override|mcp_catalog|workspace_mcp_overrides" \
+  backend/cubebox frontend/packages/core frontend/packages/web \
+  -g '!**/.venv/**' -g '!**/node_modules/**'
 ```
 
-Expected: all selected backend tests pass.
+Expected remaining matches are limited to migration filenames, migration comments, or tests
+that assert old routes are absent.
 
 - [ ] **Step 2: Run backend quality gate**
 
@@ -2269,7 +1631,7 @@ pnpm --filter @cubebox/web test:e2e -- mcp/ws-mcp.spec.ts mcp/admin-mcp.spec.ts
 
 Expected: all commands pass.
 
-- [ ] **Step 4: Manual runtime smoke check**
+- [ ] **Step 4: Manual smoke test**
 
 Run:
 
@@ -2286,28 +1648,20 @@ cd frontend
 pnpm dev
 ```
 
-Open the `BASE_URL` printed by `.worktree.env`, install a no-auth MCP template in one
-workspace, and confirm it appears as ready in workspace settings without creating a
-credential grant.
+Open the worktree `BASE_URL`, install a no-auth connector template into a workspace,
+and confirm the connector appears as `Ready` without creating any credential grant.
 
-- [ ] **Step 5: Review known design risks**
+- [ ] **Step 5: Commit verification cleanup**
 
-Confirm these are true before merging:
-
-- `catalog` remains only as a compatibility name for old URLs and DB tables.
-- Product copy uses template, install, workspace state, and grant.
-- Runtime reads one effective-state path.
-- `auth_method="none"` never creates a user credential requirement.
-- `install_status` separates deletion from credential readiness.
-- Workspace-local installs are workspace-scoped, not creator-private.
-- Disconnecting a user grant does not uninstall the connector.
-
-- [ ] **Step 6: Final commit if verification changed files**
+Run:
 
 ```bash
 git status --short
-git add <changed-files>
-git commit -m "test(mcp): verify four-layer connector management"
 ```
 
-If `git status --short` is empty, no commit is needed.
+If files changed during cleanup:
+
+```bash
+git add backend/cubebox frontend/packages
+git commit -m "chore(mcp): remove old catalog and override surfaces"
+```

--- a/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
+++ b/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
@@ -787,6 +787,15 @@ model per item; subagent decides field order, base class, etc.):
   (`available` | `missing` | `not_required`), `credential_source` (`org` | `workspace` |
   `user` | `null`), `usable`, `reason`.
 
+Cross-field validation that must live in the request schemas (the install/state
+endpoints can otherwise accept impossible combinations):
+
+- `credential_policy="none"` is allowed **only** when `auth_method="none"`. The
+  API rejects `credential_policy="none"` for OAuth or static installs with a
+  422 pointing at `credential_policy`. The DB layer is also defended by the
+  effective-state decision order (rule 5 keys on `auth_method`, not policy),
+  but request-side validation is the user-facing gate.
+
 Request schemas should also exist for:
 
 - `AdminCreateInstallIn`: `template_id?`, `install_scope` (`org`),
@@ -831,11 +840,17 @@ Rewrite `backend/cubebox/api/routes/v1/ws_mcp.py` to expose the workspace contra
 from Step 1. Authorization rules from spec §User Roles And Permissions:
 
 - All routes require workspace membership (`require_member`).
-- `POST /installs`, `DELETE /installs/{id}`, `PATCH /installs/{id}/state`, and
-  the workspace-scope grant routes require `role=admin` on the workspace.
+- `POST /installs`, `DELETE /installs/{id}`, `PATCH /connectors/{id}/state`,
+  and the workspace-scope grant routes (`POST`/`DELETE`/`oauth/start` under
+  `/installs/{id}/grants/workspace`) require `role=admin` on the workspace.
 - `*/grants/me*` routes are open to any member.
 - A workspace member cannot delete a workspace-local install they did not create
   unless they are workspace admin.
+
+Pay attention to the route prefixes when wiring the admin guard: the state edit
+lives under `/connectors`, not `/installs`. A handler registered without the
+workspace-admin dependency would let ordinary members enable/disable connectors
+or change credential policy.
 
 Remove old server/catalog/org-install override handlers from this module.
 
@@ -950,9 +965,15 @@ Decision order in `compute_effective_state` (first match wins):
 3. `template_status` is set and not `active` → `template_deprecated`.
 4. `workspace_state_present=False` or `workspace_enabled=False` →
    `not_enabled_in_workspace`.
-5. `auth_method == "none"` OR `credential_policy == "none"` → `usable`,
-   `credential_availability="not_required"`.
-6. `auth_status == "pending"` AND grant absent → `pending_oauth`.
+5. `auth_method == "none"` → `usable`, `credential_availability="not_required"`.
+   Do **not** key this branch on `credential_policy == "none"` alone — an OAuth
+   or static install with `credential_policy="none"` is a configuration bug
+   (a credentialed connector cannot run without a credential), and the API
+   layer must reject `credential_policy="none"` whenever `auth_method != "none"`
+   so it can never reach this branch.
+6. `auth_method == "oauth"` AND `auth_status == "pending"` AND grant absent →
+   `pending_oauth`. Static installs are not "pending OAuth"; their missing
+   grant must be reported by rule 7 instead.
 7. Grant absent → scope-specific missing reason
    (`missing_org_grant` / `missing_workspace_grant` / `user_needs_connection`
    based on `credential_policy`).

--- a/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
+++ b/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
@@ -1,0 +1,2313 @@
+# MCP Management Four-Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the four-layer MCP management model so templates, installs, workspace state, and credential grants have separate product and runtime semantics.
+
+**Architecture:** Add a backend effective-state service over the current tables first, then move runtime, APIs, and UI to consume that service. Keep legacy `catalog`/`override` URLs as compatibility wrappers while the product language changes to connector templates, installs, workspace state, and grants.
+
+**Tech Stack:** FastAPI, SQLModel, Alembic, PostgreSQL, Redis, OAuthTokenManager, Next.js, Zustand, TypeScript, pytest, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-05-15-mcp-management-four-layer-design.md`
+
+**Conventions:**
+
+- Run backend commands from `backend/`.
+- Run frontend commands from `frontend/`.
+- In this worktree, read `.worktree.env` before manual server checks.
+- Keep one logical commit per task unless a task only updates this plan.
+- Do not physically rename existing DB tables in this implementation pass.
+- Preserve old endpoints until frontend and runtime have migrated.
+
+---
+
+## File Structure
+
+**Backend — new files:**
+
+- `backend/cubebox/mcp/effective.py` — four-layer domain types, pure state computation,
+  DB-backed effective connector service, and runtime spec conversion.
+- `backend/tests/unit/mcp/test_effective_state.py` — pure decision-table tests.
+- `backend/tests/unit/mcp/test_effective_service.py` — service tests using fake rows/repos.
+- `backend/tests/e2e/test_mcp_effective_connectors.py` — route and runtime-level coverage.
+
+**Backend — modified files:**
+
+- `backend/cubebox/models/mcp.py` — add `install_status` to separate install lifecycle
+  from credential readiness.
+- `backend/cubebox/repositories/mcp.py` — filter active installs and add active-list helpers.
+- `backend/cubebox/services/mcp_catalog.py` — no-auth workspace install fix,
+  `install_status` transitions, and reactivation behavior.
+- `backend/cubebox/mcp/dependencies.py` — add `get_effective_connector_service`.
+- `backend/cubebox/api/schemas/mcp.py` — effective connector response and patch schemas.
+- `backend/cubebox/api/schemas/ws_settings.py` — tighten MCP credential mode literals.
+- `backend/cubebox/api/routes/v1/ws_mcp.py` — add normalized workspace connector routes.
+- `backend/cubebox/api/routes/v1/mcp_catalog.py` — expose template aliases while keeping
+  catalog routes.
+- `backend/cubebox/api/routes/v1/ws_settings.py` — delegate MCP settings to the
+  effective service.
+- `backend/cubebox/mcp/cubepi_discovery.py` — stop duplicating effective-state logic.
+- `backend/cubebox/mcp/cubepi_runtime.py` — load runtime specs from the effective service.
+- `backend/cubebox/streams/run_manager.py` — pass OAuth token manager into MCP runtime load.
+
+**Frontend — modified files:**
+
+- `frontend/packages/core/src/types/mcp.ts` — add template, install, state, grant,
+  and effective connector types.
+- `frontend/packages/core/src/api/mcp.ts` — add effective connector API helpers.
+- `frontend/packages/core/src/api/workspace-settings.ts` — route MCP settings through
+  the normalized connector endpoints.
+- `frontend/packages/core/src/stores/workspaceSettingsStore.ts` — store effective connector
+  state and update it after workspace-state patches.
+- `frontend/packages/core/__tests__/api/mcp.test.ts` — API path and payload coverage.
+- `frontend/packages/web/components/workspace-settings/McpPanel.tsx` — show four-layer
+  semantics without exposing `override` as product language.
+- `frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx` — present catalog as
+  connector templates.
+- `frontend/packages/web/messages/en.json` and
+  `frontend/packages/web/messages/zh.json` — terminology updates.
+
+---
+
+## Task 1: Effective State Domain Model
+
+**Files:**
+
+- Create: `backend/cubebox/mcp/effective.py`
+- Create: `backend/tests/unit/mcp/test_effective_state.py`
+
+- [ ] **Step 1: Write the pure state tests**
+
+Create `backend/tests/unit/mcp/test_effective_state.py`:
+
+```python
+from cubebox.mcp.effective import (
+    ConnectorInstallView,
+    ConnectorTemplateView,
+    CredentialGrantView,
+    WorkspaceConnectorStateView,
+    compute_effective_state,
+)
+
+
+def _install(
+    *,
+    auth_method: str = "static",
+    credential_scope: str = "org",
+    install_status: str = "active",
+    origin: str = "org",
+) -> ConnectorInstallView:
+    return ConnectorInstallView(
+        install_id="mcp-1",
+        name="GitHub",
+        server_url="https://github.example.com/mcp",
+        transport="streamable_http",
+        auth_method=auth_method,
+        credential_scope=credential_scope,
+        install_status=install_status,
+        origin=origin,
+        owner_workspace_id=None if origin == "org" else "ws-1",
+        credential_id="cred-1" if credential_scope == "org" else None,
+        headers={},
+        tools_cache=[],
+        tool_citations={},
+    )
+
+
+def _template(status: str = "active") -> ConnectorTemplateView:
+    return ConnectorTemplateView(
+        template_id="mctlg-1",
+        slug="github",
+        name="GitHub",
+        provider="GitHub",
+        status=status,
+    )
+
+
+def test_no_auth_connector_is_usable_without_grant() -> None:
+    state = compute_effective_state(
+        template=_template(),
+        install=_install(auth_method="none", credential_scope="none"),
+        workspace_state=WorkspaceConnectorStateView(enabled=True, credential_policy=None),
+        grant=None,
+    )
+
+    assert state.usable is True
+    assert state.reason == "usable"
+    assert state.credential_policy == "none"
+    assert state.credential_availability == "not_required"
+
+
+def test_user_policy_requires_current_user_grant() -> None:
+    state = compute_effective_state(
+        template=_template(),
+        install=_install(credential_scope="org"),
+        workspace_state=WorkspaceConnectorStateView(enabled=True, credential_policy="user"),
+        grant=None,
+    )
+
+    assert state.usable is False
+    assert state.reason == "credential_missing"
+    assert state.credential_policy == "user"
+    assert state.credential_availability == "missing"
+
+
+def test_available_user_grant_makes_user_policy_usable() -> None:
+    state = compute_effective_state(
+        template=_template(),
+        install=_install(credential_scope="org"),
+        workspace_state=WorkspaceConnectorStateView(enabled=True, credential_policy="user"),
+        grant=CredentialGrantView(policy="user", available=True, source="user"),
+    )
+
+    assert state.usable is True
+    assert state.reason == "usable"
+    assert state.credential_source == "user"
+
+
+def test_disabled_workspace_state_blocks_runtime() -> None:
+    state = compute_effective_state(
+        template=_template(),
+        install=_install(credential_scope="org"),
+        workspace_state=WorkspaceConnectorStateView(enabled=False, credential_policy=None),
+        grant=CredentialGrantView(policy="org", available=True, source="org"),
+    )
+
+    assert state.usable is False
+    assert state.reason == "workspace_disabled"
+
+
+def test_inactive_template_blocks_catalog_backed_install() -> None:
+    state = compute_effective_state(
+        template=_template(status="disabled"),
+        install=_install(credential_scope="org"),
+        workspace_state=WorkspaceConnectorStateView(enabled=True, credential_policy=None),
+        grant=CredentialGrantView(policy="org", available=True, source="org"),
+    )
+
+    assert state.usable is False
+    assert state.reason == "template_inactive"
+
+
+def test_deleted_install_blocks_runtime_before_credentials() -> None:
+    state = compute_effective_state(
+        template=_template(),
+        install=_install(credential_scope="org", install_status="deleted"),
+        workspace_state=WorkspaceConnectorStateView(enabled=True, credential_policy=None),
+        grant=CredentialGrantView(policy="org", available=True, source="org"),
+    )
+
+    assert state.usable is False
+    assert state.reason == "install_deleted"
+```
+
+- [ ] **Step 2: Run tests and confirm the missing module failure**
+
+Run: `cd backend && uv run pytest -q tests/unit/mcp/test_effective_state.py`
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'cubebox.mcp.effective'`.
+
+- [ ] **Step 3: Add the domain model and pure computation**
+
+Create `backend/cubebox/mcp/effective.py`:
+
+```python
+"""Effective MCP connector state.
+
+This module is the semantic boundary for the four-layer MCP model:
+template, install, workspace state, and credential grant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast
+
+AuthMethod = Literal["static", "oauth", "none"]
+ConnectorOrigin = Literal["org", "workspace"]
+CredentialPolicy = Literal["org", "workspace", "user", "none"]
+CredentialAvailability = Literal["available", "missing", "not_required"]
+CredentialSource = Literal["org", "workspace", "user"]
+EffectiveReason = Literal[
+    "usable",
+    "template_inactive",
+    "install_deleted",
+    "workspace_disabled",
+    "credential_missing",
+    "unsupported_transport",
+]
+
+_VALID_CREDENTIAL_POLICIES: frozenset[str] = frozenset({"org", "workspace", "user", "none"})
+_VALID_TRANSPORTS: frozenset[str] = frozenset({"sse", "streamable_http"})
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorTemplateView:
+    template_id: str | None
+    slug: str | None
+    name: str
+    provider: str | None
+    status: str
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorInstallView:
+    install_id: str
+    name: str
+    server_url: str
+    transport: str
+    auth_method: str
+    credential_scope: str
+    install_status: str
+    origin: str
+    owner_workspace_id: str | None
+    credential_id: str | None
+    headers: dict[str, str] = field(default_factory=dict)
+    tools_cache: list[dict[str, Any]] = field(default_factory=list)
+    tool_citations: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceConnectorStateView:
+    enabled: bool
+    credential_policy: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class CredentialGrantView:
+    policy: str
+    available: bool
+    source: str | None = None
+    shared_by: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EffectiveConnectorState:
+    template: ConnectorTemplateView | None
+    install: ConnectorInstallView
+    workspace_state: WorkspaceConnectorStateView
+    credential_policy: CredentialPolicy
+    credential_availability: CredentialAvailability
+    credential_source: str | None
+    credential_shared_by: str | None
+    usable: bool
+    reason: EffectiveReason
+
+
+def normalize_credential_policy(
+    *,
+    auth_method: str,
+    install_scope: str,
+    workspace_policy: str | None,
+) -> CredentialPolicy:
+    if auth_method == "none":
+        return "none"
+    raw = workspace_policy or install_scope
+    if raw not in _VALID_CREDENTIAL_POLICIES or raw == "none":
+        return "user"
+    return cast(CredentialPolicy, raw)
+
+
+def compute_effective_state(
+    *,
+    template: ConnectorTemplateView | None,
+    install: ConnectorInstallView,
+    workspace_state: WorkspaceConnectorStateView,
+    grant: CredentialGrantView | None,
+) -> EffectiveConnectorState:
+    policy = normalize_credential_policy(
+        auth_method=install.auth_method,
+        install_scope=install.credential_scope,
+        workspace_policy=workspace_state.credential_policy,
+    )
+
+    if policy == "none":
+        availability: CredentialAvailability = "not_required"
+        source: str | None = None
+        shared_by: str | None = None
+    elif grant is not None and grant.available and grant.policy == policy:
+        availability = "available"
+        source = grant.source
+        shared_by = grant.shared_by
+    else:
+        availability = "missing"
+        source = None
+        shared_by = None
+
+    reason: EffectiveReason = "usable"
+    usable = True
+    if template is not None and template.status != "active":
+        reason = "template_inactive"
+        usable = False
+    elif install.install_status != "active":
+        reason = "install_deleted"
+        usable = False
+    elif install.transport not in _VALID_TRANSPORTS:
+        reason = "unsupported_transport"
+        usable = False
+    elif not workspace_state.enabled:
+        reason = "workspace_disabled"
+        usable = False
+    elif availability == "missing":
+        reason = "credential_missing"
+        usable = False
+
+    return EffectiveConnectorState(
+        template=template,
+        install=install,
+        workspace_state=workspace_state,
+        credential_policy=policy,
+        credential_availability=availability,
+        credential_source=source,
+        credential_shared_by=shared_by,
+        usable=usable,
+        reason=reason,
+    )
+```
+
+- [ ] **Step 4: Run the pure tests**
+
+Run: `cd backend && uv run pytest -q tests/unit/mcp/test_effective_state.py`
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/mcp/effective.py backend/tests/unit/mcp/test_effective_state.py
+git commit -m "feat(mcp): add effective connector state model"
+```
+
+---
+
+## Task 2: Install Lifecycle and No-Auth Correctness
+
+**Files:**
+
+- Modify: `backend/cubebox/models/mcp.py`
+- Modify: `backend/cubebox/repositories/mcp.py`
+- Modify: `backend/cubebox/services/mcp_catalog.py`
+- Modify: `backend/tests/unit/test_mcp_models.py`
+- Modify: `backend/tests/e2e/test_mcp_catalog_routes.py`
+- Create: `backend/alembic/versions/<ts>_add_mcp_install_status.py`
+
+- [ ] **Step 1: Add model and route tests for `install_status`**
+
+Append to `backend/tests/unit/test_mcp_models.py`:
+
+```python
+def test_mcp_server_install_status_defaults_active() -> None:
+    from cubebox.models import MCPServer
+
+    row = MCPServer(
+        org_id="org-1",
+        name="GitHub",
+        server_url="https://github.example.com/mcp",
+        server_url_hash="hash",
+        transport="streamable_http",
+        auth_method="none",
+        credential_scope="none",
+        created_by_user_id="user-1",
+    )
+
+    assert row.install_status == "active"
+```
+
+Append to `backend/tests/e2e/test_mcp_catalog_routes.py`:
+
+```python
+async def test_workspace_no_auth_catalog_install_uses_none_scope(
+    client: httpx.AsyncClient,
+    workspace_id: str,
+    db_session: AsyncSession,
+) -> None:
+    from cubebox.repositories.mcp_catalog import MCPCatalogConnectorRepository
+
+    row = await MCPCatalogConnectorRepository(db_session).upsert_by_slug(
+        slug="noauth-effective-test",
+        name="NoAuth Effective Test",
+        description="No auth connector.",
+        provider="Cubebox",
+        server_url="https://noauth-effective.example.com/mcp",
+        transport="streamable_http",
+        supported_auth_methods=["none"],
+        default_credential_scope="none",
+    )
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/ws/{workspace_id}/mcp/catalog/{row.id}/install",
+        json={"auth_method": "none"},
+    )
+
+    assert resp.status_code == 201, resp.text
+    install_id = resp.json()["install_id"]
+    detail = await client.get(f"/api/v1/ws/{workspace_id}/mcp/servers/{install_id}")
+    assert detail.status_code == 200, detail.text
+    body = detail.json()
+    assert body["auth_method"] == "none"
+    assert body["credential_scope"] == "none"
+    assert body["authed"] is True
+```
+
+- [ ] **Step 2: Run tests and confirm failures**
+
+Run: `cd backend && uv run pytest -q tests/unit/test_mcp_models.py::test_mcp_server_install_status_defaults_active`
+
+Expected: FAIL with `AttributeError: 'MCPServer' object has no attribute 'install_status'`.
+
+Run: `cd backend && uv run pytest -q tests/e2e/test_mcp_catalog_routes.py::test_workspace_no_auth_catalog_install_uses_none_scope`
+
+Expected: FAIL because workspace catalog install currently forces user scope.
+
+- [ ] **Step 3: Add `install_status` to the model**
+
+Edit `backend/cubebox/models/mcp.py` inside `MCPServer`, after `credential_scope`:
+
+```python
+    install_status: str = Field(
+        default="active",
+        max_length=16,
+        sa_column_kwargs={"server_default": text("'active'")},
+    )
+```
+
+- [ ] **Step 4: Add the Alembic migration**
+
+Run:
+
+```bash
+cd backend
+uv run alembic revision --autogenerate -m "add mcp install status"
+```
+
+Edit the generated migration so `upgrade()` contains:
+
+```python
+op.add_column(
+    "mcp_servers",
+    sa.Column(
+        "install_status",
+        sa.String(length=16),
+        server_default=sa.text("'active'"),
+        nullable=False,
+    ),
+)
+op.create_check_constraint(
+    "ck_mcp_servers_install_status",
+    "mcp_servers",
+    "install_status IN ('active', 'deleted')",
+)
+```
+
+Ensure `downgrade()` contains:
+
+```python
+op.drop_constraint("ck_mcp_servers_install_status", "mcp_servers", type_="check")
+op.drop_column("mcp_servers", "install_status")
+```
+
+- [ ] **Step 5: Filter deleted installs in repository list helpers**
+
+Edit `backend/cubebox/repositories/mcp.py`.
+
+In `list_for_org`, add this filter before returning:
+
+```python
+        stmt = stmt.where(MCPServer.install_status == "active")  # type: ignore[arg-type]
+```
+
+In `list_for_workspace`, replace the `MCPServer.authed` filter with:
+
+```python
+            MCPServer.install_status == "active",  # type: ignore[arg-type]
+```
+
+Keep credential readiness out of this repository method. Effective-state code will decide
+whether an active install is usable for a specific user.
+
+In `list_org_wide_with_workspace_override`, add:
+
+```python
+                MCPServer.install_status == "active",  # type: ignore[arg-type]
+```
+
+- [ ] **Step 6: Set lifecycle state during delete and re-key**
+
+Edit `backend/cubebox/services/mcp_catalog.py`.
+
+In `delete_install`, replace the block that sets `server.authed = False` with:
+
+```python
+        server.install_status = "deleted"
+        server.authed = False
+        server.last_error = None
+        server.tools_cache = []
+        server.last_discovered_at = datetime.now(UTC)
+        await self.server_repo.update(server)
+```
+
+In `switch_auth_method`, immediately after `server.auth_method = new_auth_method`, add:
+
+```python
+        server.install_status = "active"
+```
+
+In `_finalize_install`, add this as the first statement:
+
+```python
+        server.install_status = "active"
+```
+
+- [ ] **Step 7: Fix workspace no-auth catalog install scope**
+
+Edit `_install_workspace_user` in `backend/cubebox/services/mcp_catalog.py`.
+
+Replace the server constructor's hard-coded user scope with:
+
+```python
+            credential_scope="none" if auth_method == "none" else "user",
+```
+
+Keep static and OAuth user installs as user-scope because those grants are owned by the
+installing user.
+
+- [ ] **Step 8: Run migration and tests**
+
+Run:
+
+```bash
+cd backend
+uv run alembic upgrade head
+uv run pytest -q tests/unit/test_mcp_models.py::test_mcp_server_install_status_defaults_active
+uv run pytest -q tests/e2e/test_mcp_catalog_routes.py::test_workspace_no_auth_catalog_install_uses_none_scope
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/cubebox/models/mcp.py \
+        backend/cubebox/repositories/mcp.py \
+        backend/cubebox/services/mcp_catalog.py \
+        backend/alembic/versions/*add_mcp_install_status* \
+        backend/tests/unit/test_mcp_models.py \
+        backend/tests/e2e/test_mcp_catalog_routes.py
+git commit -m "feat(mcp): separate install lifecycle from credential readiness"
+```
+
+---
+
+## Task 3: DB-Backed Effective Connector Service
+
+**Files:**
+
+- Modify: `backend/cubebox/mcp/effective.py`
+- Modify: `backend/cubebox/mcp/dependencies.py`
+- Create: `backend/tests/unit/mcp/test_effective_service.py`
+
+- [ ] **Step 1: Add service tests with fake dependencies**
+
+Create `backend/tests/unit/mcp/test_effective_service.py`:
+
+```python
+from types import SimpleNamespace
+
+import pytest
+
+from cubebox.mcp.effective import EffectiveConnectorService
+
+
+def _server(**overrides: object) -> SimpleNamespace:
+    base = {
+        "id": "mcp-1",
+        "catalog_connector_id": "mctlg-1",
+        "name": "GitHub",
+        "server_url": "https://github.example.com/mcp",
+        "transport": "streamable_http",
+        "auth_method": "static",
+        "credential_scope": "org",
+        "install_status": "active",
+        "owner_workspace_id": None,
+        "credential_id": "cred-1",
+        "headers": {},
+        "tools_cache": [],
+        "tool_citations": {},
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _catalog(**overrides: object) -> SimpleNamespace:
+    base = {
+        "id": "mctlg-1",
+        "slug": "github",
+        "name": "GitHub",
+        "provider": "GitHub",
+        "status": "active",
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class _ServerRepo:
+    def __init__(self, rows: list[SimpleNamespace]) -> None:
+        self.rows = rows
+
+    async def list_for_org(self, *, owner_workspace_id: str | None | object = ...) -> list[object]:
+        if owner_workspace_id is ...:
+            return list(self.rows)
+        return [row for row in self.rows if row.owner_workspace_id == owner_workspace_id]
+
+    async def list_org_wide_with_workspace_override(self, workspace_id: str) -> list[tuple[object, object | None]]:
+        return [(row, SimpleNamespace(enabled=True, credential_mode=None)) for row in self.rows]
+
+
+class _CatalogRepo:
+    async def get_by_id(self, catalog_id: str) -> object:
+        assert catalog_id == "mctlg-1"
+        return _catalog()
+
+
+class _WorkspaceCredRepo:
+    async def get(self, *, workspace_id: str, mcp_server_id: str) -> object | None:
+        return None
+
+
+class _UserCredRepo:
+    async def get(self, *, user_id: str, mcp_server_id: str) -> object | None:
+        return None
+
+
+class _Session:
+    async def get(self, model: object, key: str) -> object | None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_effective_service_lists_active_org_install_with_org_grant() -> None:
+    service = EffectiveConnectorService(
+        session=_Session(),  # type: ignore[arg-type]
+        server_repo=_ServerRepo([_server()]),  # type: ignore[arg-type]
+        catalog_repo=_CatalogRepo(),  # type: ignore[arg-type]
+        ws_cred_repo=_WorkspaceCredRepo(),  # type: ignore[arg-type]
+        user_cred_repo=_UserCredRepo(),  # type: ignore[arg-type]
+    )
+
+    rows = await service.list_for_workspace_user(
+        workspace_id="ws-1",
+        user_id="user-1",
+        include_unusable=True,
+    )
+
+    assert len(rows) == 1
+    assert rows[0].usable is True
+    assert rows[0].credential_policy == "org"
+    assert rows[0].credential_source == "org"
+
+
+@pytest.mark.asyncio
+async def test_effective_service_marks_missing_user_grant_unusable() -> None:
+    service = EffectiveConnectorService(
+        session=_Session(),  # type: ignore[arg-type]
+        server_repo=_ServerRepo([_server(credential_scope="user", credential_id=None)]),  # type: ignore[arg-type]
+        catalog_repo=_CatalogRepo(),  # type: ignore[arg-type]
+        ws_cred_repo=_WorkspaceCredRepo(),  # type: ignore[arg-type]
+        user_cred_repo=_UserCredRepo(),  # type: ignore[arg-type]
+    )
+
+    rows = await service.list_for_workspace_user(
+        workspace_id="ws-1",
+        user_id="user-1",
+        include_unusable=True,
+    )
+
+    assert rows[0].usable is False
+    assert rows[0].reason == "credential_missing"
+```
+
+- [ ] **Step 2: Run tests and confirm service is missing**
+
+Run: `cd backend && uv run pytest -q tests/unit/mcp/test_effective_service.py`
+
+Expected: FAIL with `ImportError` for `EffectiveConnectorService`.
+
+- [ ] **Step 3: Add service construction and row mapping**
+
+Append to `backend/cubebox/mcp/effective.py`:
+
+```python
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.models import User
+from cubebox.repositories.mcp import (
+    MCPServerRepository,
+    UserMCPCredentialRepository,
+    WorkspaceMCPCredentialRepository,
+)
+from cubebox.repositories.mcp_catalog import MCPCatalogConnectorRepository
+
+
+class EffectiveConnectorService:
+    def __init__(
+        self,
+        *,
+        session: AsyncSession,
+        server_repo: MCPServerRepository,
+        catalog_repo: MCPCatalogConnectorRepository,
+        ws_cred_repo: WorkspaceMCPCredentialRepository,
+        user_cred_repo: UserMCPCredentialRepository,
+    ) -> None:
+        self._session = session
+        self._server_repo = server_repo
+        self._catalog_repo = catalog_repo
+        self._ws_cred_repo = ws_cred_repo
+        self._user_cred_repo = user_cred_repo
+
+    async def list_for_workspace_user(
+        self,
+        *,
+        workspace_id: str,
+        user_id: str,
+        include_unusable: bool = True,
+    ) -> list[EffectiveConnectorState]:
+        org_rows = await self._server_repo.list_org_wide_with_workspace_override(workspace_id)
+        workspace_rows = [
+            (row, None)
+            for row in await self._server_repo.list_for_org(owner_workspace_id=workspace_id)
+        ]
+        states: list[EffectiveConnectorState] = []
+
+        for server, override in [*org_rows, *workspace_rows]:
+            enabled = bool(server.owner_workspace_id == workspace_id)
+            credential_policy: str | None = None
+            if server.owner_workspace_id is None:
+                enabled = bool(override is not None and override.enabled)
+                credential_policy = getattr(override, "credential_mode", None)
+
+            template = await self._template_view(server.catalog_connector_id)
+            install = ConnectorInstallView(
+                install_id=server.id,
+                name=server.name,
+                server_url=server.server_url,
+                transport=server.transport,
+                auth_method=server.auth_method,
+                credential_scope=server.credential_scope,
+                install_status=server.install_status,
+                origin="workspace" if server.owner_workspace_id else "org",
+                owner_workspace_id=server.owner_workspace_id,
+                credential_id=server.credential_id,
+                headers=dict(server.headers or {}),
+                tools_cache=list(server.tools_cache or []),
+                tool_citations=dict(server.tool_citations or {}),
+            )
+            workspace_state = WorkspaceConnectorStateView(
+                enabled=enabled,
+                credential_policy=credential_policy,
+            )
+            policy = normalize_credential_policy(
+                auth_method=server.auth_method,
+                install_scope=server.credential_scope,
+                workspace_policy=credential_policy,
+            )
+            grant = await self._grant_view(
+                policy=policy,
+                server_id=server.id,
+                server_credential_id=server.credential_id,
+                workspace_id=workspace_id,
+                user_id=user_id,
+            )
+            state = compute_effective_state(
+                template=template,
+                install=install,
+                workspace_state=workspace_state,
+                grant=grant,
+            )
+            if include_unusable or state.usable:
+                states.append(state)
+
+        return states
+
+    async def _template_view(self, catalog_connector_id: str | None) -> ConnectorTemplateView | None:
+        if catalog_connector_id is None:
+            return None
+        row = await self._catalog_repo.get_by_id(catalog_connector_id)
+        if row is None:
+            return None
+        return ConnectorTemplateView(
+            template_id=row.id,
+            slug=row.slug,
+            name=row.name,
+            provider=row.provider,
+            status=row.status,
+        )
+
+    async def _grant_view(
+        self,
+        *,
+        policy: CredentialPolicy,
+        server_id: str,
+        server_credential_id: str | None,
+        workspace_id: str,
+        user_id: str,
+    ) -> CredentialGrantView | None:
+        if policy == "none":
+            return None
+        if policy == "org":
+            return CredentialGrantView(
+                policy="org",
+                available=server_credential_id is not None,
+                source="org" if server_credential_id is not None else None,
+            )
+        if policy == "workspace":
+            row = await self._ws_cred_repo.get(
+                workspace_id=workspace_id,
+                mcp_server_id=server_id,
+            )
+            shared_by = None
+            if row is not None:
+                user = await self._session.get(User, row.created_by_user_id)
+                shared_by = user.email if user is not None else None
+            return CredentialGrantView(
+                policy="workspace",
+                available=row is not None,
+                source="workspace" if row is not None else None,
+                shared_by=shared_by,
+            )
+        row = await self._user_cred_repo.get(user_id=user_id, mcp_server_id=server_id)
+        return CredentialGrantView(
+            policy="user",
+            available=row is not None,
+            source="user" if row is not None else None,
+        )
+```
+
+- [ ] **Step 4: Add the FastAPI dependency**
+
+Edit `backend/cubebox/mcp/dependencies.py`.
+
+Add the import:
+
+```python
+from cubebox.mcp.effective import EffectiveConnectorService
+```
+
+Add this provider after `get_member_catalog_service`:
+
+```python
+async def get_effective_connector_service(
+    session: AsyncSession = Depends(get_session),
+    ctx: RequestContext = Depends(require_member),
+) -> EffectiveConnectorService:
+    return EffectiveConnectorService(
+        session=session,
+        server_repo=MCPServerRepository(session, org_id=ctx.org_id),
+        catalog_repo=MCPCatalogConnectorRepository(session),
+        ws_cred_repo=WorkspaceMCPCredentialRepository(session, org_id=ctx.org_id),
+        user_cred_repo=UserMCPCredentialRepository(session, org_id=ctx.org_id),
+    )
+```
+
+- [ ] **Step 5: Run service tests**
+
+Run: `cd backend && uv run pytest -q tests/unit/mcp/test_effective_state.py tests/unit/mcp/test_effective_service.py`
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/mcp/effective.py \
+        backend/cubebox/mcp/dependencies.py \
+        backend/tests/unit/mcp/test_effective_service.py
+git commit -m "feat(mcp): add effective connector service"
+```
+
+---
+
+## Task 4: Normalized Workspace Connector API
+
+**Files:**
+
+- Modify: `backend/cubebox/api/schemas/mcp.py`
+- Modify: `backend/cubebox/api/routes/v1/ws_mcp.py`
+- Modify: `backend/cubebox/api/schemas/ws_settings.py`
+- Modify: `backend/cubebox/api/routes/v1/ws_settings.py`
+- Modify: `backend/tests/e2e/conftest.py`
+- Create: `backend/tests/e2e/test_mcp_effective_connectors.py`
+
+- [ ] **Step 1: Add the no-auth catalog fixture**
+
+Append to `backend/tests/e2e/conftest.py`:
+
+```python
+@pytest_asyncio.fixture
+async def noauth_catalog_id(db_session: AsyncSession) -> AsyncIterator[str]:
+    from cubebox.repositories.mcp_catalog import MCPCatalogConnectorRepository
+
+    row = await MCPCatalogConnectorRepository(db_session).upsert_by_slug(
+        slug="noauth-effective",
+        name="NoAuth Effective",
+        description="No auth connector for effective-state tests.",
+        provider="Cubebox",
+        server_url="https://noauth-effective.example.com/mcp",
+        transport="streamable_http",
+        supported_auth_methods=["none"],
+        default_credential_scope="none",
+    )
+    await db_session.commit()
+    yield row.id
+```
+
+- [ ] **Step 2: Add API tests for effective connector listing and state patching**
+
+Create `backend/tests/e2e/test_mcp_effective_connectors.py`:
+
+```python
+import httpx
+import pytest
+
+
+@pytest.mark.usefixtures("stub_discover_tools")
+async def test_effective_connectors_report_missing_user_grant(
+    admin_client: tuple[httpx.AsyncClient, str],
+    github_catalog_id: str,
+) -> None:
+    client, workspace_id = admin_client
+
+    install = await client.post(
+        f"/api/v1/admin/mcp/catalog/{github_catalog_id}/install",
+        json={"auth_method": "static", "credential_plaintext": "ghp_test"},
+    )
+    assert install.status_code == 201, install.text
+    install_id = install.json()["install_id"]
+
+    patch = await client.patch(
+        f"/api/v1/ws/{workspace_id}/mcp/connectors/{install_id}/state",
+        json={"enabled": True, "credential_policy": "user"},
+    )
+    assert patch.status_code == 200, patch.text
+
+    resp = await client.get(f"/api/v1/ws/{workspace_id}/mcp/connectors")
+    assert resp.status_code == 200, resp.text
+    rows = resp.json()["items"]
+    row = next(item for item in rows if item["install"]["install_id"] == install_id)
+    assert row["workspace_state"]["enabled"] is True
+    assert row["credential_policy"] == "user"
+    assert row["credential_availability"] == "missing"
+    assert row["usable"] is False
+    assert row["reason"] == "credential_missing"
+
+
+@pytest.mark.usefixtures("stub_discover_tools")
+async def test_effective_connectors_report_no_auth_as_usable(
+    client: httpx.AsyncClient,
+    workspace_id: str,
+    noauth_catalog_id: str,
+) -> None:
+    install = await client.post(
+        f"/api/v1/ws/{workspace_id}/mcp/catalog/{noauth_catalog_id}/install",
+        json={"auth_method": "none"},
+    )
+    assert install.status_code == 201, install.text
+
+    resp = await client.get(f"/api/v1/ws/{workspace_id}/mcp/connectors")
+    assert resp.status_code == 200, resp.text
+    row = next(
+        item
+        for item in resp.json()["items"]
+        if item["install"]["install_id"] == install.json()["install_id"]
+    )
+    assert row["credential_policy"] == "none"
+    assert row["credential_availability"] == "not_required"
+    assert row["usable"] is True
+```
+
+- [ ] **Step 3: Run route tests and confirm missing route failure**
+
+Run: `cd backend && uv run pytest -q tests/e2e/test_mcp_effective_connectors.py`
+
+Expected: FAIL with 404 for `/api/v1/ws/{workspace_id}/mcp/connectors`.
+
+- [ ] **Step 4: Add response and patch schemas**
+
+Append to `backend/cubebox/api/schemas/mcp.py`:
+
+```python
+class MCPConnectorTemplateOut(BaseModel):
+    template_id: str | None
+    slug: str | None
+    name: str
+    provider: str | None
+    status: str
+
+
+class MCPConnectorInstallOut(BaseModel):
+    install_id: str
+    name: str
+    server_url: str
+    transport: str
+    auth_method: str
+    credential_scope: str
+    install_status: str
+    origin: str
+    owner_workspace_id: str | None
+    tool_count: int
+
+
+class MCPWorkspaceConnectorStateOut(BaseModel):
+    enabled: bool
+    credential_policy: str | None
+
+
+class MCPEffectiveConnectorOut(BaseModel):
+    template: MCPConnectorTemplateOut | None
+    install: MCPConnectorInstallOut
+    workspace_state: MCPWorkspaceConnectorStateOut
+    credential_policy: str
+    credential_availability: str
+    credential_source: str | None
+    credential_shared_by: str | None
+    usable: bool
+    reason: str
+
+
+class MCPEffectiveConnectorListOut(BaseModel):
+    items: list[MCPEffectiveConnectorOut]
+
+
+class MCPWorkspaceConnectorStatePatch(BaseModel):
+    enabled: bool | None = None
+    credential_policy: Literal["org", "workspace", "user", "none"] | None = None
+```
+
+- [ ] **Step 5: Add route mapping helpers and endpoints**
+
+Edit `backend/cubebox/api/routes/v1/ws_mcp.py`.
+
+Add imports:
+
+```python
+from cubebox.api.schemas.mcp import (
+    MCPEffectiveConnectorListOut,
+    MCPEffectiveConnectorOut,
+    MCPConnectorInstallOut,
+    MCPConnectorTemplateOut,
+    MCPWorkspaceConnectorStateOut,
+    MCPWorkspaceConnectorStatePatch,
+)
+from cubebox.mcp.dependencies import get_effective_connector_service
+from cubebox.mcp.effective import EffectiveConnectorService, EffectiveConnectorState
+```
+
+Add helper:
+
+```python
+def _effective_to_out(state: EffectiveConnectorState) -> MCPEffectiveConnectorOut:
+    template = None
+    if state.template is not None:
+        template = MCPConnectorTemplateOut(
+            template_id=state.template.template_id,
+            slug=state.template.slug,
+            name=state.template.name,
+            provider=state.template.provider,
+            status=state.template.status,
+        )
+    return MCPEffectiveConnectorOut(
+        template=template,
+        install=MCPConnectorInstallOut(
+            install_id=state.install.install_id,
+            name=state.install.name,
+            server_url=state.install.server_url,
+            transport=state.install.transport,
+            auth_method=state.install.auth_method,
+            credential_scope=state.install.credential_scope,
+            install_status=state.install.install_status,
+            origin=state.install.origin,
+            owner_workspace_id=state.install.owner_workspace_id,
+            tool_count=len(state.install.tools_cache),
+        ),
+        workspace_state=MCPWorkspaceConnectorStateOut(
+            enabled=state.workspace_state.enabled,
+            credential_policy=state.workspace_state.credential_policy,
+        ),
+        credential_policy=state.credential_policy,
+        credential_availability=state.credential_availability,
+        credential_source=state.credential_source,
+        credential_shared_by=state.credential_shared_by,
+        usable=state.usable,
+        reason=state.reason,
+    )
+```
+
+Add endpoints near the top of the router:
+
+```python
+@router.get("/connectors", response_model=MCPEffectiveConnectorListOut)
+async def list_effective_connectors(
+    workspace_id: str,
+    ctx: RequestContext = Depends(require_member),
+    effective: EffectiveConnectorService = Depends(get_effective_connector_service),
+) -> MCPEffectiveConnectorListOut:
+    rows = await effective.list_for_workspace_user(
+        workspace_id=workspace_id,
+        user_id=ctx.user.id,
+        include_unusable=True,
+    )
+    return MCPEffectiveConnectorListOut(items=[_effective_to_out(row) for row in rows])
+
+
+@router.patch(
+    "/connectors/{install_id}/state",
+    response_model=MCPEffectiveConnectorOut,
+)
+async def patch_effective_connector_state(
+    workspace_id: str,
+    install_id: str,
+    body: MCPWorkspaceConnectorStatePatch,
+    svc: MCPServerService = Depends(get_mcp_service),
+    ctx: RequestContext = Depends(require_member),
+    effective: EffectiveConnectorService = Depends(get_effective_connector_service),
+) -> MCPEffectiveConnectorOut:
+    server = await svc.server_repo.get(install_id)
+    if server is None or server.owner_workspace_id is not None:
+        raise HTTPException(404, detail={"code": "mcp_install_not_found"})
+
+    if body.enabled is not None:
+        if body.enabled:
+            await svc.override_repo.upsert(
+                workspace_id=workspace_id,
+                mcp_server_id=install_id,
+                enabled=True,
+                updated_by_user_id=ctx.user.id,
+            )
+        else:
+            await svc.override_repo.delete(
+                workspace_id=workspace_id,
+                mcp_server_id=install_id,
+            )
+
+    if body.credential_policy is not None:
+        override = await svc.override_repo.get_for_workspace_and_server(
+            workspace_id=workspace_id,
+            mcp_server_id=install_id,
+        )
+        if override is None:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                detail={"code": "mcp_connector_state_required"},
+            )
+        override.credential_mode = body.credential_policy
+        override.updated_by_user_id = ctx.user.id
+        svc.server_repo.session.add(override)
+        await svc.server_repo.session.commit()
+
+    rows = await effective.list_for_workspace_user(
+        workspace_id=workspace_id,
+        user_id=ctx.user.id,
+        include_unusable=True,
+    )
+    for row in rows:
+        if row.install.install_id == install_id:
+            return _effective_to_out(row)
+    raise HTTPException(404, detail={"code": "mcp_install_not_found"})
+```
+
+- [ ] **Step 6: Tighten workspace settings schema literals**
+
+Edit `backend/cubebox/api/schemas/ws_settings.py`.
+
+Add import:
+
+```python
+from typing import Literal
+```
+
+Replace:
+
+```python
+    credential_mode: str = "org"
+```
+
+with:
+
+```python
+    credential_mode: Literal["org", "workspace", "user", "none"] = "org"
+```
+
+Replace:
+
+```python
+    credential_mode: str | None = None
+```
+
+with:
+
+```python
+    credential_mode: Literal["org", "workspace", "user", "none"] | None = None
+```
+
+- [ ] **Step 7: Delegate settings MCP list to effective service**
+
+Edit `backend/cubebox/api/routes/v1/ws_settings.py`.
+
+Replace `list_workspace_mcp`'s body with:
+
+```python
+    from cubebox.mcp.dependencies import get_effective_connector_service
+
+    effective = await get_effective_connector_service(session=session, ctx=ctx)
+    rows = await effective.list_for_workspace_user(
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+        include_unusable=True,
+    )
+    org_servers: list[MCPServerItem] = []
+    workspace_servers: list[MCPServerItem] = []
+    for row in rows:
+        item = MCPServerItem(
+            server_id=row.install.install_id,
+            name=row.install.name,
+            server_url=row.install.server_url,
+            transport=row.install.transport,
+            enabled=row.workspace_state.enabled,
+            scope=row.install.origin,
+            credential_mode=row.credential_policy,
+            credential_source=(
+                row.credential_source
+                if row.credential_availability == "available"
+                else "needs_setup"
+                if row.credential_availability == "missing"
+                else None
+            ),
+            credential_shared_by=row.credential_shared_by,
+        )
+        if row.install.origin == "org":
+            org_servers.append(item)
+        else:
+            workspace_servers.append(item)
+    return WorkspaceMCPOut(org_servers=org_servers, workspace_servers=workspace_servers)
+```
+
+- [ ] **Step 8: Run API tests**
+
+Run:
+
+```bash
+cd backend
+uv run pytest -q tests/e2e/test_mcp_effective_connectors.py
+uv run pytest -q tests/e2e/test_ws_settings.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/cubebox/api/schemas/mcp.py \
+        backend/cubebox/api/routes/v1/ws_mcp.py \
+        backend/cubebox/api/schemas/ws_settings.py \
+        backend/cubebox/api/routes/v1/ws_settings.py \
+        backend/tests/e2e/conftest.py \
+        backend/tests/e2e/test_mcp_effective_connectors.py
+git commit -m "feat(mcp): expose effective workspace connector state"
+```
+
+---
+
+## Task 5: Runtime Uses Effective Service and OAuth Refresh
+
+**Files:**
+
+- Modify: `backend/cubebox/mcp/effective.py`
+- Modify: `backend/cubebox/mcp/cubepi_discovery.py`
+- Modify: `backend/cubebox/mcp/cubepi_runtime.py`
+- Modify: `backend/cubebox/streams/run_manager.py`
+- Modify: `backend/tests/unit/test_mcp_cubepi_runtime.py`
+- Modify: `backend/tests/unit/mcp/test_oauth_token_manager.py`
+
+- [ ] **Step 1: Add runtime token resolver tests**
+
+Append to `backend/tests/unit/test_mcp_cubepi_runtime.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_load_only_discovers_usable_effective_connectors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from cubebox.mcp.effective import (
+        ConnectorInstallView,
+        EffectiveConnectorState,
+        WorkspaceConnectorStateView,
+    )
+
+    usable = EffectiveConnectorState(
+        template=None,
+        install=ConnectorInstallView(
+            install_id="s1",
+            name="good",
+            server_url="http://good",
+            transport="streamable_http",
+            auth_method="none",
+            credential_scope="none",
+            install_status="active",
+            origin="workspace",
+            owner_workspace_id="ws-1",
+            credential_id=None,
+        ),
+        workspace_state=WorkspaceConnectorStateView(enabled=True, credential_policy=None),
+        credential_policy="none",
+        credential_availability="not_required",
+        credential_source=None,
+        credential_shared_by=None,
+        usable=True,
+        reason="usable",
+    )
+    unusable = dataclasses.replace(usable, usable=False, reason="credential_missing")
+
+    class _Effective:
+        async def list_for_workspace_user(
+            self, *, workspace_id: str, user_id: str, include_unusable: bool
+        ) -> list[EffectiveConnectorState]:
+            return [usable, unusable]
+
+    async def _fake_loader(
+        url: str,
+        *,
+        headers: dict[str, str] | None,
+        timeout: float,
+        transport: str,
+    ) -> list[object]:
+        assert url == "http://good"
+        return [_FakeTool(name="search")]
+
+    monkeypatch.setattr("cubebox.mcp.cubepi_runtime.load_mcp_tools_http", _fake_loader)
+
+    tools, _citation_configs = await load_workspace_mcp_tools_for_cubepi(
+        session=None,  # type: ignore[arg-type]
+        workspace_id="ws-1",
+        org_id="org-1",
+        user_id="user-1",
+        cred_service=None,  # type: ignore[arg-type]
+        signer=None,  # type: ignore[arg-type]
+        effective_service=_Effective(),  # type: ignore[arg-type]
+        token_manager=None,
+    )
+
+    assert [tool.name for tool in tools] == ["good__search"]
+```
+
+- [ ] **Step 2: Run the runtime test and confirm signature failure**
+
+Run:
+
+```bash
+cd backend
+uv run pytest -q tests/unit/test_mcp_cubepi_runtime.py::test_load_only_discovers_usable_effective_connectors
+```
+
+Expected: FAIL because `load_workspace_mcp_tools_for_cubepi` does not accept
+`effective_service`.
+
+- [ ] **Step 3: Add runtime spec conversion to effective service**
+
+Append to `backend/cubebox/mcp/effective.py`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class RuntimeConnectorSpec:
+    server_id: str
+    server_name: str
+    url: str
+    transport: str
+    headers: dict[str, str]
+    tool_citations: dict[str, dict[str, Any]]
+    credential_policy: CredentialPolicy
+    auth_method: str
+    credential_id: str | None
+
+
+def effective_state_to_runtime_spec(state: EffectiveConnectorState) -> RuntimeConnectorSpec:
+    return RuntimeConnectorSpec(
+        server_id=state.install.install_id,
+        server_name=state.install.name,
+        url=state.install.server_url,
+        transport=state.install.transport,
+        headers=dict(state.install.headers),
+        tool_citations=dict(state.install.tool_citations),
+        credential_policy=state.credential_policy,
+        auth_method=state.install.auth_method,
+        credential_id=state.install.credential_id,
+    )
+```
+
+- [ ] **Step 4: Change runtime loader signature and filtering**
+
+Edit `backend/cubebox/mcp/cubepi_runtime.py`.
+
+Add imports:
+
+```python
+from cubebox.mcp.effective import (
+    EffectiveConnectorService,
+    RuntimeConnectorSpec,
+    effective_state_to_runtime_spec,
+)
+from cubebox.mcp.oauth.token_manager import OAuthTokenManager
+```
+
+Change `load_workspace_mcp_tools_for_cubepi` signature to include:
+
+```python
+    effective_service: EffectiveConnectorService | None = None,
+    token_manager: OAuthTokenManager | None = None,
+```
+
+Replace the call to `discover_workspace_mcp_servers_for_cubepi` with:
+
+```python
+    if effective_service is None:
+        servers = await discover_workspace_mcp_servers_for_cubepi(
+            session=session,
+            workspace_id=workspace_id,
+            org_id=org_id,
+            user_id=user_id,
+            cred_service=cred_service,
+            signer=signer,
+            token_manager=token_manager,
+        )
+    else:
+        states = await effective_service.list_for_workspace_user(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            include_unusable=False,
+        )
+        servers = [
+            CubepiMCPServerSpec(
+                server_id=spec.server_id,
+                server_name=spec.server_name,
+                url=spec.url,
+                transport=cast(Any, spec.transport),
+                headers=spec.headers,
+                tool_citations=spec.tool_citations,
+            )
+            for spec in [effective_state_to_runtime_spec(state) for state in states]
+        ]
+```
+
+Add `cast` to the typing imports if it is not present.
+
+- [ ] **Step 5: Add OAuth token manager pass-through in discovery**
+
+Edit `backend/cubebox/mcp/cubepi_discovery.py`.
+
+Import:
+
+```python
+from cubebox.mcp.oauth.token_manager import OAuthTokenManager
+```
+
+Add parameter to `discover_workspace_mcp_servers_for_cubepi`:
+
+```python
+    token_manager: OAuthTokenManager | None = None,
+```
+
+Pass it into `_resolve_token_for_cubepi`:
+
+```python
+                token_manager=token_manager,
+```
+
+Add parameter to `_resolve_token_for_cubepi`:
+
+```python
+    token_manager: OAuthTokenManager | None,
+```
+
+At the top of the user-scope branch, before falling back to direct vault decryption:
+
+```python
+        if auth_method == "oauth" and token_manager is not None:
+            return await token_manager.get_access_token(
+                server_id=server_id,
+                user_id=user_id,
+            )
+```
+
+This keeps OAuth refresh in one manager instead of decrypting stale access tokens directly.
+
+- [ ] **Step 6: Wire token manager and effective service in run manager**
+
+Edit `backend/cubebox/streams/run_manager.py`.
+
+Inside the MCP tools block, import:
+
+```python
+import httpx
+
+from cubebox.mcp.dependencies import _build_token_manager_for_org
+from cubebox.mcp.effective import EffectiveConnectorService
+from cubebox.mcp.oauth.metadata import OAuthMetadataDiscovery
+from cubebox.repositories.mcp import (
+    MCPServerRepository,
+    UserMCPCredentialRepository,
+    WorkspaceMCPCredentialRepository,
+)
+from cubebox.repositories.mcp_catalog import MCPCatalogConnectorRepository
+```
+
+Before calling `load_workspace_mcp_tools_for_cubepi`, construct:
+
+```python
+                oauth_http_client = getattr(
+                    self._app.state,
+                    "_mcp_oauth_http_client",
+                    None,
+                )
+                if oauth_http_client is None:
+                    oauth_http_client = httpx.AsyncClient(timeout=30.0)
+                    setattr(
+                        self._app.state,
+                        "_mcp_oauth_http_client",
+                        oauth_http_client,
+                    )
+
+                oauth_metadata = getattr(
+                    self._app.state,
+                    "_mcp_oauth_metadata_discovery",
+                    None,
+                )
+                if oauth_metadata is None:
+                    oauth_metadata = OAuthMetadataDiscovery(oauth_http_client)
+                    setattr(
+                        self._app.state,
+                        "_mcp_oauth_metadata_discovery",
+                        oauth_metadata,
+                    )
+
+                token_manager = _build_token_manager_for_org(
+                    session=mcp_session,
+                    backend=self._app.state.encryption_backend,
+                    redis=self._app.state.redis,
+                    http_client=oauth_http_client,
+                    metadata=oauth_metadata,
+                    org_id=ctx.org_id,
+                )
+```
+
+Then pass:
+
+```python
+                effective_service = EffectiveConnectorService(
+                    session=mcp_session,
+                    server_repo=MCPServerRepository(mcp_session, org_id=ctx.org_id),
+                    catalog_repo=MCPCatalogConnectorRepository(mcp_session),
+                    ws_cred_repo=WorkspaceMCPCredentialRepository(mcp_session, org_id=ctx.org_id),
+                    user_cred_repo=UserMCPCredentialRepository(mcp_session, org_id=ctx.org_id),
+                )
+```
+
+and call the loader with:
+
+```python
+                    effective_service=effective_service,
+                    token_manager=token_manager,
+```
+
+- [ ] **Step 7: Run runtime tests**
+
+Run:
+
+```bash
+cd backend
+uv run pytest -q tests/unit/test_mcp_cubepi_runtime.py
+uv run pytest -q tests/unit/mcp/test_oauth_token_manager.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/cubebox/mcp/effective.py \
+        backend/cubebox/mcp/cubepi_discovery.py \
+        backend/cubebox/mcp/cubepi_runtime.py \
+        backend/cubebox/streams/run_manager.py \
+        backend/tests/unit/test_mcp_cubepi_runtime.py \
+        backend/tests/unit/mcp/test_oauth_token_manager.py
+git commit -m "feat(mcp): load runtime tools from effective connector state"
+```
+
+---
+
+## Task 6: Template Aliases and Grant-Oriented Compatibility
+
+**Files:**
+
+- Modify: `backend/cubebox/api/routes/v1/mcp_catalog.py`
+- Modify: `backend/cubebox/api/routes/v1/ws_mcp.py`
+- Modify: `backend/tests/unit/test_ws_mcp_routes.py`
+- Modify: `backend/tests/e2e/test_mcp_effective_connectors.py`
+
+- [ ] **Step 1: Add route registration tests**
+
+Append to `backend/tests/unit/test_ws_mcp_routes.py`:
+
+```python
+def test_workspace_mcp_effective_routes_are_registered() -> None:
+    from cubebox.api.app import create_app
+
+    app = create_app()
+    paths = {route.path for route in app.routes}
+
+    assert "/api/v1/ws/{workspace_id}/mcp/connectors" in paths
+    assert "/api/v1/ws/{workspace_id}/mcp/connectors/{install_id}/state" in paths
+    assert "/api/v1/ws/{workspace_id}/mcp/templates" in paths
+```
+
+- [ ] **Step 2: Add template alias endpoint**
+
+Edit `backend/cubebox/api/routes/v1/mcp_catalog.py`.
+
+Below `list_catalog`, add:
+
+```python
+@catalog_member_router.get("/templates", response_model=MCPCatalogListOut)
+async def list_templates(
+    workspace_id: str = Path(..., max_length=20),
+    q: str | None = Query(default=None),
+    provider: str | None = Query(default=None),
+    svc: MCPCatalogService = Depends(get_member_catalog_service),
+) -> MCPCatalogListOut:
+    dtos = await svc.list_for_member(workspace_id, q=q, provider=provider)
+    return MCPCatalogListOut(items=[_connector_to_out(dto) for dto in dtos])
+```
+
+This preserves the existing response shape while moving product language off `catalog`.
+
+- [ ] **Step 3: Add grant alias routes for user and workspace credentials**
+
+Edit `backend/cubebox/api/routes/v1/ws_mcp.py`.
+
+For the existing user credential handlers, add route decorators above the same functions:
+
+```python
+@router.get("/connectors/{server_id}/grants/me", response_model=MCPCredentialStatus)
+```
+
+```python
+@router.put("/connectors/{server_id}/grants/me", response_model=MCPCredentialStatus)
+```
+
+```python
+@router.delete("/connectors/{server_id}/grants/me", status_code=status.HTTP_204_NO_CONTENT)
+```
+
+For workspace credential handlers, add:
+
+```python
+@router.get("/connectors/{server_id}/grants/workspace", response_model=MCPCredentialStatus)
+```
+
+```python
+@router.put("/connectors/{server_id}/grants/workspace", response_model=MCPCredentialStatus)
+```
+
+```python
+@router.delete(
+    "/connectors/{server_id}/grants/workspace",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+```
+
+- [ ] **Step 4: Run route registration and E2E tests**
+
+Run:
+
+```bash
+cd backend
+uv run pytest -q tests/unit/test_ws_mcp_routes.py::test_workspace_mcp_effective_routes_are_registered
+uv run pytest -q tests/e2e/test_mcp_effective_connectors.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/api/routes/v1/mcp_catalog.py \
+        backend/cubebox/api/routes/v1/ws_mcp.py \
+        backend/tests/unit/test_ws_mcp_routes.py \
+        backend/tests/e2e/test_mcp_effective_connectors.py
+git commit -m "feat(mcp): add template and grant route aliases"
+```
+
+---
+
+## Task 7: Frontend Core API and State Types
+
+**Files:**
+
+- Modify: `frontend/packages/core/src/types/mcp.ts`
+- Modify: `frontend/packages/core/src/api/mcp.ts`
+- Modify: `frontend/packages/core/src/types/workspace-settings.ts`
+- Modify: `frontend/packages/core/src/api/workspace-settings.ts`
+- Modify: `frontend/packages/core/src/stores/workspaceSettingsStore.ts`
+- Modify: `frontend/packages/core/__tests__/api/mcp.test.ts`
+
+- [ ] **Step 1: Add API tests**
+
+Append to `frontend/packages/core/__tests__/api/mcp.test.ts`:
+
+```typescript
+it('lists effective workspace connectors', async () => {
+  const { client, fetchMock } = makeClient({
+    ok: true,
+    json: async () => ({ items: [] }),
+  })
+
+  const out = await wsListEffectiveConnectors(client, 'ws-x')
+
+  expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/ws/ws-x/mcp/connectors')
+  expect(out).toEqual({ items: [] })
+})
+
+it('patches effective workspace connector state', async () => {
+  const { client, fetchMock } = makeClient({
+    ok: true,
+    json: async () => ({
+      install: { install_id: 'mcp-1' },
+      workspace_state: { enabled: true, credential_policy: 'user' },
+    }),
+  })
+
+  await wsPatchConnectorState(client, 'ws-x', 'mcp-1', {
+    enabled: true,
+    credential_policy: 'user',
+  })
+
+  expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/ws/ws-x/mcp/connectors/mcp-1/state')
+  expect(JSON.parse(fetchMock.mock.calls[0][1]?.body as string)).toEqual({
+    enabled: true,
+    credential_policy: 'user',
+  })
+})
+```
+
+- [ ] **Step 2: Run tests and confirm missing exports**
+
+Run:
+
+```bash
+cd frontend
+pnpm --filter @cubebox/core test -- mcp.test.ts
+```
+
+Expected: FAIL because `wsListEffectiveConnectors` and `wsPatchConnectorState` are
+not exported.
+
+- [ ] **Step 3: Add effective connector types**
+
+Append to `frontend/packages/core/src/types/mcp.ts`:
+
+```typescript
+export type MCPEffectiveReason =
+  | 'usable'
+  | 'template_inactive'
+  | 'install_deleted'
+  | 'workspace_disabled'
+  | 'credential_missing'
+  | 'unsupported_transport'
+
+export type MCPCredentialAvailability = 'available' | 'missing' | 'not_required'
+
+export interface MCPConnectorTemplate {
+  template_id: string | null
+  slug: string | null
+  name: string
+  provider: string | null
+  status: string
+}
+
+export interface MCPConnectorInstall {
+  install_id: string
+  name: string
+  server_url: string
+  transport: MCPTransport
+  auth_method: MCPAuthMethod
+  credential_scope: MCPCredentialScope
+  install_status: 'active' | 'deleted'
+  origin: 'org' | 'workspace'
+  owner_workspace_id: string | null
+  tool_count: number
+}
+
+export interface MCPWorkspaceConnectorState {
+  enabled: boolean
+  credential_policy: MCPCredentialScope | null
+}
+
+export interface MCPEffectiveConnector {
+  template: MCPConnectorTemplate | null
+  install: MCPConnectorInstall
+  workspace_state: MCPWorkspaceConnectorState
+  credential_policy: MCPCredentialScope
+  credential_availability: MCPCredentialAvailability
+  credential_source: 'org' | 'workspace' | 'user' | null
+  credential_shared_by: string | null
+  usable: boolean
+  reason: MCPEffectiveReason
+}
+
+export interface MCPEffectiveConnectorList {
+  items: MCPEffectiveConnector[]
+}
+
+export interface MCPWorkspaceConnectorStatePatch {
+  enabled?: boolean
+  credential_policy?: MCPCredentialScope
+}
+```
+
+- [ ] **Step 4: Add API helpers**
+
+Edit `frontend/packages/core/src/api/mcp.ts`.
+
+Add imports:
+
+```typescript
+  MCPEffectiveConnector,
+  MCPEffectiveConnectorList,
+  MCPWorkspaceConnectorStatePatch,
+```
+
+Add functions:
+
+```typescript
+export async function wsListEffectiveConnectors(
+  client: ApiClient,
+  wsId: string,
+): Promise<MCPEffectiveConnectorList> {
+  const res = await client.get(`/api/v1/ws/${wsId}/mcp/connectors`)
+  if (!res.ok) throw await toApiError(res)
+  return (await res.json()) as MCPEffectiveConnectorList
+}
+
+export async function wsPatchConnectorState(
+  client: ApiClient,
+  wsId: string,
+  installId: string,
+  body: MCPWorkspaceConnectorStatePatch,
+): Promise<MCPEffectiveConnector> {
+  const res = await client.patch(`/api/v1/ws/${wsId}/mcp/connectors/${installId}/state`, body)
+  if (!res.ok) throw await toApiError(res)
+  return (await res.json()) as MCPEffectiveConnector
+}
+```
+
+- [ ] **Step 5: Extend workspace settings types**
+
+Edit `frontend/packages/core/src/types/workspace-settings.ts`.
+
+Change:
+
+```typescript
+export type MCPCredentialMode = 'org' | 'workspace' | 'user'
+```
+
+to:
+
+```typescript
+export type MCPCredentialMode = 'org' | 'workspace' | 'user' | 'none'
+```
+
+Add import:
+
+```typescript
+import type { MCPEffectiveConnector } from './mcp'
+```
+
+Add to `WorkspaceMCP`:
+
+```typescript
+  connectors?: MCPEffectiveConnector[]
+```
+
+- [ ] **Step 6: Route workspace settings store through normalized helpers**
+
+Edit `frontend/packages/core/src/api/workspace-settings.ts`.
+
+Keep existing functions for compatibility, but make `patchWorkspaceMCPCredentialMode`
+call the connector state endpoint when the `ApiClient` has a workspace id in scope:
+
+```typescript
+export async function patchWorkspaceMCPCredentialMode(
+  client: ApiClient,
+  serverId: string,
+  credentialMode: MCPCredentialMode,
+): Promise<{ server_id: string; credential_mode: MCPCredentialMode }> {
+  const res = await client.patch(`/api/v1/mcp/connectors/${serverId}/state`, {
+    credential_policy: credentialMode,
+  })
+  if (!res.ok) throw await toApiError(res)
+  const body = await res.json()
+  return {
+    server_id: body.install.install_id,
+    credential_mode: body.credential_policy,
+  }
+}
+```
+
+- [ ] **Step 7: Run frontend core tests and typecheck**
+
+Run:
+
+```bash
+cd frontend
+pnpm --filter @cubebox/core test -- mcp.test.ts
+pnpm --filter @cubebox/core type-check
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/packages/core/src/types/mcp.ts \
+        frontend/packages/core/src/api/mcp.ts \
+        frontend/packages/core/src/types/workspace-settings.ts \
+        frontend/packages/core/src/api/workspace-settings.ts \
+        frontend/packages/core/src/stores/workspaceSettingsStore.ts \
+        frontend/packages/core/__tests__/api/mcp.test.ts
+git commit -m "feat(mcp): add effective connector types and API client"
+```
+
+---
+
+## Task 8: Workspace UI Uses Four-Layer Semantics
+
+**Files:**
+
+- Modify: `frontend/packages/web/components/workspace-settings/McpPanel.tsx`
+- Modify: `frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx`
+- Modify: `frontend/packages/web/messages/en.json`
+- Modify: `frontend/packages/web/messages/zh.json`
+- Modify: `frontend/packages/web/__tests__/e2e/mcp/ws-mcp.spec.ts`
+
+- [ ] **Step 1: Add Playwright assertions for visible semantics**
+
+Edit `frontend/packages/web/__tests__/e2e/mcp/ws-mcp.spec.ts`.
+
+Add a test that navigates to workspace settings and asserts these user-facing strings:
+
+```typescript
+await expect(page.getByText('Connector templates')).toBeVisible()
+await expect(page.getByText('Installed in this workspace')).toBeVisible()
+await expect(page.getByText('Needs your credential')).toBeVisible()
+```
+
+For Chinese locale coverage, add the same assertion pattern using:
+
+```typescript
+await expect(page.getByText('连接器模板')).toBeVisible()
+await expect(page.getByText('已安装到此工作区')).toBeVisible()
+await expect(page.getByText('需要你的凭证')).toBeVisible()
+```
+
+- [ ] **Step 2: Update workspace panel terminology**
+
+Edit `frontend/packages/web/components/workspace-settings/McpPanel.tsx`.
+
+Use these display labels:
+
+```typescript
+const reasonLabel: Record<string, string> = {
+  usable: t('state.usable'),
+  template_inactive: t('state.templateInactive'),
+  install_deleted: t('state.installDeleted'),
+  workspace_disabled: t('state.workspaceDisabled'),
+  credential_missing: t('state.credentialMissing'),
+  unsupported_transport: t('state.unsupportedTransport'),
+}
+```
+
+Use "Enable for workspace" for workspace state, "Credential policy" for mode,
+and "Disconnect" for deleting a user grant. Do not display the word "override".
+
+- [ ] **Step 3: Present catalog as templates**
+
+Edit `frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx`.
+
+Change the heading and empty state keys to:
+
+```typescript
+const title = t('templates.title')
+const empty = t('templates.empty')
+```
+
+Ensure actions still call the existing install helpers. The endpoint alias will be used by
+core API after compatibility is verified.
+
+- [ ] **Step 4: Add message keys**
+
+Add under `mcp.wsPanel` in `frontend/packages/web/messages/en.json`:
+
+```json
+"templates": {
+  "title": "Connector templates",
+  "empty": "No connector templates match this filter."
+},
+"installedWorkspace": "Installed in this workspace",
+"credentialPolicy": "Credential policy",
+"enableWorkspace": "Enable for workspace",
+"disconnect": "Disconnect",
+"state": {
+  "usable": "Ready",
+  "templateInactive": "Template unavailable",
+  "installDeleted": "Install removed",
+  "workspaceDisabled": "Disabled in this workspace",
+  "credentialMissing": "Needs your credential",
+  "unsupportedTransport": "Unsupported transport"
+}
+```
+
+Add under `mcp.wsPanel` in `frontend/packages/web/messages/zh.json`:
+
+```json
+"templates": {
+  "title": "连接器模板",
+  "empty": "没有匹配的连接器模板。"
+},
+"installedWorkspace": "已安装到此工作区",
+"credentialPolicy": "凭证策略",
+"enableWorkspace": "为工作区启用",
+"disconnect": "断开连接",
+"state": {
+  "usable": "可用",
+  "templateInactive": "模板不可用",
+  "installDeleted": "安装已移除",
+  "workspaceDisabled": "此工作区已停用",
+  "credentialMissing": "需要你的凭证",
+  "unsupportedTransport": "不支持的传输方式"
+}
+```
+
+- [ ] **Step 5: Run frontend checks**
+
+Run:
+
+```bash
+cd frontend
+pnpm --filter @cubebox/web type-check
+pnpm --filter @cubebox/web test:e2e -- mcp/ws-mcp.spec.ts
+```
+
+Expected: typecheck passes and the MCP workspace spec passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/packages/web/components/workspace-settings/McpPanel.tsx \
+        frontend/packages/web/components/mcp/MCPCatalogInstallPanel.tsx \
+        frontend/packages/web/messages/en.json \
+        frontend/packages/web/messages/zh.json \
+        frontend/packages/web/__tests__/e2e/mcp/ws-mcp.spec.ts
+git commit -m "feat(mcp): clarify workspace connector management UI"
+```
+
+---
+
+## Task 9: Admin UI and Compatibility Cleanup
+
+**Files:**
+
+- Modify: `frontend/packages/web/app/admin/mcp/page.tsx`
+- Modify: `frontend/packages/web/components/mcp/MCPConnectorList.tsx`
+- Modify: `frontend/packages/web/components/mcp/MCPWorkspacesTab.tsx`
+- Modify: `frontend/packages/web/components/mcp/MCPCredentialPanel.tsx`
+- Modify: `frontend/packages/web/messages/en.json`
+- Modify: `frontend/packages/web/messages/zh.json`
+- Modify: `frontend/packages/web/__tests__/e2e/mcp/admin-mcp.spec.ts`
+- Modify: `backend/tests/e2e/test_mcp_auto_enroll.py`
+
+- [ ] **Step 1: Add admin E2E assertions for install vs workspace state**
+
+Edit `frontend/packages/web/__tests__/e2e/mcp/admin-mcp.spec.ts`.
+
+Add assertions for these visible labels:
+
+```typescript
+await expect(page.getByText('Connector installs')).toBeVisible()
+await expect(page.getByText('Workspace state')).toBeVisible()
+await expect(page.getByText('Org grant')).toBeVisible()
+```
+
+- [ ] **Step 2: Update admin labels**
+
+In the admin MCP page and components, replace visible "Catalog" labels with
+"Templates" and "Override" labels with "Workspace state".
+
+Use this map for admin badges:
+
+```typescript
+const scopeLabel: Record<string, string> = {
+  org: t('scope.orgInstall'),
+  workspace: t('scope.workspaceInstall'),
+  user: t('scope.userGrant'),
+  none: t('scope.noGrantRequired'),
+}
+```
+
+- [ ] **Step 3: Keep old endpoint names inside API helpers only**
+
+Do not rename functions that still target old backend URLs in UI components. Keep old
+endpoint terminology in `frontend/packages/core/src/api/mcp.ts` until backend compatibility
+metrics show no remaining callers.
+
+- [ ] **Step 4: Verify delete vs disconnect semantics**
+
+Extend `backend/tests/e2e/test_mcp_auto_enroll.py` with:
+
+```python
+async def test_admin_delete_install_removes_workspace_state_not_user_grants(
+    admin_client: tuple[httpx.AsyncClient, str],
+    github_catalog_id: str,
+) -> None:
+    client, workspace_id = admin_client
+    install = await client.post(
+        f"/api/v1/admin/mcp/catalog/{github_catalog_id}/install",
+        json={"auth_method": "static", "credential_plaintext": "ghp_test"},
+    )
+    assert install.status_code == 201, install.text
+    install_id = install.json()["install_id"]
+
+    delete_resp = await client.delete(f"/api/v1/admin/mcp/installs/{install_id}")
+    assert delete_resp.status_code == 204, delete_resp.text
+
+    rows = await client.get(f"/api/v1/ws/{workspace_id}/mcp/connectors")
+    assert rows.status_code == 200, rows.text
+    assert all(item["install"]["install_id"] != install_id for item in rows.json()["items"])
+```
+
+- [ ] **Step 5: Run admin checks**
+
+Run:
+
+```bash
+cd backend
+uv run pytest -q tests/e2e/test_mcp_auto_enroll.py
+cd ../frontend
+pnpm --filter @cubebox/web type-check
+pnpm --filter @cubebox/web test:e2e -- mcp/admin-mcp.spec.ts
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/packages/web/app/admin/mcp/page.tsx \
+        frontend/packages/web/components/mcp/MCPConnectorList.tsx \
+        frontend/packages/web/components/mcp/MCPWorkspacesTab.tsx \
+        frontend/packages/web/components/mcp/MCPCredentialPanel.tsx \
+        frontend/packages/web/messages/en.json \
+        frontend/packages/web/messages/zh.json \
+        frontend/packages/web/__tests__/e2e/mcp/admin-mcp.spec.ts \
+        backend/tests/e2e/test_mcp_auto_enroll.py
+git commit -m "feat(mcp): align admin terminology with connector model"
+```
+
+---
+
+## Task 10: Final Verification and Risk Review
+
+**Files:**
+
+- Modify: this plan only if verification finds command or path drift.
+
+- [ ] **Step 1: Run backend MCP slices**
+
+Run:
+
+```bash
+cd backend
+uv run pytest -q tests/unit/mcp tests/unit/test_mcp_*.py
+uv run pytest -q tests/e2e/test_mcp_catalog_routes.py \
+                 tests/e2e/test_mcp_effective_connectors.py \
+                 tests/e2e/test_mcp_catalog_runtime.py \
+                 tests/e2e/test_mcp_auto_enroll.py \
+                 tests/e2e/test_mcp_user_credentials.py \
+                 tests/e2e/test_mcp_bindings.py \
+                 tests/e2e/test_ws_settings.py
+```
+
+Expected: all selected backend tests pass.
+
+- [ ] **Step 2: Run backend quality gate**
+
+Run:
+
+```bash
+cd backend
+make check
+```
+
+Expected: format, lint, type-check, and tests pass.
+
+- [ ] **Step 3: Run frontend quality gate**
+
+Run:
+
+```bash
+cd frontend
+pnpm --filter @cubebox/core type-check
+pnpm --filter @cubebox/web type-check
+pnpm --filter @cubebox/web test:e2e -- mcp/ws-mcp.spec.ts mcp/admin-mcp.spec.ts
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 4: Manual runtime smoke check**
+
+Run:
+
+```bash
+./scripts/worktree-env show
+cd backend
+python main.py
+```
+
+In another shell:
+
+```bash
+cd frontend
+pnpm dev
+```
+
+Open the `BASE_URL` printed by `.worktree.env`, install a no-auth MCP template in one
+workspace, and confirm it appears as ready in workspace settings without creating a
+credential grant.
+
+- [ ] **Step 5: Review known design risks**
+
+Confirm these are true before merging:
+
+- `catalog` remains only as a compatibility name for old URLs and DB tables.
+- Product copy uses template, install, workspace state, and grant.
+- Runtime reads one effective-state path.
+- `auth_method="none"` never creates a user credential requirement.
+- `install_status` separates deletion from credential readiness.
+- Workspace-local installs are workspace-scoped, not creator-private.
+- Disconnecting a user grant does not uninstall the connector.
+
+- [ ] **Step 6: Final commit if verification changed files**
+
+```bash
+git status --short
+git add <changed-files>
+git commit -m "test(mcp): verify four-layer connector management"
+```
+
+If `git status --short` is empty, no commit is needed.

--- a/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
+++ b/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
@@ -796,6 +796,17 @@ endpoints can otherwise accept impossible combinations):
   effective-state decision order (rule 5 keys on `auth_method`, not policy),
   but request-side validation is the user-facing gate.
 
+- For PATCH endpoints whose body carries `credential_policy` without
+  `auth_method` (`PATCH /admin/mcp/installs/{id}` setting
+  `default_credential_policy`, `PATCH /ws/{ws}/mcp/connectors/{id}/state`
+  setting `credential_policy`), schema-only validation can't enforce the
+  pairing because the request body lacks `auth_method`. The **service layer**
+  must load the install row first and reject any patch that sets
+  `credential_policy="none"` on a row whose `auth_method != "none"` (and vice
+  versa: cannot raise a non-`none` policy on an `auth_method="none"` install).
+  Return 422 with the same field error shape the schema validator would have
+  emitted.
+
 Request schemas should also exist for:
 
 - `AdminCreateInstallIn`: `template_id?`, `install_scope` (`org`),
@@ -971,9 +982,14 @@ Decision order in `compute_effective_state` (first match wins):
    (a credentialed connector cannot run without a credential), and the API
    layer must reject `credential_policy="none"` whenever `auth_method != "none"`
    so it can never reach this branch.
-6. `auth_method == "oauth"` AND `auth_status == "pending"` AND grant absent →
-   `pending_oauth`. Static installs are not "pending OAuth"; their missing
-   grant must be reported by rule 7 instead.
+6. `auth_method == "oauth"` AND `credential_policy IN {"org", "workspace"}` AND
+   `auth_status == "pending"` AND grant absent → `pending_oauth`. `pending_oauth`
+   is an *install-scoped* state ("admin / workspace has not finished the OAuth
+   handshake"); it must not mask per-user state. For
+   `credential_policy == "user"`, every member has their own OAuth flow, so a
+   missing user grant always falls through to rule 7 and reports
+   `user_needs_connection` — even when the install row's `auth_status` is still
+   `pending` from an earlier abandoned admin flow.
 7. Grant absent → scope-specific missing reason
    (`missing_org_grant` / `missing_workspace_grant` / `user_needs_connection`
    based on `credential_policy`).

--- a/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
+++ b/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
@@ -927,7 +927,8 @@ reasons):
 | --- | --- | --- |
 | no template, no install | `install_state="active"` but no install row for this template in org/ws | `not_installed` |
 | install uninstalled | `install_state="uninstalled"` | `install_uninstalled` |
-| template deprecated, install still active | `template_status="deprecated"` | `template_deprecated` |
+| template disabled | `template_status="disabled"` | `template_deprecated` (hard block) |
+| template deprecated, install still active | `template_status="deprecated"`, otherwise authorized | `usable` — deprecation surfaces via the DTO's `template_status` field but does NOT block runtime |
 | workspace state missing/disabled | `workspace_enabled=False` | `not_enabled_in_workspace` |
 | unsupported transport | `transport="stdio"` | (skipped — spec doesn't include this; replace with `server_unreachable` if needed) |
 | no-auth happy path | `auth_method="none"`, `credential_policy="none"`, no grant | `usable` |
@@ -973,7 +974,13 @@ Decision order in `compute_effective_state` (first match wins):
 
 1. `install_present=False` → `not_installed`.
 2. `install_state == "uninstalled"` → `install_uninstalled`.
-3. `template_status` is set and not `active` → `template_deprecated`.
+3. `template_status == "disabled"` → `template_deprecated` (treated as a hard
+   block — disabled means the template can no longer ship). `deprecated` is
+   **not** a block: per the spec, "Template can be deprecated without breaking
+   existing installs." Surface `template_status="deprecated"` in the DTO as a
+   warning, but continue evaluating the remaining rules; the install can still
+   be `usable=true`. Templates that are `None` (custom installs) skip this
+   rule entirely.
 4. `workspace_state_present=False` or `workspace_enabled=False` →
    `not_enabled_in_workspace`.
 5. `auth_method == "none"` → `usable`, `credential_availability="not_required"`.
@@ -1088,8 +1095,8 @@ Run:
 
 ```bash
 cd backend
-uv run pytest -q tests/unit/mcp/test_effective_state.py \
-                 tests/unit/mcp/test_effective_service.py \
+uv run pytest -q tests/unit/test_mcp_effective_state.py \
+                 tests/unit/test_mcp_effective_service.py \
                  tests/unit/test_mcp_cubepi_runtime.py
 ```
 

--- a/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
+++ b/docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md
@@ -210,13 +210,28 @@ Required shape per model:
 - Distribution: `auto_enroll_new_workspaces` (bool, server_default `true`) —
   flips `WorkspaceConnectorState` auto-creation when a new workspace lands in the org.
 - Audit: `created_by_user_id` (FK).
-- Constraints:
-  - `UniqueConstraint(org_id, workspace_id, server_url_hash)` — duplicate-URL guard.
-  - `UniqueConstraint(org_id, workspace_id, name)` — name uniqueness inside scope.
-  - Partial unique index `uq_mcp_connector_install_per_template` on
-    `(org_id, COALESCE(workspace_id, '_org'), template_id)` where
-    `template_id IS NOT NULL AND install_state = 'active'` — at most one active
-    install per template per scope, but uninstalled rows must not block reinstall.
+- Constraints (Postgres treats NULL as distinct for plain `UNIQUE`, so use
+  partial unique indexes per scope rather than multi-column `UniqueConstraint`
+  with nullable columns — otherwise two org-scope installs with the same URL
+  both pass uniqueness):
+  - Partial index `uq_mcp_connector_install_url_org` on `(org_id, server_url_hash)`
+    where `workspace_id IS NULL AND install_state = 'active'`.
+  - Partial index `uq_mcp_connector_install_url_ws` on
+    `(org_id, workspace_id, server_url_hash)` where
+    `workspace_id IS NOT NULL AND install_state = 'active'`.
+  - Partial index `uq_mcp_connector_install_name_org` on `(org_id, name)` where
+    `workspace_id IS NULL AND install_state = 'active'`.
+  - Partial index `uq_mcp_connector_install_name_ws` on
+    `(org_id, workspace_id, name)` where
+    `workspace_id IS NOT NULL AND install_state = 'active'`.
+  - Partial index `uq_mcp_connector_install_per_template_org` on
+    `(org_id, template_id)` where
+    `workspace_id IS NULL AND template_id IS NOT NULL AND install_state = 'active'`.
+  - Partial index `uq_mcp_connector_install_per_template_ws` on
+    `(org_id, workspace_id, template_id)` where
+    `workspace_id IS NOT NULL AND template_id IS NOT NULL AND install_state = 'active'`.
+  - All install_state-gated indexes intentionally exclude `uninstalled` rows so
+    a tombstoned install does not block reinstalling the same template/URL/name.
   - Check constraints (`ck_*`): `install_scope IN ('org','workspace')`,
     `auth_method IN ('oauth','static','none')`.
 
@@ -241,8 +256,21 @@ Required shape per model:
 - `expires_at` (nullable, OAuth access-token expiry), `grant_status`
   (`valid` | `missing` | `expired` | `revoked` | `error`, default `valid`),
   `created_by_user_id` (FK).
-- Unique on `(install_id, grant_scope, workspace_id, user_id)`.
-- Check: `grant_scope IN ('org','workspace','user')`.
+- Uniqueness — same NULL-distinct issue as installs; replace the single
+  multi-column `UniqueConstraint` with three partial unique indexes, one per
+  scope, so org grants can't be duplicated under NULL `workspace_id`/`user_id`:
+  - `uq_mcp_credential_grant_org` on `(install_id)` where `grant_scope = 'org'`.
+  - `uq_mcp_credential_grant_workspace` on `(install_id, workspace_id)` where
+    `grant_scope = 'workspace'`.
+  - `uq_mcp_credential_grant_user` on `(install_id, workspace_id, user_id)` where
+    `grant_scope = 'user'`.
+- Check: `grant_scope IN ('org','workspace','user')`, plus row-level guards
+  enforced at the service layer (`workspace_id` non-null iff scope ∈
+  `{workspace,user}`; `user_id` non-null iff scope = `user`). The check
+  constraint version of the row-level guards (`(grant_scope='org' AND
+  workspace_id IS NULL AND user_id IS NULL) OR ...`) should also be added —
+  it costs nothing and turns a programming bug into a DB error before the
+  partial unique index sees it.
 
 Update `backend/cubebox/models/__init__.py` to export the four classes and remove
 old MCP model exports.
@@ -267,28 +295,26 @@ containing:
 
 Then open the generated file and manually add what autogenerate cannot infer:
 
-1. **Partial unique index** on installs (autogen does not produce `postgresql_where`):
+1. **All partial unique indexes** — autogen cannot produce `postgresql_where`,
+   so every entry from the Step 3 partial-index list lands here as an explicit
+   `op.create_index(..., unique=True, postgresql_where=sa.text(...))`. That covers
+   the six install indexes (URL × org/ws, name × org/ws, template × org/ws) and
+   the three grant scope indexes (`org`, `workspace`, `user`). All install indexes
+   that exclude `install_state='uninstalled'` must include that predicate in their
+   `postgresql_where` so uninstalled rows do not block reinstall.
 
-   ```python
-   op.create_index(
-       "uq_mcp_connector_install_per_template",
-       "mcp_connector_installs",
-       ["org_id", sa.text("COALESCE(workspace_id, '_org')"), "template_id"],
-       unique=True,
-       postgresql_where=sa.text(
-           "template_id IS NOT NULL AND install_state = 'active'"
-       ),
-   )
-   ```
-
-2. **Four `CHECK` constraints** (autogen ignores `CheckConstraint` produced by SQLModel
-   in some versions; verify and add as needed):
+2. **Check constraints** (autogen sometimes drops `CheckConstraint` produced by
+   SQLModel; verify the generated file and add any that are missing):
 
    - `ck_mcp_connector_installs_scope`: `install_scope IN ('org','workspace')`
    - `ck_mcp_connector_installs_auth_method`: `auth_method IN ('oauth','static','none')`
    - `ck_mcp_workspace_connector_states_policy`:
      `credential_policy IN ('org','workspace','user','none')`
    - `ck_mcp_credential_grants_scope`: `grant_scope IN ('org','workspace','user')`
+   - `ck_mcp_credential_grants_scope_columns`:
+     `(grant_scope='org' AND workspace_id IS NULL AND user_id IS NULL)
+      OR (grant_scope='workspace' AND workspace_id IS NOT NULL AND user_id IS NULL)
+      OR (grant_scope='user' AND workspace_id IS NOT NULL AND user_id IS NOT NULL)`
 
 3. **Downgrade**: destructive migration is not reversible. Replace the autogenerated
    `downgrade()` body with:
@@ -662,9 +688,11 @@ the workspace-side contract. The test must assert each of the following is regis
 
 - `GET    /api/v1/ws/{workspace_id}/mcp/templates`
 - `GET    /api/v1/ws/{workspace_id}/mcp/connectors`
-- `POST   /api/v1/ws/{workspace_id}/mcp/installs`
+- `POST   /api/v1/ws/{workspace_id}/mcp/installs`  (workspace-local install create)
 - `DELETE /api/v1/ws/{workspace_id}/mcp/installs/{install_id}`  (workspace-local uninstall)
-- `PATCH  /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/state`
+- `PATCH  /api/v1/ws/{workspace_id}/mcp/connectors/{install_id}/state`
+  (matches spec §API Shape — workspace state edit lives under `/connectors`, not
+  `/installs`; the install path is reserved for install-lifecycle operations)
 - `POST   /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me`
 - `DELETE /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me`
 - `POST   /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me/oauth/start`
@@ -840,127 +868,84 @@ git commit -m "feat(mcp): replace catalog routes with four-layer API"
 - Create: `backend/tests/unit/test_mcp_effective_service.py`
 - Modify: `backend/tests/unit/test_mcp_cubepi_runtime.py`
 
-- [ ] **Step 1: Add effective state tests**
+- [ ] **Step 1: Add effective state tests (full reason matrix)**
 
-Create `backend/tests/unit/test_mcp_effective_state.py`:
+`backend/tests/unit/test_mcp_effective_state.py` is the contract for the pure
+function. Cover **every** terminal reason in the spec's reason table — the
+function should never collapse "user vs workspace vs org grant missing" into a
+single `credential_missing`, otherwise UI/admin cannot diagnose the connector.
+Concrete test cases (subagent writes one test per row, names map to spec
+reasons):
 
-```python
-from cubebox.mcp.effective import MCPEffectiveInput, MCPGrantInput, compute_effective_state
+| Test case | Input shape | Expected `reason` |
+| --- | --- | --- |
+| no template, no install | `install_state="active"` but no install row for this template in org/ws | `not_installed` |
+| install uninstalled | `install_state="uninstalled"` | `install_uninstalled` |
+| template deprecated, install still active | `template_status="deprecated"` | `template_deprecated` |
+| workspace state missing/disabled | `workspace_enabled=False` | `not_enabled_in_workspace` |
+| unsupported transport | `transport="stdio"` | (skipped — spec doesn't include this; replace with `server_unreachable` if needed) |
+| no-auth happy path | `auth_method="none"`, `credential_policy="none"`, no grant | `usable` |
+| pending OAuth at org scope | `auth_status="pending"`, `credential_policy="org"`, no grant | `pending_oauth` |
+| missing org grant | `auth_status="authorized"` but no row with `grant_scope="org"` | `missing_org_grant` |
+| missing workspace grant | `credential_policy="workspace"`, no row at workspace scope | `missing_workspace_grant` |
+| user needs to connect | `credential_policy="user"`, no row for current `user_id` | `user_needs_connection` |
+| grant expired (refresh failed) | grant `status="expired"` and no refresh credential | `grant_expired` |
+| discovery failed | `discovery_status="error"`, otherwise authorized | `discovery_failed` |
+| valid user grant | `credential_policy="user"`, grant `scope="user" status="valid"` | `usable` |
 
-
-def test_no_auth_connector_is_usable_without_grant() -> None:
-    result = compute_effective_state(
-        MCPEffectiveInput(
-            template_status="active",
-            install_state="active",
-            workspace_enabled=True,
-            auth_method="none",
-            credential_policy="none",
-            grant=None,
-            transport="streamable_http",
-        )
-    )
-
-    assert result.usable is True
-    assert result.reason == "usable"
-    assert result.credential_availability == "not_required"
-
-
-def test_user_policy_requires_user_grant() -> None:
-    result = compute_effective_state(
-        MCPEffectiveInput(
-            template_status="active",
-            install_state="active",
-            workspace_enabled=True,
-            auth_method="static",
-            credential_policy="user",
-            grant=None,
-            transport="streamable_http",
-        )
-    )
-
-    assert result.usable is False
-    assert result.reason == "credential_missing"
-
-
-def test_valid_user_grant_makes_user_policy_usable() -> None:
-    result = compute_effective_state(
-        MCPEffectiveInput(
-            template_status="active",
-            install_state="active",
-            workspace_enabled=True,
-            auth_method="static",
-            credential_policy="user",
-            grant=MCPGrantInput(scope="user", status="valid"),
-            transport="streamable_http",
-        )
-    )
-
-    assert result.usable is True
-    assert result.reason == "usable"
-```
+The "user_needs_connection" / scope-specific reasons distinguish *which scope's*
+grant is missing — runtime/UI consumers branch on this string.
 
 - [ ] **Step 2: Implement pure effective-state model**
 
-Create `backend/cubebox/mcp/effective.py`:
+Create `backend/cubebox/mcp/effective.py`. The module exports:
 
-```python
-from dataclasses import dataclass
-from typing import Literal
+- `CredentialPolicy = Literal["org","workspace","user","none"]`.
+- `MCPEffectiveReason` — a `Literal` covering every spec reason
+  (`usable`, `not_installed`, `not_enabled_in_workspace`, `install_uninstalled`,
+  `template_deprecated`, `pending_oauth`, `missing_org_grant`,
+  `missing_workspace_grant`, `user_needs_connection`, `grant_expired`,
+  `discovery_failed`, `server_unreachable`).
+- `MCPGrantInput(scope: str, status: str, has_refresh: bool)` — the runtime's
+  view of the resolved grant row.
+- `MCPEffectiveInput` — frozen dataclass with at least these fields:
+  - `template_status: str | None` (None ⇒ custom install with no template)
+  - `install_present: bool` (False ⇒ caller decided "not installed")
+  - `install_state: str`
+  - `workspace_state_present: bool`
+  - `workspace_enabled: bool`
+  - `auth_method: str`
+  - `auth_status: str`
+  - `discovery_status: str`
+  - `credential_policy: CredentialPolicy`
+  - `grant: MCPGrantInput | None`
+  - `transport: str`
+- `MCPEffectiveResult(usable: bool, reason: MCPEffectiveReason,
+  credential_availability: Literal["available","missing","not_required"])`.
 
-CredentialPolicy = Literal["org", "workspace", "user", "none"]
-MCPEffectiveReason = Literal[
-    "usable",
-    "template_inactive",
-    "install_uninstalled",
-    "workspace_disabled",
-    "credential_missing",
-    "credential_invalid",
-    "unsupported_transport",
-]
+Decision order in `compute_effective_state` (first match wins):
 
+1. `install_present=False` → `not_installed`.
+2. `install_state == "uninstalled"` → `install_uninstalled`.
+3. `template_status` is set and not `active` → `template_deprecated`.
+4. `workspace_state_present=False` or `workspace_enabled=False` →
+   `not_enabled_in_workspace`.
+5. `auth_method == "none"` OR `credential_policy == "none"` → `usable`,
+   `credential_availability="not_required"`.
+6. `auth_status == "pending"` AND grant absent → `pending_oauth`.
+7. Grant absent → scope-specific missing reason
+   (`missing_org_grant` / `missing_workspace_grant` / `user_needs_connection`
+   based on `credential_policy`).
+8. Grant present but `status == "expired"` and `has_refresh=False` →
+   `grant_expired`.
+9. Grant present but `scope != credential_policy` → treat as missing for that
+   scope (no cross-scope fallback).
+10. `discovery_status == "error"` → `discovery_failed`.
+11. Otherwise → `usable`, `credential_availability="available"`.
 
-@dataclass(frozen=True, slots=True)
-class MCPGrantInput:
-    scope: str
-    status: str
-
-
-@dataclass(frozen=True, slots=True)
-class MCPEffectiveInput:
-    template_status: str | None
-    install_state: str
-    workspace_enabled: bool
-    auth_method: str
-    credential_policy: CredentialPolicy
-    grant: MCPGrantInput | None
-    transport: str
-
-
-@dataclass(frozen=True, slots=True)
-class MCPEffectiveResult:
-    usable: bool
-    reason: MCPEffectiveReason
-    credential_availability: str
-
-
-def compute_effective_state(value: MCPEffectiveInput) -> MCPEffectiveResult:
-    if value.template_status is not None and value.template_status != "active":
-        return MCPEffectiveResult(False, "template_inactive", "missing")
-    if value.install_state != "active":
-        return MCPEffectiveResult(False, "install_uninstalled", "missing")
-    if value.transport not in {"streamable_http", "sse"}:
-        return MCPEffectiveResult(False, "unsupported_transport", "missing")
-    if not value.workspace_enabled:
-        return MCPEffectiveResult(False, "workspace_disabled", "missing")
-    if value.auth_method == "none" or value.credential_policy == "none":
-        return MCPEffectiveResult(True, "usable", "not_required")
-    if value.grant is None:
-        return MCPEffectiveResult(False, "credential_missing", "missing")
-    if value.grant.status != "valid" or value.grant.scope != value.credential_policy:
-        return MCPEffectiveResult(False, "credential_invalid", "missing")
-    return MCPEffectiveResult(True, "usable", "available")
-```
+The order matters: `discovery_failed` only blocks usability after all auth
+gates pass, because discovery is only attempted once the connector is
+authorized.
 
 - [ ] **Step 3: Add DB-backed effective service**
 
@@ -1097,16 +1082,38 @@ file — do not invent new auth flow). Required new fixtures:
   add the minimum scaffolding (register second user, accept invite) reusing the
   existing helpers.
 
-- [ ] **Step 2: No-auth happy path (spec test #1, #5-no-auth variant)**
+- [ ] **Step 2a: Workspace-local no-auth happy path (spec test #2)**
 
-Test `test_workspace_installs_noauth_template_and_gets_usable_connector` in
+`test_workspace_local_noauth_install_renders_usable` in
 `backend/tests/e2e/test_mcp_four_layer_routes.py`:
 
-- Workspace admin POSTs `/installs` with the no-auth template id.
-- GET `/connectors` returns a row whose `enabled=true`, `credential_policy="none"`,
+- Workspace admin POSTs `/ws/{ws}/mcp/installs` with the no-auth template id.
+- GET `/ws/{ws}/mcp/connectors` returns a row whose `install_scope="workspace"`,
+  `enabled=true`, `credential_policy="none"`,
   `credential_availability="not_required"`, `usable=true`.
-- Runtime smoke (in the runtime-side test file): `list_runtime_specs(...)`
+- Runtime smoke (in `test_mcp_four_layer_runtime.py`): `list_runtime_specs(...)`
   returns the connector and no grant lookup is performed.
+
+- [ ] **Step 2b: Org admin no-auth install + distribution (spec test #1)**
+
+`test_org_admin_noauth_install_distributed_to_workspace_renders_usable` in
+the same file. This is the dedicated org-path test — without it, an
+implementation could pass Step 2a but break the `install_scope="org"` +
+`WorkspaceConnectorState` codepath:
+
+- Org admin POSTs `/admin/mcp/installs` with `template_id=noauth_template_id`,
+  `install_scope="org"`, `auth_method="none"`, and
+  `auto_enable={"mode":"selected","workspace_ids":[workspace_id]}`.
+- Assert the install row is `install_scope="org"`, `workspace_id IS NULL`,
+  `auth_status="not_required"`.
+- Assert a `WorkspaceConnectorState` row was created for the target workspace
+  with `enablement_source="admin_manual"` and `enabled=true`.
+- GET `/ws/{ws}/mcp/connectors` returns the same install with
+  `install_scope="org"`, `credential_availability="not_required"`,
+  `usable=true`. A non-targeted workspace in the same org must NOT see this
+  install as enabled.
+- Runtime smoke: `list_runtime_specs(ws, user)` for the targeted workspace
+  returns the connector; for a non-targeted workspace it does not.
 
 - [ ] **Step 3: User-policy scope isolation (spec test #3)**
 

--- a/docs/superpowers/specs/2026-05-15-mcp-management-four-layer-design.md
+++ b/docs/superpowers/specs/2026-05-15-mcp-management-four-layer-design.md
@@ -469,7 +469,7 @@ Admin install create supports:
 
 ```json
 {
-  "template_id": "ctpl-example",
+  "template_id": "mctpl-example",
   "install_scope": "org",
   "auth_method": "oauth",
   "auto_enable": {
@@ -496,7 +496,7 @@ Example:
 ```json
 {
   "template_slug": "github",
-  "install_id": "cins-example",
+  "install_id": "mcins-example",
   "install_scope": "org",
   "enabled": true,
   "credential_policy": "user",
@@ -631,12 +631,12 @@ Implementation naming uses one explicit MCP prefix:
 - Product copy can still use the shorter nouns: template, install, workspace state,
   and grant.
 
-| Concept | Python Model | Target Table |
-| --- | --- | --- |
-| `ConnectorTemplate` | `MCPConnectorTemplate` | `mcp_connector_templates` |
-| `ConnectorInstall` | `MCPConnectorInstall` | `mcp_connector_installs` |
-| `WorkspaceConnectorState` | `MCPWorkspaceConnectorState` | `mcp_workspace_connector_states` |
-| `CredentialGrant` | `MCPCredentialGrant` | `mcp_credential_grants` |
+| Concept | Python Model | ID Prefix | Target Table |
+| --- | --- | --- | --- |
+| `ConnectorTemplate` | `MCPConnectorTemplate` | `mctpl` | `mcp_connector_templates` |
+| `ConnectorInstall` | `MCPConnectorInstall` | `mcins` | `mcp_connector_installs` |
+| `WorkspaceConnectorState` | `MCPWorkspaceConnectorState` | `mcwcs` | `mcp_workspace_connector_states` |
+| `CredentialGrant` | `MCPCredentialGrant` | `mcgrn` | `mcp_credential_grants` |
 
 Existing MCP tables (`mcp_catalog_connectors`, `mcp_servers`,
 `workspace_mcp_overrides`, `workspace_mcp_credentials`, `user_mcp_credentials`) are

--- a/docs/superpowers/specs/2026-05-15-mcp-management-four-layer-design.md
+++ b/docs/superpowers/specs/2026-05-15-mcp-management-four-layer-design.md
@@ -1,0 +1,746 @@
+# MCP Management Four-Layer Design
+
+Date: 2026-05-15
+Status: Draft
+Branch: `feat/mcp-management-spec`
+Worktree slot: 23
+
+## Problem
+
+MCP 管理当前已经具备 catalog、install、workspace enablement、credential 等能力，
+但功能语义没有稳定收敛：
+
+1. `mcp_servers` 同时表达安装、运行实例、授权状态和 workspace 私有性。
+2. `workspace_mcp_overrides` 实际表达 workspace 是否启用 org install，但名字仍像
+   "覆盖默认继承"。
+3. `workspace-private install` 在一些路径像 workspace 级安装，在另一些路径像
+   creator-private 安装。
+4. `authed=false` 同时可能表示 pending OAuth、credential 被删除、发现失败、token
+   过期或被 revoke。
+5. UI/API/runtime 都在重复推断 "当前用户在当前 workspace 能否使用这个 connector"。
+
+这导致用户心智模型复杂，功能状态难解释，后续 OAuth、workspace credential、user
+credential、admin distribution 继续叠加时会变得更难维护。
+
+本设计把 MCP 管理重新抽象成四个明确对象：
+
+1. `ConnectorTemplate`
+2. `ConnectorInstall`
+3. `WorkspaceConnectorState`
+4. `CredentialGrant`
+
+核心目标是让系统始终能回答一个问题：
+
+> 某个用户在某个 workspace 中能否使用某个 connector？如果不能，原因是什么？
+
+## Goals
+
+- 建立清晰的功能模型，使 org、workspace、user 三层职责分离。
+- 明确安装、启用、授权、可运行四个状态不是同一件事。
+- 统一 admin 页面、workspace settings、catalog 页面、runtime loading 的状态来源。
+- 支持以下产品场景：
+  - org admin 安装 connector，并分发到一个或多个 workspace。
+  - workspace admin 启用 org connector，并选择 credential policy。
+  - workspace admin 创建 workspace-local connector。
+  - workspace member 为 user policy connector 连接自己的授权。
+  - no-auth connector 可以被正确安装、启用并运行。
+- 为后续重构 API、DB schema、UI 和 runtime 提供共同设计基准。
+
+## Non-Goals
+
+- 不在本 spec 中定义具体迁移脚本步骤。
+- 不要求一次 PR 完成所有对象重命名。
+- 不设计 MCP server tool invocation 的 try-it 后端。
+- 不改变 Organization、Workspace、Membership、OrganizationMembership 的基础身份模型。
+- 不移除 credential vault；本设计继续使用现有 vault 作为 secret 存储层。
+
+## Recommended Direction
+
+推荐采用分层自助模型：
+
+- Org admin 管理 org-level connector install 和 org shared credential。
+- Workspace admin 管理 workspace 是否启用 connector、credential policy、workspace shared
+  credential，以及 workspace-local install。
+- Workspace member 只能管理自己的 user credential grant。
+
+不推荐完全收紧成 "只有 org admin 安装"，因为 cubebox 的 workspace 是独立协作单元，
+workspace-local connector 是合理能力。
+
+也不推荐完全放开成 "每个成员都能安装自己的 connector"，因为那会引入 personal
+connector 语义。personal connector 可以作为未来功能，但不应混入 workspace install。
+
+## Conceptual Model
+
+### ConnectorTemplate
+
+`ConnectorTemplate` 是系统 catalog 中的可安装模板。它只回答：
+
+> 系统支持什么 connector？安装它需要哪些信息？
+
+它不属于任何 organization，不保存 tenant secret，也不表示已经安装。
+
+Conceptual fields:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Template id |
+| `slug` | Stable key, such as `github`, `notion`, `mslearn` |
+| `name` | Display name |
+| `provider` | Provider name |
+| `description` | User-facing description |
+| `server_url` | Default remote MCP endpoint |
+| `transport` | `streamable_http` or `sse` |
+| `supported_auth_methods` | `oauth`, `static`, `none` |
+| `default_credential_policy` | Suggested policy: `org`, `workspace`, `user`, `none` |
+| `static_form_schema` | Static credential form schema |
+| `oauth_metadata` | OAuth/DCR/static client metadata |
+| `tool_citation_defaults` | Default citation config by tool name |
+| `status` | `active`, `deprecated`, `disabled` |
+
+Rules:
+
+- Template is global.
+- Template rows are seeded by system catalog seeding.
+- Template can be deprecated without breaking existing installs.
+- Template cannot be "enabled" in a workspace directly.
+- Template cannot be "authorized".
+
+### ConnectorInstall
+
+`ConnectorInstall` is a materialized connector in an organization or workspace.
+It answers:
+
+> Has this org or workspace installed this connector capability?
+
+Conceptual fields:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Install id |
+| `template_id` | Optional reference to `ConnectorTemplate` |
+| `org_id` | Owning organization |
+| `install_scope` | `org` or `workspace` |
+| `workspace_id` | Present when `install_scope=workspace` |
+| `server_url` | Runtime MCP endpoint |
+| `transport` | Runtime transport |
+| `auth_method` | `oauth`, `static`, `none` |
+| `auth_status` | `not_required`, `pending`, `authorized`, `disconnected`, `error` |
+| `discovery_status` | `not_run`, `success`, `error` |
+| `tools_cache` | Last successful discovered tools |
+| `tool_citations` | Install-specific citation mappings |
+| `install_state` | `active` or `uninstalled` |
+| `created_by_user_id` | Actor who created the install |
+
+Rules:
+
+- Install does not by itself mean every workspace can use the connector.
+- Org install requires workspace enablement before runtime use.
+- Workspace install belongs to exactly one workspace.
+- `disconnect` clears authorization but keeps install.
+- `uninstall` removes or tombstones install and should not block reinstall.
+- Custom connectors are installs with no template reference.
+
+### WorkspaceConnectorState
+
+`WorkspaceConnectorState` describes one workspace's relationship to one install.
+It answers:
+
+> Is this install enabled in this workspace, and what credential policy should
+> this workspace use?
+
+Conceptual fields:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | State id |
+| `org_id` | Organization |
+| `workspace_id` | Workspace |
+| `install_id` | Connector install |
+| `enabled` | Whether the workspace has enabled this install |
+| `credential_policy` | `org`, `workspace`, `user`, `none` |
+| `enablement_source` | `admin_auto`, `admin_manual`, `workspace_manual` |
+| `updated_by_user_id` | Last actor |
+
+Rules:
+
+- State is not a credential.
+- State is not the install itself.
+- For org installs, state is required for workspace runtime use.
+- For workspace installs, state is created with `enabled=true` when install is created.
+- No state means "not enabled" unless a migration compatibility layer explicitly says otherwise.
+- The object should not be named "override" in product language.
+
+### CredentialGrant
+
+`CredentialGrant` represents an authorization usable by runtime. It answers:
+
+> Which credential should runtime use for this install under this workspace/user?
+
+Conceptual fields:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Grant id |
+| `org_id` | Organization |
+| `install_id` | Connector install |
+| `grant_scope` | `org`, `workspace`, `user` |
+| `workspace_id` | Required for workspace grant |
+| `user_id` | Required for user grant |
+| `credential_id` | Vault access token/static credential id |
+| `refresh_credential_id` | OAuth refresh token credential id |
+| `expires_at` | OAuth access token expiry |
+| `grant_status` | `valid`, `missing`, `expired`, `revoked`, `error` |
+| `created_by_user_id` | Actor who created the grant |
+
+Rules:
+
+- Grant is not an install.
+- Grant is not workspace enablement.
+- Static token and OAuth token are both grants.
+- One install can have many user grants.
+- `auth_method=none` does not create a grant; runtime signs cubebox identity token.
+
+## Functional State Composition
+
+Runtime usability is derived from four independent layers:
+
+```text
+ConnectorTemplate active
+  -> ConnectorInstall active
+    -> WorkspaceConnectorState enabled
+      -> CredentialGrant available or auth_method=none
+        -> Runtime usable
+```
+
+The system should expose both usable and unusable connector states. Hiding unusable
+rows makes setup and debugging harder.
+
+Canonical effective state fields:
+
+| Field | Meaning |
+| --- | --- |
+| `template_status` | Template active/deprecated/disabled |
+| `install_state` | Install active/uninstalled |
+| `install_scope` | `org` or `workspace` |
+| `enabled` | Workspace enablement |
+| `credential_policy` | Effective policy |
+| `required_grant_scope` | Which grant runtime needs |
+| `grant_status` | Current user's relevant grant status |
+| `auth_status` | Install authorization status |
+| `discovery_status` | Last discovery state |
+| `usable` | Whether runtime should load it |
+| `reason` | Machine-readable reason when not usable |
+
+Recommended `reason` values:
+
+| Reason | Meaning |
+| --- | --- |
+| `not_installed` | Template has no install in this org/workspace |
+| `not_enabled_in_workspace` | Install exists but workspace has not enabled it |
+| `install_uninstalled` | Install was removed/tombstoned |
+| `template_deprecated` | Template is deprecated but install may still exist |
+| `pending_oauth` | OAuth install not completed |
+| `missing_org_grant` | Org credential required but missing |
+| `missing_workspace_grant` | Workspace credential required but missing |
+| `user_needs_connection` | Current user credential required but missing |
+| `grant_expired` | Token expired and refresh unavailable |
+| `discovery_failed` | Tool discovery failed |
+| `server_unreachable` | Runtime/tool loading cannot reach server |
+
+## User Roles And Permissions
+
+### Org Owner/Admin
+
+Can:
+
+- View all org installs.
+- Create org install from template.
+- Create custom org install.
+- Configure org credential grant.
+- Complete org OAuth.
+- Disconnect org grant.
+- Uninstall org install.
+- Auto-enable an org install into workspaces.
+- Manually enable/disable an org install for any workspace.
+- Set default workspace credential policy for an org install.
+
+Cannot:
+
+- Create a user grant for another user.
+
+### Workspace Admin
+
+Can:
+
+- View effective connector state for the workspace.
+- Enable/disable org installs in the workspace, if org policy allows workspace control.
+- Choose credential policy for the workspace.
+- Create workspace-local install.
+- Configure workspace shared credential grant.
+- Disconnect workspace shared grant.
+- Uninstall workspace-local install.
+
+Cannot:
+
+- Change org grant.
+- Change connector template.
+- Enable an install from another org.
+
+### Workspace Member
+
+Can:
+
+- View connector state relevant to the workspace.
+- Create/update/delete their own user grant.
+- Start OAuth for their own user grant.
+
+Cannot:
+
+- Enable/disable workspace connector state.
+- Change credential policy.
+- Create workspace shared credential.
+- Uninstall workspace-local install unless they also have workspace admin rights.
+
+## Product Flows
+
+### Flow 1: Org Admin Installs GitHub For Organization
+
+1. Admin opens MCP admin page.
+2. Admin selects GitHub `ConnectorTemplate`.
+3. Admin creates `ConnectorInstall(install_scope=org, auth_method=oauth)`.
+4. Install enters `auth_status=pending`.
+5. Admin starts OAuth.
+6. OAuth callback creates `CredentialGrant(grant_scope=org)`.
+7. Install enters `auth_status=authorized`.
+8. Discovery runs and stores tools.
+9. Admin chooses distribution:
+   - auto-enable all current workspaces; or
+   - manually enable selected workspaces.
+10. For each enabled workspace, create `WorkspaceConnectorState(enabled=true)`.
+
+Outcome:
+
+- GitHub is installed at org level.
+- Selected workspaces can use it.
+- Workspaces use org credential unless their state selects another policy.
+
+### Flow 2: Workspace Admin Enables Existing Org Install
+
+1. Workspace admin opens workspace settings.
+2. System shows org installs available to this workspace.
+3. Admin enables the GitHub install.
+4. System creates or updates `WorkspaceConnectorState(enabled=true)`.
+5. Admin selects credential policy:
+   - `org`: use org shared grant.
+   - `workspace`: prompt for workspace shared credential.
+   - `user`: each member must connect.
+   - `none`: no external credential required.
+
+Outcome:
+
+- Workspace enablement is explicit.
+- Credential policy is visible and auditable.
+- Runtime has a deterministic resolver path.
+
+### Flow 3: Member Connects User Grant
+
+1. Workspace state has `credential_policy=user`.
+2. Member sees connector with `reason=user_needs_connection`.
+3. Member clicks Connect.
+4. For OAuth, backend starts user OAuth flow.
+5. Callback creates `CredentialGrant(grant_scope=user, user_id=current_user)`.
+6. Member's effective state becomes `usable=true`.
+7. Other members still see `user_needs_connection`.
+
+Outcome:
+
+- Workspace decision and user authorization are separate.
+- No user's credential leaks into another user's runtime.
+
+### Flow 4: Workspace Admin Creates Workspace-Local Install
+
+1. Workspace admin selects a template or custom connector in workspace settings.
+2. System creates `ConnectorInstall(install_scope=workspace, workspace_id=ws)`.
+3. System creates `WorkspaceConnectorState(enabled=true)` for that install.
+4. Admin chooses credential policy.
+5. Runtime only considers this install inside that workspace.
+
+Outcome:
+
+- Workspace-local install is shareable within workspace according to policy.
+- It is not creator-private.
+- If future personal connectors are needed, they should be a separate concept.
+
+### Flow 5: No-Auth Connector
+
+1. Admin or workspace admin installs a no-auth template such as Microsoft Learn.
+2. Install uses `auth_method=none` and `auth_status=not_required`.
+3. Workspace state uses `credential_policy=none`.
+4. Runtime signs a short-lived cubebox identity token for the MCP server when needed.
+5. No `CredentialGrant` is created.
+
+Outcome:
+
+- No-auth does not accidentally become user-scope.
+- Runtime can load tools without looking for a user grant.
+
+### Flow 6: Disconnect Versus Uninstall
+
+Disconnect:
+
+1. Actor removes a grant.
+2. Install remains active.
+3. Workspace state remains enabled.
+4. Effective state becomes missing grant or pending auth.
+5. User can reconnect without reinstalling.
+
+Uninstall:
+
+1. Actor removes or tombstones install.
+2. Workspace states are removed or marked inactive.
+3. Grants are revoked/deleted as appropriate.
+4. Duplicate install checks ignore uninstalled rows.
+5. User can install the same template again.
+
+Outcome:
+
+- "Disconnect" and "Uninstall" are no longer overloaded.
+
+## Effective Connector Service
+
+Introduce one conceptual service as the only source of truth:
+
+```text
+EffectiveConnectorService.list_for_workspace_user(
+  org_id,
+  workspace_id,
+  user_id,
+  include_unusable=true
+)
+```
+
+Responsibilities:
+
+1. Load templates relevant to catalog display.
+2. Load org installs and workspace-local installs.
+3. Load workspace connector states.
+4. Resolve credential policy.
+5. Resolve required grant.
+6. Refresh OAuth grants when needed.
+7. Compute `usable` and `reason`.
+8. Return normalized DTOs for UI and runtime.
+
+Consumers:
+
+- Admin MCP page.
+- Workspace MCP/settings page.
+- Catalog page.
+- Runtime MCP tool loader.
+- Future diagnostics/support endpoints.
+
+Runtime should not manually inspect install/state/grant tables. It should consume
+only normalized effective connector DTOs where `usable=true`.
+
+## API Shape
+
+This is a product/API shape, not a final route-by-route implementation plan.
+
+### Templates
+
+```text
+GET /api/v1/mcp/templates
+```
+
+Returns active/deprecated connector templates. The response may include install
+summary for the current org if the caller is authenticated.
+
+### Admin Installs
+
+```text
+GET    /api/v1/admin/mcp/installs
+POST   /api/v1/admin/mcp/installs
+GET    /api/v1/admin/mcp/installs/{install_id}
+PATCH  /api/v1/admin/mcp/installs/{install_id}
+DELETE /api/v1/admin/mcp/installs/{install_id}
+```
+
+Admin install create supports:
+
+```json
+{
+  "template_id": "mctlg-...",
+  "install_scope": "org",
+  "auth_method": "oauth",
+  "auto_enable": {
+    "mode": "selected",
+    "workspace_ids": ["ws-..."]
+  },
+  "default_credential_policy": "org"
+}
+```
+
+`DELETE` means uninstall. Disconnect should be a separate grant action.
+
+### Workspace Connector State
+
+```text
+GET   /api/v1/ws/{workspace_id}/mcp/connectors
+PATCH /api/v1/ws/{workspace_id}/mcp/connectors/{install_id}/state
+```
+
+`GET` returns normalized effective connector DTOs for the current user.
+
+Example:
+
+```json
+{
+  "template_slug": "github",
+  "install_id": "mcp-...",
+  "install_scope": "org",
+  "enabled": true,
+  "credential_policy": "user",
+  "required_grant_scope": "user",
+  "grant_status": "missing",
+  "auth_status": "authorized",
+  "discovery_status": "success",
+  "usable": false,
+  "reason": "user_needs_connection"
+}
+```
+
+`PATCH state` supports:
+
+```json
+{
+  "enabled": true,
+  "credential_policy": "user"
+}
+```
+
+### Workspace-Local Installs
+
+```text
+POST   /api/v1/ws/{workspace_id}/mcp/installs
+DELETE /api/v1/ws/{workspace_id}/mcp/installs/{install_id}
+```
+
+Workspace install creates `ConnectorInstall(scope=workspace)` and
+`WorkspaceConnectorState(enabled=true)`.
+
+### Grants
+
+```text
+POST   /api/v1/admin/mcp/installs/{install_id}/grants/org
+DELETE /api/v1/admin/mcp/installs/{install_id}/grants/org
+
+POST   /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/workspace
+DELETE /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/workspace
+
+POST   /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me
+DELETE /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me
+```
+
+OAuth start can be scoped to the grant being created:
+
+```text
+POST /api/v1/.../grants/{org|workspace|me}/oauth/start
+```
+
+This makes OAuth intent explicit. The callback should know whether it is creating
+an org, workspace, or user grant.
+
+## UI Model
+
+### Admin MCP Page
+
+Admin page should be organized around org installs:
+
+- Catalog/templates list.
+- Installed org connectors.
+- Install detail:
+  - Overview: auth/discovery/install state.
+  - Credentials: org grant status and reconnect/disconnect.
+  - Workspaces: enablement matrix and credential policy per workspace.
+  - Tools: discovered tools and citation mapping.
+
+Primary admin actions:
+
+- Install.
+- Authenticate/Reauthenticate.
+- Enable in workspaces.
+- Set default credential policy.
+- Refresh tools.
+- Disconnect org credential.
+- Uninstall.
+
+### Workspace MCP Settings
+
+Workspace settings should show effective connector states:
+
+- Available from org.
+- Enabled in workspace.
+- Workspace-local installs.
+- User connection needed.
+- Missing workspace credential.
+- Discovery/error state.
+
+Primary workspace admin actions:
+
+- Enable/disable connector.
+- Change credential policy.
+- Add workspace shared credential.
+- Create workspace-local install.
+- Uninstall workspace-local install.
+
+Primary member actions:
+
+- Connect my account/token.
+- Reconnect my account/token.
+- Disconnect my grant.
+
+### Status Language
+
+Use precise labels:
+
+| Label | Meaning |
+| --- | --- |
+| Installed | A `ConnectorInstall` exists and is active |
+| Enabled | Workspace state is enabled |
+| Connected | Required grant is available |
+| Needs connection | User/workspace/org grant missing |
+| Pending OAuth | OAuth flow not completed |
+| Tools synced | Discovery succeeded |
+| Tools sync failed | Discovery failed |
+| Disconnected | Grant was removed but install remains |
+| Uninstalled | Install was removed/tombstoned |
+
+Avoid using "override" in UI.
+
+## Data Model Mapping To Current Tables
+
+The four concepts can map onto current tables initially:
+
+| Concept | Current Table |
+| --- | --- |
+| `ConnectorTemplate` | `mcp_catalog_connectors` |
+| `ConnectorInstall` | `mcp_servers` |
+| `WorkspaceConnectorState` | `workspace_mcp_overrides` |
+| `CredentialGrant(org)` | `mcp_servers.credential_id` initially |
+| `CredentialGrant(workspace)` | `workspace_mcp_credentials` |
+| `CredentialGrant(user)` | `user_mcp_credentials` |
+
+Short-term compatibility is acceptable, but product/service names should move
+toward the four concepts even before physical table names change.
+
+Longer term, org grants should move out of `mcp_servers.credential_id` into a
+dedicated grant table or unified grant repository. That will make org/workspace/user
+grant resolution symmetrical.
+
+## Migration Strategy
+
+### Phase 1: Semantic Service Layer
+
+- Introduce normalized DTOs for effective connector state.
+- Implement one effective-state service over current tables.
+- Update workspace catalog/settings/runtime to consume this service.
+- Keep existing routes as compatibility wrappers.
+
+### Phase 2: Correctness Fixes
+
+- Fix no-auth workspace install to use `credential_policy=none`.
+- Validate credential policy values.
+- Reject custom OAuth installs unless hand-rolled OAuth metadata is supported.
+- Wire OAuth refresh into runtime effective state resolution.
+
+### Phase 3: API And UI Realignment
+
+- Add new connector/state/grant routes.
+- Update admin MCP page to use install/state/grant language.
+- Update workspace settings to show normalized reason states.
+- Deprecate ambiguous fields such as `user_install_id` for workspace-local install.
+
+### Phase 4: Schema Cleanup
+
+- Rename or replace `workspace_mcp_overrides` with workspace connector state.
+- Add explicit `install_state`.
+- Split disconnect and uninstall persistence.
+- Consider unified credential grant table.
+
+## Invariants
+
+- A workspace can use an org install only if workspace state is enabled.
+- A workspace-local install can only be used inside its owning workspace.
+- A user grant can only satisfy runtime for the same user.
+- A workspace grant can only satisfy runtime for the same workspace.
+- An org grant can satisfy any enabled workspace inside the same org.
+- `auth_method=none` must never require a credential grant.
+- `credential_policy=user` must never fall back to org/workspace grants.
+- `credential_policy=workspace` must never fall back to org/user grants.
+- Uninstalled installs must not block reinstall of the same template.
+- Runtime must not load connectors with `usable=false`.
+
+## Error Handling
+
+Errors should preserve the layer where the problem happened:
+
+- Template errors: template disabled, deprecated, unsupported auth method.
+- Install errors: install missing, uninstalled, pending auth, discovery failed.
+- Workspace state errors: not enabled, invalid credential policy.
+- Grant errors: missing, expired, revoked, refresh failed.
+- Runtime errors: server unreachable, tool load failed.
+
+API responses should return stable machine codes. UI can map codes to clear copy.
+
+## Testing Strategy
+
+High-value E2E tests:
+
+1. Org admin installs no-auth template, enables workspace, runtime loads tools.
+2. Workspace admin installs no-auth workspace-local template, runtime loads tools.
+3. Org install with `credential_policy=user`: user A connected, user B not connected.
+4. Workspace policy changed from org to workspace: runtime stops using org grant.
+5. Disconnect org grant keeps install and workspace state, but effective state becomes
+   `missing_org_grant`.
+6. Uninstall org install removes/tombstones state and allows reinstall.
+7. OAuth grant refresh happens before runtime returns usable connector.
+8. Invalid credential policy is rejected before persistence.
+
+Unit tests:
+
+- Effective state service reason matrix.
+- Credential policy resolver.
+- Grant scope isolation.
+- Install state transitions.
+
+Frontend tests:
+
+- Workspace settings renders `usable=false` reasons correctly.
+- Member sees "Connect" but not workspace/admin actions.
+- Workspace admin sees enable/policy/workspace credential actions.
+- Admin install detail shows install, workspace enablement, and grant state separately.
+
+## Open Decisions
+
+These decisions should be made before implementation planning:
+
+1. Should workspace members be allowed to create personal connectors in a future phase?
+   Recommended answer: not in this redesign; keep it separate.
+2. Should workspace state rows be created explicitly for disabled org installs?
+   Recommended answer: yes for auditability, but runtime can treat missing as disabled during
+   migration.
+3. Should workspace admin be allowed to enable any org install, or only those admin marks
+   distributable?
+   Recommended answer: add an org install policy later; v1 can allow enable for all org installs.
+4. Should org grant stay on `mcp_servers.credential_id` short-term?
+   Recommended answer: yes short-term; introduce unified grants after API semantics settle.
+
+## Success Criteria
+
+- A product manager can explain MCP state using four nouns: template, install, workspace
+  state, grant.
+- UI can show why a connector is unavailable without reading raw DB fields.
+- Runtime loads connectors from one effective-state service.
+- No-auth, org credential, workspace credential, and user credential connectors all follow
+  the same state composition rules.
+- Disconnect and uninstall are separate user actions with separate persistence semantics.
+- Workspace-local install is consistently workspace-local, not creator-private.

--- a/docs/superpowers/specs/2026-05-15-mcp-management-four-layer-design.md
+++ b/docs/superpowers/specs/2026-05-15-mcp-management-four-layer-design.md
@@ -37,7 +37,7 @@ credential、admin distribution 继续叠加时会变得更难维护。
 
 - 建立清晰的功能模型，使 org、workspace、user 三层职责分离。
 - 明确安装、启用、授权、可运行四个状态不是同一件事。
-- 统一 admin 页面、workspace settings、catalog 页面、runtime loading 的状态来源。
+- 统一 admin 页面、workspace settings、template library 页面、runtime loading 的状态来源。
 - 支持以下产品场景：
   - org admin 安装 connector，并分发到一个或多个 workspace。
   - workspace admin 启用 org connector，并选择 credential policy。
@@ -48,8 +48,9 @@ credential、admin distribution 继续叠加时会变得更难维护。
 
 ## Non-Goals
 
-- 不在本 spec 中定义具体迁移脚本步骤。
-- 不要求一次 PR 完成所有对象重命名。
+- 不保留旧 `catalog` / `override` API、产品文案或服务命名的向前兼容层；产品尚未发布，
+  可以直接切到正确模型。
+- 不保留旧 MCP 表结构的长期兼容；实现时应直接迁移到四层目标 schema。
 - 不设计 MCP server tool invocation 的 try-it 后端。
 - 不改变 Organization、Workspace、Membership、OrganizationMembership 的基础身份模型。
 - 不移除 credential vault；本设计继续使用现有 vault 作为 secret 存储层。
@@ -73,7 +74,7 @@ connector 语义。personal connector 可以作为未来功能，但不应混入
 
 ### ConnectorTemplate
 
-`ConnectorTemplate` 是系统 catalog 中的可安装模板。它只回答：
+`ConnectorTemplate` 是系统连接器模板库中的可安装模板。它只回答：
 
 > 系统支持什么 connector？安装它需要哪些信息？
 
@@ -100,7 +101,7 @@ Conceptual fields:
 Rules:
 
 - Template is global.
-- Template rows are seeded by system catalog seeding.
+- Template rows are seeded by connector template seeding.
 - Template can be deprecated without breaking existing installs.
 - Template cannot be "enabled" in a workspace directly.
 - Template cannot be "authorized".
@@ -167,8 +168,8 @@ Rules:
 - State is not the install itself.
 - For org installs, state is required for workspace runtime use.
 - For workspace installs, state is created with `enabled=true` when install is created.
-- No state means "not enabled" unless a migration compatibility layer explicitly says otherwise.
-- The object should not be named "override" in product language.
+- No state means "not enabled".
+- The object must not be named "override" in product language, API, service, or DB schema.
 
 ### CredentialGrant
 
@@ -398,7 +399,7 @@ Uninstall:
 
 1. Actor removes or tombstones install.
 2. Workspace states are removed or marked inactive.
-3. Grants are revoked/deleted as appropriate.
+3. Grants are revoked at the provider when OAuth revoke is available, then deleted locally.
 4. Duplicate install checks ignore uninstalled rows.
 5. User can install the same template again.
 
@@ -421,7 +422,7 @@ EffectiveConnectorService.list_for_workspace_user(
 
 Responsibilities:
 
-1. Load templates relevant to catalog display.
+1. Load templates relevant to template library display.
 2. Load org installs and workspace-local installs.
 3. Load workspace connector states.
 4. Resolve credential policy.
@@ -434,7 +435,7 @@ Consumers:
 
 - Admin MCP page.
 - Workspace MCP/settings page.
-- Catalog page.
+- Template library page.
 - Runtime MCP tool loader.
 - Future diagnostics/support endpoints.
 
@@ -468,12 +469,12 @@ Admin install create supports:
 
 ```json
 {
-  "template_id": "mctlg-...",
+  "template_id": "ctpl-example",
   "install_scope": "org",
   "auth_method": "oauth",
   "auto_enable": {
     "mode": "selected",
-    "workspace_ids": ["ws-..."]
+    "workspace_ids": ["ws-example"]
   },
   "default_credential_policy": "org"
 }
@@ -495,7 +496,7 @@ Example:
 ```json
 {
   "template_slug": "github",
-  "install_id": "mcp-...",
+  "install_id": "cins-example",
   "install_scope": "org",
   "enabled": true,
   "credential_policy": "user",
@@ -543,7 +544,9 @@ DELETE /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me
 OAuth start can be scoped to the grant being created:
 
 ```text
-POST /api/v1/.../grants/{org|workspace|me}/oauth/start
+POST /api/v1/admin/mcp/installs/{install_id}/grants/org/oauth/start
+POST /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/workspace/oauth/start
+POST /api/v1/ws/{workspace_id}/mcp/installs/{install_id}/grants/me/oauth/start
 ```
 
 This makes OAuth intent explicit. The callback should know whether it is creating
@@ -555,7 +558,7 @@ an org, workspace, or user grant.
 
 Admin page should be organized around org installs:
 
-- Catalog/templates list.
+- Connector template list.
 - Installed org connectors.
 - Install detail:
   - Overview: auth/discovery/install state.
@@ -614,57 +617,60 @@ Use precise labels:
 | Disconnected | Grant was removed but install remains |
 | Uninstalled | Install was removed/tombstoned |
 
-Avoid using "override" in UI.
+Avoid using "catalog" or "override" in UI.
 
-## Data Model Mapping To Current Tables
+## Target Data Model
 
-The four concepts can map onto current tables initially:
+Because the product has not shipped, implementation should move directly to
+the target schema instead of layering compatibility names on top of old tables:
 
-| Concept | Current Table |
+| Concept | Target Table |
 | --- | --- |
-| `ConnectorTemplate` | `mcp_catalog_connectors` |
-| `ConnectorInstall` | `mcp_servers` |
-| `WorkspaceConnectorState` | `workspace_mcp_overrides` |
-| `CredentialGrant(org)` | `mcp_servers.credential_id` initially |
-| `CredentialGrant(workspace)` | `workspace_mcp_credentials` |
-| `CredentialGrant(user)` | `user_mcp_credentials` |
+| `ConnectorTemplate` | `connector_templates` |
+| `ConnectorInstall` | `connector_installs` |
+| `WorkspaceConnectorState` | `workspace_connector_states` |
+| `CredentialGrant` | `credential_grants` |
 
-Short-term compatibility is acceptable, but product/service names should move
-toward the four concepts even before physical table names change.
+Existing MCP tables (`mcp_catalog_connectors`, `mcp_servers`,
+`workspace_mcp_overrides`, `workspace_mcp_credentials`, `user_mcp_credentials`) are
+implementation history, not product model. The implementation plan may use destructive
+migration for local/dev data, because there is no released external contract.
 
-Longer term, org grants should move out of `mcp_servers.credential_id` into a
-dedicated grant table or unified grant repository. That will make org/workspace/user
-grant resolution symmetrical.
+Org, workspace, and user grants should all be rows in `credential_grants`. The
+credential vault remains the secret storage layer; `credential_grants.credential_id`
+and `credential_grants.refresh_credential_id` point to vault rows.
 
-## Migration Strategy
+## Implementation Strategy
 
-### Phase 1: Semantic Service Layer
+### Phase 1: Target Schema And Domain Names
 
-- Introduce normalized DTOs for effective connector state.
-- Implement one effective-state service over current tables.
-- Update workspace catalog/settings/runtime to consume this service.
-- Keep existing routes as compatibility wrappers.
+- Create target tables for templates, installs, workspace states, and grants.
+- Replace old model class names with `ConnectorTemplate`, `ConnectorInstall`,
+  `WorkspaceConnectorState`, and `CredentialGrant`.
+- Replace catalog/override repositories and services with template/install/state/grant
+  repositories and services.
 
-### Phase 2: Correctness Fixes
+### Phase 2: Correct State Machine
 
+- Implement install lifecycle with `install_state`.
+- Implement auth lifecycle with grants, not `authed` on installs.
 - Fix no-auth workspace install to use `credential_policy=none`.
-- Validate credential policy values.
+- Validate credential policy values at the API boundary and repository layer.
 - Reject custom OAuth installs unless hand-rolled OAuth metadata is supported.
-- Wire OAuth refresh into runtime effective state resolution.
 
-### Phase 3: API And UI Realignment
+### Phase 3: Correct API And UI
 
-- Add new connector/state/grant routes.
+- Expose only template/install/state/grant routes.
+- Remove old catalog/override routes and frontend helpers.
 - Update admin MCP page to use install/state/grant language.
 - Update workspace settings to show normalized reason states.
-- Deprecate ambiguous fields such as `user_install_id` for workspace-local install.
 
-### Phase 4: Schema Cleanup
+### Phase 4: Runtime And Verification
 
-- Rename or replace `workspace_mcp_overrides` with workspace connector state.
-- Add explicit `install_state`.
-- Split disconnect and uninstall persistence.
-- Consider unified credential grant table.
+- Runtime loads connectors from one effective-state service.
+- OAuth access tokens are resolved through `OAuthTokenManager`.
+- Tests assert old catalog/override routes are absent.
+- Tests cover no-auth, org grant, workspace grant, user grant, disconnect, and uninstall.
 
 ## Invariants
 
@@ -721,18 +727,17 @@ Frontend tests:
 
 ## Open Decisions
 
-These decisions should be made before implementation planning:
+These decisions are resolved for the first implementation:
 
 1. Should workspace members be allowed to create personal connectors in a future phase?
    Recommended answer: not in this redesign; keep it separate.
 2. Should workspace state rows be created explicitly for disabled org installs?
-   Recommended answer: yes for auditability, but runtime can treat missing as disabled during
-   migration.
+   Recommended answer: yes for auditability; runtime treats missing as disabled.
 3. Should workspace admin be allowed to enable any org install, or only those admin marks
    distributable?
    Recommended answer: add an org install policy later; v1 can allow enable for all org installs.
 4. Should org grant stay on `mcp_servers.credential_id` short-term?
-   Recommended answer: yes short-term; introduce unified grants after API semantics settle.
+   Recommended answer: no. Use unified `credential_grants` now.
 
 ## Success Criteria
 
@@ -744,3 +749,5 @@ These decisions should be made before implementation planning:
   the same state composition rules.
 - Disconnect and uninstall are separate user actions with separate persistence semantics.
 - Workspace-local install is consistently workspace-local, not creator-private.
+- Product/API/DB names use template, install, workspace state, and grant; there is no
+  `catalog` or `override` compatibility surface.

--- a/docs/superpowers/specs/2026-05-15-mcp-management-four-layer-design.md
+++ b/docs/superpowers/specs/2026-05-15-mcp-management-four-layer-design.md
@@ -412,7 +412,7 @@ Outcome:
 Introduce one conceptual service as the only source of truth:
 
 ```text
-EffectiveConnectorService.list_for_workspace_user(
+MCPEffectiveConnectorService.list_for_workspace_user(
   org_id,
   workspace_id,
   user_id,
@@ -624,29 +624,36 @@ Avoid using "catalog" or "override" in UI.
 Because the product has not shipped, implementation should move directly to
 the target schema instead of layering compatibility names on top of old tables:
 
-| Concept | Target Table |
-| --- | --- |
-| `ConnectorTemplate` | `connector_templates` |
-| `ConnectorInstall` | `connector_installs` |
-| `WorkspaceConnectorState` | `workspace_connector_states` |
-| `CredentialGrant` | `credential_grants` |
+Implementation naming uses one explicit MCP prefix:
+
+- Python model/repository/service classes use `MCP...`.
+- Database tables use `mcp_...`.
+- Product copy can still use the shorter nouns: template, install, workspace state,
+  and grant.
+
+| Concept | Python Model | Target Table |
+| --- | --- | --- |
+| `ConnectorTemplate` | `MCPConnectorTemplate` | `mcp_connector_templates` |
+| `ConnectorInstall` | `MCPConnectorInstall` | `mcp_connector_installs` |
+| `WorkspaceConnectorState` | `MCPWorkspaceConnectorState` | `mcp_workspace_connector_states` |
+| `CredentialGrant` | `MCPCredentialGrant` | `mcp_credential_grants` |
 
 Existing MCP tables (`mcp_catalog_connectors`, `mcp_servers`,
 `workspace_mcp_overrides`, `workspace_mcp_credentials`, `user_mcp_credentials`) are
 implementation history, not product model. The implementation plan may use destructive
 migration for local/dev data, because there is no released external contract.
 
-Org, workspace, and user grants should all be rows in `credential_grants`. The
-credential vault remains the secret storage layer; `credential_grants.credential_id`
-and `credential_grants.refresh_credential_id` point to vault rows.
+Org, workspace, and user grants should all be rows in `mcp_credential_grants`. The
+credential vault remains the secret storage layer; `mcp_credential_grants.credential_id`
+and `mcp_credential_grants.refresh_credential_id` point to vault rows.
 
 ## Implementation Strategy
 
 ### Phase 1: Target Schema And Domain Names
 
 - Create target tables for templates, installs, workspace states, and grants.
-- Replace old model class names with `ConnectorTemplate`, `ConnectorInstall`,
-  `WorkspaceConnectorState`, and `CredentialGrant`.
+- Replace old model class names with `MCPConnectorTemplate`, `MCPConnectorInstall`,
+  `MCPWorkspaceConnectorState`, and `MCPCredentialGrant`.
 - Replace catalog/override repositories and services with template/install/state/grant
   repositories and services.
 
@@ -737,7 +744,7 @@ These decisions are resolved for the first implementation:
    distributable?
    Recommended answer: add an org install policy later; v1 can allow enable for all org installs.
 4. Should org grant stay on `mcp_servers.credential_id` short-term?
-   Recommended answer: no. Use unified `credential_grants` now.
+   Recommended answer: no. Use unified `mcp_credential_grants` now.
 
 ## Success Criteria
 


### PR DESCRIPTION
## Summary

- Adds the **MCP Management Four-Layer Design** spec — replaces the current
  `catalog` / `server` / `override` model with four clear nouns: connector
  templates, connector installs, workspace connector states, and credential
  grants. Single source of runtime truth becomes the effective-connector
  service.
- Adds the **implementation plan** for the redesign. Plan is written at the
  design-level — fields, contracts, route inventory, invariants, test
  contracts — not as code to be copy-pasted by a subagent.
- Defines the MCP public-ID prefixes (`mctpl`, `mcins`, `mcwcs`, `mcgrn`) and
  table names (`mcp_connector_templates`, …).

Plan highlights worth a careful review:

- Migration uses `alembic revision --autogenerate`, then patches three things
  autogen cannot infer (partial unique index, four CHECK constraints,
  destructive downgrade).
- New org-only repository base (not `ScopedRepository[T]` — installs/grants
  have nullable `workspace_id`/`user_id` so they can't use `OrgScopedMixin`).
- Full grant surface per spec (POST/DELETE org/workspace/me + oauth/start at
  every scope). Plan explicitly forbids cross-scope fall-back.
- OAuth callback alignment is folded into the routes task — it must write to
  the new grant table and recover scope from the state token.
- Backend E2E covers all 8 spec scenarios including A/B user isolation,
  policy-change scope flip, disconnect, uninstall+reinstall, OAuth refresh,
  and invalid policy rejection.
- Frontend i18n keys: both locales updated together (CI parity check runs
  on every commit since `884920a0`); old `mcpCatalog.*` / `mcpOverride*`
  keys are removed.

## Spec

`docs/superpowers/specs/2026-05-15-mcp-management-four-layer-design.md`

## Plan

`docs/superpowers/plans/2026-05-16-mcp-management-four-layer.md`

## Test plan

- [ ] Review spec for product-model coherence (template / install / workspace
      state / grant separation; reason matrix completeness).
- [ ] Review plan for design-level granularity (no full code dumps; contracts
      are clear enough for a fresh subagent to execute).
- [ ] Confirm migration approach matches `backend/CLAUDE.md` autogenerate
      rule.
- [ ] Confirm route inventory matches the spec's API shape (methods,
      scopes, missing `oauth/start` endpoints).
- [ ] Confirm E2E task covers all 8 spec scenarios.