### PR TITLE
refactor(tracing): use cubepi trace() scope with a process-level Tracer

### DIFF
--- a/backend/cubebox/agents/tracing.py
+++ b/backend/cubebox/agents/tracing.py
@@ -1,8 +1,13 @@
-"""Build a per-run cubepi Tracer from cubebox config.
+"""Build the process-level cubepi Tracer from cubebox config.
 
 Tracing is opt-in via the ``tracing:`` config block. When disabled — or when
-construction fails for any reason — the run proceeds untraced. A tracing fault
-must never break a run, so every failure path returns ``None``.
+construction fails for any reason — this returns ``None`` and runs proceed
+untraced. A tracing fault must never break the app, so every failure path
+returns ``None``.
+
+The Tracer is built once at app startup and reused across runs (each run
+attaches/detaches via :func:`cubepi.tracing.trace`); it is shut down once at
+app shutdown.
 """
 
 from __future__ import annotations
@@ -17,7 +22,7 @@ if TYPE_CHECKING:
     from cubepi.tracing import Tracer
 
 
-def build_run_tracer() -> Tracer | None:
+def build_tracer() -> Tracer | None:
     """Return a configured cubepi Tracer, or ``None`` when tracing is disabled.
 
     Reads ``tracing.enabled`` / ``tracing.directory`` / ``tracing.record_content``

--- a/backend/cubebox/agents/tracing.py
+++ b/backend/cubebox/agents/tracing.py
@@ -28,9 +28,10 @@ def build_tracer() -> Tracer | None:
     Reads ``tracing.enabled`` / ``tracing.directory`` / ``tracing.record_content``
     from config. Import or construction failures are logged and swallowed.
     """
-    if not config.get("tracing.enabled", False):
-        return None
     try:
+        if not config.get("tracing.enabled", False):
+            return None
+
         from cubepi.tracing import JsonlSpanExporter, Tracer
 
         directory = config.get("tracing.directory", "./cubepi-traces")

--- a/backend/cubebox/api/app.py
+++ b/backend/cubebox/api/app.py
@@ -56,6 +56,14 @@ async def lifespan(_app: FastAPI):  # type: ignore
     logger.info("Application starting up")
     _app.state.encryption_backend = _build_encryption_backend()
     _app.state.mcp_user_token_signer = _build_mcp_user_token_signer()
+
+    # Build the process-level cubepi Tracer once (None when tracing is disabled
+    # or unavailable). Each run attaches/detaches it via cubepi.tracing.trace;
+    # it is shut down in the shutdown phase below.
+    from cubebox.agents.tracing import build_tracer
+
+    _app.state.tracer = build_tracer()
+
     from cubebox.audit.sink import NoOpAuditSink
 
     _app.state.audit_sink = NoOpAuditSink()
@@ -306,6 +314,12 @@ async def lifespan(_app: FastAPI):  # type: ignore
         _app.state.drain_state.enter_draining()
         drain_timeout = _lifecycle_config.get("lifecycle.graceful_drain_timeout_seconds", 3600)
         await run_manager.drain(timeout_seconds=float(drain_timeout))
+    tracer = getattr(_app.state, "tracer", None)
+    if tracer is not None:
+        try:
+            await tracer.shutdown()
+        except Exception as exc:  # tracing teardown must never break shutdown
+            logger.warning("Tracer shutdown failed: {}", exc)
     if redis_client is not None:
         await redis_client.aclose()
     mcp_oauth_http_client = getattr(_app.state, "_mcp_oauth_http_client", None)

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import AsyncExitStack, suppress
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -1130,38 +1130,17 @@ class RunManager:
                 timestamp=_time.time(),
                 metadata=_user_msg_metadata,
             )
-            from cubebox.agents.tracing import build_run_tracer
+            # Attach the process-level Tracer to this run via cubepi's
+            # best-effort scope: it swallows every tracing fault (attach,
+            # detach, flush) so tracing can never break the run, and is a
+            # no-op when tracing is disabled (tracer is None).
+            from cubepi.tracing import trace
 
-            # Tracing is best-effort: neither attach nor flush/shutdown may
-            # break or fail an otherwise-successful run. The AsyncExitStack is
-            # managed manually (not via `async with`) so its exit path —
-            # attached() detach + flush, then Tracer shutdown — can be wrapped
-            # in its own try/except. attached().__aenter__ also does provider/
-            # recorder subscription work that can raise, so the enter is
-            # isolated too; either failure logs and runs the turn untraced.
-            tracer = build_run_tracer()
-            _trace_stack = AsyncExitStack()
-            if tracer is not None:
-                try:
-                    # LIFO close: attached() detaches + awaits its flush task
-                    # first, then the tracer's __aexit__ shuts down
-                    # (force_flush + close exporters) — so this run's spans
-                    # are on disk before _run_cubepi_path returns.
-                    await _trace_stack.enter_async_context(tracer)
-                    await _trace_stack.enter_async_context(tracer.attached(agent))
-                except Exception as _trace_exc:
-                    logger.warning("Tracing attach failed, continuing untraced: {}", _trace_exc)
-                    with suppress(Exception):
-                        await _trace_stack.aclose()
+            tracer = getattr(self._app.state, "tracer", None)
             try:
-                await agent.prompt(_user_msg)
+                async with trace(tracer, agent):
+                    await agent.prompt(_user_msg)
             finally:
-                # Flush + shut down tracing (best-effort; a teardown failure
-                # must not fail the run). aclose() is a no-op if attach failed.
-                try:
-                    await _trace_stack.aclose()
-                except Exception as _trace_exc:
-                    logger.warning("Tracing flush/shutdown failed: {}", _trace_exc)
                 # Signal drainer and wait for it to flush remaining events so
                 # all SSE dicts are published before citation buffers flush.
                 await sse_queue.put(None)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -157,6 +157,9 @@ exclude_lines = [
     "@abstractmethod",
 ]
 
+[tool.uv.sources]
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "b8ea8a8" }
+
 [dependency-groups]
 dev = [
     "aiosqlite>=0.20",

--- a/backend/tests/unit/agents/test_tracing.py
+++ b/backend/tests/unit/agents/test_tracing.py
@@ -1,4 +1,4 @@
-"""Unit tests for the per-run cubepi Tracer factory."""
+"""Unit tests for the process-level cubepi Tracer factory."""
 
 from __future__ import annotations
 
@@ -17,19 +17,19 @@ def _fake_config(values: dict[str, object]):
     return _Stub()
 
 
-def test_build_run_tracer_disabled_returns_none(monkeypatch):
+def test_build_tracer_disabled_returns_none(monkeypatch):
     monkeypatch.setattr(tracing_mod, "config", _fake_config({"tracing.enabled": False}))
-    assert tracing_mod.build_run_tracer() is None
+    assert tracing_mod.build_tracer() is None
 
 
-def test_build_run_tracer_missing_key_defaults_disabled(monkeypatch):
+def test_build_tracer_missing_key_defaults_disabled(monkeypatch):
     # No tracing.enabled key at all -> default False -> None.
     monkeypatch.setattr(tracing_mod, "config", _fake_config({}))
-    assert tracing_mod.build_run_tracer() is None
+    assert tracing_mod.build_tracer() is None
 
 
 @pytest.mark.asyncio
-async def test_build_run_tracer_enabled_returns_tracer(monkeypatch, tmp_path):
+async def test_build_tracer_enabled_returns_tracer(monkeypatch, tmp_path):
     from cubepi.tracing import Tracer
 
     monkeypatch.setattr(
@@ -44,7 +44,7 @@ async def test_build_run_tracer_enabled_returns_tracer(monkeypatch, tmp_path):
             }
         ),
     )
-    tracer = tracing_mod.build_run_tracer()
+    tracer = tracing_mod.build_tracer()
     assert isinstance(tracer, Tracer)
     # Clean up so the BatchSpanProcessor / atexit hook doesn't leak.
     await tracer.shutdown()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -841,7 +841,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "tracing", "tracing-otlp"], specifier = ">=0.4.0" },
+    { name = "cubepi", extras = ["mcp", "postgres", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=b8ea8a8" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -885,15 +885,11 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=b8ea8a8#b8ea8a8eaacb1e3ba08d1bb1a562fe1b959af17b" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },
     { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/20/dc/addb6bd924f55ea37fd979df5030ee4181698fa9fcdd82ac8a3ab0a0a8fc/cubepi-0.4.0.tar.gz", hash = "sha256:b34e203f89e05ad09c840f4c6bf75e7717e853e96ed8ada8235f87f716994bde", size = 985333, upload-time = "2026-05-19T08:31:56.124Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/9f/32cce93c442f297f432e54241899bf383b82240b5a756f0e3036c33f2d15/cubepi-0.4.0-py3-none-any.whl", hash = "sha256:7dc938e0fa68b6858bf5f905d11b3e14107000b5713a78f4bdfd47f0eb000d51", size = 109837, upload-time = "2026-05-19T08:31:54.46Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
Adopts cubepi's new best-effort `cubepi.tracing.trace(tracer, agent)` scope (merged in cubepi) and switches cubebox from a **per-run** Tracer to a **process-level** one.

- Build the Tracer **once** at app startup (`app.state.tracer = build_tracer()`) and shut it down **once** in the lifespan shutdown phase (guarded). No more rebuilding a `TracerProvider` every turn.
- `RunManager._run_cubepi_path` now wraps the turn in `async with trace(tracer, agent): await agent.prompt(...)`. `trace()` swallows every tracing fault (attach/detach/flush) and is a no-op when tracing is disabled — so the hand-rolled `AsyncExitStack` + `try/except` block (and the `AsyncExitStack` import) are gone.
- Renamed `build_run_tracer` → `build_tracer` to reflect the process-level lifecycle.
- Pins cubepi to git `b8ea8a8` (the merged `trace()` helper) via `[tool.uv.sources]`; the `>=0.4.0` floor in `[project.dependencies]` is unchanged.

Net: the run-path tracing code drops from ~35 lines of bespoke isolation to a 3-line `async with`.

## Why process-level
`trace()` flushes per run but deliberately does **not** `shutdown()` the Tracer (it's reusable). Building per-run would leak `BatchSpanProcessor` threads + atexit hooks, so the Tracer is now owned by the app lifespan. This is also cubepi's documented pattern.

## Concurrency
A single process-level Tracer is attached/detached by every concurrent run. Verified safe against cubepi: `Tracer.attach()` creates a fresh `Recorder` per call (all per-run state lives there), and the Tracer's only shared state is the OTel `TracerProvider`/`BatchSpanProcessor`, which are thread-safe and used the standard one-per-process way.

## Verification
- Unit (`tests/unit/agents/test_tracing.py`, 3) + stream unit tests (12) pass.
- Real-LLM E2E (`tests/e2e/test_cubepi_path_tools.py`) run with tracing forced on — through the real app lifespan (which now builds `app.state.tracer`) — emits a well-formed trace:
  ```
  1  invoke_agent
  2  cubepi.turn
  2  chat qwen3.6-flash
  1  execute_tool calculator
  ```
- mypy + ruff clean.

## Codex review
Local Codex reviewed: confirmed lifecycle placement, no stale `build_run_tracer`/`AsyncExitStack` refs, preserved `finally` semantics, and concurrency safety. Fixed one finding — the `tracing.enabled` lookup now sits inside `build_tracer`'s `try`, so a config fault can't break app startup.

## Test plan
- [x] Unit + stream tests pass
- [x] Real-LLM E2E emits a valid trace through the app lifespan
- [x] mypy + ruff clean
- [ ] Reviewer: confirm pinning cubepi to a git commit (vs. published release) is acceptable for now