### PR TITLE
fix(streams): restore live subagent + tool_result SSE shape after cubepi migration

### DIFF
--- a/backend/cubebox/agents/stream.py
+++ b/backend/cubebox/agents/stream.py
@@ -20,13 +20,38 @@ from __future__ import annotations
 
 from typing import Any
 
+from cubepi import AgentToolResult
 from cubepi.agent.types import (
     AgentEvent,
     MessageEndEvent,
     MessageUpdateEvent,
     ToolExecutionEndEvent,
 )
-from cubepi.providers.base import AssistantMessage, StreamEvent, ToolCall
+from cubepi.providers.base import AssistantMessage, StreamEvent, TextContent, ToolCall
+
+
+def _stringify_tool_result(result: Any) -> tuple[str, Any]:
+    """Extract a string and details payload from a cubepi tool result.
+
+    ``ToolExecutionEndEvent.result`` is typed ``Any`` but is in practice an
+    ``AgentToolResult`` whose ``content`` is a list of cubepi content blocks
+    (text/image/etc.). The previous implementation forwarded the model
+    object as-is and let downstream ``str()`` produce a Pydantic repr —
+    which broke frontend JSON parsers (e.g. ``save_artifact`` rendering
+    fell through to a regular tool-call card instead of the artifact card).
+
+    We concatenate ``TextContent.text`` blocks and surface
+    ``AgentToolResult.details`` separately so the live SSE shape matches
+    the post-reload one (``ToolResultMessage.details``).
+    """
+    if isinstance(result, AgentToolResult):
+        text = "".join(b.text for b in result.content if isinstance(b, TextContent))
+        return text, result.details
+    if isinstance(result, str):
+        return result, None
+    if result is None:
+        return "", None
+    return str(result), None
 
 
 def convert_event_to_sse(evt: StreamEvent) -> list[dict[str, Any]]:
@@ -89,12 +114,14 @@ def convert_agent_event_to_sse(evt: AgentEvent) -> list[dict[str, Any]]:
         return convert_event_to_sse(evt.stream_event)
 
     if isinstance(evt, ToolExecutionEndEvent):
+        text, details = _stringify_tool_result(evt.result)
         return [
             {
                 "type": "tool_result",
                 "tool_call_id": evt.tool_call_id,
                 "name": evt.tool_name,
-                "result": evt.result,
+                "result": text,
+                "details": details,
                 "is_error": evt.is_error,
             }
         ]

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -186,6 +186,59 @@ async def _drain_cubepi_sse_queue(
         await publish(sse_event, None)
 
 
+async def _drain_subagent_citation_queue(
+    queue: asyncio.Queue[tuple[str, Any, Any] | None],
+    publish: Any,
+) -> None:
+    """Drain (kind, agent_id, payload) tuples and publish typed AgentEvents.
+
+    Counterpart to :func:`_drain_cubepi_sse_queue` for the shared queue that
+    ``SubAgentMiddleware`` and ``CitationMiddleware`` push onto:
+
+    - ``("subagent", agent_id, sse_dict)`` — already-translated cubepi SSE
+      dict produced by ``convert_agent_event_to_sse``. We retranslate via
+      :func:`cubepi_dict_to_agent_event` and stamp the originating subagent
+      ``agent_id`` so the frontend's per-agent stream buckets work.
+    - ``("citation", agent_id, citation_payload)`` — wrapped into a
+      :class:`CitationEvent`.
+
+    Unknown kinds and unmappable subagent dicts are silently dropped.
+    Exits on the ``None`` sentinel.
+
+    Background: when the langgraph dispatch branch was removed in M6.6,
+    the only consumer of this queue went with it; subagent live events
+    accumulated and were discarded at run end. This drainer restores live
+    delivery so the frontend doesn't have to wait for a page reload to
+    see what a subagent did.
+    """
+    while True:
+        item = await queue.get()
+        if item is None:
+            return
+        try:
+            kind, agent_id, payload = item
+        except (TypeError, ValueError):
+            logger.warning("subagent/citation queue produced malformed item: {!r}", item)
+            continue
+
+        timestamp = datetime.now(UTC).isoformat()
+        sse_event: AgentEvent | None = None
+        if kind == "subagent":
+            sse_event = cubepi_dict_to_agent_event(payload, timestamp)
+            if sse_event is not None and agent_id is not None:
+                sse_event.agent_id = agent_id
+        elif kind == "citation":
+            from cubebox.agents.schemas import CitationEvent
+
+            sse_event = CitationEvent(timestamp=timestamp, data=payload, agent_id=agent_id)
+        else:
+            continue
+
+        if sse_event is None:
+            continue
+        await publish(sse_event, agent_id)
+
+
 def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent | None:
     """Translate a single SSE dict produced by ``convert_agent_event_to_sse``
     into a typed cubebox ``AgentEvent``.
@@ -224,6 +277,12 @@ def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent 
             },
         )
     if t == "tool_result":
+        # ``convert_agent_event_to_sse`` extracts a string from cubepi's
+        # ``AgentToolResult`` before the dict reaches this translator; the
+        # ``str()`` here is defensive against unexpected producers and is
+        # a no-op for the expected string case. ``details`` carries
+        # middleware-attached payloads such as ``subagent_events`` so the
+        # live SSE shape matches the post-reload one.
         return ToolResultEvent(
             timestamp=timestamp,
             data={
@@ -231,6 +290,7 @@ def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent 
                 "name": d.get("name", ""),
                 "content": str(d.get("result", "")),
                 "is_error": d.get("is_error", False),
+                "details": d.get("details"),
             },
         )
     if t == "usage":
@@ -1163,6 +1223,15 @@ class RunManager:
                     turn_usage[key] += sse_event.data.get(key, 0)
             await publish_event(sse_event)
 
+        # Drainer for the shared subagent/citation queue (see
+        # _drain_subagent_citation_queue). Without this, SubAgentMiddleware
+        # and CitationMiddleware push events that never reach the SSE
+        # consumer, breaking live subagent rendering and live citations.
+        event_q_drainer: asyncio.Task[None] = asyncio.create_task(
+            _drain_subagent_citation_queue(event_q, publish_stream_event),
+            name=f"event_q_drainer:{run_id}",
+        )
+
         try:
             # Open a long-lived session for the SkillCatalogService — used by
             # both SkillsMiddleware (read prompts) and LazySandbox (push files
@@ -1355,6 +1424,19 @@ class RunManager:
                 stream_task.cancel()
                 with suppress(asyncio.CancelledError):
                     await stream_task
+
+            # Signal the subagent/citation drainer and wait for it to flush
+            # any in-flight events. Bounded wait so a stuck consumer can't
+            # delay run teardown forever.
+            with suppress(Exception):
+                event_q.put_nowait(None)
+            try:
+                await asyncio.wait_for(event_q_drainer, timeout=5.0)
+            except (TimeoutError, Exception):
+                if not event_q_drainer.done():
+                    event_q_drainer.cancel()
+                    with suppress(asyncio.CancelledError, Exception):
+                        await event_q_drainer
 
             if sandbox_create_task is not None and not sandbox_create_task.done():
                 sandbox_create_task.cancel()

--- a/backend/tests/unit/streams/test_drain_event_q.py
+++ b/backend/tests/unit/streams/test_drain_event_q.py
@@ -1,0 +1,182 @@
+"""Unit tests for ``_drain_subagent_citation_queue`` (regression #1).
+
+Regression background: when the langgraph dispatch branch was removed in
+the cubepi cleanup (M6.6), the ``while True: event_q.get()`` consumer
+loop went with it. ``SubAgentMiddleware`` and ``CitationMiddleware`` kept
+pushing tagged tuples onto ``event_q`` (set into both
+``subagent_event_queue`` and ``citation_event_queue`` ContextVars by
+``_execute_run``), but nothing drained them — so subagent live streaming
+and citation live events were silently dropped. They only resurfaced
+after a page reload via the cubepi checkpointer's ``details`` round-trip.
+
+This test pins the contract of the replacement drainer that consumes
+3-tuple items from the shared event queue and forwards typed AgentEvents
+through ``publish_stream_event``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from cubebox.agents.schemas import (
+    CitationEvent,
+    TextDeltaEvent,
+    ToolResultEvent,
+)
+from cubebox.streams.run_manager import _drain_subagent_citation_queue
+
+
+@pytest.mark.asyncio
+async def test_drainer_translates_subagent_item_with_agent_id() -> None:
+    """('subagent', agent_id, sse_dict) → typed AgentEvent carrying agent_id."""
+    queue: asyncio.Queue[tuple[str, Any, Any] | None] = asyncio.Queue()
+    published: list[tuple[Any, str | None]] = []
+
+    async def fake_publish(sse_event: Any, agent_key: str | None) -> None:
+        published.append((sse_event, agent_key))
+
+    drainer = asyncio.create_task(_drain_subagent_citation_queue(queue, fake_publish))
+    queue.put_nowait(
+        (
+            "subagent",
+            "subagent:tc-1",
+            {"type": "text_delta", "delta": "sub says hi", "agent_id": "subagent:tc-1"},
+        )
+    )
+    queue.put_nowait(None)
+    await asyncio.wait_for(drainer, timeout=1.0)
+
+    assert len(published) == 1
+    event, agent_key = published[0]
+    assert isinstance(event, TextDeltaEvent)
+    assert event.data["content"] == "sub says hi"
+    assert event.agent_id == "subagent:tc-1"
+    assert agent_key == "subagent:tc-1"
+
+
+@pytest.mark.asyncio
+async def test_drainer_forwards_subagent_tool_result_with_details() -> None:
+    """Subagent tool_result events round-trip details (so inner save_artifact
+    details survive to the frontend live, not only after reload)."""
+    queue: asyncio.Queue[tuple[str, Any, Any] | None] = asyncio.Queue()
+    published: list[Any] = []
+
+    async def fake_publish(sse_event: Any, _agent_key: str | None) -> None:
+        published.append(sse_event)
+
+    drainer = asyncio.create_task(_drain_subagent_citation_queue(queue, fake_publish))
+    queue.put_nowait(
+        (
+            "subagent",
+            "subagent:tc-9",
+            {
+                "type": "tool_result",
+                "tool_call_id": "inner-tc",
+                "name": "save_artifact",
+                "result": '{"action":"created","artifact":{"id":"art-1"}}',
+                "details": {"foo": "bar"},
+                "is_error": False,
+                "agent_id": "subagent:tc-9",
+            },
+        )
+    )
+    queue.put_nowait(None)
+    await asyncio.wait_for(drainer, timeout=1.0)
+
+    assert len(published) == 1
+    evt = published[0]
+    assert isinstance(evt, ToolResultEvent)
+    assert evt.agent_id == "subagent:tc-9"
+    assert evt.data["details"] == {"foo": "bar"}
+
+
+@pytest.mark.asyncio
+async def test_drainer_wraps_citation_item_into_citation_event() -> None:
+    """('citation', agent_id, citation_data_dict) → CitationEvent."""
+    queue: asyncio.Queue[tuple[str, Any, Any] | None] = asyncio.Queue()
+    published: list[tuple[Any, str | None]] = []
+
+    async def fake_publish(sse_event: Any, agent_key: str | None) -> None:
+        published.append((sse_event, agent_key))
+
+    drainer = asyncio.create_task(_drain_subagent_citation_queue(queue, fake_publish))
+    citation_payload = {
+        "citation_id": 7,
+        "chunks": [{"chunk_index": 0, "content": "snippet"}],
+        "metadata": {"source_type": "web", "url": "https://x"},
+        "tool_call_id": "tc-w",
+    }
+    queue.put_nowait(("citation", None, citation_payload))
+    queue.put_nowait(None)
+    await asyncio.wait_for(drainer, timeout=1.0)
+
+    assert len(published) == 1
+    event, agent_key = published[0]
+    assert isinstance(event, CitationEvent)
+    assert event.data == citation_payload
+    assert event.agent_id is None
+    assert agent_key is None
+
+
+@pytest.mark.asyncio
+async def test_drainer_exits_on_none_sentinel() -> None:
+    """Posting None terminates the drainer cleanly with no publishes."""
+    queue: asyncio.Queue[tuple[str, Any, Any] | None] = asyncio.Queue()
+    published: list[Any] = []
+
+    async def fake_publish(sse_event: Any, _agent_key: str | None) -> None:
+        published.append(sse_event)
+
+    drainer = asyncio.create_task(_drain_subagent_citation_queue(queue, fake_publish))
+    queue.put_nowait(None)
+    await asyncio.wait_for(drainer, timeout=1.0)
+    assert published == []
+
+
+@pytest.mark.asyncio
+async def test_drainer_skips_unknown_kinds() -> None:
+    """Items whose kind is neither 'subagent' nor 'citation' are silently dropped."""
+    queue: asyncio.Queue[tuple[str, Any, Any] | None] = asyncio.Queue()
+    published: list[Any] = []
+
+    async def fake_publish(sse_event: Any, _agent_key: str | None) -> None:
+        published.append(sse_event)
+
+    drainer = asyncio.create_task(_drain_subagent_citation_queue(queue, fake_publish))
+    queue.put_nowait(("unknown_kind", None, {"type": "text_delta", "delta": "x"}))
+    queue.put_nowait(
+        ("subagent", "subagent:tc-2", {"type": "text_delta", "delta": "ok", "agent_id": "x"})
+    )
+    queue.put_nowait(None)
+    await asyncio.wait_for(drainer, timeout=1.0)
+
+    assert len(published) == 1
+    assert isinstance(published[0], TextDeltaEvent)
+    assert published[0].data["content"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_drainer_skips_subagent_dicts_with_unmappable_type() -> None:
+    """Subagent SSE dicts that the cubepi→AgentEvent translator can't map
+    (e.g. tool_call_delta, done) are silently dropped, mirroring
+    _drain_cubepi_sse_queue's behavior for the main agent stream."""
+    queue: asyncio.Queue[tuple[str, Any, Any] | None] = asyncio.Queue()
+    published: list[Any] = []
+
+    async def fake_publish(sse_event: Any, _agent_key: str | None) -> None:
+        published.append(sse_event)
+
+    drainer = asyncio.create_task(_drain_subagent_citation_queue(queue, fake_publish))
+    queue.put_nowait(("subagent", "subagent:tc-3", {"type": "done"}))
+    queue.put_nowait(
+        ("subagent", "subagent:tc-3", {"type": "text_delta", "delta": "after", "agent_id": "x"})
+    )
+    queue.put_nowait(None)
+    await asyncio.wait_for(drainer, timeout=1.0)
+
+    assert len(published) == 1
+    assert isinstance(published[0], TextDeltaEvent)
+    assert published[0].data["content"] == "after"

--- a/backend/tests/unit/test_run_manager_cubepi_dict_to_event.py
+++ b/backend/tests/unit/test_run_manager_cubepi_dict_to_event.py
@@ -48,7 +48,7 @@ def test_tool_result_dict_maps_to_tool_result_event() -> None:
             "type": "tool_result",
             "tool_call_id": "t1",
             "name": "calc",
-            "result": 42,
+            "result": "42",
             "is_error": False,
         },
         TS,
@@ -59,7 +59,27 @@ def test_tool_result_dict_maps_to_tool_result_event() -> None:
         "name": "calc",
         "content": "42",
         "is_error": False,
+        "details": None,
     }
+
+
+def test_tool_result_dict_propagates_details() -> None:
+    """Details (e.g. subagent_events from SubAgentMiddleware's AgentToolResult)
+    must survive to the typed event so the frontend gets the live shape that
+    matches the post-reload one."""
+    evt = cubepi_dict_to_agent_event(
+        {
+            "type": "tool_result",
+            "tool_call_id": "tc-sub",
+            "name": "subagent",
+            "result": "inner final text",
+            "is_error": False,
+            "details": {"subagent_events": [{"type": "text_delta", "delta": "hi"}]},
+        },
+        TS,
+    )
+    assert isinstance(evt, ToolResultEvent)
+    assert evt.data["details"] == {"subagent_events": [{"type": "text_delta", "delta": "hi"}]}
 
 
 def test_usage_dict_maps_to_usage_event() -> None:

--- a/backend/tests/unit/test_stream.py
+++ b/backend/tests/unit/test_stream.py
@@ -1,6 +1,7 @@
 """stream tests — cubepi StreamEvent → cubebox SSE (M1.3)."""
 
-from cubepi.agent.types import MessageEndEvent
+from cubepi import AgentToolResult
+from cubepi.agent.types import MessageEndEvent, ToolExecutionEndEvent
 from cubepi.providers.base import (
     AssistantMessage,
     StreamEvent,
@@ -142,3 +143,75 @@ def test_message_end_with_none_usage_is_dropped() -> None:
     evt = MessageEndEvent(message=msg)
     out = convert_agent_event_to_sse(evt)
     assert out == []
+
+
+# ---------------------------------------------------------------------------
+# convert_agent_event_to_sse — ToolExecutionEndEvent → tool_result
+#
+# Regression: cubepi's ToolExecutionEndEvent.result is an ``AgentToolResult``
+# Pydantic model. The previous implementation forwarded the model object as
+# the SSE dict's ``result`` field; downstream ``str()`` produced a Pydantic
+# repr like ``content=[TextContent(text='{"foo":1}')] details=None ...``
+# which broke frontend JSON.parse and surfaced ``save_artifact`` as a regular
+# tool call card instead of an artifact card during live runs.
+
+
+def test_tool_result_extracts_text_from_agent_tool_result() -> None:
+    """AgentToolResult.content TextContent → string in SSE ``result`` field."""
+    payload = AgentToolResult(content=[TextContent(text='{"action":"created"}')])
+    evt = ToolExecutionEndEvent(tool_call_id="tc-a", tool_name="save_artifact", result=payload)
+    out = convert_agent_event_to_sse(evt)
+    assert len(out) == 1
+    d = out[0]
+    assert d["type"] == "tool_result"
+    assert d["tool_call_id"] == "tc-a"
+    assert d["name"] == "save_artifact"
+    assert d["result"] == '{"action":"created"}'
+    assert d["is_error"] is False
+
+
+def test_tool_result_concatenates_multiple_text_blocks() -> None:
+    """Multiple TextContent blocks concatenate; non-text blocks are dropped."""
+    payload = AgentToolResult(content=[TextContent(text="part-1 "), TextContent(text="part-2")])
+    evt = ToolExecutionEndEvent(tool_call_id="tc-b", tool_name="echo", result=payload)
+    out = convert_agent_event_to_sse(evt)
+    assert out[0]["result"] == "part-1 part-2"
+
+
+def test_tool_result_propagates_details() -> None:
+    """AgentToolResult.details survives to the SSE dict, so frontend gets
+    ``details.subagent_events`` live (matching the reload-from-DB shape)."""
+    payload = AgentToolResult(
+        content=[TextContent(text="inner final")],
+        details={"subagent_events": [{"type": "text_delta", "delta": "hi"}]},
+    )
+    evt = ToolExecutionEndEvent(tool_call_id="tc-c", tool_name="subagent", result=payload)
+    out = convert_agent_event_to_sse(evt)
+    assert out[0]["details"] == {"subagent_events": [{"type": "text_delta", "delta": "hi"}]}
+
+
+def test_tool_result_handles_plain_string_result() -> None:
+    """If a producer ever hands us a plain string instead of AgentToolResult,
+    pass it through unchanged."""
+    evt = ToolExecutionEndEvent(tool_call_id="tc-d", tool_name="raw", result="plain text")
+    out = convert_agent_event_to_sse(evt)
+    assert out[0]["result"] == "plain text"
+    assert out[0]["details"] is None
+
+
+def test_tool_result_handles_none_result() -> None:
+    """None result → empty string + no details, no exception."""
+    evt = ToolExecutionEndEvent(tool_call_id="tc-e", tool_name="silent", result=None)
+    out = convert_agent_event_to_sse(evt)
+    assert out[0]["result"] == ""
+    assert out[0]["details"] is None
+
+
+def test_tool_result_preserves_is_error_flag() -> None:
+    payload = AgentToolResult(content=[TextContent(text="boom")])
+    evt = ToolExecutionEndEvent(
+        tool_call_id="tc-f", tool_name="fail", result=payload, is_error=True
+    )
+    out = convert_agent_event_to_sse(evt)
+    assert out[0]["is_error"] is True
+    assert out[0]["result"] == "boom"


### PR DESCRIPTION
## Summary

Two cubepi-migration regressions both surface as "frontend stops working live, reload brings it back":

1. **Subagent live output never appears.** Inner-agent events are dropped between the middleware and the SSE consumer.
2. **`save_artifact` renders as a regular tool-call card during a live run.** Click → tool-call preview instead of the artifact preview. After reload it renders correctly.

Same root: cubepi's wire shape leaked through translation paths that were never adapted after the langgraph branch was removed.

## Root causes

### #1 — Subagent/citation queue has no consumer

`_execute_run` creates `event_q`, wires it to both `subagent_event_queue` and `citation_event_queue` ContextVars. `SubAgentMiddleware._execute` pushes `("subagent", agent_id, sse_dict)` tuples; `CitationMiddleware` pushes `("citation", None, payload)`. Nothing drains them.

The langgraph cleanup (commit d9c537f7, M6.6) removed the `while True: event_q.get()` loop that used to drain the queue; the cubepi-only path was never given an equivalent. Subagent events still round-trip via `AgentToolResult.details["subagent_events"]` through the cubepi checkpointer, so reload-from-DB works — masking the live regression.

### #2 — `str(AgentToolResult)` in `tool_result` conversion

`ToolExecutionEndEvent.result` is the `AgentToolResult` Pydantic model. `convert_agent_event_to_sse` forwarded it as-is; `cubepi_dict_to_agent_event` then did `str(d.get("result", ""))`, producing a Pydantic repr like `content=[TextContent(text='{"action":"created","artifact":{...}}')] details=None ...`. The frontend's `JSON.parse(toolResult.content)` failed, falling through to the regular `<ToolCallGroup>` render instead of `<ArtifactCard>`.

After reload, the history endpoint serializes via `model_dump(mode="json")`, so `content` is the actual JSON text — masking the live regression.

## Changes

- `cubebox/streams/run_manager.py`:
  - Add `_drain_subagent_citation_queue(queue, publish)` that consumes `(kind, agent_id, payload)` tuples, retranslates subagent dicts via `cubepi_dict_to_agent_event` with `agent_id` stamped, and wraps citation payloads in `CitationEvent`.
  - Spawn the drainer in `_execute_run`; signal `None` + bounded `wait_for(timeout=5.0)` in the `finally` block.
  - Propagate `details` through `cubepi_dict_to_agent_event` into `ToolResultEvent.data`.
- `cubebox/agents/stream.py`: extract `TextContent.text` from `AgentToolResult.content`; surface `result.details` separately on the SSE dict.

## Test plan

- [x] `tests/unit/streams/test_drain_event_q.py` — new file covering the drainer contract (subagent translation + agent_id stamping, citation wrapping, `details` round-trip, `None` sentinel, unknown-kind drop, unmappable-subagent-dict drop).
- [x] `tests/unit/test_stream.py` — new cases for `ToolExecutionEndEvent` covering text extraction, multi-text concat, `details` propagation, plain-string fallback, `None` result, `is_error` preservation.
- [x] `tests/unit/test_run_manager_cubepi_dict_to_event.py` — extend `tool_result` test for the new `details` field; add `test_tool_result_dict_propagates_details`.
- [x] Full unit suite: `pytest tests/unit/ -x` → 571 passed.
- [x] `make check` (backend) → ruff format + lint + mypy clean.
- [ ] Manual smoke: run cubepi path with a real LLM that calls `subagent` + `save_artifact`, verify the artifact card appears live and subagent text streams live.

cc @codex