### PR TITLE
feat: preset catalog redesign — cubebox-owned vendor catalog + preset-referenced config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,11 @@ Full details, role tables, operator CLI, system endpoints:
   `compress: false`.
 - **Worktree ports**: `8000` / `3000` are wrong inside worktrees — port
   collisions silently test the wrong code.
+- **Worktree test DB**: `tests/conftest.py` auto-routes worktree tests to
+  the per-slot `cubebox_test_<slug>` DB (and pins the rustfs object-store
+  creds), so plain `uv run pytest` is safe and never touches your dev DB.
+  S3 tests need rustfs on `:9000` (`~/infra/rustfs`). See
+  [docs/worktrees.md](docs/worktrees.md) → "Running tests in a worktree".
 
 ---
 

--- a/backend/cubebox/agents/graph.py
+++ b/backend/cubebox/agents/graph.py
@@ -13,7 +13,7 @@ from typing import Any
 from cubepi import Agent, Model
 from cubepi.agent.types import AgentTool
 from cubepi.middleware.base import Middleware
-from cubepi.providers.base import Provider
+from cubepi.providers.base import Provider, ThinkingLevel
 
 from cubebox.middleware._compose import compose_after_tool_call
 
@@ -30,6 +30,8 @@ def create_cubebox_agent(
     middleware: list[Middleware] | None = None,
     max_tokens: int = 8192,
     temperature: float = 0.7,
+    reasoning: bool = False,
+    thinking: ThinkingLevel = "off",
 ) -> Agent[Any]:
     """Build a cubepi.Agent for cubebox's cubepi runtime path.
 
@@ -47,13 +49,23 @@ def create_cubebox_agent(
         max_tokens: Maximum output tokens forwarded to the provider (defaults to
             8192; callers should pass the model's configured max_tokens).
         temperature: Sampling temperature forwarded to the provider (default 0.7).
+        reasoning: Whether the model is reasoning-capable. Must be True for the
+            capability layer to apply the reasoning payload (cubepi guards the
+            thinking toggle on Model.reasoning).
+        thinking: Thinking level for the run ("off" disables it). Only takes
+            effect when ``reasoning`` is True.
     """
     mw_list = middleware or []
     return Agent(
         provider=provider,
         model=Model(
-            id=model_id, provider=provider_name, max_tokens=max_tokens, temperature=temperature
+            id=model_id,
+            provider=provider_name,
+            reasoning=reasoning,
+            max_tokens=max_tokens,
+            temperature=temperature,
         ),
+        thinking=thinking,
         system_prompt=system_prompt,
         tools=tools or [],
         checkpointer=checkpointer,

--- a/backend/cubebox/api/routes/v1/admin_llm.py
+++ b/backend/cubebox/api/routes/v1/admin_llm.py
@@ -17,7 +17,7 @@ async def list_provider_presets(
     *,
     user: Annotated[User, Depends(require_org_admin)],
 ) -> list[dict[str, Any]]:
-    """Return cubepi's bundled provider-preset catalog (read-only passthrough)."""
-    from cubepi.providers.catalog import list_provider_presets as _list_presets
+    """Return cubebox's provider-preset catalog as a nested vendor list (spec §5.1)."""
+    from cubebox.llm.catalog import load_catalog
 
-    return [p.model_dump(mode="json") for p in _list_presets()]
+    return load_catalog().to_api()

--- a/backend/cubebox/api/routes/v1/admin_providers.py
+++ b/backend/cubebox/api/routes/v1/admin_providers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from cubepi.providers.catalog import get_provider_preset
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy import func, select
@@ -146,13 +145,24 @@ def _model_readiness_out(m: Model, p: Provider) -> ModelReadinessOut:
 
 
 def _resolve_logo(preset_slug: str | None) -> str | None:
-    """Resolve the brand-icon id from the preset catalog. None if unknown."""
+    """Resolve the brand-icon id from the catalog vendor. None if unknown.
+
+    Goes through ``catalog.resolve`` so ``key:`` overrides (preset_keys that do
+    not start with the vendor) still resolve — not a ``split("/")`` shortcut.
+    """
     if not preset_slug:
         return None
     try:
-        return get_provider_preset(preset_slug).logo
+        from cubebox.llm.catalog import load_catalog
+
+        catalog = load_catalog()
+        ep = catalog.resolve(preset_slug)
+        for v in catalog.vendors:
+            if v.vendor == ep.vendor:
+                return v.logo
     except Exception:
         return None
+    return None
 
 
 def _provider_out(

--- a/backend/cubebox/llm/catalog/__init__.py
+++ b/backend/cubebox/llm/catalog/__init__.py
@@ -1,0 +1,33 @@
+from cubebox.llm.catalog.loader import (
+    build_catalog,
+    compose_base_url,
+    load_catalog,
+    preset_key_for,
+    resolve_capability,
+)
+from cubebox.llm.catalog.types import (
+    Catalog,
+    Endpoint,
+    ModelPreset,
+    Pricing,
+    Region,
+    ResolvedEndpoint,
+    Vendor,
+    WireApi,
+)
+
+__all__ = [
+    "Catalog",
+    "Endpoint",
+    "ModelPreset",
+    "Pricing",
+    "Region",
+    "ResolvedEndpoint",
+    "Vendor",
+    "WireApi",
+    "build_catalog",
+    "compose_base_url",
+    "load_catalog",
+    "preset_key_for",
+    "resolve_capability",
+]

--- a/backend/cubebox/llm/catalog/data/capabilities.yaml
+++ b/backend/cubebox/llm/catalog/data/capabilities.yaml
@@ -1,0 +1,125 @@
+# Named capability profiles, referenced by endpoints in vendors.yaml (spec §4.3).
+# Ported verbatim from the flat providers.yaml capability blocks, deduped.
+
+anthropic-native:
+  reasoning_off_payload: { thinking: { type: disabled } }
+  reasoning_on_payload: { thinking: { type: enabled } }
+  reasoning_level:
+    path: thinking.budget_tokens
+    kind: int_budget
+    level_budgets: { "off": 0, minimal: 1024, low: 2048, medium: 8192, high: 16384, xhigh: 16384 }
+  temperature: { mode: free, min: 0.0, max: 1.0, default: 1.0 }
+  max_tokens_field: max_tokens
+  supports_tools: true
+  supports_images: true
+
+openai-responses:
+  reasoning_on_payload:
+    reasoning: { summary: auto }
+    include: [reasoning.encrypted_content]
+  reasoning_level:
+    path: reasoning.effort
+    kind: effort
+    level_to_effort: { minimal: minimal, low: low, medium: medium, high: high, xhigh: high }
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  max_tokens_field: max_tokens
+  supports_tools: true
+  supports_images: true
+
+openai-chat-completions:
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  max_tokens_field: max_completion_tokens
+  supports_tools: true
+  supports_images: true
+
+qwen-compat:
+  reasoning_off_payload: { extra_body: { enable_thinking: false } }
+  reasoning_on_payload: { extra_body: { enable_thinking: true } }
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  supports_tools: true
+  supports_images: true
+
+doubao-compat:
+  reasoning_off_payload: { extra_body: { thinking: { type: disabled } } }
+  reasoning_on_payload: { extra_body: { thinking: { type: enabled } } }
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  supports_tools: true
+  supports_images: true
+
+deepseek-anthropic:
+  reasoning_off_payload: { thinking: { type: disabled } }
+  reasoning_on_payload: { thinking: { type: enabled } }
+  reasoning_level:
+    path: output_config.effort
+    kind: effort
+    level_to_effort: { minimal: minimal, low: low, medium: medium, high: high, xhigh: max }
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+
+deepseek-openai:
+  reasoning_off_payload: { extra_body: { reasoning: { exclude: true } } }
+  reasoning_on_payload: { extra_body: { reasoning: { exclude: false } } }
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+
+moonshot-compat:
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+  supports_tools: true
+
+zhipu-compat:
+  reasoning_off_payload: { extra_body: { thinking: { type: disabled } } }
+  reasoning_on_payload: { extra_body: { thinking: { type: enabled } } }
+  temperature: { mode: free, min: 0.0, max: 1.0, default: 0.7 }
+  supports_tools: true
+  supports_images: true
+
+minimax-compat:
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  supports_tools: true
+  supports_images: true
+
+minimax-anthropic:
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  max_tokens_field: max_tokens
+  supports_tools: true
+  supports_images: true
+
+xai-compat:
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  supports_tools: true
+  supports_images: true
+
+openrouter-compat:
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  supports_tools: true
+  supports_images: true
+
+mistral-compat:
+  temperature: { mode: free, min: 0.0, max: 1.0, default: 0.7 }
+  supports_tools: true
+  supports_images: true
+
+together-compat:
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+
+groq-compat:
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+
+fireworks-compat:
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+
+oss-no-tools:
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+  supports_tools: false
+
+volcengine-coding:
+  reasoning_off_payload: { thinking: { type: disabled } }
+  reasoning_on_payload: { thinking: { type: enabled } }
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  max_tokens_field: max_tokens
+  supports_tools: true
+  supports_images: true
+
+custom-openai:
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+
+custom-anthropic:
+  temperature: { mode: free, min: 0.0, max: 1.0, default: 1.0 }

--- a/backend/cubebox/llm/catalog/data/capabilities.yaml
+++ b/backend/cubebox/llm/catalog/data/capabilities.yaml
@@ -120,6 +120,10 @@ volcengine-coding:
 
 custom-openai:
   temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  supports_tools: true
+  supports_images: true
 
 custom-anthropic:
   temperature: { mode: free, min: 0.0, max: 1.0, default: 1.0 }
+  supports_tools: true
+  supports_images: true

--- a/backend/cubebox/llm/catalog/data/vendors.yaml
+++ b/backend/cubebox/llm/catalog/data/vendors.yaml
@@ -247,7 +247,7 @@
   models: []
 
 - vendor: vllm
-  display_name: vLLM (self-hosted)
+  display_name: vLLM
   short_name: vLLM
   logo: vllm
   category: oss-framework

--- a/backend/cubebox/llm/catalog/data/vendors.yaml
+++ b/backend/cubebox/llm/catalog/data/vendors.yaml
@@ -60,12 +60,14 @@
     intl: { host: https://dashscope-intl.aliyuncs.com }
     cn: { host: https://dashscope.aliyuncs.com }
   endpoints:
-    - { region: intl, protocol: openai-completions, path: /compatible-mode/v1, capability: qwen-compat }
-    - { region: cn, protocol: openai-completions, path: /compatible-mode/v1, capability: qwen-compat }
+    - { region: intl, protocol: openai-completions, plan: general, path: /compatible-mode/v1, capability: qwen-compat }
+    - { region: cn, protocol: openai-completions, plan: general, path: /compatible-mode/v1, capability: qwen-compat }
+    # Coding Plan lives on a different host (coding.dashscope), not just a path.
+    - { region: cn, protocol: openai-completions, plan: coding, host: https://coding.dashscope.aliyuncs.com, path: /v1, capability: qwen-compat }
   models:
-    - { model_id: qwen3-max, display_name: Qwen3 Max, context_window: 262144, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
-    - { model_id: qwen3.6-plus, display_name: Qwen 3.6 Plus, context_window: 262144, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
-    - { model_id: qwen3.6-flash, display_name: Qwen 3.6 Flash, context_window: 131072, max_tokens: 16384, input_modalities: [text, image], reasoning: false, pricing: { input: 0, output: 0 } }
+    - { model_id: qwen3-max, display_name: Qwen3 Max, plan: general, context_window: 262144, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: qwen3.6-plus, display_name: Qwen 3.6 Plus, plan: [general, coding], context_window: 262144, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: qwen3.6-flash, display_name: Qwen 3.6 Flash, plan: general, context_window: 131072, max_tokens: 16384, input_modalities: [text, image], reasoning: false, pricing: { input: 0, output: 0 } }
 
 - vendor: volcengine
   display_name: 豆包 (火山方舟)
@@ -76,12 +78,17 @@
   regions:
     cn: { host: https://ark.cn-beijing.volces.com }
   endpoints:
-    - { region: cn, protocol: openai-completions, path: /api/v3, capability: doubao-compat }
+    - { region: cn, protocol: openai-completions, plan: general, path: /api/v3, capability: doubao-compat }
+    # Coding Plan: OpenAI-compat wire on /api/coding/v3 (distinct from the
+    # anthropic-shape volcengine-coding placeholder vendor on /api/coding).
+    - { region: cn, protocol: openai-completions, plan: coding, path: /api/coding/v3, capability: doubao-compat }
   models:
-    - { model_id: doubao-seed-2.0-pro, display_name: Doubao Seed 2.0 Pro, context_window: 256000, max_tokens: 16384, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
-    - { model_id: doubao-seed-2.0-code, display_name: Doubao Seed 2.0 Code, context_window: 256000, max_tokens: 16384, input_modalities: [text], reasoning: true, pricing: { input: 0, output: 0 } }
-    - { model_id: doubao-seed-2.0-lite, display_name: Doubao Seed 2.0 Lite, context_window: 256000, max_tokens: 16384, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
-    - { model_id: doubao-seed-2.0-mini, display_name: Doubao Seed 2.0 Mini, context_window: 256000, max_tokens: 16384, input_modalities: [text], reasoning: false, pricing: { input: 0, output: 0 } }
+    - { model_id: doubao-seed-2.0-pro, display_name: Doubao Seed 2.0 Pro, plan: [general, coding], context_window: 256000, max_tokens: 16384, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: doubao-seed-2.0-code, display_name: Doubao Seed 2.0 Code, plan: general, context_window: 256000, max_tokens: 16384, input_modalities: [text], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: doubao-seed-2.0-lite, display_name: Doubao Seed 2.0 Lite, plan: general, context_window: 256000, max_tokens: 16384, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: doubao-seed-2.0-mini, display_name: Doubao Seed 2.0 Mini, plan: general, context_window: 256000, max_tokens: 16384, input_modalities: [text], reasoning: false, pricing: { input: 0, output: 0 } }
+    - { model_id: doubao-seed-1-8-251228, display_name: DouBao Seed 1.8, plan: general, context_window: 256000, max_tokens: 32700, input_modalities: [text, image], reasoning: true, pricing: { input: 2.4, output: 24 } }
+    - { model_id: kimi-k2.6, display_name: Kimi K2.6, plan: coding, context_window: 256000, max_tokens: 32000, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
 
 - vendor: deepseek
   display_name: DeepSeek
@@ -187,7 +194,9 @@
     intl: { host: https://openrouter.ai }
   endpoints:
     - { region: intl, protocol: openai-completions, path: /api/v1, capability: openrouter-compat }
-  models: []
+  models:
+    - { model_id: "google/gemma-4-31b-it:free", display_name: Gemma 4 31B (free), context_window: 262000, max_tokens: 32000, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: "stepfun/step-3.5-flash:free", display_name: StepFun 3.5 Flash (free), context_window: 256000, max_tokens: 32000, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
 
 - vendor: together-ai
   display_name: Together AI

--- a/backend/cubebox/llm/catalog/data/vendors.yaml
+++ b/backend/cubebox/llm/catalog/data/vendors.yaml
@@ -62,7 +62,9 @@
   endpoints:
     - { region: intl, protocol: openai-completions, plan: general, path: /compatible-mode/v1, capability: qwen-compat }
     - { region: cn, protocol: openai-completions, plan: general, path: /compatible-mode/v1, capability: qwen-compat }
-    # Coding Plan lives on a different host (coding.dashscope), not just a path.
+    # Coding Plan. CN lives on a different host (coding.dashscope) — the actual
+    # deployed endpoint; intl coding shares the compatible-mode endpoint.
+    - { region: intl, protocol: openai-completions, plan: coding, path: /compatible-mode/v1, capability: qwen-compat }
     - { region: cn, protocol: openai-completions, plan: coding, host: https://coding.dashscope.aliyuncs.com, path: /v1, capability: qwen-compat }
   models:
     - { model_id: qwen3-max, display_name: Qwen3 Max, plan: general, context_window: 262144, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
@@ -79,9 +81,10 @@
     cn: { host: https://ark.cn-beijing.volces.com }
   endpoints:
     - { region: cn, protocol: openai-completions, plan: general, path: /api/v3, capability: doubao-compat }
-    # Coding Plan: OpenAI-compat wire on /api/coding/v3 (distinct from the
-    # anthropic-shape volcengine-coding placeholder vendor on /api/coding).
+    # Coding Plan, two wires: OpenAI-compat on /api/coding/v3 (arkcode) and the
+    # Claude-Code-compatible anthropic wire on /api/coding.
     - { region: cn, protocol: openai-completions, plan: coding, path: /api/coding/v3, capability: doubao-compat }
+    - { region: cn, protocol: anthropic-messages, plan: coding, path: /api/coding, capability: volcengine-coding }
   models:
     - { model_id: doubao-seed-2.0-pro, display_name: Doubao Seed 2.0 Pro, plan: [general, coding], context_window: 256000, max_tokens: 16384, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
     - { model_id: doubao-seed-2.0-code, display_name: Doubao Seed 2.0 Code, plan: general, context_window: 256000, max_tokens: 16384, input_modalities: [text], reasoning: true, pricing: { input: 0, output: 0 } }
@@ -115,11 +118,14 @@
     intl: { host: https://api.moonshot.ai }
     cn: { host: https://api.moonshot.cn }
   endpoints:
-    - { region: intl, protocol: openai-completions, path: /v1, capability: moonshot-compat }
-    - { region: cn, protocol: openai-completions, path: /v1, capability: moonshot-compat }
+    - { region: intl, protocol: openai-completions, plan: general, path: /v1, capability: moonshot-compat }
+    - { region: cn, protocol: openai-completions, plan: general, path: /v1, capability: moonshot-compat }
+    # Coding Plan: same /v1 wire, separate subscription api_key.
+    - { region: intl, protocol: openai-completions, plan: coding, path: /v1, capability: moonshot-compat }
+    - { region: cn, protocol: openai-completions, plan: coding, path: /v1, capability: moonshot-compat }
   models:
-    - { model_id: kimi-k2.6, display_name: Kimi K2.6, context_window: 262144, max_tokens: 32768, input_modalities: [text], reasoning: true, pricing: { input: 0, output: 0 } }
-    - { model_id: kimi-k2, display_name: Kimi K2, context_window: 131072, max_tokens: 16384, input_modalities: [text], reasoning: false, pricing: { input: 0, output: 0 } }
+    - { model_id: kimi-k2.6, display_name: Kimi K2.6, plan: [general, coding], context_window: 262144, max_tokens: 32768, input_modalities: [text], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: kimi-k2, display_name: Kimi K2, plan: [general, coding], context_window: 131072, max_tokens: 16384, input_modalities: [text], reasoning: false, pricing: { input: 0, output: 0 } }
 
 - vendor: zhipu
   display_name: 智谱 GLM
@@ -131,12 +137,15 @@
     intl: { host: https://api.z.ai }
     cn: { host: https://open.bigmodel.cn }
   endpoints:
-    - { region: intl, protocol: openai-completions, path: /api/paas/v4, capability: zhipu-compat }
-    - { region: cn, protocol: openai-completions, path: /api/paas/v4, capability: zhipu-compat }
+    - { region: intl, protocol: openai-completions, plan: general, path: /api/paas/v4, capability: zhipu-compat }
+    - { region: cn, protocol: openai-completions, plan: general, path: /api/paas/v4, capability: zhipu-compat }
+    # Coding Plan: dedicated /coding/ route, separate subscription api_key.
+    - { region: intl, protocol: openai-completions, plan: coding, path: /api/coding/paas/v4, capability: zhipu-compat }
+    - { region: cn, protocol: openai-completions, plan: coding, path: /api/coding/paas/v4, capability: zhipu-compat }
   models:
-    - { model_id: glm-5, display_name: GLM-5, context_window: 200000, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
-    - { model_id: glm-4.7, display_name: GLM-4.7, context_window: 200000, max_tokens: 16384, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
-    - { model_id: glm-4.7-flash, display_name: GLM-4.7 Flash, context_window: 128000, max_tokens: 16384, input_modalities: [text], reasoning: false, pricing: { input: 0, output: 0 } }
+    - { model_id: glm-5, display_name: GLM-5, plan: [general, coding], context_window: 200000, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: glm-4.7, display_name: GLM-4.7, plan: [general, coding], context_window: 200000, max_tokens: 16384, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: glm-4.7-flash, display_name: GLM-4.7 Flash, plan: general, context_window: 128000, max_tokens: 16384, input_modalities: [text], reasoning: false, pricing: { input: 0, output: 0 } }
 
 - vendor: minimax
   display_name: MiniMax
@@ -148,12 +157,15 @@
     intl: { host: https://api.minimax.io }
     cn: { host: https://api.minimaxi.com }
   endpoints:
-    - { region: intl, protocol: openai-completions, path: /v1, capability: minimax-compat }
-    - { region: cn, protocol: openai-completions, path: /v1, capability: minimax-compat }
+    - { region: intl, protocol: openai-completions, plan: general, path: /v1, capability: minimax-compat }
+    - { region: cn, protocol: openai-completions, plan: general, path: /v1, capability: minimax-compat }
+    # Coding Plan: anthropic-shape wire (/anthropic), separate subscription api_key.
+    - { region: intl, protocol: anthropic-messages, plan: coding, path: /anthropic, capability: minimax-anthropic }
+    - { region: cn, protocol: anthropic-messages, plan: coding, path: /anthropic, capability: minimax-anthropic }
   models:
-    - { model_id: MiniMax-M2.7, display_name: MiniMax M2.7, context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
-    - { model_id: MiniMax-M2.7-highspeed, display_name: MiniMax M2.7 Highspeed, context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: false, pricing: { input: 0, output: 0 } }
-    - { model_id: MiniMax-M2.5, display_name: MiniMax M2.5, context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: MiniMax-M2.7, display_name: MiniMax M2.7, plan: [general, coding], context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: MiniMax-M2.7-highspeed, display_name: MiniMax M2.7 Highspeed, plan: [general, coding], context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: false, pricing: { input: 0, output: 0 } }
+    - { model_id: MiniMax-M2.5, display_name: MiniMax M2.5, plan: [general, coding], context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
 
 - vendor: xai
   display_name: xAI
@@ -304,114 +316,6 @@
     intl: { host: https://chatgpt.com }
   endpoints:
     - { region: intl, protocol: openai-responses, path: /backend-api/codex, capability: openai-responses }
-  models: []
-
-- vendor: zhipu-coding
-  display_name: 智谱 GLM Coding Plan (国际)
-  short_name: GLM Coding
-  logo: zhipu
-  category: saas
-  description: Zhipu Coding Plan dedicated endpoint (Z.AI global), routed through /coding/.
-  regions:
-    intl: { host: https://api.z.ai }
-  endpoints:
-    - { region: intl, protocol: openai-completions, path: /api/coding/paas/v4, capability: zhipu-compat }
-  models: []
-
-- vendor: zhipu-coding-cn
-  display_name: 智谱 GLM Coding Plan (国内)
-  short_name: GLM Coding CN
-  logo: zhipu
-  category: saas
-  description: Zhipu Coding Plan 国内站 (open.bigmodel.cn) dedicated /coding/ endpoint.
-  regions:
-    cn: { host: https://open.bigmodel.cn }
-  endpoints:
-    - { region: cn, protocol: openai-completions, path: /api/coding/paas/v4, capability: zhipu-compat }
-  models: []
-
-- vendor: minimax-coding
-  display_name: MiniMax Coding Plan (国际)
-  short_name: MiniMax Coding
-  logo: minimax
-  category: saas
-  description: MiniMax Coding Plan — anthropic-shape wire on global (.minimax.io).
-  regions:
-    intl: { host: https://api.minimax.io }
-  endpoints:
-    - { region: intl, protocol: anthropic-messages, path: /anthropic, capability: minimax-anthropic }
-  models: []
-
-- vendor: minimax-coding-cn
-  display_name: MiniMax Coding Plan (国内)
-  short_name: MiniMax Coding CN
-  logo: minimax
-  category: saas
-  description: MiniMax Coding Plan 国内站 (minimaxi.com), anthropic-shape.
-  regions:
-    cn: { host: https://api.minimaxi.com }
-  endpoints:
-    - { region: cn, protocol: anthropic-messages, path: /anthropic, capability: minimax-anthropic }
-  models: []
-
-- vendor: moonshot-coding
-  display_name: Moonshot Kimi Coding (国际)
-  short_name: Kimi Coding
-  logo: moonshot
-  category: saas
-  description: Moonshot Kimi Coding subscription (.ai global). Shares /v1 with token API.
-  regions:
-    intl: { host: https://api.moonshot.ai }
-  endpoints:
-    - { region: intl, protocol: openai-completions, path: /v1, capability: moonshot-compat }
-  models: []
-
-- vendor: moonshot-coding-cn
-  display_name: Moonshot Kimi Coding (国内)
-  short_name: Kimi Coding CN
-  logo: moonshot
-  category: saas
-  description: Moonshot Kimi Coding subscription 国内站 (.cn). Shares /v1 with token API.
-  regions:
-    cn: { host: https://api.moonshot.cn }
-  endpoints:
-    - { region: cn, protocol: openai-completions, path: /v1, capability: moonshot-compat }
-  models: []
-
-- vendor: qwen-coding
-  display_name: 通义千问 Coding Plan (国际)
-  short_name: Qwen Coding
-  logo: qwen
-  category: saas
-  description: Alibaba Cloud Qwen Coding Plan (Singapore) subscription tier.
-  regions:
-    intl: { host: https://dashscope-intl.aliyuncs.com }
-  endpoints:
-    - { region: intl, protocol: openai-completions, path: /compatible-mode/v1, capability: qwen-compat }
-  models: []
-
-- vendor: qwen-coding-cn
-  display_name: 通义千问 Coding Plan (国内)
-  short_name: Qwen Coding CN
-  logo: qwen
-  category: saas
-  description: Alibaba Cloud Qwen Coding Plan 国内站 subscription tier.
-  regions:
-    cn: { host: https://dashscope.aliyuncs.com }
-  endpoints:
-    - { region: cn, protocol: openai-completions, path: /compatible-mode/v1, capability: qwen-compat }
-  models: []
-
-- vendor: volcengine-coding
-  display_name: 火山方舟 Coding Plan
-  short_name: Ark Coding
-  logo: doubao
-  category: saas
-  description: 火山方舟 Coding Plan — anthropic-shape wire serving Doubao + 3rd-party models.
-  regions:
-    cn: { host: https://ark.cn-beijing.volces.com }
-  endpoints:
-    - { region: cn, protocol: anthropic-messages, path: /api/coding, capability: volcengine-coding }
   models: []
 
 - vendor: custom-openai

--- a/backend/cubebox/llm/catalog/data/vendors.yaml
+++ b/backend/cubebox/llm/catalog/data/vendors.yaml
@@ -1,0 +1,426 @@
+# Provider catalog — nested vendor → region×protocol×plan endpoints → model pool.
+# Spec docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md §4.
+# Ported from the flat cubepi providers.yaml (frozen at
+# tests/unit/llm/catalog/data/flat_providers_snapshot.yaml). Pricing defaults to
+# zero for ported presets (the flat catalog had none); real cost is supplied per
+# deployment via config `cost:` override or added here when known.
+
+- vendor: anthropic
+  display_name: Anthropic
+  short_name: Anthropic
+  logo: anthropic
+  category: saas
+  description: Anthropic Claude (Messages API). Native thinking + budget.
+  regions:
+    intl: { host: https://api.anthropic.com }
+  endpoints:
+    - { region: intl, protocol: anthropic-messages, capability: anthropic-native }
+  models:
+    - { model_id: claude-opus-4-7, display_name: Claude Opus 4.7, context_window: 1000000, max_tokens: 128000, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: claude-sonnet-4-6, display_name: Claude Sonnet 4.6, context_window: 1000000, max_tokens: 64000, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: claude-haiku-4-5, display_name: Claude Haiku 4.5, context_window: 200000, max_tokens: 8192, input_modalities: [text, image], reasoning: false, pricing: { input: 0, output: 0 } }
+
+- vendor: openai
+  display_name: OpenAI
+  short_name: OpenAI
+  logo: openai
+  category: saas
+  description: OpenAI Responses API (GPT-5 series, o-series reasoning).
+  regions:
+    intl: { host: https://api.openai.com }
+  endpoints:
+    - { region: intl, protocol: openai-responses, path: /v1, capability: openai-responses }
+  models:
+    - { model_id: gpt-5.5, display_name: GPT-5.5, context_window: 1000000, max_tokens: 128000, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: gpt-5.4, display_name: GPT-5.4, context_window: 1000000, max_tokens: 65536, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: gpt-5.4-mini, display_name: GPT-5.4 Mini, context_window: 1000000, max_tokens: 65536, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: o4-mini, display_name: o4-mini, context_window: 200000, max_tokens: 100000, input_modalities: [text], reasoning: true, pricing: { input: 0, output: 0 } }
+
+- vendor: openai-legacy
+  display_name: OpenAI (Chat Completions)
+  short_name: OpenAI-Chat
+  logo: openai
+  category: saas
+  description: OpenAI legacy chat/completions wire (GPT-4o, GPT-4.1).
+  regions:
+    intl: { host: https://api.openai.com }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /v1, capability: openai-chat-completions }
+  models:
+    - { model_id: gpt-4o, display_name: GPT-4o, context_window: 128000, max_tokens: 16384, input_modalities: [text, image], reasoning: false, pricing: { input: 0, output: 0 } }
+    - { model_id: gpt-4.1, display_name: GPT-4.1, context_window: 1000000, max_tokens: 32768, input_modalities: [text, image], reasoning: false, pricing: { input: 0, output: 0 } }
+
+- vendor: aliyun
+  display_name: 通义千问 (Alibaba Cloud DashScope)
+  short_name: Qwen
+  logo: qwen
+  category: saas
+  description: Alibaba Cloud Model Studio OpenAI-compatible endpoint for Qwen (intl + CN).
+  regions:
+    intl: { host: https://dashscope-intl.aliyuncs.com }
+    cn: { host: https://dashscope.aliyuncs.com }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /compatible-mode/v1, capability: qwen-compat }
+    - { region: cn, protocol: openai-completions, path: /compatible-mode/v1, capability: qwen-compat }
+  models:
+    - { model_id: qwen3-max, display_name: Qwen3 Max, context_window: 262144, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: qwen3.6-plus, display_name: Qwen 3.6 Plus, context_window: 262144, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: qwen3.6-flash, display_name: Qwen 3.6 Flash, context_window: 131072, max_tokens: 16384, input_modalities: [text, image], reasoning: false, pricing: { input: 0, output: 0 } }
+
+- vendor: volcengine
+  display_name: 豆包 (火山方舟)
+  short_name: Doubao
+  logo: doubao
+  category: saas
+  description: ByteDance Volcengine OpenAI-compatible endpoint for Doubao Seed models.
+  regions:
+    cn: { host: https://ark.cn-beijing.volces.com }
+  endpoints:
+    - { region: cn, protocol: openai-completions, path: /api/v3, capability: doubao-compat }
+  models:
+    - { model_id: doubao-seed-2.0-pro, display_name: Doubao Seed 2.0 Pro, context_window: 256000, max_tokens: 16384, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: doubao-seed-2.0-code, display_name: Doubao Seed 2.0 Code, context_window: 256000, max_tokens: 16384, input_modalities: [text], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: doubao-seed-2.0-lite, display_name: Doubao Seed 2.0 Lite, context_window: 256000, max_tokens: 16384, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: doubao-seed-2.0-mini, display_name: Doubao Seed 2.0 Mini, context_window: 256000, max_tokens: 16384, input_modalities: [text], reasoning: false, pricing: { input: 0, output: 0 } }
+
+- vendor: deepseek
+  display_name: DeepSeek
+  short_name: DeepSeek
+  logo: deepseek
+  category: saas
+  description: DeepSeek V-series, via Anthropic-shape and OpenAI chat-completions endpoints.
+  regions:
+    cn: { host: https://api.deepseek.com }
+  endpoints:
+    - { region: cn, protocol: anthropic-messages, path: /anthropic, capability: deepseek-anthropic }
+    - { region: cn, protocol: openai-completions, capability: deepseek-openai }
+  models:
+    - { model_id: deepseek-v4-pro, display_name: DeepSeek V4 Pro, context_window: 1000000, max_tokens: 32768, input_modalities: [text], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: deepseek-v4-flash, display_name: DeepSeek V4 Flash, context_window: 1000000, max_tokens: 32768, input_modalities: [text], reasoning: true, pricing: { input: 0, output: 0 } }
+
+- vendor: moonshot
+  display_name: Moonshot Kimi
+  short_name: Moonshot
+  logo: moonshot
+  category: saas
+  description: Moonshot AI Kimi OpenAI-compatible endpoint (intl .ai + CN .cn).
+  regions:
+    intl: { host: https://api.moonshot.ai }
+    cn: { host: https://api.moonshot.cn }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /v1, capability: moonshot-compat }
+    - { region: cn, protocol: openai-completions, path: /v1, capability: moonshot-compat }
+  models:
+    - { model_id: kimi-k2.6, display_name: Kimi K2.6, context_window: 262144, max_tokens: 32768, input_modalities: [text], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: kimi-k2, display_name: Kimi K2, context_window: 131072, max_tokens: 16384, input_modalities: [text], reasoning: false, pricing: { input: 0, output: 0 } }
+
+- vendor: zhipu
+  display_name: 智谱 GLM
+  short_name: Zhipu
+  logo: zhipu
+  category: saas
+  description: Zhipu AI GLM OpenAI-compatible endpoint (Z.AI intl + BigModel CN).
+  regions:
+    intl: { host: https://api.z.ai }
+    cn: { host: https://open.bigmodel.cn }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /api/paas/v4, capability: zhipu-compat }
+    - { region: cn, protocol: openai-completions, path: /api/paas/v4, capability: zhipu-compat }
+  models:
+    - { model_id: glm-5, display_name: GLM-5, context_window: 200000, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: glm-4.7, display_name: GLM-4.7, context_window: 200000, max_tokens: 16384, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: glm-4.7-flash, display_name: GLM-4.7 Flash, context_window: 128000, max_tokens: 16384, input_modalities: [text], reasoning: false, pricing: { input: 0, output: 0 } }
+
+- vendor: minimax
+  display_name: MiniMax
+  short_name: MiniMax
+  logo: minimax
+  category: saas
+  description: MiniMax OpenAI-compatible endpoint (intl .io + CN .com), M-series models.
+  regions:
+    intl: { host: https://api.minimax.io }
+    cn: { host: https://api.minimaxi.com }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /v1, capability: minimax-compat }
+    - { region: cn, protocol: openai-completions, path: /v1, capability: minimax-compat }
+  models:
+    - { model_id: MiniMax-M2.7, display_name: MiniMax M2.7, context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: MiniMax-M2.7-highspeed, display_name: MiniMax M2.7 Highspeed, context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: false, pricing: { input: 0, output: 0 } }
+    - { model_id: MiniMax-M2.5, display_name: MiniMax M2.5, context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+
+- vendor: xai
+  display_name: xAI
+  short_name: xAI
+  logo: xai
+  category: saas
+  description: xAI Grok OpenAI-compatible endpoint.
+  regions:
+    intl: { host: https://api.x.ai }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /v1, capability: xai-compat }
+  models:
+    - { model_id: grok-4.3, display_name: Grok 4.3, context_window: 1000000, max_tokens: 32768, input_modalities: [text, image, video], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: grok-4.20, display_name: Grok 4.20, context_window: 2000000, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+
+- vendor: mistral
+  display_name: Mistral
+  short_name: Mistral
+  logo: mistral
+  category: saas
+  description: Mistral La Plateforme OpenAI-compatible.
+  regions:
+    intl: { host: https://api.mistral.ai }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /v1, capability: mistral-compat }
+  models:
+    - { model_id: mistral-large-latest, display_name: Mistral Large 3, context_window: 256000, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: mistral-medium-latest, display_name: Mistral Medium 3.5, context_window: 256000, max_tokens: 32768, input_modalities: [text, image], reasoning: true, pricing: { input: 0, output: 0 } }
+    - { model_id: mistral-small-latest, display_name: Mistral Small 4, context_window: 256000, max_tokens: 16384, input_modalities: [text, image], reasoning: false, pricing: { input: 0, output: 0 } }
+
+- vendor: openrouter
+  display_name: OpenRouter
+  short_name: OpenRouter
+  logo: openrouter
+  category: saas
+  description: OpenRouter unified gateway.
+  regions:
+    intl: { host: https://openrouter.ai }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /api/v1, capability: openrouter-compat }
+  models: []
+
+- vendor: together-ai
+  display_name: Together AI
+  short_name: Together
+  logo: together
+  category: saas
+  description: Together AI OpenAI-compatible.
+  regions:
+    intl: { host: https://api.together.xyz }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /v1, capability: together-compat }
+  models: []
+
+- vendor: groq
+  display_name: Groq
+  short_name: Groq
+  logo: groq
+  category: saas
+  description: Groq high-throughput OpenAI-compatible.
+  regions:
+    intl: { host: https://api.groq.com }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /openai/v1, capability: groq-compat }
+  models: []
+
+- vendor: fireworks
+  display_name: Fireworks AI
+  short_name: Fireworks
+  logo: fireworks
+  category: saas
+  description: Fireworks AI OpenAI-compatible.
+  regions:
+    intl: { host: https://api.fireworks.ai }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /inference/v1, capability: fireworks-compat }
+  models: []
+
+- vendor: vllm
+  display_name: vLLM (self-hosted)
+  short_name: vLLM
+  logo: vllm
+  category: oss-framework
+  description: vLLM OpenAI-compatible server.
+  regions:
+    local: { host: http://localhost:8000 }
+  endpoints:
+    - { region: local, protocol: openai-completions, path: /v1, capability: oss-no-tools }
+  models: []
+
+- vendor: ollama
+  display_name: Ollama
+  short_name: Ollama
+  logo: ollama
+  category: oss-framework
+  description: Ollama local OpenAI-compatible endpoint.
+  regions:
+    local: { host: http://localhost:11434 }
+  endpoints:
+    - { region: local, protocol: openai-completions, path: /v1, capability: oss-no-tools }
+  models: []
+
+- vendor: lm-studio
+  display_name: LM Studio
+  short_name: LM Studio
+  logo: lmstudio
+  category: oss-framework
+  description: LM Studio local server.
+  regions:
+    local: { host: http://localhost:1234 }
+  endpoints:
+    - { region: local, protocol: openai-completions, path: /v1, capability: oss-no-tools }
+  models: []
+
+- vendor: tgi
+  display_name: HuggingFace TGI
+  short_name: TGI
+  logo: huggingface
+  category: oss-framework
+  description: Text Generation Inference OpenAI-compatible endpoint.
+  regions:
+    local: { host: http://localhost:8080 }
+  endpoints:
+    - { region: local, protocol: openai-completions, path: /v1, capability: oss-no-tools }
+  models: []
+
+- vendor: anthropic-claude-code
+  display_name: Anthropic Claude Code (Max plan)
+  short_name: Claude Code
+  logo: anthropic
+  category: saas
+  description: Claude Code via Claude Pro/Max subscription. OAuth (no API key billing).
+  regions:
+    intl: { host: https://api.anthropic.com }
+  endpoints:
+    - { region: intl, protocol: anthropic-messages, capability: anthropic-native }
+  models: []
+
+- vendor: openai-codex
+  display_name: OpenAI Codex (ChatGPT plan)
+  short_name: Codex
+  logo: openai
+  category: saas
+  description: Codex CLI via ChatGPT Plus/Pro/Business subscription. OAuth login.
+  regions:
+    intl: { host: https://chatgpt.com }
+  endpoints:
+    - { region: intl, protocol: openai-responses, path: /backend-api/codex, capability: openai-responses }
+  models: []
+
+- vendor: zhipu-coding
+  display_name: 智谱 GLM Coding Plan (国际)
+  short_name: GLM Coding
+  logo: zhipu
+  category: saas
+  description: Zhipu Coding Plan dedicated endpoint (Z.AI global), routed through /coding/.
+  regions:
+    intl: { host: https://api.z.ai }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /api/coding/paas/v4, capability: zhipu-compat }
+  models: []
+
+- vendor: zhipu-coding-cn
+  display_name: 智谱 GLM Coding Plan (国内)
+  short_name: GLM Coding CN
+  logo: zhipu
+  category: saas
+  description: Zhipu Coding Plan 国内站 (open.bigmodel.cn) dedicated /coding/ endpoint.
+  regions:
+    cn: { host: https://open.bigmodel.cn }
+  endpoints:
+    - { region: cn, protocol: openai-completions, path: /api/coding/paas/v4, capability: zhipu-compat }
+  models: []
+
+- vendor: minimax-coding
+  display_name: MiniMax Coding Plan (国际)
+  short_name: MiniMax Coding
+  logo: minimax
+  category: saas
+  description: MiniMax Coding Plan — anthropic-shape wire on global (.minimax.io).
+  regions:
+    intl: { host: https://api.minimax.io }
+  endpoints:
+    - { region: intl, protocol: anthropic-messages, path: /anthropic, capability: minimax-anthropic }
+  models: []
+
+- vendor: minimax-coding-cn
+  display_name: MiniMax Coding Plan (国内)
+  short_name: MiniMax Coding CN
+  logo: minimax
+  category: saas
+  description: MiniMax Coding Plan 国内站 (minimaxi.com), anthropic-shape.
+  regions:
+    cn: { host: https://api.minimaxi.com }
+  endpoints:
+    - { region: cn, protocol: anthropic-messages, path: /anthropic, capability: minimax-anthropic }
+  models: []
+
+- vendor: moonshot-coding
+  display_name: Moonshot Kimi Coding (国际)
+  short_name: Kimi Coding
+  logo: moonshot
+  category: saas
+  description: Moonshot Kimi Coding subscription (.ai global). Shares /v1 with token API.
+  regions:
+    intl: { host: https://api.moonshot.ai }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /v1, capability: moonshot-compat }
+  models: []
+
+- vendor: moonshot-coding-cn
+  display_name: Moonshot Kimi Coding (国内)
+  short_name: Kimi Coding CN
+  logo: moonshot
+  category: saas
+  description: Moonshot Kimi Coding subscription 国内站 (.cn). Shares /v1 with token API.
+  regions:
+    cn: { host: https://api.moonshot.cn }
+  endpoints:
+    - { region: cn, protocol: openai-completions, path: /v1, capability: moonshot-compat }
+  models: []
+
+- vendor: qwen-coding
+  display_name: 通义千问 Coding Plan (国际)
+  short_name: Qwen Coding
+  logo: qwen
+  category: saas
+  description: Alibaba Cloud Qwen Coding Plan (Singapore) subscription tier.
+  regions:
+    intl: { host: https://dashscope-intl.aliyuncs.com }
+  endpoints:
+    - { region: intl, protocol: openai-completions, path: /compatible-mode/v1, capability: qwen-compat }
+  models: []
+
+- vendor: qwen-coding-cn
+  display_name: 通义千问 Coding Plan (国内)
+  short_name: Qwen Coding CN
+  logo: qwen
+  category: saas
+  description: Alibaba Cloud Qwen Coding Plan 国内站 subscription tier.
+  regions:
+    cn: { host: https://dashscope.aliyuncs.com }
+  endpoints:
+    - { region: cn, protocol: openai-completions, path: /compatible-mode/v1, capability: qwen-compat }
+  models: []
+
+- vendor: volcengine-coding
+  display_name: 火山方舟 Coding Plan
+  short_name: Ark Coding
+  logo: doubao
+  category: saas
+  description: 火山方舟 Coding Plan — anthropic-shape wire serving Doubao + 3rd-party models.
+  regions:
+    cn: { host: https://ark.cn-beijing.volces.com }
+  endpoints:
+    - { region: cn, protocol: anthropic-messages, path: /api/coding, capability: volcengine-coding }
+  models: []
+
+- vendor: custom-openai
+  display_name: Custom OpenAI-compatible
+  short_name: Custom
+  logo: null
+  category: custom
+  description: Bring your own OpenAI chat-completions endpoint.
+  endpoints:
+    - { region: any, protocol: openai-completions, base_url: "", capability: custom-openai }
+  models: []
+
+- vendor: custom-anthropic
+  display_name: Custom Anthropic-compatible
+  short_name: Custom
+  logo: null
+  category: custom
+  description: Bring your own Anthropic Messages endpoint.
+  endpoints:
+    - { region: any, protocol: anthropic-messages, base_url: "", capability: custom-anthropic }
+  models: []

--- a/backend/cubebox/llm/catalog/loader.py
+++ b/backend/cubebox/llm/catalog/loader.py
@@ -19,3 +19,13 @@ def compose_base_url(regions: dict[str, Region], endpoint: Endpoint) -> str:
             raise ValueError(f"endpoint references unknown region {endpoint.region!r}")
         host = region.host
     return host + endpoint.path
+
+
+def preset_key_for(vendor: str, endpoint: Endpoint) -> str:
+    """preset_key = vendor/region/protocol[/plan], or endpoint.key override (§4.4)."""
+    if endpoint.key is not None:
+        return endpoint.key
+    parts = [vendor, endpoint.region, endpoint.protocol]
+    if endpoint.plan is not None:
+        parts.append(endpoint.plan)
+    return "/".join(parts)

--- a/backend/cubebox/llm/catalog/loader.py
+++ b/backend/cubebox/llm/catalog/loader.py
@@ -1,0 +1,21 @@
+"""Catalog loader: YAML → validated, flattened catalog. Spec §4."""
+
+from __future__ import annotations
+
+from cubebox.llm.catalog.types import Endpoint, Region
+
+
+def compose_base_url(regions: dict[str, Region], endpoint: Endpoint) -> str:
+    """base_url = (endpoint.host || regions[endpoint.region].host) + endpoint.path.
+
+    A full ``endpoint.base_url`` bypasses composition entirely (§4.1).
+    """
+    if endpoint.base_url is not None:
+        return endpoint.base_url
+    host = endpoint.host
+    if host is None:
+        region = regions.get(endpoint.region)
+        if region is None:
+            raise ValueError(f"endpoint references unknown region {endpoint.region!r}")
+        host = region.host
+    return host + endpoint.path

--- a/backend/cubebox/llm/catalog/loader.py
+++ b/backend/cubebox/llm/catalog/loader.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from cubepi.providers.capability import CapabilityDescriptor
+
 from cubebox.llm.catalog.types import Endpoint, Region
 
 
@@ -29,3 +31,17 @@ def preset_key_for(vendor: str, endpoint: Endpoint) -> str:
     if endpoint.plan is not None:
         parts.append(endpoint.plan)
     return "/".join(parts)
+
+
+def resolve_capability(
+    ref: str | dict[str, object], profiles: dict[str, dict[str, object]]
+) -> CapabilityDescriptor:
+    """A scalar string is a profile reference; a mapping is inline (§4.3).
+
+    An unknown profile name fails loudly (not a silent empty descriptor).
+    """
+    if isinstance(ref, str):
+        if ref not in profiles:
+            raise ValueError(f"unknown capability profile {ref!r}")
+        return CapabilityDescriptor.model_validate(profiles[ref])
+    return CapabilityDescriptor.model_validate(ref)

--- a/backend/cubebox/llm/catalog/loader.py
+++ b/backend/cubebox/llm/catalog/loader.py
@@ -2,9 +2,23 @@
 
 from __future__ import annotations
 
+from functools import cache
+from pathlib import Path
+from typing import Any
+
+import yaml
 from cubepi.providers.capability import CapabilityDescriptor
 
-from cubebox.llm.catalog.types import Endpoint, Region
+from cubebox.llm.catalog.types import (
+    Catalog,
+    Endpoint,
+    ModelPreset,
+    Region,
+    ResolvedEndpoint,
+    Vendor,
+)
+
+_DATA_DIR = Path(__file__).parent / "data"
 
 
 def compose_base_url(regions: dict[str, Region], endpoint: Endpoint) -> str:
@@ -45,3 +59,74 @@ def resolve_capability(
             raise ValueError(f"unknown capability profile {ref!r}")
         return CapabilityDescriptor.model_validate(profiles[ref])
     return CapabilityDescriptor.model_validate(ref)
+
+
+def _validate_plan_consistency(v: Vendor) -> None:
+    tagged = [e.plan is not None for e in v.endpoints] + [m.plan is not None for m in v.models]
+    if any(tagged) and not all(tagged):
+        raise ValueError(
+            f"vendor {v.vendor!r} may not mix plan-tagged and untagged endpoints/models"
+        )
+
+
+def _models_for(v: Vendor, endpoint: Endpoint) -> list[ModelPreset]:
+    if endpoint.plan is None:  # untagged vendor -> every endpoint serves every model
+        return list(v.models)
+    return [m for m in v.models if endpoint.plan in (m.plans() or [])]
+
+
+def build_catalog(
+    raw_vendors: list[dict[str, Any] | Vendor], profiles: dict[str, dict[str, object]]
+) -> Catalog:
+    vendors = [v if isinstance(v, Vendor) else Vendor.model_validate(v) for v in raw_vendors]
+    endpoints: dict[str, ResolvedEndpoint] = {}
+    for v in vendors:
+        _validate_plan_consistency(v)
+        # unreachable-model check first: every model's plan(s) must hit some endpoint.
+        # (Done before the per-endpoint dangling check so a model with no endpoint is
+        # reported as unreachable rather than incidentally as a dangling endpoint.)
+        ep_plans = {e.plan for e in v.endpoints}
+        for m in v.models:
+            mplans = m.plans()
+            if mplans is not None and not (set(mplans) & ep_plans):
+                raise ValueError(
+                    f"vendor {v.vendor!r} model {m.model_id!r} plan(s) {mplans} "
+                    f"match no endpoint (unreachable)"
+                )
+        # (region, protocol, plan) tuple uniqueness — enforced INDEPENDENTLY of
+        # preset_key, because a `key:` override would otherwise let two identical
+        # tuples through the preset_key dedup (spec §4.2).
+        seen_tuples: set[tuple[str, str, str | None]] = set()
+        for ep in v.endpoints:
+            tup = (ep.region, ep.protocol, ep.plan)
+            if tup in seen_tuples:
+                raise ValueError(f"vendor {v.vendor!r} duplicate endpoint tuple {tup!r}")
+            seen_tuples.add(tup)
+            models = _models_for(v, ep)
+            if ep.plan is not None and not models:
+                raise ValueError(
+                    f"vendor {v.vendor!r} endpoint plan {ep.plan!r} matches no model (dangling)"
+                )
+            key = preset_key_for(v.vendor, ep)
+            if key in endpoints:
+                raise ValueError(f"duplicate preset_key {key!r}")
+            endpoints[key] = ResolvedEndpoint(
+                preset_key=key,
+                vendor=v.vendor,
+                region=ep.region,
+                protocol=ep.protocol,
+                plan=ep.plan,
+                base_url=compose_base_url(v.regions, ep),
+                capability=resolve_capability(ep.capability, profiles),
+                models=models,
+            )
+    return Catalog(vendors=vendors, endpoints=endpoints)
+
+
+@cache
+def load_catalog() -> Catalog:
+    vendors_raw = yaml.safe_load((_DATA_DIR / "vendors.yaml").read_text("utf-8"))
+    profiles = yaml.safe_load((_DATA_DIR / "capabilities.yaml").read_text("utf-8"))
+    if not isinstance(vendors_raw, list):
+        raise ValueError("vendors.yaml must be a top-level list")
+    return build_catalog(vendors_raw, profiles or {})

--- a/backend/cubebox/llm/catalog/types.py
+++ b/backend/cubebox/llm/catalog/types.py
@@ -88,3 +88,44 @@ class Catalog(BaseModel):
         if preset_key not in self.endpoints:
             raise KeyError(preset_key)
         return self.endpoints[preset_key]
+
+    def to_api(self) -> list[dict[str, Any]]:
+        """Nested vendor list for GET /admin/llm/presets (spec §5.1)."""
+        out: list[dict[str, Any]] = []
+        for v in self.vendors:
+            v_eps = [e for e in self.endpoints.values() if e.vendor == v.vendor]
+            out.append(
+                {
+                    "vendor": v.vendor,
+                    "display_name": v.display_name,
+                    "short_name": v.short_name,
+                    "logo": v.logo,
+                    "category": v.category,
+                    "description": v.description,
+                    "endpoints": [
+                        {
+                            "preset_key": e.preset_key,
+                            "region": e.region,
+                            "protocol": e.protocol,
+                            "plan": e.plan,
+                            "base_url": e.base_url,
+                            "model_ids": [m.model_id for m in e.models],
+                        }
+                        for e in v_eps
+                    ],
+                    "models": [
+                        {
+                            "model_id": m.model_id,
+                            "display_name": m.display_name,
+                            "plan": m.plans(),
+                            "context_window": m.context_window,
+                            "max_tokens": m.max_tokens,
+                            "input_modalities": m.input_modalities,
+                            "reasoning": m.reasoning,
+                            "pricing": m.pricing.model_dump(),
+                        }
+                        for m in v.models
+                    ],
+                }
+            )
+        return out

--- a/backend/cubebox/llm/catalog/types.py
+++ b/backend/cubebox/llm/catalog/types.py
@@ -1,0 +1,80 @@
+"""Catalog source-schema + resolved/derived types. Spec §4."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from cubepi.providers.capability import CapabilityDescriptor
+from pydantic import BaseModel, Field
+
+# The protocols cubebox offers in its catalog. Mirrors cubepi's WireApi but
+# declared locally so the catalog does not import cubepi's (to-be-deleted)
+# catalog package. See spec §3 "WireApi decoupling".
+WireApi = Literal["anthropic-messages", "openai-completions", "openai-responses"]
+
+# A model's plan membership: a single plan, a list, or None (untagged vendor).
+PlanRef = str | list[str] | None
+
+
+class Pricing(BaseModel):
+    input: float
+    output: float
+    cache_read: float = 0.0
+    cache_write: float = 0.0
+
+
+class ModelPreset(BaseModel):
+    model_id: str
+    display_name: str
+    context_window: int
+    max_tokens: int
+    input_modalities: list[str]
+    reasoning: bool = False
+    plan: PlanRef = None
+    pricing: Pricing
+
+    def plans(self) -> list[str] | None:
+        """Normalized plan list, or None for untagged."""
+        if self.plan is None:
+            return None
+        return [self.plan] if isinstance(self.plan, str) else list(self.plan)
+
+
+class Region(BaseModel):
+    host: str
+
+
+class Endpoint(BaseModel):
+    region: str
+    protocol: WireApi
+    plan: str | None = None
+    path: str = ""
+    host: str | None = None  # overrides region host (§4.1)
+    base_url: str | None = None  # full override, bypasses composition (§4.1)
+    capability: str | dict[str, Any]  # profile name (str) or inline descriptor (dict)
+    key: str | None = None  # optional preset_key override (§4.4)
+
+
+class Vendor(BaseModel):
+    vendor: str
+    display_name: str
+    short_name: str
+    logo: str | None = None
+    category: Literal["saas", "oss-framework", "custom"]
+    description: str
+    regions: dict[str, Region] = Field(default_factory=dict)
+    endpoints: list[Endpoint] = Field(default_factory=list)
+    models: list[ModelPreset] = Field(default_factory=list)
+
+
+class ResolvedEndpoint(BaseModel):
+    """One flattened endpoint preset — what consumers (seeder/API) read."""
+
+    preset_key: str
+    vendor: str
+    region: str
+    protocol: WireApi
+    plan: str | None
+    base_url: str
+    capability: CapabilityDescriptor
+    models: list[ModelPreset]  # the subset serving this endpoint (§4 membership)

--- a/backend/cubebox/llm/catalog/types.py
+++ b/backend/cubebox/llm/catalog/types.py
@@ -110,6 +110,9 @@ class Catalog(BaseModel):
                             "plan": e.plan,
                             "base_url": e.base_url,
                             "model_ids": [m.model_id for m in e.models],
+                            # Resolved capability so the wizard can prefill the editor
+                            # and send it back only when the user overrides it.
+                            "capability": e.capability.model_dump(mode="json"),
                         }
                         for e in v_eps
                     ],

--- a/backend/cubebox/llm/catalog/types.py
+++ b/backend/cubebox/llm/catalog/types.py
@@ -78,3 +78,13 @@ class ResolvedEndpoint(BaseModel):
     base_url: str
     capability: CapabilityDescriptor
     models: list[ModelPreset]  # the subset serving this endpoint (§4 membership)
+
+
+class Catalog(BaseModel):
+    vendors: list[Vendor]
+    endpoints: dict[str, ResolvedEndpoint]  # keyed by preset_key
+
+    def resolve(self, preset_key: str) -> ResolvedEndpoint:
+        if preset_key not in self.endpoints:
+            raise KeyError(preset_key)
+        return self.endpoints[preset_key]

--- a/backend/cubebox/llm/readiness.py
+++ b/backend/cubebox/llm/readiness.py
@@ -28,6 +28,7 @@ STALE = "stale"
 MODEL_ERROR = "model_error"
 UNAVAILABLE = "unavailable"
 PROVIDER_ERROR = "provider_error"
+AUTH_ERROR = "auth_error"
 
 
 def derive_readiness(
@@ -39,17 +40,23 @@ def derive_readiness(
     """Map (provider liveness, model test, capability-edit) → readiness enum.
 
     Precedence (spec §4.1), highest first:
-    1. provider liveness == "fail"             -> "provider_error" (all models)
-    2. model_test_status == "unavailable"      -> "unavailable"
-    3. model_test_status == "fail"             -> "model_error"
-    4. capability_changed_since_test           -> "stale"
-    5. model_test_status == "warn"             -> "degraded"
-    6. otherwise                               -> "ready"
+    1. provider liveness == "auth_error"       -> "auth_error" (all models)
+    2. provider liveness == "fail"             -> "provider_error" (all models)
+    3. model_test_status == "unavailable"      -> "unavailable"
+    4. model_test_status == "fail"             -> "model_error"
+    5. capability_changed_since_test           -> "stale"
+    6. model_test_status == "warn"             -> "degraded"
+    7. otherwise                               -> "ready"
+
+    ``auth_error`` and ``fail`` are both provider-grain (they black out every
+    model), but split so the UI can say "fix the key" vs "endpoint is down".
 
     Never-probed inputs are presumed healthy: ``liveness_status is None`` is
     treated as "not failed" and ``model_test_status is None`` falls through to
     "ready". See module docstring for the rationale.
     """
+    if liveness_status == "auth_error":
+        return AUTH_ERROR
     if liveness_status == "fail":
         return PROVIDER_ERROR
     if model_test_status == "unavailable":

--- a/backend/cubebox/models/provider.py
+++ b/backend/cubebox/models/provider.py
@@ -55,7 +55,9 @@ class Provider(CubeboxBase, table=True):
     model_capability_overrides: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
     # Provider-level test = liveness/credential ONLY (spec §4.1).
     last_liveness_at: datetime | None = Field(default=None)
-    last_liveness_status: str | None = Field(default=None, max_length=16)  # "ok" | "fail"
+    last_liveness_status: str | None = Field(
+        default=None, max_length=16
+    )  # "ok" | "auth_error" | "fail"
     last_liveness_summary: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
     enabled: bool = Field(default=True)
     created_by_user_id: str | None = Field(

--- a/backend/cubebox/seeders/provider_seeder.py
+++ b/backend/cubebox/seeders/provider_seeder.py
@@ -6,15 +6,17 @@ Provider api keys are written to the credential vault as system credentials
 migration.
 """
 
+from dataclasses import dataclass, field
 from typing import Any
 
-from cubepi.providers.catalog import get_provider_preset
 from loguru import logger
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.config import config as settings
 from cubebox.credentials.encryption import EncryptionBackend
+from cubebox.llm.catalog import load_catalog
+from cubebox.llm.catalog.types import ModelPreset
 from cubebox.models import Credential
 from cubebox.models.provider import Model, Provider
 from cubebox.utils.slug import slugify
@@ -46,22 +48,93 @@ def _merge_cost(
     return merged
 
 
-def _capability_for(slug: str) -> tuple[dict[str, Any], dict[str, Any]] | None:
-    """Resolve a cubepi preset slug to its cached capability snapshot.
+@dataclass
+class ResolvedProviderConfig:
+    """The seed-ready shape of one configured provider after preset resolution."""
 
-    Returns ``(capability, model_capability_overrides)`` as JSON-ready dicts, or
-    ``None`` when the slug is not a known preset. The mapping key is the provider
-    ``name`` matched exactly against a preset slug.
-    """
-    try:
-        preset = get_provider_preset(slug)
-    except KeyError:
-        return None
-    capability = preset.capability.model_dump(mode="json")
-    overrides = {
-        mid: cap.model_dump(mode="json") for mid, cap in preset.model_capability_overrides.items()
+    base_url: str
+    provider_type: str
+    preset_key: str | None
+    capability: dict[str, Any]
+    model_capability_overrides: dict[str, Any] = field(default_factory=dict)
+    models: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _model_from_preset(m: ModelPreset, override: dict[str, Any] | None) -> dict[str, Any]:
+    """Catalog ModelPreset -> the seeder's per-model dict, applying config overrides."""
+    out: dict[str, Any] = {
+        "id": m.model_id,
+        "name": m.display_name,
+        "reasoning": m.reasoning,
+        "input": list(m.input_modalities),
+        "context_window": m.context_window,
+        "max_tokens": m.max_tokens,
+        "cost": _merge_cost(m.pricing.model_dump(), (override or {}).get("cost")),
     }
-    return capability, overrides
+    # Model-level deployment knobs (not catalog data) pass through from config.
+    if override:
+        for knob in ("extra_body", "extra_headers"):
+            if knob in override:
+                out[knob] = override[knob]
+    return out
+
+
+def resolve_provider_config(name: str, cfg: dict[str, Any]) -> ResolvedProviderConfig:
+    """Resolve a configured provider, inheriting from its ``preset:`` (spec §6.2)."""
+    preset_key = cfg.get("preset")
+    if not preset_key:
+        # No preset -> config must specify the provider (§6.2.4). Validate the
+        # genuinely-required fields (base_url + a non-empty model list) so an
+        # under-specified custom provider fails loudly instead of silently
+        # seeding an empty base_url. `api` keeps its long-standing
+        # openai-completions default (most custom endpoints are OpenAI-compatible).
+        base_url = cfg.get("base_url")
+        models = list(cfg.get("models", []))
+        if not base_url or not models:
+            raise ValueError(
+                f"provider {name!r}: a custom provider (no 'preset:') requires "
+                f"'base_url' and a non-empty 'models' list (§6.2.4)"
+            )
+        return ResolvedProviderConfig(
+            base_url=str(base_url),
+            provider_type=str(cfg.get("api", "openai-completions")),
+            preset_key=None,
+            capability={},
+            models=models,
+        )
+    # §6.2.3: under a preset, neither 'api' (protocol) nor 'capability' is overridable.
+    if cfg.get("api") is not None:
+        raise ValueError(f"provider {name!r}: 'api' is not overridable under a preset (§6.2.3)")
+    if cfg.get("capability") is not None:
+        raise ValueError(
+            f"provider {name!r}: 'capability' is not overridable under a preset (§6.2.3)"
+        )
+    try:
+        ep = load_catalog().resolve(str(preset_key))
+    except KeyError:
+        raise ValueError(f"provider {name!r}: unknown preset {preset_key!r}") from None
+
+    pool = {m.model_id: m for m in ep.models}
+    subset = cfg.get("models")
+    overrides: dict[str, dict[str, Any]] = {}
+    if subset is None:
+        chosen = list(pool.keys())
+    else:
+        chosen = []
+        for item in subset:
+            mid = item if isinstance(item, str) else str(item["id"])
+            if mid not in pool:
+                raise ValueError(f"provider {name!r}: model {mid!r} not in preset {preset_key!r}")
+            chosen.append(mid)
+            if isinstance(item, dict):
+                overrides[mid] = item
+    return ResolvedProviderConfig(
+        base_url=str(cfg.get("base_url") or ep.base_url),  # base_url override allowed
+        provider_type=ep.protocol,
+        preset_key=str(preset_key),
+        capability=ep.capability.model_dump(mode="json"),
+        models=[_model_from_preset(pool[mid], overrides.get(mid)) for mid in chosen],
+    )
 
 
 async def _upsert_system_credential(
@@ -141,15 +214,21 @@ async def seed_system_providers_from_config(
     for name, cfg_dict_raw in config_providers.items():
         cfg_dict: dict[str, Any] = dict(cfg_dict_raw)
 
-        # Skip providers with no models declared. Why this guard exists:
-        # in the `test` env, dynaconf may surface a CUBEBOX_LLM__PROVIDERS__<NAME>__*
-        # env var (from operator's local .env) for a provider that the test
-        # yaml does not declare. Dynaconf creates a phantom entry with only
-        # the env-var fields (e.g. just api_key, no models). A Provider row
-        # with zero models is useless downstream and breaks the
-        # seed-idempotency assertion (every Provider must have >=1 Model).
-        if not list(cfg_dict.get("models", [])):
-            logger.debug("Provider '{}' has no models declared -- skipping seed", name)
+        # Skip phantom/incomplete providers: a provider with neither a `preset:`
+        # nor any declared models is useless. Why this guard exists: in the `test`
+        # env, dynaconf may surface a CUBEBOX_LLM__PROVIDERS__<NAME>__* env var
+        # (from the operator's local .env) for a provider the test yaml does not
+        # declare, creating a phantom entry with only an env-var api_key. A
+        # Provider row with zero models breaks the seed-idempotency assertion.
+        if not cfg_dict.get("preset") and not list(cfg_dict.get("models", [])):
+            logger.debug("Provider '{}' has no preset and no models -- skipping seed", name)
+            continue
+
+        # Resolve the config against the catalog: a `preset:` inherits
+        # base_url/api/capability/model-pool; no preset means config-verbatim (§6.2).
+        resolved = resolve_provider_config(name, cfg_dict)
+        if not resolved.models:
+            logger.debug("Provider '{}' resolved to zero models -- skipping seed", name)
             continue
 
         existing = await session.execute(
@@ -160,8 +239,8 @@ async def seed_system_providers_from_config(
         )
         provider: Provider | None = existing.scalar_one_or_none()
 
-        base_url: str = str(cfg_dict.get("base_url", ""))
-        provider_type: str = str(cfg_dict.get("api", "openai-completions"))
+        base_url: str = resolved.base_url
+        provider_type: str = resolved.provider_type
 
         if provider is None:
             slug = _dedup_slug(slugify(name), used_slugs)
@@ -188,18 +267,18 @@ async def seed_system_providers_from_config(
                 provider.slug = slug
             logger.debug("System provider '{}' already exists, updated", name)
 
-        # Backfill cached capability snapshot from the cubepi preset catalog.
-        # The mapping key is the provider name matched exactly against a preset
-        # slug. Only fill when the row's capability is still empty so re-seeding
-        # never clobbers admin edits.
-        if not provider.capability:
-            resolved = _capability_for(name)
-            if resolved is not None:
-                capability, overrides = resolved
-                provider.preset_slug = name
-                provider.capability = capability
-                provider.model_capability_overrides = overrides
-                logger.info("Seeded capability snapshot for provider '{}' (slug={})", name, name)
+        # Backfill the cached capability snapshot + preset_key from the catalog.
+        # Only fill when the row's capability is still empty so re-seeding never
+        # clobbers admin edits. Custom providers (no preset) get no backfill.
+        if not provider.capability and resolved.preset_key:
+            provider.preset_slug = resolved.preset_key
+            provider.capability = resolved.capability
+            provider.model_capability_overrides = resolved.model_capability_overrides
+            logger.info(
+                "Seeded capability snapshot for provider '{}' (preset={})",
+                name,
+                resolved.preset_key,
+            )
 
         api_key_raw = cfg_dict.get("api_key")
         api_key: str | None = (
@@ -213,7 +292,9 @@ async def seed_system_providers_from_config(
                 provider.credential_id = cred.id
 
         config_model_ids[name] = set()
-        models_list: list[dict[str, Any]] = list(cfg_dict.get("models", []))
+        # Resolved models: catalog pool (preset) or config-verbatim (custom), each
+        # already normalized to id/name/cost/context_window/max_tokens/reasoning/input.
+        models_list: list[dict[str, Any]] = resolved.models
 
         for mc_raw in models_list:
             mc: dict[str, Any] = dict(mc_raw)

--- a/backend/cubebox/seeders/provider_seeder.py
+++ b/backend/cubebox/seeders/provider_seeder.py
@@ -34,6 +34,18 @@ def _dedup_slug(base: str, taken: set[str]) -> str:
         n += 1
 
 
+def _merge_cost(
+    catalog_cost: dict[str, float], override: dict[str, Any] | None
+) -> dict[str, float]:
+    """Per-leg deep-merge: an override leg replaces only that leg (§6.2.3)."""
+    merged = dict(catalog_cost)
+    if override:
+        for leg in ("input", "output", "cache_read", "cache_write"):
+            if leg in override:
+                merged[leg] = float(override[leg])
+    return merged
+
+
 def _capability_for(slug: str) -> tuple[dict[str, Any], dict[str, Any]] | None:
     """Resolve a cubepi preset slug to its cached capability snapshot.
 

--- a/backend/cubebox/services/provider_probe.py
+++ b/backend/cubebox/services/provider_probe.py
@@ -170,28 +170,28 @@ def _status_from_text(text: str) -> int | None:
 def _liveness_error_is_provider_level(error: ProbeError) -> bool:
     """Does a failed liveness probe mean the *provider* is bad, not just the model?
 
-    Liveness is provider-grain: it must only condemn the provider when the
-    failure is shared by every model, not when one probe model happens to be
-    dead. The deciding signal is whether the endpoint answered at all:
+    Liveness is provider-grain, so it defaults to a provider-level failure: a
+    network error, 5xx, rejected credential, wrong base_url/path (a bare 404), or
+    a malformed request (400) all break *every* model and must surface as
+    ``provider_error`` — masking them as healthy would hide a real outage.
 
-    - No HTTP status (network / DNS / timeout / connection refused) → provider
-      is unreachable → provider-level fail.
-    - 5xx → the provider's server is broken → provider-level fail.
-    - 401 / 403 → the credential is rejected, which breaks every model →
-      provider-level fail.
-    - Any other 4xx (402 out-of-credits, 404 model removed, 429 rate-limited,
-      400 bad request, …) → the provider ANSWERED, so it is reachable; the
-      problem is scoped to that model/request. NOT provider-level — the
-      per-model probe surfaces the model-specific verdict instead.
+    The only exceptions — where the endpoint clearly answered about the one probe
+    model, so the provider is reachable and the per-model probe should carry the
+    verdict instead — are:
+
+    - HTTP 402 (out-of-credits / insufficient quota) for that model/account, and
+    - an explicit model-not-found marker (e.g. OpenRouter's "no endpoints found
+      for <model>"). A *bare* 404 without such a marker is NOT model-scoped — it
+      is treated as a provider/config failure (matching ``_error_says_model_not_found``).
     """
     status = error.raw_status
     if status is None:
         status = _status_from_text(f"{error.type} {error.message}")
-    if status is None:
-        return True
-    if status in (401, 403):
-        return True
-    return status >= 500
+    if status == 402:
+        return False
+    if _error_says_model_not_found(error):
+        return False
+    return True
 
 
 async def probe_liveness(provider: Any, *, model_id: str) -> ProbeStep:
@@ -381,6 +381,7 @@ _MODEL_NOT_FOUND_MARKERS = (
     "unknown model",
     "no such model",
     "invalid model",
+    "no endpoints found for",  # OpenRouter's phrasing for a removed/unavailable model
 )
 
 

--- a/backend/cubebox/services/provider_probe.py
+++ b/backend/cubebox/services/provider_probe.py
@@ -137,7 +137,11 @@ def _first_error_event(events: list[Any]) -> Any | None:
 
 
 def _error_event_detail(evt: Any) -> str:
-    for attr in ("error", "message", "detail"):
+    # cubepi's StreamEvent carries the upstream failure in `error_message` (see
+    # cubepi.providers.base.StreamEvent); the others are defensive fallbacks for
+    # differently-shaped event objects. Without error_message a 401/403 would be
+    # masked by the generic string below, making a wrong key look like a bug.
+    for attr in ("error_message", "error", "message", "detail"):
         v = getattr(evt, attr, None)
         if v:
             return str(v)[:200]

--- a/backend/cubebox/services/provider_probe.py
+++ b/backend/cubebox/services/provider_probe.py
@@ -213,7 +213,7 @@ async def probe_liveness(provider: Any, *, model_id: str) -> ProbeStep:
         detail = _error_event_detail(err_evt)
         err = ProbeError(type="StreamError", message=detail, raw_status=_status_from_text(detail))
         if _liveness_error_is_provider_level(err):
-            return ProbeStep(name="liveness", status="fail", detail=detail)
+            return ProbeStep(name="liveness", status="fail", detail=detail, error=err)
         return ProbeStep(
             name="liveness",
             status="pass",
@@ -415,6 +415,22 @@ def _error_says_auth_failure(error: ProbeError) -> bool:
         return True
     haystack = f"{error.type} {error.message}".lower()
     return any(marker in haystack for marker in _AUTH_ERROR_MARKERS)
+
+
+def liveness_status_for(step: ProbeStep) -> Literal["ok", "auth_error", "fail"]:
+    """Map a liveness ProbeStep to the persisted provider liveness status.
+
+    Splits a provider-level failure into a rejected-credential case
+    (``auth_error``) and everything else (``fail``) so the UI can tell the user
+    to fix the key versus the endpoint. A pass is ``ok``. (A model-specific
+    failure already returns a passing step — see ``probe_liveness`` — so it
+    never reaches here as a fail.)
+    """
+    if step.status == "pass":
+        return "ok"
+    if step.error is not None and _error_says_auth_failure(step.error):
+        return "auth_error"
+    return "fail"
 
 
 def _is_model_not_found(step: ProbeStep) -> bool:

--- a/backend/cubebox/services/provider_probe.py
+++ b/backend/cubebox/services/provider_probe.py
@@ -6,6 +6,7 @@ See spec §4.4 for the two-phase sequence (liveness + per-model capability).
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from collections.abc import Callable
 from typing import Any, Literal, cast
@@ -148,6 +149,44 @@ def _error_event_detail(evt: Any) -> str:
     return "stream returned an error event"
 
 
+# Pull an HTTP status out of a cubepi error string. cubepi formats upstream
+# failures as "... Error code: 404 - {...}", so the status isn't a structured
+# field on the error event — we have to read it back out of the message.
+_ERROR_CODE_RE = re.compile(r"error code:\s*(\d{3})", re.IGNORECASE)
+
+
+def _status_from_text(text: str) -> int | None:
+    m = _ERROR_CODE_RE.search(text)
+    return int(m.group(1)) if m else None
+
+
+def _liveness_error_is_provider_level(error: ProbeError) -> bool:
+    """Does a failed liveness probe mean the *provider* is bad, not just the model?
+
+    Liveness is provider-grain: it must only condemn the provider when the
+    failure is shared by every model, not when one probe model happens to be
+    dead. The deciding signal is whether the endpoint answered at all:
+
+    - No HTTP status (network / DNS / timeout / connection refused) → provider
+      is unreachable → provider-level fail.
+    - 5xx → the provider's server is broken → provider-level fail.
+    - 401 / 403 → the credential is rejected, which breaks every model →
+      provider-level fail.
+    - Any other 4xx (402 out-of-credits, 404 model removed, 429 rate-limited,
+      400 bad request, …) → the provider ANSWERED, so it is reachable; the
+      problem is scoped to that model/request. NOT provider-level — the
+      per-model probe surfaces the model-specific verdict instead.
+    """
+    status = error.raw_status
+    if status is None:
+        status = _status_from_text(f"{error.type} {error.message}")
+    if status is None:
+        return True
+    if status in (401, 403):
+        return True
+    return status >= 500
+
+
 async def probe_liveness(provider: Any, *, model_id: str) -> ProbeStep:
     # Spec §4.4 step 1: minimal completion — max_tokens=1, prompt ".",
     # 5s timeout. Proves base_url + key + network reach the endpoint.
@@ -161,10 +200,25 @@ async def probe_liveness(provider: Any, *, model_id: str) -> ProbeStep:
             max_seconds=5.0,
         )
     except Exception as exc:
-        return ProbeStep(name="liveness", status="fail", error=_probe_error(exc))
-    err = _first_error_event(events)
-    if err is not None:
-        return ProbeStep(name="liveness", status="fail", detail=_error_event_detail(err))
+        err = _probe_error(exc)
+        if _liveness_error_is_provider_level(err):
+            return ProbeStep(name="liveness", status="fail", error=err)
+        return ProbeStep(
+            name="liveness",
+            status="pass",
+            detail=f"provider reachable; probe model '{model_id}' unusable: {err.message[:140]}",
+        )
+    err_evt = _first_error_event(events)
+    if err_evt is not None:
+        detail = _error_event_detail(err_evt)
+        err = ProbeError(type="StreamError", message=detail, raw_status=_status_from_text(detail))
+        if _liveness_error_is_provider_level(err):
+            return ProbeStep(name="liveness", status="fail", detail=detail)
+        return ProbeStep(
+            name="liveness",
+            status="pass",
+            detail=f"provider reachable; probe model '{model_id}' unusable: {detail[:140]}",
+        )
     return ProbeStep(
         name="liveness",
         status="pass",

--- a/backend/cubebox/services/provider_probe.py
+++ b/backend/cubebox/services/provider_probe.py
@@ -26,6 +26,11 @@ from pydantic import BaseModel, Field
 ProbeStepName = Literal["liveness", "reasoning", "temperature", "tools", "streaming", "usage"]
 ProbeStepStatus = Literal["pass", "fail", "skip", "warn"]
 
+# Cap stored error text so a verbose upstream body can't bloat last_test_summary,
+# while leaving enough room for the human message the UI extracts (the cubepi
+# "[probe/<model> @ <url>] ..." prefix alone eats ~80 chars).
+_MAX_DETAIL_CHARS = 500
+
 
 class ProbeError(BaseModel):
     type: str
@@ -85,7 +90,9 @@ def _probe_error(exc: Exception) -> ProbeError:
         raw_status = getattr(getattr(exc, "response", None), "status_code", None)
     if not isinstance(raw_status, int):
         raw_status = None
-    return ProbeError(type=type(exc).__name__, message=str(exc)[:200], raw_status=raw_status)
+    return ProbeError(
+        type=type(exc).__name__, message=str(exc)[:_MAX_DETAIL_CHARS], raw_status=raw_status
+    )
 
 
 async def _drain_stream(
@@ -145,7 +152,7 @@ def _error_event_detail(evt: Any) -> str:
     for attr in ("error_message", "error", "message", "detail"):
         v = getattr(evt, attr, None)
         if v:
-            return str(v)[:200]
+            return str(v)[:_MAX_DETAIL_CHARS]
     return "stream returned an error event"
 
 

--- a/backend/cubebox/services/provider_service.py
+++ b/backend/cubebox/services/provider_service.py
@@ -181,6 +181,20 @@ class ProviderService:
 
         slug = await self._resolve_slug(data.name, data.slug)
 
+        # Backfill the capability snapshot from the catalog when the client sent a
+        # `preset_slug` (preset_key) but no capability — the presets API no longer
+        # exposes capability (resolved server-side). Mirrors the seeder.
+        capability = data.capability
+        if data.preset_slug and not capability:
+            try:
+                from cubebox.llm.catalog import load_catalog
+
+                capability = (
+                    load_catalog().resolve(data.preset_slug).capability.model_dump(mode="json")
+                )
+            except Exception:
+                capability = data.capability
+
         credential_id: str | None = None
         if data.auth_type != "none" and data.api_key:
             credential_id = await self._credentials.create(
@@ -201,7 +215,7 @@ class ProviderService:
             extra_body=data.extra_body,
             extra_headers=data.extra_headers,
             preset_slug=data.preset_slug,
-            capability=data.capability,
+            capability=capability,
             model_capability_overrides=data.model_capability_overrides,
             created_by_user_id=self.actor_user_id,
         )

--- a/backend/cubebox/services/provider_service.py
+++ b/backend/cubebox/services/provider_service.py
@@ -415,7 +415,7 @@ class ProviderService:
         system-readonly guard — instead of going through ``_check_not_system``.
         """
         provider.last_liveness_at = datetime.now(UTC)
-        provider.last_liveness_status = "ok" if step.status == "pass" else "fail"
+        provider.last_liveness_status = provider_probe.liveness_status_for(step)
         provider.last_liveness_summary = step.model_dump(mode="json")
         await self._providers.update(provider)
 

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1112,6 +1112,10 @@ class RunManager:
                 middleware=cubepi_middleware,
                 max_tokens=_model_max_tokens,
                 temperature=_model_temperature,
+                # Reasoning-capable models think by default ("medium"); a
+                # per-conversation toggle (UI) can override this later.
+                reasoning=_model_config.reasoning,
+                thinking="medium" if _model_config.reasoning else "off",
             )
 
             # Late-bind extra_ref to the live agent._extra dict so compaction /

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,23 +7,58 @@ os.environ.setdefault(
     "CUBEBOX_AUTH__VAULT_KEY",
     "Nmu-K8QhP_uhdjmwbaiNmgxVQHbGeCkMOCz8RKp1LMM=",
 )
-# In the MAIN repo, pin the test database name so the suite doesn't run against
-# the live dev DB. The dev .env sets CUBEBOX_DATABASE__NAME=cubebox, and a
-# dynaconf envvar override beats config.test.yaml — without this the tests would
-# clobber the dev DB's vault-encrypted credentials (re-encrypted with the test
-# key above, then undecryptable by the running dev service).
+# Route the suite to a TEST database — NEVER the live dev DB. A dynaconf envvar
+# override beats config.test.yaml, and clobbering the dev DB re-encrypts its
+# vault credentials with the test key above (then undecryptable by the running
+# dev service) and truncates seeded data — so getting this wrong is destructive.
 #
-# In a WORKTREE, do NOT set it: .worktree.env (loaded later by cubebox.config)
-# provides a per-slot DB name that must win. Setting it here would run first and,
-# because dynaconf's load_dotenv uses override=False, would block the per-slot
-# name — collapsing every worktree onto one shared DB and breaking isolation.
-if not (Path(__file__).resolve().parents[2] / ".worktree.env").exists():
+# - MAIN repo: pin the shared `cubebox_test` DB.
+# - WORKTREE: `.worktree.env` only declares the per-slot DEV db
+#   (CUBEBOX_DATABASE__NAME=cubebox_<slug>), which `cubebox.config` would load via
+#   load_dotenv and run the suite against the dev DB. Derive the per-slot TEST db
+#   (cubebox_test_<slug>, matching scripts/worktree-env's `db_test_schema`) and
+#   force it, so each worktree stays isolated AND its dev data is never touched.
+_wt_env = Path(__file__).resolve().parents[2] / ".worktree.env"
+if _wt_env.exists():
+    _dev_db = next(
+        (
+            line.split("=", 1)[1].strip()
+            for line in _wt_env.read_text().splitlines()
+            if line.startswith("CUBEBOX_DATABASE__NAME=")
+        ),
+        None,
+    )
+    if _dev_db and not _dev_db.startswith("cubebox_test_"):
+        # cubebox_<slug> -> cubebox_test_<slug>
+        os.environ["CUBEBOX_DATABASE__NAME"] = _dev_db.replace("cubebox_", "cubebox_test_", 1)
+else:
     os.environ.setdefault("CUBEBOX_DATABASE__NAME", "cubebox_test")
 
-import pytest
+# Backstop: never run against a non-test database, whatever leaked into the env
+# (e.g. a stray `source .worktree.env` before pytest, or an exported dev name).
+_db_name = os.environ.get("CUBEBOX_DATABASE__NAME", "cubebox_test")
+if "test" not in _db_name:
+    raise RuntimeError(
+        f"Refusing to run the test suite against non-test database {_db_name!r}. "
+        "Unset CUBEBOX_DATABASE__NAME (don't `source .worktree.env` before pytest) "
+        "or point it at a *_test database."
+    )
 
-from cubebox.config import config  # noqa: F401  -- ensures dynaconf is initialised pre-import
-from cubebox.plugins import ensure_registry_bound, reset_registry_for_tests
+# Test env always uses the local rustfs object store (config.test.yaml:
+# 127.0.0.1:9000, rustfsadmin). A developer's .env may set real cloud (Aliyun
+# OSS) objectstore creds for the dev server; those envvars override
+# config.test.yaml even in test env and break S3 tests with InvalidAccessKeyId.
+# Force the test creds.
+os.environ["CUBEBOX_OBJECTSTORE__ACCESS_KEY"] = "rustfsadmin"
+os.environ["CUBEBOX_OBJECTSTORE__ACCESS_SECRET"] = "rustfsadmin"
+
+import pytest  # noqa: E402  -- imports must follow the env setup above
+
+from cubebox.config import config  # noqa: E402, F401  -- ensures dynaconf is initialised pre-import
+from cubebox.plugins import (  # noqa: E402
+    ensure_registry_bound,
+    reset_registry_for_tests,
+)
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/e2e/test_admin_llm_endpoints.py
+++ b/backend/tests/e2e/test_admin_llm_endpoints.py
@@ -7,7 +7,7 @@ pytestmark = pytest.mark.e2e  # ensure marker even though conftest auto-adds
 
 # Tracks the cubebox nested vendor catalog (cubebox/llm/catalog/data/vendors.yaml).
 # Bump if vendors are added/removed.
-EXPECTED_VENDOR_COUNT = 32
+EXPECTED_VENDOR_COUNT = 23
 
 
 async def test_list_provider_presets(
@@ -29,6 +29,9 @@ async def test_list_provider_presets(
     assert ep["protocol"] == "anthropic-messages"
     assert ep["preset_key"] == "anthropic/intl/anthropic-messages"
     assert ep["base_url"] == "https://api.anthropic.com"
+    # Resolved capability ships with each endpoint so the wizard can prefill it.
+    assert isinstance(ep["capability"], dict)
+    assert "supports_tools" in ep["capability"]
     assert any(m["model_id"] == "claude-opus-4-7" for m in anthropic["models"])
 
 

--- a/backend/tests/e2e/test_admin_llm_endpoints.py
+++ b/backend/tests/e2e/test_admin_llm_endpoints.py
@@ -5,15 +5,15 @@ from httpx import AsyncClient
 
 pytestmark = pytest.mark.e2e  # ensure marker even though conftest auto-adds
 
-# Tracks the cubepi bundled provider-preset catalog (feat branch). Bump if the
-# upstream catalog changes.
-EXPECTED_PRESET_COUNT = 37
+# Tracks the cubebox nested vendor catalog (cubebox/llm/catalog/data/vendors.yaml).
+# Bump if vendors are added/removed.
+EXPECTED_VENDOR_COUNT = 32
 
 
 async def test_list_provider_presets(
     admin_client: tuple[AsyncClient, str],
 ) -> None:
-    """Admin sees the full cubepi preset catalog with the expected shape."""
+    """Admin sees the nested vendor catalog with the expected shape (spec §5.1)."""
     client, _ws_id = admin_client
 
     res = await client.get("/api/v1/admin/llm/presets")
@@ -21,12 +21,15 @@ async def test_list_provider_presets(
     data = res.json()
 
     assert isinstance(data, list)
-    assert len(data) == EXPECTED_PRESET_COUNT
+    assert len(data) == EXPECTED_VENDOR_COUNT
 
-    anthropic = next(p for p in data if p["slug"] == "anthropic")
-    assert anthropic["api"] == "anthropic-messages"
+    anthropic = next(v for v in data if v["vendor"] == "anthropic")
     assert anthropic["logo"] == "anthropic"
-    assert anthropic["capability"]["reasoning_level"]["kind"] == "int_budget"
+    ep = anthropic["endpoints"][0]
+    assert ep["protocol"] == "anthropic-messages"
+    assert ep["preset_key"] == "anthropic/intl/anthropic-messages"
+    assert ep["base_url"] == "https://api.anthropic.com"
+    assert any(m["model_id"] == "claude-opus-4-7" for m in anthropic["models"])
 
 
 async def test_get_provider_returns_liveness_and_per_model_readiness(

--- a/backend/tests/e2e/test_admin_providers_crud.py
+++ b/backend/tests/e2e/test_admin_providers_crud.py
@@ -279,7 +279,7 @@ async def test_create_provider_persists_capability(
 async def test_provider_out_resolves_brand_logo_from_preset(
     admin_client: tuple[AsyncClient, str],
 ) -> None:
-    """A provider with a known preset_slug exposes its brand-icon id as `logo`."""
+    """A provider with a known preset_slug (preset_key) exposes its brand-icon id as `logo`."""
     client, _ = admin_client
     res = await client.post(
         "/api/v1/admin/providers",
@@ -289,7 +289,7 @@ async def test_provider_out_resolves_brand_logo_from_preset(
             "base_url": "https://example.com",
             "auth_type": "api_key",
             "api_key": "sk-x",
-            "preset_slug": "anthropic",
+            "preset_slug": "anthropic/intl/anthropic-messages",
         },
     )
     assert res.status_code == 201

--- a/backend/tests/unit/llm/catalog/data/flat_providers_snapshot.yaml
+++ b/backend/tests/unit/llm/catalog/data/flat_providers_snapshot.yaml
@@ -1,0 +1,712 @@
+# Provider preset catalog. Spec: docs/dev/specs/2026-05-19-llm-provider-platform-design.md §3.7
+# Each entry parses into cubepi.providers.catalog.types.ProviderPreset.
+
+- slug: anthropic
+  display_name: Anthropic
+  short_name: Anthropic
+  logo: anthropic
+  category: saas
+  description: Anthropic Claude (Messages API). Native thinking + budget.
+  api: anthropic-messages
+  base_url: https://api.anthropic.com
+  auth: { mode: api_key, header_name: x-api-key, header_prefix: "" }
+  capability:
+    reasoning_off_payload: { thinking: { type: disabled } }
+    reasoning_on_payload:  { thinking: { type: enabled  } }
+    reasoning_level:
+      path: thinking.budget_tokens
+      kind: int_budget
+      # Aligned with cubepi.providers.base.ThinkingBudgets so AnthropicProvider's
+      # capability=None default-capability reproduces today's wire bytes.
+      level_budgets: { "off": 0, minimal: 1024, low: 2048, medium: 8192, high: 16384, xhigh: 16384 }
+    temperature: { mode: free, min: 0.0, max: 1.0, default: 1.0 }
+    max_tokens_field: max_tokens
+    supports_tools: true
+    supports_images: true
+  default_models:
+    # Opus 4.7 + Sonnet 4.6: 1M context window (Sonnet via beta header).
+    # Opus 4.7 supports up to 128K output tokens; Sonnet 4.6 up to 64K.
+    - { model_id: claude-opus-4-7,    display_name: Claude Opus 4.7,    context_window: 1000000, max_tokens: 128000, input_modalities: [text, image], reasoning: true }
+    - { model_id: claude-sonnet-4-6,  display_name: Claude Sonnet 4.6,  context_window: 1000000, max_tokens: 64000,  input_modalities: [text, image], reasoning: true }
+    - { model_id: claude-haiku-4-5,   display_name: Claude Haiku 4.5,   context_window: 200000,  max_tokens: 8192,   input_modalities: [text, image], reasoning: false }
+
+- slug: openai
+  display_name: OpenAI
+  short_name: OpenAI
+  logo: openai
+  category: saas
+  description: OpenAI Responses API (GPT-5 series, o-series reasoning).
+  api: openai-responses
+  base_url: https://api.openai.com/v1
+  auth: { mode: api_key }
+  capability:
+    # Request reasoning summaries + opt in to encrypted reasoning content for
+    # stateless multi-turn reasoning. Mirrors the legacy
+    # OpenAIResponsesProvider path. merge runs before write_reasoning_level,
+    # which adds reasoning.effort into the existing dict.
+    reasoning_on_payload:
+      reasoning: { summary: auto }
+      include: [reasoning.encrypted_content]
+    reasoning_level:
+      path: reasoning.effort
+      kind: effort
+      level_to_effort: { minimal: minimal, low: low, medium: medium, high: high, xhigh: high }
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    max_tokens_field: max_tokens
+    supports_tools: true
+    supports_images: true
+  default_models:
+    # GPT-5.5 (Apr 23 2026): 1M context, 128K output. GPT-5.4 series 1M context.
+    # o4-mini = cost-efficient reasoning model, 200K context.
+    - { model_id: gpt-5.5,        display_name: GPT-5.5,       context_window: 1000000, max_tokens: 128000, input_modalities: [text, image], reasoning: true }
+    - { model_id: gpt-5.4,        display_name: GPT-5.4,       context_window: 1000000, max_tokens: 65536,  input_modalities: [text, image], reasoning: true }
+    - { model_id: gpt-5.4-mini,   display_name: GPT-5.4 Mini,  context_window: 1000000, max_tokens: 65536,  input_modalities: [text, image], reasoning: true }
+    - { model_id: o4-mini,        display_name: o4-mini,       context_window: 200000,  max_tokens: 100000, input_modalities: [text],        reasoning: true }
+
+- slug: openai-legacy
+  display_name: OpenAI (Chat Completions)
+  short_name: OpenAI-Chat
+  logo: openai
+  category: saas
+  description: OpenAI legacy chat/completions wire (GPT-4o, GPT-4.1).
+  api: openai-completions
+  base_url: https://api.openai.com/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    max_tokens_field: max_completion_tokens
+    supports_tools: true
+    supports_images: true
+  default_models:
+    - { model_id: gpt-4o,   display_name: GPT-4o,   context_window: 128000, max_tokens: 16384, input_modalities: [text, image], reasoning: false }
+    - { model_id: gpt-4.1,  display_name: GPT-4.1,  context_window: 1000000, max_tokens: 32768, input_modalities: [text, image], reasoning: false }
+
+- slug: qwen-dashscope
+  display_name: 通义千问 (DashScope International)
+  short_name: Qwen
+  logo: qwen
+  category: saas
+  description: Alibaba Cloud Model Studio (Singapore) OpenAI-compatible endpoint for Qwen.
+  api: openai-completions
+  # International (Singapore) endpoint. CN companion: qwen-dashscope-cn.
+  base_url: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+  auth: { mode: api_key }
+  capability:
+    reasoning_off_payload: { extra_body: { enable_thinking: false } }
+    reasoning_on_payload:  { extra_body: { enable_thinking: true  } }
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    supports_tools: true
+    supports_images: true
+  default_models:
+    # Qwen3.6 series (2026): Max/Plus/Flash tiers via DashScope OpenAI-compat.
+    - { model_id: qwen3-max,      display_name: Qwen3 Max,      context_window: 262144, max_tokens: 32768, input_modalities: [text, image], reasoning: true }
+    - { model_id: qwen3.6-plus,   display_name: Qwen 3.6 Plus,  context_window: 262144, max_tokens: 32768, input_modalities: [text, image], reasoning: true }
+    - { model_id: qwen3.6-flash,  display_name: Qwen 3.6 Flash, context_window: 131072, max_tokens: 16384, input_modalities: [text, image], reasoning: false }
+
+- slug: doubao-volcengine
+  display_name: 豆包 (火山方舟)
+  short_name: Doubao
+  logo: doubao
+  category: saas
+  description: ByteDance Volcengine OpenAI-compatible endpoint for Doubao Seed models.
+  api: openai-completions
+  base_url: https://ark.cn-beijing.volces.com/api/v3
+  auth: { mode: api_key }
+  capability:
+    reasoning_off_payload: { extra_body: { thinking: { type: disabled } } }
+    reasoning_on_payload:  { extra_body: { thinking: { type: enabled  } } }
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    supports_tools: true
+    supports_images: true
+  default_models:
+    # Doubao Seed 2.0 family (Feb 14 2026 GA). 256K context across chat tiers.
+    - { model_id: doubao-seed-2.0-pro,   display_name: Doubao Seed 2.0 Pro,   context_window: 256000, max_tokens: 16384, input_modalities: [text, image], reasoning: true }
+    - { model_id: doubao-seed-2.0-code,  display_name: Doubao Seed 2.0 Code,  context_window: 256000, max_tokens: 16384, input_modalities: [text],        reasoning: true }
+    - { model_id: doubao-seed-2.0-lite,  display_name: Doubao Seed 2.0 Lite,  context_window: 256000, max_tokens: 16384, input_modalities: [text, image], reasoning: true }
+    - { model_id: doubao-seed-2.0-mini,  display_name: Doubao Seed 2.0 Mini,  context_window: 256000, max_tokens: 16384, input_modalities: [text],        reasoning: false }
+
+- slug: deepseek-anthropic
+  display_name: DeepSeek (Anthropic shape)
+  short_name: DeepSeek
+  logo: deepseek
+  category: saas
+  description: DeepSeek via its Anthropic-shape endpoint.
+  api: anthropic-messages
+  base_url: https://api.deepseek.com/anthropic
+  auth: { mode: api_key, header_name: x-api-key, header_prefix: "" }
+  capability:
+    reasoning_off_payload: { thinking: { type: disabled } }
+    reasoning_on_payload:  { thinking: { type: enabled } }
+    reasoning_level:
+      # DeepSeek's Anthropic-shape endpoint ignores `thinking.budget_tokens` and
+      # routes effort through `output_config.effort` instead.
+      # See https://api-docs.deepseek.com/guides/anthropic_api and
+      # https://api-docs.deepseek.com/guides/thinking_mode
+      path: output_config.effort
+      kind: effort
+      level_to_effort: { minimal: minimal, low: low, medium: medium, high: high, xhigh: max }
+    # DeepSeek's Anthropic-shape endpoint accepts temperature in [0.0, 2.0]
+    # (broader than vanilla Anthropic's [0.0, 1.0]).
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  default_models:
+    # DeepSeek V4 (Apr 24 2026 preview): 1M context across Pro / Flash.
+    - { model_id: deepseek-v4-pro,    display_name: DeepSeek V4 Pro,    context_window: 1000000, max_tokens: 32768, input_modalities: [text], reasoning: true }
+    - { model_id: deepseek-v4-flash,  display_name: DeepSeek V4 Flash,  context_window: 1000000, max_tokens: 32768, input_modalities: [text], reasoning: true }
+
+- slug: deepseek-openai
+  display_name: DeepSeek (OpenAI shape)
+  short_name: DeepSeek
+  logo: deepseek
+  category: saas
+  description: DeepSeek via its OpenAI chat-completions endpoint.
+  api: openai-completions
+  base_url: https://api.deepseek.com
+  auth: { mode: api_key }
+  capability:
+    reasoning_off_payload: { extra_body: { reasoning: { exclude: true } } }
+    reasoning_on_payload:  { extra_body: { reasoning: { exclude: false } } }
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  default_models:
+    - { model_id: deepseek-v4-pro,    display_name: DeepSeek V4 Pro,    context_window: 1000000, max_tokens: 32768, input_modalities: [text], reasoning: true }
+    - { model_id: deepseek-v4-flash,  display_name: DeepSeek V4 Flash,  context_window: 1000000, max_tokens: 32768, input_modalities: [text], reasoning: true }
+
+- slug: moonshot
+  display_name: Moonshot Kimi (International)
+  short_name: Moonshot
+  logo: moonshot
+  category: saas
+  description: Moonshot AI Kimi OpenAI-compatible endpoint (.ai global region).
+  api: openai-completions
+  # International endpoint. CN companion: moonshot-cn.
+  base_url: https://api.moonshot.ai/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+    supports_tools: true
+  default_models:
+    # Kimi K2.6 (Apr 20 2026): 256K context, MoE 1T total / 32B active params.
+    - { model_id: kimi-k2.6,         display_name: Kimi K2.6,        context_window: 262144, max_tokens: 32768, input_modalities: [text], reasoning: true }
+    - { model_id: kimi-k2,           display_name: Kimi K2,          context_window: 131072, max_tokens: 16384, input_modalities: [text], reasoning: false }
+
+- slug: zhipu
+  display_name: 智谱 GLM (Z.AI International)
+  short_name: Zhipu
+  logo: zhipu
+  category: saas
+  description: Zhipu AI GLM OpenAI-compatible endpoint (Z.AI global region).
+  api: openai-completions
+  # International endpoint. CN companion (BigModel): zhipu-cn.
+  base_url: https://api.z.ai/api/paas/v4
+  auth: { mode: api_key }
+  capability:
+    # GLM thinking mode toggle (GLM-4.5+/GLM-5). Stays inside extra_body to
+    # ride through OpenAI-compat dispatch unchanged.
+    reasoning_off_payload: { extra_body: { thinking: { type: disabled } } }
+    reasoning_on_payload:  { extra_body: { thinking: { type: enabled  } } }
+    temperature: { mode: free, min: 0.0, max: 1.0, default: 0.7 }
+    supports_tools: true
+    supports_images: true
+  default_models:
+    # GLM-5 (Feb 11 2026): 744B MoE, MIT-licensed open weights. 200K context.
+    - { model_id: glm-5,         display_name: GLM-5,         context_window: 200000, max_tokens: 32768, input_modalities: [text, image], reasoning: true }
+    - { model_id: glm-4.7,       display_name: GLM-4.7,       context_window: 200000, max_tokens: 16384, input_modalities: [text, image], reasoning: true }
+    - { model_id: glm-4.7-flash, display_name: GLM-4.7 Flash, context_window: 128000, max_tokens: 16384, input_modalities: [text],        reasoning: false }
+
+- slug: minimax
+  display_name: MiniMax
+  short_name: MiniMax
+  logo: minimax
+  category: saas
+  description: MiniMax OpenAI-compatible endpoint (M-series chat / agent models).
+  api: openai-completions
+  base_url: https://api.minimax.io/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    supports_tools: true
+    supports_images: true
+  default_models:
+    # MiniMax M2.7 (Mar 18 2026): 204800-token context, up to 131072 max output.
+    - { model_id: MiniMax-M2.7,            display_name: MiniMax M2.7,            context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: true }
+    - { model_id: MiniMax-M2.7-highspeed,  display_name: MiniMax M2.7 Highspeed,  context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: false }
+    - { model_id: MiniMax-M2.5,            display_name: MiniMax M2.5,            context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: true }
+
+- slug: xai
+  display_name: xAI
+  short_name: xAI
+  logo: xai
+  category: saas
+  description: xAI Grok OpenAI-compatible endpoint.
+  api: openai-completions
+  base_url: https://api.x.ai/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    supports_tools: true
+    supports_images: true
+  default_models:
+    # Grok 4.3 (May 6 2026): 1M context, always-on reasoning, native multimodal.
+    # Older grok-4 / grok-4-fast etc. retire May 15 2026.
+    - { model_id: grok-4.3,       display_name: Grok 4.3,       context_window: 1000000, max_tokens: 32768, input_modalities: [text, image, video], reasoning: true }
+    - { model_id: grok-4.20,      display_name: Grok 4.20,      context_window: 2000000, max_tokens: 32768, input_modalities: [text, image],        reasoning: true }
+
+- slug: mistral
+  display_name: Mistral
+  short_name: Mistral
+  logo: mistral
+  category: saas
+  description: Mistral La Plateforme OpenAI-compatible.
+  api: openai-completions
+  base_url: https://api.mistral.ai/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 1.0, default: 0.7 }
+    supports_tools: true
+    supports_images: true
+  default_models:
+    # Mistral Medium 3.5 (Apr 29 2026): 128B dense, 256K context, native multimodal.
+    # Mistral Large 3: 675B MoE, 256K context.
+    - { model_id: mistral-large-latest,   display_name: Mistral Large 3,    context_window: 256000, max_tokens: 32768, input_modalities: [text, image], reasoning: true }
+    - { model_id: mistral-medium-latest,  display_name: Mistral Medium 3.5, context_window: 256000, max_tokens: 32768, input_modalities: [text, image], reasoning: true }
+    - { model_id: mistral-small-latest,   display_name: Mistral Small 4,    context_window: 256000, max_tokens: 16384, input_modalities: [text, image], reasoning: false }
+
+- slug: openrouter
+  display_name: OpenRouter
+  short_name: OpenRouter
+  logo: openrouter
+  category: saas
+  description: OpenRouter unified gateway. Per-model reasoning overrides for known reasoning models.
+  api: openai-completions
+  base_url: https://openrouter.ai/api/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    supports_tools: true
+    supports_images: true
+  model_capability_overrides:
+    deepseek/deepseek-r1:
+      reasoning_off_payload: { reasoning: { exclude: true } }
+      reasoning_on_payload:  { reasoning: { exclude: false } }
+      reasoning_level:
+        path: reasoning.effort
+        kind: effort
+        level_to_effort: { low: low, medium: medium, high: high }
+    openai/o4-mini:
+      reasoning_level:
+        path: reasoning.effort
+        kind: effort
+        level_to_effort: { low: low, medium: medium, high: high }
+  default_models: []
+
+- slug: together-ai
+  display_name: Together AI
+  short_name: Together
+  logo: together
+  category: saas
+  description: Together AI OpenAI-compatible.
+  api: openai-completions
+  base_url: https://api.together.xyz/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+  default_models: []
+
+- slug: groq
+  display_name: Groq
+  short_name: Groq
+  logo: groq
+  category: saas
+  description: Groq high-throughput OpenAI-compatible.
+  api: openai-completions
+  base_url: https://api.groq.com/openai/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  default_models: []
+
+- slug: fireworks
+  display_name: Fireworks AI
+  short_name: Fireworks
+  logo: fireworks
+  category: saas
+  description: Fireworks AI OpenAI-compatible.
+  api: openai-completions
+  base_url: https://api.fireworks.ai/inference/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+  default_models: []
+
+- slug: vllm
+  display_name: vLLM (self-hosted)
+  short_name: vLLM
+  logo: vllm
+  category: oss-framework
+  description: vLLM OpenAI-compatible server. Reasoning conventions depend on the loaded model and reasoning parser plugin.
+  api: openai-completions
+  base_url: http://localhost:8000/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+    supports_tools: false
+  default_models: []
+
+- slug: ollama
+  display_name: Ollama
+  short_name: Ollama
+  logo: ollama
+  category: oss-framework
+  description: Ollama local OpenAI-compatible endpoint.
+  api: openai-completions
+  base_url: http://localhost:11434/v1
+  auth: { mode: none }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+    supports_tools: false
+  default_models: []
+
+- slug: lm-studio
+  display_name: LM Studio
+  short_name: LM Studio
+  logo: lmstudio
+  category: oss-framework
+  description: LM Studio local server.
+  api: openai-completions
+  base_url: http://localhost:1234/v1
+  auth: { mode: none }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+    supports_tools: false
+  default_models: []
+
+- slug: tgi
+  display_name: HuggingFace TGI
+  short_name: TGI
+  logo: huggingface
+  category: oss-framework
+  description: Text Generation Inference OpenAI-compatible endpoint.
+  api: openai-completions
+  base_url: http://localhost:8080/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+    supports_tools: false
+  default_models: []
+
+# ────────────────────────────────────────────────────────────────────────
+# CN companions (mainland endpoints). Convention: default slug = international,
+# `-cn` suffix = mainland China endpoint.
+# ────────────────────────────────────────────────────────────────────────
+
+- slug: qwen-dashscope-cn
+  display_name: 通义千问 (DashScope 国内)
+  short_name: Qwen CN
+  logo: qwen
+  category: saas
+  description: Alibaba Cloud DashScope 国内站 (Beijing) OpenAI-compatible endpoint.
+  api: openai-completions
+  base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+  auth: { mode: api_key }
+  capability:
+    reasoning_off_payload: { extra_body: { enable_thinking: false } }
+    reasoning_on_payload:  { extra_body: { enable_thinking: true  } }
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    supports_tools: true
+    supports_images: true
+  default_models:
+    - { model_id: qwen3-max,      display_name: Qwen3 Max,      context_window: 262144, max_tokens: 32768, input_modalities: [text, image], reasoning: true }
+    - { model_id: qwen3.6-plus,   display_name: Qwen 3.6 Plus,  context_window: 262144, max_tokens: 32768, input_modalities: [text, image], reasoning: true }
+    - { model_id: qwen3.6-flash,  display_name: Qwen 3.6 Flash, context_window: 131072, max_tokens: 16384, input_modalities: [text, image], reasoning: false }
+
+- slug: moonshot-cn
+  display_name: Moonshot Kimi (国内)
+  short_name: Moonshot CN
+  logo: moonshot
+  category: saas
+  description: Moonshot AI Kimi 国内站 OpenAI-compatible endpoint.
+  api: openai-completions
+  base_url: https://api.moonshot.cn/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+    supports_tools: true
+  default_models:
+    - { model_id: kimi-k2.6,  display_name: Kimi K2.6,  context_window: 262144, max_tokens: 32768, input_modalities: [text], reasoning: true }
+    - { model_id: kimi-k2,    display_name: Kimi K2,    context_window: 131072, max_tokens: 16384, input_modalities: [text], reasoning: false }
+
+- slug: zhipu-cn
+  display_name: 智谱 GLM (BigModel 国内)
+  short_name: Zhipu CN
+  logo: zhipu
+  category: saas
+  description: Zhipu AI GLM 国内站 (open.bigmodel.cn) OpenAI-compatible endpoint.
+  api: openai-completions
+  base_url: https://open.bigmodel.cn/api/paas/v4
+  auth: { mode: api_key }
+  capability:
+    reasoning_off_payload: { extra_body: { thinking: { type: disabled } } }
+    reasoning_on_payload:  { extra_body: { thinking: { type: enabled  } } }
+    temperature: { mode: free, min: 0.0, max: 1.0, default: 0.7 }
+    supports_tools: true
+    supports_images: true
+  default_models:
+    - { model_id: glm-5,         display_name: GLM-5,         context_window: 200000, max_tokens: 32768, input_modalities: [text, image], reasoning: true }
+    - { model_id: glm-4.7,       display_name: GLM-4.7,       context_window: 200000, max_tokens: 16384, input_modalities: [text, image], reasoning: true }
+    - { model_id: glm-4.7-flash, display_name: GLM-4.7 Flash, context_window: 128000, max_tokens: 16384, input_modalities: [text],        reasoning: false }
+
+- slug: minimax-cn
+  display_name: MiniMax (国内)
+  short_name: MiniMax CN
+  logo: minimax
+  category: saas
+  description: MiniMax 国内站 OpenAI-compatible endpoint (minimaxi.com).
+  api: openai-completions
+  base_url: https://api.minimaxi.com/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    supports_tools: true
+    supports_images: true
+  default_models:
+    - { model_id: MiniMax-M2.7,            display_name: MiniMax M2.7,            context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: true }
+    - { model_id: MiniMax-M2.7-highspeed,  display_name: MiniMax M2.7 Highspeed,  context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: false }
+    - { model_id: MiniMax-M2.5,            display_name: MiniMax M2.5,            context_window: 204800, max_tokens: 131072, input_modalities: [text, image], reasoning: true }
+
+# ────────────────────────────────────────────────────────────────────────
+# Coding plans (subscription tier — separate endpoints / auth from token API).
+# Placeholders for the cubebox UX; OAuth flow + cross-vendor model lists land
+# in a follow-up PR. All `default_models: []` until that work lands.
+# ────────────────────────────────────────────────────────────────────────
+
+- slug: anthropic-claude-code
+  display_name: Anthropic Claude Code (Max plan)
+  short_name: Claude Code
+  logo: anthropic
+  category: saas
+  description: Claude Code via Claude Pro/Max subscription. OAuth (no API key billing).
+  api: anthropic-messages
+  # Wire endpoint same as token API; auth flow is OAuth via `claude setup-token`.
+  # OAuth refresh URL is restricted to Anthropic-owned hosts. cubebox needs to
+  # implement the device-code login flow before this preset is usable.
+  base_url: https://api.anthropic.com
+  auth: { mode: oauth, header_name: Authorization, header_prefix: "Bearer " }
+  capability:
+    reasoning_off_payload: { thinking: { type: disabled } }
+    reasoning_on_payload:  { thinking: { type: enabled  } }
+    reasoning_level:
+      path: thinking.budget_tokens
+      kind: int_budget
+      level_budgets: { "off": 0, minimal: 1024, low: 2048, medium: 8192, high: 16384, xhigh: 16384 }
+    temperature: { mode: free, min: 0.0, max: 1.0, default: 1.0 }
+    max_tokens_field: max_tokens
+    supports_tools: true
+    supports_images: true
+  default_models: []  # populated dynamically from Claude Code plan entitlements
+
+- slug: openai-codex
+  display_name: OpenAI Codex (ChatGPT plan)
+  short_name: Codex
+  logo: openai
+  category: saas
+  description: Codex CLI via ChatGPT Plus/Pro/Business subscription. OAuth login.
+  api: openai-responses
+  # OAuth via `codex login` (browser flow) or `codex login --device-auth`.
+  # Tokens exchanged to ChatGPT backend; cubebox needs OAuth flow before use.
+  base_url: https://chatgpt.com/backend-api/codex
+  auth: { mode: oauth, header_name: Authorization, header_prefix: "Bearer " }
+  capability:
+    reasoning_on_payload:
+      reasoning: { summary: auto }
+      include: [reasoning.encrypted_content]
+    reasoning_level:
+      path: reasoning.effort
+      kind: effort
+      level_to_effort: { minimal: minimal, low: low, medium: medium, high: high, xhigh: high }
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    max_tokens_field: max_tokens
+    supports_tools: true
+    supports_images: true
+  default_models: []  # populated dynamically from ChatGPT plan entitlements
+
+- slug: zhipu-coding
+  display_name: 智谱 GLM Coding Plan (国际)
+  short_name: GLM Coding
+  logo: zhipu
+  category: saas
+  description: Zhipu Coding Plan dedicated endpoint (Z.AI global). Same api_key as zhipu, routed through /coding/.
+  api: openai-completions
+  base_url: https://api.z.ai/api/coding/paas/v4
+  auth: { mode: api_key }
+  capability:
+    reasoning_off_payload: { extra_body: { thinking: { type: disabled } } }
+    reasoning_on_payload:  { extra_body: { thinking: { type: enabled  } } }
+    temperature: { mode: free, min: 0.0, max: 1.0, default: 0.7 }
+    supports_tools: true
+    supports_images: true
+  default_models: []  # GLM-5 / GLM-4.7 — quota-gated; pulled at runtime
+
+- slug: zhipu-coding-cn
+  display_name: 智谱 GLM Coding Plan (国内)
+  short_name: GLM Coding CN
+  logo: zhipu
+  category: saas
+  description: Zhipu Coding Plan 国内站 (open.bigmodel.cn) dedicated /coding/ endpoint.
+  api: openai-completions
+  base_url: https://open.bigmodel.cn/api/coding/paas/v4
+  auth: { mode: api_key }
+  capability:
+    reasoning_off_payload: { extra_body: { thinking: { type: disabled } } }
+    reasoning_on_payload:  { extra_body: { thinking: { type: enabled  } } }
+    temperature: { mode: free, min: 0.0, max: 1.0, default: 0.7 }
+    supports_tools: true
+    supports_images: true
+  default_models: []
+
+- slug: minimax-coding
+  display_name: MiniMax Coding Plan (国际)
+  short_name: MiniMax Coding
+  logo: minimax
+  category: saas
+  description: MiniMax Coding Plan — anthropic-shape wire on global (.minimax.io). Separate coding api_key.
+  api: anthropic-messages
+  # MiniMax Coding Plan is served on Anthropic-shape, NOT OpenAI-compat.
+  # https://github.com/badlogic/pi-mono/issues/2768
+  base_url: https://api.minimax.io/anthropic
+  auth: { mode: api_key, header_name: x-api-key, header_prefix: "" }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    max_tokens_field: max_tokens
+    supports_tools: true
+    supports_images: true
+  default_models: []  # MiniMax-M2 / M2.1 / M2.5 — coding-plan gated
+
+- slug: minimax-coding-cn
+  display_name: MiniMax Coding Plan (国内)
+  short_name: MiniMax Coding CN
+  logo: minimax
+  category: saas
+  description: MiniMax Coding Plan 国内站 (minimaxi.com), anthropic-shape.
+  api: anthropic-messages
+  base_url: https://api.minimaxi.com/anthropic
+  auth: { mode: api_key, header_name: x-api-key, header_prefix: "" }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    max_tokens_field: max_tokens
+    supports_tools: true
+    supports_images: true
+  default_models: []
+
+- slug: moonshot-coding
+  display_name: Moonshot Kimi Coding (国际)
+  short_name: Kimi Coding
+  logo: moonshot
+  category: saas
+  description: Moonshot Kimi Coding subscription (.ai global). Currently shares /v1 with token API.
+  api: openai-completions
+  # No dedicated /coding/ route as of 2026-05; coding plan uses the same /v1
+  # base but with a separate api_key from the subscription dashboard.
+  base_url: https://api.moonshot.ai/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+    supports_tools: true
+  default_models: []
+
+- slug: moonshot-coding-cn
+  display_name: Moonshot Kimi Coding (国内)
+  short_name: Kimi Coding CN
+  logo: moonshot
+  category: saas
+  description: Moonshot Kimi Coding subscription 国内站 (.cn). Same /v1 wire as token API; coding api_key.
+  api: openai-completions
+  base_url: https://api.moonshot.cn/v1
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 0.7 }
+    supports_tools: true
+  default_models: []
+
+- slug: qwen-coding
+  display_name: 通义千问 Coding Plan (国际)
+  short_name: Qwen Coding
+  logo: qwen
+  category: saas
+  description: Alibaba Cloud Qwen Coding Plan (Singapore). $50/mo subscription tier.
+  api: openai-completions
+  base_url: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+  auth: { mode: api_key }
+  capability:
+    reasoning_off_payload: { extra_body: { enable_thinking: false } }
+    reasoning_on_payload:  { extra_body: { enable_thinking: true  } }
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    supports_tools: true
+    supports_images: true
+  default_models: []  # qwen3-coder-plus + qwen3.6 coder variants
+
+- slug: qwen-coding-cn
+  display_name: 通义千问 Coding Plan (国内)
+  short_name: Qwen Coding CN
+  logo: qwen
+  category: saas
+  description: Alibaba Cloud Qwen Coding Plan 国内站. ¥7.9 起 (Lite) / ¥39.9 (Pro) 订阅.
+  api: openai-completions
+  base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+  auth: { mode: api_key }
+  capability:
+    reasoning_off_payload: { extra_body: { enable_thinking: false } }
+    reasoning_on_payload:  { extra_body: { enable_thinking: true  } }
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    supports_tools: true
+    supports_images: true
+  default_models: []
+
+- slug: volcengine-coding
+  display_name: 火山方舟 Coding Plan
+  short_name: Ark Coding
+  logo: doubao
+  category: saas
+  description: 火山方舟 Coding Plan — anthropic-shape wire serving Doubao + 3rd-party (Kimi/GLM/MiniMax/DeepSeek).
+  api: anthropic-messages
+  # Coding Plan exposes a Claude-Code-compatible Anthropic wire at /api/coding,
+  # in addition to the OpenAI-compat /api/v3 used by the doubao-volcengine preset.
+  # Only 国内 endpoint as of 2026-05.
+  base_url: https://ark.cn-beijing.volces.com/api/coding
+  auth: { mode: api_key, header_name: x-api-key, header_prefix: "" }
+  capability:
+    reasoning_off_payload: { thinking: { type: disabled } }
+    reasoning_on_payload:  { thinking: { type: enabled  } }
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+    max_tokens_field: max_tokens
+    supports_tools: true
+    supports_images: true
+  default_models: []  # Doubao-Seed-2.0-Code/Pro + Kimi-K2.5 + GLM-4.7 + MiniMax-M2.5 + DeepSeek-V4 (quota-gated)
+
+# ────────────────────────────────────────────────────────────────────────
+# Custom (bring-your-own) endpoints.
+# ────────────────────────────────────────────────────────────────────────
+
+- slug: custom-openai
+  display_name: Custom OpenAI-compatible
+  short_name: Custom
+  logo: null
+  category: custom
+  description: Bring your own OpenAI chat-completions endpoint.
+  api: openai-completions
+  base_url: ""
+  auth: { mode: api_key }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  default_models: []
+
+- slug: custom-anthropic
+  display_name: Custom Anthropic-compatible
+  short_name: Custom
+  logo: null
+  category: custom
+  description: Bring your own Anthropic Messages endpoint.
+  api: anthropic-messages
+  base_url: ""
+  auth: { mode: api_key, header_name: x-api-key, header_prefix: "" }
+  capability:
+    temperature: { mode: free, min: 0.0, max: 1.0, default: 1.0 }
+  default_models: []

--- a/backend/tests/unit/llm/catalog/test_composition.py
+++ b/backend/tests/unit/llm/catalog/test_composition.py
@@ -69,6 +69,11 @@ def test_every_flat_base_url_is_reproduced():
     A plain set would let one new endpoint satisfy both; a Counter requires the new
     catalog to produce at least as many endpoints per (api, base_url). Flat entries
     with base_url == "" (custom-*) are excluded — they have no composed URL.
+
+    INTENTIONAL_DIVERGENCE: a few flat coding-plan presets carried placeholder
+    URLs (identical to the general plan) that the consolidated catalog replaces
+    with the real, deployed coding-plan host. Those flat slugs are excluded — the
+    divergence is deliberate, not a porting regression.
     """
     from collections import Counter
     from pathlib import Path
@@ -77,11 +82,23 @@ def test_every_flat_base_url_is_reproduced():
 
     from cubebox.llm.catalog import load_catalog
 
+    # flat slug -> reason. The consolidated catalog folds coding plans into their
+    # parent vendor and uses the real coding host; these flat URLs were placeholders.
+    intentional_divergence = {
+        "qwen-coding-cn": "Aliyun coding plan lives on coding.dashscope.aliyuncs.com "
+        "(real deployment, folded into aliyun/cn/.../coding), not the flat placeholder "
+        "dashscope.aliyuncs.com/compatible-mode/v1",
+    }
+
     snapshot = Path(__file__).parent / "data" / "flat_providers_snapshot.yaml"
     flat = yaml.safe_load(snapshot.read_text("utf-8"))
     catalog = load_catalog()
     produced = Counter((e.protocol, e.base_url) for e in catalog.endpoints.values())
-    expected = Counter((entry["api"], entry["base_url"]) for entry in flat if entry.get("base_url"))
+    expected = Counter(
+        (entry["api"], entry["base_url"])
+        for entry in flat
+        if entry.get("base_url") and entry["slug"] not in intentional_divergence
+    )
     deficits = {
         pair: (cnt, produced[pair]) for pair, cnt in expected.items() if produced[pair] < cnt
     }

--- a/backend/tests/unit/llm/catalog/test_composition.py
+++ b/backend/tests/unit/llm/catalog/test_composition.py
@@ -59,3 +59,30 @@ def test_compose_base_url_unknown_region_raises():
             {"cn": Region(host="https://x")},
             Endpoint(region="intl", protocol="openai-completions", capability="x"),
         )
+
+
+def test_every_flat_base_url_is_reproduced():
+    """Each flat (api, base_url) must be reproduced with the SAME MULTIPLICITY.
+
+    Multiplicity matters: two flat entries can share an identical (api, base_url)
+    (e.g. moonshot vs moonshot-coding both openai-completions on api.moonshot.ai/v1).
+    A plain set would let one new endpoint satisfy both; a Counter requires the new
+    catalog to produce at least as many endpoints per (api, base_url). Flat entries
+    with base_url == "" (custom-*) are excluded — they have no composed URL.
+    """
+    from collections import Counter
+    from pathlib import Path
+
+    import yaml
+
+    from cubebox.llm.catalog import load_catalog
+
+    snapshot = Path(__file__).parent / "data" / "flat_providers_snapshot.yaml"
+    flat = yaml.safe_load(snapshot.read_text("utf-8"))
+    catalog = load_catalog()
+    produced = Counter((e.protocol, e.base_url) for e in catalog.endpoints.values())
+    expected = Counter((entry["api"], entry["base_url"]) for entry in flat if entry.get("base_url"))
+    deficits = {
+        pair: (cnt, produced[pair]) for pair, cnt in expected.items() if produced[pair] < cnt
+    }
+    assert not deficits, f"flat URLs under-reproduced (expected, got): {deficits}"

--- a/backend/tests/unit/llm/catalog/test_composition.py
+++ b/backend/tests/unit/llm/catalog/test_composition.py
@@ -1,0 +1,61 @@
+import pytest
+
+from cubebox.llm.catalog.loader import compose_base_url
+from cubebox.llm.catalog.types import Endpoint, Region
+
+
+@pytest.mark.parametrize(
+    "regions,endpoint,expected",
+    [
+        # A. path differs, region host
+        (
+            {"cn": Region(host="https://open.bigmodel.cn")},
+            Endpoint(
+                region="cn",
+                protocol="openai-completions",
+                path="/api/coding/paas/v4",
+                capability="x",
+            ),
+            "https://open.bigmodel.cn/api/coding/paas/v4",
+        ),
+        # B. host override (Alibaba coding lives on a different domain)
+        (
+            {"cn": Region(host="https://dashscope.aliyuncs.com")},
+            Endpoint(
+                region="cn",
+                protocol="openai-completions",
+                host="https://coding.dashscope.aliyuncs.com",
+                path="/v1",
+                capability="x",
+            ),
+            "https://coding.dashscope.aliyuncs.com/v1",
+        ),
+        # C. empty path (DeepSeek openai)
+        (
+            {"cn": Region(host="https://api.deepseek.com")},
+            Endpoint(region="cn", protocol="openai-completions", capability="x"),
+            "https://api.deepseek.com",
+        ),
+        # D. full base_url override bypasses composition
+        (
+            {"intl": Region(host="https://ignored")},
+            Endpoint(
+                region="intl",
+                protocol="openai-responses",
+                base_url="https://chatgpt.com/backend-api/codex",
+                capability="x",
+            ),
+            "https://chatgpt.com/backend-api/codex",
+        ),
+    ],
+)
+def test_compose_base_url(regions, endpoint, expected):
+    assert compose_base_url(regions, endpoint) == expected
+
+
+def test_compose_base_url_unknown_region_raises():
+    with pytest.raises(ValueError, match="unknown region"):
+        compose_base_url(
+            {"cn": Region(host="https://x")},
+            Endpoint(region="intl", protocol="openai-completions", capability="x"),
+        )

--- a/backend/tests/unit/llm/catalog/test_loader.py
+++ b/backend/tests/unit/llm/catalog/test_loader.py
@@ -1,4 +1,6 @@
-from cubebox.llm.catalog.loader import preset_key_for
+import pytest
+
+from cubebox.llm.catalog.loader import preset_key_for, resolve_capability
 from cubebox.llm.catalog.types import Endpoint, Vendor
 
 
@@ -52,3 +54,23 @@ def test_preset_key_with_plan():
 def test_preset_key_override_wins():
     ep = Endpoint(region="cn", protocol="openai-completions", key="pretty-key", capability="x")
     assert preset_key_for("zhipu", ep) == "pretty-key"
+
+
+def test_resolve_capability_named():
+    profiles = {"openai-compat-basic": {"supports_tools": True, "supports_images": True}}
+    cap = resolve_capability("openai-compat-basic", profiles)
+    assert cap.supports_tools is True
+    assert cap.supports_images is True
+
+
+def test_resolve_capability_inline_dict():
+    cap = resolve_capability(
+        {"supports_images": True, "max_tokens_field": "max_completion_tokens"}, {}
+    )
+    assert cap.supports_images is True
+    assert cap.max_tokens_field == "max_completion_tokens"
+
+
+def test_resolve_capability_unknown_name_fails_loudly():
+    with pytest.raises(ValueError, match="unknown capability profile"):
+        resolve_capability("does-not-exist", {"openai-compat-basic": {}})

--- a/backend/tests/unit/llm/catalog/test_loader.py
+++ b/backend/tests/unit/llm/catalog/test_loader.py
@@ -1,0 +1,38 @@
+from cubebox.llm.catalog.types import Vendor
+
+
+def test_vendor_parses_minimal():
+    v = Vendor.model_validate(
+        {
+            "vendor": "deepseek",
+            "display_name": "DeepSeek",
+            "short_name": "DeepSeek",
+            "logo": "deepseek",
+            "category": "saas",
+            "description": "DeepSeek V-series.",
+            "regions": {"cn": {"host": "https://api.deepseek.com"}},
+            "endpoints": [
+                {
+                    "region": "cn",
+                    "protocol": "openai-completions",
+                    "capability": "openai-compat-basic",
+                }
+            ],
+            "models": [
+                {
+                    "model_id": "deepseek-v4",
+                    "display_name": "DeepSeek V4",
+                    "context_window": 64000,
+                    "max_tokens": 8192,
+                    "input_modalities": ["text"],
+                    "reasoning": True,
+                    "pricing": {"input": 0.27, "output": 1.10},
+                }
+            ],
+        }
+    )
+    assert v.regions["cn"].host == "https://api.deepseek.com"
+    assert v.endpoints[0].protocol == "openai-completions"
+    assert v.endpoints[0].plan is None
+    assert v.models[0].pricing.cache_read == 0.0
+    assert v.models[0].plan is None

--- a/backend/tests/unit/llm/catalog/test_loader.py
+++ b/backend/tests/unit/llm/catalog/test_loader.py
@@ -241,3 +241,34 @@ def test_duplicate_endpoint_tuple_rejected_even_with_distinct_key_overrides():
     )
     with pytest.raises(ValueError, match="duplicate endpoint"):
         build_catalog([v], PROFILES)
+
+
+def test_catalog_to_api_shape():
+    from cubebox.llm.catalog import load_catalog
+
+    api = load_catalog().to_api()
+    assert isinstance(api, list)
+    v = next(x for x in api if x["vendor"] == "deepseek")
+    assert {
+        "vendor",
+        "display_name",
+        "short_name",
+        "logo",
+        "category",
+        "description",
+        "endpoints",
+        "models",
+    } <= v.keys()
+    ep = v["endpoints"][0]
+    assert {"preset_key", "region", "protocol", "plan", "base_url", "model_ids"} <= ep.keys()
+    m = v["models"][0]
+    assert {
+        "model_id",
+        "display_name",
+        "plan",
+        "context_window",
+        "max_tokens",
+        "input_modalities",
+        "reasoning",
+        "pricing",
+    } <= m.keys()

--- a/backend/tests/unit/llm/catalog/test_loader.py
+++ b/backend/tests/unit/llm/catalog/test_loader.py
@@ -1,7 +1,34 @@
 import pytest
 
-from cubebox.llm.catalog.loader import preset_key_for, resolve_capability
+from cubebox.llm.catalog.loader import build_catalog, preset_key_for, resolve_capability
 from cubebox.llm.catalog.types import Endpoint, Vendor
+
+PROFILES: dict[str, dict[str, object]] = {"x": {}}
+
+
+def _vendor(**over):
+    base = {
+        "vendor": "v",
+        "display_name": "V",
+        "short_name": "V",
+        "logo": None,
+        "category": "saas",
+        "description": "d",
+        "regions": {"cn": {"host": "https://h"}},
+        "endpoints": [{"region": "cn", "protocol": "openai-completions", "capability": "x"}],
+        "models": [
+            {
+                "model_id": "m1",
+                "display_name": "M1",
+                "context_window": 1,
+                "max_tokens": 1,
+                "input_modalities": ["text"],
+                "pricing": {"input": 1, "output": 1},
+            }
+        ],
+    }
+    base.update(over)
+    return base
 
 
 def test_vendor_parses_minimal():
@@ -74,3 +101,143 @@ def test_resolve_capability_inline_dict():
 def test_resolve_capability_unknown_name_fails_loudly():
     with pytest.raises(ValueError, match="unknown capability profile"):
         resolve_capability("does-not-exist", {"openai-compat-basic": {}})
+
+
+def test_untagged_endpoint_serves_all_models():
+    cat = build_catalog([_vendor()], PROFILES)
+    ep = cat.resolve("v/cn/openai-completions")
+    assert [m.model_id for m in ep.models] == ["m1"]
+
+
+def test_tiered_membership_by_plan_intersection():
+    v = _vendor(
+        endpoints=[
+            {
+                "region": "cn",
+                "protocol": "openai-completions",
+                "plan": "general",
+                "capability": "x",
+            },
+            {
+                "region": "cn",
+                "protocol": "openai-completions",
+                "plan": "coding",
+                "path": "/coding",
+                "capability": "x",
+            },
+        ],
+        models=[
+            {
+                "model_id": "g",
+                "display_name": "G",
+                "context_window": 1,
+                "max_tokens": 1,
+                "input_modalities": ["text"],
+                "plan": "general",
+                "pricing": {"input": 1, "output": 1},
+            },
+            {
+                "model_id": "c",
+                "display_name": "C",
+                "context_window": 1,
+                "max_tokens": 1,
+                "input_modalities": ["text"],
+                "plan": "coding",
+                "pricing": {"input": 1, "output": 1},
+            },
+        ],
+    )
+    cat = build_catalog([v], PROFILES)
+    assert [m.model_id for m in cat.resolve("v/cn/openai-completions/general").models] == ["g"]
+    assert [m.model_id for m in cat.resolve("v/cn/openai-completions/coding").models] == ["c"]
+
+
+def test_mixed_tagged_untagged_rejected():
+    v = _vendor(
+        endpoints=[
+            {"region": "cn", "protocol": "openai-completions", "plan": "coding", "capability": "x"}
+        ],
+        models=[
+            {
+                "model_id": "m",
+                "display_name": "M",
+                "context_window": 1,
+                "max_tokens": 1,
+                "input_modalities": ["text"],
+                "pricing": {"input": 1, "output": 1},
+            }
+        ],
+    )
+    with pytest.raises(ValueError, match="mix"):
+        build_catalog([v], PROFILES)
+
+
+def test_dangling_endpoint_rejected():
+    v = _vendor(
+        endpoints=[
+            {
+                "region": "cn",
+                "protocol": "openai-completions",
+                "plan": "general",
+                "capability": "x",
+            },
+            {
+                "region": "cn",
+                "protocol": "openai-completions",
+                "plan": "coding",
+                "path": "/c",
+                "capability": "x",
+            },
+        ],
+        models=[
+            {
+                "model_id": "g",
+                "display_name": "G",
+                "context_window": 1,
+                "max_tokens": 1,
+                "input_modalities": ["text"],
+                "plan": "general",
+                "pricing": {"input": 1, "output": 1},
+            }
+        ],
+    )
+    with pytest.raises(ValueError, match="no model"):
+        build_catalog([v], PROFILES)
+
+
+def test_unreachable_model_rejected():
+    v = _vendor(
+        endpoints=[
+            {"region": "cn", "protocol": "openai-completions", "plan": "general", "capability": "x"}
+        ],
+        models=[
+            {
+                "model_id": "c",
+                "display_name": "C",
+                "context_window": 1,
+                "max_tokens": 1,
+                "input_modalities": ["text"],
+                "plan": "coding",
+                "pricing": {"input": 1, "output": 1},
+            }
+        ],
+    )
+    with pytest.raises(ValueError, match="no endpoint"):
+        build_catalog([v], PROFILES)
+
+
+def test_duplicate_preset_key_rejected():
+    v1, v2 = _vendor(), _vendor()  # same vendor name -> same composed key
+    with pytest.raises(ValueError, match="duplicate preset_key"):
+        build_catalog([v1, v2], PROFILES)
+
+
+def test_duplicate_endpoint_tuple_rejected_even_with_distinct_key_overrides():
+    v = _vendor(
+        endpoints=[
+            {"region": "cn", "protocol": "openai-completions", "key": "k1", "capability": "x"},
+            {"region": "cn", "protocol": "openai-completions", "key": "k2", "capability": "x"},
+        ]
+    )
+    with pytest.raises(ValueError, match="duplicate endpoint"):
+        build_catalog([v], PROFILES)

--- a/backend/tests/unit/llm/catalog/test_loader.py
+++ b/backend/tests/unit/llm/catalog/test_loader.py
@@ -1,4 +1,5 @@
-from cubebox.llm.catalog.types import Vendor
+from cubebox.llm.catalog.loader import preset_key_for
+from cubebox.llm.catalog.types import Endpoint, Vendor
 
 
 def test_vendor_parses_minimal():
@@ -36,3 +37,18 @@ def test_vendor_parses_minimal():
     assert v.endpoints[0].plan is None
     assert v.models[0].pricing.cache_read == 0.0
     assert v.models[0].plan is None
+
+
+def test_preset_key_without_plan():
+    ep = Endpoint(region="cn", protocol="anthropic-messages", capability="x")
+    assert preset_key_for("deepseek", ep) == "deepseek/cn/anthropic-messages"
+
+
+def test_preset_key_with_plan():
+    ep = Endpoint(region="cn", protocol="openai-completions", plan="coding", capability="x")
+    assert preset_key_for("zhipu", ep) == "zhipu/cn/openai-completions/coding"
+
+
+def test_preset_key_override_wins():
+    ep = Endpoint(region="cn", protocol="openai-completions", key="pretty-key", capability="x")
+    assert preset_key_for("zhipu", ep) == "pretty-key"

--- a/backend/tests/unit/test_provider_probe.py
+++ b/backend/tests/unit/test_provider_probe.py
@@ -11,6 +11,7 @@ from cubebox.services.provider_probe import (
     ProbeStep,
     _aggregate_overall,
     _is_model_not_found,
+    liveness_status_for,
     probe_liveness,
     probe_reasoning_toggle,
     probe_streaming,
@@ -305,6 +306,27 @@ async def test_liveness_no_status_is_provider_level_fail():
         _StubProvider(events=[_err_event("connection refused")]), model_id="m"
     )
     assert step.status == "fail"
+
+
+@pytest.mark.asyncio
+async def test_liveness_status_for_401_is_auth_error():
+    # A 401 liveness fail persists as "auth_error" so the badge says "fix key".
+    evt = _err_event("AuthenticationError: Error code: 401 - Missing Authentication header")
+    step = await probe_liveness(_StubProvider(events=[evt]), model_id="m")
+    assert liveness_status_for(step) == "auth_error"
+
+
+def test_liveness_status_for_pass_is_ok():
+    assert liveness_status_for(ProbeStep(name="liveness", status="pass")) == "ok"
+
+
+def test_liveness_status_for_non_auth_fail_is_fail():
+    step = ProbeStep(
+        name="liveness",
+        status="fail",
+        error=ProbeError(type="StreamError", message="503 service unavailable", raw_status=503),
+    )
+    assert liveness_status_for(step) == "fail"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_provider_probe.py
+++ b/backend/tests/unit/test_provider_probe.py
@@ -253,6 +253,60 @@ async def test_probe_liveness_surfaces_cubepi_error_message():
     assert "Authentication" in step.detail
 
 
+def _err_event(message: str):
+    return type("E", (), {"type": "error", "error_message": message})()
+
+
+@pytest.mark.asyncio
+async def test_liveness_402_is_provider_reachable():
+    # OpenRouter "out of credits" for one free model: the endpoint answered, so
+    # the provider is reachable — liveness must NOT condemn the whole provider.
+    evt = _err_event(
+        "[probe/deepseek:free @ .../] APIStatusError: Error code: 402 - "
+        "{'error': {'message': 'Provider returned error', 'code': 402}}"
+    )
+    step = await probe_liveness(_StubProvider(events=[evt]), model_id="deepseek:free")
+    assert step.status == "pass"
+    assert "reachable" in step.detail
+
+
+@pytest.mark.asyncio
+async def test_liveness_404_model_removed_is_provider_reachable():
+    # OpenRouter 404 "No endpoints found for <model>": model gone, provider up.
+    evt = _err_event(
+        "[probe/stepfun:free @ .../] NotFoundError: Error code: 404 - "
+        "{'error': {'message': 'No endpoints found for stepfun:free.', 'code': 404}}"
+    )
+    step = await probe_liveness(_StubProvider(events=[evt]), model_id="stepfun:free")
+    assert step.status == "pass"
+    assert "reachable" in step.detail
+
+
+@pytest.mark.asyncio
+async def test_liveness_401_is_provider_level_fail():
+    # A rejected credential breaks every model → provider-grain fail.
+    evt = _err_event("AuthenticationError: Error code: 401 - Missing Authentication header")
+    step = await probe_liveness(_StubProvider(events=[evt]), model_id="m")
+    assert step.status == "fail"
+    assert "401" in step.detail
+
+
+@pytest.mark.asyncio
+async def test_liveness_5xx_is_provider_level_fail():
+    evt = _err_event("APIStatusError: Error code: 503 - service unavailable")
+    step = await probe_liveness(_StubProvider(events=[evt]), model_id="m")
+    assert step.status == "fail"
+
+
+@pytest.mark.asyncio
+async def test_liveness_no_status_is_provider_level_fail():
+    # No HTTP status at all (network/DNS/timeout) → unreachable.
+    step = await probe_liveness(
+        _StubProvider(events=[_err_event("connection refused")]), model_id="m"
+    )
+    assert step.status == "fail"
+
+
 @pytest.mark.asyncio
 async def test_probe_streaming_fails_on_error_event():
     err = type("E", (), {"type": "error", "error": "boom"})()

--- a/backend/tests/unit/test_provider_probe.py
+++ b/backend/tests/unit/test_provider_probe.py
@@ -284,6 +284,23 @@ async def test_liveness_404_model_removed_is_provider_reachable():
 
 
 @pytest.mark.asyncio
+async def test_liveness_bare_404_is_provider_level_fail():
+    # A 404 WITHOUT a model-not-found marker is a wrong base_url/path (config), which
+    # breaks every model → must surface as provider_error, not a passing liveness.
+    evt = _err_event("NotFoundError: Error code: 404 - {'detail': 'Not Found'}")
+    step = await probe_liveness(_StubProvider(events=[evt]), model_id="m")
+    assert step.status == "fail"
+
+
+@pytest.mark.asyncio
+async def test_liveness_400_bad_request_is_provider_level_fail():
+    # A 400 request-shape mismatch affects every model → provider-grain fail.
+    evt = _err_event("BadRequestError: Error code: 400 - {'error': 'unsupported parameter'}")
+    step = await probe_liveness(_StubProvider(events=[evt]), model_id="m")
+    assert step.status == "fail"
+
+
+@pytest.mark.asyncio
 async def test_liveness_401_is_provider_level_fail():
     # A rejected credential breaks every model → provider-grain fail.
     evt = _err_event("AuthenticationError: Error code: 401 - Missing Authentication header")

--- a/backend/tests/unit/test_provider_probe.py
+++ b/backend/tests/unit/test_provider_probe.py
@@ -234,6 +234,26 @@ async def test_probe_liveness_fails_on_error_event():
 
 
 @pytest.mark.asyncio
+async def test_probe_liveness_surfaces_cubepi_error_message():
+    # cubepi's StreamEvent carries the upstream failure in `error_message` (see
+    # cubepi.providers.base.StreamEvent), NOT `error`/`message`/`detail`. The
+    # probe must read that field so a 401 reaches the UI instead of a generic
+    # "stream returned an error event".
+    err = type(
+        "E",
+        (),
+        {
+            "type": "error",
+            "error_message": "AuthenticationError: 401 - Missing Authentication header",
+        },
+    )()
+    step = await probe_liveness(_StubProvider(events=[err]), model_id="m")
+    assert step.status == "fail"
+    assert "401" in step.detail
+    assert "Authentication" in step.detail
+
+
+@pytest.mark.asyncio
 async def test_probe_streaming_fails_on_error_event():
     err = type("E", (), {"type": "error", "error": "boom"})()
     step = await probe_streaming(_StubProvider(events=[err]), model_id="m")

--- a/backend/tests/unit/test_provider_seeder_resolve.py
+++ b/backend/tests/unit/test_provider_seeder_resolve.py
@@ -1,4 +1,6 @@
-from cubebox.seeders.provider_seeder import _merge_cost
+import pytest
+
+from cubebox.seeders.provider_seeder import _merge_cost, resolve_provider_config
 
 
 def test_merge_cost_partial_override_inherits_other_legs():
@@ -15,3 +17,100 @@ def test_merge_cost_partial_override_inherits_other_legs():
 def test_merge_cost_no_override_returns_catalog():
     catalog = {"input": 1.0, "output": 2.0, "cache_read": 0.0, "cache_write": 0.0}
     assert _merge_cost(catalog, None) == catalog
+
+
+def test_resolve_with_preset_inherits_base_url_models_capability():
+    cfg = {"preset": "deepseek/cn/anthropic-messages", "api_key": "k"}
+    r = resolve_provider_config("deepseek", cfg)
+    assert r.base_url == "https://api.deepseek.com/anthropic"
+    assert r.provider_type == "anthropic-messages"
+    assert r.preset_key == "deepseek/cn/anthropic-messages"
+    assert r.capability  # non-empty descriptor dict
+    assert len(r.models) >= 1
+    assert all("cost" in m and "input" in m["cost"] for m in r.models)
+
+
+def test_resolve_models_subset_filter():
+    cfg = {
+        "preset": "deepseek/cn/anthropic-messages",
+        "api_key": "k",
+        "models": ["deepseek-v4-flash"],
+    }
+    r = resolve_provider_config("deepseek", cfg)
+    assert [m["id"] for m in r.models] == ["deepseek-v4-flash"]
+
+
+def test_resolve_unknown_preset_fails_loudly():
+    with pytest.raises(ValueError, match="unknown preset"):
+        resolve_provider_config("x", {"preset": "no/such/key", "api_key": "k"})
+
+
+def test_resolve_unknown_subset_model_fails_loudly():
+    with pytest.raises(ValueError, match="not in preset"):
+        resolve_provider_config(
+            "deepseek",
+            {"preset": "deepseek/cn/anthropic-messages", "api_key": "k", "models": ["ghost"]},
+        )
+
+
+def test_resolve_api_override_with_preset_rejected():
+    with pytest.raises(ValueError, match="api.*not overridable"):
+        resolve_provider_config(
+            "deepseek",
+            {
+                "preset": "deepseek/cn/anthropic-messages",
+                "api_key": "k",
+                "api": "openai-completions",
+            },
+        )
+
+
+def test_resolve_capability_override_with_preset_rejected():
+    with pytest.raises(ValueError, match="capability.*not overridable"):
+        resolve_provider_config(
+            "deepseek",
+            {
+                "preset": "deepseek/cn/anthropic-messages",
+                "api_key": "k",
+                "capability": {"supports_tools": False},
+            },
+        )
+
+
+def test_resolve_without_preset_requires_base_url_and_models():
+    # base_url + non-empty models are required; api defaults to openai-completions.
+    for bad in (
+        {"api": "openai-completions", "models": [{"id": "m"}]},  # missing base_url
+        {"base_url": "http://x/v1"},  # missing models
+        {"base_url": "http://x/v1", "models": []},  # empty models
+    ):
+        with pytest.raises(ValueError, match="custom provider.*requires"):
+            resolve_provider_config("custom", bad)
+
+
+def test_resolve_without_preset_defaults_api_to_openai_completions():
+    r = resolve_provider_config("custom", {"base_url": "http://x/v1", "models": [{"id": "m"}]})
+    assert r.provider_type == "openai-completions"
+
+
+def test_resolve_base_url_override_allowed():
+    cfg = {
+        "preset": "deepseek/cn/anthropic-messages",
+        "api_key": "k",
+        "base_url": "https://proxy.internal/anthropic",
+    }
+    r = resolve_provider_config("deepseek", cfg)
+    assert r.base_url == "https://proxy.internal/anthropic"
+
+
+def test_resolve_without_preset_uses_config_verbatim():
+    cfg = {
+        "base_url": "http://localhost:8000/v1",
+        "api": "openai-completions",
+        "models": [
+            {"id": "m", "name": "M", "context_window": 1, "max_tokens": 1, "input": ["text"]}
+        ],
+    }
+    r = resolve_provider_config("vllm", cfg)
+    assert r.base_url == "http://localhost:8000/v1"
+    assert r.preset_key is None

--- a/backend/tests/unit/test_provider_seeder_resolve.py
+++ b/backend/tests/unit/test_provider_seeder_resolve.py
@@ -1,0 +1,17 @@
+from cubebox.seeders.provider_seeder import _merge_cost
+
+
+def test_merge_cost_partial_override_inherits_other_legs():
+    catalog = {"input": 0.27, "output": 1.10, "cache_read": 0.07, "cache_write": 0.0}
+    override = {"input": 0.5}
+    assert _merge_cost(catalog, override) == {
+        "input": 0.5,
+        "output": 1.10,
+        "cache_read": 0.07,
+        "cache_write": 0.0,
+    }
+
+
+def test_merge_cost_no_override_returns_catalog():
+    catalog = {"input": 1.0, "output": 2.0, "cache_read": 0.0, "cache_write": 0.0}
+    assert _merge_cost(catalog, None) == catalog

--- a/backend/tests/unit/test_readiness.py
+++ b/backend/tests/unit/test_readiness.py
@@ -33,6 +33,19 @@ def test_provider_fail_with_never_tested_model() -> None:
     )
 
 
+def test_auth_error_is_distinct_from_provider_error() -> None:
+    # A rejected credential is provider-grain like "fail", but must surface as a
+    # separate enum so the UI says "fix the key", not "endpoint unreachable".
+    assert (
+        derive_readiness(
+            liveness_status="auth_error",
+            model_test_status="ok",
+            capability_changed_since_test=True,
+        )
+        == "auth_error"
+    )
+
+
 def test_model_unavailable() -> None:
     assert (
         derive_readiness(

--- a/backend/tests/unit/test_resolve_logo.py
+++ b/backend/tests/unit/test_resolve_logo.py
@@ -1,0 +1,54 @@
+from cubebox.api.routes.v1.admin_providers import _resolve_logo
+
+
+def test_resolve_logo_by_preset_key():
+    assert _resolve_logo("deepseek/cn/anthropic-messages") == "deepseek"
+
+
+def test_resolve_logo_by_key_override(monkeypatch):
+    # A `key:`-overridden preset_key does NOT start with the vendor, so a split("/")
+    # approach would fail. Inject a catalog whose endpoint key is "pretty-id" and
+    # assert the logo still resolves via the vendor — a real regression guard.
+    import cubebox.api.routes.v1.admin_providers as mod
+    import cubebox.llm.catalog as catmod  # _resolve_logo does `from cubebox.llm.catalog import load_catalog`
+    from cubebox.llm.catalog import build_catalog
+
+    catalog = build_catalog(
+        [
+            {
+                "vendor": "deepseek",
+                "display_name": "DeepSeek",
+                "short_name": "DeepSeek",
+                "logo": "deepseek",
+                "category": "saas",
+                "description": "d",
+                "regions": {"cn": {"host": "https://api.deepseek.com"}},
+                "endpoints": [
+                    {
+                        "region": "cn",
+                        "protocol": "openai-completions",
+                        "key": "pretty-id",
+                        "capability": "x",
+                    }
+                ],
+                "models": [
+                    {
+                        "model_id": "m",
+                        "display_name": "M",
+                        "context_window": 1,
+                        "max_tokens": 1,
+                        "input_modalities": ["text"],
+                        "pricing": {"input": 1, "output": 1},
+                    }
+                ],
+            }
+        ],
+        {"x": {}},
+    )
+    monkeypatch.setattr(catmod, "load_catalog", lambda: catalog)
+    assert mod._resolve_logo("pretty-id") == "deepseek"
+
+
+def test_resolve_logo_none_for_unknown():
+    assert _resolve_logo("nope/x/y") is None
+    assert _resolve_logo(None) is None

--- a/backend/tests/unit/test_seed_backfill_parity.py
+++ b/backend/tests/unit/test_seed_backfill_parity.py
@@ -1,0 +1,65 @@
+"""§6.4 backfill-parity guard: the preset cutover must not silently drop a
+provider that USED to receive capability backfill under the old name==slug rule.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cubebox.config import config as settings
+from cubebox.seeders.provider_seeder import resolve_provider_config
+
+_SNAPSHOT = Path(__file__).parent / "llm" / "catalog" / "data" / "flat_providers_snapshot.yaml"
+
+# Providers that DID match a flat slug (so were backfilled) but are DELIBERATELY
+# downgraded to custom in the rewrite, each with a recorded §6.4 reason. A name
+# here is an intentional drop, not a silent one.
+DELIBERATE_CUSTOM = {
+    "vllm": "self-hosted OSS framework; model is deployment-specific (not catalog data), "
+    "openai-compatible so cubepi defaults suffice",
+}
+
+
+def _old_backfilled_provider_names() -> set[str]:
+    """Provider names that matched a flat preset slug under the OLD rule."""
+    flat_slugs = {e["slug"] for e in yaml.safe_load(_SNAPSHOT.read_text("utf-8"))}
+    cfg_providers = dict(dict(settings.get("llm", {})).get("providers", {}))
+    return {name for name in cfg_providers if name in flat_slugs}
+
+
+def test_no_provider_silently_loses_capability_backfill():
+    """Every old-backfilled provider still resolves a capability now, UNLESS it
+    is an intentional, documented downgrade in DELIBERATE_CUSTOM."""
+    cfg_providers = dict(dict(settings.get("llm", {})).get("providers", {}))
+    regressed = []
+    for name in _old_backfilled_provider_names():
+        if name in DELIBERATE_CUSTOM:
+            continue
+        r = resolve_provider_config(name, dict(cfg_providers[name]))
+        if r.preset_key is None or not r.capability:
+            regressed.append(name)
+    assert not regressed, (
+        f"providers lost capability backfill in the rewrite (map to a preset, "
+        f"or add to DELIBERATE_CUSTOM with a reason): {regressed}"
+    )
+
+
+# The §6.4 inventory of preset-mapped providers — each MUST resolve a capability
+# + at least one model from the catalog.
+PRESET_MAPPED = {
+    "deepseek": "deepseek/cn/anthropic-messages",
+    "minimax": "minimax/cn/openai-completions",
+    "arkcode": "volcengine/cn/openai-completions/coding",
+    "alicode": "aliyun/cn/openai-completions/coding",
+    "volengine": "volcengine/cn/openai-completions/general",
+    "openrouter": "openrouter/intl/openai-completions",
+}
+
+
+@pytest.mark.parametrize("name,key", list(PRESET_MAPPED.items()))
+def test_preset_mapped_providers_get_capability_and_models(name, key):
+    r = resolve_provider_config(name, {"preset": key, "api_key": "k"})
+    assert r.preset_key == key
+    assert r.capability is not None
+    assert len(r.models) >= 1

--- a/backend/tests/unit/test_seed_backfill_parity.py
+++ b/backend/tests/unit/test_seed_backfill_parity.py
@@ -49,7 +49,7 @@ def test_no_provider_silently_loses_capability_backfill():
 # + at least one model from the catalog.
 PRESET_MAPPED = {
     "deepseek": "deepseek/cn/anthropic-messages",
-    "minimax": "minimax/cn/openai-completions",
+    "minimax": "minimax/cn/openai-completions/general",
     "arkcode": "volcengine/cn/openai-completions/coding",
     "alicode": "aliyun/cn/openai-completions/coding",
     "volengine": "volcengine/cn/openai-completions/general",

--- a/backend/tests/unit/test_seed_idempotent.py
+++ b/backend/tests/unit/test_seed_idempotent.py
@@ -99,23 +99,22 @@ async def test_seed_updates_existing_provider_url(
     assert updated.provider_type == "openai-completions"
 
 
-async def test_seed_backfills_capability_for_known_slug(
+async def test_seed_backfills_capability_for_preset_ref(
     clean_db: AsyncSession,
     backend: FernetBackend,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A provider whose name matches a cubepi preset slug gets its capability snapshot.
+    """A provider with a ``preset:`` ref gets its capability snapshot + preset_key.
 
-    ``vllm`` is a cubepi preset slug, so when the seed config declares a provider
-    named ``vllm`` the seeder must fill ``preset_slug`` + ``capability`` from the
-    catalog. A provider whose name has no matching preset is left empty.
+    Under the new rule (spec §6.2), backfill is driven by an explicit ``preset:``
+    reference into the cubebox catalog — not a name==slug match. A custom provider
+    (no preset) is left with no preset_slug and no capability.
     """
     fake_llm = {
         "providers": {
-            "vllm": {
-                "base_url": "http://localhost:8000/v1",
-                "api": "openai-completions",
-                "models": [{"id": "qwen", "name": "Qwen"}],
+            "ds": {
+                "preset": "deepseek/cn/openai-completions",
+                "api_key": "k",
             },
             "house-brand": {
                 "base_url": "http://localhost:9000/v1",
@@ -132,15 +131,15 @@ async def test_seed_backfills_capability_for_known_slug(
 
     await seed_system_providers_from_config(clean_db, backend)
 
-    vllm = (
-        await clean_db.execute(select(Provider).where(Provider.name == "vllm"))
+    ds = (
+        await clean_db.execute(select(Provider).where(Provider.name == "ds"))
     ).scalar_one_or_none()
-    assert vllm is not None, "expected a seeded 'vllm' provider"
-    assert vllm.preset_slug == "vllm"
-    assert vllm.capability, "capability snapshot must be populated for a known slug"
-    assert "supports_tools" in vllm.capability
+    assert ds is not None, "expected a seeded 'ds' provider"
+    assert ds.preset_slug == "deepseek/cn/openai-completions"
+    assert ds.capability, "capability snapshot must be populated for a preset ref"
+    assert ds.base_url == "https://api.deepseek.com"
 
-    # No preset matches this name -> capability stays empty.
+    # No preset -> custom provider, capability stays empty.
     house = (
         await clean_db.execute(select(Provider).where(Provider.name == "house-brand"))
     ).scalar_one()

--- a/docs/dev/plans/2026-05-23-preset-catalog-redesign.md
+++ b/docs/dev/plans/2026-05-23-preset-catalog-redesign.md
@@ -651,7 +651,7 @@ This is data entry, not logic — but it must reproduce every flat entry. Work v
 | anthropic | intl/anthropic-messages | api.anthropic.com |
 | openai | intl/openai-responses, intl/openai-completions (`openai-legacy`) | api.openai.com/v1 |
 | deepseek | cn/anthropic-messages (`/anthropic`), cn/openai-completions | api.deepseek.com |
-| qwen | intl & cn /openai-completions, +coding (intl & cn) | dashscope-intl / dashscope |
+| aliyun (Qwen models) | intl & cn /openai-completions, +coding (intl & cn) | dashscope-intl / dashscope |
 | doubao (volcengine) | cn/openai-completions (`/api/v3`), cn/anthropic-messages coding (`/api/coding`) | ark.cn-beijing.volces.com |
 | moonshot | intl & cn /openai-completions, +coding (same URL, diff models) | api.moonshot.ai / .cn |
 | zhipu | intl & cn /openai-completions, +coding (`/api/coding/paas/v4`) | api.z.ai / open.bigmodel.cn |
@@ -1171,7 +1171,7 @@ The 9 seeded providers and their mapping (§6.4 inventory):
 | `deepseek` | api.deepseek.com/anthropic | `preset: deepseek/cn/anthropic-messages` |
 | `minimax` | api.minimaxi.com/v1 | `preset: minimax/cn/openai-completions` (carry `extra_body`) |
 | `arkcode` | ark…/api/coding/v3 (openai) | NEW catalog endpoint: volcengine coding **openai-completions** `/api/coding/v3` → `preset: volcengine/cn/openai-completions/coding` |
-| `alicode` | coding.dashscope…/v1 | `preset: qwen/cn/openai-completions/coding` (host override in catalog) |
+| `alicode` | coding.dashscope…/v1 | `preset: aliyun/cn/openai-completions/coding` (host override in catalog) |
 | `volengine` | ark…/api/v3 | `preset: volcengine/cn/openai-completions` (general) |
 | `openrouter` | openrouter.ai/api/v1 | `preset: openrouter/intl/openai-completions` |
 | `sensedeal` | private gateway | **custom** — keep verbatim (no preset); reason: private gateway, not in catalog |
@@ -1182,7 +1182,7 @@ The 9 seeded providers and their mapping (§6.4 inventory):
   - deepseek pool: `deepseek-v4-pro`, `deepseek-v4-flash`.
   - minimax pool: `MiniMax-M2.7`.
   - volcengine general: `doubao-seed-1-8-251228` (cost input 2.4/output 24); coding: `doubao-seed-2.0-pro`, `kimi-k2.6`.
-  - qwen coding pool: `qwen3.6-plus`.
+  - aliyun coding pool: `qwen3.6-plus`.
   - openrouter pool: `google/gemma-4-31b-it:free`, `stepfun/step-3.5-flash:free`.
   - Add the `volcengine/cn/openai-completions/coding` endpoint (path `/api/coding/v3`) and make volcengine a **tiered** vendor (general + coding) — so tag its general models `plan: general` and coding models `plan: coding`.
 
@@ -1201,7 +1201,7 @@ The 9 seeded providers and their mapping (§6.4 inventory):
         preset: volcengine/cn/openai-completions/coding
         api_key: ark-…
       alicode:
-        preset: qwen/cn/openai-completions/coding
+        preset: aliyun/cn/openai-completions/coding
         api_key: sk-sp-…
       volengine:
         preset: volcengine/cn/openai-completions
@@ -1246,7 +1246,7 @@ PRESET_MAPPED = {
     "deepseek": "deepseek/cn/anthropic-messages",
     "minimax": "minimax/cn/openai-completions",
     "arkcode": "volcengine/cn/openai-completions/coding",
-    "alicode": "qwen/cn/openai-completions/coding",
+    "alicode": "aliyun/cn/openai-completions/coding",
     "volengine": "volcengine/cn/openai-completions",
     "openrouter": "openrouter/intl/openai-completions",
 }

--- a/docs/dev/plans/2026-05-23-preset-catalog-redesign.md
+++ b/docs/dev/plans/2026-05-23-preset-catalog-redesign.md
@@ -1,0 +1,1448 @@
+# Preset Catalog Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the LLM provider preset catalog from cubepi into cubebox, restructure it from a flat `(slug, api, base_url)` list into `vendor → region×protocol×plan endpoints → models-with-pricing`, compose `base_url` from parts, and let `config.yaml` reference catalog entries by `preset:` instead of restating base_url/models/pricing.
+
+**Architecture:** A new `cubebox/llm/catalog/` package owns the data (`vendors.yaml`, `capabilities.yaml`) and a validating loader. The loader flattens vendors into endpoint presets keyed by `preset_key = vendor/region/protocol[/plan]`, composes `base_url = (endpoint.host || region.host) + path`, and resolves named capability profiles into cubepi `CapabilityDescriptor` objects. Three existing consumers (admin presets endpoint, logo lookup, seeder) repoint to it; the seeder gains preset-reference resolution with field-precedence rules. The wizard becomes two-step (vendor → endpoint). Finally cubepi's catalog package is deleted.
+
+**Tech Stack:** Python 3.13 / FastAPI / Pydantic v2 / SQLModel / Alembic (backend); pytest; Next.js 15 / React 19 / TypeScript / Vitest (frontend); `uv` (backend deps), `pnpm` (frontend deps).
+
+**Spec:** `docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md` (read it first — every `§` reference below points there).
+
+**Worktree:** `/home/chris/cubebox/.worktrees/feat/preset-catalog-redesign` (branch `feat/preset-catalog-redesign`, slot 82 — backend `:8082`, frontend `:3082`, DB `cubebox_feat_preset_catalog_redesign`). Run `cat .worktree.env` before starting; backend tests run from `backend/`, frontend from `frontend/`.
+
+**Conventions (from CLAUDE.md):** type annotations everywhere (mypy strict), 100-char lines, `uv add` for deps, `alembic revision --autogenerate` for migrations (none expected here — no schema change), `utc_isoformat()` for DB datetimes. Stay on this branch; never switch to main. Commit after every green step.
+
+---
+
+## File Structure
+
+**New (cubebox backend):**
+- `cubebox/llm/catalog/__init__.py` — public API: `load_catalog()`, `get_catalog()` (cached), re-exports.
+- `cubebox/llm/catalog/types.py` — Pydantic models: `Pricing`, `ModelPreset`, `Endpoint`, `Region`, `Vendor`, and the resolved/derived `ResolvedEndpoint`, `Catalog`.
+- `cubebox/llm/catalog/loader.py` — YAML load + all validations (§4.2/§4.3/§4.4) + `compose_base_url` + `preset_key_for` + capability resolution + flattening.
+- `cubebox/llm/catalog/data/vendors.yaml` — ported nested catalog data.
+- `cubebox/llm/catalog/data/capabilities.yaml` — named capability profiles.
+- `tests/unit/llm/catalog/test_loader.py` — loader unit tests.
+- `tests/unit/llm/catalog/test_composition.py` — base_url composition + parity test.
+- `tests/unit/llm/catalog/data/flat_providers_snapshot.yaml` — frozen copy of today's cubepi `providers.yaml` (parity fixture).
+
+**Modified (cubebox backend):**
+- `cubebox/api/routes/v1/admin_llm.py` — return nested vendor list (§5.1).
+- `cubebox/api/routes/v1/admin_providers.py` — `_resolve_logo` resolves via catalog vendor.
+- `cubebox/seeders/provider_seeder.py` — `preset:` resolution + precedence (§6.2) + validation (§6.3).
+- `config.development.local.yaml` (+ `config.yaml` if present) — exhaustive rewrite to `preset:` form (§6.1/§6.4).
+
+**Modified (frontend):**
+- `frontend/packages/core/src/types/provider.ts` — replace flat `ProviderPreset` with nested `VendorPreset` + `EndpointPreset`.
+- `frontend/packages/core/src/api/providers.ts` — `listPresets` returns `VendorPreset[]`.
+- `frontend/packages/web/components/admin/models/wizard/PresetPicker.tsx` — list vendors.
+- `frontend/packages/web/components/admin/models/wizard/ConfigureStep.tsx` + `ProviderConfigForm.tsx` — region/protocol/plan selectors driving composed base_url + filtered models.
+- `frontend/packages/web/components/admin/models/wizard/wizardMachine.ts` — `pickVendor` + selected endpoint state.
+
+**Deleted (cubepi, Phase G):**
+- `cubepi/providers/catalog/` (loader, types, `data/providers.yaml`, tests) — via a cubepi release + dependency bump.
+
+**Decoupling decision:** cubebox's catalog `types.py` declares its **own** `WireApi` literal (the 3 protocol strings) and imports only `CapabilityDescriptor` from `cubepi.providers.capability` (a stable, non-catalog module). This removes any cubebox→cubepi-catalog import so Phases A–F do not depend on the cubepi release; Phase G only deletes cubepi's now-unused catalog.
+
+---
+
+## Phase A — Catalog package: types, composition, loader, validations
+
+No real data yet — tests use small inline fixtures so logic is verified in isolation.
+
+### Task A1: Pydantic source-schema types
+
+**Files:**
+- Create: `cubebox/llm/catalog/__init__.py` (empty for now)
+- Create: `cubebox/llm/catalog/types.py`
+- Test: `tests/unit/llm/catalog/test_loader.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/llm/catalog/__init__.py` (empty) and `tests/unit/llm/catalog/test_loader.py`:
+
+```python
+from cubebox.llm.catalog.types import Endpoint, ModelPreset, Pricing, Region, Vendor
+
+
+def test_vendor_parses_minimal():
+    v = Vendor.model_validate(
+        {
+            "vendor": "deepseek",
+            "display_name": "DeepSeek",
+            "short_name": "DeepSeek",
+            "logo": "deepseek",
+            "category": "saas",
+            "description": "DeepSeek V-series.",
+            "regions": {"cn": {"host": "https://api.deepseek.com"}},
+            "endpoints": [
+                {"region": "cn", "protocol": "openai-completions", "capability": "openai-compat-basic"}
+            ],
+            "models": [
+                {
+                    "model_id": "deepseek-v4",
+                    "display_name": "DeepSeek V4",
+                    "context_window": 64000,
+                    "max_tokens": 8192,
+                    "input_modalities": ["text"],
+                    "reasoning": True,
+                    "pricing": {"input": 0.27, "output": 1.10},
+                }
+            ],
+        }
+    )
+    assert v.regions["cn"].host == "https://api.deepseek.com"
+    assert v.endpoints[0].protocol == "openai-completions"
+    assert v.endpoints[0].plan is None
+    assert v.models[0].pricing.cache_read == 0.0
+    assert v.models[0].plan is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/llm/catalog/test_loader.py::test_vendor_parses_minimal -v`
+Expected: FAIL — `ModuleNotFoundError: cubebox.llm.catalog.types`.
+
+- [ ] **Step 3: Write the types**
+
+`cubebox/llm/catalog/types.py`:
+
+```python
+"""Catalog source-schema + resolved/derived types. Spec §4."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from cubepi.providers.capability import CapabilityDescriptor
+from pydantic import BaseModel, Field
+
+# The protocols cubebox offers in its catalog. Mirrors cubepi's WireApi but
+# declared locally so the catalog does not import cubepi's (to-be-deleted)
+# catalog package. See plan "Decoupling decision".
+WireApi = Literal["anthropic-messages", "openai-completions", "openai-responses"]
+
+# A model's plan membership: a single plan, a list, or None (untagged vendor).
+PlanRef = str | list[str] | None
+
+
+class Pricing(BaseModel):
+    input: float
+    output: float
+    cache_read: float = 0.0
+    cache_write: float = 0.0
+
+
+class ModelPreset(BaseModel):
+    model_id: str
+    display_name: str
+    context_window: int
+    max_tokens: int
+    input_modalities: list[str]
+    reasoning: bool = False
+    plan: PlanRef = None
+    pricing: Pricing
+
+    def plans(self) -> list[str] | None:
+        """Normalized plan list, or None for untagged."""
+        if self.plan is None:
+            return None
+        return [self.plan] if isinstance(self.plan, str) else list(self.plan)
+
+
+class Region(BaseModel):
+    host: str
+
+
+class Endpoint(BaseModel):
+    region: str
+    protocol: WireApi
+    plan: str | None = None
+    path: str = ""
+    host: str | None = None  # overrides region host (§4.1)
+    base_url: str | None = None  # full override, bypasses composition (§4.1)
+    capability: str | dict  # profile name (str) or inline descriptor (dict)
+    key: str | None = None  # optional preset_key override (§4.4)
+
+
+class Vendor(BaseModel):
+    vendor: str
+    display_name: str
+    short_name: str
+    logo: str | None = None
+    category: Literal["saas", "oss-framework", "custom"]
+    description: str
+    regions: dict[str, Region] = Field(default_factory=dict)
+    endpoints: list[Endpoint] = Field(default_factory=list)
+    models: list[ModelPreset] = Field(default_factory=list)
+
+
+class ResolvedEndpoint(BaseModel):
+    """One flattened endpoint preset — what consumers (seeder/API) read."""
+
+    preset_key: str
+    vendor: str
+    region: str
+    protocol: WireApi
+    plan: str | None
+    base_url: str
+    capability: CapabilityDescriptor
+    models: list[ModelPreset]  # the subset serving this endpoint (§4 membership)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/llm/catalog/test_loader.py::test_vendor_parses_minimal -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cubebox/llm/catalog/__init__.py cubebox/llm/catalog/types.py tests/unit/llm/catalog/
+git commit -m "feat(catalog): source-schema + resolved types for nested preset catalog"
+```
+
+### Task A2: `compose_base_url` (§4.1)
+
+**Files:**
+- Create: `cubebox/llm/catalog/loader.py`
+- Test: `tests/unit/llm/catalog/test_composition.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/llm/catalog/test_composition.py`:
+
+```python
+import pytest
+
+from cubebox.llm.catalog.loader import compose_base_url
+from cubebox.llm.catalog.types import Endpoint, Region
+
+
+@pytest.mark.parametrize(
+    "regions,endpoint,expected",
+    [
+        # A. path differs, region host
+        ({"cn": Region(host="https://open.bigmodel.cn")},
+         Endpoint(region="cn", protocol="openai-completions", path="/api/coding/paas/v4", capability="x"),
+         "https://open.bigmodel.cn/api/coding/paas/v4"),
+        # B. host override (Alibaba coding lives on a different domain)
+        ({"cn": Region(host="https://dashscope.aliyuncs.com")},
+         Endpoint(region="cn", protocol="openai-completions",
+                  host="https://coding.dashscope.aliyuncs.com", path="/v1", capability="x"),
+         "https://coding.dashscope.aliyuncs.com/v1"),
+        # C. empty path (DeepSeek openai)
+        ({"cn": Region(host="https://api.deepseek.com")},
+         Endpoint(region="cn", protocol="openai-completions", capability="x"),
+         "https://api.deepseek.com"),
+        # D. full base_url override bypasses composition
+        ({"intl": Region(host="https://ignored")},
+         Endpoint(region="intl", protocol="openai-responses",
+                  base_url="https://chatgpt.com/backend-api/codex", capability="x"),
+         "https://chatgpt.com/backend-api/codex"),
+    ],
+)
+def test_compose_base_url(regions, endpoint, expected):
+    assert compose_base_url(regions, endpoint) == expected
+
+
+def test_compose_base_url_unknown_region_raises():
+    with pytest.raises(ValueError, match="unknown region"):
+        compose_base_url({"cn": Region(host="https://x")},
+                         Endpoint(region="intl", protocol="openai-completions", capability="x"))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/llm/catalog/test_composition.py -v`
+Expected: FAIL — `ModuleNotFoundError: cubebox.llm.catalog.loader`.
+
+- [ ] **Step 3: Implement `compose_base_url`**
+
+Create `cubebox/llm/catalog/loader.py`:
+
+```python
+"""Catalog loader: YAML → validated, flattened catalog. Spec §4."""
+
+from __future__ import annotations
+
+from cubebox.llm.catalog.types import Endpoint, Region
+
+
+def compose_base_url(regions: dict[str, Region], endpoint: Endpoint) -> str:
+    """base_url = (endpoint.host || regions[endpoint.region].host) + endpoint.path.
+
+    A full ``endpoint.base_url`` bypasses composition entirely (§4.1).
+    """
+    if endpoint.base_url is not None:
+        return endpoint.base_url
+    host = endpoint.host
+    if host is None:
+        region = regions.get(endpoint.region)
+        if region is None:
+            raise ValueError(f"endpoint references unknown region {endpoint.region!r}")
+        host = region.host
+    return host + endpoint.path
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/llm/catalog/test_composition.py -v`
+Expected: PASS (5 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cubebox/llm/catalog/loader.py tests/unit/llm/catalog/test_composition.py
+git commit -m "feat(catalog): compose_base_url with host/path/full-override (§4.1)"
+```
+
+### Task A3: `preset_key_for` (§4.4)
+
+**Files:**
+- Modify: `cubebox/llm/catalog/loader.py`
+- Test: `tests/unit/llm/catalog/test_loader.py`
+
+- [ ] **Step 1: Write the failing test** (append to `test_loader.py`)
+
+```python
+from cubebox.llm.catalog.loader import preset_key_for
+
+
+def test_preset_key_without_plan():
+    ep = Endpoint(region="cn", protocol="anthropic-messages", capability="x")
+    assert preset_key_for("deepseek", ep) == "deepseek/cn/anthropic-messages"
+
+
+def test_preset_key_with_plan():
+    ep = Endpoint(region="cn", protocol="openai-completions", plan="coding", capability="x")
+    assert preset_key_for("zhipu", ep) == "zhipu/cn/openai-completions/coding"
+
+
+def test_preset_key_override_wins():
+    ep = Endpoint(region="cn", protocol="openai-completions", key="pretty-key", capability="x")
+    assert preset_key_for("zhipu", ep) == "pretty-key"
+```
+
+(Add `from cubebox.llm.catalog.types import Endpoint` to the imports if not present.)
+
+- [ ] **Step 2: Run** `uv run pytest tests/unit/llm/catalog/test_loader.py -k preset_key -v` → FAIL (`preset_key_for` undefined).
+
+- [ ] **Step 3: Implement** (append to `loader.py`):
+
+```python
+def preset_key_for(vendor: str, endpoint: Endpoint) -> str:
+    """preset_key = vendor/region/protocol[/plan], or endpoint.key override (§4.4)."""
+    if endpoint.key is not None:
+        return endpoint.key
+    parts = [vendor, endpoint.region, endpoint.protocol]
+    if endpoint.plan is not None:
+        parts.append(endpoint.plan)
+    return "/".join(parts)
+```
+
+- [ ] **Step 4: Run** the same command → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cubebox/llm/catalog/loader.py tests/unit/llm/catalog/test_loader.py
+git commit -m "feat(catalog): preset_key_for vendor/region/protocol[/plan] (§4.4)"
+```
+
+### Task A4: capability profile resolution (§4.3)
+
+**Files:**
+- Modify: `cubebox/llm/catalog/loader.py`
+- Test: `tests/unit/llm/catalog/test_loader.py`
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```python
+import pytest
+
+from cubebox.llm.catalog.loader import resolve_capability
+
+
+def test_resolve_capability_named():
+    profiles = {"openai-compat-basic": {"supports_tools": True, "supports_images": True}}
+    cap = resolve_capability("openai-compat-basic", profiles)
+    assert cap.supports_tools is True
+    assert cap.supports_images is True
+
+
+def test_resolve_capability_inline_dict():
+    cap = resolve_capability({"supports_images": True, "max_tokens_field": "max_completion_tokens"}, {})
+    assert cap.supports_images is True
+    assert cap.max_tokens_field == "max_completion_tokens"
+
+
+def test_resolve_capability_unknown_name_fails_loudly():
+    with pytest.raises(ValueError, match="unknown capability profile"):
+        resolve_capability("does-not-exist", {"openai-compat-basic": {}})
+```
+
+- [ ] **Step 2: Run** `uv run pytest tests/unit/llm/catalog/test_loader.py -k resolve_capability -v` → FAIL.
+
+- [ ] **Step 3: Implement** (append to `loader.py`; add `from cubebox.llm.catalog.types import CapabilityDescriptor` — re-export it from types, or import from cubepi directly):
+
+```python
+from cubepi.providers.capability import CapabilityDescriptor
+
+
+def resolve_capability(
+    ref: str | dict, profiles: dict[str, dict]
+) -> CapabilityDescriptor:
+    """A scalar string is a profile reference; a mapping is inline (§4.3).
+
+    An unknown profile name fails loudly (not a silent empty descriptor).
+    """
+    if isinstance(ref, str):
+        if ref not in profiles:
+            raise ValueError(f"unknown capability profile {ref!r}")
+        return CapabilityDescriptor.model_validate(profiles[ref])
+    return CapabilityDescriptor.model_validate(ref)
+```
+
+- [ ] **Step 4: Run** the same command → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cubebox/llm/catalog/loader.py tests/unit/llm/catalog/test_loader.py
+git commit -m "feat(catalog): capability profile resolution, loud-fail on unknown (§4.3)"
+```
+
+### Task A5: membership + plan validations (§4.2) and full `load_catalog`
+
+**Files:**
+- Modify: `cubebox/llm/catalog/loader.py`, `cubebox/llm/catalog/__init__.py`
+- Test: `tests/unit/llm/catalog/test_loader.py`
+
+- [ ] **Step 1: Write the failing tests** (append). These cover: untagged-serves-all, tiered membership by plan intersection, all-or-nothing mixing rejected, dangling endpoint rejected, unreachable model rejected, duplicate preset_key rejected.
+
+```python
+from cubebox.llm.catalog.loader import build_catalog
+
+PROFILES = {"x": {}}
+
+
+def _vendor(**over):
+    base = {
+        "vendor": "v", "display_name": "V", "short_name": "V", "logo": None,
+        "category": "saas", "description": "d",
+        "regions": {"cn": {"host": "https://h"}},
+        "endpoints": [{"region": "cn", "protocol": "openai-completions", "capability": "x"}],
+        "models": [{"model_id": "m1", "display_name": "M1", "context_window": 1, "max_tokens": 1,
+                    "input_modalities": ["text"], "pricing": {"input": 1, "output": 1}}],
+    }
+    base.update(over)
+    return base
+
+
+def test_untagged_endpoint_serves_all_models():
+    cat = build_catalog([_vendor()], PROFILES)
+    ep = cat.resolve("v/cn/openai-completions")
+    assert [m.model_id for m in ep.models] == ["m1"]
+
+
+def test_tiered_membership_by_plan_intersection():
+    v = _vendor(
+        endpoints=[
+            {"region": "cn", "protocol": "openai-completions", "plan": "general", "capability": "x"},
+            {"region": "cn", "protocol": "openai-completions", "plan": "coding",
+             "path": "/coding", "capability": "x"},
+        ],
+        models=[
+            {"model_id": "g", "display_name": "G", "context_window": 1, "max_tokens": 1,
+             "input_modalities": ["text"], "plan": "general", "pricing": {"input": 1, "output": 1}},
+            {"model_id": "c", "display_name": "C", "context_window": 1, "max_tokens": 1,
+             "input_modalities": ["text"], "plan": "coding", "pricing": {"input": 1, "output": 1}},
+        ],
+    )
+    cat = build_catalog([v], PROFILES)
+    assert [m.model_id for m in cat.resolve("v/cn/openai-completions/general").models] == ["g"]
+    assert [m.model_id for m in cat.resolve("v/cn/openai-completions/coding").models] == ["c"]
+
+
+def test_mixed_tagged_untagged_rejected():
+    v = _vendor(
+        endpoints=[{"region": "cn", "protocol": "openai-completions", "plan": "coding", "capability": "x"}],
+        models=[{"model_id": "m", "display_name": "M", "context_window": 1, "max_tokens": 1,
+                 "input_modalities": ["text"], "pricing": {"input": 1, "output": 1}}],  # untagged model
+    )
+    with pytest.raises(ValueError, match="mix"):
+        build_catalog([v], PROFILES)
+
+
+def test_dangling_endpoint_rejected():
+    v = _vendor(
+        endpoints=[
+            {"region": "cn", "protocol": "openai-completions", "plan": "general", "capability": "x"},
+            {"region": "cn", "protocol": "openai-completions", "plan": "coding", "path": "/c", "capability": "x"},
+        ],
+        models=[{"model_id": "g", "display_name": "G", "context_window": 1, "max_tokens": 1,
+                 "input_modalities": ["text"], "plan": "general", "pricing": {"input": 1, "output": 1}}],
+    )
+    with pytest.raises(ValueError, match="no model"):
+        build_catalog([v], PROFILES)
+
+
+def test_unreachable_model_rejected():
+    v = _vendor(
+        endpoints=[{"region": "cn", "protocol": "openai-completions", "plan": "general", "capability": "x"}],
+        models=[{"model_id": "c", "display_name": "C", "context_window": 1, "max_tokens": 1,
+                 "input_modalities": ["text"], "plan": "coding", "pricing": {"input": 1, "output": 1}}],
+    )
+    with pytest.raises(ValueError, match="no endpoint"):
+        build_catalog([v], PROFILES)
+
+
+def test_duplicate_preset_key_rejected():
+    v1, v2 = _vendor(), _vendor()  # same vendor name → same composed key
+    with pytest.raises(ValueError, match="duplicate preset_key"):
+        build_catalog([v1, v2], PROFILES)
+```
+
+- [ ] **Step 2: Run** `uv run pytest tests/unit/llm/catalog/test_loader.py -v` → the new tests FAIL (`build_catalog` undefined).
+
+- [ ] **Step 3: Implement** the `Catalog` type and `build_catalog`. Add `Catalog` to `types.py`:
+
+```python
+class Catalog(BaseModel):
+    vendors: list[Vendor]
+    endpoints: dict[str, ResolvedEndpoint]  # keyed by preset_key
+
+    def resolve(self, preset_key: str) -> ResolvedEndpoint:
+        if preset_key not in self.endpoints:
+            raise KeyError(preset_key)
+        return self.endpoints[preset_key]
+```
+
+Append to `loader.py`:
+
+```python
+from cubebox.llm.catalog.types import Catalog, ResolvedEndpoint, Vendor
+
+
+def _validate_plan_consistency(v: Vendor) -> None:
+    ep_tagged = [e.plan is not None for e in v.endpoints]
+    m_tagged = [m.plan is not None for m in v.models]
+    tagged = ep_tagged + m_tagged
+    if any(tagged) and not all(tagged):
+        raise ValueError(f"vendor {v.vendor!r} may not mix plan-tagged and untagged endpoints/models")
+
+
+def _models_for(v: Vendor, endpoint: Endpoint) -> list[ModelPreset]:
+    if endpoint.plan is None:  # untagged vendor → every endpoint serves every model
+        return list(v.models)
+    return [m for m in v.models if endpoint.plan in (m.plans() or [])]
+
+
+def build_catalog(raw_vendors: list[dict | Vendor], profiles: dict[str, dict]) -> Catalog:
+    vendors = [v if isinstance(v, Vendor) else Vendor.model_validate(v) for v in raw_vendors]
+    endpoints: dict[str, ResolvedEndpoint] = {}
+    for v in vendors:
+        _validate_plan_consistency(v)
+        # uniqueness of (region, protocol, plan) is enforced via preset_key dedup below
+        for ep in v.endpoints:
+            models = _models_for(v, ep)
+            if ep.plan is not None and not models:
+                raise ValueError(
+                    f"vendor {v.vendor!r} endpoint plan {ep.plan!r} matches no model (dangling)"
+                )
+            key = preset_key_for(v.vendor, ep)
+            if key in endpoints:
+                raise ValueError(f"duplicate preset_key {key!r}")
+            endpoints[key] = ResolvedEndpoint(
+                preset_key=key, vendor=v.vendor, region=ep.region, protocol=ep.protocol,
+                plan=ep.plan, base_url=compose_base_url(v.regions, ep),
+                capability=resolve_capability(ep.capability, profiles), models=models,
+            )
+        # unreachable-model check: every model's plan(s) must hit some endpoint
+        ep_plans = {e.plan for e in v.endpoints}
+        for m in v.models:
+            mplans = m.plans()
+            if mplans is not None and not (set(mplans) & ep_plans):
+                raise ValueError(
+                    f"vendor {v.vendor!r} model {m.model_id!r} plan(s) {mplans} match no endpoint (unreachable)"
+                )
+    return Catalog(vendors=vendors, endpoints=endpoints)
+```
+
+- [ ] **Step 4: Run** `uv run pytest tests/unit/llm/catalog/test_loader.py -v` → all PASS.
+
+- [ ] **Step 5: Implement `load_catalog()` + cache.** Append to `loader.py`:
+
+```python
+from functools import cache
+from pathlib import Path
+
+import yaml
+
+_DATA_DIR = Path(__file__).parent / "data"
+
+
+@cache
+def load_catalog() -> Catalog:
+    vendors_raw = yaml.safe_load((_DATA_DIR / "vendors.yaml").read_text("utf-8"))
+    profiles = yaml.safe_load((_DATA_DIR / "capabilities.yaml").read_text("utf-8"))
+    if not isinstance(vendors_raw, list):
+        raise ValueError("vendors.yaml must be a top-level list")
+    return build_catalog(vendors_raw, profiles or {})
+```
+
+`cubebox/llm/catalog/__init__.py`:
+
+```python
+from cubebox.llm.catalog.loader import build_catalog, compose_base_url, load_catalog, preset_key_for
+from cubebox.llm.catalog.types import (
+    Catalog, Endpoint, ModelPreset, Pricing, Region, ResolvedEndpoint, Vendor, WireApi,
+)
+
+__all__ = [
+    "Catalog", "Endpoint", "ModelPreset", "Pricing", "Region", "ResolvedEndpoint",
+    "Vendor", "WireApi", "build_catalog", "compose_base_url", "load_catalog", "preset_key_for",
+]
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cubebox/llm/catalog/ tests/unit/llm/catalog/test_loader.py
+git commit -m "feat(catalog): build_catalog with plan/membership validations + load_catalog (§4.2)"
+```
+
+---
+
+## Phase B — Port the data + parity guard
+
+### Task B1: Freeze the current flat catalog as a parity fixture
+
+**Files:**
+- Create: `tests/unit/llm/catalog/data/flat_providers_snapshot.yaml`
+
+- [ ] **Step 1: Copy the published flat catalog** (the file cubebox currently resolves at runtime):
+
+```bash
+cp backend/.venv/lib/python3.13/site-packages/cubepi/providers/catalog/data/providers.yaml \
+   backend/tests/unit/llm/catalog/data/flat_providers_snapshot.yaml
+```
+
+- [ ] **Step 2: Commit the fixture**
+
+```bash
+git add tests/unit/llm/catalog/data/flat_providers_snapshot.yaml
+git commit -m "test(catalog): freeze current flat providers.yaml as parity fixture"
+```
+
+### Task B2: Author `vendors.yaml` + `capabilities.yaml`
+
+**Files:**
+- Create: `cubebox/llm/catalog/data/vendors.yaml`
+- Create: `cubebox/llm/catalog/data/capabilities.yaml`
+
+This is data entry, not logic — but it must reproduce every flat entry. Work vendor-by-vendor from `flat_providers_snapshot.yaml`. The snapshot's flat entries group into these vendors (regions/plans/protocols noted):
+
+| Vendor | endpoints (region/protocol/plan) | host(s) |
+|---|---|---|
+| anthropic | intl/anthropic-messages | api.anthropic.com |
+| openai | intl/openai-responses, intl/openai-completions (`openai-legacy`) | api.openai.com/v1 |
+| deepseek | cn/anthropic-messages (`/anthropic`), cn/openai-completions | api.deepseek.com |
+| qwen | intl & cn /openai-completions, +coding (intl & cn) | dashscope-intl / dashscope |
+| doubao (volcengine) | cn/openai-completions (`/api/v3`), cn/anthropic-messages coding (`/api/coding`) | ark.cn-beijing.volces.com |
+| moonshot | intl & cn /openai-completions, +coding (same URL, diff models) | api.moonshot.ai / .cn |
+| zhipu | intl & cn /openai-completions, +coding (`/api/coding/paas/v4`) | api.z.ai / open.bigmodel.cn |
+| minimax | intl & cn /openai-completions, +coding /anthropic-messages | api.minimax.io / api.minimaxi.com |
+| xai, mistral, openrouter, together-ai, groq, fireworks | intl/openai-completions | per-vendor |
+| vllm, ollama, lm-studio, tgi | localhost/openai-completions, category oss-framework | localhost |
+| anthropic-claude-code, openai-codex | use `base_url` full override (irregular) | — |
+| custom-openai, custom-anthropic | category custom, base_url "" | — |
+
+Define capability profiles in `capabilities.yaml`: at minimum `openai-compat-basic` (the ~20 vanilla `openai-completions` vendors), `anthropic-native`, `openai-responses`, and the per-vendor reasoning variants present in the snapshot (deepseek-anthropic, etc. — copy the `capability:` blocks verbatim from the snapshot, deduping identical ones into one profile name).
+
+- [ ] **Step 1:** Author `capabilities.yaml` first — extract each distinct `capability:` block from the snapshot, name it, dedup. Example head:
+
+```yaml
+openai-compat-basic:
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  max_tokens_field: max_tokens
+  supports_tools: true
+  supports_images: true
+anthropic-native:
+  reasoning_off_payload: { thinking: { type: disabled } }
+  reasoning_on_payload:  { thinking: { type: enabled } }
+  reasoning_level: { path: thinking.budget_tokens, kind: int_budget, level_budgets: { off: 0, minimal: 1024, low: 2048, medium: 8192, high: 16384, xhigh: 16384 } }
+  temperature: { mode: free, min: 0.0, max: 1.0, default: 1.0 }
+  max_tokens_field: max_tokens
+  supports_tools: true
+  supports_images: true
+# … openai-responses, deepseek-anthropic, etc. — verbatim from snapshot blocks
+```
+
+- [ ] **Step 2:** Author `vendors.yaml` — one entry per vendor per the table, moving each flat entry's `default_models` into the vendor `models` pool (tagging `plan:` only for tiered vendors), referencing capability profiles by name. Models need `pricing:` — for ported presets that had none, set `pricing: { input: 0, output: 0 }` (cost is filled per-deployment via config override; the catalog default is zero so nothing silently bills wrong). Carry over `context_window`, `max_tokens`, `input_modalities`, `reasoning`.
+
+- [ ] **Step 3: Sanity-load** to catch validation errors early:
+
+Run: `cd backend && uv run python -c "from cubebox.llm.catalog import load_catalog; c=load_catalog(); print(len(c.vendors), 'vendors', len(c.endpoints), 'endpoints')"`
+Expected: prints counts, no exception. Fix any validation error it raises.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cubebox/llm/catalog/data/vendors.yaml cubebox/llm/catalog/data/capabilities.yaml
+git commit -m "feat(catalog): port flat providers.yaml to nested vendors + capability profiles"
+```
+
+### Task B3: base_url parity test (§4.1 regression guard)
+
+**Files:**
+- Modify: `tests/unit/llm/catalog/test_composition.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from pathlib import Path
+
+import yaml
+
+from cubebox.llm.catalog import load_catalog
+
+_SNAPSHOT = Path(__file__).parent / "data" / "flat_providers_snapshot.yaml"
+
+
+def test_every_flat_base_url_is_reproduced():
+    """Each flat entry's (api, base_url) must be reproduced by some resolved endpoint.
+
+    Flat entries with base_url == "" (custom-*) are excluded — they have no
+    composed URL by design.
+    """
+    flat = yaml.safe_load(_SNAPSHOT.read_text("utf-8"))
+    catalog = load_catalog()
+    produced = {(e.protocol, e.base_url) for e in catalog.endpoints.values()}
+    missing = []
+    for entry in flat:
+        if not entry.get("base_url"):
+            continue
+        pair = (entry["api"], entry["base_url"])
+        if pair not in produced:
+            missing.append((entry["slug"], pair))
+    assert not missing, f"flat URLs not reproduced by composition: {missing}"
+```
+
+- [ ] **Step 2: Run** `cd backend && uv run pytest tests/unit/llm/catalog/test_composition.py::test_every_flat_base_url_is_reproduced -v`
+Expected: FAIL initially if any vendor entry is missing/mismatched — the failure message lists exactly which `(slug, api, base_url)` is not reproduced.
+
+- [ ] **Step 3: Fix `vendors.yaml`** until the test passes (adjust host/path/override for each listed miss). No code change — data only.
+
+- [ ] **Step 4: Run** the test → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/llm/catalog/test_composition.py cubebox/llm/catalog/data/vendors.yaml
+git commit -m "test(catalog): byte-parity of composed base_url vs frozen flat catalog (§4.1)"
+```
+
+---
+
+## Phase C — Repoint consumers + API contract + core types
+
+### Task C1: `admin_llm.py` returns the nested vendor list (§5.1)
+
+**Files:**
+- Modify: `cubebox/api/routes/v1/admin_llm.py`
+- Modify: `cubebox/llm/catalog/loader.py` (add `to_api()` serializer)
+- Test: `tests/unit/llm/catalog/test_loader.py`, `tests/e2e` (existing presets endpoint test if any)
+
+- [ ] **Step 1: Write the failing test** (append to `test_loader.py`) for the API shape:
+
+```python
+def test_catalog_to_api_shape():
+    from cubebox.llm.catalog import load_catalog
+
+    api = load_catalog().to_api()
+    assert isinstance(api, list)
+    v = next(x for x in api if x["vendor"] == "deepseek")
+    assert {"vendor", "display_name", "short_name", "logo", "category",
+            "description", "endpoints", "models"} <= v.keys()
+    ep = v["endpoints"][0]
+    assert {"preset_key", "region", "protocol", "plan", "base_url", "model_ids"} <= ep.keys()
+    m = v["models"][0]
+    assert {"model_id", "display_name", "plan", "context_window", "max_tokens",
+            "input_modalities", "reasoning", "pricing"} <= m.keys()
+```
+
+- [ ] **Step 2: Run** → FAIL (`to_api` undefined).
+
+- [ ] **Step 3: Implement `Catalog.to_api()`** in `types.py` (uses `endpoints` already grouped by vendor). Add a helper on `Catalog`:
+
+```python
+def to_api(self) -> list[dict]:
+    """Nested vendor list for GET /admin/llm/presets (spec §5.1)."""
+    out: list[dict] = []
+    for v in self.vendors:
+        v_eps = [e for e in self.endpoints.values() if e.vendor == v.vendor]
+        out.append({
+            "vendor": v.vendor, "display_name": v.display_name, "short_name": v.short_name,
+            "logo": v.logo, "category": v.category, "description": v.description,
+            "endpoints": [{
+                "preset_key": e.preset_key, "region": e.region, "protocol": e.protocol,
+                "plan": e.plan, "base_url": e.base_url,
+                "model_ids": [m.model_id for m in e.models],
+            } for e in v_eps],
+            "models": [{
+                "model_id": m.model_id, "display_name": m.display_name, "plan": m.plans(),
+                "context_window": m.context_window, "max_tokens": m.max_tokens,
+                "input_modalities": m.input_modalities, "reasoning": m.reasoning,
+                "pricing": m.pricing.model_dump(),
+            } for m in v.models],
+        })
+    return out
+```
+
+- [ ] **Step 4: Rewrite the endpoint** `cubebox/api/routes/v1/admin_llm.py`:
+
+```python
+@router.get("/presets")
+async def list_provider_presets(
+    *,
+    user: Annotated[User, Depends(require_org_admin)],
+) -> list[dict[str, Any]]:
+    """Return cubebox's provider-preset catalog as a nested vendor list (spec §5.1)."""
+    from cubebox.llm.catalog import load_catalog
+
+    return load_catalog().to_api()
+```
+
+- [ ] **Step 5: Run** `cd backend && uv run pytest tests/unit/llm/catalog/ -v` → PASS. Also run any existing presets-endpoint test: `uv run pytest tests/ -k preset -v`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cubebox/api/routes/v1/admin_llm.py cubebox/llm/catalog/ tests/unit/llm/catalog/test_loader.py
+git commit -m "feat(catalog): /admin/llm/presets returns nested vendor list (§5.1)"
+```
+
+### Task C2: `admin_providers.py` logo via catalog
+
+**Files:**
+- Modify: `cubebox/api/routes/v1/admin_providers.py:148-156`
+- Test: `tests/unit` (add a focused test for `_resolve_logo`)
+
+`_resolve_logo` currently calls `get_provider_preset(preset_slug).logo`. The new `preset_slug` is a `preset_key` (`vendor/region/protocol[/plan]`); logo lives on the **vendor**.
+
+- [ ] **Step 1: Write the failing test** `tests/unit/test_resolve_logo.py`:
+
+```python
+from cubebox.api.routes.v1.admin_providers import _resolve_logo
+
+
+def test_resolve_logo_by_preset_key():
+    assert _resolve_logo("deepseek/cn/anthropic-messages") == "deepseek"
+
+
+def test_resolve_logo_none_for_unknown():
+    assert _resolve_logo("nope/x/y") is None
+    assert _resolve_logo(None) is None
+```
+
+- [ ] **Step 2: Run** → FAIL (still uses cubepi `get_provider_preset`).
+
+- [ ] **Step 3: Implement** — replace the import `from cubepi.providers.catalog import get_provider_preset` and `_resolve_logo`:
+
+```python
+def _resolve_logo(preset_slug: str | None) -> str | None:
+    """Resolve the brand-icon id from the catalog vendor. None if unknown."""
+    if not preset_slug:
+        return None
+    try:
+        vendor = preset_slug.split("/", 1)[0]
+        from cubebox.llm.catalog import load_catalog
+
+        for v in load_catalog().vendors:
+            if v.vendor == vendor:
+                return v.logo
+    except Exception:
+        return None
+    return None
+```
+
+- [ ] **Step 4: Run** `uv run pytest tests/unit/test_resolve_logo.py -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cubebox/api/routes/v1/admin_providers.py tests/unit/test_resolve_logo.py
+git commit -m "feat(catalog): resolve provider logo via catalog vendor (preset_key)"
+```
+
+### Task C3: `@cubebox/core` nested preset types + `listPresets`
+
+**Files:**
+- Modify: `frontend/packages/core/src/types/provider.ts:17-37`
+- Modify: `frontend/packages/core/src/api/providers.ts:95-98`
+
+- [ ] **Step 1: Replace `ProviderPreset`** in `provider.ts` with the nested shape:
+
+```typescript
+export interface EndpointPreset {
+  preset_key: string
+  region: string
+  protocol: WireApi
+  plan: string | null
+  base_url: string
+  model_ids: string[]
+}
+
+export interface ModelPresetEntry {
+  model_id: string
+  display_name: string
+  plan: string[] | null
+  context_window: number
+  max_tokens: number
+  input_modalities: string[]
+  reasoning: boolean
+  pricing: { input: number; output: number; cache_read?: number; cache_write?: number }
+}
+
+export interface VendorPreset {
+  vendor: string
+  display_name: string
+  short_name: string
+  logo: string | null
+  category: 'saas' | 'oss-framework' | 'custom'
+  description: string
+  endpoints: EndpointPreset[]
+  models: ModelPresetEntry[]
+}
+```
+
+Remove the old `ProviderPreset` interface and its `AuthSpec`/`default_models` usage if now unused elsewhere (grep first — `git grep -n ProviderPreset frontend/packages`).
+
+- [ ] **Step 2: Update `listPresets`** in `api/providers.ts`:
+
+```typescript
+export async function listPresets(client: ApiClient): Promise<VendorPreset[]> {
+  const res = await client.fetch('/api/v1/admin/llm/presets')
+  if (!res.ok) throw new Error(`listPresets failed: ${res.status}`)
+  return res.json() as Promise<VendorPreset[]>
+}
+```
+
+Update the `import` and any barrel re-export (`frontend/packages/core/src/index.ts` / `types/index.ts`) to export `VendorPreset`, `EndpointPreset`, `ModelPresetEntry` and drop `ProviderPreset`.
+
+- [ ] **Step 3: Build core** (web depends on the built package):
+
+Run: `cd frontend && pnpm --filter @cubebox/core build`
+Expected: builds; TypeScript errors elsewhere (PresetPicker/ConfigureStep) are expected and fixed in Phase F.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/packages/core/src
+git commit -m "feat(core): nested VendorPreset/EndpointPreset types for catalog API"
+```
+
+---
+
+## Phase D — Seeder: preset resolution + precedence (§6.2/§6.3)
+
+### Task D1: cost deep-merge helper (§6.2.3)
+
+**Files:**
+- Modify: `cubebox/seeders/provider_seeder.py`
+- Test: `tests/unit/test_provider_seeder_resolve.py`
+
+- [ ] **Step 1: Write the failing test** `tests/unit/test_provider_seeder_resolve.py`:
+
+```python
+from cubebox.seeders.provider_seeder import _merge_cost
+
+
+def test_merge_cost_partial_override_inherits_other_legs():
+    catalog = {"input": 0.27, "output": 1.10, "cache_read": 0.07, "cache_write": 0.0}
+    override = {"input": 0.5}
+    assert _merge_cost(catalog, override) == {
+        "input": 0.5, "output": 1.10, "cache_read": 0.07, "cache_write": 0.0
+    }
+
+
+def test_merge_cost_no_override_returns_catalog():
+    catalog = {"input": 1.0, "output": 2.0, "cache_read": 0.0, "cache_write": 0.0}
+    assert _merge_cost(catalog, None) == catalog
+```
+
+- [ ] **Step 2: Run** → FAIL.
+
+- [ ] **Step 3: Implement** in `provider_seeder.py`:
+
+```python
+def _merge_cost(catalog_cost: dict[str, float], override: dict[str, Any] | None) -> dict[str, float]:
+    """Per-leaf deep-merge: an override leg replaces only that leg (§6.2.3)."""
+    merged = dict(catalog_cost)
+    if override:
+        for leg in ("input", "output", "cache_read", "cache_write"):
+            if leg in override:
+                merged[leg] = float(override[leg])
+    return merged
+```
+
+- [ ] **Step 4: Run** → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cubebox/seeders/provider_seeder.py tests/unit/test_provider_seeder_resolve.py
+git commit -m "feat(seeder): per-leg cost deep-merge for preset overrides (§6.2.3)"
+```
+
+### Task D2: preset resolution + precedence + validation in the seed loop
+
+**Files:**
+- Modify: `cubebox/seeders/provider_seeder.py`
+- Test: `tests/unit/test_provider_seeder_resolve.py` (a focused resolver test)
+
+The seed loop (`seed_system_providers_from_config`) reads each `config_providers[name]` dict. Add: if `preset:` is present, resolve it and inherit. This means restructuring how `base_url`, `provider_type`, the model list, and `capability` are derived.
+
+- [ ] **Step 1: Write the failing test** for a pure resolver function (extract the per-provider derivation so it's unit-testable without a DB):
+
+```python
+import pytest
+
+from cubebox.seeders.provider_seeder import resolve_provider_config
+
+
+def test_resolve_with_preset_inherits_base_url_models_capability():
+    cfg = {"preset": "deepseek/cn/anthropic-messages", "api_key": "k"}
+    r = resolve_provider_config("deepseek", cfg)
+    assert r.base_url == "https://api.deepseek.com/anthropic"
+    assert r.provider_type == "anthropic-messages"
+    assert r.preset_key == "deepseek/cn/anthropic-messages"
+    assert r.capability  # non-empty descriptor dict
+    assert len(r.models) >= 1
+    assert all("cost" in m and "input" in m["cost"] for m in r.models)
+
+
+def test_resolve_models_subset_filter():
+    cfg = {"preset": "deepseek/cn/anthropic-messages", "api_key": "k", "models": ["deepseek-v4-flash"]}
+    r = resolve_provider_config("deepseek", cfg)
+    assert [m["id"] for m in r.models] == ["deepseek-v4-flash"]
+
+
+def test_resolve_unknown_preset_fails_loudly():
+    with pytest.raises(ValueError, match="unknown preset"):
+        resolve_provider_config("x", {"preset": "no/such/key", "api_key": "k"})
+
+
+def test_resolve_unknown_subset_model_fails_loudly():
+    with pytest.raises(ValueError, match="not in preset"):
+        resolve_provider_config("deepseek", {"preset": "deepseek/cn/anthropic-messages",
+                                             "api_key": "k", "models": ["ghost"]})
+
+
+def test_resolve_api_override_with_preset_rejected():
+    with pytest.raises(ValueError, match="api.*not overridable"):
+        resolve_provider_config("deepseek", {"preset": "deepseek/cn/anthropic-messages",
+                                             "api_key": "k", "api": "openai-completions"})
+
+
+def test_resolve_base_url_override_allowed():
+    cfg = {"preset": "deepseek/cn/anthropic-messages", "api_key": "k",
+           "base_url": "https://proxy.internal/anthropic"}
+    r = resolve_provider_config("deepseek", cfg)
+    assert r.base_url == "https://proxy.internal/anthropic"
+
+
+def test_resolve_without_preset_uses_config_verbatim():
+    cfg = {"base_url": "http://localhost:8000/v1", "api": "openai-completions",
+           "models": [{"id": "m", "name": "M", "context_window": 1, "max_tokens": 1, "input": ["text"]}]}
+    r = resolve_provider_config("vllm", cfg)
+    assert r.base_url == "http://localhost:8000/v1"
+    assert r.preset_key is None
+```
+
+NOTE: these tests require the deepseek vendor/endpoint to exist in `vendors.yaml` (Phase B) and the seed config models (`deepseek-v4-pro`, `deepseek-v4-flash`) to be present in that vendor's model pool. Add them to `vendors.yaml` in Phase E when wiring the real config; for this task's test, they must already be in the catalog. **Add `deepseek-v4-pro` / `deepseek-v4-flash` to the deepseek vendor pool now** (they are the real seeded ids) if not done in B2.
+
+- [ ] **Step 2: Run** → FAIL (`resolve_provider_config` undefined).
+
+- [ ] **Step 3: Implement** the resolver. Add to `provider_seeder.py`:
+
+```python
+from dataclasses import dataclass
+
+from cubebox.llm.catalog import load_catalog
+
+
+@dataclass
+class ResolvedProviderConfig:
+    base_url: str
+    provider_type: str
+    preset_key: str | None
+    capability: dict[str, Any]
+    model_capability_overrides: dict[str, Any]
+    models: list[dict[str, Any]]  # normalized to seeder's per-model dict (id/name/cost/…)
+
+
+def _model_from_preset(m: Any, cost_override: dict[str, Any] | None) -> dict[str, Any]:
+    base_cost = m.pricing.model_dump()
+    return {
+        "id": m.model_id,
+        "name": m.display_name,
+        "reasoning": m.reasoning,
+        "input": list(m.input_modalities),
+        "context_window": m.context_window,
+        "max_tokens": m.max_tokens,
+        "cost": _merge_cost(base_cost, cost_override),
+    }
+
+
+def resolve_provider_config(name: str, cfg: dict[str, Any]) -> ResolvedProviderConfig:
+    preset_key = cfg.get("preset")
+    if not preset_key:
+        # No preset → config verbatim (custom/self-hosted). §6.2.4
+        return ResolvedProviderConfig(
+            base_url=str(cfg.get("base_url", "")),
+            provider_type=str(cfg.get("api", "openai-completions")),
+            preset_key=None, capability={}, model_capability_overrides={},
+            models=list(cfg.get("models", [])),
+        )
+    if cfg.get("api") is not None:
+        raise ValueError(f"provider {name!r}: 'api' is not overridable under a preset (§6.2.3)")
+    try:
+        ep = load_catalog().resolve(preset_key)
+    except KeyError:
+        raise ValueError(f"provider {name!r}: unknown preset {preset_key!r}") from None
+    pool = {m.model_id: m for m in ep.models}
+    subset = cfg.get("models")
+    # Per-model cost overrides keyed by model id when config lists dicts.
+    overrides: dict[str, dict] = {}
+    chosen: list[str]
+    if subset is None:
+        chosen = list(pool.keys())
+    else:
+        chosen = []
+        for item in subset:
+            mid = item if isinstance(item, str) else str(item["id"])
+            if mid not in pool:
+                raise ValueError(f"provider {name!r}: model {mid!r} not in preset {preset_key!r}")
+            chosen.append(mid)
+            if isinstance(item, dict) and "cost" in item:
+                overrides[mid] = item["cost"]
+    return ResolvedProviderConfig(
+        base_url=str(cfg.get("base_url") or ep.base_url),  # base_url override allowed
+        provider_type=ep.protocol,
+        preset_key=preset_key,
+        capability=ep.capability.model_dump(mode="json"),
+        model_capability_overrides={},
+        models=[_model_from_preset(pool[mid], overrides.get(mid)) for mid in chosen],
+    )
+```
+
+- [ ] **Step 4: Run** `uv run pytest tests/unit/test_provider_seeder_resolve.py -v` → all PASS.
+
+- [ ] **Step 5: Wire the resolver into `seed_system_providers_from_config`.** Replace the inline `base_url` / `provider_type` / capability-backfill / models-loop derivation with a call to `resolve_provider_config(name, cfg_dict)`, then use `resolved.base_url`, `resolved.provider_type`, set `provider.preset_slug = resolved.preset_key`, `provider.capability = resolved.capability` (when non-empty and `provider.capability` empty), and iterate `resolved.models` (each already has `id/name/cost/context_window/max_tokens/reasoning/input`). Keep the existing credential-vault + stale-model-disable logic unchanged. Keep the "skip provider with no models" guard.
+
+- [ ] **Step 6: Run the seeder idempotency test** (existing): `uv run pytest tests/ -k seed -v`. Fix fallout.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cubebox/seeders/provider_seeder.py tests/unit/test_provider_seeder_resolve.py cubebox/llm/catalog/data/vendors.yaml
+git commit -m "feat(seeder): resolve config preset: into base_url/api/capability/model-pool (§6.2/§6.3)"
+```
+
+---
+
+## Phase E — Exhaustive seed-config rewrite + backfill parity (§6.4)
+
+### Task E1: Inventory + rewrite `config.development.local.yaml`
+
+**Files:**
+- Modify: `backend/config.development.local.yaml` (lines 57–212, the `llm.providers` block)
+- Modify: `cubebox/llm/catalog/data/vendors.yaml` (add any seeded model/endpoint not yet present)
+
+The 9 seeded providers and their mapping (§6.4 inventory):
+
+| config name | base_url today | mapping |
+|---|---|---|
+| `deepseek` | api.deepseek.com/anthropic | `preset: deepseek/cn/anthropic-messages` |
+| `minimax` | api.minimaxi.com/v1 | `preset: minimax/cn/openai-completions` (carry `extra_body`) |
+| `arkcode` | ark…/api/coding/v3 (openai) | NEW catalog endpoint: volcengine coding **openai-completions** `/api/coding/v3` → `preset: volcengine/cn/openai-completions/coding` |
+| `alicode` | coding.dashscope…/v1 | `preset: qwen/cn/openai-completions/coding` (host override in catalog) |
+| `volengine` | ark…/api/v3 | `preset: volcengine/cn/openai-completions` (general) |
+| `openrouter` | openrouter.ai/api/v1 | `preset: openrouter/intl/openai-completions` |
+| `sensedeal` | private gateway | **custom** — keep verbatim (no preset); reason: private gateway, not in catalog |
+| `google` | local IP | **custom** — keep verbatim; reason: self-hosted test endpoint |
+| `vllm` | local IP | **custom** — keep verbatim; reason: self-hosted |
+
+- [ ] **Step 1:** For each *preset-mapped* provider, ensure its real model ids exist in the catalog vendor pool with correct `context_window`/`max_tokens`/`input`/`reasoning` + a `pricing` (use the config's `cost` when present, else `{input:0,output:0}`). Add to `vendors.yaml`:
+  - deepseek pool: `deepseek-v4-pro`, `deepseek-v4-flash`.
+  - minimax pool: `MiniMax-M2.7`.
+  - volcengine general: `doubao-seed-1-8-251228` (cost input 2.4/output 24); coding: `doubao-seed-2.0-pro`, `kimi-k2.6`.
+  - qwen coding pool: `qwen3.6-plus`.
+  - openrouter pool: `google/gemma-4-31b-it:free`, `stepfun/step-3.5-flash:free`.
+  - Add the `volcengine/cn/openai-completions/coding` endpoint (path `/api/coding/v3`) and make volcengine a **tiered** vendor (general + coding) — so tag its general models `plan: general` and coding models `plan: coding`.
+
+- [ ] **Step 2:** Rewrite the `llm.providers` block. Preset-mapped example:
+
+```yaml
+    providers:
+      deepseek:
+        preset: deepseek/cn/anthropic-messages
+        api_key: key-in-env
+      minimax:
+        preset: minimax/cn/openai-completions
+        api_key: sk-cp-…
+        extra_body: { "reasoning_split": true }
+      arkcode:
+        preset: volcengine/cn/openai-completions/coding
+        api_key: ark-…
+      alicode:
+        preset: qwen/cn/openai-completions/coding
+        api_key: sk-sp-…
+      volengine:
+        preset: volcengine/cn/openai-completions
+        api_key: 87d0c8f5-…
+      openrouter:
+        preset: openrouter/intl/openai-completions
+        api_key: sk-or-…
+      # custom (no preset) — kept verbatim:
+      sensedeal: { base_url: https://gateway.chat.sensedeal.vip/v1, api_key: …, api: openai-completions, models: [...] }
+      google:    { base_url: http://192.168.1.218:8000/v1, api_key: test, api: openai-completions, models: [...] }
+      vllm:      { base_url: http://192.168.1.218:8008/v1, api_key: test, api: openai-completions, models: [...], extra_body: {...} }
+```
+
+(Keep `extra_body`/`extra_headers` on providers/models that had them — those are deployment knobs, not catalog data, and pass through unchanged.)
+
+- [ ] **Step 3: Boot the seeder** against the worktree DB to confirm it resolves:
+
+Run: `cd backend && set -a && source ../.worktree.env && set +a && uv run python -c "import asyncio; from cubebox.db import ...; ..."` — or simpler, run the app's seed entrypoint / the seed test that exercises real config. Confirm no `ValueError` and that previously-seeded providers still produce models.
+Expected: seed completes; `deepseek/minimax/arkcode/alicode/volengine/openrouter` get their models from the catalog.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/config.development.local.yaml cubebox/llm/catalog/data/vendors.yaml
+git commit -m "feat(config): rewrite seed providers to preset: refs; add seeded models to catalog (§6.4)"
+```
+
+### Task E2: Backfill-parity test (§6.4 P1 guard)
+
+**Files:**
+- Create: `tests/unit/test_seed_backfill_parity.py`
+
+- [ ] **Step 1: Write the test** — every preset-mapped provider yields a capability snapshot (the regression guard against silent custom-downgrade):
+
+```python
+import pytest
+
+from cubebox.seeders.provider_seeder import resolve_provider_config
+
+# The §6.4 inventory: preset-mapped providers MUST resolve a capability.
+PRESET_MAPPED = {
+    "deepseek": "deepseek/cn/anthropic-messages",
+    "minimax": "minimax/cn/openai-completions",
+    "arkcode": "volcengine/cn/openai-completions/coding",
+    "alicode": "qwen/cn/openai-completions/coding",
+    "volengine": "volcengine/cn/openai-completions",
+    "openrouter": "openrouter/intl/openai-completions",
+}
+
+
+@pytest.mark.parametrize("name,key", PRESET_MAPPED.items())
+def test_preset_mapped_providers_get_capability_and_models(name, key):
+    r = resolve_provider_config(name, {"preset": key, "api_key": "k"})
+    assert r.preset_key == key
+    assert r.capability is not None
+    assert len(r.models) >= 1
+```
+
+- [ ] **Step 2: Run** `cd backend && uv run pytest tests/unit/test_seed_backfill_parity.py -v` → PASS (proves the inventory + catalog are wired).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/test_seed_backfill_parity.py
+git commit -m "test(seeder): backfill-parity guard for preset-mapped providers (§6.4)"
+```
+
+---
+
+## Phase F — Frontend two-step wizard
+
+### Task F1: wizard state — pick vendor + selected endpoint
+
+**Files:**
+- Modify: `frontend/packages/web/components/admin/models/wizard/wizardMachine.ts`
+- Test: `frontend/packages/web/components/admin/models/wizard/__tests__/wizardMachine.test.ts`
+
+- [ ] **Step 1: Write the failing test** — `pickVendor` sets vendor, `selectEndpoint` sets the chosen `preset_key`, step 1 advance requires both a vendor AND a selected endpoint:
+
+```typescript
+import { describe, expect, it } from 'vitest'
+import { canAdvance, initialWizardState, wizardReducer } from '../wizardMachine'
+import type { VendorPreset } from '@cubebox/core'
+
+const vendor = {
+  vendor: 'zhipu', display_name: 'Zhipu', short_name: 'Zhipu', logo: 'zhipu',
+  category: 'saas', description: '', endpoints: [
+    { preset_key: 'zhipu/cn/openai-completions/coding', region: 'cn',
+      protocol: 'openai-completions', plan: 'coding', base_url: 'https://x', model_ids: ['m'] },
+  ], models: [],
+} as VendorPreset
+
+it('requires a vendor and a selected endpoint to advance from step 1', () => {
+  let s = initialWizardState
+  expect(canAdvance(s)).toBe(false)
+  s = wizardReducer(s, { type: 'pickVendor', vendor })
+  expect(canAdvance(s)).toBe(false) // vendor but no endpoint yet
+  s = wizardReducer(s, { type: 'selectEndpoint', presetKey: 'zhipu/cn/openai-completions/coding' })
+  expect(canAdvance(s)).toBe(true)
+})
+```
+
+- [ ] **Step 2: Run** `cd frontend && pnpm --filter @cubebox/web test wizardMachine` → FAIL.
+
+- [ ] **Step 3: Implement** — update `wizardMachine.ts`: replace `preset: ProviderPreset | null` with `vendor: VendorPreset | null` and `selectedPresetKey: string | null`; actions `pickVendor` / `selectEndpoint`; `canAdvance` step 1 → `vendor !== null && selectedPresetKey !== null`.
+
+- [ ] **Step 4: Run** → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/packages/web/components/admin/models/wizard/wizardMachine.ts \
+        frontend/packages/web/components/admin/models/wizard/__tests__/wizardMachine.test.ts
+git commit -m "feat(wizard): vendor + endpoint selection state (two-step)"
+```
+
+### Task F2: `PresetPicker` lists vendors
+
+**Files:**
+- Modify: `frontend/packages/web/components/admin/models/wizard/PresetPicker.tsx`
+
+- [ ] **Step 1:** Change `presets`/`ProviderPreset[]` to `vendors`/`VendorPreset[]`; `onPick(preset)` → `onPickVendor(vendor)`. Filter/search over `vendor.display_name`/`vendor.vendor`. Card renders `vendor.logo`, `display_name`, `description`, a count badge (`${vendor.endpoints.length} endpoints`). Drop the reasoning-shape badge (it read `preset.capability`, which no longer exists at vendor level). `selectedSlug` → `selectedVendor: string | null` compared to `vendor.vendor`.
+
+- [ ] **Step 2: Verify build + existing test** `cd frontend && pnpm --filter @cubebox/core build && pnpm --filter @cubebox/web test PresetPicker` (update the test fixture to `VendorPreset`). Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/packages/web/components/admin/models/wizard/PresetPicker.tsx \
+        frontend/packages/web/components/admin/models/wizard/__tests__/
+git commit -m "feat(wizard): PresetPicker lists vendors (step 1)"
+```
+
+### Task F3: `ConfigureStep`/`ProviderConfigForm` — endpoint selectors drive base_url + models
+
+**Files:**
+- Modify: `frontend/packages/web/components/admin/models/wizard/ConfigureStep.tsx`
+- Modify: `frontend/packages/web/components/admin/models/ProviderConfigForm.tsx`
+
+- [ ] **Step 1:** `ConfigureStep` now receives `vendor: VendorPreset` + `selectedPresetKey` (+ a setter). Add **region / protocol / plan** selectors derived from `vendor.endpoints` (distinct regions, then protocols within region, then plans). Selecting them resolves the matching `EndpointPreset` → its `base_url` (read-only display, composed server-side) and the model list filtered to `endpoint.model_ids` (mapped against `vendor.models`). The created `ProviderCreate` body sends `preset_slug: endpoint.preset_key`, `provider_type: endpoint.protocol`, `base_url: endpoint.base_url`, and the chosen models with pricing prefilled from `vendor.models[].pricing`.
+
+- [ ] **Step 2:** `ProviderConfigForm` `preset` prop type changes from `ProviderPreset` to a small `{ base_url, provider_type, logo, models }` shape derived from the selected endpoint (or pass `vendor` + `endpoint` and compute inside). Prefill cost fields from `pricing`.
+
+- [ ] **Step 3: Build + typecheck + tests**
+
+Run: `cd frontend && pnpm --filter @cubebox/core build && pnpm --filter @cubebox/web type-check && pnpm --filter @cubebox/web test`
+Expected: PASS (update `ConfigureStep.test.tsx` fixtures to the nested shape).
+
+- [ ] **Step 4: Manual E2E (golden path)** — per CLAUDE.md, exercise the UI. Start backend + frontend on slot-82 ports (bind `0.0.0.0` — user is remote):
+
+```bash
+# backend
+cd backend && set -a && source ../.worktree.env && set +a && CUBEBOX_API__HOST=0.0.0.0 uv run python main.py
+# frontend (separate shell) — uses the with-worktree-env wrapper so PORT=3082
+cd frontend && HOSTNAME=0.0.0.0 pnpm dev
+```
+
+Open `http://192.168.1.150:3082/admin/models/new`, add a provider: pick **Zhipu** (step 1) → choose **CN / OpenAI / Coding** (step 2) → confirm base_url shows `https://open.bigmodel.cn/api/coding/paas/v4` and the model list + prefilled pricing. Report what you saw (screenshot or description) — do not claim success without observing it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/packages/web/components/admin/models/
+git commit -m "feat(wizard): endpoint selectors drive composed base_url + filtered models (step 2)"
+```
+
+---
+
+## Phase G — Delete cubepi catalog + bump dependency
+
+This phase requires a **cubepi release** because cubebox consumes cubepi from PyPI. Do it last, after Phases A–F prove cubebox no longer imports cubepi's catalog.
+
+### Task G1: Confirm cubebox has zero cubepi-catalog imports
+
+- [ ] **Step 1: Grep**
+
+Run: `cd backend && git grep -n "cubepi.providers.catalog" cubebox/ tests/`
+Expected: **no matches** (Phases C/D removed them). If any remain, fix before proceeding.
+
+- [ ] **Step 2:** also confirm nothing imports the old flat `ProviderPreset`/`get_provider_preset`/`list_provider_presets` from cubepi:
+
+Run: `git grep -n "get_provider_preset\|list_provider_presets\|from cubepi.providers.catalog" backend/`
+Expected: no matches in `cubebox/` (the snapshot fixture under `tests/` is local YAML, not an import — OK).
+
+### Task G2: cubepi PR — delete catalog package
+
+**Repo:** `/home/chris/cubepi` (separate worktree per cubepi's own workflow).
+
+- [ ] **Step 1:** In cubepi, confirm `WireApi` (in `cubepi/providers/catalog/types.py`) is only referenced by the catalog package: `git grep -n WireApi` in cubepi. If referenced elsewhere, relocate `WireApi` to a non-catalog module (e.g. `cubepi/providers/wire.py`) and update imports. (cubebox does NOT depend on this — it declares its own; see Decoupling decision.)
+- [ ] **Step 2:** Delete `cubepi/providers/catalog/` (loader, types, `data/providers.yaml`, tests). Remove any `__init__` re-exports of catalog symbols.
+- [ ] **Step 3:** Run cubepi's test suite + lint. Fix fallout (likely just removing catalog tests + dead re-exports).
+- [ ] **Step 4:** Open the cubepi PR; run its codex review loop; merge; cut a release (per cubepi's release process — likely a version bump + publish).
+
+### Task G3: cubebox — bump cubepi dependency
+
+**Files:**
+- Modify: `backend/pyproject.toml` (cubepi version), `backend/uv.lock`
+
+- [ ] **Step 1: Bump** to the new cubepi release:
+
+Run: `cd backend && uv add 'cubepi==<new-version>'` (do NOT hand-edit pyproject — CLAUDE.md).
+
+- [ ] **Step 2: Full backend sweep**
+
+Run: `cd backend && uv run pytest tests/unit tests/integration -q && uv run mypy cubebox/`
+Expected: PASS — cubebox uses only `cubepi.providers.capability` now.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/pyproject.toml backend/uv.lock
+git commit -m "chore(deps): bump cubepi to <new-version> (catalog moved to cubebox)"
+```
+
+---
+
+## Pre-PR sweep (after all phases)
+
+- [ ] Backend: `cd backend && uv run pytest -q && uv run mypy cubebox/ && uv run ruff check cubebox/`
+- [ ] Frontend: `cd frontend && pnpm --filter @cubebox/core build && pnpm --filter @cubebox/web lint && pnpm --filter @cubebox/web type-check && pnpm --filter @cubebox/web test`
+- [ ] Confirm the wizard golden path (F3 step 4) once more end-to-end.
+- [ ] Open PR; run the `pr-codex-review-loop` skill until clean.
+
+---
+
+## Self-Review (plan vs spec)
+
+**Spec coverage:**
+- §3 ownership/delete cubepi → Phase G. ✓
+- §4.1 base_url composition → A2 + B3 parity. ✓
+- §4.2 plan all-or-nothing + dangling/unreachable + uniqueness → A5. ✓
+- §4.3 capability profiles + loud-fail → A4. ✓
+- §4.4 preset_key + uniqueness → A3 + A5 dedup. ✓
+- §5.1 nested API shape → C1. ✓
+- §5 consumers (admin_llm, admin_providers, seeder, frontend) → C1/C2/D/F. ✓
+- §6.1 simplified config → E1. ✓
+- §6.2 precedence (cost deep-merge, api/capability not overridable, base_url overridable, subset filter, no-preset verbatim) → D1/D2. ✓
+- §6.3 validation (unknown preset_key, unknown subset id, api+preset) → D2. ✓
+- §6.4 exhaustive inventory + backfill-parity test → E1/E2. ✓
+- §7 testing (composition parity, loader validations, seeder, wizard E2E) → A/B/D/F. ✓
+
+**Known judgment calls handed to the implementer:**
+- B2/E1 pricing for ported presets defaults to `{input:0, output:0}` (catalog had none); real costs come from config `cost` override or are added to the catalog when known. Flagged so zero-cost is deliberate, not silent.
+- The `model_capability_overrides` path is carried as empty in the resolver (D2) — the flat catalog's per-model overrides were rare; if `vendors.yaml` needs them, add a `model_capability_overrides` field to `Vendor`/`ModelPreset` and thread it through `ResolvedEndpoint`. Not required by the seeded set.

--- a/docs/dev/plans/2026-05-23-preset-catalog-redesign.md
+++ b/docs/dev/plans/2026-05-23-preset-catalog-redesign.md
@@ -504,6 +504,17 @@ def test_duplicate_preset_key_rejected():
     v1, v2 = _vendor(), _vendor()  # same vendor name → same composed key
     with pytest.raises(ValueError, match="duplicate preset_key"):
         build_catalog([v1, v2], PROFILES)
+
+
+def test_duplicate_endpoint_tuple_rejected_even_with_distinct_key_overrides():
+    # Two endpoints with the SAME (region, protocol, plan) but different key:
+    # overrides must still be rejected — preset_key dedup alone wouldn't catch it.
+    v = _vendor(endpoints=[
+        {"region": "cn", "protocol": "openai-completions", "key": "k1", "capability": "x"},
+        {"region": "cn", "protocol": "openai-completions", "key": "k2", "capability": "x"},
+    ])
+    with pytest.raises(ValueError, match="duplicate endpoint"):
+        build_catalog([v], PROFILES)
 ```
 
 - [ ] **Step 2: Run** `uv run pytest tests/unit/llm/catalog/test_loader.py -v` → the new tests FAIL (`build_catalog` undefined).
@@ -546,8 +557,15 @@ def build_catalog(raw_vendors: list[dict | Vendor], profiles: dict[str, dict]) -
     endpoints: dict[str, ResolvedEndpoint] = {}
     for v in vendors:
         _validate_plan_consistency(v)
-        # uniqueness of (region, protocol, plan) is enforced via preset_key dedup below
+        # (region, protocol, plan) tuple uniqueness — enforced INDEPENDENTLY of
+        # preset_key, because a `key:` override would otherwise let two identical
+        # tuples through the preset_key dedup (codex P2, spec §4.2).
+        seen_tuples: set[tuple[str, str, str | None]] = set()
         for ep in v.endpoints:
+            tup = (ep.region, ep.protocol, ep.plan)
+            if tup in seen_tuples:
+                raise ValueError(f"vendor {v.vendor!r} duplicate endpoint tuple {tup!r}")
+            seen_tuples.add(tup)
             models = _models_for(v, ep)
             if ep.plan is not None and not models:
                 raise ValueError(
@@ -704,6 +722,7 @@ git commit -m "feat(catalog): port flat providers.yaml to nested vendors + capab
 - [ ] **Step 1: Write the failing test**
 
 ```python
+from collections import Counter
 from pathlib import Path
 
 import yaml
@@ -714,22 +733,25 @@ _SNAPSHOT = Path(__file__).parent / "data" / "flat_providers_snapshot.yaml"
 
 
 def test_every_flat_base_url_is_reproduced():
-    """Each flat entry's (api, base_url) must be reproduced by some resolved endpoint.
+    """Each flat (api, base_url) must be reproduced with the SAME MULTIPLICITY.
 
-    Flat entries with base_url == "" (custom-*) are excluded — they have no
-    composed URL by design.
+    Multiplicity matters (codex P2): two flat entries can share an identical
+    (api, base_url) — e.g. moonshot vs moonshot-coding both
+    (openai-completions, https://api.moonshot.ai/v1). A plain set would let one
+    new endpoint satisfy both; a Counter requires the new catalog to produce
+    the same number of endpoints per (api, base_url). Flat entries with
+    base_url == "" (custom-*) are excluded — they have no composed URL.
     """
     flat = yaml.safe_load(_SNAPSHOT.read_text("utf-8"))
     catalog = load_catalog()
-    produced = {(e.protocol, e.base_url) for e in catalog.endpoints.values()}
-    missing = []
-    for entry in flat:
-        if not entry.get("base_url"):
-            continue
-        pair = (entry["api"], entry["base_url"])
-        if pair not in produced:
-            missing.append((entry["slug"], pair))
-    assert not missing, f"flat URLs not reproduced by composition: {missing}"
+    produced = Counter((e.protocol, e.base_url) for e in catalog.endpoints.values())
+    expected = Counter(
+        (entry["api"], entry["base_url"]) for entry in flat if entry.get("base_url")
+    )
+    # Every expected (api, base_url) must appear at least as many times as the
+    # flat catalog had it. (>= not == so genuinely new endpoints are allowed.)
+    deficits = {pair: (cnt, produced[pair]) for pair, cnt in expected.items() if produced[pair] < cnt}
+    assert not deficits, f"flat URLs under-reproduced (expected,got): {deficits}"
 ```
 
 - [ ] **Step 2: Run** `cd backend && uv run pytest tests/unit/llm/catalog/test_composition.py::test_every_flat_base_url_is_reproduced -v`
@@ -844,6 +866,14 @@ def test_resolve_logo_by_preset_key():
     assert _resolve_logo("deepseek/cn/anthropic-messages") == "deepseek"
 
 
+def test_resolve_logo_by_key_override():
+    # A `key:`-overridden preset_key does NOT start with the vendor — must still resolve.
+    # (Add a vendors.yaml endpoint with `key: pretty-deepseek` for this to pass, or
+    #  use whatever override exists; the point is resolution goes through the catalog,
+    #  not a string split.)
+    pass  # implementer: assert against a real key-override endpoint if one exists
+
+
 def test_resolve_logo_none_for_unknown():
     assert _resolve_logo("nope/x/y") is None
     assert _resolve_logo(None) is None
@@ -851,7 +881,7 @@ def test_resolve_logo_none_for_unknown():
 
 - [ ] **Step 2: Run** → FAIL (still uses cubepi `get_provider_preset`).
 
-- [ ] **Step 3: Implement** — replace the import `from cubepi.providers.catalog import get_provider_preset` and `_resolve_logo`:
+- [ ] **Step 3: Implement** — replace the import `from cubepi.providers.catalog import get_provider_preset` and `_resolve_logo`. Resolve the endpoint **through the catalog** (so `key:` overrides work — codex P2 — not a `split("/")` that assumes the key starts with the vendor):
 
 ```python
 def _resolve_logo(preset_slug: str | None) -> str | None:
@@ -859,11 +889,12 @@ def _resolve_logo(preset_slug: str | None) -> str | None:
     if not preset_slug:
         return None
     try:
-        vendor = preset_slug.split("/", 1)[0]
         from cubebox.llm.catalog import load_catalog
 
-        for v in load_catalog().vendors:
-            if v.vendor == vendor:
+        catalog = load_catalog()
+        ep = catalog.resolve(preset_slug)  # works for composed keys AND key: overrides
+        for v in catalog.vendors:
+            if v.vendor == ep.vendor:
                 return v.logo
     except Exception:
         return None
@@ -1049,6 +1080,24 @@ def test_resolve_api_override_with_preset_rejected():
                                              "api_key": "k", "api": "openai-completions"})
 
 
+def test_resolve_capability_override_with_preset_rejected():
+    with pytest.raises(ValueError, match="capability.*not overridable"):
+        resolve_provider_config("deepseek", {"preset": "deepseek/cn/anthropic-messages",
+                                             "api_key": "k", "capability": {"supports_tools": False}})
+
+
+def test_resolve_without_preset_requires_base_url_api_models():
+    # §6.2.4: no preset → config MUST supply base_url, api, and non-empty models.
+    for bad in (
+        {"api": "openai-completions", "models": [{"id": "m"}]},          # missing base_url
+        {"base_url": "http://x/v1", "models": [{"id": "m"}]},            # missing api
+        {"base_url": "http://x/v1", "api": "openai-completions"},        # missing models
+        {"base_url": "http://x/v1", "api": "openai-completions", "models": []},  # empty models
+    ):
+        with pytest.raises(ValueError, match="custom provider.*requires"):
+            resolve_provider_config("custom", bad)
+
+
 def test_resolve_base_url_override_allowed():
     cfg = {"preset": "deepseek/cn/anthropic-messages", "api_key": "k",
            "base_url": "https://proxy.internal/anthropic"}
@@ -1099,18 +1148,31 @@ def _model_from_preset(m: Any, cost_override: dict[str, Any] | None) -> dict[str
     }
 
 
+_OVERRIDABLE_UNDER_PRESET = "base_url"  # the ONLY catalog field a preset config may override
+
+
 def resolve_provider_config(name: str, cfg: dict[str, Any]) -> ResolvedProviderConfig:
     preset_key = cfg.get("preset")
     if not preset_key:
-        # No preset → config verbatim (custom/self-hosted). §6.2.4
+        # No preset → config must fully specify the provider (§6.2.4). Validate
+        # rather than default, so an under-specified custom provider fails loudly.
+        base_url = cfg.get("base_url")
+        api = cfg.get("api")
+        models = list(cfg.get("models", []))
+        if not base_url or not api or not models:
+            raise ValueError(
+                f"provider {name!r}: a custom provider (no 'preset:') requires "
+                f"'base_url', 'api', and a non-empty 'models' list (§6.2.4)"
+            )
         return ResolvedProviderConfig(
-            base_url=str(cfg.get("base_url", "")),
-            provider_type=str(cfg.get("api", "openai-completions")),
-            preset_key=None, capability={}, model_capability_overrides={},
-            models=list(cfg.get("models", [])),
+            base_url=str(base_url), provider_type=str(api),
+            preset_key=None, capability={}, model_capability_overrides={}, models=models,
         )
+    # §6.2.3: under a preset, neither 'api' (protocol) nor 'capability' is overridable.
     if cfg.get("api") is not None:
         raise ValueError(f"provider {name!r}: 'api' is not overridable under a preset (§6.2.3)")
+    if cfg.get("capability") is not None:
+        raise ValueError(f"provider {name!r}: 'capability' is not overridable under a preset (§6.2.3)")
     try:
         ep = load_catalog().resolve(preset_key)
     except KeyError:
@@ -1145,6 +1207,8 @@ def resolve_provider_config(name: str, cfg: dict[str, Any]) -> ResolvedProviderC
 
 - [ ] **Step 5: Wire the resolver into `seed_system_providers_from_config`.** Replace the inline `base_url` / `provider_type` / capability-backfill / models-loop derivation with a call to `resolve_provider_config(name, cfg_dict)`, then use `resolved.base_url`, `resolved.provider_type`, set `provider.preset_slug = resolved.preset_key`, `provider.capability = resolved.capability` (when non-empty and `provider.capability` empty), and iterate `resolved.models` (each already has `id/name/cost/context_window/max_tokens/reasoning/input`). Keep the existing credential-vault + stale-model-disable logic unchanged. Keep the "skip provider with no models" guard.
 
+  **Deployment-knob pass-through (codex P2 fix):** `extra_body` / `extra_headers` are *deployment* knobs, **not** catalog data — the resolver intentionally does not carry them. The seed loop continues to read **provider-level** `cfg_dict.get("extra_body")` / `cfg_dict.get("extra_headers")` directly onto the `Provider` row (unchanged from today, and it works the same whether or not `preset:` is set). For **model-level** extras on a preset-sourced model, the operator adds them via a config `models:` override entry (a dict with `id` + `extra_body`/`extra_headers`); extend `_model_from_preset` to merge those override keys when the subset item is a dict. Add a test: a config `models: [{id: X, extra_body: {...}}]` under a preset yields a model dict carrying that `extra_body`.
+
 - [ ] **Step 6: Run the seeder idempotency test** (existing): `uv run pytest tests/ -k seed -v`. Fix fallout.
 
 - [ ] **Step 7: Commit**
@@ -1158,13 +1222,25 @@ git commit -m "feat(seeder): resolve config preset: into base_url/api/capability
 
 ## Phase E — Exhaustive seed-config rewrite + backfill parity (§6.4)
 
-### Task E1: Inventory + rewrite `config.development.local.yaml`
+### Task E1: Inventory + rewrite ALL seed configs
 
 **Files:**
-- Modify: `backend/config.development.local.yaml` (lines 57–212, the `llm.providers` block)
+- Modify: `backend/config.development.local.yaml` (the `llm.providers` block)
+- Modify: any other seed config that declares `llm.providers` (see Step 0)
 - Modify: `cubebox/llm/catalog/data/vendors.yaml` (add any seeded model/endpoint not yet present)
 
-The 9 seeded providers and their mapping (§6.4 inventory):
+- [ ] **Step 0: Enumerate every seed config (codex P1 — §6.4 is exhaustive, not illustrative).** The inventory below covers `config.development.local.yaml` only; before rewriting, list **all** files that carry an `llm.providers` block and inventory each:
+
+```bash
+cd backend && git grep -l "^\s*providers:" -- 'config*.yaml' ; ls config*.yaml
+# Inspect each hit (config.yaml / config.development.yaml / config.development.local.yaml /
+# any env-specific seed). For EVERY provider in EACH file: map it to a preset_key OR
+# record it as deliberately-custom with a one-line reason. Record absent files explicitly.
+```
+
+Write the resulting full inventory into this task (extend the table) before editing — a provider silently left out is exactly the §6.4 backfill-loss this guards against.
+
+The seeded providers in `config.development.local.yaml` and their mapping (§6.4 inventory):
 
 | config name | base_url today | mapping |
 |---|---|---|
@@ -1234,14 +1310,43 @@ git commit -m "feat(config): rewrite seed providers to preset: refs; add seeded 
 **Files:**
 - Create: `tests/unit/test_seed_backfill_parity.py`
 
-- [ ] **Step 1: Write the test** — every preset-mapped provider yields a capability snapshot (the regression guard against silent custom-downgrade):
+**Codex P1:** a hand-written `PRESET_MAPPED` list cannot catch a provider that was silently dropped to custom. The guard must **derive** the at-risk set: every provider that received capability backfill under the *old* name-match rule must still resolve a capability under the *new* config. The old rule backfilled when the config provider **name matched a flat preset slug** (`get_provider_preset(name)` succeeded). So compute that set from the frozen flat snapshot + the actual seed configs, and assert each still resolves.
+
+- [ ] **Step 1: Write the test** — derive the old-backfilled set and assert new-config parity:
 
 ```python
-import pytest
+from pathlib import Path
 
+import pytest
+import yaml
+
+from cubebox.config import config as settings
 from cubebox.seeders.provider_seeder import resolve_provider_config
 
-# The §6.4 inventory: preset-mapped providers MUST resolve a capability.
+_SNAPSHOT = (
+    Path(__file__).parent / "llm" / "catalog" / "data" / "flat_providers_snapshot.yaml"
+)
+
+
+def _old_backfilled_provider_names() -> set[str]:
+    """Provider names that matched a flat preset slug under the OLD rule."""
+    flat_slugs = {e["slug"] for e in yaml.safe_load(_SNAPSHOT.read_text("utf-8"))}
+    cfg_providers = dict(dict(settings.get("llm", {})).get("providers", {}))
+    return {name for name in cfg_providers if name in flat_slugs}
+
+
+def test_no_provider_silently_loses_capability_backfill():
+    """§6.4: every provider backfilled under the old rule still resolves one now."""
+    cfg_providers = dict(dict(settings.get("llm", {})).get("providers", {}))
+    regressed = []
+    for name in _old_backfilled_provider_names():
+        r = resolve_provider_config(name, dict(cfg_providers[name]))
+        if r.preset_key is None or not r.capability:
+            regressed.append(name)
+    assert not regressed, f"providers lost capability backfill in the rewrite: {regressed}"
+
+
+# Also assert the preset-mapped providers resolve a capability + models.
 PRESET_MAPPED = {
     "deepseek": "deepseek/cn/anthropic-messages",
     "minimax": "minimax/cn/openai-completions",
@@ -1259,6 +1364,8 @@ def test_preset_mapped_providers_get_capability_and_models(name, key):
     assert r.capability is not None
     assert len(r.models) >= 1
 ```
+
+NOTE: `_old_backfilled_provider_names()` derives the at-risk set so a forgotten provider is caught automatically — the hand-written `PRESET_MAPPED` is a secondary, explicit check. If the loaded config's provider names don't match any flat slug (likely for the local config, whose names like `deepseek` differ from flat slugs like `deepseek-anthropic`), the derived set is empty and the guard matters most for the production `config.yaml` — which Step 0 of E1 must also inventory.
 
 - [ ] **Step 2: Run** `cd backend && uv run pytest tests/unit/test_seed_backfill_parity.py -v` → PASS (proves the inventory + catalog are wired).
 
@@ -1279,7 +1386,9 @@ git commit -m "test(seeder): backfill-parity guard for preset-mapped providers (
 - Modify: `frontend/packages/web/components/admin/models/wizard/wizardMachine.ts`
 - Test: `frontend/packages/web/components/admin/models/wizard/__tests__/wizardMachine.test.ts`
 
-- [ ] **Step 1: Write the failing test** — `pickVendor` sets vendor, `selectEndpoint` sets the chosen `preset_key`, step 1 advance requires both a vendor AND a selected endpoint:
+**Step ordering (codex P1 fix):** endpoint (region/protocol/plan) selection happens in **step 2** (ConfigureStep), not step 1. So **step 1 advance requires only `vendor`**; the `selectedPresetKey` is set during step 2 and gates the *create/confirm* action there (`canAdvance(step 2)` requires `selectedPresetKey != null && providerId == null`-pre-create → see F3). Requiring the endpoint to advance *from* step 1 would make step 2 unreachable.
+
+- [ ] **Step 1: Write the failing test** — `pickVendor` sets vendor and allows step-1 advance; `selectEndpoint` (used in step 2) sets the chosen `preset_key`:
 
 ```typescript
 import { describe, expect, it } from 'vitest'
@@ -1294,19 +1403,24 @@ const vendor = {
   ], models: [],
 } as VendorPreset
 
-it('requires a vendor and a selected endpoint to advance from step 1', () => {
+it('advances from step 1 once a vendor is picked', () => {
   let s = initialWizardState
   expect(canAdvance(s)).toBe(false)
   s = wizardReducer(s, { type: 'pickVendor', vendor })
-  expect(canAdvance(s)).toBe(false) // vendor but no endpoint yet
+  expect(canAdvance(s)).toBe(true) // vendor alone is enough to reach step 2
+})
+
+it('records the endpoint selected in step 2', () => {
+  let s = wizardReducer(initialWizardState, { type: 'pickVendor', vendor })
+  s = wizardReducer(s, { type: 'next' }) // now on step 2
   s = wizardReducer(s, { type: 'selectEndpoint', presetKey: 'zhipu/cn/openai-completions/coding' })
-  expect(canAdvance(s)).toBe(true)
+  expect(s.selectedPresetKey).toBe('zhipu/cn/openai-completions/coding')
 })
 ```
 
 - [ ] **Step 2: Run** `cd frontend && pnpm --filter @cubebox/web test wizardMachine` → FAIL.
 
-- [ ] **Step 3: Implement** — update `wizardMachine.ts`: replace `preset: ProviderPreset | null` with `vendor: VendorPreset | null` and `selectedPresetKey: string | null`; actions `pickVendor` / `selectEndpoint`; `canAdvance` step 1 → `vendor !== null && selectedPresetKey !== null`.
+- [ ] **Step 3: Implement** — update `wizardMachine.ts`: replace `preset: ProviderPreset | null` with `vendor: VendorPreset | null` and `selectedPresetKey: string | null`; actions `pickVendor` / `selectEndpoint`; `canAdvance` **step 1 → `vendor !== null`** (endpoint not required here); the step-2 create action in ConfigureStep is what requires `selectedPresetKey` (F3).
 
 - [ ] **Step 4: Run** → PASS.
 

--- a/docs/dev/plans/2026-05-23-preset-catalog-redesign.md
+++ b/docs/dev/plans/2026-05-23-preset-catalog-redesign.md
@@ -1262,7 +1262,7 @@ The seeded providers in `config.development.local.yaml` and their mapping (§6.4
 | config name | base_url today | mapping |
 |---|---|---|
 | `deepseek` | api.deepseek.com/anthropic | `preset: deepseek/cn/anthropic-messages` |
-| `minimax` | api.minimaxi.com/v1 | `preset: minimax/cn/openai-completions` (carry `extra_body`) |
+| `minimax` | api.minimaxi.com/v1 | `preset: minimax/cn/openai-completions/general` (carry `extra_body`) |
 | `arkcode` | ark…/api/coding/v3 (openai) | NEW catalog endpoint: volcengine coding **openai-completions** `/api/coding/v3` → `preset: volcengine/cn/openai-completions/coding` |
 | `alicode` | coding.dashscope…/v1 | `preset: aliyun/cn/openai-completions/coding` (host override in catalog) |
 | `volengine` | ark…/api/v3 | `preset: volcengine/cn/openai-completions` (general) |
@@ -1289,7 +1289,7 @@ The seeded providers in `config.development.local.yaml` and their mapping (§6.4
         preset: deepseek/cn/anthropic-messages
         api_key: key-in-env
       minimax:
-        preset: minimax/cn/openai-completions
+        preset: minimax/cn/openai-completions/general
         api_key: sk-cp-…
         extra_body: { "reasoning_split": true }
       arkcode:
@@ -1386,7 +1386,7 @@ def test_no_provider_silently_loses_capability_backfill():
 # Also assert the preset-mapped providers resolve a capability + models.
 PRESET_MAPPED = {
     "deepseek": "deepseek/cn/anthropic-messages",
-    "minimax": "minimax/cn/openai-completions",
+    "minimax": "minimax/cn/openai-completions/general",
     "arkcode": "volcengine/cn/openai-completions/coding",
     "alicode": "aliyun/cn/openai-completions/coding",
     "volengine": "volcengine/cn/openai-completions",

--- a/docs/dev/plans/2026-05-23-preset-catalog-redesign.md
+++ b/docs/dev/plans/2026-05-23-preset-catalog-redesign.md
@@ -755,7 +755,7 @@ def test_every_flat_base_url_is_reproduced():
 ```
 
 - [ ] **Step 2: Run** `cd backend && uv run pytest tests/unit/llm/catalog/test_composition.py::test_every_flat_base_url_is_reproduced -v`
-Expected: FAIL initially if any vendor entry is missing/mismatched — the failure message lists exactly which `(slug, api, base_url)` is not reproduced.
+Expected: FAIL initially if any vendor entry is missing/mismatched — the failure message lists the under-reproduced `(api, base_url)` pairs as `{pair: (expected_count, got_count)}`.
 
 - [ ] **Step 3: Fix `vendors.yaml`** until the test passes (adjust host/path/override for each listed miss). No code change — data only.
 
@@ -866,12 +866,29 @@ def test_resolve_logo_by_preset_key():
     assert _resolve_logo("deepseek/cn/anthropic-messages") == "deepseek"
 
 
-def test_resolve_logo_by_key_override():
-    # A `key:`-overridden preset_key does NOT start with the vendor — must still resolve.
-    # (Add a vendors.yaml endpoint with `key: pretty-deepseek` for this to pass, or
-    #  use whatever override exists; the point is resolution goes through the catalog,
-    #  not a string split.)
-    pass  # implementer: assert against a real key-override endpoint if one exists
+def test_resolve_logo_by_key_override(monkeypatch):
+    # A `key:`-overridden preset_key does NOT start with the vendor, so a split("/")
+    # approach would fail. Inject a catalog whose endpoint key is "pretty-id" and
+    # assert the logo still resolves via the vendor — a real regression guard.
+    from cubebox.llm.catalog import build_catalog
+    import cubebox.api.routes.v1.admin_providers as mod
+    import cubebox.llm.catalog as catmod  # _resolve_logo does `from cubebox.llm.catalog import load_catalog`
+
+    catalog = build_catalog(
+        [{
+            "vendor": "deepseek", "display_name": "DeepSeek", "short_name": "DeepSeek",
+            "logo": "deepseek", "category": "saas", "description": "d",
+            "regions": {"cn": {"host": "https://api.deepseek.com"}},
+            "endpoints": [{"region": "cn", "protocol": "openai-completions",
+                           "key": "pretty-id", "capability": "x"}],
+            "models": [{"model_id": "m", "display_name": "M", "context_window": 1,
+                        "max_tokens": 1, "input_modalities": ["text"],
+                        "pricing": {"input": 1, "output": 1}}],
+        }],
+        {"x": {}},
+    )
+    monkeypatch.setattr(catmod, "load_catalog", lambda: catalog)
+    assert mod._resolve_logo("pretty-id") == "deepseek"
 
 
 def test_resolve_logo_none_for_unknown():
@@ -1238,9 +1255,9 @@ cd backend && git grep -l "^\s*providers:" -- 'config*.yaml' ; ls config*.yaml
 # record it as deliberately-custom with a one-line reason. Record absent files explicitly.
 ```
 
-Write the resulting full inventory into this task (extend the table) before editing — a provider silently left out is exactly the §6.4 backfill-loss this guards against.
+Write the resulting full inventory into this task (extend the table) before editing — a provider silently left out is exactly the §6.4 backfill-loss this guards against. **Do not start Step 2 until the table below has a row for every provider in every file Step 0 found** (the table as written covers only `config.development.local.yaml`; add the rows for any other seed file, or explicitly record "no other seed file with llm.providers exists" if Step 0 finds none).
 
-The seeded providers in `config.development.local.yaml` and their mapping (§6.4 inventory):
+The seeded providers in `config.development.local.yaml` and their mapping (§6.4 inventory — **local-config slice; extend per Step 0**):
 
 | config name | base_url today | mapping |
 |---|---|---|
@@ -1250,9 +1267,11 @@ The seeded providers in `config.development.local.yaml` and their mapping (§6.4
 | `alicode` | coding.dashscope…/v1 | `preset: aliyun/cn/openai-completions/coding` (host override in catalog) |
 | `volengine` | ark…/api/v3 | `preset: volcengine/cn/openai-completions` (general) |
 | `openrouter` | openrouter.ai/api/v1 | `preset: openrouter/intl/openai-completions` |
-| `sensedeal` | private gateway | **custom** — keep verbatim (no preset); reason: private gateway, not in catalog |
-| `google` | local IP | **custom** — keep verbatim; reason: self-hosted test endpoint |
-| `vllm` | local IP | **custom** — keep verbatim; reason: self-hosted |
+| `sensedeal` | private gateway | **custom** — keep verbatim (no preset); reason: private gateway, not in catalog. (Did NOT match a flat slug → no backfill to lose.) |
+| `google` | local IP | **custom** — keep verbatim; reason: self-hosted test endpoint. (Did NOT match a flat slug → no backfill to lose.) |
+| `vllm` | local IP | **custom** + add to `DELIBERATE_CUSTOM` (E2). reason: self-hosted OSS framework — its model (`gemma-4-31b-it`) is deployment-specific and not a catalog entry, so the subset filter can't apply; it's openai-compatible, so empty capability → cubepi defaults is fine. |
+
+**Backfill note (codex):** `minimax`, `openrouter`, `vllm` config names match flat slugs (`minimax`/`openrouter`/`vllm`) so they were backfilled under the old rule. `minimax`/`openrouter` are preset-mapped above (backfill preserved). `vllm` is a **deliberate** downgrade to custom — it MUST be listed in `DELIBERATE_CUSTOM` in E2 (with the reason above) so the §6.4 guard treats it as intentional, not a silent loss. `sensedeal`/`google` never matched a flat slug, so custom loses nothing. **Self-hosted OSS frameworks (vllm/ollama/lm-studio) are custom by nature — their models aren't catalog data.**
 
 - [ ] **Step 1:** For each *preset-mapped* provider, ensure its real model ids exist in the catalog vendor pool with correct `context_window`/`max_tokens`/`input`/`reasoning` + a `pricing` (use the config's `cost` when present, else `{input:0,output:0}`). Add to `vendors.yaml`:
   - deepseek pool: `deepseek-v4-pro`, `deepseek-v4-flash`.
@@ -1301,7 +1320,9 @@ Expected: seed completes; `deepseek/minimax/arkcode/alicode/volengine/openrouter
 - [ ] **Step 4: Commit**
 
 ```bash
+# stage EVERY seed file Step 0 enumerated, not just the local one
 git add backend/config.development.local.yaml cubebox/llm/catalog/data/vendors.yaml
+# + any other seed config Step 0 found (e.g. backend/config.yaml / config.development.yaml)
 git commit -m "feat(config): rewrite seed providers to preset: refs; add seeded models to catalog (§6.4)"
 ```
 
@@ -1328,6 +1349,16 @@ _SNAPSHOT = (
 )
 
 
+# Providers that DID match a flat slug (so were backfilled) but are DELIBERATELY
+# downgraded to custom in the rewrite, each with a recorded §6.4 reason. A name
+# here is an intentional drop, not a silent one. Keep this list in lockstep with
+# the E1 inventory "custom" rows; an accidental omission must NOT be added here.
+DELIBERATE_CUSTOM = {
+    "vllm": "self-hosted OSS framework; model is deployment-specific (not catalog data), "
+            "openai-compatible so cubepi defaults suffice",
+}
+
+
 def _old_backfilled_provider_names() -> set[str]:
     """Provider names that matched a flat preset slug under the OLD rule."""
     flat_slugs = {e["slug"] for e in yaml.safe_load(_SNAPSHOT.read_text("utf-8"))}
@@ -1336,14 +1367,20 @@ def _old_backfilled_provider_names() -> set[str]:
 
 
 def test_no_provider_silently_loses_capability_backfill():
-    """§6.4: every provider backfilled under the old rule still resolves one now."""
+    """§6.4: every old-backfilled provider still resolves a capability now,
+    UNLESS it is an intentional, documented downgrade in DELIBERATE_CUSTOM."""
     cfg_providers = dict(dict(settings.get("llm", {})).get("providers", {}))
     regressed = []
     for name in _old_backfilled_provider_names():
+        if name in DELIBERATE_CUSTOM:
+            continue
         r = resolve_provider_config(name, dict(cfg_providers[name]))
         if r.preset_key is None or not r.capability:
             regressed.append(name)
-    assert not regressed, f"providers lost capability backfill in the rewrite: {regressed}"
+    assert not regressed, (
+        f"providers lost capability backfill in the rewrite (map to a preset, "
+        f"or add to DELIBERATE_CUSTOM with a reason): {regressed}"
+    )
 
 
 # Also assert the preset-mapped providers resolve a capability + models.

--- a/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
+++ b/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
@@ -279,8 +279,8 @@ Clean cutover, no shim. Ordered so each step is independently reviewable.
    `capabilities.yaml`. Add the §4.1 parity test against a frozen snapshot of
    today's flat URLs.
 3. **cubebox: repoint the 3 consumers**:
-   - `admin_llm.py:list_provider_presets` → return the flattened endpoint
-     presets (new shape; §5.1).
+   - `admin_llm.py:list_provider_presets` → return the **nested vendor list**
+     (new shape; §5.1).
    - `admin_providers.py` logo lookup → resolve via vendor.
    - `provider_seeder.py` → resolve the config provider's `preset:` to a catalog
      endpoint and inherit base_url/api/capability/**model pool** with the §6.2
@@ -441,8 +441,10 @@ To prevent that, the migration is **exhaustive, not illustrative**:
   parse, host-override and full-`base_url`-override paths.
 - **Seeder test:** `preset:`-referenced providers (deepseek/arkcode/alicode/
   sensedeal) seed the right base_url + full model pool + pricing + capability;
-  `models:` subset filters correctly; a config field override beats the catalog;
-  an unknown `preset_key` or unknown subset model id fails loudly (§6.3); a
+  `models:` subset filters correctly; an **allowed** config override (`base_url`,
+  per-model `cost`) beats the catalog while `api`/`capability` overrides are
+  rejected (§6.2.3); an unknown `preset_key` or unknown subset model id fails
+  loudly (§6.3); a
   partial `cost` override deep-merges (inherits the unspecified legs); `api`
   alongside `preset:` is rejected.
 - **Backfill-parity test (§6.4):** every provider that got a capability snapshot
@@ -473,6 +475,7 @@ To prevent that, the migration is **exhaustive, not illustrative**:
 6. **Seeder match via explicit `config.yaml` `preset:` field** — no name
    heuristic.
 7. **Config references the catalog instead of restating it** — a `preset:` +
-   `api_key` is enough; base_url/models/pricing/capability inherit, with config
-   fields overriding and an optional `models:` subset filter (§6). The seeded
-   config is rewritten to this form.
+   `api_key` is enough; base_url/models/pricing/capability inherit. Only
+   *allowed* fields override (`base_url`, per-model `cost`); `api`/`capability`
+   are fixed by the chosen endpoint (§6.2.3). Optional `models:` subset filter.
+   The seeded config is rewritten to this form (§6.4 exhaustive).

--- a/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
+++ b/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
@@ -102,8 +102,17 @@ provider is constructed. So the split is clean:
 
 **Decision:** cubepi's `cubepi/providers/catalog/` package (loader + types +
 `providers.yaml` + tests) is **deleted**. Nothing outside cubebox consumes it.
-cubebox keeps its existing dependency on cubepi for `CapabilityDescriptor` and
-`WireApi`.
+cubebox keeps its dependency on cubepi for `CapabilityDescriptor` (the stable,
+non-catalog `cubepi.providers.capability` module).
+
+**`WireApi` decoupling (settled):** `WireApi` is just the 3-string protocol
+literal. To avoid a cubebox→cubepi-catalog import (the catalog package is being
+deleted) and to keep the cubebox work independent of the cubepi release,
+**cubebox declares its own `WireApi` literal** in `cubebox/llm/catalog/types.py`.
+cubepi keeps its own `WireApi` for its runtime; the two are intentionally
+parallel 3-value literals, not a shared import. (cubepi may relocate its
+`WireApi` out of the deleted catalog package — see plan Phase G — but cubebox
+does not depend on that.)
 
 ---
 

--- a/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
+++ b/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
@@ -30,7 +30,7 @@ top-level entries. From the live catalog:
 | Moonshot | `moonshot`, `moonshot-cn`, `moonshot-coding`, `moonshot-coding-cn` |
 | Zhipu | `zhipu`, `zhipu-cn`, `zhipu-coding`, `zhipu-coding-cn` |
 | MiniMax | `minimax`, `minimax-cn`, `minimax-coding`, `minimax-coding-cn` |
-| Qwen | `qwen-dashscope`, `qwen-dashscope-cn`, `qwen-coding`, `qwen-coding-cn` |
+| Aliyun (Qwen) | `qwen-dashscope`, `qwen-dashscope-cn`, `qwen-coding`, `qwen-coding-cn` |
 | Volcengine | `doubao-volcengine`, `volcengine-coding` |
 
 Each entry repeats the vendor's `logo`, `short_name`, `description`, and a
@@ -162,7 +162,7 @@ This expresses all four real shapes of a coding plan:
 - { region: cn, protocol: openai-completions, plan: coding, path: /api/coding/paas/v4 }
 
 # B. domain differs (Alibaba coding lives on coding.dashscope.aliyuncs.com) — override host
-- vendor: qwen
+- vendor: aliyun
   regions: { cn: { host: https://dashscope.aliyuncs.com }, intl: { host: https://dashscope-intl.aliyuncs.com } }
   endpoints:
     - { region: cn, protocol: openai-completions, plan: general, path: /compatible-mode/v1 }
@@ -354,7 +354,7 @@ the rest**, so a seeded provider shrinks to a `preset` + an `api_key`.
 llm:
   providers:
     alicode:
-      preset: qwen/cn/openai-completions/coding   # → base_url, api, models, pricing, capability
+      preset: aliyun/cn/openai-completions/coding   # → base_url, api, models, pricing, capability
       api_key: ${ALICODE_KEY}                      # secret: always from config, never in catalog
       # models: [qwen3.6-plus]                     # OPTIONAL subset filter; omit = all preset models
 ```

--- a/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
+++ b/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
@@ -1,0 +1,338 @@
+# Preset Catalog Redesign — Design
+
+**Date:** 2026-05-22
+**Branch:** `feat/preset-catalog-redesign` (off `main`)
+**Status:** ready for review
+
+**Related:**
+- `docs/dev/specs/2026-05-19-llm-provider-platform-design.md` (§3.6/§3.7 — current catalog)
+- `docs/dev/specs/2026-05-18-llm-vendor-compat-design.md` (capability descriptor)
+- `docs/dev/specs/2026-05-20-provider-slug-design.md` (provider *instance* slug — distinct from the catalog `preset_key` defined here)
+
+---
+
+## 1. Why
+
+The provider preset catalog today (`cubepi/providers/catalog/data/providers.yaml`)
+is a **flat list**: one entry per `(slug, api, base_url)` triple. That shape has
+three concrete problems.
+
+### 1.1 The same vendor is shredded into parallel entries
+
+A single vendor that offers more than one wire protocol, more than one region,
+or a "coding" plan in addition to its general plan, becomes several unrelated
+top-level entries. From the live catalog:
+
+| Vendor | Entries today |
+|---|---|
+| OpenAI | `openai` (responses), `openai-legacy` (completions), `openai-codex` |
+| DeepSeek | `deepseek-anthropic`, `deepseek-openai` |
+| Moonshot | `moonshot`, `moonshot-cn`, `moonshot-coding`, `moonshot-coding-cn` |
+| Zhipu | `zhipu`, `zhipu-cn`, `zhipu-coding`, `zhipu-coding-cn` |
+| MiniMax | `minimax`, `minimax-cn`, `minimax-coding`, `minimax-coding-cn` |
+| Qwen | `qwen-dashscope`, `qwen-dashscope-cn`, `qwen-coding`, `qwen-coding-cn` |
+| Volcengine | `doubao-volcengine`, `volcengine-coding` |
+
+Each entry repeats the vendor's `logo`, `short_name`, `description`, and a
+near-identical model list. There is no way to express "DeepSeek, but over the
+OpenAI wire instead of the Anthropic wire" — they are just two rows that happen
+to share a logo. 37 flat entries collapse to ~15 vendors.
+
+### 1.2 No pricing in the catalog
+
+`ModelPreset` carries `context_window`, `max_tokens`, `input_modalities`,
+`reasoning` — but **no price**. Pricing exists only in the operator's
+`config.yaml` (`models[].cost.{input,output,cache_read,cache_write}`). So the
+catalog (the menu the Add-Provider wizard prefills from) can't show or pre-fill
+cost; it has to be hand-entered for every model.
+
+### 1.3 `base_url` is hand-written when it's largely derivable
+
+Most base URLs are **`host(region) + path(endpoint)`**, with the pieces repeated
+in full on every row:
+
+```
+minimax        intl  openai     https://api.minimax.io/v1
+minimax-cn     cn    openai     https://api.minimaxi.com/v1
+minimax-coding intl  anthropic  https://api.minimax.io/anthropic
+```
+
+`host` tracks region; the path tail tracks protocol/plan. The flat file
+denormalizes all of it.
+
+---
+
+## 2. Goals / Non-Goals
+
+**Goals**
+- Model the catalog as **vendor → region × protocol × plan endpoints → models**,
+  eliminating per-row duplication.
+- **Compose `base_url`** from `host + path`, where region supplies a default
+  host and an endpoint may override host and/or path. Full-URL override remains
+  as an escape hatch.
+- Carry **pricing on each model** so the wizard can prefill cost.
+- **Move the catalog data + loader to cubebox** (product/business data). Keep
+  the **capability descriptor mechanism in cubepi** (protocol runtime contract),
+  and **delete the catalog package from cubepi**.
+- Clean cutover — no back-compat shim (project hasn't shipped publicly).
+
+**Non-Goals**
+- Changing the `CapabilityDescriptor` schema or the cubepi wire runtime.
+- Changing the `Provider` / `Model` DB tables or the provider-instance `slug`
+  (separate, already-merged feature).
+- Changing how operators declare *deployed* providers in `config.yaml`. The
+  catalog is the **menu**; `config.yaml` stays the **deployment manifest** (§6).
+
+---
+
+## 3. Ownership split: cubepi mechanism vs cubebox data
+
+cubebox touches the cubepi catalog at only three sites, and **cubepi never loads
+the catalog at runtime** — capability descriptors flow cubebox→cubepi when a
+provider is constructed. So the split is clean:
+
+| Concern | Owner after | Rationale |
+|---|---|---|
+| `CapabilityDescriptor` type + the wire runtime that applies it (`reasoning`, `temperature`, `max_tokens_field`, …) | **cubepi** | Protocol mechanism. cubebox imports the type to validate/construct. |
+| `WireApi` literal (`anthropic-messages`/`openai-completions`/`openai-responses`) | **cubepi** | Names of protocols cubepi implements. |
+| Catalog **data** (vendors, regions, endpoints, models, pricing, the capability *values* per endpoint) | **cubebox** | Product/business data. |
+| Catalog **loader / types** (`ProviderPreset` equivalent, `ModelPreset`, YAML readers) | **cubebox** | Moves with the data. |
+
+**Decision:** cubepi's `cubepi/providers/catalog/` package (loader + types +
+`providers.yaml` + tests) is **deleted**. Nothing outside cubebox consumes it.
+cubebox keeps its existing dependency on cubepi for `CapabilityDescriptor` and
+`WireApi`.
+
+---
+
+## 4. New catalog schema
+
+Lives in cubebox: `cubebox/llm/catalog/` with `data/vendors.yaml`,
+`data/capabilities.yaml`, `types.py`, `loader.py`.
+
+Three nested levels: **Vendor** → **Endpoint** (region × protocol × plan) →
+**Model**. Models are a vendor-level pool; each endpoint names the subset (by
+`plan`, or explicit `model_ids`) it serves.
+
+```yaml
+# cubebox/llm/catalog/data/vendors.yaml
+- vendor: zhipu
+  display_name: Zhipu / GLM
+  short_name: Zhipu
+  logo: zhipu                    # @lobehub/icons id
+  category: saas
+  description: Zhipu GLM. General + coding plans, CN + intl.
+
+  regions:
+    intl: { host: https://api.z.ai }
+    cn:   { host: https://open.bigmodel.cn }
+
+  endpoints:
+    - { region: intl, protocol: openai-completions, plan: general, path: /api/paas/v4,        capability: openai-compat-basic }
+    - { region: intl, protocol: openai-completions, plan: coding,  path: /api/coding/paas/v4, capability: openai-compat-basic }
+    - { region: cn,   protocol: openai-completions, plan: general, path: /api/paas/v4,        capability: openai-compat-basic }
+    - { region: cn,   protocol: openai-completions, plan: coding,  path: /api/coding/paas/v4, capability: openai-compat-basic }
+
+  models:
+    - { model_id: glm-4.6,        display_name: GLM-4.6,        plan: general, context_window: 200000, max_tokens: 8192, input_modalities: [text], reasoning: true, pricing: { input: 0.60, output: 2.20 } }
+    - { model_id: glm-4.6-coding, display_name: GLM-4.6 Coding, plan: coding,  context_window: 200000, max_tokens: 8192, input_modalities: [text], reasoning: true, pricing: { input: 0.60, output: 2.20 } }
+```
+
+### 4.1 `base_url` composition
+
+```
+base_url = (endpoint.host || regions[endpoint.region].host) + (endpoint.path || "")
+```
+
+- **region** supplies the default `host` (the part that varies by geography for
+  most vendors).
+- an **endpoint** may override `host` and/or set `path`.
+- **escape hatch:** an endpoint may set a full `base_url:` to bypass composition
+  entirely for pathological cases.
+
+This expresses all four real shapes of a coding plan:
+
+```yaml
+# A. path differs, same domain (Zhipu, Volcengine) — set path
+- { region: cn, protocol: openai-completions, plan: coding, path: /api/coding/paas/v4 }
+
+# B. domain differs (Alibaba coding lives on coding.dashscope.aliyuncs.com) — override host
+- vendor: qwen
+  regions: { cn: { host: https://dashscope.aliyuncs.com }, intl: { host: https://dashscope-intl.aliyuncs.com } }
+  endpoints:
+    - { region: cn, protocol: openai-completions, plan: general, path: /compatible-mode/v1 }
+    - { region: cn, protocol: openai-completions, plan: coding, host: https://coding.dashscope.aliyuncs.com, path: /v1 }
+
+# C. identical URL, only the model list differs (Moonshot) — host/path same; plan partitions models
+- { region: intl, protocol: openai-completions, plan: general, path: /v1 }
+- { region: intl, protocol: openai-completions, plan: coding,  path: /v1 }
+
+# D. fully irregular — explicit override
+- { region: intl, protocol: openai-responses, base_url: https://chatgpt.com/backend-api/codex }
+```
+
+**Parity guard:** a table-driven test asserts that, for every entry in today's
+flat `providers.yaml` (frozen as a snapshot fixture), the new composition
+produces the byte-identical `base_url`. This is the regression net for the
+rewrite.
+
+### 4.2 The `plan` dimension
+
+`plan` (e.g. `general`, `coding`) is both:
+- a **display label** in the wizard ("Zhipu · CN · Coding"), and
+- a **model-membership selector** — each model is tagged with the `plan`(s) it
+  belongs to; an endpoint serves the models matching its `plan`. (A model may
+  also list explicit `endpoints`/`plans` if the default `plan` match is
+  insufficient.)
+- a **`preset_key` disambiguator** — see §4.4.
+
+`plan` is optional. A vendor with no plan tiers omits it everywhere; its single
+endpoint per (region, protocol) serves all models.
+
+### 4.3 Capability by reference (named profiles)
+
+Most `openai-completions` vendors share an identical capability block. Instead of
+inlining it per endpoint, define **named profiles** referenced by name.
+
+```yaml
+# cubebox/llm/catalog/data/capabilities.yaml
+openai-compat-basic:                 # covers ~20 vendors (moonshot, minimax, xai, mistral, groq, …)
+  temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
+  max_tokens_field: max_tokens
+  supports_tools: true
+  supports_images: true
+
+anthropic-native:
+  reasoning_off_payload: { thinking: { type: disabled } }
+  reasoning_on_payload:  { thinking: { type: enabled } }
+  reasoning_level: { path: thinking.budget_tokens, kind: int_budget, level_budgets: { off: 0, minimal: 1024, low: 2048, medium: 8192, high: 16384, xhigh: 16384 } }
+  temperature: { mode: free, min: 0.0, max: 1.0, default: 1.0 }
+  max_tokens_field: max_tokens
+  supports_tools: true
+  supports_images: true
+
+deepseek-anthropic:
+  # … vendor-specific reasoning wiring …
+```
+
+An endpoint's `capability:` is **either** a profile name (string → looked up in
+`capabilities.yaml`) **or** an inline descriptor (dict → constructed directly,
+for one-offs). The loader resolves both into a cubepi `CapabilityDescriptor`.
+
+### 4.4 `preset_key` (catalog identity)
+
+The loader flattens `vendor × endpoint` into **endpoint presets**, each with a
+stable synthesized key:
+
+```
+preset_key = vendor / region / protocol [ / plan ]
+# e.g.  deepseek/cn/anthropic-messages
+#       zhipu/cn/openai-completions/coding   ← plan segment present only when the vendor has plan tiers
+```
+
+`preset_key` replaces today's flat `slug` as the catalog identity — the value
+`provider.preset_slug` records and the seeder matches on (§6). An endpoint may
+set an optional `key:` override for a prettier public id; otherwise the
+composed key is used.
+
+---
+
+## 5. Migration / cutover
+
+Clean cutover, no shim. Ordered so each step is independently reviewable.
+
+1. **cubebox: new catalog package.** Create `cubebox/llm/catalog/`
+   (`types.py`, `loader.py`, `data/vendors.yaml`, `data/capabilities.yaml`).
+   Port the loader; import `CapabilityDescriptor`/`WireApi` from cubepi. Unit
+   tests: base_url composition (incl. host override + full override), flattening
+   to `preset_key`, capability profile resolution, model→plan membership,
+   pricing parse.
+2. **cubebox: port the data** to vendors/regions/endpoints/models+pricing +
+   `capabilities.yaml`. Add the §4.1 parity test against a frozen snapshot of
+   today's flat URLs.
+3. **cubebox: repoint the 3 consumers**:
+   - `admin_llm.py:list_provider_presets` → return the flattened endpoint
+     presets (new shape; §5.1).
+   - `admin_providers.py` logo lookup → resolve via vendor.
+   - `provider_seeder.py` capability backfill → match on the config provider's
+     explicit `preset:` field (§6) instead of name==flat-slug.
+4. **Frontend wizard (two-step preset selection):**
+   - **Step 1 (`PresetPicker`)** lists **vendors** (~15) instead of 37 flat
+     presets. `pickPreset` → `pickVendor`.
+   - **Step 2 (`ConfigureStep`)** gains **region / protocol / plan** selectors.
+     Choosing them selects the endpoint, which drives the composed `base_url`
+     and filters the model list. Existing configure fields (name, slug, key)
+     stay. This matches the already-multi-step wizard — it only enriches step 2.
+   - `@cubebox/core` preset types update in lockstep.
+5. **cubepi: delete `providers/catalog/`** + tests; bump cubepi; switch
+   cubebox's dependency.
+
+### 5.1 API contract change
+
+`GET /api/v1/admin/llm/presets` changes shape: flat `ProviderPreset[]` →
+either the nested vendor list or the flattened endpoint presets (with
+`preset_key`, composed `base_url`, pricing on models). Since nothing has
+shipped, change it in place; frontend types follow.
+
+**Likely shape:** return **vendors nested** (so step 1 lists vendors, step 2
+reads `vendor.endpoints`), with the loader also able to produce a flat
+`preset_key`-keyed lookup server-side for the seeder/logo paths.
+
+---
+
+## 6. Catalog vs config.yaml (kept separate)
+
+- **Catalog** (this doc) = the **menu** the wizard prefills from + the source of
+  capability snapshots.
+- **`config.yaml` `llm.providers`** = the **deployment manifest** the seeder
+  instantiates (real keys, real cost overrides). Unchanged.
+
+The seeder links the two to backfill a provider's capability snapshot. Today it
+matches `config provider name == flat preset slug`. **New rule:** a configured
+provider gains an explicit `preset:` field naming its `preset_key`:
+
+```yaml
+llm:
+  providers:
+    alicode:
+      preset: qwen/cn/openai-completions/coding   # explicit catalog link
+      base_url: https://coding.dashscope.aliyuncs.com/v1
+      api: openai-completions
+      models: [...]
+```
+
+The seeder resolves `preset` → catalog entry → capability snapshot. No more
+name-guessing. Providers with no `preset` get no catalog-backfilled capability
+(unchanged fallback behavior).
+
+---
+
+## 7. Testing
+
+- **Composition parity** (§4.1): every current flat URL reproduced byte-for-byte
+  by the new composition. Primary regression guard.
+- **Loader unit tests:** flattening to `preset_key` (with/without plan segment),
+  capability profile resolution (named + inline), model→plan membership, pricing
+  parse, host-override and full-`base_url`-override paths.
+- **Seeder test:** capability backfill resolves for the seeded providers
+  (deepseek/arkcode/alicode/sensedeal) via the new `preset:` field.
+- **Wizard E2E:** Add-Provider — pick vendor (step 1), choose region/protocol/
+  plan (step 2), confirm composed base_url + filtered models (+ prefilled
+  pricing).
+
+---
+
+## 8. Decisions (settled)
+
+1. **cubepi catalog removed entirely** — data + loader move to cubebox; cubepi
+   keeps only `CapabilityDescriptor` + `WireApi`.
+2. **`plan` dimension** — optional; display label + model-membership selector +
+   `preset_key` disambiguator. coding-plan URL differences handled by host/path
+   overrides on the endpoint (§4.1).
+3. **Named capability profiles** in `capabilities.yaml`, referenced by name;
+   inline still allowed for one-offs.
+4. **`preset_key = vendor/region/protocol[/plan]`**, optional `key:` override.
+5. **Two-step preset selection** — vendor in step 1, endpoint (region/protocol/
+   plan) selectors added to the existing Configure step.
+6. **Seeder match via explicit `config.yaml` `preset:` field** — no name
+   heuristic.

--- a/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
+++ b/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
@@ -398,8 +398,10 @@ For each configured provider:
      catalog's `output`/`cache_*`. (A whole-object replace would silently zero
      the unspecified legs.)
    - any other unset config field inherits from the catalog.
-4. **No `preset:`** → behaves like today: config must supply `base_url`, `api`,
-   and full `models`; no catalog backfill. (Custom/self-hosted providers.)
+4. **No `preset:`** → behaves like today: config must supply `base_url` and a
+   non-empty `models` list (validated, fail loudly); `api` keeps its
+   long-standing `openai-completions` default (most custom endpoints are
+   OpenAI-compatible). No catalog backfill. (Custom/self-hosted providers.)
 
 This supersedes the old "match by name, backfill only capability" rule — the
 catalog now backfills the whole model set, not just the capability descriptor.

--- a/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
+++ b/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
@@ -113,8 +113,11 @@ Lives in cubebox: `cubebox/llm/catalog/` with `data/vendors.yaml`,
 `data/capabilities.yaml`, `types.py`, `loader.py`.
 
 Three nested levels: **Vendor** → **Endpoint** (region × protocol × plan) →
-**Model**. Models are a vendor-level pool; each endpoint names the subset (by
-`plan`, or explicit `model_ids`) it serves.
+**Model**. Models are a vendor-level pool. Membership has **exactly one
+mechanism**: each model carries a `plan` tag (or list of plans), and an endpoint
+serves the models whose `plan` intersects the endpoint's `plan`. Endpoints never
+list model ids; models never list endpoints/regions/protocols. (Untagged
+vendors — §4.2 — every endpoint serves every model.)
 
 ```yaml
 # cubebox/llm/catalog/data/vendors.yaml
@@ -180,16 +183,28 @@ rewrite.
 
 ### 4.2 The `plan` dimension
 
-`plan` (e.g. `general`, `coding`) is both:
-- a **display label** in the wizard ("Zhipu · CN · Coding"), and
-- a **model-membership selector** — each model is tagged with the `plan`(s) it
-  belongs to; an endpoint serves the models matching its `plan`. (A model may
-  also list explicit `endpoints`/`plans` if the default `plan` match is
-  insufficient.)
-- a **`preset_key` disambiguator** — see §4.4.
+`plan` (e.g. `general`, `coding`) is:
+- a **display label** in the wizard ("Zhipu · CN · Coding"),
+- the **sole model-membership selector** (§4 intro): a model's `plan` (string or
+  list) intersected with an endpoint's `plan`, and
+- a **`preset_key` disambiguator** (§4.4).
 
-`plan` is optional. A vendor with no plan tiers omits it everywhere; its single
-endpoint per (region, protocol) serves all models.
+**All-or-nothing per vendor.** A vendor is either *untagged* (no `plan` anywhere
+— on any endpoint or model) or *tiered* (every endpoint AND every model carries a
+`plan`). Mixing is rejected by the loader. Rationale: a mixed vendor makes "does
+this untagged model belong to the coding endpoint?" undefined.
+
+- **Untagged vendor:** at most one endpoint per `(region, protocol)`; every
+  endpoint serves every model.
+- **Tiered vendor:** `plan` is **required** and the `(region, protocol, plan)`
+  tuple must be **unique** across endpoints (this is what keeps the §4.4
+  `preset_key` unique). A model may belong to multiple plans via `plan: [a, b]`.
+
+**Loader validations (fail loudly at load):**
+- A tiered endpoint whose `plan` matches **no** model → error (dangling
+  endpoint).
+- A model whose `plan` matches **no** endpoint → error (unreachable model).
+- A vendor mixing tagged and untagged endpoints/models → error.
 
 ### 4.3 Capability by reference (named profiles)
 
@@ -219,7 +234,10 @@ deepseek-anthropic:
 
 An endpoint's `capability:` is **either** a profile name (string → looked up in
 `capabilities.yaml`) **or** an inline descriptor (dict → constructed directly,
-for one-offs). The loader resolves both into a cubepi `CapabilityDescriptor`.
+for one-offs). Discrimination is by YAML type: a scalar string is a profile
+reference; a mapping is inline. The loader resolves both into a cubepi
+`CapabilityDescriptor`. **A string that names no profile in `capabilities.yaml`
+fails loudly at load** (not a silent empty descriptor).
 
 ### 4.4 `preset_key` (catalog identity)
 
@@ -236,6 +254,14 @@ preset_key = vendor / region / protocol [ / plan ]
 `provider.preset_slug` records and the seeder matches on (§6). An endpoint may
 set an optional `key:` override for a prettier public id; otherwise the
 composed key is used.
+
+**Uniqueness (loader validations, fail loudly at load):**
+- No two endpoints may produce the same `preset_key` (whether composed or
+  `key:`-overridden). For tiered vendors this is guaranteed by the unique
+  `(region, protocol, plan)` rule in §4.2; for untagged vendors by the unique
+  `(region, protocol)` rule.
+- A `key:` override may not collide with any other endpoint's composed key or
+  override across the whole catalog.
 
 ---
 
@@ -259,10 +285,12 @@ Clean cutover, no shim. Ordered so each step is independently reviewable.
    - `provider_seeder.py` → resolve the config provider's `preset:` to a catalog
      endpoint and inherit base_url/api/capability/**model pool** with the §6.2
      precedence + §6.3 validation (no longer just a capability backfill).
-   - **Rewrite the seed config** (`config.yaml` / `config.development.local.yaml`)
-     for the seeded providers (deepseek/arkcode/alicode/sensedeal/…) to the §6.1
-     `preset:` + `api_key` form. New catalog vendor/endpoint/model+pricing entries
-     are added for any seeded model not already in the ported catalog.
+   - **Rewrite the seed config exhaustively** (`config.yaml` /
+     `config.development.local.yaml` / any env seed) to the §6.1 `preset:` +
+     `api_key` form, following the **§6.4 inventory** — every existing provider
+     is mapped to a `preset:` or deliberately kept custom with a reason. New
+     catalog vendor/endpoint/model+pricing entries are added for any seeded model
+     not already in the ported catalog.
 4. **Frontend wizard (two-step preset selection):**
    - **Step 1 (`PresetPicker`)** lists **vendors** (~15) instead of 37 flat
      presets. `pickPreset` → `pickVendor`.
@@ -276,14 +304,35 @@ Clean cutover, no shim. Ordered so each step is independently reviewable.
 
 ### 5.1 API contract change
 
-`GET /api/v1/admin/llm/presets` changes shape: flat `ProviderPreset[]` →
-either the nested vendor list or the flattened endpoint presets (with
-`preset_key`, composed `base_url`, pricing on models). Since nothing has
-shipped, change it in place; frontend types follow.
+`GET /api/v1/admin/llm/presets` changes shape, decided here (not left open):
+it returns a **nested vendor list**, so the wizard's step 1 lists vendors and
+step 2 reads `vendor.endpoints`. Concrete shape:
 
-**Likely shape:** return **vendors nested** (so step 1 lists vendors, step 2
-reads `vendor.endpoints`), with the loader also able to produce a flat
-`preset_key`-keyed lookup server-side for the seeder/logo paths.
+```jsonc
+[
+  {
+    "vendor": "zhipu", "display_name": "Zhipu / GLM", "short_name": "Zhipu",
+    "logo": "zhipu", "category": "saas", "description": "…",
+    "endpoints": [
+      { "preset_key": "zhipu/cn/openai-completions/coding",
+        "region": "cn", "protocol": "openai-completions", "plan": "coding",
+        "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",   // already composed server-side
+        "model_ids": ["glm-4.6-coding"] }    // loader-DERIVED from plan intersection (§4 intro); not in source YAML
+    ],
+    "models": [
+      { "model_id": "glm-4.6-coding", "display_name": "GLM-4.6 Coding",
+        "plan": ["coding"], "context_window": 200000, "max_tokens": 8192,
+        "input_modalities": ["text"], "reasoning": true,
+        "pricing": { "input": 0.60, "output": 2.20 } }
+    ]
+  }
+]
+```
+
+`base_url` is composed server-side (the frontend never composes). The loader
+also exposes a flat `preset_key → endpoint` lookup **in-process** for the
+seeder and logo paths (not a separate HTTP shape). The `@cubebox/core` types
+mirror this nested structure.
 
 ---
 
@@ -325,9 +374,21 @@ For each configured provider:
 2. **Model selection:** if config lists `models: [...]` (ids, or id+overrides),
    seed that subset from the pool; **omit `models` → seed all** of the endpoint's
    models.
-3. **Field precedence:** an explicitly set config field wins over the catalog
-   (e.g. a self-hosted `base_url`, a `cost` override on one model). `api_key`
-   always comes from config. Unset config fields inherit from the catalog.
+3. **Field precedence (explicit, per field):**
+   - `api_key` — always from config; never in the catalog.
+   - `base_url` — config override allowed (self-hosted / proxy). Overriding the
+     host does **not** change the protocol, so the inherited `capability` still
+     applies.
+   - `api` (protocol) and `capability` — **not** independently overridable under
+     `preset:`. The protocol is intrinsic to the chosen endpoint, and capability
+     is protocol-specific; to use a different protocol, reference a different
+     `preset_key`. Setting `api` alongside `preset:` is a **validation error**
+     (caught at boot), rather than a silent capability mismatch.
+   - per-model `cost`/`pricing` — config override **deep-merges by leaf**: a
+     config `cost: { input: 0.5 }` replaces only `input` and inherits the
+     catalog's `output`/`cache_*`. (A whole-object replace would silently zero
+     the unspecified legs.)
+   - any other unset config field inherits from the catalog.
 4. **No `preset:`** → behaves like today: config must supply `base_url`, `api`,
    and full `models`; no catalog backfill. (Custom/self-hosted providers.)
 
@@ -337,9 +398,37 @@ catalog now backfills the whole model set, not just the capability descriptor.
 
 ### 6.3 Validation
 
+Catalog-load validations (§4.2 plan/membership, §4.3 capability profile, §4.4
+`preset_key` uniqueness) run first, at import. Then, per config provider:
+
 - A `preset:` that names no catalog endpoint → seed fails loudly (not silent
   skip), so a typo'd `preset_key` is caught at boot.
 - A `models:` subset id not present in the endpoint's pool → fail loudly.
+- `api` set alongside `preset:` → fail loudly (§6.2.3).
+- **No silent custom-downgrade:** see §6.4 — a provider that *used* to receive
+  capability backfill must not become an un-backfilled "custom" provider just
+  because it was overlooked in the rewrite.
+
+### 6.4 Exhaustive migration inventory (no silent backfill loss)
+
+Under the new rule, a provider with no `preset:` gets no catalog inheritance.
+The old rule backfilled capability for any provider whose name matched a flat
+slug. So an existing seeded provider that is *omitted* from the rewrite would
+**silently** drop from "capability-backfilled" to "custom."
+
+To prevent that, the migration is **exhaustive, not illustrative**:
+
+- Enumerate **every** provider in the seed configs (`config.yaml`,
+  `config.development.local.yaml`, and any env-specific seed). The
+  deepseek/arkcode/alicode/sensedeal list in §5/§6.1 is illustrative; the plan
+  must inventory the full set.
+- Each one is **either** given a `preset:` (and a matching catalog endpoint is
+  added if missing) **or** explicitly and deliberately left as `preset:`-less
+  custom, recorded in the plan with a one-line reason.
+- A migration test asserts: for every provider that resolved to a capability
+  snapshot under the *old* name-match rule, the *new* config still yields a
+  capability snapshot (via `preset:`). This is the regression guard for the P1
+  risk.
 
 ---
 
@@ -353,7 +442,14 @@ catalog now backfills the whole model set, not just the capability descriptor.
 - **Seeder test:** `preset:`-referenced providers (deepseek/arkcode/alicode/
   sensedeal) seed the right base_url + full model pool + pricing + capability;
   `models:` subset filters correctly; a config field override beats the catalog;
-  an unknown `preset_key` or unknown subset model id fails loudly (§6.3).
+  an unknown `preset_key` or unknown subset model id fails loudly (§6.3); a
+  partial `cost` override deep-merges (inherits the unspecified legs); `api`
+  alongside `preset:` is rejected.
+- **Backfill-parity test (§6.4):** every provider that got a capability snapshot
+  under the old name-match rule still gets one under the new `preset:` config.
+- **Catalog-load validation tests (§4.2/§4.3/§4.4):** dangling endpoint,
+  unreachable model, mixed tagged/untagged vendor, duplicate `preset_key`,
+  unknown capability-profile name — each fails loudly at load.
 - **Wizard E2E:** Add-Provider — pick vendor (step 1), choose region/protocol/
   plan (step 2), confirm composed base_url + filtered models (+ prefilled
   pricing).
@@ -364,9 +460,11 @@ catalog now backfills the whole model set, not just the capability descriptor.
 
 1. **cubepi catalog removed entirely** — data + loader move to cubebox; cubepi
    keeps only `CapabilityDescriptor` + `WireApi`.
-2. **`plan` dimension** — optional; display label + model-membership selector +
+2. **`plan` dimension** — all-or-nothing per vendor (untagged vs tiered); the
+   model `plan` tag is the *sole* membership mechanism; display label +
    `preset_key` disambiguator. coding-plan URL differences handled by host/path
-   overrides on the endpoint (§4.1).
+   overrides on the endpoint (§4.1). Loader validates uniqueness + no
+   dangling/unreachable (§4.2).
 3. **Named capability profiles** in `capabilities.yaml`, referenced by name;
    inline still allowed for one-offs.
 4. **`preset_key = vendor/region/protocol[/plan]`**, optional `key:` override.

--- a/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
+++ b/docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md
@@ -80,8 +80,10 @@ denormalizes all of it.
 - Changing the `CapabilityDescriptor` schema or the cubepi wire runtime.
 - Changing the `Provider` / `Model` DB tables or the provider-instance `slug`
   (separate, already-merged feature).
-- Changing how operators declare *deployed* providers in `config.yaml`. The
-  catalog is the **menu**; `config.yaml` stays the **deployment manifest** (§6).
+- Changing the `config.yaml` *file format* beyond adding a `preset:` reference
+  and making model/base_url/pricing fields optional (inherited from the
+  catalog). The catalog is the **menu**; `config.yaml` stays the **deployment
+  manifest** but is simplified to reference the menu rather than restate it (§6).
 
 ---
 
@@ -254,8 +256,13 @@ Clean cutover, no shim. Ordered so each step is independently reviewable.
    - `admin_llm.py:list_provider_presets` → return the flattened endpoint
      presets (new shape; §5.1).
    - `admin_providers.py` logo lookup → resolve via vendor.
-   - `provider_seeder.py` capability backfill → match on the config provider's
-     explicit `preset:` field (§6) instead of name==flat-slug.
+   - `provider_seeder.py` → resolve the config provider's `preset:` to a catalog
+     endpoint and inherit base_url/api/capability/**model pool** with the §6.2
+     precedence + §6.3 validation (no longer just a capability backfill).
+   - **Rewrite the seed config** (`config.yaml` / `config.development.local.yaml`)
+     for the seeded providers (deepseek/arkcode/alicode/sensedeal/…) to the §6.1
+     `preset:` + `api_key` form. New catalog vendor/endpoint/model+pricing entries
+     are added for any seeded model not already in the ported catalog.
 4. **Frontend wizard (two-step preset selection):**
    - **Step 1 (`PresetPicker`)** lists **vendors** (~15) instead of 37 flat
      presets. `pickPreset` → `pickVendor`.
@@ -280,30 +287,59 @@ reads `vendor.endpoints`), with the loader also able to produce a flat
 
 ---
 
-## 6. Catalog vs config.yaml (kept separate)
+## 6. Catalog ⇄ config.yaml: reference, don't restate
 
-- **Catalog** (this doc) = the **menu** the wizard prefills from + the source of
-  capability snapshots.
-- **`config.yaml` `llm.providers`** = the **deployment manifest** the seeder
-  instantiates (real keys, real cost overrides). Unchanged.
+- **Catalog** (this doc) = the **menu**: per endpoint it knows `base_url`
+  (composed), `api`, `capability`, and the full model list with `pricing`,
+  `context_window`, `max_tokens`, `input_modalities`, `reasoning`.
+- **`config.yaml` `llm.providers`** = the **deployment manifest**: which
+  endpoints this deployment actually turns on, and the secrets to reach them.
 
-The seeder links the two to backfill a provider's capability snapshot. Today it
-matches `config provider name == flat preset slug`. **New rule:** a configured
-provider gains an explicit `preset:` field naming its `preset_key`:
+Today config restates everything the catalog already knows (base_url, every
+model, every cost). The redesign lets config **reference a `preset:` and inherit
+the rest**, so a seeded provider shrinks to a `preset` + an `api_key`.
+
+### 6.1 Simplified config shape
 
 ```yaml
 llm:
   providers:
     alicode:
-      preset: qwen/cn/openai-completions/coding   # explicit catalog link
-      base_url: https://coding.dashscope.aliyuncs.com/v1
-      api: openai-completions
-      models: [...]
+      preset: qwen/cn/openai-completions/coding   # → base_url, api, models, pricing, capability
+      api_key: ${ALICODE_KEY}                      # secret: always from config, never in catalog
+      # models: [qwen3.6-plus]                     # OPTIONAL subset filter; omit = all preset models
 ```
 
-The seeder resolves `preset` → catalog entry → capability snapshot. No more
-name-guessing. Providers with no `preset` get no catalog-backfilled capability
-(unchanged fallback behavior).
+vs today's ~15-line block per provider (base_url + api + per-model id/name/cost/
+context_window/max_tokens). The seeded set (deepseek/arkcode/alicode/sensedeal/…)
+is rewritten to this form as part of this change.
+
+### 6.2 Resolution & precedence (seeder)
+
+For each configured provider:
+
+1. If `preset:` is set, resolve it to a catalog endpoint. Pull `base_url`, `api`
+   (`provider_type`), `capability` snapshot, and the **candidate model pool**
+   (the endpoint's models, each with pricing + window + max_tokens + modalities +
+   reasoning).
+2. **Model selection:** if config lists `models: [...]` (ids, or id+overrides),
+   seed that subset from the pool; **omit `models` → seed all** of the endpoint's
+   models.
+3. **Field precedence:** an explicitly set config field wins over the catalog
+   (e.g. a self-hosted `base_url`, a `cost` override on one model). `api_key`
+   always comes from config. Unset config fields inherit from the catalog.
+4. **No `preset:`** → behaves like today: config must supply `base_url`, `api`,
+   and full `models`; no catalog backfill. (Custom/self-hosted providers.)
+
+This supersedes the old "match by name, backfill only capability" rule — the
+catalog now backfills the whole model set, not just the capability descriptor.
+`provider.preset_slug` records the resolved `preset_key`.
+
+### 6.3 Validation
+
+- A `preset:` that names no catalog endpoint → seed fails loudly (not silent
+  skip), so a typo'd `preset_key` is caught at boot.
+- A `models:` subset id not present in the endpoint's pool → fail loudly.
 
 ---
 
@@ -314,8 +350,10 @@ name-guessing. Providers with no `preset` get no catalog-backfilled capability
 - **Loader unit tests:** flattening to `preset_key` (with/without plan segment),
   capability profile resolution (named + inline), model→plan membership, pricing
   parse, host-override and full-`base_url`-override paths.
-- **Seeder test:** capability backfill resolves for the seeded providers
-  (deepseek/arkcode/alicode/sensedeal) via the new `preset:` field.
+- **Seeder test:** `preset:`-referenced providers (deepseek/arkcode/alicode/
+  sensedeal) seed the right base_url + full model pool + pricing + capability;
+  `models:` subset filters correctly; a config field override beats the catalog;
+  an unknown `preset_key` or unknown subset model id fails loudly (§6.3).
 - **Wizard E2E:** Add-Provider — pick vendor (step 1), choose region/protocol/
   plan (step 2), confirm composed base_url + filtered models (+ prefilled
   pricing).
@@ -336,3 +374,7 @@ name-guessing. Providers with no `preset` get no catalog-backfilled capability
    plan) selectors added to the existing Configure step.
 6. **Seeder match via explicit `config.yaml` `preset:` field** — no name
    heuristic.
+7. **Config references the catalog instead of restating it** — a `preset:` +
+   `api_key` is enough; base_url/models/pricing/capability inherit, with config
+   fields overriding and an optional `models:` subset filter (§6). The seeded
+   config is rewritten to this form.

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -60,6 +60,44 @@ The frontend `pnpm dev` is wrapped via
 `frontend/scripts/with-worktree-env.mjs`. Bypassing the wrapper means
 PORT defaults to 3000 and silently collides with the main worktree.
 
+## Running tests in a worktree
+
+The dev server and the test suite use **separate** databases — the suite
+must never touch your dev data:
+
+| | dynaconf env | config | database |
+|---|---|---|---|
+| `python main.py` (dev server) | `development` | `config.development(.local).yaml` | dev DB (`cubebox_<slug>`, from `.worktree.env`) |
+| `pytest` / e2e | `test` | `config.test.yaml` | per-slot test DB (`cubebox_test_<slug>`) |
+
+`tests/conftest.py` handles the routing for you. In a worktree it reads
+`.worktree.env`'s dev DB name and **force-derives the per-slot test DB**
+(`cubebox_<slug>` → `cubebox_test_<slug>`), so a plain `uv run pytest`
+runs against the test DB and **cannot** clobber your dev data — no env
+juggling needed. (It also pins the object-store creds to the local rustfs
+values and refuses to start if the resolved DB name isn't a test DB.)
+
+```bash
+# Just works — routed to cubebox_test_<slug>, dev DB untouched:
+cd backend && uv run pytest tests/e2e/...
+```
+
+Prerequisites:
+
+- The per-slot test DB must be migrated. Worktree provisioning runs
+  `alembic upgrade head` on it; if it's behind, `worktree-env reseed-db`
+  (or `CUBEBOX_DATABASE__NAME=cubebox_test_<slug> uv run alembic upgrade
+  head`) fixes it.
+- S3-backed tests (skills, attachments) need the local **rustfs** object
+  store on `:9000` — see `~/infra/rustfs` (`docker compose up -d`). conftest
+  pins the `rustfsadmin` creds; the bucket is `cubebox-test`.
+
+Why conftest pins these: a dynaconf env var beats `config.test.yaml`, so a
+developer's `.env` (real dev DB name + real Aliyun OSS creds) would
+otherwise leak into the test env — the DB leak truncates your dev DB, the
+creds leak breaks S3 with `InvalidAccessKeyId`. The conftest force-set
+neutralizes both.
+
 ## Subcommands
 
 ```bash

--- a/frontend/packages/core/src/api/providers.ts
+++ b/frontend/packages/core/src/api/providers.ts
@@ -9,7 +9,7 @@ import type {
   ModelUpdate,
   OrgLLMSettings,
   OrgLLMSettingsUpdate,
-  ProviderPreset,
+  VendorPreset,
   ProbeStep,
   ProbeResult,
 } from '../types/provider'
@@ -92,10 +92,10 @@ export async function updateOrgLLMSettings(
   return res.json() as Promise<OrgLLMSettings>
 }
 
-export async function listPresets(client: ApiClient): Promise<ProviderPreset[]> {
+export async function listPresets(client: ApiClient): Promise<VendorPreset[]> {
   const res = await client.get('/api/v1/admin/llm/presets')
   if (!res.ok) throw await toApiError(res)
-  return res.json() as Promise<ProviderPreset[]>
+  return res.json() as Promise<VendorPreset[]>
 }
 
 interface LivenessBody {

--- a/frontend/packages/core/src/types/provider.ts
+++ b/frontend/packages/core/src/types/provider.ts
@@ -22,6 +22,9 @@ export interface EndpointPreset {
   plan: string | null
   base_url: string
   model_ids: string[]
+  /** Resolved capability descriptor for this endpoint. The wizard prefills the
+   *  capability editor with it and sends it back only when the user overrides it. */
+  capability: Record<string, unknown>
 }
 
 export interface ModelPresetEntry {

--- a/frontend/packages/core/src/types/provider.ts
+++ b/frontend/packages/core/src/types/provider.ts
@@ -5,6 +5,7 @@ export type Readiness =
   | 'degraded'
   | 'stale'
   | 'provider_error'
+  | 'auth_error'
   | 'model_error'
   | 'unavailable'
 

--- a/frontend/packages/core/src/types/provider.ts
+++ b/frontend/packages/core/src/types/provider.ts
@@ -14,26 +14,35 @@ export interface AuthSpec {
   header_prefix?: string
 }
 
-export interface ProviderPreset {
-  slug: string
+export interface EndpointPreset {
+  preset_key: string
+  region: string
+  protocol: WireApi
+  plan: string | null
+  base_url: string
+  model_ids: string[]
+}
+
+export interface ModelPresetEntry {
+  model_id: string
+  display_name: string
+  plan: string[] | null
+  context_window: number
+  max_tokens: number
+  input_modalities: string[]
+  reasoning: boolean
+  pricing: { input: number; output: number; cache_read?: number; cache_write?: number }
+}
+
+export interface VendorPreset {
+  vendor: string
   display_name: string
   short_name: string
+  logo: string | null
   category: 'saas' | 'oss-framework' | 'custom'
   description: string
-  logo: string | null
-  api: WireApi
-  base_url: string
-  auth: AuthSpec
-  capability: Record<string, unknown>
-  model_capability_overrides: Record<string, Record<string, unknown>>
-  default_models: Array<{
-    model_id: string
-    display_name: string
-    context_window: number
-    max_tokens: number
-    input_modalities: string[]
-    reasoning: boolean
-  }>
+  endpoints: EndpointPreset[]
+  models: ModelPresetEntry[]
 }
 
 export interface ProbeStep {

--- a/frontend/packages/web/app/admin/models/new/page.tsx
+++ b/frontend/packages/web/app/admin/models/new/page.tsx
@@ -76,6 +76,8 @@ export default function AddProviderWizardPage() {
                   dispatch({ type: 'providerCreated', providerId: id })
                   dispatch({ type: 'next' })
                 }}
+                configDraft={state.configDraft}
+                onConfigDraftChange={(draft) => dispatch({ type: 'setConfigDraft', draft })}
               />
             )}
             {state.step === 3 && state.vendor && state.selectedPresetKey && state.providerId && (

--- a/frontend/packages/web/app/admin/models/new/page.tsx
+++ b/frontend/packages/web/app/admin/models/new/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useMemo, useReducer } from 'react'
+import { useMemo, useReducer, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
-import { createApiClient } from '@cubebox/core'
+import { createApiClient, deleteProvider } from '@cubebox/core'
 import { Button } from '@/components/ui/button'
 import { WizardStepRail } from '@/components/admin/models/wizard/WizardStepRail'
 import { PresetPicker } from '@/components/admin/models/wizard/PresetPicker'
@@ -17,9 +17,31 @@ export default function AddProviderWizardPage() {
   const router = useRouter()
   const client = useMemo(() => createApiClient(''), [])
   const [state, dispatch] = useReducer(wizardReducer, initialWizardState)
+  const [confirmingDiscard, setConfirmingDiscard] = useState(false)
+  const [discarding, setDiscarding] = useState(false)
 
+  // Leave the wizard but keep the provider (created at step 2). Its models stay
+  // disabled until a passing test enables them — the user can finish from the
+  // models page later. Also the success path (TestStep "Finish").
   function finish() {
     router.push('/admin/models')
+  }
+
+  // Throw away a provider created in this wizard session (and its models), then
+  // leave. Best-effort: navigate even if the delete fails so the user isn't stuck.
+  async function discard() {
+    if (!state.providerId) {
+      finish()
+      return
+    }
+    setDiscarding(true)
+    try {
+      await deleteProvider(client, state.providerId)
+    } catch {
+      // ignore — nothing actionable for the user on a cleanup delete
+    } finally {
+      router.push('/admin/models')
+    }
   }
 
   return (
@@ -80,10 +102,54 @@ export default function AddProviderWizardPage() {
             )}
           </div>
 
-          <footer className="flex items-center justify-between border-t border-border/70 px-6 py-3">
-            <Button type="button" variant="ghost" size="sm" onClick={finish}>
-              {t('cancel')}
-            </Button>
+          <footer className="flex items-center justify-between gap-3 border-t border-border/70 px-6 py-3">
+            <div className="flex items-center gap-2">
+              {state.providerId == null ? (
+                // Nothing persisted yet — plain cancel just leaves.
+                <Button type="button" variant="ghost" size="sm" onClick={finish}>
+                  {t('cancel')}
+                </Button>
+              ) : confirmingDiscard ? (
+                <>
+                  <span className="text-xs text-muted-foreground">{t('discardPrompt')}</span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="text-destructive hover:text-destructive"
+                    disabled={discarding}
+                    onClick={() => void discard()}
+                  >
+                    {t('discardYes')}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={discarding}
+                    onClick={() => setConfirmingDiscard(false)}
+                  >
+                    {t('discardNo')}
+                  </Button>
+                </>
+              ) : (
+                // Provider exists: discard (delete) or keep it disabled and finish later.
+                <>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="text-destructive hover:text-destructive"
+                    onClick={() => setConfirmingDiscard(true)}
+                  >
+                    {t('discard')}
+                  </Button>
+                  <Button type="button" variant="ghost" size="sm" onClick={finish}>
+                    {t('finishLater')}
+                  </Button>
+                </>
+              )}
+            </div>
             <div className="flex items-center gap-2">
               {state.step > 1 && (
                 <Button

--- a/frontend/packages/web/app/admin/models/new/page.tsx
+++ b/frontend/packages/web/app/admin/models/new/page.tsx
@@ -39,14 +39,16 @@ export default function AddProviderWizardPage() {
             {state.step === 1 && (
               <PresetPicker
                 client={client}
-                selectedSlug={state.preset?.slug ?? null}
-                onPick={(preset) => dispatch({ type: 'pickPreset', preset })}
+                selectedVendor={state.vendor?.vendor ?? null}
+                onPickVendor={(vendor) => dispatch({ type: 'pickVendor', vendor })}
               />
             )}
-            {state.step === 2 && state.preset && (
+            {state.step === 2 && state.vendor && (
               <ConfigureStep
                 client={client}
-                preset={state.preset}
+                vendor={state.vendor}
+                selectedPresetKey={state.selectedPresetKey}
+                onSelectEndpoint={(presetKey) => dispatch({ type: 'selectEndpoint', presetKey })}
                 existingProviderId={state.providerId}
                 onProviderCreated={(id) => {
                   dispatch({ type: 'providerCreated', providerId: id })
@@ -54,10 +56,11 @@ export default function AddProviderWizardPage() {
                 }}
               />
             )}
-            {state.step === 3 && state.preset && state.providerId && (
+            {state.step === 3 && state.vendor && state.selectedPresetKey && state.providerId && (
               <ModelsStep
                 client={client}
-                preset={state.preset}
+                vendor={state.vendor}
+                presetKey={state.selectedPresetKey}
                 providerId={state.providerId}
                 onModelsCreated={(models) => {
                   dispatch({ type: 'modelsCreated', models })
@@ -95,7 +98,7 @@ export default function AddProviderWizardPage() {
                 <Button
                   type="button"
                   size="sm"
-                  disabled={!state.preset}
+                  disabled={!state.vendor}
                   onClick={() => dispatch({ type: 'next' })}
                 >
                   {t('next')}

--- a/frontend/packages/web/app/admin/models/new/page.tsx
+++ b/frontend/packages/web/app/admin/models/new/page.tsx
@@ -62,6 +62,7 @@ export default function AddProviderWizardPage() {
                 vendor={state.vendor}
                 presetKey={state.selectedPresetKey}
                 providerId={state.providerId}
+                existingModels={state.models}
                 onModelsCreated={(models) => {
                   dispatch({ type: 'modelsCreated', models })
                   dispatch({ type: 'next' })

--- a/frontend/packages/web/components/admin/models/ModelFormDialog.tsx
+++ b/frontend/packages/web/components/admin/models/ModelFormDialog.tsx
@@ -210,7 +210,7 @@ export function ModelFormDialog({ open, onOpenChange, model, onSave }: ModelForm
               </div>
             </div>
 
-            <Accordion className="mt-1">
+            <Accordion className="mt-1" multiple defaultValue={['costs', 'limits']}>
               <AccordionItem value="costs">
                 <AccordionTrigger className="text-xs text-muted-foreground">
                   {t('costPerMillion')}

--- a/frontend/packages/web/components/admin/models/ModelRow.tsx
+++ b/frontend/packages/web/components/admin/models/ModelRow.tsx
@@ -2,11 +2,12 @@
 
 import { useState } from 'react'
 import { useTranslations } from 'next-intl'
-import { Brain, Check, Loader2, Pencil, RotateCw, Trash2, X } from 'lucide-react'
+import { Brain, Check, Loader2, Pencil, RotateCw, TriangleAlert, Trash2, X } from 'lucide-react'
 import { testModel, type ApiClient, type Model } from '@cubebox/core'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { formatProbeDetail } from '@/lib/probeDetail'
 import { ReadinessBadge } from './ReadinessBadge'
 
 interface ModelRowProps {
@@ -41,7 +42,7 @@ function testIssues(summary: Record<string, unknown> | undefined): TestIssue[] {
       return {
         name: String(s.name ?? ''),
         status: String(s.status ?? ''),
-        detail: String(s.detail ?? error?.message ?? ''),
+        detail: formatProbeDetail(String(s.detail ?? error?.message ?? '')),
       }
     })
 }
@@ -59,7 +60,6 @@ export function ModelRow({
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [retesting, setRetesting] = useState(false)
   const issues = testIssues(model.last_test_summary)
-  const hasFail = issues.some((i) => i.status === 'fail')
 
   async function handleRetest() {
     setRetesting(true)
@@ -97,14 +97,29 @@ export function ModelRow({
           <span className="mt-0.5 block truncate text-muted-foreground">{model.display_name}</span>
         )}
         {issues.length > 0 && (
-          <span
-            className={cn(
-              'mt-0.5 block text-[11px]',
-              hasFail ? 'text-destructive' : 'text-amber-700 dark:text-amber-300',
-            )}
-          >
-            {issues.map((i) => (i.detail ? `${i.name} — ${i.detail}` : i.name)).join(' · ')}
-          </span>
+          <ul className="mt-1 flex flex-col gap-0.5">
+            {issues.map((i) => {
+              const isFail = i.status === 'fail'
+              return (
+                <li key={i.name} className="flex items-start gap-1.5 text-[11px]">
+                  {isFail ? (
+                    <X className="mt-px size-3 shrink-0 text-destructive" />
+                  ) : (
+                    <TriangleAlert className="mt-px size-3 shrink-0 text-amber-600 dark:text-amber-400" />
+                  )}
+                  <span
+                    className={cn(
+                      'min-w-0',
+                      isFail ? 'text-destructive' : 'text-amber-700 dark:text-amber-300',
+                    )}
+                  >
+                    <span className="font-medium">{i.name}</span>
+                    {i.detail ? ` — ${i.detail}` : ''}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
         )}
       </div>
 

--- a/frontend/packages/web/components/admin/models/ProviderConfigForm.tsx
+++ b/frontend/packages/web/components/admin/models/ProviderConfigForm.tsx
@@ -104,12 +104,11 @@ export function ProviderConfigForm({
   const [advancedOpen, setAdvancedOpen] = useState(false)
   const [headersError, setHeadersError] = useState<string | null>(null)
 
-  // Effective auth_type sent to the backend.
-  const authType: 'api_key' | 'bearer_token' | 'none' = isCreate
-    ? 'api_key'
-    : authChoice === 'none'
-      ? 'none'
-      : 'api_key'
+  // Effective auth_type sent to the backend. The catalog no longer carries
+  // per-preset auth, so the user picks it (api_key default / none) in both
+  // modes — this preserves no-auth semantics for keyless endpoints (ollama,
+  // lm-studio, tgi, …) instead of forcing a dummy key (codex P1).
+  const authType: 'api_key' | 'bearer_token' | 'none' = authChoice === 'none' ? 'none' : 'api_key'
   const needsKey = authType !== 'none'
   // Key required in create (when the auth needs one); optional in edit.
   const keyRequired = isCreate && needsKey
@@ -227,7 +226,7 @@ export function ProviderConfigForm({
         </div>
       )}
 
-      {supported && !isCreate && (
+      {supported && (
         <div className="flex flex-col gap-1.5">
           <Label>{t('authType')}</Label>
           <RadioGroup

--- a/frontend/packages/web/components/admin/models/ProviderConfigForm.tsx
+++ b/frontend/packages/web/components/admin/models/ProviderConfigForm.tsx
@@ -3,13 +3,7 @@
 import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { AlertTriangle, ChevronDown } from 'lucide-react'
-import type {
-  Provider,
-  ProviderCreate,
-  ProviderPreset,
-  ProviderUpdate,
-  WireApi,
-} from '@cubebox/core'
+import type { Provider, ProviderCreate, ProviderUpdate, WireApi } from '@cubebox/core'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -35,35 +29,30 @@ function slugifyTs(name: string): string {
 // wire shape, so it folds into 'api_key' in the radio (matching the old dialog).
 type AuthChoice = 'api_key' | 'none'
 
+// Create-mode seed: a single catalog endpoint selected in the wizard's step 2.
+// (The catalog no longer carries auth/capability — auth defaults to api_key and
+// capability is resolved server-side from preset_key.)
+export interface CreatePreset {
+  display_name: string
+  base_url: string
+  provider_type: WireApi
+  /** The endpoint's preset_key, recorded as Provider.preset_slug. */
+  preset_key: string
+  category: 'saas' | 'oss-framework' | 'custom'
+}
+
 interface ProviderConfigFormProps {
   mode: 'create' | 'edit'
-  // create: seeds fields; provider_type is locked to preset.api; auth derived
-  // from preset.auth.mode; capability seeded from preset.capability.
-  preset?: ProviderPreset
+  // create: seeds fields from the selected endpoint; provider_type is locked to
+  // the endpoint protocol; auth defaults to api_key; capability resolves
+  // server-side from preset_key.
+  preset?: CreatePreset
   // edit: seeds from the existing row; provider_type/auth editable; key optional.
   provider?: Provider
   saving: boolean
   error: string | null
   submitLabel: string
   onSubmit: (body: ProviderCreate | ProviderUpdate) => void
-}
-
-// Map preset auth mode → backend auth_type. Backend _validate_auth_creds
-// expects "bearer_token" (not "bearer"). oauth/iam are not yet supported.
-function authTypeForPreset(
-  mode: ProviderPreset['auth']['mode'],
-): 'api_key' | 'bearer_token' | 'none' | null {
-  switch (mode) {
-    case 'api_key':
-      return 'api_key'
-    case 'bearer':
-      return 'bearer_token'
-    case 'none':
-      return 'none'
-    case 'oauth':
-    case 'iam':
-      return null
-  }
 }
 
 export function ProviderConfigForm({
@@ -79,10 +68,9 @@ export function ProviderConfigForm({
   const tc = useTranslations('adminModels.wizard.configure')
   const isCreate = mode === 'create'
 
-  // Create: auth is fixed by the preset (and may be unsupported). Edit: auth is
-  // user-editable via the radio (api_key / none).
-  const presetAuthType = preset ? authTypeForPreset(preset.auth.mode) : null
-  const supported = isCreate ? presetAuthType !== null : true
+  // Create: auth defaults to api_key (the catalog no longer carries auth).
+  // Edit: auth is user-editable via the radio (api_key / none).
+  const supported = true
 
   const [name, setName] = useState(() =>
     isCreate ? (preset?.display_name ?? '') : (provider?.name ?? ''),
@@ -95,17 +83,17 @@ export function ProviderConfigForm({
     isCreate ? (preset?.base_url ?? '') : (provider?.base_url ?? ''),
   )
   const [providerType, setProviderType] = useState<WireApi>(() => {
-    if (isCreate) return (preset?.api ?? 'openai-completions') as WireApi
+    if (isCreate) return (preset?.provider_type ?? 'openai-completions') as WireApi
     return (provider?.provider_type ?? 'openai-completions') as WireApi
   })
   const [authChoice, setAuthChoice] = useState<AuthChoice>(() => {
-    if (isCreate) return presetAuthType === 'none' ? 'none' : 'api_key'
+    if (isCreate) return 'api_key'
     // bearer_token folds into api_key for the radio (same wire shape).
     return provider?.auth_type === 'none' ? 'none' : 'api_key'
   })
   const [apiKey, setApiKey] = useState('')
   const [capability, setCapability] = useState<Record<string, unknown>>(() =>
-    isCreate ? (preset?.capability ?? {}) : (provider?.capability ?? {}),
+    isCreate ? {} : (provider?.capability ?? {}),
   )
   const [logoUrl, setLogoUrl] = useState(() => (isCreate ? '' : (provider?.logo_url ?? '')))
   const [extraHeaders, setExtraHeaders] = useState(() =>
@@ -118,11 +106,11 @@ export function ProviderConfigForm({
 
   // Effective auth_type sent to the backend.
   const authType: 'api_key' | 'bearer_token' | 'none' = isCreate
-    ? (presetAuthType ?? 'none')
+    ? 'api_key'
     : authChoice === 'none'
       ? 'none'
       : 'api_key'
-  const needsKey = authType === 'api_key' || authType === 'bearer_token'
+  const needsKey = authType !== 'none'
   // Key required in create (when the auth needs one); optional in edit.
   const keyRequired = isCreate && needsKey
 
@@ -153,9 +141,10 @@ export function ProviderConfigForm({
         base_url: baseUrl.trim(),
         auth_type: authType,
         api_key: needsKey ? apiKey : null,
-        preset_slug: preset.slug,
-        capability,
-        model_capability_overrides: preset.model_capability_overrides,
+        preset_slug: preset.preset_key,
+        // capability is resolved server-side from preset_slug; only send it if
+        // the user explicitly edited the (initially empty) advanced editor.
+        capability: Object.keys(capability).length > 0 ? capability : undefined,
         logo_url: logoUrl.trim() || null,
         extra_headers: parsedHeaders,
       }

--- a/frontend/packages/web/components/admin/models/ProviderConfigForm.tsx
+++ b/frontend/packages/web/components/admin/models/ProviderConfigForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { AlertTriangle, ChevronDown } from 'lucide-react'
 import type { Provider, ProviderCreate, ProviderUpdate, WireApi } from '@cubebox/core'
@@ -30,8 +30,9 @@ function slugifyTs(name: string): string {
 type AuthChoice = 'api_key' | 'none'
 
 // Create-mode seed: a single catalog endpoint selected in the wizard's step 2.
-// (The catalog no longer carries auth/capability — auth defaults to api_key and
-// capability is resolved server-side from preset_key.)
+// (The catalog no longer carries auth — auth defaults to api_key. Capability is
+// prefilled from the endpoint and only sent back when the user overrides it;
+// otherwise the server resolves it from preset_key.)
 export interface CreatePreset {
   display_name: string
   base_url: string
@@ -39,6 +40,8 @@ export interface CreatePreset {
   /** The endpoint's preset_key, recorded as Provider.preset_slug. */
   preset_key: string
   category: 'saas' | 'oss-framework' | 'custom'
+  /** Resolved capability for the chosen endpoint; prefills the editor. */
+  capability: Record<string, unknown>
 }
 
 interface ProviderConfigFormProps {
@@ -93,7 +96,14 @@ export function ProviderConfigForm({
   })
   const [apiKey, setApiKey] = useState('')
   const [capability, setCapability] = useState<Record<string, unknown>>(() =>
-    isCreate ? {} : (provider?.capability ?? {}),
+    isCreate ? (preset?.capability ?? {}) : (provider?.capability ?? {}),
+  )
+  // The endpoint's resolved capability as first prefilled. On create we only send
+  // capability when the user edits it away from this; an untouched value lets the
+  // server resolve it from preset_slug (keeps the provider row preset-tracked).
+  const presetCapabilityJson = useMemo(
+    () => JSON.stringify(preset?.capability ?? {}),
+    [preset?.capability],
   )
   const [logoUrl, setLogoUrl] = useState(() => (isCreate ? '' : (provider?.logo_url ?? '')))
   const [extraHeaders, setExtraHeaders] = useState(() =>
@@ -141,9 +151,10 @@ export function ProviderConfigForm({
         auth_type: authType,
         api_key: needsKey ? apiKey : null,
         preset_slug: preset.preset_key,
-        // capability is resolved server-side from preset_slug; only send it if
-        // the user explicitly edited the (initially empty) advanced editor.
-        capability: Object.keys(capability).length > 0 ? capability : undefined,
+        // Capability is prefilled from the endpoint. Send it only when the user
+        // edited it away from the preset default; otherwise let the server
+        // resolve it from preset_slug.
+        capability: JSON.stringify(capability) !== presetCapabilityJson ? capability : undefined,
         logo_url: logoUrl.trim() || null,
         extra_headers: parsedHeaders,
       }

--- a/frontend/packages/web/components/admin/models/ProviderConfigForm.tsx
+++ b/frontend/packages/web/components/admin/models/ProviderConfigForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { AlertTriangle, ChevronDown } from 'lucide-react'
 import type { Provider, ProviderCreate, ProviderUpdate, WireApi } from '@cubebox/core'
@@ -10,6 +10,7 @@ import { Label } from '@/components/ui/label'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { cn } from '@/lib/utils'
 import { CapabilityEditor } from './wizard/CapabilityEditor'
+import type { ConfigFormValues } from './wizard/wizardMachine'
 
 const PROVIDER_TYPES: readonly WireApi[] = [
   'openai-completions',
@@ -52,6 +53,10 @@ interface ProviderConfigFormProps {
   preset?: CreatePreset
   // edit: seeds from the existing row; provider_type/auth editable; key optional.
   provider?: Provider
+  // create: restore previously-entered values (wizard step revisit) instead of
+  // re-seeding from the preset; emit edits so the wizard can persist them.
+  initialValues?: ConfigFormValues | null
+  onValuesChange?: (values: ConfigFormValues) => void
   saving: boolean
   error: string | null
   submitLabel: string
@@ -62,6 +67,8 @@ export function ProviderConfigForm({
   mode,
   preset,
   provider,
+  initialValues,
+  onValuesChange,
   saving,
   error,
   submitLabel,
@@ -75,28 +82,30 @@ export function ProviderConfigForm({
   // Edit: auth is user-editable via the radio (api_key / none).
   const supported = true
 
+  // In create mode, a restored draft (wizard revisit) wins over preset defaults.
+  const seed = isCreate ? initialValues : null
   const [name, setName] = useState(() =>
-    isCreate ? (preset?.display_name ?? '') : (provider?.name ?? ''),
+    isCreate ? (seed?.name ?? preset?.display_name ?? '') : (provider?.name ?? ''),
   )
   const [slug, setSlug] = useState(() =>
-    isCreate ? slugifyTs(preset?.display_name ?? '') : (provider?.slug ?? ''),
+    isCreate ? (seed?.slug ?? slugifyTs(preset?.display_name ?? '')) : (provider?.slug ?? ''),
   )
-  const [slugTouched, setSlugTouched] = useState(false)
+  const [slugTouched, setSlugTouched] = useState(() => seed?.slugTouched ?? false)
   const [baseUrl, setBaseUrl] = useState(() =>
-    isCreate ? (preset?.base_url ?? '') : (provider?.base_url ?? ''),
+    isCreate ? (seed?.baseUrl ?? preset?.base_url ?? '') : (provider?.base_url ?? ''),
   )
   const [providerType, setProviderType] = useState<WireApi>(() => {
     if (isCreate) return (preset?.provider_type ?? 'openai-completions') as WireApi
     return (provider?.provider_type ?? 'openai-completions') as WireApi
   })
   const [authChoice, setAuthChoice] = useState<AuthChoice>(() => {
-    if (isCreate) return 'api_key'
+    if (isCreate) return seed?.authChoice ?? 'api_key'
     // bearer_token folds into api_key for the radio (same wire shape).
     return provider?.auth_type === 'none' ? 'none' : 'api_key'
   })
-  const [apiKey, setApiKey] = useState('')
+  const [apiKey, setApiKey] = useState(() => seed?.apiKey ?? '')
   const [capability, setCapability] = useState<Record<string, unknown>>(() =>
-    isCreate ? (preset?.capability ?? {}) : (provider?.capability ?? {}),
+    isCreate ? (seed?.capability ?? preset?.capability ?? {}) : (provider?.capability ?? {}),
   )
   // The endpoint's resolved capability as first prefilled. On create we only send
   // capability when the user edits it away from this; an untouched value lets the
@@ -105,14 +114,49 @@ export function ProviderConfigForm({
     () => JSON.stringify(preset?.capability ?? {}),
     [preset?.capability],
   )
-  const [logoUrl, setLogoUrl] = useState(() => (isCreate ? '' : (provider?.logo_url ?? '')))
+  const [logoUrl, setLogoUrl] = useState(() =>
+    isCreate ? (seed?.logoUrl ?? '') : (provider?.logo_url ?? ''),
+  )
   const [extraHeaders, setExtraHeaders] = useState(() =>
-    !isCreate && provider?.extra_headers && Object.keys(provider.extra_headers).length > 0
-      ? JSON.stringify(provider.extra_headers, null, 2)
-      : '',
+    isCreate
+      ? (seed?.extraHeaders ?? '')
+      : provider?.extra_headers && Object.keys(provider.extra_headers).length > 0
+        ? JSON.stringify(provider.extra_headers, null, 2)
+        : '',
   )
   const [advancedOpen, setAdvancedOpen] = useState(false)
   const [headersError, setHeadersError] = useState<string | null>(null)
+
+  // Emit the current values so the wizard can persist them across step changes.
+  // Use a ref for the callback so its (unstable) identity doesn't retrigger the
+  // effect — it must fire on value changes only, never on parent re-renders.
+  const onValuesChangeRef = useRef(onValuesChange)
+  onValuesChangeRef.current = onValuesChange
+  useEffect(() => {
+    if (!isCreate) return
+    onValuesChangeRef.current?.({
+      name,
+      slug,
+      slugTouched,
+      baseUrl,
+      apiKey,
+      authChoice,
+      capability,
+      logoUrl,
+      extraHeaders,
+    })
+  }, [
+    isCreate,
+    name,
+    slug,
+    slugTouched,
+    baseUrl,
+    apiKey,
+    authChoice,
+    capability,
+    logoUrl,
+    extraHeaders,
+  ])
 
   // Effective auth_type sent to the backend. The catalog no longer carries
   // per-preset auth, so the user picks it (api_key default / none) in both

--- a/frontend/packages/web/components/admin/models/ReadinessBadge.tsx
+++ b/frontend/packages/web/components/admin/models/ReadinessBadge.tsx
@@ -6,6 +6,7 @@ const MAP = {
   degraded: { dot: 'bg-amber-500', key: 'degraded' },
   stale: { dot: 'bg-amber-400', key: 'stale' },
   provider_error: { dot: 'bg-red-500', key: 'providerError' },
+  auth_error: { dot: 'bg-red-500', key: 'authError' },
   model_error: { dot: 'bg-red-500', key: 'modelError' },
   unavailable: { dot: 'bg-zinc-400', key: 'unavailable' },
 } as const satisfies Record<Readiness, { dot: string; key: string }>

--- a/frontend/packages/web/components/admin/models/__tests__/ModelRow.test.tsx
+++ b/frontend/packages/web/components/admin/models/__tests__/ModelRow.test.tsx
@@ -81,9 +81,11 @@ describe('ModelRow', () => {
         },
       }),
     )
-    expect(screen.getByText(/streaming — no SSE chunks observed/)).toBeInTheDocument()
+    // Issues render as a per-step list (name + cleaned detail).
+    const items = screen.getAllByRole('listitem')
+    expect(items.some((li) => li.textContent === 'streaming — no SSE chunks observed')).toBe(true)
     // passing steps are not listed as issues
-    expect(screen.queryByText(/temperature/)).not.toBeInTheDocument()
+    expect(items.some((li) => li.textContent?.includes('temperature'))).toBe(false)
   })
 
   it('clicking re-test calls testModel with the provider and model db ids', async () => {

--- a/frontend/packages/web/components/admin/models/__tests__/ProviderConfigForm.test.tsx
+++ b/frontend/packages/web/components/admin/models/__tests__/ProviderConfigForm.test.tsx
@@ -3,8 +3,18 @@ import { NextIntlClientProvider } from 'next-intl'
 import { describe, expect, it, vi } from 'vitest'
 import type { Provider, ProviderCreate, ProviderUpdate } from '@cubebox/core'
 import en from '../../../../messages/en.json'
-import { ProviderConfigForm } from '../ProviderConfigForm'
-import { makePreset } from '../wizard/__tests__/fixtures'
+import { ProviderConfigForm, type CreatePreset } from '../ProviderConfigForm'
+
+function makeCreatePreset(over: Partial<CreatePreset> = {}): CreatePreset {
+  return {
+    display_name: 'Anthropic',
+    base_url: 'https://api.anthropic.com',
+    provider_type: 'anthropic-messages',
+    preset_key: 'anthropic/intl/anthropic-messages',
+    category: 'saas',
+    ...over,
+  }
+}
 
 function renderForm(props: Partial<Parameters<typeof ProviderConfigForm>[0]> = {}) {
   const onSubmit = vi.fn()
@@ -12,7 +22,7 @@ function renderForm(props: Partial<Parameters<typeof ProviderConfigForm>[0]> = {
     <NextIntlClientProvider locale="en" messages={en}>
       <ProviderConfigForm
         mode="create"
-        preset={makePreset()}
+        preset={makeCreatePreset()}
         saving={false}
         error={null}
         submitLabel="Next"
@@ -49,7 +59,7 @@ function makeProvider(over: Partial<Provider> = {}): Provider {
 }
 
 describe('ProviderConfigForm — create', () => {
-  it('seeds from preset, locks provider_type, passes capability and preset_slug', () => {
+  it('seeds from the endpoint preset, locks provider_type, sends preset_slug', () => {
     const { onSubmit } = renderForm()
 
     // provider_type is read-only in create mode.
@@ -68,13 +78,14 @@ describe('ProviderConfigForm — create', () => {
       base_url: 'https://api.anthropic.com',
       auth_type: 'api_key',
       api_key: 'sk-123',
-      preset_slug: 'anthropic',
+      preset_slug: 'anthropic/intl/anthropic-messages',
     })
-    expect(body.capability).toEqual(makePreset().capability)
+    // capability resolves server-side from preset_slug -> not sent.
+    expect(body.capability).toBeUndefined()
   })
 
   it('typing name auto-fills slug field', () => {
-    renderForm({ preset: makePreset({ display_name: '' }) })
+    renderForm({ preset: makeCreatePreset({ display_name: '' }) })
     const nameInput = screen.getByLabelText('Name')
     const slugInput = screen.getByLabelText('Slug') as HTMLInputElement
     fireEvent.change(nameInput, { target: { value: 'My Provider' } })
@@ -82,35 +93,27 @@ describe('ProviderConfigForm — create', () => {
   })
 
   it('editing slug then changing name keeps the edited slug', () => {
-    renderForm({ preset: makePreset({ display_name: '' }) })
+    renderForm({ preset: makeCreatePreset({ display_name: '' }) })
     const nameInput = screen.getByLabelText('Name')
     const slugInput = screen.getByLabelText('Slug') as HTMLInputElement
-    // User edits slug manually
     fireEvent.change(slugInput, { target: { value: 'custom-slug' } })
-    // Then changes name — slug should remain unchanged
     fireEvent.change(nameInput, { target: { value: 'New Name' } })
     expect(slugInput.value).toBe('custom-slug')
   })
 
   it('submitted ProviderCreate body carries slug', () => {
-    const { onSubmit } = renderForm({ preset: makePreset({ display_name: 'Test Provider' }) })
+    const { onSubmit } = renderForm({ preset: makeCreatePreset({ display_name: 'Test Provider' }) })
     fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-1' } })
     fireEvent.click(screen.getByRole('button', { name: 'Next' }))
     const body = onSubmit.mock.calls[0][0] as ProviderCreate
     expect(body.slug).toBe('test-provider')
   })
 
-  it('requires a key for api_key presets', () => {
+  it('requires a key (auth defaults to api_key)', () => {
     renderForm()
     expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
     fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-1' } })
     expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled()
-  })
-
-  it('oauth preset is unsubmittable with the unsupported note', () => {
-    renderForm({ preset: makePreset({ auth: { mode: 'oauth' } }) })
-    expect(screen.getByText("OAuth/IAM presets aren't supported yet.")).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
   })
 })
 
@@ -132,19 +135,16 @@ describe('ProviderConfigForm — edit', () => {
     )
 
     expect(screen.getByLabelText('Name')).toHaveValue('My OpenAI')
-    // provider_type is an editable select in edit mode.
     const ptSelect = screen.getByLabelText('Provider type') as HTMLSelectElement
     expect(ptSelect.tagName).toBe('SELECT')
     expect(ptSelect).toHaveValue('openai-completions')
     fireEvent.change(ptSelect, { target: { value: 'anthropic-messages' } })
 
-    // No key entered → submit without api_key (keep existing).
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     expect(onSubmit).toHaveBeenCalledTimes(1)
     const body = onSubmit.mock.calls[0][0] as ProviderUpdate
     expect(body.api_key).toBeNull()
     expect(body.provider_type).toBe('anthropic-messages')
-    // Capability seeded from the existing provider.
     expect(body.capability).toEqual({ supports_tools: true })
     expect(body.model_capability_overrides).toEqual({ 'gpt-x': { reasoning: true } })
   })

--- a/frontend/packages/web/components/admin/models/__tests__/ProviderConfigForm.test.tsx
+++ b/frontend/packages/web/components/admin/models/__tests__/ProviderConfigForm.test.tsx
@@ -138,6 +138,36 @@ describe('ProviderConfigForm — create', () => {
     expect(body.capability).toEqual({ supports_tools: false })
   })
 
+  it('restores entered values from initialValues instead of preset defaults', () => {
+    const onSubmit = vi.fn()
+    render(
+      <NextIntlClientProvider locale="en" messages={en}>
+        <ProviderConfigForm
+          mode="create"
+          preset={makeCreatePreset({ display_name: 'Anthropic' })}
+          initialValues={{
+            name: 'My Custom Name',
+            slug: 'my-custom-slug',
+            slugTouched: true,
+            baseUrl: 'https://api.anthropic.com',
+            apiKey: 'sk-kept',
+            authChoice: 'api_key',
+            capability: { supports_tools: true },
+            logoUrl: '',
+            extraHeaders: '',
+          }}
+          saving={false}
+          error={null}
+          submitLabel="Next"
+          onSubmit={onSubmit}
+        />
+      </NextIntlClientProvider>,
+    )
+    // Restored values win over the preset's default name/slug.
+    expect(screen.getByLabelText('Name')).toHaveValue('My Custom Name')
+    expect(screen.getByLabelText('Slug')).toHaveValue('my-custom-slug')
+  })
+
   it('requires a key (auth defaults to api_key)', () => {
     renderForm()
     expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()

--- a/frontend/packages/web/components/admin/models/__tests__/ProviderConfigForm.test.tsx
+++ b/frontend/packages/web/components/admin/models/__tests__/ProviderConfigForm.test.tsx
@@ -115,6 +115,19 @@ describe('ProviderConfigForm — create', () => {
     fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-1' } })
     expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled()
   })
+
+  it('lets a keyless preset be created with auth_type none (no dummy key)', () => {
+    const { onSubmit } = renderForm({
+      preset: makeCreatePreset({ display_name: 'Ollama', base_url: 'http://localhost:11434/v1' }),
+    })
+    // Pick "None" auth → the API key field disappears and Next enables w/o a key.
+    fireEvent.click(screen.getByText('None'))
+    expect(screen.queryByLabelText('API key')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    const body = onSubmit.mock.calls[0][0] as ProviderCreate
+    expect(body.auth_type).toBe('none')
+    expect(body.api_key).toBeNull()
+  })
 })
 
 describe('ProviderConfigForm — edit', () => {

--- a/frontend/packages/web/components/admin/models/__tests__/ProviderConfigForm.test.tsx
+++ b/frontend/packages/web/components/admin/models/__tests__/ProviderConfigForm.test.tsx
@@ -12,6 +12,7 @@ function makeCreatePreset(over: Partial<CreatePreset> = {}): CreatePreset {
     provider_type: 'anthropic-messages',
     preset_key: 'anthropic/intl/anthropic-messages',
     category: 'saas',
+    capability: { supports_tools: true },
     ...over,
   }
 }
@@ -107,6 +108,34 @@ describe('ProviderConfigForm — create', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Next' }))
     const body = onSubmit.mock.calls[0][0] as ProviderCreate
     expect(body.slug).toBe('test-provider')
+  })
+
+  it('prefills capability from the preset and omits it on submit when unchanged', () => {
+    const { onSubmit } = renderForm({
+      preset: makeCreatePreset({ capability: { supports_tools: true } }),
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Advanced: capability' }))
+    // Editor is prefilled with the preset capability JSON.
+    const editor = screen.getByLabelText('Capability JSON') as HTMLTextAreaElement
+    expect(JSON.parse(editor.value)).toEqual({ supports_tools: true })
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-1' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    const body = onSubmit.mock.calls[0][0] as ProviderCreate
+    // Unchanged → not sent; server resolves from preset_slug.
+    expect(body.capability).toBeUndefined()
+  })
+
+  it('sends capability as override when the user edits it', () => {
+    const { onSubmit } = renderForm({
+      preset: makeCreatePreset({ capability: { supports_tools: true } }),
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Advanced: capability' }))
+    const editor = screen.getByLabelText('Capability JSON') as HTMLTextAreaElement
+    fireEvent.change(editor, { target: { value: '{"supports_tools": false}' } })
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-1' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    const body = onSubmit.mock.calls[0][0] as ProviderCreate
+    expect(body.capability).toEqual({ supports_tools: false })
   })
 
   it('requires a key (auth defaults to api_key)', () => {

--- a/frontend/packages/web/components/admin/models/wizard/ConfigureStep.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/ConfigureStep.tsx
@@ -15,6 +15,7 @@ import {
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
 import { ProviderConfigForm, type CreatePreset } from '../ProviderConfigForm'
+import type { ConfigDraft, ConfigFormValues } from './wizardMachine'
 
 interface ConfigureStepProps {
   client: ApiClient
@@ -25,6 +26,9 @@ interface ConfigureStepProps {
   // creating a second row.
   existingProviderId?: string | null
   onProviderCreated: (providerId: string) => void
+  // Persisted form values, so stepping back into this step restores them.
+  configDraft: ConfigDraft | null
+  onConfigDraftChange: (draft: ConfigDraft) => void
 }
 
 function uniq<T>(xs: T[]): T[] {
@@ -38,6 +42,8 @@ export function ConfigureStep({
   onSelectEndpoint,
   existingProviderId,
   onProviderCreated,
+  configDraft,
+  onConfigDraftChange,
 }: ConfigureStepProps) {
   const t = useTranslations('adminModels.wizard.configure')
   const tw = useTranslations('adminModels.wizard')
@@ -166,6 +172,12 @@ export function ConfigureStep({
         key={chosen.preset_key}
         mode="create"
         preset={createPreset}
+        // Restore the draft only when it belongs to the current endpoint; a
+        // different endpoint should fall back to that endpoint's defaults.
+        initialValues={configDraft?.presetKey === chosen.preset_key ? configDraft : null}
+        onValuesChange={(values: ConfigFormValues) =>
+          onConfigDraftChange({ ...values, presetKey: chosen.preset_key })
+        }
         saving={saving}
         error={error}
         submitLabel={tw('next')}

--- a/frontend/packages/web/components/admin/models/wizard/ConfigureStep.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/ConfigureStep.tsx
@@ -84,6 +84,7 @@ export function ConfigureStep({
     provider_type: chosen.protocol,
     preset_key: chosen.preset_key,
     category: vendor.category,
+    capability: chosen.capability,
   }
 
   async function handleSubmit(body: ProviderCreate | ProviderUpdate) {

--- a/frontend/packages/web/components/admin/models/wizard/ConfigureStep.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/ConfigureStep.tsx
@@ -1,30 +1,40 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import {
   createProvider,
   updateProvider,
   type ApiClient,
+  type EndpointPreset,
   type ProviderCreate,
-  type ProviderPreset,
   type ProviderUpdate,
+  type VendorPreset,
 } from '@cubebox/core'
-import { ProviderConfigForm } from '../ProviderConfigForm'
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+import { ProviderConfigForm, type CreatePreset } from '../ProviderConfigForm'
 
 interface ConfigureStepProps {
   client: ApiClient
-  preset: ProviderPreset
-  // Set once the provider has been created (e.g. user went forward then back to
-  // this step). When present, Next updates the existing row instead of creating
-  // a second provider (which would 409 on the name or orphan a row).
+  vendor: VendorPreset
+  selectedPresetKey: string | null
+  onSelectEndpoint: (presetKey: string) => void
+  // Set once the provider has been created (revisit case): update instead of
+  // creating a second row.
   existingProviderId?: string | null
   onProviderCreated: (providerId: string) => void
 }
 
+function uniq<T>(xs: T[]): T[] {
+  return [...new Set(xs)]
+}
+
 export function ConfigureStep({
   client,
-  preset,
+  vendor,
+  selectedPresetKey,
+  onSelectEndpoint,
   existingProviderId,
   onProviderCreated,
 }: ConfigureStepProps) {
@@ -33,12 +43,54 @@ export function ConfigureStep({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // The currently-selected endpoint: the one matching selectedPresetKey, else
+  // the vendor's first endpoint.
+  const endpoint: EndpointPreset =
+    vendor.endpoints.find((e) => e.preset_key === selectedPresetKey) ?? vendor.endpoints[0]
+
+  const [region, setRegion] = useState(endpoint.region)
+  const [protocol, setProtocol] = useState<string>(endpoint.protocol)
+  const [plan, setPlan] = useState<string | null>(endpoint.plan)
+
+  const regions = useMemo(() => uniq(vendor.endpoints.map((e) => e.region)), [vendor])
+  const protocols = useMemo(
+    () => uniq(vendor.endpoints.filter((e) => e.region === region).map((e) => e.protocol)),
+    [vendor, region],
+  )
+  const plans = useMemo(
+    () =>
+      vendor.endpoints
+        .filter((e) => e.region === region && e.protocol === protocol)
+        .map((e) => e.plan),
+    [vendor, region, protocol],
+  )
+
+  // The endpoint resolved from the three selectors (falls back to first match).
+  const chosen: EndpointPreset =
+    vendor.endpoints.find(
+      (e) => e.region === region && e.protocol === protocol && e.plan === plan,
+    ) ??
+    vendor.endpoints.find((e) => e.region === region && e.protocol === protocol) ??
+    endpoint
+
+  // Keep the wizard state's selectedPresetKey in sync with the chosen endpoint.
+  useEffect(() => {
+    if (chosen.preset_key !== selectedPresetKey) onSelectEndpoint(chosen.preset_key)
+  }, [chosen.preset_key, selectedPresetKey, onSelectEndpoint])
+
+  const createPreset: CreatePreset = {
+    display_name: vendor.display_name,
+    base_url: chosen.base_url,
+    provider_type: chosen.protocol,
+    preset_key: chosen.preset_key,
+    category: vendor.category,
+  }
+
   async function handleSubmit(body: ProviderCreate | ProviderUpdate) {
     setSaving(true)
     setError(null)
     try {
       if (existingProviderId) {
-        // Revisit: update the already-created provider instead of creating again.
         await updateProvider(client, existingProviderId, body as ProviderUpdate)
         onProviderCreated(existingProviderId)
       } else {
@@ -51,16 +103,91 @@ export function ConfigureStep({
     }
   }
 
+  const showSelectors = regions.length > 1 || protocols.length > 1 || plans.length > 1
+
   return (
-    <div className="mx-auto w-full max-w-xl">
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-4">
+      {showSelectors && (
+        <div className="grid grid-cols-3 gap-3 rounded-lg border border-border/70 p-3">
+          <Selector
+            label={t('region')}
+            value={region}
+            options={regions.map((r) => ({ value: r, label: r }))}
+            onChange={(v) => {
+              setRegion(v)
+              // reset downstream choices to the first valid value
+              const proto = vendor.endpoints.find((e) => e.region === v)?.protocol
+              if (proto) setProtocol(proto)
+              const pl = vendor.endpoints.find((e) => e.region === v && e.protocol === proto)?.plan
+              setPlan(pl ?? null)
+            }}
+          />
+          <Selector
+            label={t('protocol')}
+            value={protocol}
+            options={protocols.map((p) => ({ value: p, label: p }))}
+            onChange={(v) => {
+              setProtocol(v)
+              const pl = vendor.endpoints.find((e) => e.region === region && e.protocol === v)?.plan
+              setPlan(pl ?? null)
+            }}
+          />
+          <Selector
+            label={t('plan')}
+            value={plan ?? ''}
+            disabled={plans.length <= 1}
+            options={plans.map((p) => ({ value: p ?? '', label: p ?? '—' }))}
+            onChange={(v) => setPlan(v || null)}
+          />
+        </div>
+      )}
+
       <ProviderConfigForm
+        key={chosen.preset_key}
         mode="create"
-        preset={preset}
+        preset={createPreset}
         saving={saving}
         error={error}
         submitLabel={tw('next')}
         onSubmit={(body) => void handleSubmit(body)}
       />
+    </div>
+  )
+}
+
+function Selector({
+  label,
+  value,
+  options,
+  onChange,
+  disabled,
+}: {
+  label: string
+  value: string
+  options: { value: string; label: string }[]
+  onChange: (v: string) => void
+  disabled?: boolean
+}) {
+  const id = `endpoint-sel-${label.toLowerCase()}`
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <select
+        id={id}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        className={cn(
+          'h-8 w-full rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50',
+          disabled && 'opacity-60',
+        )}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
     </div>
   )
 }

--- a/frontend/packages/web/components/admin/models/wizard/ConfigureStep.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/ConfigureStep.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import {
+  ApiError,
   createProvider,
   updateProvider,
   type ApiClient,
@@ -99,9 +100,27 @@ export function ConfigureStep({
         onProviderCreated(provider.id)
       }
     } catch (e) {
-      setError((e as Error).message || t('createFailed'))
+      setError(errorMessage(e))
       setSaving(false)
     }
+  }
+
+  // Map the backend's stable error code (ApiError.code) to a human message —
+  // otherwise a slug/name conflict surfaces as a bare "HTTP 409".
+  function errorMessage(e: unknown): string {
+    if (e instanceof ApiError) {
+      switch (e.code) {
+        case 'provider_slug_conflict':
+          return t('errors.provider_slug_conflict')
+        case 'provider_name_conflict':
+          return t('errors.provider_name_conflict')
+        case 'invalid_provider_slug':
+          return t('errors.invalid_provider_slug')
+        case 'provider_oauth_not_implemented':
+          return t('errors.provider_oauth_not_implemented')
+      }
+    }
+    return (e as Error).message || t('createFailed')
   }
 
   const showSelectors = regions.length > 1 || protocols.length > 1 || plans.length > 1

--- a/frontend/packages/web/components/admin/models/wizard/LivenessRow.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/LivenessRow.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl'
 import { CheckCircle2, Loader2, XCircle } from 'lucide-react'
 import type { ProbeStep } from '@cubebox/core'
 import { cn } from '@/lib/utils'
+import { formatProbeDetail } from '@/lib/probeDetail'
 
 interface LivenessRowProps {
   step: ProbeStep | null
@@ -14,11 +15,13 @@ export function LivenessRow({ step, running }: LivenessRowProps) {
   const t = useTranslations('adminModels.wizard.test')
   const status = step?.status ?? null
   const ok = status === 'pass' || status === 'warn'
+  // Show the failure reason in full (wrapping) rather than a clipped raw blob.
+  const reason = status === 'fail' ? formatProbeDetail(step?.detail ?? step?.error?.message) : ''
 
   return (
     <div
       className={cn(
-        'flex items-center gap-2.5 rounded-lg border px-3 py-2.5',
+        'flex flex-col gap-1.5 rounded-lg border px-3 py-2.5',
         ok
           ? 'border-green-500/40 bg-green-500/5'
           : status === 'fail'
@@ -26,23 +29,23 @@ export function LivenessRow({ step, running }: LivenessRowProps) {
             : 'border-border/70',
       )}
     >
-      {!step && running ? (
-        <Loader2 className="size-4 animate-spin text-muted-foreground" />
-      ) : ok ? (
-        <CheckCircle2 className="size-4 text-green-600 dark:text-green-400" />
-      ) : status === 'fail' ? (
-        <XCircle className="size-4 text-destructive" />
-      ) : (
-        <Loader2 className="size-4 animate-spin text-muted-foreground" />
-      )}
-      <span className="flex-1 text-sm font-medium">{t('liveness')}</span>
-      {step?.latency_ms != null && (
-        <span className="text-xs text-muted-foreground">{step.latency_ms} ms</span>
-      )}
-      {step?.error?.message && (
-        <span className="truncate text-xs text-destructive">{step.error.message}</span>
-      )}
-      {!step && <span className="text-xs text-muted-foreground">{t('livenessPending')}</span>}
+      <div className="flex items-center gap-2.5">
+        {!step && running ? (
+          <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground" />
+        ) : ok ? (
+          <CheckCircle2 className="size-4 shrink-0 text-green-600 dark:text-green-400" />
+        ) : status === 'fail' ? (
+          <XCircle className="size-4 shrink-0 text-destructive" />
+        ) : (
+          <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground" />
+        )}
+        <span className="flex-1 text-sm font-medium">{t('liveness')}</span>
+        {step?.latency_ms != null && (
+          <span className="text-xs text-muted-foreground">{step.latency_ms} ms</span>
+        )}
+        {!step && <span className="text-xs text-muted-foreground">{t('livenessPending')}</span>}
+      </div>
+      {reason && <p className="pl-[26px] text-xs break-words text-destructive">{reason}</p>}
     </div>
   )
 }

--- a/frontend/packages/web/components/admin/models/wizard/ModelTestCard.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/ModelTestCard.tsx
@@ -6,6 +6,7 @@ import type { ProbeResult, ProbeStep } from '@cubebox/core'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { formatProbeDetail } from '@/lib/probeDetail'
 
 export interface ModelTestState extends ProbeResult {
   model_db_id: string
@@ -36,7 +37,7 @@ function StepChip({ step }: { step: ProbeStep }) {
           : Minus
   return (
     <span
-      title={step.detail ?? step.error?.message ?? step.name}
+      title={formatProbeDetail(step.detail ?? step.error?.message) || step.name}
       className={cn(
         'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium',
         tone,
@@ -81,7 +82,7 @@ export function ModelTestCard({ state, onRetest }: ModelTestCardProps) {
         <ul className="flex flex-col gap-1 border-t border-border/60 pt-2">
           {issues.map((s) => {
             const isFail = s.status === 'fail'
-            const detail = s.detail ?? s.error?.message
+            const detail = formatProbeDetail(s.detail ?? s.error?.message)
             return (
               <li key={s.name} className="flex items-start gap-1.5 text-xs">
                 {isFail ? (

--- a/frontend/packages/web/components/admin/models/wizard/ModelsStep.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/ModelsStep.tsx
@@ -39,6 +39,10 @@ interface ModelsStepProps {
   /** The endpoint chosen in step 2 — its preset_key. */
   presetKey: string
   providerId: string
+  /** Models persisted on a prior visit to this step (the wizard keeps them when
+   *  the user steps back). Seeds the dedupe cache so re-entering doesn't re-POST
+   *  and 409 on the already-created ids. */
+  existingModels: CreatedModel[]
   onModelsCreated: (models: CreatedModel[]) => void
 }
 
@@ -47,6 +51,7 @@ export function ModelsStep({
   vendor,
   presetKey,
   providerId,
+  existingModels,
   onModelsCreated,
 }: ModelsStepProps) {
   const t = useTranslations('adminModels.wizard.models')
@@ -80,9 +85,13 @@ export function ModelsStep({
   const [draftName, setDraftName] = useState('')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  // Models already created in a prior (failed) attempt, keyed by model_id, so a
-  // retry skips them instead of re-POSTing and 409-ing on the duplicate id.
-  const createdByModelId = useRef<Map<string, CreatedModel>>(new Map())
+  // Models already created — by a prior (failed) attempt within this mount, or by
+  // an earlier visit before the user stepped back (seeded from existingModels) —
+  // keyed by model_id, so a retry/re-entry skips them instead of re-POSTing and
+  // 409-ing on the duplicate id.
+  const createdByModelId = useRef<Map<string, CreatedModel>>(
+    new Map(existingModels.map((m) => [m.model_id, m])),
+  )
 
   const checkedCount = rows.filter((r) => r.checked).length
 

--- a/frontend/packages/web/components/admin/models/wizard/ModelsStep.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/ModelsStep.tsx
@@ -1,9 +1,15 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { Plus, Trash2 } from 'lucide-react'
-import { createModel, type ApiClient, type ModelCreate, type ProviderPreset } from '@cubebox/core'
+import {
+  createModel,
+  type ApiClient,
+  type ModelCreate,
+  type ModelPresetEntry,
+  type VendorPreset,
+} from '@cubebox/core'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -19,23 +25,42 @@ interface ModelRow {
   max_tokens: number
   input_modalities: string[]
   reasoning: boolean
+  cost_input: number
+  cost_output: number
+  cost_cache_read: number
+  cost_cache_write: number
   checked: boolean
   custom: boolean
 }
 
 interface ModelsStepProps {
   client: ApiClient
-  preset: ProviderPreset
+  vendor: VendorPreset
+  /** The endpoint chosen in step 2 — its preset_key. */
+  presetKey: string
   providerId: string
   onModelsCreated: (models: CreatedModel[]) => void
 }
 
-export function ModelsStep({ client, preset, providerId, onModelsCreated }: ModelsStepProps) {
+export function ModelsStep({
+  client,
+  vendor,
+  presetKey,
+  providerId,
+  onModelsCreated,
+}: ModelsStepProps) {
   const t = useTranslations('adminModels.wizard.models')
   const tw = useTranslations('adminModels.wizard')
 
+  // Models the chosen endpoint serves (its model_ids mapped against the pool).
+  const endpointModels = useMemo<ModelPresetEntry[]>(() => {
+    const ep = vendor.endpoints.find((e) => e.preset_key === presetKey) ?? vendor.endpoints[0]
+    const ids = new Set(ep?.model_ids ?? [])
+    return vendor.models.filter((m) => ids.has(m.model_id))
+  }, [vendor, presetKey])
+
   const [rows, setRows] = useState<ModelRow[]>(() =>
-    preset.default_models.map((m, i) => ({
+    endpointModels.map((m, i) => ({
       key: `preset-${i}`,
       model_id: m.model_id,
       display_name: m.display_name,
@@ -43,6 +68,10 @@ export function ModelsStep({ client, preset, providerId, onModelsCreated }: Mode
       max_tokens: m.max_tokens,
       input_modalities: m.input_modalities,
       reasoning: m.reasoning,
+      cost_input: m.pricing.input,
+      cost_output: m.pricing.output,
+      cost_cache_read: m.pricing.cache_read ?? 0,
+      cost_cache_write: m.pricing.cache_write ?? 0,
       checked: true,
       custom: false,
     })),
@@ -74,6 +103,10 @@ export function ModelsStep({ client, preset, providerId, onModelsCreated }: Mode
         max_tokens: 4096,
         input_modalities: ['text'],
         reasoning: false,
+        cost_input: 0,
+        cost_output: 0,
+        cost_cache_read: 0,
+        cost_cache_write: 0,
         checked: true,
         custom: true,
       },
@@ -110,6 +143,10 @@ export function ModelsStep({ client, preset, providerId, onModelsCreated }: Mode
           max_tokens: r.max_tokens,
           input_modalities: r.input_modalities,
           reasoning: r.reasoning,
+          cost_input: r.cost_input,
+          cost_output: r.cost_output,
+          cost_cache_read: r.cost_cache_read,
+          cost_cache_write: r.cost_cache_write,
           enabled: false,
         }
         const model = await createModel(client, providerId, body)

--- a/frontend/packages/web/components/admin/models/wizard/ModelsStep.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/ModelsStep.tsx
@@ -8,13 +8,14 @@ import {
   type ApiClient,
   type ModelCreate,
   type ModelPresetEntry,
+  type ModelUpdate,
   type VendorPreset,
 } from '@cubebox/core'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
-import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
+import { ModelFormDialog } from '../ModelFormDialog'
 import type { CreatedModel } from './wizardMachine'
 
 interface ModelRow {
@@ -81,8 +82,7 @@ export function ModelsStep({
       custom: false,
     })),
   )
-  const [draftId, setDraftId] = useState('')
-  const [draftName, setDraftName] = useState('')
+  const [addOpen, setAddOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   // Models already created — by a prior (failed) attempt within this mount, or by
@@ -99,29 +99,32 @@ export function ModelsStep({
     setRows((prev) => prev.map((r) => (r.key === key ? { ...r, checked: !r.checked } : r)))
   }
 
-  function addCustom() {
-    const id = draftId.trim()
-    if (!id) return
+  // Custom models use the same full form as the models-management page (model id,
+  // modalities, reasoning, context/limits, pricing) instead of a stripped id+name
+  // pair — the dialog collects a ModelCreate, which we stage as a row (the POST
+  // happens on Next, like every other selected row).
+  function handleAddCustom(body: ModelCreate | ModelUpdate): Promise<void> {
+    const m = body as ModelCreate
     setRows((prev) => [
       ...prev,
       {
         key: `custom-${Date.now()}`,
-        model_id: id,
-        display_name: draftName.trim() || id,
-        context_window: 128000,
-        max_tokens: 4096,
-        input_modalities: ['text'],
-        reasoning: false,
-        cost_input: 0,
-        cost_output: 0,
-        cost_cache_read: 0,
-        cost_cache_write: 0,
+        model_id: m.model_id,
+        display_name: m.display_name || m.model_id,
+        context_window: m.context_window ?? 0,
+        max_tokens: m.max_tokens ?? 0,
+        input_modalities: m.input_modalities ?? ['text'],
+        reasoning: m.reasoning ?? false,
+        cost_input: m.cost_input ?? 0,
+        cost_output: m.cost_output ?? 0,
+        cost_cache_read: m.cost_cache_read ?? 0,
+        cost_cache_write: m.cost_cache_write ?? 0,
         checked: true,
         custom: true,
       },
     ])
-    setDraftId('')
-    setDraftName('')
+    setAddOpen(false)
+    return Promise.resolve()
   }
 
   function removeRow(key: string) {
@@ -217,34 +220,23 @@ export function ModelsStep({
         ))}
       </div>
 
-      <div className="flex items-end gap-2 rounded-lg border border-dashed border-border/70 p-3">
-        <div className="flex flex-1 flex-col gap-1">
-          <Input
-            value={draftId}
-            onChange={(e) => setDraftId(e.target.value)}
-            placeholder={t('modelId')}
-            aria-label={t('modelId')}
-          />
-        </div>
-        <div className="flex flex-1 flex-col gap-1">
-          <Input
-            value={draftName}
-            onChange={(e) => setDraftName(e.target.value)}
-            placeholder={t('displayName')}
-            aria-label={t('displayName')}
-          />
-        </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={!draftId.trim()}
-          onClick={addCustom}
-        >
-          <Plus className="size-3.5" />
-          {t('add')}
-        </Button>
-      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="self-start"
+        onClick={() => setAddOpen(true)}
+      >
+        <Plus className="size-3.5" />
+        {t('addCustom')}
+      </Button>
+
+      <ModelFormDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        model={null}
+        onSave={handleAddCustom}
+      />
 
       {checkedCount === 0 && <p className="text-xs text-muted-foreground">{t('empty')}</p>}
 

--- a/frontend/packages/web/components/admin/models/wizard/PresetPicker.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/PresetPicker.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { Search } from 'lucide-react'
-import { listPresets, type ApiClient, type ProviderPreset } from '@cubebox/core'
+import { listPresets, type ApiClient, type VendorPreset } from '@cubebox/core'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -11,26 +11,16 @@ import { ProviderLogo } from '@/components/admin/models/ProviderLogo'
 import { cn } from '@/lib/utils'
 
 type Category = 'all' | 'saas' | 'oss-framework' | 'custom'
-type ReasoningShapeKey = 'reasoningBudget' | 'reasoningEffort' | 'reasoningStandard'
 
 interface PresetPickerProps {
   client: ApiClient
-  selectedSlug: string | null
-  onPick: (preset: ProviderPreset) => void
+  selectedVendor: string | null
+  onPickVendor: (vendor: VendorPreset) => void
 }
 
-// The reasoning "shape" badge is derived from capability.reasoning_level.kind:
-// int_budget → budget, effort/enum → effort, otherwise standard.
-function reasoningShapeKey(preset: ProviderPreset): ReasoningShapeKey {
-  const level = preset.capability.reasoning_level as { kind?: string } | undefined
-  if (level?.kind === 'int_budget') return 'reasoningBudget'
-  if (level?.kind === 'effort' || level?.kind === 'enum') return 'reasoningEffort'
-  return 'reasoningStandard'
-}
-
-export function PresetPicker({ client, selectedSlug, onPick }: PresetPickerProps) {
+export function PresetPicker({ client, selectedVendor, onPickVendor }: PresetPickerProps) {
   const t = useTranslations('adminModels.wizard.preset')
-  const [presets, setPresets] = useState<ProviderPreset[]>([])
+  const [vendors, setVendors] = useState<VendorPreset[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [query, setQuery] = useState('')
@@ -41,8 +31,8 @@ export function PresetPicker({ client, selectedSlug, onPick }: PresetPickerProps
     // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount loading flag
     setLoading(true)
     listPresets(client)
-      .then((ps) => {
-        if (!cancelled) setPresets(ps)
+      .then((vs) => {
+        if (!cancelled) setVendors(vs)
       })
       .catch(() => {
         if (!cancelled) setError(t('loadFailed'))
@@ -57,14 +47,14 @@ export function PresetPicker({ client, selectedSlug, onPick }: PresetPickerProps
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()
-    return presets.filter((p) => {
-      if (category !== 'all' && p.category !== category) return false
-      if (q && !p.display_name.toLowerCase().includes(q) && !p.slug.toLowerCase().includes(q)) {
+    return vendors.filter((v) => {
+      if (category !== 'all' && v.category !== category) return false
+      if (q && !v.display_name.toLowerCase().includes(q) && !v.vendor.toLowerCase().includes(q)) {
         return false
       }
       return true
     })
-  }, [presets, query, category])
+  }, [vendors, query, category])
 
   return (
     <div className="flex flex-col gap-4">
@@ -97,15 +87,15 @@ export function PresetPicker({ client, selectedSlug, onPick }: PresetPickerProps
         <p className="py-12 text-center text-sm text-muted-foreground">{t('empty')}</p>
       ) : (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-          {filtered.map((preset) => {
-            const selected = preset.slug === selectedSlug
+          {filtered.map((vendor) => {
+            const selected = vendor.vendor === selectedVendor
             return (
               <button
-                key={preset.slug}
+                key={vendor.vendor}
                 type="button"
-                aria-label={preset.display_name}
+                aria-label={vendor.display_name}
                 aria-pressed={selected}
-                onClick={() => onPick(preset)}
+                onClick={() => onPickVendor(vendor)}
                 className={cn(
                   'group flex flex-col gap-2 rounded-lg border bg-card p-4 text-left transition-all hover:border-primary/50 hover:shadow-sm',
                   selected ? 'border-primary ring-1 ring-primary/30' : 'border-border/70',
@@ -113,25 +103,29 @@ export function PresetPicker({ client, selectedSlug, onPick }: PresetPickerProps
               >
                 <div className="flex items-center gap-2.5">
                   <ProviderLogo
-                    name={preset.display_name}
+                    name={vendor.display_name}
                     logoUrl={null}
-                    logo={preset.logo}
+                    logo={vendor.logo}
                     size="lg"
                   />
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-semibold leading-tight">
-                      {preset.display_name}
+                      {vendor.display_name}
                     </p>
-                    <p className="truncate text-xs text-muted-foreground">{preset.api}</p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {t('endpointCount', { count: vendor.endpoints.length })}
+                    </p>
                   </div>
                 </div>
                 <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground/80">
-                  {preset.description}
+                  {vendor.description}
                 </p>
                 <div className="mt-auto flex flex-wrap gap-1.5 pt-1">
-                  <Badge variant="secondary" className="font-normal">
-                    {t(reasoningShapeKey(preset))}
-                  </Badge>
+                  {uniqueProtocols(vendor).map((p) => (
+                    <Badge key={p} variant="secondary" className="font-normal">
+                      {p}
+                    </Badge>
+                  ))}
                 </div>
               </button>
             )
@@ -140,4 +134,8 @@ export function PresetPicker({ client, selectedSlug, onPick }: PresetPickerProps
       )}
     </div>
   )
+}
+
+function uniqueProtocols(vendor: VendorPreset): string[] {
+  return [...new Set(vendor.endpoints.map((e) => e.protocol))]
 }

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/ConfigureStep.test.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/ConfigureStep.test.tsx
@@ -119,6 +119,23 @@ describe('ConfigureStep', () => {
     await waitFor(() => expect(onProviderCreated).toHaveBeenCalledWith('prv_existing'))
   })
 
+  it('shows a friendly message on a slug conflict instead of a bare HTTP 409', async () => {
+    vi.mocked(core.createProvider).mockRejectedValueOnce(
+      new core.ApiError('HTTP 409', 409, 'provider_slug_conflict', {
+        code: 'provider_slug_conflict',
+      }),
+    )
+    renderStep()
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-123' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await waitFor(() =>
+      expect(
+        screen.getByText(en.adminModels.wizard.configure.errors.provider_slug_conflict),
+      ).toBeInTheDocument(),
+    )
+    expect(screen.queryByText('HTTP 409')).not.toBeInTheDocument()
+  })
+
   it('endpoint selectors drive the composed base_url + preset_key', async () => {
     const { onSelectEndpoint } = renderStep(zhipu)
 

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/ConfigureStep.test.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/ConfigureStep.test.tsx
@@ -51,6 +51,7 @@ const zhipu = makeVendor({
       plan: 'general',
       base_url: 'https://api.z.ai/api/paas/v4',
       model_ids: ['glm-5'],
+      capability: { supports_tools: true, temperature: { mode: 'free', default: 0.7 } },
     },
     {
       preset_key: 'zhipu/cn/openai-completions/general',
@@ -59,6 +60,7 @@ const zhipu = makeVendor({
       plan: 'general',
       base_url: 'https://open.bigmodel.cn/api/paas/v4',
       model_ids: ['glm-5'],
+      capability: { supports_tools: true, temperature: { mode: 'free', default: 0.7 } },
     },
   ],
   models: [

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/ConfigureStep.test.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/ConfigureStep.test.tsx
@@ -33,6 +33,8 @@ function renderStep(
         onSelectEndpoint={onSelectEndpoint}
         existingProviderId={existingProviderId}
         onProviderCreated={onProviderCreated}
+        configDraft={null}
+        onConfigDraftChange={vi.fn()}
       />
     </NextIntlClientProvider>,
   )
@@ -134,6 +136,69 @@ describe('ConfigureStep', () => {
       ).toBeInTheDocument(),
     )
     expect(screen.queryByText('HTTP 409')).not.toBeInTheDocument()
+  })
+
+  it('restores a saved draft for the current endpoint (revisit)', () => {
+    const vendor = makeVendor()
+    const draft = {
+      presetKey: vendor.endpoints[0].preset_key,
+      name: 'Restored Name',
+      slug: 'restored-slug',
+      slugTouched: true,
+      baseUrl: 'https://api.anthropic.com',
+      apiKey: 'sk-kept',
+      authChoice: 'api_key' as const,
+      capability: {},
+      logoUrl: '',
+      extraHeaders: '',
+    }
+    render(
+      <NextIntlClientProvider locale="en" messages={en}>
+        <ConfigureStep
+          client={fakeClient}
+          vendor={vendor}
+          selectedPresetKey={vendor.endpoints[0].preset_key}
+          onSelectEndpoint={vi.fn()}
+          existingProviderId="prv_1"
+          onProviderCreated={vi.fn()}
+          configDraft={draft}
+          onConfigDraftChange={vi.fn()}
+        />
+      </NextIntlClientProvider>,
+    )
+    expect(screen.getByLabelText('Name')).toHaveValue('Restored Name')
+  })
+
+  it('ignores a draft from a different endpoint (falls back to preset default)', () => {
+    const vendor = makeVendor()
+    const draft = {
+      presetKey: 'some/other/endpoint',
+      name: 'Restored Name',
+      slug: 'restored-slug',
+      slugTouched: true,
+      baseUrl: 'x',
+      apiKey: '',
+      authChoice: 'api_key' as const,
+      capability: {},
+      logoUrl: '',
+      extraHeaders: '',
+    }
+    render(
+      <NextIntlClientProvider locale="en" messages={en}>
+        <ConfigureStep
+          client={fakeClient}
+          vendor={vendor}
+          selectedPresetKey={vendor.endpoints[0].preset_key}
+          onSelectEndpoint={vi.fn()}
+          existingProviderId={null}
+          onProviderCreated={vi.fn()}
+          configDraft={draft}
+          onConfigDraftChange={vi.fn()}
+        />
+      </NextIntlClientProvider>,
+    )
+    // Mismatched endpoint → preset default name, not the stale draft.
+    expect(screen.getByLabelText('Name')).toHaveValue('Anthropic')
   })
 
   it('endpoint selectors drive the composed base_url + preset_key', async () => {

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/ConfigureStep.test.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/ConfigureStep.test.tsx
@@ -1,11 +1,11 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { NextIntlClientProvider } from 'next-intl'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { ApiClient, Provider } from '@cubebox/core'
+import type { ApiClient, Provider, VendorPreset } from '@cubebox/core'
 import * as core from '@cubebox/core'
 import en from '../../../../../messages/en.json'
 import { ConfigureStep } from '../ConfigureStep'
-import { makePreset } from './fixtures'
+import { makeVendor } from './fixtures'
 
 vi.mock('@cubebox/core', async (importOriginal) => {
   const actual = await importOriginal<typeof core>()
@@ -19,22 +19,61 @@ function created(id: string): Provider {
 }
 
 function renderStep(
-  preset = makePreset(),
+  vendor: VendorPreset = makeVendor(),
   onProviderCreated = vi.fn(),
   existingProviderId?: string | null,
+  onSelectEndpoint = vi.fn(),
 ) {
   render(
     <NextIntlClientProvider locale="en" messages={en}>
       <ConfigureStep
         client={fakeClient}
-        preset={preset}
+        vendor={vendor}
+        selectedPresetKey={vendor.endpoints[0].preset_key}
+        onSelectEndpoint={onSelectEndpoint}
         existingProviderId={existingProviderId}
         onProviderCreated={onProviderCreated}
       />
     </NextIntlClientProvider>,
   )
-  return { onProviderCreated }
+  return { onProviderCreated, onSelectEndpoint }
 }
+
+// A tiered, multi-region vendor for exercising the endpoint selectors.
+const zhipu = makeVendor({
+  vendor: 'zhipu',
+  display_name: 'Zhipu',
+  endpoints: [
+    {
+      preset_key: 'zhipu/intl/openai-completions/general',
+      region: 'intl',
+      protocol: 'openai-completions',
+      plan: 'general',
+      base_url: 'https://api.z.ai/api/paas/v4',
+      model_ids: ['glm-5'],
+    },
+    {
+      preset_key: 'zhipu/cn/openai-completions/general',
+      region: 'cn',
+      protocol: 'openai-completions',
+      plan: 'general',
+      base_url: 'https://open.bigmodel.cn/api/paas/v4',
+      model_ids: ['glm-5'],
+    },
+  ],
+  models: [
+    {
+      model_id: 'glm-5',
+      display_name: 'GLM-5',
+      plan: ['general'],
+      context_window: 200000,
+      max_tokens: 32768,
+      input_modalities: ['text'],
+      reasoning: true,
+      pricing: { input: 0, output: 0 },
+    },
+  ],
+})
 
 describe('ConfigureStep', () => {
   beforeEach(() => {
@@ -44,24 +83,11 @@ describe('ConfigureStep', () => {
     vi.mocked(core.updateProvider).mockResolvedValue(created('prv_existing'))
   })
 
-  it('revisit: updates the existing provider instead of creating a second one', async () => {
-    const preset = makePreset({ auth: { mode: 'api_key', header_name: 'x-api-key' } })
-    const { onProviderCreated } = renderStep(preset, vi.fn(), 'prv_existing')
-    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-123' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
-    await waitFor(() => expect(core.updateProvider).toHaveBeenCalled())
-    expect(vi.mocked(core.updateProvider).mock.calls[0][1]).toBe('prv_existing')
-    expect(core.createProvider).not.toHaveBeenCalled()
-    await waitFor(() => expect(onProviderCreated).toHaveBeenCalledWith('prv_existing'))
-  })
-
-  it('api_key preset: requires a key, then creates provider with mapped body', async () => {
-    const preset = makePreset({ auth: { mode: 'api_key', header_name: 'x-api-key' } })
-    const { onProviderCreated } = renderStep(preset)
+  it('creates a provider with the selected endpoint mapped into the body', async () => {
+    const { onProviderCreated } = renderStep()
 
     const next = screen.getByRole('button', { name: 'Next' })
     expect(next).toBeDisabled()
-
     fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-123' } })
     expect(next).toBeEnabled()
     fireEvent.click(next)
@@ -74,36 +100,36 @@ describe('ConfigureStep', () => {
       base_url: 'https://api.anthropic.com',
       auth_type: 'api_key',
       api_key: 'sk-123',
-      preset_slug: 'anthropic',
+      preset_slug: 'anthropic/intl/anthropic-messages',
     })
-    expect(body.capability).toEqual(preset.capability)
+    // capability is resolved server-side -> not sent from the wizard.
+    expect(body.capability).toBeUndefined()
     await waitFor(() => expect(onProviderCreated).toHaveBeenCalledWith('prv_new'))
   })
 
-  it('bearer preset maps auth_type to bearer_token', async () => {
-    const preset = makePreset({ slug: 'tgi', auth: { mode: 'bearer' } })
-    renderStep(preset)
-    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'tok' } })
+  it('revisit: updates the existing provider instead of creating a second one', async () => {
+    const { onProviderCreated } = renderStep(makeVendor(), vi.fn(), 'prv_existing')
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-123' } })
     fireEvent.click(screen.getByRole('button', { name: 'Next' }))
-    await waitFor(() => expect(core.createProvider).toHaveBeenCalled())
-    expect(vi.mocked(core.createProvider).mock.calls[0][1].auth_type).toBe('bearer_token')
+    await waitFor(() => expect(core.updateProvider).toHaveBeenCalled())
+    expect(vi.mocked(core.updateProvider).mock.calls[0][1]).toBe('prv_existing')
+    expect(core.createProvider).not.toHaveBeenCalled()
+    await waitFor(() => expect(onProviderCreated).toHaveBeenCalledWith('prv_existing'))
   })
 
-  it('none preset: no key input, Next enabled, auth_type none', async () => {
-    const preset = makePreset({ slug: 'ollama', auth: { mode: 'none' } })
-    renderStep(preset)
-    expect(screen.queryByLabelText('API key')).not.toBeInTheDocument()
-    const next = screen.getByRole('button', { name: 'Next' })
-    expect(next).toBeEnabled()
-    fireEvent.click(next)
-    await waitFor(() => expect(core.createProvider).toHaveBeenCalled())
-    expect(vi.mocked(core.createProvider).mock.calls[0][1].auth_type).toBe('none')
-  })
+  it('endpoint selectors drive the composed base_url + preset_key', async () => {
+    const { onSelectEndpoint } = renderStep(zhipu)
 
-  it('oauth preset: Next disabled with unsupported note', () => {
-    const preset = makePreset({ slug: 'anthropic-cc', auth: { mode: 'oauth' } })
-    renderStep(preset)
-    expect(screen.getByText("OAuth/IAM presets aren't supported yet.")).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
+    // Default endpoint = first (intl) -> its base_url shows in the form.
+    const baseUrl = screen.getByLabelText('Base URL') as HTMLInputElement
+    expect(baseUrl.value).toBe('https://api.z.ai/api/paas/v4')
+
+    // Switch the Region selector to CN.
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'cn' } })
+    await waitFor(() =>
+      expect(onSelectEndpoint).toHaveBeenCalledWith('zhipu/cn/openai-completions/general'),
+    )
+    const baseUrlAfter = screen.getByLabelText('Base URL') as HTMLInputElement
+    expect(baseUrlAfter.value).toBe('https://open.bigmodel.cn/api/paas/v4')
   })
 })

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/ModelsStep.test.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/ModelsStep.test.tsx
@@ -5,7 +5,7 @@ import type { ApiClient, Model } from '@cubebox/core'
 import * as core from '@cubebox/core'
 import en from '../../../../../messages/en.json'
 import { ModelsStep } from '../ModelsStep'
-import { makePreset } from './fixtures'
+import { makeVendor } from './fixtures'
 
 vi.mock('@cubebox/core', async (importOriginal) => {
   const actual = await importOriginal<typeof core>()
@@ -14,23 +14,39 @@ vi.mock('@cubebox/core', async (importOriginal) => {
 
 const fakeClient = {} as ApiClient
 
-const preset = makePreset({
-  default_models: [
+const PRESET_KEY = 'v/intl/openai-completions'
+const vendor = makeVendor({
+  vendor: 'v',
+  endpoints: [
+    {
+      preset_key: PRESET_KEY,
+      region: 'intl',
+      protocol: 'openai-completions',
+      plan: null,
+      base_url: 'https://x/v1',
+      model_ids: ['m-a', 'm-b'],
+    },
+  ],
+  models: [
     {
       model_id: 'm-a',
       display_name: 'Model A',
+      plan: null,
       context_window: 100,
       max_tokens: 50,
       input_modalities: ['text'],
       reasoning: true,
+      pricing: { input: 0, output: 0 },
     },
     {
       model_id: 'm-b',
       display_name: 'Model B',
+      plan: null,
       context_window: 200,
       max_tokens: 80,
       input_modalities: ['text', 'image'],
       reasoning: false,
+      pricing: { input: 0, output: 0 },
     },
   ],
 })
@@ -40,7 +56,8 @@ function renderStep(onModelsCreated = vi.fn()) {
     <NextIntlClientProvider locale="en" messages={en}>
       <ModelsStep
         client={fakeClient}
-        preset={preset}
+        vendor={vendor}
+        presetKey={PRESET_KEY}
         providerId="prv_1"
         onModelsCreated={onModelsCreated}
       />
@@ -59,7 +76,7 @@ describe('ModelsStep', () => {
     })
   })
 
-  it('renders default models checked by default', () => {
+  it('renders endpoint models checked by default', () => {
     renderStep()
     expect(screen.getByText('Model A')).toBeInTheDocument()
     expect(screen.getByText('Model B')).toBeInTheDocument()

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/ModelsStep.test.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/ModelsStep.test.tsx
@@ -5,6 +5,7 @@ import type { ApiClient, Model } from '@cubebox/core'
 import * as core from '@cubebox/core'
 import en from '../../../../../messages/en.json'
 import { ModelsStep } from '../ModelsStep'
+import type { CreatedModel } from '../wizardMachine'
 import { makeVendor } from './fixtures'
 
 vi.mock('@cubebox/core', async (importOriginal) => {
@@ -51,7 +52,7 @@ const vendor = makeVendor({
   ],
 })
 
-function renderStep(onModelsCreated = vi.fn()) {
+function renderStep(onModelsCreated = vi.fn(), existingModels: CreatedModel[] = []) {
   render(
     <NextIntlClientProvider locale="en" messages={en}>
       <ModelsStep
@@ -59,6 +60,7 @@ function renderStep(onModelsCreated = vi.fn()) {
         vendor={vendor}
         presetKey={PRESET_KEY}
         providerId="prv_1"
+        existingModels={existingModels}
         onModelsCreated={onModelsCreated}
       />
     </NextIntlClientProvider>,
@@ -118,6 +120,20 @@ describe('ModelsStep', () => {
         { id: 'mdl_1', model_id: 'm-a', display_name: 'Model A' },
       ]),
     )
+  })
+
+  it('re-entering after stepping back does not re-create models already persisted', async () => {
+    // The wizard unmounts this step on "back" and remounts on "next", passing the
+    // previously-created models as existingModels. handleNext must reuse them
+    // instead of re-POSTing (which 409s "already exists in this provider").
+    const existing: CreatedModel[] = [
+      { id: 'mdl_1', model_id: 'm-a', display_name: 'Model A' },
+      { id: 'mdl_2', model_id: 'm-b', display_name: 'Model B' },
+    ]
+    const { onModelsCreated } = renderStep(vi.fn(), existing)
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await waitFor(() => expect(onModelsCreated).toHaveBeenCalledWith(existing))
+    expect(core.createModel).not.toHaveBeenCalled()
   })
 
   it('retry after a mid-import failure skips already-created models', async () => {

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/ModelsStep.test.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/ModelsStep.test.tsx
@@ -85,6 +85,34 @@ describe('ModelsStep', () => {
     expect(screen.getByText('Model B')).toBeInTheDocument()
   })
 
+  it('adds a custom model via the full form dialog with config + pricing', async () => {
+    renderStep()
+    fireEvent.click(screen.getByRole('button', { name: en.adminModels.wizard.models.addCustom }))
+    // The shared model form dialog opens (same as the management page).
+    expect(await screen.findByTestId('model-form-dialog')).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('gpt-4o'), { target: { value: 'custom-x' } })
+    fireEvent.change(screen.getByPlaceholderText('GPT-4o'), { target: { value: 'Custom X' } })
+    fireEvent.change(screen.getByLabelText(en.adminModels.costInput), { target: { value: '1.5' } })
+    fireEvent.change(screen.getByLabelText(en.adminModels.contextWindow), {
+      target: { value: '64000' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: en.adminModels.save }))
+
+    // The new row is staged and included on Next, carrying its config + pricing.
+    expect(await screen.findByText('Custom X')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await waitFor(() => {
+      const call = vi.mocked(core.createModel).mock.calls.find((c) => c[2].model_id === 'custom-x')
+      expect(call).toBeDefined()
+      expect(call?.[2]).toMatchObject({
+        model_id: 'custom-x',
+        cost_input: 1.5,
+        context_window: 64000,
+        enabled: false,
+      })
+    })
+  })
+
   it('Next creates a model per checked entry with enabled:false and collects ids', async () => {
     const { onModelsCreated } = renderStep()
     fireEvent.click(screen.getByRole('button', { name: 'Next' }))

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/ModelsStep.test.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/ModelsStep.test.tsx
@@ -26,6 +26,7 @@ const vendor = makeVendor({
       plan: null,
       base_url: 'https://x/v1',
       model_ids: ['m-a', 'm-b'],
+      capability: { supports_tools: true },
     },
   ],
   models: [

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/PresetPicker.test.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/PresetPicker.test.tsx
@@ -45,6 +45,7 @@ const ollama = makeVendor({
       plan: null,
       base_url: 'http://localhost:11434/v1',
       model_ids: [],
+      capability: {},
     },
   ],
   models: [],

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/PresetPicker.test.tsx
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/PresetPicker.test.tsx
@@ -5,7 +5,7 @@ import type { ApiClient } from '@cubebox/core'
 import * as core from '@cubebox/core'
 import en from '../../../../../messages/en.json'
 import { PresetPicker } from '../PresetPicker'
-import { makePreset } from './fixtures'
+import { makeVendor } from './fixtures'
 
 vi.mock('@cubebox/core', async (importOriginal) => {
   const actual = await importOriginal<typeof core>()
@@ -13,34 +13,41 @@ vi.mock('@cubebox/core', async (importOriginal) => {
 })
 
 // ProviderLogo pulls @lobehub/icons, whose transitive @lobehub/ui has an ESM
-// resolution bug under vitest. Stub it — the picker test cares about behavior,
-// not the brand glyph.
+// resolution bug under vitest. Stub it — the picker test cares about behavior.
 vi.mock('@/components/admin/models/ProviderLogo', () => ({
   ProviderLogo: () => <div data-testid="provider-logo" aria-hidden />,
 }))
 
 const fakeClient = {} as ApiClient
 
-function renderPicker(onPick = vi.fn()): { onPick: ReturnType<typeof vi.fn> } {
+function renderPicker(onPickVendor = vi.fn()): { onPickVendor: ReturnType<typeof vi.fn> } {
   render(
     <NextIntlClientProvider locale="en" messages={en}>
-      <PresetPicker client={fakeClient} selectedSlug={null} onPick={onPick} />
+      <PresetPicker client={fakeClient} selectedVendor={null} onPickVendor={onPickVendor} />
     </NextIntlClientProvider>,
   )
-  return { onPick }
+  return { onPickVendor }
 }
 
-const anthropic = makePreset({ slug: 'anthropic', display_name: 'Anthropic', category: 'saas' })
-const ollama = makePreset({
-  slug: 'ollama',
+const anthropic = makeVendor({ vendor: 'anthropic', display_name: 'Anthropic', category: 'saas' })
+const ollama = makeVendor({
+  vendor: 'ollama',
   display_name: 'Ollama',
   short_name: 'Ollama',
   category: 'oss-framework',
   description: 'Local Ollama server.',
   logo: 'ollama',
-  api: 'openai-completions',
-  auth: { mode: 'none' },
-  capability: {},
+  endpoints: [
+    {
+      preset_key: 'ollama/local/openai-completions',
+      region: 'local',
+      protocol: 'openai-completions',
+      plan: null,
+      base_url: 'http://localhost:11434/v1',
+      model_ids: [],
+    },
+  ],
+  models: [],
 })
 
 describe('PresetPicker', () => {
@@ -48,18 +55,18 @@ describe('PresetPicker', () => {
     vi.mocked(core.listPresets).mockResolvedValue([anthropic, ollama])
   })
 
-  it('renders a card per preset from listPresets', async () => {
+  it('renders a card per vendor from listPresets', async () => {
     renderPicker()
     expect(await screen.findByText('Anthropic')).toBeInTheDocument()
     expect(screen.getByText('Ollama')).toBeInTheDocument()
     expect(core.listPresets).toHaveBeenCalledWith(fakeClient)
   })
 
-  it('calls onPick when a card is clicked', async () => {
-    const { onPick } = renderPicker()
+  it('calls onPickVendor when a card is clicked', async () => {
+    const { onPickVendor } = renderPicker()
     const card = await screen.findByRole('button', { name: /Anthropic/ })
     fireEvent.click(card)
-    expect(onPick).toHaveBeenCalledWith(anthropic)
+    expect(onPickVendor).toHaveBeenCalledWith(anthropic)
   })
 
   it('filters by search query', async () => {
@@ -82,10 +89,10 @@ describe('PresetPicker', () => {
     expect(screen.getByText('Ollama')).toBeInTheDocument()
   })
 
-  it('marks the selected preset', async () => {
+  it('marks the selected vendor', async () => {
     render(
       <NextIntlClientProvider locale="en" messages={en}>
-        <PresetPicker client={fakeClient} selectedSlug="anthropic" onPick={vi.fn()} />
+        <PresetPicker client={fakeClient} selectedVendor="anthropic" onPickVendor={vi.fn()} />
       </NextIntlClientProvider>,
     )
     const card = await screen.findByRole('button', { name: /Anthropic/ })

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/fixtures.ts
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/fixtures.ts
@@ -1,29 +1,33 @@
-import type { ProviderPreset } from '@cubebox/core'
+import type { VendorPreset } from '@cubebox/core'
 
-export function makePreset(over: Partial<ProviderPreset> = {}): ProviderPreset {
+export function makeVendor(over: Partial<VendorPreset> = {}): VendorPreset {
   return {
-    slug: 'anthropic',
+    vendor: 'anthropic',
     display_name: 'Anthropic',
     short_name: 'Anthropic',
     category: 'saas',
     description: 'Anthropic Claude (Messages API).',
     logo: 'anthropic',
-    api: 'anthropic-messages',
-    base_url: 'https://api.anthropic.com',
-    auth: { mode: 'api_key', header_name: 'x-api-key', header_prefix: '' },
-    capability: {
-      reasoning_level: { kind: 'int_budget' },
-      supports_tools: true,
-    },
-    model_capability_overrides: {},
-    default_models: [
+    endpoints: [
+      {
+        preset_key: 'anthropic/intl/anthropic-messages',
+        region: 'intl',
+        protocol: 'anthropic-messages',
+        plan: null,
+        base_url: 'https://api.anthropic.com',
+        model_ids: ['claude-opus-4-7'],
+      },
+    ],
+    models: [
       {
         model_id: 'claude-opus-4-7',
         display_name: 'Claude Opus 4.7',
+        plan: null,
         context_window: 1000000,
         max_tokens: 128000,
         input_modalities: ['text', 'image'],
         reasoning: true,
+        pricing: { input: 0, output: 0 },
       },
     ],
     ...over,

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/fixtures.ts
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/fixtures.ts
@@ -16,6 +16,7 @@ export function makeVendor(over: Partial<VendorPreset> = {}): VendorPreset {
         plan: null,
         base_url: 'https://api.anthropic.com',
         model_ids: ['claude-opus-4-7'],
+        capability: { supports_tools: true },
       },
     ],
     models: [

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/wizardMachine.test.ts
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/wizardMachine.test.ts
@@ -10,7 +10,25 @@ describe('wizardMachine', () => {
       selectedPresetKey: null,
       providerId: null,
       models: [],
+      configDraft: null,
     })
+  })
+
+  it('setConfigDraft stores the entered form values', () => {
+    const draft = {
+      presetKey: 'anthropic/intl/anthropic-messages',
+      name: 'My Provider',
+      slug: 'my-provider',
+      slugTouched: true,
+      baseUrl: 'https://api.anthropic.com',
+      apiKey: 'sk-1',
+      authChoice: 'api_key' as const,
+      capability: {},
+      logoUrl: '',
+      extraHeaders: '',
+    }
+    const s = wizardReducer(initialWizardState, { type: 'setConfigDraft', draft })
+    expect(s.configDraft).toEqual(draft)
   })
 
   it('pickVendor stores the vendor and resets the endpoint choice', () => {

--- a/frontend/packages/web/components/admin/models/wizard/__tests__/wizardMachine.test.ts
+++ b/frontend/packages/web/components/admin/models/wizard/__tests__/wizardMachine.test.ts
@@ -1,22 +1,38 @@
 import { describe, expect, it } from 'vitest'
 import { canAdvance, initialWizardState, wizardReducer, type WizardState } from '../wizardMachine'
-import { makePreset } from './fixtures'
+import { makeVendor } from './fixtures'
 
 describe('wizardMachine', () => {
   it('starts at step 1 with empty state', () => {
     expect(initialWizardState).toEqual({
       step: 1,
-      preset: null,
+      vendor: null,
+      selectedPresetKey: null,
       providerId: null,
       models: [],
     })
   })
 
-  it('pickPreset stores the preset', () => {
-    const preset = makePreset()
-    const s = wizardReducer(initialWizardState, { type: 'pickPreset', preset })
-    expect(s.preset).toBe(preset)
+  it('pickVendor stores the vendor and resets the endpoint choice', () => {
+    const vendor = makeVendor()
+    let s = wizardReducer(initialWizardState, {
+      type: 'selectEndpoint',
+      presetKey: 'stale/key',
+    })
+    s = wizardReducer(s, { type: 'pickVendor', vendor })
+    expect(s.vendor).toBe(vendor)
+    expect(s.selectedPresetKey).toBeNull()
     expect(s.step).toBe(1)
+  })
+
+  it('selectEndpoint records the chosen preset_key (step 2)', () => {
+    let s = wizardReducer(initialWizardState, { type: 'pickVendor', vendor: makeVendor() })
+    s = wizardReducer(s, { type: 'next' })
+    s = wizardReducer(s, {
+      type: 'selectEndpoint',
+      presetKey: 'anthropic/intl/anthropic-messages',
+    })
+    expect(s.selectedPresetKey).toBe('anthropic/intl/anthropic-messages')
   })
 
   it('providerCreated stores the provider id', () => {
@@ -38,19 +54,20 @@ describe('wizardMachine', () => {
     ])
   })
 
-  it('next does not advance from step 1 without a preset', () => {
+  it('next does not advance from step 1 without a vendor', () => {
     const s = wizardReducer(initialWizardState, { type: 'next' })
     expect(s.step).toBe(1)
   })
 
-  it('next advances to step 2 once a preset is picked', () => {
-    let s = wizardReducer(initialWizardState, { type: 'pickPreset', preset: makePreset() })
+  it('advances to step 2 once a vendor is picked (endpoint chosen in step 2)', () => {
+    let s = wizardReducer(initialWizardState, { type: 'pickVendor', vendor: makeVendor() })
+    expect(canAdvance(s)).toBe(true)
     s = wizardReducer(s, { type: 'next' })
     expect(s.step).toBe(2)
   })
 
   it('cannot advance to step 3 unless providerId is set', () => {
-    const atStep2: WizardState = { ...initialWizardState, step: 2, preset: makePreset() }
+    const atStep2: WizardState = { ...initialWizardState, step: 2, vendor: makeVendor() }
     expect(canAdvance(atStep2)).toBe(false)
     expect(wizardReducer(atStep2, { type: 'next' }).step).toBe(2)
 
@@ -63,7 +80,7 @@ describe('wizardMachine', () => {
     const atStep3: WizardState = {
       ...initialWizardState,
       step: 3,
-      preset: makePreset(),
+      vendor: makeVendor(),
       providerId: 'prv_1',
     }
     expect(canAdvance(atStep3)).toBe(false)

--- a/frontend/packages/web/components/admin/models/wizard/wizardMachine.ts
+++ b/frontend/packages/web/components/admin/models/wizard/wizardMachine.ts
@@ -11,6 +11,26 @@ export interface CreatedModel {
   display_name: string
 }
 
+/** The Configure-step form fields. Persisted in wizard state so stepping away
+ *  and back (which unmounts ConfigureStep) doesn't reset them to preset defaults. */
+export interface ConfigFormValues {
+  name: string
+  slug: string
+  slugTouched: boolean
+  baseUrl: string
+  apiKey: string
+  authChoice: 'api_key' | 'none'
+  capability: Record<string, unknown>
+  logoUrl: string
+  extraHeaders: string
+}
+
+/** Tagged with the endpoint it was entered under, so switching endpoints
+ *  (a different preset_key) correctly falls back to that endpoint's defaults. */
+export interface ConfigDraft extends ConfigFormValues {
+  presetKey: string
+}
+
 export interface WizardState {
   step: WizardStep
   vendor: VendorPreset | null
@@ -18,6 +38,8 @@ export interface WizardState {
   selectedPresetKey: string | null
   providerId: string | null
   models: CreatedModel[]
+  /** Last-entered Configure-step values, so a revisit restores them. */
+  configDraft: ConfigDraft | null
 }
 
 export type WizardAction =
@@ -25,6 +47,7 @@ export type WizardAction =
   | { type: 'selectEndpoint'; presetKey: string }
   | { type: 'providerCreated'; providerId: string }
   | { type: 'modelsCreated'; models: CreatedModel[] }
+  | { type: 'setConfigDraft'; draft: ConfigDraft }
   | { type: 'next' }
   | { type: 'back' }
 
@@ -34,6 +57,7 @@ export const initialWizardState: WizardState = {
   selectedPresetKey: null,
   providerId: null,
   models: [],
+  configDraft: null,
 }
 
 // Whether `next` may advance from the given state. Step 1 needs a vendor (the
@@ -63,6 +87,8 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
       return { ...state, providerId: action.providerId }
     case 'modelsCreated':
       return { ...state, models: action.models }
+    case 'setConfigDraft':
+      return { ...state, configDraft: action.draft }
     case 'next': {
       if (!canAdvance(state)) return state
       return { ...state, step: (state.step + 1) as WizardStep }

--- a/frontend/packages/web/components/admin/models/wizard/wizardMachine.ts
+++ b/frontend/packages/web/components/admin/models/wizard/wizardMachine.ts
@@ -1,4 +1,4 @@
-import type { ProviderPreset } from '@cubebox/core'
+import type { VendorPreset } from '@cubebox/core'
 
 export type WizardStep = 1 | 2 | 3 | 4
 
@@ -13,13 +13,16 @@ export interface CreatedModel {
 
 export interface WizardState {
   step: WizardStep
-  preset: ProviderPreset | null
+  vendor: VendorPreset | null
+  /** Endpoint chosen in step 2 (region/protocol/plan) — its preset_key. */
+  selectedPresetKey: string | null
   providerId: string | null
   models: CreatedModel[]
 }
 
 export type WizardAction =
-  | { type: 'pickPreset'; preset: ProviderPreset }
+  | { type: 'pickVendor'; vendor: VendorPreset }
+  | { type: 'selectEndpoint'; presetKey: string }
   | { type: 'providerCreated'; providerId: string }
   | { type: 'modelsCreated'; models: CreatedModel[] }
   | { type: 'next' }
@@ -27,17 +30,19 @@ export type WizardAction =
 
 export const initialWizardState: WizardState = {
   step: 1,
-  preset: null,
+  vendor: null,
+  selectedPresetKey: null,
   providerId: null,
   models: [],
 }
 
-// Whether `next` may advance from the given state. Step 1 needs a preset,
-// step 2 needs a persisted provider, step 3 needs at least one model.
+// Whether `next` may advance from the given state. Step 1 needs a vendor (the
+// endpoint is chosen in step 2); step 2 needs a persisted provider; step 3 needs
+// at least one model.
 export function canAdvance(state: WizardState): boolean {
   switch (state.step) {
     case 1:
-      return state.preset !== null
+      return state.vendor !== null
     case 2:
       return state.providerId !== null
     case 3:
@@ -49,8 +54,11 @@ export function canAdvance(state: WizardState): boolean {
 
 export function wizardReducer(state: WizardState, action: WizardAction): WizardState {
   switch (action.type) {
-    case 'pickPreset':
-      return { ...state, preset: action.preset }
+    case 'pickVendor':
+      // Picking a (new) vendor resets the downstream endpoint choice.
+      return { ...state, vendor: action.vendor, selectedPresetKey: null }
+    case 'selectEndpoint':
+      return { ...state, selectedPresetKey: action.presetKey }
     case 'providerCreated':
       return { ...state, providerId: action.providerId }
     case 'modelsCreated':

--- a/frontend/packages/web/components/admin/settings/OrgLLMSettingsCard.tsx
+++ b/frontend/packages/web/components/admin/settings/OrgLLMSettingsCard.tsx
@@ -22,8 +22,8 @@ import { useAllModels, type ProviderModelOption } from '@/hooks/useAllModels'
 import { cn } from '@/lib/utils'
 
 // A model is selectable when it is enabled and not in a hard-error/unavailable
-// state. ready/degraded/stale stay usable; provider_error/model_error/unavailable
-// (or a disabled model) are shown but not selectable.
+// state. ready/degraded/stale stay usable; provider_error/auth_error/model_error/
+// unavailable (or a disabled model) are shown but not selectable.
 function isUsable(opt: ProviderModelOption): boolean {
   if (!opt.enabled) return false
   return opt.readiness === 'ready' || opt.readiness === 'degraded' || opt.readiness === 'stale'

--- a/frontend/packages/web/lib/probeDetail.test.ts
+++ b/frontend/packages/web/lib/probeDetail.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { formatProbeDetail } from './probeDetail'
+
+describe('formatProbeDetail', () => {
+  it('collapses a 402 blob to status + upstream message', () => {
+    const raw =
+      '[probe/deepseek/deepseek-v4-flash:free @ https://openrouter.ai/api/v1/] ' +
+      "APIStatusError: Error code: 402 - {'error': {'message': 'Provider returned error', " +
+      "'code': 402, 'metadata': {'raw': '{\"error\":{\""
+    expect(formatProbeDetail(raw)).toBe('HTTP 402 · Provider returned error')
+  })
+
+  it('handles a 404 model-removed message', () => {
+    const raw =
+      '[probe/stepfun:free @ .../] NotFoundError: Error code: 404 - ' +
+      "{'error': {'message': 'No endpoints found for stepfun:free.', 'code': 404}}"
+    expect(formatProbeDetail(raw)).toBe('HTTP 404 · No endpoints found for stepfun:free.')
+  })
+
+  it('handles a double-quoted JSON message', () => {
+    const raw = 'Error code: 401 - {"error": {"message": "Missing Authentication header"}}'
+    expect(formatProbeDetail(raw)).toBe('HTTP 401 · Missing Authentication header')
+  })
+
+  it('falls back to HTTP status when no message is extractable', () => {
+    expect(formatProbeDetail('APIStatusError: Error code: 503 - {garbage')).toBe(
+      'APIStatusError: Error code: 503',
+    )
+  })
+
+  it('leaves an already-clean advisory detail untouched', () => {
+    expect(formatProbeDetail('no usage block → cost recorded as zero')).toBe(
+      'no usage block → cost recorded as zero',
+    )
+  })
+
+  it('returns empty string for nullish input', () => {
+    expect(formatProbeDetail(null)).toBe('')
+    expect(formatProbeDetail(undefined)).toBe('')
+  })
+})

--- a/frontend/packages/web/lib/probeDetail.test.ts
+++ b/frontend/packages/web/lib/probeDetail.test.ts
@@ -22,6 +22,16 @@ describe('formatProbeDetail', () => {
     expect(formatProbeDetail(raw)).toBe('HTTP 401 · Missing Authentication header')
   })
 
+  it('extracts a 401 auth message that contains a URL', () => {
+    const raw =
+      '[probe/qwen3-max @ https://dashscope-intl.aliyuncs.com/compatible-mode/v1/] ' +
+      "AuthenticationError: Error code: 401 - {'error': {'message': 'Incorrect API key provided. " +
+      "For details, see: https://www.alibabacloud.com/help/x', 'type': 'invalid_request_error'}}"
+    expect(formatProbeDetail(raw)).toBe(
+      'HTTP 401 · Incorrect API key provided. For details, see: https://www.alibabacloud.com/help/x',
+    )
+  })
+
   it('falls back to HTTP status when no message is extractable', () => {
     expect(formatProbeDetail('APIStatusError: Error code: 503 - {garbage')).toBe(
       'APIStatusError: Error code: 503',

--- a/frontend/packages/web/lib/probeDetail.ts
+++ b/frontend/packages/web/lib/probeDetail.ts
@@ -1,0 +1,27 @@
+// cubepi formats upstream probe failures as a dense, often-truncated blob:
+//   "[probe/<model> @ <url>] APIStatusError: Error code: 402 - {'error': {'message': '...'}} <- HTTPStatusError ..."
+// Rendered verbatim that is unreadable. This collapses it to a concise
+// "HTTP <status> · <message>" while leaving already-clean step details
+// (e.g. "no usage block → cost recorded as zero") untouched.
+export function formatProbeDetail(raw: string | null | undefined): string {
+  if (!raw) return ''
+  // Drop the "[probe/<model> @ <url>] " prefix and the secondary
+  // "<- HTTPStatusError ..." cause chain.
+  const s = raw
+    .replace(/^\[probe\/[^\]]*\]\s*/, '')
+    .split(' <- ')[0]
+    .trim()
+
+  const status = s.match(/error code:\s*(\d{3})/i)?.[1]
+  // Upstream APIs nest the human message under a "message" key, single- or
+  // double-quoted depending on whether cubepi repr'd a dict or kept raw JSON.
+  const message = s.match(/["']message["']\s*:\s*["']([^"']+)["']/)?.[1]
+
+  if (status && message) return `HTTP ${status} · ${message}`
+  if (status) {
+    // No extractable message: keep the leading clause, drop the "- {json..." tail.
+    const head = s.split(/\s*-\s*[{[]/)[0].trim()
+    return head || `HTTP ${status}`
+  }
+  return s
+}

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -399,7 +399,13 @@
         "unsupportedAuth": "OAuth/IAM presets aren't supported yet.",
         "advanced": "Advanced: capability",
         "creating": "Creating…",
-        "createFailed": "Failed to create provider"
+        "createFailed": "Failed to create provider",
+        "errors": {
+          "provider_slug_conflict": "This slug is already in use. Choose a different one.",
+          "provider_name_conflict": "A provider with this name already exists. Pick another name.",
+          "invalid_provider_slug": "Slug must be lowercase letters, numbers and hyphens (max 64 chars).",
+          "provider_oauth_not_implemented": "OAuth authentication isn't supported yet."
+        }
       },
       "capability": {
         "label": "Capability JSON",

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -355,6 +355,7 @@
       "degraded": "Degraded",
       "stale": "Stale",
       "providerError": "Provider unreachable",
+      "authError": "Authentication failed",
       "modelError": "Model test failed",
       "unavailable": "Unavailable"
     },

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -383,11 +383,15 @@
         "categoryCustom": "Custom",
         "reasoningBudget": "Budget reasoning",
         "reasoningEffort": "Effort reasoning",
-        "reasoningStandard": "Standard"
+        "reasoningStandard": "Standard",
+        "endpointCount": "{count} endpoints"
       },
       "configure": {
         "name": "Display name",
         "baseUrl": "Base URL",
+        "region": "Region",
+        "protocol": "Protocol",
+        "plan": "Plan",
         "apiKey": "API key",
         "apiKeyRequired": "An API key is required for this provider.",
         "noAuth": "This provider needs no credentials.",

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -366,6 +366,11 @@
       "next": "Next",
       "cancel": "Cancel",
       "finish": "Finish",
+      "discard": "Discard",
+      "finishLater": "Finish later",
+      "discardPrompt": "Discard this provider? It and its models will be deleted.",
+      "discardYes": "Delete",
+      "discardNo": "Keep",
       "step": {
         "preset": { "label": "Preset", "hint": "Choose a provider" },
         "configure": { "label": "Configure", "hint": "Credentials & capability" },

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -383,11 +383,15 @@
         "categoryCustom": "自定义",
         "reasoningBudget": "预算式推理",
         "reasoningEffort": "强度式推理",
-        "reasoningStandard": "标准"
+        "reasoningStandard": "标准",
+        "endpointCount": "{count} 个接入点"
       },
       "configure": {
         "name": "显示名称",
         "baseUrl": "Base URL",
+        "region": "区域",
+        "protocol": "协议",
+        "plan": "套餐",
         "apiKey": "API Key",
         "apiKeyRequired": "该 provider 需要 API Key。",
         "noAuth": "该 provider 无需凭证。",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -355,6 +355,7 @@
       "degraded": "降级",
       "stale": "已过期",
       "providerError": "Provider 不可达",
+      "authError": "认证失败",
       "modelError": "模型测试失败",
       "unavailable": "不可用"
     },

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -366,6 +366,11 @@
       "next": "下一步",
       "cancel": "取消",
       "finish": "完成",
+      "discard": "丢弃",
+      "finishLater": "稍后完成",
+      "discardPrompt": "丢弃此 provider？将删除它及其模型。",
+      "discardYes": "删除",
+      "discardNo": "返回",
       "step": {
         "preset": { "label": "选择预设", "hint": "挑选 provider" },
         "configure": { "label": "配置", "hint": "凭证与能力" },

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -399,7 +399,13 @@
         "unsupportedAuth": "暂不支持 OAuth/IAM 类型的预设。",
         "advanced": "高级：能力配置",
         "creating": "创建中…",
-        "createFailed": "创建 provider 失败"
+        "createFailed": "创建 provider 失败",
+        "errors": {
+          "provider_slug_conflict": "该 slug 已被占用，请换一个。",
+          "provider_name_conflict": "已存在同名 provider，请换一个名称。",
+          "invalid_provider_slug": "slug 只能包含小写字母、数字和连字符（最长 64 字符）。",
+          "provider_oauth_not_implemented": "暂不支持 OAuth 认证。"
+        }
       },
       "capability": {
         "label": "Capability JSON",


### PR DESCRIPTION
## Summary

Moves the LLM provider **preset catalog** from cubepi into cubebox and restructures it from a flat `(slug, api, base_url)` list into **vendor → region×protocol×plan endpoints → models-with-pricing**, with `base_url` composed from parts. `config.yaml` providers can now reference a catalog entry via `preset:` and inherit base_url/api/capability/model-pool, instead of restating it all.

Spec: `docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md` · Plan: `docs/dev/plans/2026-05-23-preset-catalog-redesign.md` (both codex-reviewed to clean).

## What's in it

- **`cubebox/llm/catalog/`** (new): validating loader — `compose_base_url` (host/path/full-override), `preset_key = vendor/region/protocol[/plan]`, named capability profiles (loud-fail on unknown), plan all-or-nothing + dangling/unreachable/duplicate-key validations.
- **Data port**: 37 flat entries → 32 nested vendors + 23 capability profiles, guarded by a **byte-parity test** against a frozen snapshot of the old `providers.yaml`.
- **Consumers repointed**: `/admin/llm/presets` returns a nested vendor list; logo resolves via `catalog.resolve(preset_key).vendor`; seeder resolves `preset:` → base_url/api/capability/model-pool (cost deep-merge, `api`/`capability` not overridable, `base_url` overridable, subset filter, loud validation); `create_provider` backfills capability from `preset_slug`.
- **Config simplification**: seeded providers rewritten to `preset:` + `api_key`; §6.4 exhaustive inventory + backfill-parity guard.
- **Frontend two-step wizard**: step 1 picks a vendor, step 2 adds region/protocol/plan selectors driving composed base_url + filtered models with prefilled pricing. `@cubebox/core` gains `VendorPreset`/`EndpointPreset`.

## Decoupling

cubebox declares its own `WireApi` literal and imports only `CapabilityDescriptor` from cubepi's stable `capability` module — so this PR does not depend on the cubepi catalog-removal release. Companion cubepi PR: cubeplexai/cubepi#115; the cubepi dependency bump is a follow-up.

## Test plan

- [x] Backend catalog/seeder/logo/parity unit tests green; mypy strict + ruff clean.
- [x] Seeder verified end-to-end against the slot DB (6 preset-mapped providers).
- [x] Frontend: 98 vitest pass; type-check + lint + i18n parity clean.
- [x] Browser golden path (headless): vendor pick → region/protocol/plan composes host-override base_url, creates provider with backfilled capability, filtered model + pricing.
- [ ] CI green