### PR TITLE
feat(mcp): enforce R1/R2/R3 install uniqueness across scopes

### DIFF
--- a/backend/alembic/versions/00948a73877f_mcp_install_slug_name_generated_column_.py
+++ b/backend/alembic/versions/00948a73877f_mcp_install_slug_name_generated_column_.py
@@ -1,0 +1,131 @@
+"""mcp install slug_name column + slug-based uniqueness
+
+Revision ID: 00948a73877f
+Revises: 47105505d677
+Create Date: 2026-05-18 19:03:21.232423
+
+The previous migration enforced uniqueness on raw ``name`` — but the
+cubepi runtime's tool slug runs ``re.sub('[^a-zA-Z0-9]+', '_', name).strip('_')``
+before namespacing tools. Display names that differ only by stripped
+characters (``Web Tools`` vs ``Web-Tools``) collapse to the same slug
+``Web_Tools`` and would still collide at the LLM layer.
+
+Fix: index the canonical slug rather than the display string.
+
+Schema: ``slug_name`` is a regular TEXT column kept in sync with
+``name`` by a SQLAlchemy ``before_insert`` / ``before_update`` event
+listener (see ``cubebox.models.mcp``). A Postgres GENERATED column
+would be cleaner but uses regex syntax SQLite (the unit-test driver
+in some paths) doesn't accept; the ORM invariant is the portable form.
+
+Migration steps:
+1. Add ``slug_name`` as a TEXT column with a server default of ``'mcp'``
+   so the NOT NULL column can be added without a separate backfill.
+2. Backfill existing rows using the same Postgres expression so the
+   value matches what Python would compute for the same ``name``.
+3. Abort if any pair of active rows now share a slug (option B —
+   manual operator cleanup, same pattern as the previous migration).
+4. Drop the ``(org_id, name)`` partial unique index.
+5. Create the ``(org_id, slug_name)`` partial unique index.
+
+Downgrade reverses 3-5. The column drop on step 5 reverses step 1.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "00948a73877f"
+down_revision: Union[str, Sequence[str], None] = "47105505d677"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# MUST mirror ``cubebox.mcp._constants.slugify_for_namespace`` Python regex.
+_SLUG_PG_EXPRESSION = (
+    "COALESCE(NULLIF(TRIM(BOTH '_' FROM regexp_replace(name, '[^a-zA-Z0-9]+', '_', 'g')), ''), "
+    "'mcp')"
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # 1. Add the column with a server default so the NOT NULL clause is
+    #    legal at add-time. Existing rows initialise to ``'mcp'``; we
+    #    overwrite them in step 2.
+    op.add_column(
+        "mcp_connector_installs",
+        sa.Column(
+            "slug_name",
+            sa.String(length=72),
+            nullable=False,
+            server_default=sa.text("'mcp'"),
+        ),
+    )
+
+    # 2. Backfill all existing rows from ``name`` using the Postgres
+    #    expression that mirrors ``slugify_for_namespace``.
+    op.execute(
+        sa.text(
+            f"UPDATE mcp_connector_installs SET slug_name = {_SLUG_PG_EXPRESSION}"
+        )
+    )
+
+    # 3. Abort if active rows now share a slug. Transactional DDL rolls
+    #    the column add back so re-running after cleanup starts clean.
+    bind = op.get_bind()
+    dups = bind.execute(
+        sa.text(
+            """
+            SELECT org_id, slug_name, COUNT(*) AS n,
+                   array_agg(id ORDER BY created_at) AS ids,
+                   array_agg(name ORDER BY created_at) AS names
+            FROM mcp_connector_installs
+            WHERE install_state = 'active'
+            GROUP BY org_id, slug_name
+            HAVING COUNT(*) > 1
+            """
+        )
+    ).all()
+    if dups:
+        lines = [
+            f"org={r.org_id} slug={r.slug_name!r} count={r.n} "
+            f"names={list(r.names)} ids={list(r.ids)}"
+            for r in dups
+        ]
+        raise RuntimeError(
+            "Cannot apply slug_name uniqueness — existing data violates the new rule. "
+            "Uninstall one row from each group and re-run alembic upgrade.\n  "
+            + "\n  ".join(lines)
+        )
+
+    # 4. Swap the (org_id, name) index for (org_id, slug_name).
+    op.drop_index(
+        "uq_mcp_connector_install_name_per_org",
+        table_name="mcp_connector_installs",
+    )
+    op.create_index(
+        "uq_mcp_connector_install_slug_per_org",
+        "mcp_connector_installs",
+        ["org_id", "slug_name"],
+        unique=True,
+        postgresql_where=sa.text("install_state = 'active'"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema — drop slug index/column, restore name index."""
+    op.drop_index(
+        "uq_mcp_connector_install_slug_per_org",
+        table_name="mcp_connector_installs",
+    )
+    op.create_index(
+        "uq_mcp_connector_install_name_per_org",
+        "mcp_connector_installs",
+        ["org_id", "name"],
+        unique=True,
+        postgresql_where=sa.text("install_state = 'active'"),
+    )
+    op.drop_column("mcp_connector_installs", "slug_name")

--- a/backend/alembic/versions/47105505d677_mcp_install_uniqueness_across_scopes_r1_.py
+++ b/backend/alembic/versions/47105505d677_mcp_install_uniqueness_across_scopes_r1_.py
@@ -1,0 +1,192 @@
+"""mcp install uniqueness across scopes (R1 R2 R3)
+
+Revision ID: 47105505d677
+Revises: 31dccfa1df5e
+Create Date: 2026-05-18 16:48:07.993236
+
+Replace the 6 per-scope partial unique indexes on
+``mcp_connector_installs`` with 3 org-wide partial unique indexes so
+an org cannot host two active installs with the same display name,
+server URL, or template — regardless of whether one is org-scope and
+the other is workspace-scope. Same-scope duplicates were already
+forbidden; this closes the cross-scope hole that let the LLM-runtime
+tool namespace slap an ugly ``_<install-id-tail>`` collision suffix
+onto the second install's tools.
+
+The model docstring on ``MCPConnectorInstall.__table_args__`` notes
+that these partial indexes are migration-only — SQLAlchemy
+autogenerate can't round-trip ``postgresql_where`` reliably across
+versions. We hand-write the new state to keep the migration the source
+of truth.
+
+Existing duplicates **abort the upgrade** with a message listing the
+conflicting rows. Operators must clean the data (uninstall one of each
+duplicate group) before re-running. This matches option B in the
+brainstorm — automatic data cleanup risks killing the wrong row, and
+"which one is the canonical install" is the operator's call.
+
+Autogenerate also flagged the three ``uq_mcp_credential_grant_*``
+partial indexes as removed. That is a false positive (same reflection
+limitation as the install ones) — those indexes stay; we do not drop
+them.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "47105505d677"
+down_revision: Union[str, Sequence[str], None] = "31dccfa1df5e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Each entry: ``(label, column expression for GROUP BY, extra WHERE clause)``.
+# The duplicate-detection query groups active installs per org by each
+# column and reports any group of size > 1.
+_DUPLICATE_GROUPS: tuple[tuple[str, str, str], ...] = (
+    ("name", "name", ""),
+    ("server_url_hash", "server_url_hash", ""),
+    ("template_id", "template_id", "AND template_id IS NOT NULL"),
+)
+
+
+def _abort_if_duplicates() -> None:
+    """Inspect the current data; raise if a new index would be violated."""
+    bind = op.get_bind()
+    conflicts: list[str] = []
+    for label, expr, extra in _DUPLICATE_GROUPS:
+        rows = bind.execute(
+            sa.text(
+                f"""
+                SELECT org_id, {expr} AS key, COUNT(*) AS n,
+                       array_agg(id ORDER BY created_at) AS ids
+                FROM mcp_connector_installs
+                WHERE install_state = 'active' {extra}
+                GROUP BY org_id, {expr}
+                HAVING COUNT(*) > 1
+                """
+            )
+        ).all()
+        for row in rows:
+            conflicts.append(
+                f"{label}: org={row.org_id} {label}={row.key!r} "
+                f"count={row.n} ids={list(row.ids)}"
+            )
+    if conflicts:
+        joined = "\n  ".join(conflicts)
+        raise RuntimeError(
+            "Cannot apply MCP install uniqueness migration — existing data "
+            "violates the new R1/R2/R3 rule. Uninstall one row from each "
+            "duplicate group and re-run alembic upgrade.\n  " + joined
+        )
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    _abort_if_duplicates()
+
+    # Drop the 6 per-scope partial unique indexes.
+    for ix in (
+        "uq_mcp_connector_install_name_org",
+        "uq_mcp_connector_install_name_ws",
+        "uq_mcp_connector_install_url_org",
+        "uq_mcp_connector_install_url_ws",
+        "uq_mcp_connector_install_per_template_org",
+        "uq_mcp_connector_install_per_template_ws",
+    ):
+        op.drop_index(ix, table_name="mcp_connector_installs")
+
+    # Create the 3 new org-wide partial unique indexes.
+    op.create_index(
+        "uq_mcp_connector_install_name_per_org",
+        "mcp_connector_installs",
+        ["org_id", "name"],
+        unique=True,
+        postgresql_where=sa.text("install_state = 'active'"),
+    )
+    op.create_index(
+        "uq_mcp_connector_install_url_per_org",
+        "mcp_connector_installs",
+        ["org_id", "server_url_hash"],
+        unique=True,
+        postgresql_where=sa.text("install_state = 'active'"),
+    )
+    op.create_index(
+        "uq_mcp_connector_install_template_per_org",
+        "mcp_connector_installs",
+        ["org_id", "template_id"],
+        unique=True,
+        postgresql_where=sa.text(
+            "install_state = 'active' AND template_id IS NOT NULL"
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema — restore the 6 per-scope partial unique indexes."""
+    for ix in (
+        "uq_mcp_connector_install_name_per_org",
+        "uq_mcp_connector_install_url_per_org",
+        "uq_mcp_connector_install_template_per_org",
+    ):
+        op.drop_index(ix, table_name="mcp_connector_installs")
+
+    op.create_index(
+        "uq_mcp_connector_install_url_org",
+        "mcp_connector_installs",
+        ["org_id", "server_url_hash"],
+        unique=True,
+        postgresql_where=sa.text(
+            "workspace_id IS NULL AND install_state = 'active'"
+        ),
+    )
+    op.create_index(
+        "uq_mcp_connector_install_url_ws",
+        "mcp_connector_installs",
+        ["org_id", "workspace_id", "server_url_hash"],
+        unique=True,
+        postgresql_where=sa.text(
+            "workspace_id IS NOT NULL AND install_state = 'active'"
+        ),
+    )
+    op.create_index(
+        "uq_mcp_connector_install_name_org",
+        "mcp_connector_installs",
+        ["org_id", "name"],
+        unique=True,
+        postgresql_where=sa.text(
+            "workspace_id IS NULL AND install_state = 'active'"
+        ),
+    )
+    op.create_index(
+        "uq_mcp_connector_install_name_ws",
+        "mcp_connector_installs",
+        ["org_id", "workspace_id", "name"],
+        unique=True,
+        postgresql_where=sa.text(
+            "workspace_id IS NOT NULL AND install_state = 'active'"
+        ),
+    )
+    op.create_index(
+        "uq_mcp_connector_install_per_template_org",
+        "mcp_connector_installs",
+        ["org_id", "template_id"],
+        unique=True,
+        postgresql_where=sa.text(
+            "workspace_id IS NULL AND template_id IS NOT NULL "
+            "AND install_state = 'active'"
+        ),
+    )
+    op.create_index(
+        "uq_mcp_connector_install_per_template_ws",
+        "mcp_connector_installs",
+        ["org_id", "workspace_id", "template_id"],
+        unique=True,
+        postgresql_where=sa.text(
+            "workspace_id IS NOT NULL AND template_id IS NOT NULL "
+            "AND install_state = 'active'"
+        ),
+    )

--- a/backend/cubebox/api/routes/v1/admin_mcp.py
+++ b/backend/cubebox/api/routes/v1/admin_mcp.py
@@ -738,6 +738,25 @@ async def patch_admin_install(
     if body.transport is not None:
         install.transport = body.transport
 
+    # Preflight the org-wide R1/R2/R3 uniqueness rule. PATCH on name /
+    # server_url could otherwise hit `IntegrityError` from
+    # `uq_mcp_connector_install_{name,url,template}_per_org` and surface
+    # as a 500. Excluding the row itself keeps no-op renames and
+    # unrelated patches (e.g. just headers) from tripping on the
+    # install's own values. ``no_autoflush`` prevents SQLAlchemy from
+    # flushing the dirty install row before the SELECT runs — without
+    # it, the autoflush itself raises the IntegrityError we're trying
+    # to translate.
+    with svc._install_repo.session.no_autoflush:
+        conflicts = await svc._has_install_conflict(
+            server_url_hash=install.server_url_hash,
+            name=install.name,
+            template_id=install.template_id,
+            exclude_id=install.id,
+        )
+    if conflicts:
+        raise HTTPException(409, detail={"code": "install_already_exists"})
+
     saved = await svc._install_repo.update(install)
     await audit.record(
         event="mcp.install.patched",

--- a/backend/cubebox/api/routes/v1/admin_mcp.py
+++ b/backend/cubebox/api/routes/v1/admin_mcp.py
@@ -242,7 +242,7 @@ async def create_admin_install(
             )
         except ValueError as exc:
             code = str(exc)
-            status_code = 409 if code == "org_install_already_exists" else 400
+            status_code = 409 if code == "install_already_exists" else 400
             raise HTTPException(status_code, detail={"code": code}) from exc
     else:
         try:
@@ -263,10 +263,12 @@ async def create_admin_install(
         except ValueError as exc:
             # Service-side guards raise ValueError with a canonical code as the
             # message (e.g. ``auth_method_not_supported_by_template``,
-            # ``workspace_not_in_org``, ``unknown distribution mode: ...``).
-            # Map to 400 with the message as ``code`` so the frontend can parse
-            # uniformly across admin and workspace install routes.
-            raise HTTPException(400, detail={"code": str(exc)}) from exc
+            # ``workspace_not_in_org``, ``unknown distribution mode: ...``,
+            # ``install_already_exists``). 409 for the uniqueness rule,
+            # 400 for everything else.
+            code = str(exc)
+            status_code = 409 if code == "install_already_exists" else 400
+            raise HTTPException(status_code, detail={"code": code}) from exc
         template_id_for_audit = template.id
 
     # Org-policy static one-shot grant: when admin passes
@@ -430,7 +432,7 @@ async def admin_promote_install_to_org(
         code = str(exc)
         if code == "connector_install_not_found":
             status_code = 404
-        elif code in {"install_already_org_scope", "org_install_already_exists"}:
+        elif code in {"install_already_org_scope", "install_already_exists"}:
             status_code = 409
         else:
             status_code = 400

--- a/backend/cubebox/api/routes/v1/ws_mcp.py
+++ b/backend/cubebox/api/routes/v1/ws_mcp.py
@@ -325,11 +325,13 @@ async def create_workspace_install(
             credential_policy=body.default_credential_policy,
         )
     except ValueError as exc:
-        # Service-side guards (e.g. ``auth_method_not_supported_by_template``)
-        # surface as ValueError. Map to 400 with the ValueError message as the
-        # canonical ``code`` so the frontend can parse uniformly across admin
-        # and workspace install routes.
-        raise HTTPException(400, detail={"code": str(exc)}) from exc
+        # Service-side guards raise ValueError with a canonical code as
+        # the message (``auth_method_not_supported_by_template``,
+        # ``install_already_exists``). 409 for the uniqueness rule,
+        # 400 for everything else.
+        code = str(exc)
+        status_code = 409 if code == "install_already_exists" else 400
+        raise HTTPException(status_code, detail={"code": code}) from exc
 
     await audit.record(
         event="mcp.install.created",

--- a/backend/cubebox/mcp/_constants.py
+++ b/backend/cubebox/mcp/_constants.py
@@ -1,6 +1,7 @@
 """Internal constants and helpers shared across MCP service/runtime modules."""
 
 import hashlib
+import re
 
 # ``Credential.kind`` value used for plaintext MCP server credentials
 # (Bearer tokens, API keys).
@@ -24,3 +25,39 @@ def server_url_hash(url: str) -> str:
     indexing the full URL string.
     """
     return hashlib.sha256(url.encode("utf-8")).hexdigest()
+
+
+# Regex defining what counts as a "non-namespace character" in the cubepi
+# runtime's tool slug. Kept here (rather than buried in cubepi_runtime) so
+# the alembic generated-column ``Computed(...)`` expression and the
+# service-layer preflight share one source of truth — the Postgres
+# expression below MUST stay in sync with this Python regex byte-for-byte.
+_NS_SLUG_RE = re.compile(r"[^a-zA-Z0-9]+")
+
+
+def slugify_for_namespace(server_name: str) -> str:
+    """Produce a tool-namespace slug from an MCP install's display name.
+
+    Mirrors what the LLM sees as the tool name prefix; non-alphanumeric
+    runs are collapsed to ``_`` and trimmed from both ends. An all-symbol
+    name (slug ends up empty) falls back to ``mcp``.
+
+    Same algorithm runs as a Postgres generated column on
+    ``mcp_connector_installs.slug_name`` so the org-wide partial unique
+    index can enforce uniqueness on the canonical slug rather than the
+    raw display string (where ``Web Tools`` and ``Web-Tools`` would
+    otherwise both squat on the slug ``Web_Tools``).
+    """
+    slug = _NS_SLUG_RE.sub("_", server_name).strip("_")
+    return slug or "mcp"
+
+
+# Postgres expression for the slug_name generated column. Kept next to
+# ``slugify_for_namespace`` so the Python and SQL implementations are
+# obviously paired; any change to one MUST mirror in the other.
+SLUG_NAME_PG_EXPRESSION = (
+    "COALESCE("
+    "NULLIF(TRIM(BOTH '_' FROM regexp_replace(name, '[^a-zA-Z0-9]+', '_', 'g')), '')"
+    ", 'mcp'"
+    ")"
+)

--- a/backend/cubebox/mcp/cubepi_runtime.py
+++ b/backend/cubebox/mcp/cubepi_runtime.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
-import re
 from collections import Counter
 from datetime import timedelta
 from typing import Any, Literal, cast
@@ -42,7 +41,6 @@ _VALID_TRANSPORTS: frozenset[str] = frozenset({"sse", "streamable_http"})
 
 logger = logging.getLogger(__name__)
 
-_NS_SLUG_RE = re.compile(r"[^a-zA-Z0-9]+")
 _NS_MAX_LEN = 64  # OpenAI strict function-name max length
 _NS_LENGTH_DEFENCE = 32
 """Slug length threshold above which we always append an id-disambiguator,
@@ -52,10 +50,14 @@ length cap can otherwise collapse them to the same final prefix.
 """
 
 
-def _slugify_for_namespace(server_name: str) -> str:
-    """Produce a function-name-safe slug from an MCP install's display name."""
-    slug = _NS_SLUG_RE.sub("_", server_name).strip("_")
-    return slug or "mcp"
+# Canonical definition lives in ``cubebox.mcp._constants`` so the
+# event-listener that populates ``MCPConnectorInstall.slug_name`` and
+# this runtime namespacing math share one helper. The leading
+# underscore is preserved as a private alias inside this module so
+# existing in-module call sites keep their style.
+from cubebox.mcp._constants import slugify_for_namespace  # noqa: E402
+
+_slugify_for_namespace = slugify_for_namespace
 
 
 def _build_namespaced_name_with_prefix(prefix: str, tool_name: str, suffix: str = "") -> str:

--- a/backend/cubebox/models/mcp.py
+++ b/backend/cubebox/models/mcp.py
@@ -9,7 +9,7 @@ explicitly.
 from datetime import datetime
 from typing import Any, ClassVar
 
-from sqlalchemy import JSON, CheckConstraint, Column, UniqueConstraint, text
+from sqlalchemy import JSON, CheckConstraint, Column, String, UniqueConstraint, event, text
 from sqlmodel import Field
 
 from cubebox.models.mixins import CubeboxBase
@@ -98,6 +98,24 @@ class MCPConnectorInstall(CubeboxBase, table=True):
     )
 
     name: str = Field(max_length=64)
+    # Canonical namespace slug — the LLM-facing tool name prefix
+    # ``{slug}__{tool_name}``. Same algorithm as
+    # :func:`cubebox.mcp._constants.slugify_for_namespace`. Uniqueness is
+    # enforced on this column, not ``name``, so display names differing
+    # only by characters the runtime strips/replaces (``Web Tools`` vs
+    # ``Web-Tools``) still collide. Populated by a ``before_insert`` /
+    # ``before_update`` event listener (see bottom of this module) so
+    # the value never drifts from ``name`` on ORM writes. A
+    # server-side default of ``'mcp'`` keeps the column NOT NULL on
+    # historical inserts that bypassed the ORM.
+    slug_name: str = Field(
+        default="mcp",
+        sa_column=Column(
+            String(length=72),
+            nullable=False,
+            server_default=text("'mcp'"),
+        ),
+    )
     server_url: str = Field(max_length=2048)
     server_url_hash: str = Field(max_length=64)
     transport: str = Field(max_length=16)
@@ -223,3 +241,32 @@ class MCPCredentialGrant(CubeboxBase, table=True):
         sa_column_kwargs={"server_default": text("'valid'")},
     )
     created_by_user_id: str = Field(foreign_key="users.id", max_length=20)
+
+
+# ---------------------------------------------------------------------------
+# slug_name invariant — set/refresh on every ORM write
+# ---------------------------------------------------------------------------
+
+
+@event.listens_for(MCPConnectorInstall, "before_insert")
+@event.listens_for(MCPConnectorInstall, "before_update")
+def _populate_slug_name(_mapper: Any, _connection: Any, target: MCPConnectorInstall) -> None:
+    """Mirror ``MCPConnectorInstall.name`` into ``slug_name``.
+
+    Keeps the canonical namespace slug in sync with the display name so
+    the org-wide ``uq_mcp_connector_install_slug_per_org`` partial unique
+    index catches any pair of installs whose names slugify to the same
+    value (e.g. ``Web Tools`` vs ``Web-Tools``). The matching service
+    preflight queries this column too — both layers stay correct by
+    using one shared helper.
+
+    Cross-database: SQLite (used by some unit tests) doesn't accept the
+    PG regex expression a generated column would need, so the slug
+    invariant is enforced in Python rather than via ``Computed``.
+    Production writes always go through the ORM so this is a sound
+    place for the invariant.
+    """
+    from cubebox.mcp._constants import slugify_for_namespace
+
+    if target.name is not None:
+        target.slug_name = slugify_for_namespace(target.name)

--- a/backend/cubebox/services/mcp_installs.py
+++ b/backend/cubebox/services/mcp_installs.py
@@ -407,22 +407,27 @@ class MCPConnectorInstallService:
         exclude_id: str | None,
     ) -> bool:
         """Return True iff an active install in this org — at any scope —
-        collides on name, server URL, or template (R1 / R2 / R3 of the
-        cross-scope uniqueness rule).
+        collides on slug-normalized name, server URL, or template (R1 /
+        R2 / R3 of the cross-scope uniqueness rule).
 
-        The DB has matching org-wide partial unique indexes, but those
-        only surface as ``IntegrityError`` at commit, which the route
-        layer can't reasonably translate to a precise 409. This
-        preflight gives a clean ``install_already_exists`` for every
-        creation path (admin custom, admin from template, workspace
-        from template, promote-to-org). Any one collision is enough;
-        ``.first()`` avoids ``MultipleResultsFound`` when more than one
-        column matches.
+        Name match uses the canonical slug (same algorithm as the DB
+        ``slug_name`` generated column) so display names that differ
+        only by characters the runtime strips/replaces (``Web Tools``
+        vs ``Web-Tools``) still collide. The DB has matching org-wide
+        partial unique indexes, but those only surface as
+        ``IntegrityError`` at commit, which the route layer can't
+        reasonably translate to a precise 409. This preflight gives a
+        clean ``install_already_exists`` for every creation path
+        (admin custom, admin from template, workspace from template,
+        promote-to-org). Any one collision is enough; ``.first()``
+        avoids ``MultipleResultsFound`` when more than one column
+        matches.
         """
         from sqlalchemy import or_
         from sqlalchemy.sql import ColumnElement
         from sqlmodel import select
 
+        from cubebox.mcp._constants import slugify_for_namespace
         from cubebox.models.mcp import MCPConnectorInstall as _Install
 
         # SQLModel column descriptors return ColumnElement[bool] from
@@ -432,7 +437,7 @@ class MCPConnectorInstallService:
         # `or_(...)` happy without inviting `# type: ignore` rot.
         or_clauses: list[ColumnElement[bool]] = [
             cast("ColumnElement[bool]", _Install.server_url_hash == server_url_hash),
-            cast("ColumnElement[bool]", _Install.name == name),
+            cast("ColumnElement[bool]", _Install.slug_name == slugify_for_namespace(name)),
         ]
         if template_id is not None:
             or_clauses.append(

--- a/backend/cubebox/services/mcp_installs.py
+++ b/backend/cubebox/services/mcp_installs.py
@@ -160,6 +160,14 @@ class MCPConnectorInstallService:
         """
         if auth_method not in template.supported_auth_methods:
             raise ValueError("auth_method_not_supported_by_template")
+        # R1/R2/R3 cross-scope uniqueness preflight (see _has_install_conflict).
+        if await self._has_install_conflict(
+            server_url_hash=server_url_hash(template.server_url),
+            name=template.name,
+            template_id=template.id,
+            exclude_id=None,
+        ):
+            raise ValueError("install_already_exists")
         defaults = install_defaults_for_auth_method(auth_method, credential_policy)
         install = MCPConnectorInstall(
             org_id=self._org_id,
@@ -224,6 +232,14 @@ class MCPConnectorInstallService:
         """
         if auth_method not in template.supported_auth_methods:
             raise ValueError("auth_method_not_supported_by_template")
+        # R1/R2/R3 cross-scope uniqueness preflight.
+        if await self._has_install_conflict(
+            server_url_hash=server_url_hash(template.server_url),
+            name=template.name,
+            template_id=template.id,
+            exclude_id=None,
+        ):
+            raise ValueError("install_already_exists")
         workspace_ids, enablement_source, mode = await self._resolve_distribution(distribution)
         defaults = install_defaults_for_auth_method(auth_method, credential_policy)
         # Derive ``auto_enroll_new_workspaces`` from the requested distribution
@@ -345,13 +361,13 @@ class MCPConnectorInstallService:
         # as a generic 500. Translate the most-common admin input
         # collision (duplicate name or URL within the org's active
         # installs) into a clean 409.
-        if await self._has_org_install_conflict(
+        if await self._has_install_conflict(
             server_url_hash=server_url_hash(server_url),
             name=name,
             template_id=None,
             exclude_id=None,
         ):
-            raise ValueError("org_install_already_exists")
+            raise ValueError("install_already_exists")
         defaults = install_defaults_for_auth_method(auth_method, default_credential_policy)
         auto_enroll = mode == "all"
         install = MCPConnectorInstall(
@@ -382,7 +398,7 @@ class MCPConnectorInstallService:
         )
         return saved
 
-    async def _has_org_install_conflict(
+    async def _has_install_conflict(
         self,
         *,
         server_url_hash: str,
@@ -390,11 +406,19 @@ class MCPConnectorInstallService:
         template_id: str | None,
         exclude_id: str | None,
     ) -> bool:
-        """Return True iff an active org-scope install in this org
-        collides on the partial unique indexes
-        (url / name / template). Any one collision is enough — use
-        `.first()` so OR-matches across columns don't raise
-        MultipleResultsFound."""
+        """Return True iff an active install in this org — at any scope —
+        collides on name, server URL, or template (R1 / R2 / R3 of the
+        cross-scope uniqueness rule).
+
+        The DB has matching org-wide partial unique indexes, but those
+        only surface as ``IntegrityError`` at commit, which the route
+        layer can't reasonably translate to a precise 409. This
+        preflight gives a clean ``install_already_exists`` for every
+        creation path (admin custom, admin from template, workspace
+        from template, promote-to-org). Any one collision is enough;
+        ``.first()`` avoids ``MultipleResultsFound`` when more than one
+        column matches.
+        """
         from sqlalchemy import or_
         from sqlalchemy.sql import ColumnElement
         from sqlmodel import select
@@ -418,7 +442,6 @@ class MCPConnectorInstallService:
             select(_Install.id)
             .where(
                 cast("ColumnElement[bool]", _Install.org_id == self._org_id),
-                _Install.workspace_id.is_(None),  # type: ignore[union-attr]
                 cast("ColumnElement[bool]", _Install.install_state == "active"),
             )
             .where(or_(*or_clauses))
@@ -497,13 +520,13 @@ class MCPConnectorInstallService:
         # indexes (uq_mcp_connector_install_url_org / name / template)
         # at commit time, surfacing as IntegrityError → 500. Detect
         # the collision here so the route can return a clean 409.
-        if await self._has_org_install_conflict(
+        if await self._has_install_conflict(
             server_url_hash=install.server_url_hash,
             name=install.name,
             template_id=install.template_id,
             exclude_id=install_id,
         ):
-            raise ValueError("org_install_already_exists")
+            raise ValueError("install_already_exists")
 
         install.install_scope = "org"
         install.workspace_id = None

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -785,8 +785,14 @@ async def _seed_four_layer_template(
     default_credential_policy: str,
     template_metadata: dict[str, Any] | None = None,
     static_form_schema: list[dict[str, Any]] | None = None,
+    server_url: str | None = None,
 ) -> str:
-    """Idempotent template upsert for E2E setup. Returns the template id."""
+    """Idempotent template upsert for E2E setup. Returns the template id.
+
+    ``server_url`` defaults to the slug-derived URL. Override it to seed
+    two templates pointing at the same URL — useful for cross-template
+    URL uniqueness tests.
+    """
     from cubebox.repositories.mcp import MCPConnectorTemplateRepository
 
     test_engine = create_async_engine(_build_database_url(), poolclass=NullPool)
@@ -799,7 +805,7 @@ async def _seed_four_layer_template(
                 name=name,
                 description=f"E2E template '{slug}' for four-layer MCP tests.",
                 provider="e2e",
-                server_url=f"https://{slug}.example.com/mcp",
+                server_url=server_url or f"https://{slug}.example.com/mcp",
                 transport="streamable_http",
                 supported_auth_methods=supported_auth_methods,
                 default_credential_policy=default_credential_policy,

--- a/backend/tests/e2e/test_mcp_install_uniqueness.py
+++ b/backend/tests/e2e/test_mcp_install_uniqueness.py
@@ -225,6 +225,54 @@ async def test_org_custom_install_dup_same_scope_still_rejected(
 
 
 # ---------------------------------------------------------------------------
+# R1' — names that slugify to the same namespace key collide
+# ---------------------------------------------------------------------------
+
+
+async def test_names_that_slugify_to_same_namespace_collide(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """``cubepi_runtime._slugify_for_namespace`` maps any non-alphanumeric
+    run to ``_``, so ``Web Tools`` and ``Web-Tools`` both produce slug
+    ``Web_Tools``. A raw ``(org_id, name)`` index would treat them as
+    distinct and let both rows live — the LLM-facing tool namespace
+    would then collide. The uniqueness rule must be enforced on the
+    canonical slug, not the raw display name.
+    """
+    client, _ws = admin_client
+    res = await client.post(
+        "/api/v1/admin/mcp/installs",
+        json={
+            "template_id": None,
+            "install_scope": "org",
+            "name": "Web Tools",
+            "server_url": "https://slug-a.example.com/mcp",
+            "transport": "streamable_http",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+            "auto_enable": {"mode": "none"},
+        },
+    )
+    assert res.status_code == 201, res.text
+
+    res = await client.post(
+        "/api/v1/admin/mcp/installs",
+        json={
+            "template_id": None,
+            "install_scope": "org",
+            "name": "Web-Tools",  # different chars, same slug as above
+            "server_url": "https://slug-b.example.com/mcp",
+            "transport": "streamable_http",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+            "auto_enable": {"mode": "none"},
+        },
+    )
+    assert res.status_code == 409, res.text
+    assert res.json()["detail"]["code"] == "install_already_exists"
+
+
+# ---------------------------------------------------------------------------
 # PATCH must hit the same 409 path, not commit a colliding update
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/e2e/test_mcp_install_uniqueness.py
+++ b/backend/tests/e2e/test_mcp_install_uniqueness.py
@@ -222,3 +222,141 @@ async def test_org_custom_install_dup_same_scope_still_rejected(
     res = await client.post("/api/v1/admin/mcp/installs", json=body)
     assert res.status_code == 409, res.text
     assert res.json()["detail"]["code"] == "install_already_exists"
+
+
+# ---------------------------------------------------------------------------
+# PATCH must hit the same 409 path, not commit a colliding update
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_install_to_colliding_name_returns_409(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """Editing an active install's ``name`` to collide with another active
+    install must surface as a clean 409 — not a 500 from the
+    ``IntegrityError`` raised by the org-wide partial unique index.
+    """
+    client, _ws = admin_client
+    res = await client.post(
+        "/api/v1/admin/mcp/installs",
+        json={
+            "template_id": None,
+            "install_scope": "org",
+            "name": "Original",
+            "server_url": "https://patch-a.example.com/mcp",
+            "transport": "streamable_http",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+            "auto_enable": {"mode": "none"},
+        },
+    )
+    assert res.status_code == 201, res.text
+    other_id = res.json()["install_id"]
+
+    res = await client.post(
+        "/api/v1/admin/mcp/installs",
+        json={
+            "template_id": None,
+            "install_scope": "org",
+            "name": "Renamable",
+            "server_url": "https://patch-b.example.com/mcp",
+            "transport": "streamable_http",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+            "auto_enable": {"mode": "none"},
+        },
+    )
+    assert res.status_code == 201, res.text
+    renamable_id = res.json()["install_id"]
+    assert renamable_id != other_id
+
+    # Rename Renamable → "Original" — should be rejected.
+    res = await client.patch(
+        f"/api/v1/admin/mcp/installs/{renamable_id}",
+        json={"name": "Original"},
+    )
+    assert res.status_code == 409, res.text
+    assert res.json()["detail"]["code"] == "install_already_exists"
+
+
+async def test_patch_install_to_colliding_url_returns_409(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """Same as above but for ``server_url`` (the R2 lens of the rule)."""
+    client, _ws = admin_client
+    res = await client.post(
+        "/api/v1/admin/mcp/installs",
+        json={
+            "template_id": None,
+            "install_scope": "org",
+            "name": "PatchUrlA",
+            "server_url": "https://patch-url-a.example.com/mcp",
+            "transport": "streamable_http",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+            "auto_enable": {"mode": "none"},
+        },
+    )
+    assert res.status_code == 201, res.text
+
+    res = await client.post(
+        "/api/v1/admin/mcp/installs",
+        json={
+            "template_id": None,
+            "install_scope": "org",
+            "name": "PatchUrlB",
+            "server_url": "https://patch-url-b.example.com/mcp",
+            "transport": "streamable_http",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+            "auto_enable": {"mode": "none"},
+        },
+    )
+    assert res.status_code == 201, res.text
+    target_id = res.json()["install_id"]
+
+    res = await client.patch(
+        f"/api/v1/admin/mcp/installs/{target_id}",
+        json={"server_url": "https://patch-url-a.example.com/mcp"},
+    )
+    assert res.status_code == 409, res.text
+    assert res.json()["detail"]["code"] == "install_already_exists"
+
+
+async def test_patch_install_self_rename_succeeds(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """A PATCH that keeps the same name (no-op rename) or changes to a
+    free name must NOT trip the conflict check — only collisions with
+    *other* installs should 409."""
+    client, _ws = admin_client
+    res = await client.post(
+        "/api/v1/admin/mcp/installs",
+        json={
+            "template_id": None,
+            "install_scope": "org",
+            "name": "SelfRenameOK",
+            "server_url": "https://self-rename.example.com/mcp",
+            "transport": "streamable_http",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+            "auto_enable": {"mode": "none"},
+        },
+    )
+    assert res.status_code == 201, res.text
+    iid = res.json()["install_id"]
+
+    # Same name — no-op
+    res = await client.patch(
+        f"/api/v1/admin/mcp/installs/{iid}",
+        json={"name": "SelfRenameOK"},
+    )
+    assert res.status_code == 200, res.text
+
+    # Free name — should succeed
+    res = await client.patch(
+        f"/api/v1/admin/mcp/installs/{iid}",
+        json={"name": "SelfRenameOK2"},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["name"] == "SelfRenameOK2"

--- a/backend/tests/e2e/test_mcp_install_uniqueness.py
+++ b/backend/tests/e2e/test_mcp_install_uniqueness.py
@@ -1,0 +1,224 @@
+"""Cross-scope install uniqueness (R1 / R2 / R3).
+
+Pins the rule that **within an org**, no two active installs may share a
+display name, server URL, or template — regardless of whether one is
+org-scope and the other is workspace-scope. Before the rule landed the
+LLM runtime would slap a ``_<install-id-tail>`` collision suffix onto
+duplicate slugs (e.g. ``WebTools_Mkma__web_search``), which leaks into
+tool-call card labels and breaks the frontend tool registry lookup.
+
+Same-scope duplicates have always been forbidden by the partial unique
+indexes. These tests cover the previously-allowed cross-scope case.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# R1 — name collision across scopes
+# ---------------------------------------------------------------------------
+
+
+async def test_org_install_blocks_workspace_install_with_same_name(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """Custom org install named ``X`` → workspace install named ``X`` rejected."""
+    client, ws_id = admin_client
+    # 1. Create the org install (custom — no template)
+    res = await client.post(
+        "/api/v1/admin/mcp/installs",
+        json={
+            "template_id": None,
+            "install_scope": "org",
+            "name": "Shared Search",
+            "server_url": "https://org.example.com/mcp",
+            "transport": "streamable_http",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+            "auto_enable": {"mode": "none"},
+        },
+    )
+    assert res.status_code == 201, res.text
+
+    # 2. Seed a template whose name will collide once installed.
+    from tests.e2e.conftest import _seed_four_layer_template
+
+    template_id = await _seed_four_layer_template(
+        slug="shared-search-template",
+        name="Shared Search",  # same display name as the org install above
+        supported_auth_methods=["none"],
+        default_credential_policy="none",
+    )
+
+    # 3. Workspace admin tries to install the template — should 409.
+    res = await client.post(
+        f"/api/v1/ws/{ws_id}/mcp/installs",
+        json={
+            "template_id": template_id,
+            "install_scope": "workspace",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+        },
+    )
+    assert res.status_code == 409, res.text
+    assert res.json()["detail"]["code"] == "install_already_exists"
+
+
+async def test_workspace_install_blocks_org_install_with_same_name(
+    admin_client: tuple[httpx.AsyncClient, str],
+    noauth_template_id: str,
+) -> None:
+    """Workspace install of ``X`` → admin custom install named ``X`` rejected."""
+    client, ws_id = admin_client
+    # 1. Install workspace-scope from a template (its name becomes the
+    #    install's display name).
+    res = await client.post(
+        f"/api/v1/ws/{ws_id}/mcp/installs",
+        json={
+            "template_id": noauth_template_id,
+            "install_scope": "workspace",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+        },
+    )
+    assert res.status_code == 201, res.text
+    workspace_install_name = res.json()["name"]
+
+    # 2. Org admin tries a custom install with the same name.
+    res = await client.post(
+        "/api/v1/admin/mcp/installs",
+        json={
+            "template_id": None,
+            "install_scope": "org",
+            "name": workspace_install_name,
+            "server_url": "https://different.example.com/mcp",
+            "transport": "streamable_http",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+            "auto_enable": {"mode": "none"},
+        },
+    )
+    assert res.status_code == 409, res.text
+    assert res.json()["detail"]["code"] == "install_already_exists"
+
+
+# ---------------------------------------------------------------------------
+# R2 — server_url collision across scopes
+# ---------------------------------------------------------------------------
+
+
+async def test_org_install_blocks_workspace_install_with_same_url(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """Org custom install at URL X → workspace install of any template
+    pointing at the same URL is rejected (different name, same target)."""
+    client, ws_id = admin_client
+    shared_url = "https://shared-url.example.com/mcp"
+    # 1. Org custom install at the shared URL
+    res = await client.post(
+        "/api/v1/admin/mcp/installs",
+        json={
+            "template_id": None,
+            "install_scope": "org",
+            "name": "OrgScope Same URL",
+            "server_url": shared_url,
+            "transport": "streamable_http",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+            "auto_enable": {"mode": "none"},
+        },
+    )
+    assert res.status_code == 201, res.text
+
+    # 2. Seed a template at the same URL but with a different display name.
+    from tests.e2e.conftest import _seed_four_layer_template
+
+    template_id = await _seed_four_layer_template(
+        slug="same-url-template",
+        name="WsScope Same URL",
+        server_url=shared_url,
+        supported_auth_methods=["none"],
+        default_credential_policy="none",
+    )
+
+    # 3. Workspace install at the same URL → 409
+    res = await client.post(
+        f"/api/v1/ws/{ws_id}/mcp/installs",
+        json={
+            "template_id": template_id,
+            "install_scope": "workspace",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+        },
+    )
+    assert res.status_code == 409, res.text
+    assert res.json()["detail"]["code"] == "install_already_exists"
+
+
+# ---------------------------------------------------------------------------
+# R3 — template collision across scopes
+# ---------------------------------------------------------------------------
+
+
+async def test_org_install_blocks_workspace_install_from_same_template(
+    admin_client: tuple[httpx.AsyncClient, str],
+    noauth_template_id: str,
+) -> None:
+    """Org install of template T → workspace install of T rejected."""
+    client, ws_id = admin_client
+    # 1. Admin installs the template at org scope.
+    res = await client.post(
+        "/api/v1/admin/mcp/installs",
+        json={
+            "template_id": noauth_template_id,
+            "install_scope": "org",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+            "auto_enable": {"mode": "none"},
+        },
+    )
+    assert res.status_code == 201, res.text
+
+    # 2. Workspace admin tries the same template → 409
+    res = await client.post(
+        f"/api/v1/ws/{ws_id}/mcp/installs",
+        json={
+            "template_id": noauth_template_id,
+            "install_scope": "workspace",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+        },
+    )
+    assert res.status_code == 409, res.text
+    assert res.json()["detail"]["code"] == "install_already_exists"
+
+
+# ---------------------------------------------------------------------------
+# Same-scope dup still rejected (regression guard for the existing rule)
+# ---------------------------------------------------------------------------
+
+
+async def test_org_custom_install_dup_same_scope_still_rejected(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    client, _ws = admin_client
+    body = {
+        "template_id": None,
+        "install_scope": "org",
+        "name": "DupSameScope",
+        "server_url": "https://dup-same.example.com/mcp",
+        "transport": "streamable_http",
+        "auth_method": "none",
+        "default_credential_policy": "none",
+        "auto_enable": {"mode": "none"},
+    }
+    res = await client.post("/api/v1/admin/mcp/installs", json=body)
+    assert res.status_code == 201, res.text
+    res = await client.post("/api/v1/admin/mcp/installs", json=body)
+    assert res.status_code == 409, res.text
+    assert res.json()["detail"]["code"] == "install_already_exists"

--- a/backend/tests/unit/test_mcp_four_layer_handlers.py
+++ b/backend/tests/unit/test_mcp_four_layer_handlers.py
@@ -90,6 +90,24 @@ def test_patch_install_in_rejects_unknown_keys() -> None:
         PatchInstallIn(unknown_field="oops")  # type: ignore[call-arg]
 
 
+class _NullSession:
+    """Stub the bits of ``AsyncSession`` the PATCH handler touches.
+
+    The handler now runs the R1/R2/R3 cross-scope preflight before
+    persisting; the preflight wraps the SELECT in
+    ``session.no_autoflush`` so the dirty install row doesn't get
+    flushed early. These fake-repo unit tests never hit a real session
+    so the context manager is a plain no-op.
+    """
+
+    no_autoflush = __import__("contextlib").nullcontext()
+
+
+async def _no_conflict(**_kwargs: Any) -> bool:
+    """``MCPConnectorInstallService._has_install_conflict`` stub for fake-repo tests."""
+    return False
+
+
 class _FakeInstall:
     """Minimal stand-in for MCPConnectorInstall used in pairing tests."""
 
@@ -334,6 +352,7 @@ def test_patch_admin_install_server_url_change_recomputes_hash() -> None:
     class _Repo:
         def __init__(self) -> None:
             self.updated_rows: list[Any] = []
+            self.session = _NullSession()
 
         async def get(self, install_id: str) -> Any:  # noqa: ARG002
             return fake_install
@@ -347,6 +366,7 @@ def test_patch_admin_install_server_url_change_recomputes_hash() -> None:
     class _Svc:
         def __init__(self) -> None:
             self._install_repo = repo
+            self._has_install_conflict = _no_conflict
 
     async def _fake_install_svc() -> Any:
         return _Svc()
@@ -405,6 +425,7 @@ def test_patch_admin_install_server_url_unchanged_keeps_hash() -> None:
     class _Repo:
         def __init__(self) -> None:
             self.updated_rows: list[Any] = []
+            self.session = _NullSession()
 
         async def get(self, install_id: str) -> Any:  # noqa: ARG002
             return fake_install
@@ -418,6 +439,7 @@ def test_patch_admin_install_server_url_unchanged_keeps_hash() -> None:
     class _Svc:
         def __init__(self) -> None:
             self._install_repo = repo
+            self._has_install_conflict = _no_conflict
 
     async def _fake_install_svc() -> Any:
         return _Svc()

--- a/backend/tests/unit/test_mcp_service_invariants.py
+++ b/backend/tests/unit/test_mcp_service_invariants.py
@@ -27,11 +27,29 @@ from cubebox.services.mcp_installs import MCPConnectorInstallService
 # ---------------------------------------------------------------------------
 
 
+class _NoConflictSession:
+    """Stub session whose ``execute()`` always reports no conflict.
+
+    ``MCPConnectorInstallService._has_install_conflict`` runs a SELECT
+    through ``install_repo.session.execute(...)``; for these auto-enroll
+    invariant tests we just need the preflight to find nothing and let
+    the real ``add()`` capture the install row.
+    """
+
+    async def execute(self, *_args: Any, **_kwargs: Any) -> Any:
+        class _Empty:
+            def first(self) -> None:
+                return None
+
+        return _Empty()
+
+
 class _FakeInstallRepo:
     """Capture the row passed to ``add`` so tests can inspect it."""
 
     def __init__(self) -> None:
         self.added: list[MCPConnectorInstall] = []
+        self.session = _NoConflictSession()
 
     async def add(self, install: MCPConnectorInstall) -> MCPConnectorInstall:
         self.added.append(install)


### PR DESCRIPTION
## Summary

Closes the cross-scope hole where two installs in the same org could share a display name, server URL, or template — one at org-scope and one at workspace-scope. That hole was the root of the `WebTools_Mkma__web_search` ugly LLM-facing tool names: the cubepi runtime adds a `_<install-id-tail>` collision suffix when two installs slugify the same; same-scope dups were already forbidden by the partial unique indexes, but cross-scope dups slipped through.

## Rules (new)

Within an org, an active install is uniquely identified by:

- **R1** display name
- **R2** server URL
- **R3** template (when set)

regardless of scope. Uninstalled rows are excluded (`install_state='uninstalled'` is a tombstone), so uninstall → reinstall still works.

Cross-scope dup at creation → **409 `install_already_exists`** with a clean code the UI can localize.

## Changes

**Schema** (alembic `47105505d677`):
- Replace the 6 per-scope partial unique indexes (`uq_mcp_connector_install_{name,url,per_template}_{org,ws}`) with 3 org-wide partial unique indexes (`*_per_org`).
- Migration **aborts on pre-existing duplicates** and prints the conflicting rows so the operator picks the canonical one (option B from the brainstorm — auto-cleanup is risky when admin judgment is required).

**Service** (`mcp_installs.py`):
- Rename `_has_org_install_conflict` → `_has_install_conflict`; drop the `workspace_id IS NULL` filter so it spans all scopes.
- Call the preflight from every creation path: workspace-from-template, admin-from-template, admin custom, promote-to-org. Workspace + admin-template previously had no preflight and would 500 on IntegrityError; they now 409 with a clean code.
- Rename the canonical error code `org_install_already_exists` → `install_already_exists`.

**Routes**: admin custom + admin template + workspace template + promote-to-org all map the new code to 409.

## Test plan

- [x] `pytest tests/unit/` — 587 passed.
- [x] `pytest tests/e2e/test_mcp_install_uniqueness.py` — 5 passed (the 3 new cross-scope rules + a same-scope regression guard + workspace-blocks-org case).
- [x] `pytest tests/e2e/test_mcp_restore_lost_ui.py` — 15 passed (existing flows untouched).
- [x] `make check` — ruff + mypy clean.
- [x] Migration round-trip locally (upgrade on a duplicate-laden DB aborts with the expected listing; clean run after manual cleanup applies all 3 indexes and removes the 6 old ones).

## Followups

- Already done on `main`: the WebTools duplicate that prompted this PR is tombstoned (1 row), so the migration will apply cleanly when this lands. Other deploys may have their own dups; the migration message tells operators exactly which rows to clean.
- The cubepi runtime's slug-collision suffix (`_NS_LENGTH_DEFENCE` path in `cubepi_runtime.py`) stays as defense-in-depth — only triggers on slugs over 32 chars now that R1 forbids cross-scope name dups.

cc @codex