### PR TITLE
fix(runs): keep conversations resumable + visible after a Stop

### DIFF
--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -365,6 +365,52 @@ async def _build_attachment_content_blocks(
         return blocks
 
 
+async def _repair_dangling_tool_calls(conversation_id: str) -> None:
+    """Backfill synthetic tool_results for tool_calls a cancel left unanswered.
+
+    Mirrors cubepi's own cancel cleanup as a fallback. Loads the checkpointed
+    thread, finds tool_calls in the last assistant message that have no
+    ToolResultMessage, and appends a synthetic error result for each so the
+    next provider call sees a structurally valid history.
+    """
+    from cubepi.providers.base import (
+        AssistantMessage,
+        TextContent,
+        ToolCall,
+        ToolResultMessage,
+    )
+
+    from cubebox.agents.checkpointer import init_checkpointer
+
+    async with init_checkpointer() as cp:
+        data = await cp.load(conversation_id)
+        if data is None or not data.messages:
+            return
+
+        last_assistant: AssistantMessage | None = None
+        for message in reversed(data.messages):
+            if isinstance(message, AssistantMessage):
+                last_assistant = message
+                break
+        if last_assistant is None:
+            return
+
+        answered = {m.tool_call_id for m in data.messages if isinstance(m, ToolResultMessage)}
+        synthetic: list[Any] = [
+            ToolResultMessage(
+                tool_call_id=block.id,
+                tool_name=block.name,
+                content=[TextContent(text="[Tool execution cancelled by user]")],
+                is_error=True,
+                timestamp=datetime.now(UTC).timestamp(),
+            )
+            for block in last_assistant.content
+            if isinstance(block, ToolCall) and block.id not in answered
+        ]
+        if synthetic:
+            await cp.append(conversation_id, synthetic)
+
+
 class RunManager:
     """Owns background run execution and Redis persistence."""
 
@@ -1536,6 +1582,13 @@ class RunManager:
                 run_id=run_id,
                 status="cancelled",
             )
+            # Defense in depth: cubepi backfills tool_results for tool_calls
+            # left dangling by a cancel, but if that cleanup was itself cut
+            # short the persisted thread would still have orphan tool_calls
+            # and every later turn would 400. Repair here too — idempotent, so
+            # it's a no-op when cubepi already handled it.
+            with suppress(Exception):
+                await _repair_dangling_tool_calls(conversation_id)
             with suppress(Exception):
                 await self._append_error(run_id, conversation_id, "Run cancelled", "Run cancelled")
             raise

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -387,15 +387,24 @@ async def _repair_dangling_tool_calls(conversation_id: str) -> None:
         if data is None or not data.messages:
             return
 
-        last_assistant: AssistantMessage | None = None
-        for message in reversed(data.messages):
-            if isinstance(message, AssistantMessage):
-                last_assistant = message
+        last_idx = -1
+        for i in range(len(data.messages) - 1, -1, -1):
+            if isinstance(data.messages[i], AssistantMessage):
+                last_idx = i
                 break
-        if last_assistant is None:
+        if last_idx == -1:
             return
+        last_assistant = data.messages[last_idx]
+        assert isinstance(last_assistant, AssistantMessage)
 
-        answered = {m.tool_call_id for m in data.messages if isinstance(m, ToolResultMessage)}
+        # Only this turn's results count as answered — tool_call ids are not
+        # globally unique, so scanning all history could treat a reused id
+        # from an earlier turn as answered and skip the needed backfill.
+        answered = {
+            m.tool_call_id
+            for m in data.messages[last_idx + 1 :]
+            if isinstance(m, ToolResultMessage)
+        }
         synthetic: list[Any] = [
             ToolResultMessage(
                 tool_call_id=block.id,

--- a/backend/tests/e2e/test_cubepi_checkpointer_integration.py
+++ b/backend/tests/e2e/test_cubepi_checkpointer_integration.py
@@ -6,9 +6,65 @@ worktree should have this from M0.3.
 """
 
 import pytest
-from cubepi.providers.base import TextContent, UserMessage
+from cubepi.providers.base import (
+    AssistantMessage,
+    TextContent,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
 
 from cubebox.agents.checkpointer import _build_dsn, init_checkpointer
+from cubebox.streams.run_manager import _repair_dangling_tool_calls
+
+
+async def _delete_thread(thread_id: str) -> None:
+    import asyncpg
+
+    conn = await asyncpg.connect(_build_dsn())
+    try:
+        await conn.execute("DELETE FROM cubepi_threads WHERE thread_id = $1", thread_id)
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_repair_dangling_tool_calls_backfills_and_is_idempotent() -> None:
+    """A thread left with an orphan tool_call (cancel mid-tool) is repaired
+    with a synthetic tool_result, and repairing again adds nothing."""
+    thread_id = "t-repair-dangling"
+    async with init_checkpointer() as cp:
+        await cp.append(
+            thread_id,
+            [
+                UserMessage(content=[TextContent(text="run it")]),
+                AssistantMessage(
+                    content=[ToolCall(id="tc-orphan", name="execute", arguments={})],
+                    stop_reason="tool_use",
+                ),
+            ],
+        )
+
+    try:
+        await _repair_dangling_tool_calls(thread_id)
+        async with init_checkpointer() as cp:
+            data = await cp.load(thread_id)
+        assert data is not None
+        roles = [m.role for m in data.messages]
+        assert roles == ["user", "assistant", "tool_result"]
+        result = data.messages[2]
+        assert isinstance(result, ToolResultMessage)
+        assert result.tool_call_id == "tc-orphan"
+        assert result.is_error is True
+
+        # Idempotent: a second pass finds no orphan and appends nothing.
+        await _repair_dangling_tool_calls(thread_id)
+        async with init_checkpointer() as cp:
+            data2 = await cp.load(thread_id)
+        assert data2 is not None
+        assert len(data2.messages) == 3
+    finally:
+        await _delete_thread(thread_id)
 
 
 @pytest.mark.asyncio

--- a/frontend/packages/core/__tests__/stores/messageStoreCancel.test.ts
+++ b/frontend/packages/core/__tests__/stores/messageStoreCancel.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { useMessageStore } from '../../src/stores/messageStore'
+import type { AgentStream } from '../../src/stores/messageStore'
+
+vi.mock('../../src/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/api')>()
+  return {
+    ...actual,
+    cancelActiveRun: vi.fn().mockResolvedValue({ cancelled: true, run_id: 'r1' }),
+  }
+})
+
+import { cancelActiveRun } from '../../src/api'
+
+const fakeClient = { resolvePath: (s: string) => s, post: vi.fn() } as never
+
+function seedStreaming(conversationId: string, stream: Partial<AgentStream>): void {
+  useMessageStore.setState({
+    messages: { [conversationId]: [] },
+    streamAgents: {
+      main: {
+        text: '',
+        toolCalls: [],
+        toolResults: [],
+        thinking: '',
+        blocks: [],
+        name: null,
+        ...stream,
+      },
+    },
+    isStreaming: true,
+    streamingConversationId: conversationId,
+    currentRunId: 'r1',
+  })
+}
+
+describe('messageStore.cancelStream', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useMessageStore.setState({
+      messages: {},
+      streamAgents: {},
+      isStreaming: false,
+      streamingConversationId: null,
+      currentRunId: null,
+    })
+  })
+
+  it('finalizes partial streamed content into a cancelled assistant message', async () => {
+    seedStreaming('conv1', {
+      text: 'partial answer',
+      blocks: [{ type: 'text', text: 'partial answer' }],
+    })
+
+    await useMessageStore.getState().cancelStream(fakeClient, 'conv1')
+
+    const state = useMessageStore.getState()
+    expect(state.isStreaming).toBe(false)
+    const msgs = state.messages.conv1
+    expect(msgs).toHaveLength(1)
+    expect(msgs[0].role).toBe('assistant')
+    expect(msgs[0].stop_reason).toBe('aborted')
+    expect(msgs[0].content).toEqual([{ type: 'text', text: 'partial answer' }])
+    expect(cancelActiveRun).toHaveBeenCalledOnce()
+  })
+
+  it('does not append an empty bubble when nothing was streamed', async () => {
+    seedStreaming('conv1', {})
+
+    await useMessageStore.getState().cancelStream(fakeClient, 'conv1')
+
+    const state = useMessageStore.getState()
+    expect(state.isStreaming).toBe(false)
+    expect(state.messages.conv1 ?? []).toHaveLength(0)
+    expect(cancelActiveRun).toHaveBeenCalledOnce()
+  })
+
+  it('is a no-op when not streaming the given conversation', async () => {
+    await useMessageStore.getState().cancelStream(fakeClient, 'conv-other')
+    expect(cancelActiveRun).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -503,6 +503,7 @@ async function finalizeCompletedStream(
   get: () => MessageStore,
   set: (partial: Partial<MessageStore> | ((state: MessageStore) => Partial<MessageStore>)) => void,
   conversationId: string,
+  stopReason: AssistantMessageType['stop_reason'] = 'stop',
 ): Promise<void> {
   const agents = get().streamAgents
   const mainStream = agents[MAIN_AGENT_KEY]
@@ -526,7 +527,7 @@ async function finalizeCompletedStream(
     id: nextMessageId('assistant'),
     role: 'assistant',
     content: finalBlocks,
-    stop_reason: 'stop',
+    stop_reason: stopReason,
     usage: usage
       ? {
           input_tokens: usage.input_tokens,
@@ -946,15 +947,34 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
     const state = get()
     if (!state.isStreaming || state.streamingConversationId !== conversationId) return
 
-    set({
-      isStreaming: false,
-      streamingConversationId: null,
-      currentRunId: null,
-      statusPhase: null,
-    })
-
+    // Stop consuming the stream first so no late event mutates streamAgents
+    // after we snapshot it below.
     activeStreamController?.abort()
     activeStreamController = null
+
+    // Persist whatever was streamed so far as a cancelled assistant turn so
+    // the partial content stays visible — otherwise it vanishes the moment
+    // isStreaming flips false and only reappears after a reload (which reads
+    // the checkpointer). Skip when nothing was produced to avoid an empty
+    // bubble.
+    const mainStream = get().streamAgents[MAIN_AGENT_KEY]
+    const hasContent =
+      !!mainStream &&
+      (mainStream.blocks.length > 0 ||
+        mainStream.text.length > 0 ||
+        mainStream.thinking.length > 0 ||
+        mainStream.toolResults.length > 0)
+
+    if (hasContent) {
+      await finalizeCompletedStream(get, set, conversationId, 'aborted')
+    } else {
+      set({
+        isStreaming: false,
+        streamingConversationId: null,
+        currentRunId: null,
+        statusPhase: null,
+      })
+    }
 
     try {
       await cancelActiveRun(client, conversationId)


### PR DESCRIPTION
## Summary
Two defects surfaced when clicking **Stop** mid-tool-call:

1. **Conversation wedged after Stop.** The run was cancelled after the assistant message (with its `tool_call`) was checkpointed but before the `tool_result` was, leaving an orphan `tool_call`. Every later turn then 400'd (`tool_use` without `tool_result`) and returned an empty reply — permanently. The real fix is upstream in cubepi (cubeplexai/cubepi#116); here `_execute_run` adds an **idempotent fallback** `_repair_dangling_tool_calls` that backfills synthetic error tool_results, so the thread stays valid even if cubepi's own cancel cleanup was cut short.
2. **Cancelled turn content vanished.** The frontend dropped the in-progress assistant turn on cancel; it only reappeared after a reload re-read the checkpointer. `cancelStream` now finalizes the partial stream into a cancelled assistant message (`stop_reason: "aborted"`) before clearing `isStreaming`.

## Test plan
- [x] `test_repair_dangling_tool_calls_backfills_and_is_idempotent` — orphan tool_call → synthetic `tool_result(is_error)`; second pass is a no-op (real test-DB checkpointer).
- [x] `messageStoreCancel.test.ts` — cancel finalizes partial content as `aborted`; no empty bubble when nothing streamed; no-op when not streaming.
- [x] `@cubebox/core` vitest green (54), `tsc` build clean.
- [x] backend mypy + ruff clean (pre-commit hooks pass).

## Note
Depends on cubeplexai/cubepi#116 for the root-cause fix; this PR is safe to merge independently since the fallback is self-contained.