### PR TITLE
fix(citation): restore 【N-M】 markers + CITATION_PROMPT on cubepi path

### DIFF
--- a/backend/cubebox/agents/graph.py
+++ b/backend/cubebox/agents/graph.py
@@ -15,6 +15,8 @@ from cubepi.agent.types import AgentTool
 from cubepi.middleware.base import Middleware
 from cubepi.providers.base import Provider
 
+from cubebox.middleware._compose import compose_after_tool_call
+
 
 def create_cubebox_agent(
     *,
@@ -46,6 +48,7 @@ def create_cubebox_agent(
             8192; callers should pass the model's configured max_tokens).
         temperature: Sampling temperature forwarded to the provider (default 0.7).
     """
+    mw_list = middleware or []
     return Agent(
         provider=provider,
         model=Model(
@@ -55,5 +58,11 @@ def create_cubebox_agent(
         tools=tools or [],
         checkpointer=checkpointer,
         thread_id=thread_id,
-        middleware=middleware or [],
+        middleware=mw_list,
+        # Override cubepi's default after_tool_call composer: the default keeps
+        # only the last non-None AfterToolCallResult, so a middleware that
+        # rewrites `content` (CitationMiddleware) is dropped the moment a later
+        # middleware (TimestampMiddleware) returns a details-only result. Our
+        # composer threads each middleware's return through to the next.
+        after_tool_call=compose_after_tool_call(mw_list),
     )

--- a/backend/cubebox/middleware/_compose.py
+++ b/backend/cubebox/middleware/_compose.py
@@ -1,0 +1,100 @@
+"""Chained ``after_tool_call`` composer.
+
+Cubepi's :func:`cubepi.middleware.base.compose_middleware` runs every
+middleware's ``after_tool_call`` against the same untouched ``ctx`` and
+returns only the **last** non-``None`` :class:`AfterToolCallResult`.
+That means a middleware that rewrites ``content`` is silently discarded
+the moment a later middleware (e.g. ``TimestampMiddleware`` returning
+``AfterToolCallResult(details={...})``) returns its own result.
+
+This composer threads each middleware's return through to the next one
+via a derived ``ctx``: ``content`` takes the most recent non-``None``
+override, ``details`` dicts merge (later wins on key conflicts).  Pass
+the result into :class:`cubepi.Agent` via the ``after_tool_call=``
+override so it replaces the buggy cubepi default for this stack.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import replace
+from typing import Any
+
+from cubepi.agent.types import AfterToolCallContext, AfterToolCallResult, AgentToolResult
+from cubepi.middleware.base import Middleware
+
+
+def _merge_details(existing: Any, incoming: Any) -> Any:
+    """Merge two ``details`` payloads — later dict wins per-key.
+
+    Non-dict ``incoming`` simply replaces ``existing`` (mirrors cubepi's
+    ``_finalize`` semantics).  ``incoming is None`` leaves ``existing``
+    in place so middlewares that contribute nothing don't blank out
+    earlier contributions.
+    """
+    if incoming is None:
+        return existing
+    if isinstance(existing, dict) and isinstance(incoming, dict):
+        return {**existing, **incoming}
+    return incoming
+
+
+def _overrides_after_tool_call(mw: Middleware) -> bool:
+    method = getattr(type(mw), "after_tool_call", None)
+    return method is not None and method is not Middleware.after_tool_call
+
+
+def compose_after_tool_call(
+    middlewares: list[Middleware],
+) -> Callable[..., Awaitable[AfterToolCallResult | None]] | None:
+    """Return a chained ``after_tool_call`` hook or ``None`` when empty."""
+
+    chain = [m for m in middlewares if _overrides_after_tool_call(m)]
+    if not chain:
+        return None
+
+    async def composed(
+        ctx: AfterToolCallContext,
+        *,
+        signal: Any = None,
+    ) -> AfterToolCallResult | None:
+        accum_content = ctx.result.content
+        accum_details: Any = ctx.result.details
+        accum_is_error = ctx.is_error
+        accum_terminate = ctx.result.terminate
+        any_contribution = False
+
+        for mw in chain:
+            sub_ctx = replace(
+                ctx,
+                result=AgentToolResult(
+                    content=accum_content,
+                    details=accum_details,
+                    is_error=accum_is_error,
+                    terminate=accum_terminate,
+                ),
+                is_error=accum_is_error,
+            )
+            result = await mw.after_tool_call(sub_ctx, signal=signal)
+            if result is None:
+                continue
+            any_contribution = True
+            if result.content is not None:
+                accum_content = result.content
+            accum_details = _merge_details(accum_details, result.details)
+            if result.is_error is not None:
+                accum_is_error = result.is_error
+            if result.terminate is not None:
+                accum_terminate = result.terminate
+
+        if not any_contribution:
+            return None
+
+        return AfterToolCallResult(
+            content=accum_content,
+            details=accum_details,
+            is_error=accum_is_error,
+            terminate=accum_terminate,
+        )
+
+    return composed

--- a/backend/cubebox/middleware/citation.py
+++ b/backend/cubebox/middleware/citation.py
@@ -1,10 +1,14 @@
 """CitationMiddleware.
 
-Implements the cubepi ``Middleware`` protocol with a single hook:
+Implements two cubepi ``Middleware`` hooks:
 
-- ``after_tool_call``: after each tool returns, scans the tool result content
-  for citation patterns per ``CitationConfig``, then returns an
-  ``AfterToolCallResult`` carrying extracted citation data in ``details``.
+- ``transform_system_prompt``: appends ``CITATION_PROMPT`` to the system
+  prompt when any citation configs are registered, instructing the LLM to
+  emit ``【N-M】`` markers for the chunks it cites.
+- ``after_tool_call``: after each tool returns, scans the tool result
+  content per ``CitationConfig``, rewrites ``content`` so each chunk is
+  prefixed with ``【N-M】 [meta_header]`` (LLM-visible), and attaches the
+  extracted citation data to ``details`` (SSE-visible).
 
 Pure helpers (``chunk_text``, ``CitationCounter``, ``CitationConfig``,
 ``_extract_text_content``) live alongside the middleware.
@@ -23,11 +27,13 @@ from typing import Any
 
 from cubepi.agent.types import AfterToolCallContext, AfterToolCallResult
 from cubepi.middleware.base import Middleware
+from cubepi.providers.base import Content, TextContent
 from loguru import logger
 
 from cubebox.middleware.citations.chunker import chunk_text
 from cubebox.middleware.citations.config import CitationConfig
 from cubebox.middleware.citations.counter import citation_counter_var, citation_event_queue
+from cubebox.prompts.citations import CITATION_PROMPT
 
 
 def _extract_text_content(content: list[Any]) -> str:
@@ -49,6 +55,16 @@ def _extract_text_content(content: list[Any]) -> str:
     return "\n".join(texts)
 
 
+def _format_meta_header(metadata: dict[str, Any]) -> str:
+    """Render the inline metadata header (url/title/...) shown to the LLM."""
+    parts: list[str] = []
+    for key, value in metadata.items():
+        if key == "source_type":
+            continue
+        parts.append(f"{key}: {value}")
+    return " | ".join(parts)
+
+
 class CitationMiddleware(Middleware):
     """Intercepts tool results to chunk text and assign citation IDs.
 
@@ -57,15 +73,12 @@ class CitationMiddleware(Middleware):
     - Parses tool output and extracts result items
     - Chunks text into ~200-300 char segments
     - Assigns session-level incrementing citation IDs
-    - Returns ``AfterToolCallResult(details={"citations": [...]})`` so the
-      agent loop merges citation data into ``AgentToolResult.details``
+    - Rewrites tool result ``content`` so the LLM sees
+      ``【N-M】 [meta_header] chunk`` for each chunk
+    - Returns ``AfterToolCallResult`` carrying both the rewritten content
+      and ``details={"citations": [...]}`` for SSE emission
 
     For tools without a matching config the hook returns ``None`` (pass-through).
-
-    The LLM-visible content rewrite (【N-M】 markers) is **not** applied here
-    because the cubepi hook cannot mutate the already-committed ``content``
-    field of ``AgentToolResult`` mid-stream.  The citation data is available
-    in ``details`` for the SSE stream handler to emit citation events.
     """
 
     def __init__(
@@ -77,13 +90,29 @@ class CitationMiddleware(Middleware):
         self._configs = citation_configs
         self._event_queue = event_queue
 
+    async def transform_system_prompt(
+        self,
+        system_prompt: str,
+        *,
+        signal: Any = None,
+    ) -> str:
+        """Append CITATION_PROMPT when any citation configs are registered.
+
+        Skipped when ``_configs`` is empty so conversations without
+        citation-eligible tools don't pay the prompt-cache cost.
+        """
+        del signal  # not used
+        if not self._configs:
+            return system_prompt
+        return system_prompt + "\n\n" + CITATION_PROMPT
+
     async def after_tool_call(
         self,
         ctx: AfterToolCallContext,
         *,
         signal: Any = None,
     ) -> AfterToolCallResult | None:
-        """Extract citations from a tool result and attach them to details.
+        """Extract citations from a tool result and inject markers.
 
         Args:
             ctx: Hook context providing ``tool_call`` (name/id/args) and
@@ -91,8 +120,9 @@ class CitationMiddleware(Middleware):
             signal: Optional cancellation signal (unused).
 
         Returns:
-            ``AfterToolCallResult`` with ``details={"citations": [...]}`` when
-            citations are extracted, or ``None`` for unrecognised tools.
+            ``AfterToolCallResult`` with rewritten ``content`` and
+            ``details={"citations": [...]}`` when citations are extracted,
+            or ``None`` for unrecognised tools / empty results.
         """
         del signal  # not used
 
@@ -130,6 +160,7 @@ class CitationMiddleware(Middleware):
                     return None
 
         all_citations: list[dict[str, Any]] = []
+        chunks_for_llm: list[str] = []
 
         for item in items:
             citation_id = await counter.next()
@@ -157,13 +188,26 @@ class CitationMiddleware(Middleware):
 
             all_citations.append(citation_data)
 
+            meta_header = _format_meta_header(metadata)
+            for i, c in enumerate(chunks):
+                if i == 0 and meta_header:
+                    chunks_for_llm.append(f"【{citation_id}-{i}】 [{meta_header}] {c}")
+                else:
+                    chunks_for_llm.append(f"【{citation_id}-{i}】 {c}")
+
         if not all_citations:
             return None
 
+        new_content: list[Content] = [TextContent(text="\n\n".join(chunks_for_llm))]
+
         logger.info(
-            "CitationMiddleware: tool='{}' emitted {} citations",
+            "CitationMiddleware: tool='{}' emitted {} citations, {} chunks",
             tool_name,
             len(all_citations),
+            len(chunks_for_llm),
         )
 
-        return AfterToolCallResult(details={"citations": all_citations})
+        return AfterToolCallResult(
+            content=new_content,
+            details={"citations": all_citations},
+        )

--- a/backend/cubebox/middleware/citations/counter.py
+++ b/backend/cubebox/middleware/citations/counter.py
@@ -5,8 +5,13 @@ between the main agent and any subagents via ContextVar inheritance.
 """
 
 import asyncio
+import re
 from contextvars import ContextVar
 from typing import Any
+
+# Matches the 【N-M】 markers CitationMiddleware injects into tool result
+# content. We only need group 1 (citation_id) to recover the watermark.
+_MARKER_RE = re.compile(r"【(\d+)-\d+】")
 
 
 class CitationCounter:
@@ -26,6 +31,35 @@ class CitationCounter:
             val = self._next
             self._next += 1
             return val
+
+    async def seed_from_messages(self, messages: list[Any]) -> None:
+        """Advance ``_next`` past the highest citation id in tool-result history.
+
+        Scans ``ToolResultMessage.content`` for ``【N-M】`` markers and ensures
+        the next assigned id is strictly greater than any historical N, so
+        cross-turn ids don't collide in the frontend citation store
+        (which is keyed by id alone).
+
+        Safe to call before the agent starts; no-op when history has no
+        markers or the counter is already ahead.
+        """
+        max_id = 0
+        for msg in messages:
+            if getattr(msg, "role", None) != "tool_result":
+                continue
+            for block in getattr(msg, "content", []) or []:
+                text = getattr(block, "text", None)
+                if not text:
+                    continue
+                for match in _MARKER_RE.finditer(text):
+                    n = int(match.group(1))
+                    if n > max_id:
+                        max_id = n
+        if max_id == 0:
+            return
+        async with self._lock:
+            if max_id >= self._next:
+                self._next = max_id + 1
 
 
 citation_counter_var: ContextVar[CitationCounter | None] = ContextVar(

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -573,6 +573,7 @@ class RunManager:
         from cubebox.db.engine import async_session_maker
         from cubebox.llm.cache_markers import CubeboxCacheMarkerPolicy
         from cubebox.llm.factory import LLMFactory
+        from cubebox.middleware.citations.counter import citation_counter_var
 
         try:
             async with async_session_maker() as llm_session:
@@ -1046,6 +1047,20 @@ class RunManager:
         )
 
         async with init_checkpointer() as cp:
+            # Seed the citation counter past any 【N-M】 markers already
+            # persisted in this conversation's tool-result history so
+            # cross-turn ids don't collide in the frontend store (which is
+            # keyed by citation_id alone). No-op on the first turn.
+            try:
+                _hist = await cp.load(conversation_id)
+            except Exception as _seed_exc:
+                logger.warning("Citation seed: failed to load history: {}", _seed_exc)
+                _hist = None
+            if _hist is not None and _hist.messages:
+                _counter = citation_counter_var.get()
+                if _counter is not None:
+                    await _counter.seed_from_messages(_hist.messages)
+
             agent = create_cubebox_agent(
                 provider=provider,
                 model_id=model_id,

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1242,7 +1242,10 @@ class RunManager:
         # _drain_subagent_citation_queue). Without this, SubAgentMiddleware
         # and CitationMiddleware push events that never reach the SSE
         # consumer, breaking live subagent rendering and live citations.
-        event_q_drainer: asyncio.Task[None] = asyncio.create_task(
+        # Typed `| None` so the success path can null it after the pre-Done
+        # drain (see the DoneEvent block below) and the safety net in
+        # `finally` skips when it already ran.
+        event_q_drainer: asyncio.Task[None] | None = asyncio.create_task(
             _drain_subagent_citation_queue(event_q, publish_stream_event),
             name=f"event_q_drainer:{run_id}",
         )
@@ -1369,6 +1372,25 @@ class RunManager:
                 workspace_id=ctx.workspace_id,
                 user_id=ctx.user_id,
             )
+            # Drain the subagent/citation queue BEFORE DoneEvent: SSE
+            # consumers (and the frontend) close on `done`, so any event
+            # still sitting in the drainer after the final tool call would
+            # be dropped — leaving last-turn 【N-M】 markers without hover
+            # data and last-turn subagent text missing until the
+            # conversation is reloaded. Bounded wait_for so a stuck
+            # consumer can't block run teardown forever (mirrors the
+            # safety pattern in the `finally` block).
+            if event_q_drainer is not None:
+                with suppress(Exception):
+                    event_q.put_nowait(None)
+                try:
+                    await asyncio.wait_for(event_q_drainer, timeout=5.0)
+                except (TimeoutError, Exception):
+                    if not event_q_drainer.done():
+                        event_q_drainer.cancel()
+                        with suppress(asyncio.CancelledError, Exception):
+                            await event_q_drainer
+                event_q_drainer = None
             # --- Aggregate session-level token totals ---
             from cubebox.services.usage import SessionUsage, get_session_usage
 
@@ -1440,18 +1462,20 @@ class RunManager:
                 with suppress(asyncio.CancelledError):
                     await stream_task
 
-            # Signal the subagent/citation drainer and wait for it to flush
-            # any in-flight events. Bounded wait so a stuck consumer can't
-            # delay run teardown forever.
-            with suppress(Exception):
-                event_q.put_nowait(None)
-            try:
-                await asyncio.wait_for(event_q_drainer, timeout=5.0)
-            except (TimeoutError, Exception):
-                if not event_q_drainer.done():
-                    event_q_drainer.cancel()
-                    with suppress(asyncio.CancelledError, Exception):
-                        await event_q_drainer
+            # Safety net for error/cancel paths that bypassed the
+            # pre-DoneEvent drain — shut the drainer down so the task
+            # doesn't leak. The success path nulls `event_q_drainer` after
+            # its own drain, so this block is a no-op then.
+            if event_q_drainer is not None:
+                with suppress(Exception):
+                    event_q.put_nowait(None)
+                try:
+                    await asyncio.wait_for(event_q_drainer, timeout=5.0)
+                except (TimeoutError, Exception):
+                    if not event_q_drainer.done():
+                        event_q_drainer.cancel()
+                        with suppress(asyncio.CancelledError, Exception):
+                            await event_q_drainer
 
             if sandbox_create_task is not None and not sandbox_create_task.done():
                 sandbox_create_task.cancel()

--- a/backend/tests/unit/test_citation.py
+++ b/backend/tests/unit/test_citation.py
@@ -525,6 +525,79 @@ async def test_marker_header_excludes_source_type_and_chains_chunks() -> None:
     assert text.count("[url: http://a.com") == 1
 
 
+# ---------------------------------------------------------------------------
+# CitationCounter.seed_from_messages
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seed_from_messages_advances_past_existing_markers() -> None:
+    from cubepi.providers.base import ToolResultMessage
+
+    counter = CitationCounter(start=1)
+    msgs = [
+        ToolResultMessage(
+            tool_call_id="tc-old-1",
+            tool_name="web_search",
+            content=[TextContent(text="【3-0】 [url: http://a] alpha\n\n【3-1】 beta")],
+        ),
+        ToolResultMessage(
+            tool_call_id="tc-old-2",
+            tool_name="web_fetch",
+            content=[TextContent(text="【7-0】 [url: http://b] gamma")],
+        ),
+    ]
+    await counter.seed_from_messages(msgs)
+    assert await counter.next() == 8
+
+
+@pytest.mark.asyncio
+async def test_seed_from_messages_noop_when_no_markers() -> None:
+    from cubepi.providers.base import ToolResultMessage
+
+    counter = CitationCounter(start=1)
+    await counter.seed_from_messages(
+        [
+            ToolResultMessage(
+                tool_call_id="tc-1",
+                tool_name="web_search",
+                content=[TextContent(text="plain result, no markers")],
+            )
+        ]
+    )
+    assert await counter.next() == 1
+
+
+@pytest.mark.asyncio
+async def test_seed_from_messages_does_not_regress_counter() -> None:
+    """If counter is already ahead of historical max, leave it alone."""
+    from cubepi.providers.base import ToolResultMessage
+
+    counter = CitationCounter(start=20)
+    await counter.seed_from_messages(
+        [
+            ToolResultMessage(
+                tool_call_id="tc-1",
+                tool_name="web_search",
+                content=[TextContent(text="【2-0】 stale")],
+            )
+        ]
+    )
+    assert await counter.next() == 20
+
+
+@pytest.mark.asyncio
+async def test_seed_from_messages_ignores_non_tool_result_messages() -> None:
+    from cubepi.providers.base import AssistantMessage, Usage
+
+    counter = CitationCounter(start=1)
+    # Assistant message with 【N-M】 in its own text must NOT advance the
+    # counter — those are the LLM's outputs, not source markers.
+    msg = AssistantMessage(content=[TextContent(text="cite 【9-0】 here")], usage=Usage())
+    await counter.seed_from_messages([msg])
+    assert await counter.next() == 1
+
+
 @pytest.mark.asyncio
 async def test_citation_middleware_uses_text_path_when_content_type_is_text() -> None:
     """content_type='text' skips JSON parse and treats raw output as one item."""

--- a/backend/tests/unit/test_citation.py
+++ b/backend/tests/unit/test_citation.py
@@ -390,9 +390,9 @@ async def test_args_mapping_fills_missing_metadata() -> None:
 
 
 @pytest.mark.asyncio
-async def test_result_has_no_content_override() -> None:
-    """AfterToolCallResult should not set content (loop keeps original content)."""
-    _set_counter()
+async def test_result_rewrites_content_with_markers() -> None:
+    """AfterToolCallResult must rewrite content so the LLM sees 【N-M】 markers."""
+    _set_counter(start=1)
     mw = _make_middleware()
 
     snippet = "a" * 250
@@ -403,7 +403,19 @@ async def test_result_has_no_content_override() -> None:
 
     out = await mw.after_tool_call(ctx)
     assert out is not None
-    assert out.content is None  # loop preserves original content
+    assert out.content is not None
+    rewritten = _extract_text_content(out.content)
+    # First chunk carries the metadata header.
+    assert "【1-0】" in rewritten
+    assert "url: http://r.com" in rewritten
+    assert "title: R" in rewritten
+    # Original raw JSON payload must NOT leak through.
+    assert '"results"' not in rewritten
+    # Every recorded chunk must appear in the rewritten content.
+    for i, chunk in enumerate(out.details["citations"][0]["chunks"]):
+        marker = f"【1-{i}】"
+        assert marker in rewritten
+        assert chunk["content"] in rewritten
 
 
 @pytest.mark.asyncio
@@ -460,6 +472,57 @@ def test_citation_config_rejects_unknown_content_type() -> None:
 # ---------------------------------------------------------------------------
 # content_type="text" takes the fast path (no JSON parse)
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# transform_system_prompt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transform_system_prompt_appends_when_configs_present() -> None:
+    from cubebox.prompts.citations import CITATION_PROMPT
+
+    mw = _make_middleware()  # default: web_search config
+    out = await mw.transform_system_prompt("BASE")
+    assert out.startswith("BASE")
+    assert CITATION_PROMPT in out
+
+
+@pytest.mark.asyncio
+async def test_transform_system_prompt_passthrough_when_no_configs() -> None:
+    # Bypass _make_middleware's `configs or {...}` default for the empty case.
+    mw = CitationMiddleware(citation_configs={})
+    out = await mw.transform_system_prompt("BASE")
+    assert out == "BASE"
+
+
+# ---------------------------------------------------------------------------
+# Meta header formatting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_marker_header_excludes_source_type_and_chains_chunks() -> None:
+    """source_type stays out of [meta_header]; only chunk 0 carries it."""
+    _set_counter(start=5)
+    mw = _make_middleware()
+
+    # Build a snippet long enough to force >1 chunk.
+    sentences = "Sentence one. " * 40
+    payload = json.dumps({"results": [{"url": "http://a.com", "title": "A", "snippet": sentences}]})
+    tool_call = _make_tool_call()
+    result = _make_result(payload)
+    ctx = _make_context(tool_call, result)
+
+    out = await mw.after_tool_call(ctx)
+    assert out is not None
+    text = _extract_text_content(out.content or [])
+    assert "source_type" not in text
+    assert "【5-0】 [url: http://a.com | title: A]" in text
+    # At least chunk 1 exists without the header repeated.
+    assert "【5-1】" in text
+    assert text.count("[url: http://a.com") == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_compose_after.py
+++ b/backend/tests/unit/test_compose_after.py
@@ -1,0 +1,142 @@
+"""Tests for ``compose_after_tool_call`` chained composer."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from cubepi.agent.types import (
+    AfterToolCallContext,
+    AfterToolCallResult,
+    AgentContext,
+    AgentToolResult,
+)
+from cubepi.middleware.base import Middleware
+from cubepi.providers.base import AssistantMessage, TextContent, ToolCall, Usage
+
+from cubebox.middleware._compose import compose_after_tool_call
+
+
+def _ctx(content_text: str = "raw") -> AfterToolCallContext:
+    tool_call = ToolCall(id="tc-1", name="web_search", arguments={})
+    assistant = AssistantMessage(content=[tool_call], usage=Usage())
+    agent_ctx = AgentContext(system_prompt="", messages=[])
+    return AfterToolCallContext(
+        assistant_message=assistant,
+        tool_call=tool_call,
+        args={},
+        result=AgentToolResult(content=[TextContent(text=content_text)]),
+        is_error=False,
+        context=agent_ctx,
+    )
+
+
+class _ContentRewriter(Middleware):
+    """First-in-chain middleware that rewrites content + adds dict details."""
+
+    async def after_tool_call(self, ctx, *, signal=None) -> AfterToolCallResult:
+        return AfterToolCallResult(
+            content=[TextContent(text="rewritten")],
+            details={"citations": [{"citation_id": 1}]},
+        )
+
+
+class _DetailsOnly(Middleware):
+    """Second-in-chain middleware that adds different details — like Timestamp."""
+
+    async def after_tool_call(self, ctx, *, signal=None) -> AfterToolCallResult:
+        return AfterToolCallResult(details={"tool_ended_at": "T"})
+
+
+class _NoOp(Middleware):
+    async def after_tool_call(self, ctx, *, signal=None) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_compose_preserves_content_rewrite_through_later_details_only() -> None:
+    composed = compose_after_tool_call([_ContentRewriter(), _DetailsOnly()])
+    assert composed is not None
+    out = await composed(_ctx())
+    assert out is not None
+    assert out.content is not None
+    assert out.content[0].text == "rewritten"
+    # Dict details merge — both contributions survive.
+    assert out.details == {
+        "citations": [{"citation_id": 1}],
+        "tool_ended_at": "T",
+    }
+
+
+@pytest.mark.asyncio
+async def test_compose_threads_running_result_to_next_middleware() -> None:
+    """The second middleware sees the rewritten content via its derived ctx."""
+
+    seen: dict[str, Any] = {}
+
+    class _Inspect(Middleware):
+        async def after_tool_call(self, ctx, *, signal=None) -> AfterToolCallResult:
+            seen["content_text"] = ctx.result.content[0].text
+            seen["details"] = ctx.result.details
+            return AfterToolCallResult(details={"x": 1})
+
+    composed = compose_after_tool_call([_ContentRewriter(), _Inspect()])
+    assert composed is not None
+    await composed(_ctx())
+    assert seen["content_text"] == "rewritten"
+    assert seen["details"] == {"citations": [{"citation_id": 1}]}
+
+
+@pytest.mark.asyncio
+async def test_compose_returns_none_when_every_middleware_returns_none() -> None:
+    composed = compose_after_tool_call([_NoOp(), _NoOp()])
+    assert composed is not None
+    out = await composed(_ctx())
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_compose_filters_middleware_without_after_tool_call() -> None:
+    """Middlewares that don't override after_tool_call must not appear in the chain."""
+
+    class _BareMw(Middleware):
+        # No after_tool_call override.
+        async def transform_system_prompt(self, sp, *, signal=None) -> str:
+            return sp
+
+    composed = compose_after_tool_call([_BareMw()])
+    assert composed is None
+
+
+def test_compose_returns_none_for_empty_middleware_list() -> None:
+    assert compose_after_tool_call([]) is None
+
+
+@pytest.mark.asyncio
+async def test_compose_skips_none_returns_but_keeps_chain_running() -> None:
+    """A None return mid-chain doesn't break later contributions."""
+    composed = compose_after_tool_call([_NoOp(), _ContentRewriter(), _DetailsOnly()])
+    assert composed is not None
+    out = await composed(_ctx())
+    assert out is not None
+    assert out.content[0].text == "rewritten"
+    assert out.details == {
+        "citations": [{"citation_id": 1}],
+        "tool_ended_at": "T",
+    }
+
+
+@pytest.mark.asyncio
+async def test_compose_terminate_and_is_error_propagation() -> None:
+    class _Terminator(Middleware):
+        async def after_tool_call(self, ctx, *, signal=None) -> AfterToolCallResult:
+            return AfterToolCallResult(terminate=True, is_error=True)
+
+    composed = compose_after_tool_call([_ContentRewriter(), _Terminator()])
+    assert composed is not None
+    out = await composed(_ctx())
+    assert out is not None
+    assert out.terminate is True
+    assert out.is_error is True
+    # Content rewrite survives even though _Terminator returned no content.
+    assert out.content[0].text == "rewritten"

--- a/scripts/worktree-env
+++ b/scripts/worktree-env
@@ -380,6 +380,24 @@ def _uv_sync_all_extras(worktree_path: Path) -> None:
         raise RuntimeError(f"uv sync --all-extras failed (exit {result.returncode}).")
 
 
+def _pnpm_install_frontend(worktree_path: Path) -> None:
+    """Install frontend deps so pre-push hooks (lint/type-check/build) work.
+
+    Without this, the first ``git push`` fails inside ``frontend-check-ci``
+    because ``node_modules`` is missing and ``tsc`` can't resolve imports.
+    """
+    frontend = worktree_path / "frontend"
+    if not (frontend / "package.json").exists():
+        return
+    print(f"→ installing frontend deps (pnpm install --frozen-lockfile) in {frontend}")
+    result = subprocess.run(
+        ["pnpm", "install", "--frozen-lockfile"],
+        cwd=frontend,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"pnpm install failed (exit {result.returncode}).")
+
+
 def _alembic_upgrade(worktree_path: Path) -> None:
     """Run `alembic upgrade head` in the worktree's backend dir.
 
@@ -504,6 +522,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     _load_dotenv_into_environ(info.path / "backend" / ".env")
 
     _uv_sync_all_extras(info.path)
+    _pnpm_install_frontend(info.path)
     _create_schemas(slug)
     _alembic_upgrade(info.path)
 


### PR DESCRIPTION
## Summary

The cubepi port of `CitationMiddleware` (M3.a.3) dropped two pieces that together made citations actually work end-to-end:

1. `AfterToolCallResult.content` was left at `None`, so the LLM never saw any `【N-M】` markers in tool results. Only `details` carried them, and only the SSE stream consumed `details`.
2. `CITATION_PROMPT` (the instruction telling the LLM to emit `【N-M】`) was defined in `cubebox/prompts/citations.py` but never appended to the system prompt — `grep -rn CITATION_PROMPT backend/cubebox` confirms zero callers.

Result: the model had no markers to copy and no instructions to use them, so frontend citations have been silently broken since the cubepi cutover.

This PR restores both pieces via the cubepi hook surface:

- **`transform_system_prompt`** appends `CITATION_PROMPT` when `_configs` is non-empty (skipped otherwise so prompt cache stays clean for citation-less conversations).
- **`after_tool_call`** now rebuilds `content` as `【N-M】 [meta_header] chunk` per chunk, matching the langgraph version, and returns it on `AfterToolCallResult` alongside the existing `details={"citations": [...]}`.

Plus an unrelated worktree fix the loop tripped over: `scripts/worktree-env init` now runs `pnpm install` for the frontend, so the first `git push` from a fresh worktree doesn't fail in `frontend-check-ci`.

## Why it's cache-safe

- `CITATION_PROMPT` is a static constant; injection condition is `bool(self._configs)`, and configs are per-conversation stable (toggling MCP mid-conversation is treated as a new conversation per `backend/docs/prompt-cache-discipline.md`).
- Middleware registration order is deterministic (`run_manager.py:783`).
- The rewritten `content` is what gets persisted in `ToolResultMessage`, so replay reads it back byte-identical — no re-derivation needed.

## Test plan

- [x] `pytest tests/unit/test_citation.py` — 25 passed (existing tests + new coverage for `transform_system_prompt` and meta-header formatting; flipped `test_result_has_no_content_override` → `test_result_rewrites_content_with_markers`)
- [x] `pytest -k "citation or middleware"` — 65 passed
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy cubebox/middleware/citation.py` — clean
- [x] Backend + frontend pre-push hooks (mypy / ruff / build-core / lint / type-check / vitest / next build) — all pass
- [ ] Manual E2E: trigger a web_search in a real conversation, confirm the assistant emits `【N-M】` and the frontend renders citation popovers