### PR TITLE
fix(web/mcp): match Installed row layout to Available (description + inline provider badge)

### DIFF
--- a/frontend/packages/web/components/mcp/MCPConnectorList.tsx
+++ b/frontend/packages/web/components/mcp/MCPConnectorList.tsx
@@ -155,11 +155,16 @@ export function MCPConnectorList({
           >
             <div className="flex items-center gap-2">
               <span className="truncate text-sm font-semibold">{nameOf(c)}</span>
+              {providerOf(c) ? (
+                <Badge variant="outline" className="shrink-0 text-[10px]">
+                  {providerOf(c)}
+                </Badge>
+              ) : null}
               <StatusPill connector={c} />
             </div>
-            {providerOf(c) && (
-              <p className="truncate text-xs text-muted-foreground">{providerOf(c)}</p>
-            )}
+            {c.template?.description ? (
+              <p className="line-clamp-1 text-xs text-muted-foreground">{c.template.description}</p>
+            ) : null}
             <div className="flex flex-wrap items-center gap-1 pt-0.5">
               <Badge variant="outline" className="px-1.5 text-[10px]">
                 {c.install.install_scope === 'org' ? t('scopeOrg') : t('scopeWorkspace')}

--- a/frontend/packages/web/components/workspace-settings/McpPanel.tsx
+++ b/frontend/packages/web/components/workspace-settings/McpPanel.tsx
@@ -107,6 +107,7 @@ function ConnectorRow({
   const t = useTranslations('mcpAdmin')
   const name = connector.install.name || connector.template?.name || connector.install.install_id
   const provider = connector.template?.provider ?? ''
+  const description = connector.template?.description ?? ''
   return (
     <button
       type="button"
@@ -123,11 +124,18 @@ function ConnectorRow({
       <div className="flex items-center gap-2">
         <Plug className="size-3.5 shrink-0 text-muted-foreground" />
         <span className="truncate text-sm font-semibold">{name}</span>
+        {provider ? (
+          <Badge variant="outline" className="shrink-0 text-[10px]">
+            {provider}
+          </Badge>
+        ) : null}
         <span className="ml-auto shrink-0">
           <StatusPill status={statusOf(connector)} />
         </span>
       </div>
-      {provider && <p className="truncate text-xs text-muted-foreground">{provider}</p>}
+      {description ? (
+        <p className="line-clamp-1 text-xs text-muted-foreground">{description}</p>
+      ) : null}
       <div className="flex flex-wrap items-center gap-1 pt-0.5">
         <Badge variant="outline" className="px-1.5 text-[10px]">
           {connector.install.install_scope === 'org' ? t('scopeOrg') : t('scopeWorkspace')}


### PR DESCRIPTION
## Summary

Side-by-side Installed and Available rows in the workspace MCP page looked
uneven after #116 — Available rows had a one-line description and an inline
provider badge, Installed rows had neither. Admin page's row had the same
gap.

Two parity fixes (one commit per page):

- `054438f7` — workspace `ConnectorRow` adds description + moves provider
  to an inline outline badge.
- `dff6bf01` — admin `MCPConnectorList` row gets the same treatment.

## Test plan

- [x] frontend type-check + vitest green.
- [x] manual smoke on `/admin/mcp` and `/w/{ws}/settings?tab=mcp` — Installed and Available rows now read identically.