### PR TITLE
feat(tracing): cubepi JSONL tracing in the agent run path

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,3 +3,5 @@
 coverage.xml
 scripts/dev
 skills_cache/
+# cubepi tracing output (default tracing.directory); may contain prompt/tool payloads
+cubepi-traces/

--- a/backend/config.development.yaml
+++ b/backend/config.development.yaml
@@ -29,3 +29,8 @@ development:
   parsers:
     docling_serve:
       base_url: "http://localhost:5001"
+
+  # Tracing on by default in dev so local runs emit trace files.
+  tracing:
+    enabled: true
+    record_content: true

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -293,3 +293,12 @@ default:
     max_summary_tokens: 1024
     min_compact_messages: 4
     fallback_context_window: 64000
+
+  # cubepi agent tracing (OTLP/JSON spans on disk; default off; opt-in per env)
+  # When enabled, each run writes <directory>/<YYYY-MM-DD>/<run_id>.jsonl.
+  tracing:
+    enabled: false
+    directory: "./cubepi-traces"
+    # record_content=true captures full prompts / responses / tool args+results
+    # in the trace — useful for debugging, larger files, may contain sensitive data.
+    record_content: false

--- a/backend/cubebox/agents/tracing.py
+++ b/backend/cubebox/agents/tracing.py
@@ -1,0 +1,42 @@
+"""Build a per-run cubepi Tracer from cubebox config.
+
+Tracing is opt-in via the ``tracing:`` config block. When disabled — or when
+construction fails for any reason — the run proceeds untraced. A tracing fault
+must never break a run, so every failure path returns ``None``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from cubebox.config import config
+
+if TYPE_CHECKING:
+    from cubepi.tracing import Tracer
+
+
+def build_run_tracer() -> Tracer | None:
+    """Return a configured cubepi Tracer, or ``None`` when tracing is disabled.
+
+    Reads ``tracing.enabled`` / ``tracing.directory`` / ``tracing.record_content``
+    from config. Import or construction failures are logged and swallowed.
+    """
+    if not config.get("tracing.enabled", False):
+        return None
+    try:
+        from cubepi.tracing import JsonlSpanExporter, Tracer
+
+        directory = config.get("tracing.directory", "./cubepi-traces")
+        record_content = bool(config.get("tracing.record_content", False))
+        return Tracer(
+            service_name="cubebox",
+            deployment_environment=str(config.get("env", "development")),
+            agent_name="cubebox-agent",
+            exporters=[JsonlSpanExporter(directory=directory)],
+            record_content=record_content,
+        )
+    except Exception as exc:
+        logger.warning("Tracing unavailable, continuing untraced: {}", exc)
+        return None

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import suppress
+from contextlib import AsyncExitStack, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -1130,8 +1130,29 @@ class RunManager:
                 timestamp=_time.time(),
                 metadata=_user_msg_metadata,
             )
+            from cubebox.agents.tracing import build_run_tracer
+
+            tracer = build_run_tracer()
             try:
-                await agent.prompt(_user_msg)
+                async with AsyncExitStack() as _trace_stack:
+                    if tracer is not None:
+                        # LIFO exit: attached() detaches + awaits its flush
+                        # task first, then the tracer's __aexit__ shuts down
+                        # (force_flush + close exporters) — so this run's
+                        # spans are on disk before _run_cubepi_path returns.
+                        # attached().__aenter__ calls Recorder/provider
+                        # subscription work that can raise; isolate it so a
+                        # tracing fault runs the turn untraced rather than
+                        # failing the run.
+                        try:
+                            await _trace_stack.enter_async_context(tracer)
+                            await _trace_stack.enter_async_context(tracer.attached(agent))
+                        except Exception as _trace_exc:
+                            logger.warning(
+                                "Tracing attach failed, continuing untraced: {}", _trace_exc
+                            )
+                            await _trace_stack.aclose()
+                    await agent.prompt(_user_msg)
             finally:
                 # Signal drainer and wait for it to flush remaining events so
                 # all SSE dicts are published before citation buffers flush.

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1132,28 +1132,36 @@ class RunManager:
             )
             from cubebox.agents.tracing import build_run_tracer
 
+            # Tracing is best-effort: neither attach nor flush/shutdown may
+            # break or fail an otherwise-successful run. The AsyncExitStack is
+            # managed manually (not via `async with`) so its exit path —
+            # attached() detach + flush, then Tracer shutdown — can be wrapped
+            # in its own try/except. attached().__aenter__ also does provider/
+            # recorder subscription work that can raise, so the enter is
+            # isolated too; either failure logs and runs the turn untraced.
             tracer = build_run_tracer()
+            _trace_stack = AsyncExitStack()
+            if tracer is not None:
+                try:
+                    # LIFO close: attached() detaches + awaits its flush task
+                    # first, then the tracer's __aexit__ shuts down
+                    # (force_flush + close exporters) — so this run's spans
+                    # are on disk before _run_cubepi_path returns.
+                    await _trace_stack.enter_async_context(tracer)
+                    await _trace_stack.enter_async_context(tracer.attached(agent))
+                except Exception as _trace_exc:
+                    logger.warning("Tracing attach failed, continuing untraced: {}", _trace_exc)
+                    with suppress(Exception):
+                        await _trace_stack.aclose()
             try:
-                async with AsyncExitStack() as _trace_stack:
-                    if tracer is not None:
-                        # LIFO exit: attached() detaches + awaits its flush
-                        # task first, then the tracer's __aexit__ shuts down
-                        # (force_flush + close exporters) — so this run's
-                        # spans are on disk before _run_cubepi_path returns.
-                        # attached().__aenter__ calls Recorder/provider
-                        # subscription work that can raise; isolate it so a
-                        # tracing fault runs the turn untraced rather than
-                        # failing the run.
-                        try:
-                            await _trace_stack.enter_async_context(tracer)
-                            await _trace_stack.enter_async_context(tracer.attached(agent))
-                        except Exception as _trace_exc:
-                            logger.warning(
-                                "Tracing attach failed, continuing untraced: {}", _trace_exc
-                            )
-                            await _trace_stack.aclose()
-                    await agent.prompt(_user_msg)
+                await agent.prompt(_user_msg)
             finally:
+                # Flush + shut down tracing (best-effort; a teardown failure
+                # must not fail the run). aclose() is a no-op if attach failed.
+                try:
+                    await _trace_stack.aclose()
+                except Exception as _trace_exc:
+                    logger.warning("Tracing flush/shutdown failed: {}", _trace_exc)
                 # Signal drainer and wait for it to flush remaining events so
                 # all SSE dicts are published before citation buffers flush.
                 await sse_queue.put(None)

--- a/backend/tests/unit/agents/test_tracing.py
+++ b/backend/tests/unit/agents/test_tracing.py
@@ -1,0 +1,50 @@
+"""Unit tests for the per-run cubepi Tracer factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from cubebox.agents import tracing as tracing_mod
+
+
+def _fake_config(values: dict[str, object]):
+    """Return a stub with a dynaconf-like .get(key, default)."""
+
+    class _Stub:
+        def get(self, key: str, default: object = None) -> object:
+            return values.get(key, default)
+
+    return _Stub()
+
+
+def test_build_run_tracer_disabled_returns_none(monkeypatch):
+    monkeypatch.setattr(tracing_mod, "config", _fake_config({"tracing.enabled": False}))
+    assert tracing_mod.build_run_tracer() is None
+
+
+def test_build_run_tracer_missing_key_defaults_disabled(monkeypatch):
+    # No tracing.enabled key at all -> default False -> None.
+    monkeypatch.setattr(tracing_mod, "config", _fake_config({}))
+    assert tracing_mod.build_run_tracer() is None
+
+
+@pytest.mark.asyncio
+async def test_build_run_tracer_enabled_returns_tracer(monkeypatch, tmp_path):
+    from cubepi.tracing import Tracer
+
+    monkeypatch.setattr(
+        tracing_mod,
+        "config",
+        _fake_config(
+            {
+                "tracing.enabled": True,
+                "tracing.directory": str(tmp_path),
+                "tracing.record_content": True,
+                "env": "development",
+            }
+        ),
+    )
+    tracer = tracing_mod.build_run_tracer()
+    assert isinstance(tracer, Tracer)
+    # Clean up so the BatchSpanProcessor / atexit hook doesn't leak.
+    await tracer.shutdown()

--- a/docs/dev/plans/2026-05-20-cubepi-tracing-jsonl.md
+++ b/docs/dev/plans/2026-05-20-cubepi-tracing-jsonl.md
@@ -1,0 +1,364 @@
+# cubepi JSONL Tracing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Attach cubepi 0.4's `Tracer` + `JsonlSpanExporter` to cubebox's per-run agent so each conversation turn writes an on-disk OTLP/JSON trace, gated behind a new `tracing:` config block.
+
+**Architecture:** A small config-driven factory (`cubebox/agents/tracing.py`) builds a per-run `Tracer` (or returns `None` when disabled / on any failure). `RunManager._run_cubepi_path` wraps `agent.prompt(...)` with the tracer via an `AsyncExitStack`, so attach/detach/flush happen per run with no global state. JSONL files shard by `run_id` automatically.
+
+**Tech Stack:** Python 3.12, cubepi 0.4 (`cubepi.tracing`), dynaconf config, pytest + pytest-asyncio.
+
+Spec: `docs/dev/specs/2026-05-20-cubepi-tracing-jsonl-design.md`.
+
+---
+
+### Task 1: Config-driven Tracer factory
+
+**Files:**
+- Create: `cubebox/agents/tracing.py`
+- Test: `tests/unit/agents/test_tracing.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/agents/test_tracing.py
+"""Unit tests for the per-run cubepi Tracer factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from cubebox.agents import tracing as tracing_mod
+
+
+def _fake_config(values: dict[str, object]):
+    """Return a stub with a dynaconf-like .get(key, default)."""
+
+    class _Stub:
+        def get(self, key: str, default: object = None) -> object:
+            return values.get(key, default)
+
+    return _Stub()
+
+
+def test_build_run_tracer_disabled_returns_none(monkeypatch):
+    monkeypatch.setattr(
+        tracing_mod, "config", _fake_config({"tracing.enabled": False})
+    )
+    assert tracing_mod.build_run_tracer() is None
+
+
+def test_build_run_tracer_missing_key_defaults_disabled(monkeypatch):
+    # No tracing.enabled key at all -> default False -> None.
+    monkeypatch.setattr(tracing_mod, "config", _fake_config({}))
+    assert tracing_mod.build_run_tracer() is None
+
+
+@pytest.mark.asyncio
+async def test_build_run_tracer_enabled_returns_tracer(monkeypatch, tmp_path):
+    from cubepi.tracing import Tracer
+
+    monkeypatch.setattr(
+        tracing_mod,
+        "config",
+        _fake_config(
+            {
+                "tracing.enabled": True,
+                "tracing.directory": str(tmp_path),
+                "tracing.record_content": True,
+                "env": "development",
+            }
+        ),
+    )
+    tracer = tracing_mod.build_run_tracer()
+    assert isinstance(tracer, Tracer)
+    # Clean up so the BatchSpanProcessor / atexit hook doesn't leak.
+    await tracer.shutdown()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/agents/test_tracing.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'cubebox.agents.tracing'` (or `AttributeError: build_run_tracer`).
+
+- [ ] **Step 3: Write the factory**
+
+```python
+# cubebox/agents/tracing.py
+"""Build a per-run cubepi Tracer from cubebox config.
+
+Tracing is opt-in via the ``tracing:`` config block. When disabled — or when
+construction fails for any reason — the run proceeds untraced. A tracing fault
+must never break a run, so every failure path returns ``None``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from cubebox.config import config
+
+if TYPE_CHECKING:
+    from cubepi.tracing import Tracer
+
+
+def build_run_tracer() -> "Tracer | None":
+    """Return a configured cubepi Tracer, or ``None`` when tracing is disabled.
+
+    Reads ``tracing.enabled`` / ``tracing.directory`` / ``tracing.record_content``
+    from config. Import or construction failures are logged and swallowed.
+    """
+    if not config.get("tracing.enabled", False):
+        return None
+    try:
+        from cubepi.tracing import JsonlSpanExporter, Tracer
+
+        directory = config.get("tracing.directory", "./cubepi-traces")
+        record_content = bool(config.get("tracing.record_content", False))
+        return Tracer(
+            service_name="cubebox",
+            deployment_environment=str(config.get("env", "development")),
+            agent_name="cubebox-agent",
+            exporters=[JsonlSpanExporter(directory=directory)],
+            record_content=record_content,
+        )
+    except Exception as exc:
+        logger.warning("Tracing unavailable, continuing untraced: {}", exc)
+        return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/agents/test_tracing.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cubebox/agents/tracing.py tests/unit/agents/test_tracing.py
+git commit -m "feat(tracing): config-driven per-run cubepi Tracer factory"
+```
+
+---
+
+### Task 2: Wire the tracer into the cubepi run path
+
+**Files:**
+- Modify: `cubebox/streams/run_manager.py` (import line ~6; the `agent.prompt(_user_msg)` block ~1133-1139)
+
+- [ ] **Step 1: Extend the contextlib import**
+
+Find (near the top of the file, currently line 6):
+
+```python
+from contextlib import suppress
+```
+
+Replace with:
+
+```python
+from contextlib import AsyncExitStack, suppress
+```
+
+- [ ] **Step 2: Wrap `agent.prompt` with the tracer**
+
+In `_run_cubepi_path`, find this block (currently ~line 1128-1139):
+
+```python
+            _user_msg = _UserMessage(
+                content=[_TextContent(text=content)],
+                timestamp=_time.time(),
+                metadata=_user_msg_metadata,
+            )
+            try:
+                await agent.prompt(_user_msg)
+            finally:
+                # Signal drainer and wait for it to flush remaining events so
+                # all SSE dicts are published before citation buffers flush.
+                await sse_queue.put(None)
+                await drainer
+```
+
+Replace with:
+
+```python
+            _user_msg = _UserMessage(
+                content=[_TextContent(text=content)],
+                timestamp=_time.time(),
+                metadata=_user_msg_metadata,
+            )
+
+            from cubebox.agents.tracing import build_run_tracer
+
+            tracer = build_run_tracer()
+            try:
+                async with AsyncExitStack() as _trace_stack:
+                    if tracer is not None:
+                        # LIFO exit: attached() detaches + awaits its flush
+                        # task first, then the tracer's __aexit__ shuts down
+                        # (force_flush + close exporters) — so this run's
+                        # spans are on disk before _run_cubepi_path returns.
+                        await _trace_stack.enter_async_context(tracer)
+                        await _trace_stack.enter_async_context(tracer.attached(agent))
+                    await agent.prompt(_user_msg)
+            finally:
+                # Signal drainer and wait for it to flush remaining events so
+                # all SSE dicts are published before citation buffers flush.
+                await sse_queue.put(None)
+                await drainer
+```
+
+- [ ] **Step 3: Verify it imports and type-checks**
+
+Run: `uv run mypy cubebox/streams/run_manager.py cubebox/agents/tracing.py`
+Expected: `Success: no issues found`.
+
+- [ ] **Step 4: Run the run-manager unit tests to confirm no regression**
+
+Run: `uv run pytest tests/unit/streams/ -v`
+Expected: PASS (no regressions; tracing is disabled by default in base config so the wrapped path behaves exactly as before).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cubebox/streams/run_manager.py
+git commit -m "feat(tracing): attach per-run cubepi Tracer around agent.prompt"
+```
+
+---
+
+### Task 3: Add the `tracing:` config block
+
+**Files:**
+- Modify: `config.yaml` (after the `compaction:` block, ~line 296)
+- Modify: `config.development.yaml` (alongside other dev overrides)
+
+- [ ] **Step 1: Add the base config block**
+
+In `config.yaml`, after the `compaction:` block (ends ~line 296), add (matching the 2-space `default:` indentation used by `compaction:` / `sandbox:`):
+
+```yaml
+
+  # cubepi agent tracing (OTLP/JSON spans on disk; default off; opt-in per env)
+  # When enabled, each run writes <directory>/<YYYY-MM-DD>/<run_id>.jsonl.
+  tracing:
+    enabled: false
+    directory: "./cubepi-traces"
+    # record_content=true captures full prompts / responses / tool args+results
+    # in the trace — useful for debugging, larger files, may contain sensitive data.
+    record_content: false
+```
+
+- [ ] **Step 2: Add the development overrides**
+
+In `config.development.yaml`, under the `development:` mapping (alongside the
+other dev override blocks such as `sandbox:`), add:
+
+```yaml
+
+  # Tracing on by default in dev so local runs emit trace files.
+  tracing:
+    enabled: true
+    record_content: true
+```
+
+- [ ] **Step 3: Verify config loads and resolves**
+
+Run:
+```bash
+ENV_FOR_DYNACONF=development uv run python -c "from cubebox.config import config; print('enabled=', config.get('tracing.enabled'), 'dir=', config.get('tracing.directory'), 'content=', config.get('tracing.record_content'))"
+```
+Expected: `enabled= True dir= ./cubepi-traces content= True`
+
+Run (base):
+```bash
+ENV_FOR_DYNACONF=production uv run python -c "from cubebox.config import config; print('enabled=', config.get('tracing.enabled', False))"
+```
+Expected: `enabled= False`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config.yaml config.development.yaml
+git commit -m "feat(tracing): add tracing config block (off base, on in dev)"
+```
+
+---
+
+### Task 4: Manual E2E — confirm trace files are emitted
+
+**Files:** none (verification only). Ports from `.worktree.env`: backend `:8038`, frontend `:3038`.
+
+This feature has no deterministic automated assertion surface beyond "a
+well-formed trace file appears," so verification is manual inspection of the
+emitted JSONL (per spec §6).
+
+- [ ] **Step 1: Start the backend (worktree env)**
+
+Run (from the worktree `backend/`):
+```bash
+ENV_FOR_DYNACONF=development uv run python main.py
+```
+Expected: server up on `127.0.0.1:8038`; logs show no tracing errors.
+
+- [ ] **Step 2: Start the frontend (worktree env)**
+
+Run (from the worktree `frontend/`):
+```bash
+pnpm dev
+```
+Expected: Next dev on `:3038` (PORT comes from `.worktree.env` via the wrapper — do not hardcode 3000).
+
+- [ ] **Step 3: Send a chat turn that uses a tool**
+
+Open `http://localhost:3038`, log in, send a prompt that triggers at least one
+tool call (e.g. ask it to run a calculation or read/write a file) so
+`execute_tool` spans are produced.
+
+- [ ] **Step 4: Inspect the emitted trace file**
+
+Run (from the worktree `backend/`):
+```bash
+ls -R cubepi-traces/
+# pick the newest file:
+f=$(ls -t cubepi-traces/*/*.jsonl | head -1); echo "$f"; wc -l "$f"
+```
+Expected: a file at `cubepi-traces/<YYYY-MM-DD>/<run_id>.jsonl` with one JSON
+object per line.
+
+- [ ] **Step 5: Verify span shape and content**
+
+Run:
+```bash
+f=$(ls -t cubepi-traces/*/*.jsonl | head -1)
+uv run python -c "import json,sys; [print(json.loads(l)['name']) for l in open(sys.argv[1])]" "$f" | sort | uniq -c
+```
+Expected: span names include `invoke_agent`, `cubepi.turn`, one or more
+`chat ...` (CLIENT) spans, and `execute_tool ...` for the tool call(s).
+
+Then confirm content recording is on (dev `record_content=true`):
+```bash
+f=$(ls -t cubepi-traces/*/*.jsonl | head -1)
+grep -c "gen_ai.input.messages\|cubepi.llm.raw_request" "$f"
+```
+Expected: a count > 0 (the chat span carries the recorded prompt/request).
+
+- [ ] **Step 6: Note the result in the PR description**
+
+No commit. Capture the `uniq -c` span-name output and paste it into the PR body
+as the verification evidence.
+
+---
+
+## Self-Review
+
+- **Spec coverage:**
+  - §2 integration point → Task 2 (wraps `agent.prompt` in `_run_cubepi_path`). ✓
+  - §3 per-run lifecycle + failure isolation → Task 1 (factory swallows failures) + Task 2 (`AsyncExitStack`, LIFO flush order). ✓
+  - §4 config (`enabled`/`directory`/`record_content`, base off / dev on) → Task 3. ✓
+  - §5 out-of-scope (OTLP/metrics) → not implemented; factory builds only `JsonlSpanExporter`. ✓
+  - §6 testing (manual JSONL inspection) → Task 4. ✓
+- **Placeholder scan:** no TBD/TODO; every code/command step is concrete. ✓
+- **Type consistency:** factory name `build_run_tracer` is used identically in Task 1 (definition) and Task 2 (import + call). `Tracer` / `JsonlSpanExporter` match cubepi's public `cubepi.tracing` exports. ✓

--- a/docs/dev/plans/2026-05-20-cubepi-tracing-jsonl.md
+++ b/docs/dev/plans/2026-05-20-cubepi-tracing-jsonl.md
@@ -200,8 +200,18 @@ Replace with:
                         # task first, then the tracer's __aexit__ shuts down
                         # (force_flush + close exporters) — so this run's
                         # spans are on disk before _run_cubepi_path returns.
-                        await _trace_stack.enter_async_context(tracer)
-                        await _trace_stack.enter_async_context(tracer.attached(agent))
+                        # attached().__aenter__ calls Recorder/provider
+                        # subscription work that can raise; isolate it so a
+                        # tracing fault runs the turn untraced rather than
+                        # failing the run (spec §3).
+                        try:
+                            await _trace_stack.enter_async_context(tracer)
+                            await _trace_stack.enter_async_context(tracer.attached(agent))
+                        except Exception as _trace_exc:
+                            logger.warning(
+                                "Tracing attach failed, continuing untraced: {}", _trace_exc
+                            )
+                            await _trace_stack.aclose()
                     await agent.prompt(_user_msg)
             finally:
                 # Signal drainer and wait for it to flush remaining events so

--- a/docs/dev/specs/2026-05-20-cubepi-tracing-jsonl-design.md
+++ b/docs/dev/specs/2026-05-20-cubepi-tracing-jsonl-design.md
@@ -1,0 +1,117 @@
+# cubepi JSONL Tracing in cubebox — Design
+
+**Date:** 2026-05-20
+**Status:** Approved — ready for implementation plan
+**Scope:** First cut — JSONL exporter only. No OTLP, no metrics/`Meter`.
+
+## 1. Goal
+
+Wire cubepi 0.4's tracing (`cubepi.tracing.Tracer` + `JsonlSpanExporter`)
+into cubebox's agent run path so that each conversation turn produces an
+on-disk OTLP/JSON trace file. Purpose: local debugging — inspect the full
+prompt, model response, per-call timing, token usage, and tool args/results
+of any run after the fact.
+
+cubepi already ships the tracing machinery (dep pinned as
+`cubepi[mcp,postgres,tracing,tracing-otlp]>=0.4.0`). This work is purely the
+cubebox-side integration: build a `Tracer`, attach it to the per-run agent,
+gate it behind config.
+
+## 2. Integration Point
+
+`cubebox/streams/run_manager.py` → `RunManager._run_cubepi_path`.
+
+The agent is built there via `create_cubebox_agent(...)` (~line 1064) and run
+via `await agent.prompt(_user_msg)` (~line 1134). The tracer attaches to that
+agent and wraps the `prompt()` call.
+
+## 3. Lifecycle — per-run Tracer
+
+Build a `Tracer` inside `_run_cubepi_path`, attach to that run's agent, flush
++ shut down per run via cubepi's own context managers:
+
+```python
+from cubepi.tracing import JsonlSpanExporter, Tracer
+
+if tracing_enabled:
+    tracer = Tracer(
+        service_name="cubebox",
+        deployment_environment=<config env>,
+        agent_name="cubebox-agent",
+        exporters=[JsonlSpanExporter(directory=<config dir>)],
+        record_content=<config>,
+    )
+    async with tracer, tracer.attached(agent):
+        await agent.prompt(_user_msg)
+else:
+    await agent.prompt(_user_msg)
+```
+
+`tracer.attached(agent)` (RAII) attaches the recorder on enter and on exit
+runs detach + awaits its flush task; the outer `async with tracer` calls
+`tracer.shutdown()` (flush + close exporters) on exit. Net effect: every run's
+spans are guaranteed written to disk before `_run_cubepi_path` returns.
+
+**Why per-run over a process-level singleton:**
+- Agents are already built per-run here — a per-run tracer matches that grain.
+- `JsonlSpanExporter` shards output by `run_id` on its own, so there is no
+  cross-run file coordination to centralize.
+- `async with` gives a deterministic per-run flush-to-disk with no app-startup
+  wiring and no shared mutable provider across concurrent runs.
+
+**Trade-off accepted:** rebuilds a `TracerProvider` per run. Cost is
+negligible relative to an LLM turn. If it ever matters, promote to a
+process-level `Tracer` (built at app startup, `attach`/`detach` per run) —
+the call-site shape barely changes.
+
+**Failure isolation:** tracer construction / attach is wrapped so a tracing
+fault never breaks a run — on exception, log a warning and run untraced
+(mirrors the existing `try/except` + `logger.warning` pattern used for every
+optional middleware in `_run_cubepi_path`).
+
+## 4. Config
+
+New `tracing:` block. Resolution mirrors the existing `compaction` / `sandbox`
+blocks (read via `config.get("tracing.<key>", <default>)`).
+
+| Key | base (`config.yaml`) | dev (`config.development.yaml`) |
+|---|---|---|
+| `tracing.enabled` | `false` | `true` |
+| `tracing.directory` | `./cubepi-traces` | (inherits) |
+| `tracing.record_content` | `false` | `true` |
+
+- `directory` resolves relative to the backend process cwd. Inside a worktree
+  the traces land under the worktree's backend dir.
+- `deployment_environment` passed to the `Tracer` comes from the existing
+  deployment/env config value.
+- `record_content=true` in dev so prompts/responses/tool bodies are visible
+  while debugging; `false` in base because the bodies can be large and contain
+  sensitive content.
+
+## 5. Out of Scope (this cut)
+
+- OTLP exporter (production / collector). Dep is already installed; wiring is a
+  later, additive change — add an OTLP exporter to the `exporters=[...]` list
+  behind config.
+- Metrics / `Meter` histograms.
+- W3C trace-context propagation from inbound HTTP requests.
+- Redaction hook for `record_content`.
+
+## 6. Testing
+
+Manual E2E in the worktree (ports from `.worktree.env`: backend `:8038`,
+frontend `:3038`):
+
+1. Set dev config so tracing is enabled (default-on in dev per §4).
+2. Start backend + frontend.
+3. Send a chat turn through the UI (one that calls at least one tool, to
+   exercise `execute_tool` spans).
+4. Confirm `<directory>/<YYYY-MM-DD>/<run_id>.jsonl` exists and contains one
+   JSON span per line: an `invoke_agent` root, a `cubepi.turn`, one or more
+   `chat` (CLIENT) spans, and `execute_tool` spans for any tool calls.
+5. With `record_content=true`, confirm `gen_ai.input.messages` /
+   `gen_ai.output.messages` (or `cubepi.llm.raw_*`) attributes are populated.
+
+This is a debugging/observability feature with no deterministic assertion
+surface beyond "a well-formed trace file appears," so verification is manual
+inspection of the emitted JSONL rather than an automated E2E test.


### PR DESCRIPTION
## Summary
- Wire cubepi 0.4's `Tracer` + `JsonlSpanExporter` into `RunManager._run_cubepi_path` so each conversation turn writes an OTLP/JSON trace to `<dir>/<YYYY-MM-DD>/<run_id>.jsonl`.
- New `cubebox/agents/tracing.py` factory builds a per-run `Tracer` from config, returning `None` (run untraced) when disabled or on any construction failure.
- New `tracing:` config block: `enabled` (base `false`, dev `true`), `directory` (`./cubepi-traces`), `record_content` (base `false`, dev `true`).
- Tracing is best-effort: both attach **and** flush/shutdown are failure-isolated so a tracing fault can never break or fail an otherwise-successful run.

Scope is JSONL only — OTLP exporter and metrics/`Meter` are out of scope (additive later). Spec: `docs/dev/specs/2026-05-20-cubepi-tracing-jsonl-design.md`; plan: `docs/dev/plans/2026-05-20-cubepi-tracing-jsonl.md`.

## Verification
- `tests/unit/agents/test_tracing.py` (3 tests) — factory gate behavior. Pass.
- `tests/unit/streams/` (12) — no regression. Pass.
- Real-LLM E2E (`tests/e2e/test_cubepi_path_tools.py`, calculator tool) run with tracing forced on — emitted a well-formed trace:
  ```
  1  invoke_agent          (root)
  2  cubepi.turn           (decide-to-call + integrate-result)
  2  chat qwen3.6-flash    (CLIENT)
  1  execute_tool calculator
  ```
  `record_content=true` captured the prompt/request attributes.

## Codex review
Local Codex reviewed the plan and the implementation:
- Plan: flagged that attach failures weren't isolated → fixed before coding.
- Impl: flagged a CRITICAL that tracer **teardown** (flush/shutdown) wasn't isolated → fixed (`f723da74`); re-review confirmed resolved.
- Remaining MEDIUM (not addressed here, by design): if cubepi's `Tracer.attach()` raises *mid-subscription*, the partial recorder subscription isn't unwound. This is an upstream cubepi hardening item, not a cubebox call-site concern — and in cubebox the agent/provider/tracer are all per-run, locally-scoped objects discarded when the run ends, so nothing leaks across runs. Tracked for cubepi upstream.

## Test plan
- [x] Unit tests pass
- [x] Stream unit tests pass (no regression)
- [x] Real-LLM E2E emits a valid JSONL trace with the expected span tree
- [ ] Reviewer: confirm dev default-on is acceptable (traces written to `backend/cubepi-traces/` during local dev)