### PR TITLE
feat: multi-instance run control (cancel + steer via Redis pub/sub)

### DIFF
--- a/backend/cubebox/api/app.py
+++ b/backend/cubebox/api/app.py
@@ -173,6 +173,7 @@ async def lifespan(_app: FastAPI):  # type: ignore
             run_stream_max_events=config.get("streaming.run_stream_max_events", 1000000),
         )
         _app.state.run_manager = run_manager
+        await run_manager.start_control_listeners()
         logger.info(
             "Redis streaming runtime initialized (prefix={})",
             _app.state.redis_key_prefix,
@@ -314,6 +315,9 @@ async def lifespan(_app: FastAPI):  # type: ignore
         _app.state.drain_state.enter_draining()
         drain_timeout = _lifecycle_config.get("lifecycle.graceful_drain_timeout_seconds", 3600)
         await run_manager.drain(timeout_seconds=float(drain_timeout))
+        # Stop control listeners AFTER draining so in-flight runs can still be
+        # cancelled/steered during graceful shutdown.
+        await run_manager.stop_control_listeners()
     tracer = getattr(_app.state, "tracer", None)
     if tracer is not None:
         try:

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -816,16 +816,14 @@ async def cancel_active_run(
         )
 
     active_run = await get_active_run(
-        rds.client,
-        prefix=rds.key_prefix,
-        conversation_id=conversation_id,
+        rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
     )
     if active_run is None or active_run.status != "running":
-        return {"cancelled": False, "run_id": None}
+        return {"status": "no_active_run", "run_id": None}
 
     run_manager = raw_request.app.state.run_manager
-    cancelled = await run_manager.cancel_run(active_run.run_id)
-    return {"cancelled": cancelled, "run_id": active_run.run_id}
+    dispatch_status = await run_manager.dispatch_cancel(active_run.run_id)
+    return {"status": dispatch_status, "run_id": active_run.run_id}
 
 
 @router.post("/{conversation_id}/steer", status_code=status.HTTP_202_ACCEPTED)
@@ -858,13 +856,11 @@ async def steer_active_run(
         )
 
     active_run = await get_active_run(
-        rds.client,
-        prefix=rds.key_prefix,
-        conversation_id=conversation_id,
+        rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
     )
     if active_run is None or active_run.status != "running":
-        return {"steered": False, "run_id": None}
+        return {"status": "no_active_run", "run_id": None}
 
     run_manager = raw_request.app.state.run_manager
-    steered = await run_manager.steer_run(active_run.run_id, body.content)
-    return {"steered": steered, "run_id": active_run.run_id}
+    dispatch_status = await run_manager.dispatch_steer(active_run.run_id, body.content)
+    return {"status": dispatch_status, "run_id": active_run.run_id}

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -439,6 +439,11 @@ class RunManager:
         self._run_stream_max_events = run_stream_max_events
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._agents: dict[str, Any] = {}
+        self._ack_waiters: dict[str, list[asyncio.Future[bool]]] = {}
+        self._control_channel = f"{key_prefix}:control"
+        self._ack_channel = f"{key_prefix}:control:ack"
+        self._control_stopping = False
+        self._control_tasks: list[asyncio.Task[None]] = []
         self._tasks_empty: asyncio.Event = asyncio.Event()
         self._tasks_empty.set()
 
@@ -535,6 +540,130 @@ class RunManager:
 
         agent.steer(UserMessage(content=[TextContent(text=content)]))
         return True
+
+    async def _publish_control(self, run_id: str, type_: str, content: str | None = None) -> None:
+        import json
+
+        payload: dict[str, Any] = {"run_id": run_id, "type": type_}
+        if content is not None:
+            payload["content"] = content
+        await self._redis.publish(self._control_channel, json.dumps(payload))
+
+    async def _publish_ack(self, run_id: str) -> None:
+        import json
+
+        await self._redis.publish(self._ack_channel, json.dumps({"run_id": run_id}))
+
+    async def dispatch_steer(self, run_id: str, content: str) -> str:
+        agent = self._agents.get(run_id)
+        if agent is not None:
+            from cubepi.providers.base import TextContent, UserMessage
+
+            agent.steer(UserMessage(content=[TextContent(text=content)]))
+            return "steered"
+        await self._publish_control(run_id, "steer", content)
+        return "published"
+
+    async def dispatch_cancel(self, run_id: str, ack_timeout: float = 3.0) -> str:
+        if run_id in self._tasks:
+            await self.cancel_run(run_id)
+            return "cancelled"
+
+        fut: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+        self._ack_waiters.setdefault(run_id, []).append(fut)
+        try:
+            await self._publish_control(run_id, "cancel")
+            await asyncio.wait_for(fut, timeout=ack_timeout)
+            return "cancelled"
+        except TimeoutError:
+            return "published"
+        finally:
+            waiters = self._ack_waiters.get(run_id)
+            if waiters and fut in waiters:
+                waiters.remove(fut)
+                if not waiters:
+                    self._ack_waiters.pop(run_id, None)
+
+    async def _handle_control(self, data: dict[str, Any]) -> None:
+        run_id = data.get("run_id")
+        type_ = data.get("type")
+        if not isinstance(run_id, str):
+            return
+        if type_ == "cancel":
+            if run_id in self._tasks:
+                await self.cancel_run(run_id)
+                await self._publish_ack(run_id)
+        elif type_ == "steer":
+            agent = self._agents.get(run_id)
+            if agent is not None:
+                from cubepi.providers.base import TextContent, UserMessage
+
+                agent.steer(UserMessage(content=[TextContent(text=data.get("content") or "")]))
+
+    async def _handle_ack(self, data: dict[str, Any]) -> None:
+        run_id = data.get("run_id")
+        if not isinstance(run_id, str):
+            return
+        for fut in self._ack_waiters.get(run_id, []):
+            if not fut.done():
+                fut.set_result(True)
+
+    async def _subscribe_loop(self, channel: str, handler: Any, ready: asyncio.Event) -> None:
+        import json
+
+        backoff = 0.5
+        while not self._control_stopping:
+            pubsub = self._redis.pubsub()
+            try:
+                await pubsub.subscribe(channel)
+                ready.set()
+                backoff = 0.5
+                async for msg in pubsub.listen():
+                    if self._control_stopping:
+                        break
+                    if msg.get("type") != "message":
+                        continue
+                    try:
+                        await handler(json.loads(msg["data"]))
+                    except Exception:
+                        logger.warning("control handler error on {}", channel, exc_info=True)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning("control listener {} dropped; reconnecting", channel, exc_info=True)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 5.0)
+            finally:
+                with suppress(Exception):
+                    await pubsub.aclose()  # type: ignore[no-untyped-call]
+
+    async def start_control_listeners(self, ready_timeout: float = 5.0) -> None:
+        self._control_stopping = False
+        ctrl_ready = asyncio.Event()
+        ack_ready = asyncio.Event()
+        self._control_tasks = [
+            asyncio.create_task(
+                self._subscribe_loop(self._control_channel, self._handle_control, ctrl_ready),
+                name="run-control-listener",
+            ),
+            asyncio.create_task(
+                self._subscribe_loop(self._ack_channel, self._handle_ack, ack_ready),
+                name="run-control-ack-listener",
+            ),
+        ]
+        with suppress(TimeoutError):
+            await asyncio.wait_for(
+                asyncio.gather(ctrl_ready.wait(), ack_ready.wait()), timeout=ready_timeout
+            )
+
+    async def stop_control_listeners(self) -> None:
+        self._control_stopping = True
+        for t in self._control_tasks:
+            t.cancel()
+        for t in self._control_tasks:
+            with suppress(asyncio.CancelledError):
+                await t
+        self._control_tasks = []
 
     async def drain(self, timeout_seconds: float) -> None:
         """Wait for in-flight runs to finish, then return.

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -651,9 +651,22 @@ class RunManager:
                 name="run-control-ack-listener",
             ),
         ]
-        with suppress(TimeoutError):
+        try:
             await asyncio.wait_for(
                 asyncio.gather(ctrl_ready.wait(), ack_ready.wait()), timeout=ready_timeout
+            )
+        except TimeoutError:
+            # Don't fail startup: single-instance deployments don't need pub/sub
+            # at all (control runs via the local fast-path), and a transient Redis
+            # blip shouldn't block boot. But don't fail *silently* either — the
+            # listeners keep retrying in the background (_subscribe_loop), so a
+            # persistent failure here (e.g. Redis ACL/connectivity) means
+            # cross-instance cancel/steer is degraded until they connect.
+            logger.warning(
+                "Run-control pub/sub listeners not subscribed within {}s; "
+                "cross-instance cancel/steer degraded until they connect "
+                "(listeners keep retrying in the background)",
+                ready_timeout,
             )
 
     async def stop_control_listeners(self) -> None:

--- a/backend/tests/e2e/test_steer_endpoint.py
+++ b/backend/tests/e2e/test_steer_endpoint.py
@@ -38,7 +38,7 @@ async def test_steer_injects_user_message_into_active_run(member_client) -> None
                 json={"content": "STEER_MARKER_42: also print 'hello from steer'"},
             )
             assert s.status_code == 202
-            steered = s.json()["steered"]
+            steered = s.json()["status"] == "steered"
             break
         await asyncio.sleep(0.1)
     assert steered is True, "run never became active / agent not registered"

--- a/backend/tests/unit/test_run_control_crossinstance.py
+++ b/backend/tests/unit/test_run_control_crossinstance.py
@@ -1,0 +1,74 @@
+import asyncio
+
+import fakeredis.aioredis
+import pytest
+
+from cubebox.streams.run_manager import RunManager
+
+
+def _mgr(redis: fakeredis.aioredis.FakeRedis) -> RunManager:
+    m = RunManager.__new__(RunManager)  # type: ignore[call-arg]
+    m._redis = redis
+    m._key_prefix = "t"
+    m._tasks = {}
+    m._agents = {}
+    m._ack_waiters = {}
+    m._control_channel = "t:control"
+    m._ack_channel = "t:control:ack"
+    m._control_stopping = False
+    m._control_tasks = []
+    return m
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.steered: list[str] = []
+
+    def steer(self, message) -> None:  # noqa: ANN001
+        self.steered.append(message.content[0].text)
+
+
+@pytest.mark.asyncio
+async def test_cross_instance_steer() -> None:
+    # Both managers share one FakeRedis instance — fakeredis routes pub/sub
+    # across all pubsub handles created from the same client, so A's listener
+    # sees B's publish without needing a real network.
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    a, b = _mgr(redis), _mgr(redis)
+    agent = _FakeAgent()
+    a._agents["r1"] = agent  # owner is A
+    await a.start_control_listeners()
+    try:
+        assert await b.dispatch_steer("r1", "redirect") == "published"
+        for _ in range(50):
+            if agent.steered:
+                break
+            await asyncio.sleep(0.05)
+        assert agent.steered == ["redirect"]
+    finally:
+        await a.stop_control_listeners()
+
+
+@pytest.mark.asyncio
+async def test_cross_instance_cancel_ack() -> None:
+    # Same shared-client setup: A owns the run task; B dispatches cancel and
+    # waits for the ack that A publishes after calling cancel_run.
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    a, b = _mgr(redis), _mgr(redis)
+
+    cancelled = asyncio.Event()
+
+    async def fake_cancel(run_id: str) -> bool:
+        cancelled.set()
+        return True
+
+    a._tasks["r1"] = object()  # owner A "has" the task
+    a.cancel_run = fake_cancel  # type: ignore[assignment]
+    await a.start_control_listeners()
+    await b.start_control_listeners()  # B needs its ack listener to resolve its future
+    try:
+        assert await b.dispatch_cancel("r1", ack_timeout=3.0) == "cancelled"
+        assert cancelled.is_set()
+    finally:
+        await a.stop_control_listeners()
+        await b.stop_control_listeners()

--- a/backend/tests/unit/test_run_control_pubsub.py
+++ b/backend/tests/unit/test_run_control_pubsub.py
@@ -1,0 +1,91 @@
+import asyncio
+import json
+
+import fakeredis.aioredis
+import pytest
+
+from cubebox.streams.run_manager import RunManager
+
+
+def _mgr(redis) -> RunManager:
+    m = RunManager.__new__(RunManager)  # type: ignore[call-arg]
+    m._redis = redis
+    m._key_prefix = "t"
+    m._tasks = {}
+    m._agents = {}
+    m._ack_waiters = {}
+    m._control_channel = "t:control"
+    m._ack_channel = "t:control:ack"
+    m._control_stopping = False
+    m._control_tasks = []
+    return m
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.steered: list[str] = []
+
+    def steer(self, message) -> None:  # noqa: ANN001
+        self.steered.append(message.content[0].text)
+
+
+@pytest.fixture
+def redis():
+    return fakeredis.aioredis.FakeRedis(decode_responses=False)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_steer_local_calls_agent(redis):
+    m = _mgr(redis)
+    agent = _FakeAgent()
+    m._agents["r1"] = agent
+    assert await m.dispatch_steer("r1", "go left") == "steered"
+    assert agent.steered == ["go left"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_steer_remote_publishes(redis):
+    m = _mgr(redis)
+    pubsub = redis.pubsub()
+    await pubsub.subscribe("t:control")
+    await asyncio.sleep(0)
+    assert await m.dispatch_steer("r-remote", "hello") == "published"
+    got = None
+    for _ in range(20):
+        msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.1)
+        if msg:
+            got = json.loads(msg["data"])
+            break
+    assert got == {"run_id": "r-remote", "type": "steer", "content": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_handle_control_steer_dispatches_locally(redis):
+    m = _mgr(redis)
+    agent = _FakeAgent()
+    m._agents["r1"] = agent
+    await m._handle_control({"run_id": "r1", "type": "steer", "content": "x"})
+    assert agent.steered == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_handle_control_unknown_run_ignored(redis):
+    m = _mgr(redis)
+    await m._handle_control({"run_id": "ghost", "type": "steer", "content": "x"})
+    await m._handle_control({"run_id": "ghost", "type": "cancel"})
+
+
+@pytest.mark.asyncio
+async def test_ack_resolves_waiter(redis):
+    m = _mgr(redis)
+    fut = asyncio.get_running_loop().create_future()
+    m._ack_waiters["r1"] = [fut]
+    await m._handle_ack({"run_id": "r1"})
+    assert fut.done() and fut.result() is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_cancel_remote_times_out_to_published(redis):
+    m = _mgr(redis)
+    assert await m.dispatch_cancel("r-remote", ack_timeout=0.2) == "published"
+    assert m._ack_waiters.get("r-remote") in (None, [])

--- a/backend/tests/unit/test_run_control_pubsub.py
+++ b/backend/tests/unit/test_run_control_pubsub.py
@@ -89,3 +89,18 @@ async def test_dispatch_cancel_remote_times_out_to_published(redis):
     m = _mgr(redis)
     assert await m.dispatch_cancel("r-remote", ack_timeout=0.2) == "published"
     assert m._ack_waiters.get("r-remote") in (None, [])
+
+
+@pytest.mark.asyncio
+async def test_start_listeners_does_not_raise_when_subscribe_never_ready(redis, monkeypatch):
+    # Persistent subscribe failure (e.g. Redis ACL) must NOT hang or crash boot:
+    # start_control_listeners logs a warning and returns; the background loop
+    # keeps retrying.
+    m = _mgr(redis)
+
+    async def _never_ready(channel, handler, ready):
+        await asyncio.sleep(10)  # never sets `ready`
+
+    monkeypatch.setattr(m, "_subscribe_loop", _never_ready)
+    await m.start_control_listeners(ready_timeout=0.05)  # returns despite no readiness
+    await m.stop_control_listeners()

--- a/docs/dev/plans/2026-05-25-multi-instance-run-control.md
+++ b/docs/dev/plans/2026-05-25-multi-instance-run-control.md
@@ -229,7 +229,7 @@ Add to `RunManager` (near `cancel_run`/`steer_run`):
 - [ ] **Step 5: Supervised reconnecting listeners + lifecycle**
 
 ```python
-    async def _subscribe_loop(self, channel: str, handler: Any) -> None:
+    async def _subscribe_loop(self, channel: str, handler: Any, ready: asyncio.Event) -> None:
         import json
 
         backoff = 0.5
@@ -237,12 +237,15 @@ Add to `RunManager` (near `cancel_run`/`steer_run`):
             pubsub = self._redis.pubsub()
             try:
                 await pubsub.subscribe(channel)
+                ready.set()  # signal first (and every) successful subscribe
                 backoff = 0.5
                 async for msg in pubsub.listen():
                     if self._control_stopping:
                         break
                     if msg.get("type") != "message":
                         continue
+                    # Per-message containment: a bad payload or handler fault must
+                    # never break the read loop and deafen the instance.
                     try:
                         await handler(json.loads(msg["data"]))
                     except Exception:
@@ -257,18 +260,27 @@ Add to `RunManager` (near `cancel_run`/`steer_run`):
                 with suppress(Exception):
                     await pubsub.aclose()
 
-    async def start_control_listeners(self) -> None:
+    async def start_control_listeners(self, ready_timeout: float = 5.0) -> None:
         self._control_stopping = False
+        ctrl_ready = asyncio.Event()
+        ack_ready = asyncio.Event()
         self._control_tasks = [
             asyncio.create_task(
-                self._subscribe_loop(self._control_channel, self._handle_control),
+                self._subscribe_loop(self._control_channel, self._handle_control, ctrl_ready),
                 name="run-control-listener",
             ),
             asyncio.create_task(
-                self._subscribe_loop(self._ack_channel, self._handle_ack),
+                self._subscribe_loop(self._ack_channel, self._handle_ack, ack_ready),
                 name="run-control-ack-listener",
             ),
         ]
+        # Don't return until both channels are actually subscribed, so controls
+        # published right after startup aren't lost. Bounded so a Redis hiccup
+        # can't hang boot.
+        with suppress(TimeoutError):
+            await asyncio.wait_for(
+                asyncio.gather(ctrl_ready.wait(), ack_ready.wait()), timeout=ready_timeout
+            )
 
     async def stop_control_listeners(self) -> None:
         self._control_stopping = True

--- a/docs/dev/plans/2026-05-25-multi-instance-run-control.md
+++ b/docs/dev/plans/2026-05-25-multi-instance-run-control.md
@@ -1,0 +1,568 @@
+# Multi-Instance Run Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make `cancel` and `steer` work across backend instances: a control request landing on any instance reaches the instance running the agent, via a Redis pub/sub control channel + local fast-path, with a bounded ack for cross-instance cancel and a unified `{status, run_id}` response.
+
+**Architecture:** See `docs/dev/specs/2026-05-25-multi-instance-run-control-design.md`. Summary: one shared channel `{key_prefix}:control` (every instance subscribes once, filters by owning `run_id`); one shared ack channel `{key_prefix}:control:ack` + per-instance `run_id → list[Future]` map; endpoints take a local fast-path or publish; cross-instance cancel waits for the owner's post-cleanup ack (`cancelled`) or times out (`published`).
+
+**Tech Stack:** FastAPI, redis.asyncio pub/sub, cubepi runtime, Zustand/React, pytest + fakeredis + vitest.
+
+**Non-goals (from spec):** changing the SSE transport; sticky LB routing; strong consumption guarantees for cross-instance steer.
+
+---
+
+## File Structure
+
+- Modify `backend/cubebox/streams/run_manager.py` — control/ack channels, `_ack_waiters`, publish helpers, two supervised pub/sub listeners (reconnecting), `_handle_control`, `dispatch_steer`/`dispatch_cancel`, `start_control_listeners`/`stop_control_listeners`.
+- Modify `backend/cubebox/api/app.py` — start listeners after `RunManager` creation; stop them on shutdown after `drain`.
+- Modify `backend/cubebox/api/routes/v1/conversations.py` — `cancel_active_run` + `steer_active_run` return unified `{status, run_id}` via `dispatch_*`.
+- Modify `frontend/packages/core/src/api/stream.ts` — `CancelRunResponse`/`SteerRunResponse` → `{status, run_id}`.
+- Modify `frontend/packages/core/src/stores/messageStore.ts` — `steer` rollback rule (only `no_active_run`); `cancelStream` records resend-safety from `status`; `send` retries once on 409.
+- Tests: `backend/tests/unit/test_run_control_pubsub.py` (dispatch + listeners + ack + reconnect, fakeredis), `backend/tests/unit/test_run_control_crossinstance.py` (two `RunManager`s, one Redis), frontend `messageStoreSteer`/`messageStoreCancel` updates.
+
+---
+
+## Task 1: RunManager — control + ack pub/sub infrastructure
+
+**Files:** Modify `backend/cubebox/streams/run_manager.py`; Test `backend/tests/unit/test_run_control_pubsub.py`.
+
+- [ ] **Step 1: Failing tests**
+
+Create `backend/tests/unit/test_run_control_pubsub.py`. Uses `fakeredis.aioredis` (dev dep). A fake agent/task stand in for the live handles.
+
+```python
+import asyncio
+import json
+
+import fakeredis.aioredis
+import pytest
+
+from cubebox.streams.run_manager import RunManager
+
+
+def _mgr(redis) -> RunManager:
+    m = RunManager.__new__(RunManager)  # type: ignore[call-arg]
+    m._redis = redis
+    m._key_prefix = "t"
+    m._tasks = {}
+    m._agents = {}
+    m._ack_waiters = {}
+    m._control_stopping = False
+    return m
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.steered: list[str] = []
+
+    def steer(self, message) -> None:  # noqa: ANN001
+        self.steered.append(message.content[0].text)
+
+
+@pytest.fixture
+def redis():
+    return fakeredis.aioredis.FakeRedis(decode_responses=False)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_steer_local_calls_agent(redis):
+    m = _mgr(redis)
+    agent = _FakeAgent()
+    m._agents["r1"] = agent
+    status = await m.dispatch_steer("r1", "go left")
+    assert status == "steered"
+    assert agent.steered == ["go left"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_steer_remote_publishes(redis):
+    m = _mgr(redis)
+    pubsub = redis.pubsub()
+    await pubsub.subscribe(f"t:control")
+    await asyncio.sleep(0)  # let subscribe settle
+    status = await m.dispatch_steer("r-remote", "hello")
+    assert status == "published"
+    # a control message was published
+    got = None
+    for _ in range(20):
+        msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.1)
+        if msg:
+            got = json.loads(msg["data"])
+            break
+    assert got == {"run_id": "r-remote", "type": "steer", "content": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_handle_control_steer_dispatches_locally(redis):
+    m = _mgr(redis)
+    agent = _FakeAgent()
+    m._agents["r1"] = agent
+    await m._handle_control({"run_id": "r1", "type": "steer", "content": "x"})
+    assert agent.steered == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_handle_control_unknown_run_is_ignored(redis):
+    m = _mgr(redis)
+    # no handle registered → no error, no action
+    await m._handle_control({"run_id": "ghost", "type": "steer", "content": "x"})
+    await m._handle_control({"run_id": "ghost", "type": "cancel"})
+
+
+@pytest.mark.asyncio
+async def test_cancel_ack_resolves_waiter(redis):
+    m = _mgr(redis)
+    fut = asyncio.get_running_loop().create_future()
+    m._ack_waiters["r1"] = [fut]
+    await m._handle_ack({"run_id": "r1"})
+    assert fut.done() and fut.result() is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_cancel_remote_times_out_to_published(redis):
+    m = _mgr(redis)
+    # no owner will ack → wait_for times out → "published"
+    status = await m.dispatch_cancel("r-remote", ack_timeout=0.2)
+    assert status == "published"
+    assert m._ack_waiters.get("r-remote") in (None, [])
+```
+
+Run: `cd backend && uv run pytest tests/unit/test_run_control_pubsub.py -v` → FAIL (methods/attrs missing).
+
+- [ ] **Step 2: Add fields + channel names in `__init__`**
+
+In `RunManager.__init__`, after `self._agents: dict[str, Any] = {}`:
+
+```python
+        self._ack_waiters: dict[str, list[asyncio.Future[bool]]] = {}
+        self._control_channel = f"{key_prefix}:control"
+        self._ack_channel = f"{key_prefix}:control:ack"
+        self._control_stopping = False
+        self._control_tasks: list[asyncio.Task[None]] = []
+```
+
+(`key_prefix` is the existing `__init__` param.)
+
+- [ ] **Step 3: Publish helpers + dispatch methods**
+
+Add to `RunManager` (near `cancel_run`/`steer_run`):
+
+```python
+    async def _publish_control(self, run_id: str, type_: str, content: str | None = None) -> None:
+        import json
+
+        payload: dict[str, Any] = {"run_id": run_id, "type": type_}
+        if content is not None:
+            payload["content"] = content
+        await self._redis.publish(self._control_channel, json.dumps(payload))
+
+    async def _publish_ack(self, run_id: str) -> None:
+        import json
+
+        await self._redis.publish(self._ack_channel, json.dumps({"run_id": run_id}))
+
+    async def dispatch_steer(self, run_id: str, content: str) -> str:
+        """Steer locally if the agent is here, else broadcast. Returns status."""
+        agent = self._agents.get(run_id)
+        if agent is not None:
+            from cubepi.providers.base import TextContent, UserMessage
+
+            agent.steer(UserMessage(content=[TextContent(text=content)]))
+            return "steered"
+        await self._publish_control(run_id, "steer", content)
+        return "published"
+
+    async def dispatch_cancel(self, run_id: str, ack_timeout: float = 3.0) -> str:
+        """Cancel locally if the task is here, else broadcast + await the owner's
+        post-cleanup ack. Returns "cancelled" or (on timeout) "published"."""
+        if run_id in self._tasks:
+            await self.cancel_run(run_id)
+            return "cancelled"
+
+        fut: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+        self._ack_waiters.setdefault(run_id, []).append(fut)
+        try:
+            await self._publish_control(run_id, "cancel")
+            await asyncio.wait_for(fut, timeout=ack_timeout)
+            return "cancelled"
+        except TimeoutError:
+            return "published"
+        finally:
+            waiters = self._ack_waiters.get(run_id)
+            if waiters and fut in waiters:
+                waiters.remove(fut)
+                if not waiters:
+                    self._ack_waiters.pop(run_id, None)
+```
+
+- [ ] **Step 4: Dispatch handlers**
+
+```python
+    async def _handle_control(self, data: dict[str, Any]) -> None:
+        run_id = data.get("run_id")
+        type_ = data.get("type")
+        if not isinstance(run_id, str):
+            return
+        if type_ == "cancel":
+            if run_id in self._tasks:
+                await self.cancel_run(run_id)
+                # Tell the requesting instance cleanup is done (active-run key cleared).
+                await self._publish_ack(run_id)
+        elif type_ == "steer":
+            agent = self._agents.get(run_id)
+            if agent is not None:
+                from cubepi.providers.base import TextContent, UserMessage
+
+                content = data.get("content") or ""
+                agent.steer(UserMessage(content=[TextContent(text=content)]))
+
+    async def _handle_ack(self, data: dict[str, Any]) -> None:
+        run_id = data.get("run_id")
+        if not isinstance(run_id, str):
+            return
+        for fut in self._ack_waiters.get(run_id, []):
+            if not fut.done():
+                fut.set_result(True)
+```
+
+- [ ] **Step 5: Supervised reconnecting listeners + lifecycle**
+
+```python
+    async def _subscribe_loop(self, channel: str, handler: Any) -> None:
+        import json
+
+        backoff = 0.5
+        while not self._control_stopping:
+            pubsub = self._redis.pubsub()
+            try:
+                await pubsub.subscribe(channel)
+                backoff = 0.5
+                async for msg in pubsub.listen():
+                    if self._control_stopping:
+                        break
+                    if msg.get("type") != "message":
+                        continue
+                    try:
+                        await handler(json.loads(msg["data"]))
+                    except Exception:
+                        logger.warning("control handler error on {}", channel, exc_info=True)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning("control listener {} dropped; reconnecting", channel, exc_info=True)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 5.0)
+            finally:
+                with suppress(Exception):
+                    await pubsub.aclose()
+
+    async def start_control_listeners(self) -> None:
+        self._control_stopping = False
+        self._control_tasks = [
+            asyncio.create_task(
+                self._subscribe_loop(self._control_channel, self._handle_control),
+                name="run-control-listener",
+            ),
+            asyncio.create_task(
+                self._subscribe_loop(self._ack_channel, self._handle_ack),
+                name="run-control-ack-listener",
+            ),
+        ]
+
+    async def stop_control_listeners(self) -> None:
+        self._control_stopping = True
+        for t in self._control_tasks:
+            t.cancel()
+        for t in self._control_tasks:
+            with suppress(asyncio.CancelledError):
+                await t
+        self._control_tasks = []
+```
+
+(`logger` and `suppress` are already imported in this module; `asyncio` too.)
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd backend && uv run pytest tests/unit/test_run_control_pubsub.py -v && uv run mypy cubebox/streams/run_manager.py`
+Expected: all pass; mypy Success. (The `test_dispatch_cancel_remote_times_out_to_published` test exercises the timeout→published path; `_handle_ack` test the resolve path.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/cubebox/streams/run_manager.py backend/tests/unit/test_run_control_pubsub.py
+git commit -m "feat(runs): Redis pub/sub control + ack infra on RunManager"
+```
+
+---
+
+## Task 2: Wire listeners to the app lifespan
+
+**Files:** Modify `backend/cubebox/api/app.py`.
+
+- [ ] **Step 1: Start listeners after RunManager is created**
+
+In `create_app`'s lifespan, find where `run_manager = RunManager(...)` is built and stashed on `_app.state.run_manager` (~line 168-175). Right after stashing it, add:
+
+```python
+        await run_manager.start_control_listeners()
+```
+
+- [ ] **Step 2: Stop listeners on shutdown, after drain**
+
+Find the shutdown path where `await run_manager.drain(timeout_seconds=...)` runs (~line 311-316). **After** the drain call, add:
+
+```python
+        await run_manager.stop_control_listeners()
+```
+
+(Order matters: drain first so in-flight runs can still receive controls during graceful shutdown, then stop the listeners.)
+
+- [ ] **Step 3: Sanity-check the app boots**
+
+Run: `cd backend && uv run python -c "from cubebox.api.app import create_app; create_app(); print('ok')"`
+Expected: `ok` (or, if `create_app` needs runtime env, grep-verify both calls are present and report).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/cubebox/api/app.py
+git commit -m "feat(runs): start/stop run-control listeners with app lifespan"
+```
+
+---
+
+## Task 3: Endpoints — unified `{status, run_id}` via dispatch
+
+**Files:** Modify `backend/cubebox/api/routes/v1/conversations.py`.
+
+- [ ] **Step 1: Rewrite `steer_active_run` body**
+
+Keep the empty-content guard, conversation lookup, and active-run lookup. Replace the tail (`run_manager.steer_run(...)`) with:
+
+```python
+    active_run = await get_active_run(
+        rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
+    )
+    if active_run is None or active_run.status != "running":
+        return {"status": "no_active_run", "run_id": None}
+
+    run_manager = raw_request.app.state.run_manager
+    status = await run_manager.dispatch_steer(active_run.run_id, body.content)
+    return {"status": status, "run_id": active_run.run_id}
+```
+
+- [ ] **Step 2: Rewrite `cancel_active_run` body**
+
+Replace the `run_manager.cancel_run(...)` tail with:
+
+```python
+    active_run = await get_active_run(
+        rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
+    )
+    if active_run is None or active_run.status != "running":
+        return {"status": "no_active_run", "run_id": None}
+
+    run_manager = raw_request.app.state.run_manager
+    status = await run_manager.dispatch_cancel(active_run.run_id)
+    return {"status": status, "run_id": active_run.run_id}
+```
+
+- [ ] **Step 3: Lint + typecheck + existing E2E (local fast-path unchanged)**
+
+```
+cd backend && uv run ruff check cubebox/api/routes/v1/conversations.py && uv run mypy cubebox/api/routes/v1/conversations.py
+```
+The existing `tests/e2e/test_steer_endpoint.py` still asserts `s.json()["steered"]` — update it to `s.json()["status"] == "steered"` (single instance → local fast-path → `steered`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/cubebox/api/routes/v1/conversations.py backend/tests/e2e/test_steer_endpoint.py
+git commit -m "feat(api): unified {status,run_id} for cancel/steer via dispatch"
+```
+
+---
+
+## Task 4: Frontend — `status` responses + resend safety
+
+**Files:** Modify `frontend/packages/core/src/api/stream.ts`, `frontend/packages/core/src/stores/messageStore.ts`; update `__tests__/stores/messageStoreSteer.test.ts` + `messageStoreCancel.test.ts`.
+
+- [ ] **Step 1: Response types**
+
+In `stream.ts`:
+
+```typescript
+export interface CancelRunResponse {
+  status: 'cancelled' | 'published' | 'no_active_run'
+  run_id: string | null
+}
+export interface SteerRunResponse {
+  status: 'steered' | 'published' | 'no_active_run'
+  run_id: string | null
+}
+```
+
+- [ ] **Step 2: `steer` rollback rule**
+
+In `messageStore.ts` `steer`, change the rollback condition from `if (!res.steered) rollback()` to:
+
+```typescript
+      const res = await steerRun(client, conversationId, text)
+      if (res.status === 'no_active_run') rollback()
+```
+
+(Keep the bubble for `steered` and `published`.)
+
+- [ ] **Step 3: `send` retries once on 409 (resend-after-cancel safety net)**
+
+In `send`, the run-start request can 409 if a just-cancelled run is still releasing its active-run lock (cross-instance cancel returned `published`, or a fast resend). Wrap the initial start so a single 409 retries after a short delay. Concretely, in `streamMessages` consumption: when the first event is `error` with an HTTP 409 message, retry the POST once after ~400ms before surfacing the error. (Implement minimally: catch the 409 path in `send` and re-invoke the stream once; if it 409s again, surface the error as today.)
+
+```typescript
+// in send(), around the streamMessages loop — pseudo-anchor; match existing code:
+// if the stream's first yielded event is an HTTP 409 error, await 400ms and retry the
+// stream once; otherwise proceed. Only one retry, then fall through to existing error handling.
+```
+
+- [ ] **Step 4: Update tests**
+
+`messageStoreSteer.test.ts`: the mock returns `{ status: 'steered', run_id: 'r1' }`; the rollback test mocks `{ status: 'no_active_run', run_id: null }`; add a `{ status: 'published' }` case asserting the bubble is **kept**.
+`messageStoreCancel.test.ts`: `cancelActiveRun` mock returns `{ status: 'cancelled', run_id: 'r1' }`.
+
+Run: `cd frontend && pnpm --filter @cubebox/core test && pnpm --filter @cubebox/core build`
+Expected: green; `tsc` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/packages/core/src/api/stream.ts frontend/packages/core/src/stores/messageStore.ts frontend/packages/core/__tests__/stores/messageStoreSteer.test.ts frontend/packages/core/__tests__/stores/messageStoreCancel.test.ts
+git commit -m "feat(store): status-based control responses + 409 resend retry"
+```
+
+---
+
+## Task 5: Cross-instance integration test (two RunManagers, one Redis)
+
+**Files:** Test `backend/tests/unit/test_run_control_crossinstance.py`.
+
+- [ ] **Step 1: Write the test**
+
+Two `RunManager`s share one `fakeredis` client. A (owner) registers a handle + starts listeners; B's `dispatch_*` publishes; assert A acts.
+
+```python
+import asyncio
+
+import fakeredis.aioredis
+import pytest
+
+from cubebox.streams.run_manager import RunManager
+
+
+def _mgr(redis):
+    m = RunManager.__new__(RunManager)  # type: ignore[call-arg]
+    m._redis = redis
+    m._key_prefix = "t"
+    m._tasks = {}
+    m._agents = {}
+    m._ack_waiters = {}
+    m._control_channel = "t:control"
+    m._ack_channel = "t:control:ack"
+    m._control_stopping = False
+    m._control_tasks = []
+    return m
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.steered = []
+
+    def steer(self, message):
+        self.steered.append(message.content[0].text)
+
+
+@pytest.mark.asyncio
+async def test_cross_instance_steer():
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    a, b = _mgr(redis), _mgr(redis)
+    agent = _FakeAgent()
+    a._agents["r1"] = agent  # owner is A
+    await a.start_control_listeners()
+    try:
+        status = await b.dispatch_steer("r1", "redirect")  # request lands on B
+        assert status == "published"
+        for _ in range(50):
+            if agent.steered:
+                break
+            await asyncio.sleep(0.05)
+        assert agent.steered == ["redirect"]
+    finally:
+        await a.stop_control_listeners()
+
+
+@pytest.mark.asyncio
+async def test_cross_instance_cancel_ack():
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    a, b = _mgr(redis), _mgr(redis)
+
+    cancelled = asyncio.Event()
+
+    async def fake_cancel(run_id):
+        cancelled.set()
+        return True
+
+    a._tasks["r1"] = object()  # owner A "has" the task
+    a.cancel_run = fake_cancel  # type: ignore[assignment]
+    await a.start_control_listeners()
+    await b.start_control_listeners()  # B needs its ack listener to resolve its future
+    try:
+        status = await b.dispatch_cancel("r1", ack_timeout=3.0)
+        assert status == "cancelled"
+        assert cancelled.is_set()
+    finally:
+        await a.stop_control_listeners()
+        await b.stop_control_listeners()
+```
+
+Run: `cd backend && uv run pytest tests/unit/test_run_control_crossinstance.py -v`
+Expected: both pass (A receives B's steer; B's cancel resolves via A's ack).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/tests/unit/test_run_control_crossinstance.py
+git commit -m "test(runs): cross-instance steer + cancel-ack integration (shared fakeredis)"
+```
+
+---
+
+## Task 6: Verification sweep
+
+**Files:** none.
+
+- [ ] **Step 1: Worktree E2E config** (copy if absent — see prior plan):
+`cp /home/chris/cubebox/backend/.env backend/.env; cp /home/chris/cubebox/backend/config.development.local.yaml backend/config.development.local.yaml` (the worktree script usually copies these; skip if present). Migrate the worktree test DB if needed: `CUBEBOX_DATABASE__NAME=cubebox_test_feat_run_control_pubsub ENV_FOR_DYNACONF=test uv run alembic upgrade head`.
+
+- [ ] **Step 2: Backend changed-module tests**
+`cd backend && uv run pytest tests/unit/test_run_control_pubsub.py tests/unit/test_run_control_crossinstance.py -v`
+
+- [ ] **Step 3: real-LLM E2E still green via local fast-path**
+`cd backend && uv run pytest tests/e2e/test_steer_endpoint.py -v` (single instance → `status == "steered"`).
+
+- [ ] **Step 4: Frontend tests**
+`cd frontend && pnpm --filter @cubebox/core test`
+
+- [ ] **Step 5: Full sweep**
+`cd /home/chris/cubebox/.worktrees/feat/run-control-pubsub && make check-ci`
+
+- [ ] **Step 6:** `/finishing-a-development-branch` → PR → `/pr-codex-review-loop`.
+
+---
+
+## Self-Review notes
+
+- **Owner publishes ack only via `_handle_control`** (cross-instance cancels). Local fast-path cancels don't publish (no remote waiter) — confirmed: `dispatch_cancel`'s local branch calls `cancel_run` directly and returns `cancelled`.
+- **Ack waiter cleanup** happens in `dispatch_cancel`'s `finally` (both resolved + timeout paths) — no leak.
+- **At-most-once apply:** the publishing instance also receives its own broadcast but `run_id` isn't in its `_tasks`/`_agents` (that's why it published) → filtered. Owner applies once.
+- **Reconnect:** `_subscribe_loop` recreates the pubsub + re-subscribes on any non-cancel exception with capped backoff; `_control_stopping` + task cancel stop it cleanly.
+- **Readiness window / owner-crash / 409 race:** documented in the spec as accepted behavior; the `send` 409-retry (Task 4 Step 3) is the client mitigation for the resend race; cross-instance cancel's ack (`cancelled`) is the primary fix.
+- **Type consistency:** `dispatch_steer`→`{steered|published}`, `dispatch_cancel`→`{cancelled|published}`, endpoints add `no_active_run`; frontend `status` unions match exactly.

--- a/docs/dev/specs/2026-05-25-multi-instance-run-control-design.md
+++ b/docs/dev/specs/2026-05-25-multi-instance-run-control-design.md
@@ -1,0 +1,454 @@
+# Multi-Instance Run Control (cancel + steer) — Design
+
+**Date:** 2026-05-25
+**Status:** Draft for review
+**Author:** (agent-assisted)
+
+## Problem
+
+`cancel` and `steer` are *control signals* aimed at an in-flight run. Today both
+find the run's live handle in a **process-local dict** on `RunManager`:
+
+- `cancel_run(run_id)` → `self._tasks[run_id]` (the background `asyncio.Task`).
+- `steer_run(run_id, content)` → `self._agents[run_id]` (the live cubepi `Agent`).
+
+A run executes as a background task **in the single uvicorn process that
+received `POST .../messages`**. With more than one backend instance behind a
+load balancer, a `cancel`/`steer` request can land on a *different* instance,
+whose `RunManager` has no handle for that `run_id`. Result:
+
+- cross-instance **cancel** → silent no-op (the run keeps going).
+- cross-instance **steer** → endpoint returns `steered: false` (message dropped).
+
+This blocks horizontal scaling of the backend. `cancel` already has this defect
+today; `steer` (shipped in #132) inherits it.
+
+## What is already multi-instance-safe (do NOT change)
+
+- **Run state** lives in Redis: active-run key, run-events Stream
+  (`cubebox/streams/run_events.py` — `create_run`, `get_active_run`,
+  `append_run_event`, `read_run_events_after`).
+- **SSE read path** (`_build_run_streaming_response` in
+  `api/routes/v1/conversations.py`) replays + tails the Redis Stream, so **any**
+  instance can serve the live stream for a run executing on another instance.
+- **History / reload** reads the shared Postgres checkpointer (`cubepi_messages`).
+- **Steered-message display** is a client-side optimistic append + reload from
+  the shared checkpointer — instance-independent.
+
+So the run **read** path is already cross-instance. Only the **control** path
+is not.
+
+### Rationale: why SSE keeps tailing the Redis Stream (not "read checkpoint directly")
+
+The Redis run-events Stream and the checkpointer hold different things at
+different granularity, and are **complementary, not redundant**:
+
+| | Redis run-events Stream | Postgres checkpointer |
+|---|---|---|
+| granularity | incremental events (text_delta, tool_call, tool_result, reasoning, usage) — token-level | complete messages, appended on cubepi `MessageEnd` |
+| timing | during generation, live | only after a message finishes |
+| purpose | live streaming + reconnect replay + cross-instance fan-out | durable post-completion history |
+
+cubepi persists a whole message at `MessageEnd`; it stores **no sub-message
+deltas**. Reading the checkpointer "directly" for the live stream would mean a
+response only appears once each message is fully complete — no token streaming,
+no live tool/reasoning progress — a clear UX regression. It would also force the
+SSE connection onto the owning instance (sticky reads), which is exactly what
+the Redis Stream lets us avoid. The Stream is **not** a langgraph-era vestige;
+it is the live-event transport layer. **Non-goal:** changing the SSE transport.
+
+## Goals
+
+- A `cancel`/`steer` request landing on **any** instance reaches the instance
+  that owns the run.
+- No new infrastructure beyond Redis (already a hard dependency).
+- Single-instance behavior is unchanged (same latency, same synchronous
+  confirmation).
+- Unify `cancel` and `steer` over one control mechanism.
+
+## Non-Goals
+
+- Changing the SSE transport (see rationale above).
+- Strong delivery/consumption guarantees for cross-instance control (we accept
+  fire-and-forget "accepted" semantics — see Confirmation).
+- Moving run execution off the receiving instance (runs still execute where
+  `POST /messages` lands).
+- Sticky load-balancer routing.
+
+## Design: Redis pub/sub control channel + local fast-path
+
+Replace "find the local handle" with "deliver a signal to whichever instance
+owns the run." The owner already holds the handles; it just needs to *hear*
+control requests that arrived elsewhere.
+
+### Control channel — one shared channel per deployment (B1)
+
+A single Redis pub/sub channel for the whole deployment:
+
+```
+{key_prefix}:control
+```
+
+Message payload (JSON) carries the target `run_id`:
+
+```json
+{ "run_id": "<id>", "type": "cancel" }
+{ "run_id": "<id>", "type": "steer", "content": "<user text>" }
+```
+
+Every instance subscribes to this **one** channel at startup and stays
+subscribed for its whole lifetime; each instance filters incoming messages by
+whether it owns the `run_id`. (See "Subscription topology" below for why a
+single shared channel beats a per-run channel.)
+
+pub/sub (not a Stream) is the right primitive: control signals are only
+meaningful while the owner is alive and subscribed. If no instance owns the
+`run_id` (run ended, or owner crashed), every instance's filter drops it — the
+existing stale-run detection (`is_stale_meta` / `mark_run_stale`) handles a dead
+owner.
+
+### Owner-side listener — one per instance, lifetime-scoped
+
+Each instance runs **one** listener coroutine for its entire lifetime (started
+in the app lifespan / `RunManager` startup, stopped on shutdown), reading from
+the single shared channel. It is NOT per-run — runs do not subscribe or
+unsubscribe; they only register/deregister their handles in the existing
+`_tasks` / `_agents` dicts, and the listener reads those:
+
+- on `{"run_id", "type":"steer", "content"}` → if `run_id in self._agents`,
+  call `agent.steer(UserMessage([TextContent(content)]))`; else ignore.
+- on `{"run_id", "type":"cancel"}` → if `run_id in self._tasks`, call
+  `self.cancel_run(run_id)` (cancels + awaits the local task, same as today);
+  else ignore.
+
+Because the listener runs in the owner process, it applies the signal through
+the **same local code path** the endpoint uses today — it just sources the
+request from Redis instead of an in-process call. The listener and the agent
+share one event loop, so `agent.steer` (lock-free `list.append`) stays safe.
+
+### Subscription topology: why one shared channel (B1), not per-run
+
+A per-run channel (`…:run:{run_id}:control`) gives targeted O(1) delivery, but
+its only advantage — not broadcasting to every instance — optimizes a dimension
+that does not matter here: control messages are **discrete, human-initiated**
+(a Stop click, a steer send), so the rate is low and broadcast fan-out is
+negligible (e.g. 50 instances × 10 controls/s = 500 trivial deliveries/s).
+Against that non-benefit, per-run costs real complexity: the subscription set
+**churns** as runs start/stop (must be serialized across concurrent
+start/stop), and there is a "run is active but not yet subscribed" window where
+a control message would be lost.
+
+A single shared channel makes the subscription **static** (subscribe once at
+startup, never change), eliminating both the churn and that setup race, for the
+cost of a local `run_id`-membership check per message. Note redis-py multiplexes
+many channels onto one connection, so per-run would NOT cost extra connections —
+the real per-run cost is churn, not connection count.
+
+If control throughput or payload size ever grows enough that broadcast waste
+matters, the upgrade path is **B2** (each instance subscribes to its own
+`…:instance:{id}:control`, plus a Redis `run_id → instance_id` registry so the
+publisher targets the owner). B2 keeps the static-subscription model and adds
+targeted delivery at the cost of maintaining + stale-handling that registry.
+We do not need it now.
+
+### Endpoint behavior (local fast-path → cross-instance publish)
+
+Both `cancel_active_run` and `steer_active_run` change to:
+
+1. Look up the active run in Redis (already done today).
+2. If no active/running run → return "no active run" (unchanged).
+3. **Local fast-path:** if `run_id` is in this instance's `_tasks`/`_agents` →
+   act directly and return synchronous confirmation (today's behavior, today's
+   latency). The owner never publishes to itself → no double-application.
+4. **Cross-instance:** otherwise `PUBLISH` `{run_id, type, ...}` to the shared
+   `{key_prefix}:control` channel and return `202 Accepted` with "published"
+   status. (The publishing instance also receives its own broadcast but its
+   filter discards it — it published precisely because the run is not local.)
+
+### Confirmation semantics (decided)
+
+- **Local fast-path (both):** synchronous, authoritative — `steer` returns
+  whether the agent accepted; `cancel` awaits cleanup (preserves the
+  no-409-on-immediate-resend guarantee).
+- **Cross-instance `steer`:** `202` "published" — delivery to the channel, not a
+  consumption guarantee. No ack (steer has no resend race).
+- **Cross-instance `cancel`:** **Option B (bounded ack)** — the endpoint waits
+  for the owner's post-cleanup ack and returns `cancelled` (safe to resend) or,
+  on timeout, `published` (best-effort). This preserves today's "cancel response
+  ⇒ safe to resend" contract cross-instance. Mechanics pinned in "Cross-instance
+  cancel ack" below; rationale + the rejected Option A in decision #2.
+
+Proposed response shape (generalizes today's `{steered, run_id}`):
+
+```json
+{ "status": "steered" | "published" | "no_active_run", "run_id": "<id|null>" }
+```
+
+- `cancel`: `{ "status": "cancelled" | "published" | "no_active_run", "run_id" }`.
+- HTTP: `202` for `steered`/`published`/`cancelled`; `200` for `no_active_run`.
+
+**Frontend impact (steer):** the optimistic bubble currently rolls back when
+`steered === false`. New rule: keep the bubble for `steered` **and**
+`published`; roll back only for `no_active_run`. (`messageStore.steer` +
+`SteerRunResponse` in `@cubebox/core`.)
+
+### Cross-instance cancel ack (Option B mechanics)
+
+Pin the ack design so it doesn't hold a subscriber connection per request:
+
+- **One ack subscriber per instance**, symmetric with the control listener:
+  each instance subscribes once at startup to a single shared ack channel
+  `{key_prefix}:control:ack` and keeps an in-process map `run_id → asyncio.Future`.
+- A cross-instance `cancel` endpoint: (1) register a `Future` under `run_id` in
+  that map, (2) `PUBLISH` the cancel to `{key_prefix}:control`, (3)
+  `await asyncio.wait_for(future, timeout≈2–3s)`. **Register before publish** so
+  the ack can't arrive before we're waiting (the ack lands as a Future
+  resolution, not a missed message). Always remove the map entry in a `finally`.
+- The **owner**, after `cancel_run` cleanup completes (active-run key cleared),
+  `PUBLISH`es `{run_id}` to `{key_prefix}:control:ack`.
+- Each instance's ack listener resolves the matching `Future` (by `run_id`) if
+  present; unknown `run_id`s are ignored (the requester is on another instance
+  or already timed out).
+- Future resolved → endpoint returns `cancelled`; `wait_for` timeout → returns
+  `published` (owner slow or gone). `run_id` is a unique uuid7, so two concurrent
+  cancels of the same run both wait on… (note) two different `Future`s only if
+  they're on the same instance keyed by the same `run_id` — use a small list /
+  resolve-all, or accept that concurrent same-run cancels on one instance are
+  rare; simplest correct choice: store a list of waiters per `run_id` and resolve
+  all. No per-request Redis subscription is created.
+
+This keeps cross-instance cancel to **two extra pub/sub messages** (cancel +
+ack) and zero per-request connections.
+
+### Connection robustness (both listeners)
+
+The control listener and the ack listener are long-lived pub/sub subscribers. A
+dropped Redis connection must **reconnect and re-subscribe** — otherwise an
+instance silently goes deaf to control/acks after a blip while still serving
+traffic (a production multi-instance hazard). The listeners run as supervised
+tasks that, on connection error, reconnect with backoff and re-issue
+`SUBSCRIBE` before resuming. Tie their lifecycle to the app lifespan: start on
+startup; on shutdown, stop them **after** in-flight runs drain (so graceful
+drain can still receive controls).
+
+## Failure modes & edge cases
+
+- **Owner crashed after a steer/cancel was published:** no subscriber consumes
+  it; message dropped. The run is already dead; `is_stale_meta` marks it stale
+  on the next bootstrap/stream read. Acceptable.
+- **Cross-instance cancel + immediate resend (409 race):** today `cancel_run`
+  awaits task cleanup so a resend doesn't hit "already has an active run."
+  Cross-instance, the publishing endpoint can't await the remote task, so a
+  fast resend may briefly 409 until the owner finishes cleanup. Addressed by the
+  recommended bounded-ack (Option B, Open question #2), which restores the
+  "cancel response ⇒ safe to resend" contract; Option A would instead rely on a
+  client 409-retry / active-run poll.
+- **Double delivery:** the owner uses the local fast-path and never publishes to
+  itself, so a signal is applied at most once. Every instance receives the
+  broadcast but only the owner's `run_id` filter matches. pub/sub at-most-once
+  delivery is fine here.
+- **Request lands on owner but run just ended:** local lookup misses → publishes
+  → its own (about-to-unsubscribe) listener may or may not catch it; if not, the
+  run is over anyway.
+- **Steer ordering:** cubepi drains the steering queue at safe points; multiple
+  steers queue in arrival order per the existing `_steering_queue` (one-at-a-
+  time). Cross-instance ordering is best-effort (pub/sub delivery order).
+- **Handle-registration readiness window (cancel/steer asymmetry):** `start_run`
+  puts the task into `_tasks` immediately, but `_agents[run_id]` is only set deep
+  in `_run_cubepi_path` after the agent (LLM + tools + sandbox) is built — a
+  multi-second gap during which the run is already "active" in Redis. So a
+  control arriving in that window: **cancel works** (owner has `_tasks[run_id]`),
+  but **steer is dropped** (owner has no `_agents[run_id]` yet → filter misses).
+  This is not multi-instance-specific — single-instance steer in this window also
+  no-ops via the fast-path (`steered:false` → `no_active_run`/`published`); there
+  is simply no agent to steer yet. Documented, not fixed: the frontend treats it
+  as a transient no-op (the user can re-send the steer once the run is underway).
+- **Owner crash blocks the conversation until stale-detection fires:** if the
+  owning instance dies mid-run, its active-run key persists until `is_stale_meta`
+  marks it stale (`lifecycle.stale_run_threshold_seconds`, default 120s). During
+  that window controls publish to nobody (dropped) and a new `send` 409s
+  (active-run held). Acceptable; operators can lower the threshold. No new
+  mechanism added here — this is existing single-instance crash behavior,
+  unchanged by multi-instance.
+
+## Security / scoping
+
+No change to the auth model. Endpoints stay workspace-scoped
+(`/api/v1/ws/{ws}/conversations/{id}/{cancel,steer}`) and verify membership +
+conversation ownership before publishing. The control channel key includes the
+Redis `key_prefix` (already per-deployment/per-worktree isolated). `run_id` is
+an opaque uuid7; we still gate on the conversation's active-run record, so a
+caller can't steer an arbitrary run_id. With the shared channel (B1) every
+instance receives every control payload (including steer text) within the
+deployment — this stays inside the trusted backend tier and the same
+`key_prefix` namespace; secure the Redis link (TLS/authn) as for all other run
+state. If broadcasting user text to all instances is later deemed too exposed,
+B2's targeted delivery removes it.
+
+## Testing strategy
+
+- **Unit (fakeredis — already a dev dep):** publish a `steer`/`cancel` message
+  to a run's control channel; assert the listener dispatches to a fake agent /
+  cancels a fake task. Assert the endpoint takes the local fast-path when the
+  handle is present and publishes when absent.
+- **Integration (two `RunManager`s, one shared Redis):** instance A starts a run
+  (registers handle + subscribes); instance B's endpoint publishes a steer;
+  assert A's agent receives it. Simulates cross-instance without real HTTP.
+- **Cancel ack round-trip:** B registers a future + publishes cancel; A's
+  `cancel_run` cleanup publishes the ack; assert B resolves to `cancelled`.
+  Separately assert `wait_for` timeout (no owner / slow owner) returns
+  `published`. Assert the per-`run_id` waiter map entry is cleaned up in both
+  paths.
+- **Listener reconnect:** assert the control/ack listeners re-`SUBSCRIBE` after a
+  simulated connection drop (fakeredis or a stubbed pubsub that raises once),
+  i.e. an instance keeps receiving after a blip.
+- **E2E (real-LLM, single instance):** unchanged — the existing
+  `test_steer_endpoint.py` still passes via the local fast-path.
+- Cross-instance E2E with two live uvicorn processes is out of scope for the
+  test suite (no fake for a real LB); the integration test above covers the
+  dispatch logic.
+
+## Rollout / compatibility
+
+- Single-instance deployments are unaffected (fast-path only; the listener still
+  runs but never receives cross-instance messages).
+- No schema/migration changes. No new dependency.
+- Backward-compatible API: the response gains a `status` field; the old
+  `steered` boolean can be retained as `status === "steered"` during a
+  transition if needed, or the frontend updated in lockstep (single repo).
+
+## Decisions
+
+1. **Subscription topology — DECIDED: B1 (single shared channel + local
+   `run_id` filter).** Control messages are low-rate and human-initiated, so
+   per-run's targeted delivery buys nothing meaningful, while a static
+   per-instance subscription removes per-run churn and the subscribe-setup race.
+   B2 (per-instance channel + `run_id → instance_id` registry) is the documented
+   upgrade path if throughput/payload ever makes broadcast waste matter. See
+   "Subscription topology" above.
+
+## Further decisions
+
+2. **Cross-instance `cancel` confirmation — DECIDED: Option B (bounded ack).**
+   This concerns only
+   `cancel`, not `steer` (steer doesn't claim the per-conversation active-run
+   mutex, so it has no analogous race).
+
+   *The race, precisely.* `start_run → create_run` claims the conversation's
+   active-run key in Redis; while it's held, a second `start_run` for the same
+   conversation raises → the API returns **409**. Today `cancel_run` does
+   `task.cancel()` **then `await task`**, so it blocks until the run task's
+   `finally` has run `clear_active_run` (released the key). That's why, on a
+   single instance, "click Stop, immediately resend" is safe: the cancel
+   response only returns *after* the key is free, so the resend's `create_run`
+   succeeds.
+
+   *Why cross-instance regresses it.* When the cancel lands on instance B, B
+   publishes and returns `202` **immediately**; the owner A receives it and runs
+   `cancel_run` (which awaits cleanup **on A**), but B never waited for A. So
+   between B's `202` and A finishing `clear_active_run` there is a window where a
+   fast resend's `create_run` can still see the key held → **409**. The window
+   is roughly A's teardown time (Redis key clear is quick, but `_execute_run`'s
+   `finally` also releases the sandbox / closes sessions, so it can be a few
+   hundred ms up to seconds). Single-instance keeps the synchronous guarantee
+   via the local fast-path; only the cross-instance path loses it.
+
+   *Why not just clear the key from B.* Eagerly clearing the active-run key from
+   the cancel endpoint would let a new run start while A's task is still alive
+   and streaming into the same conversation's Redis stream + checkpointer —
+   concurrent runs per conversation, interleaved events. The key is the mutex;
+   clearing it early is unsafe. Rejected.
+
+   *Option A — accept v1 fire-and-forget.* Cross-instance cancel returns `202`
+   without the cleanup-wait guarantee; a too-fast resend may `409`. Mitigate on
+   the client: treat a post-cancel `409` as "previous run still finishing" and
+   auto-retry after a short backoff (or gate the resend on `bootstrap.active_run`
+   going `null`) instead of surfacing a hard error. Cheapest; the race is narrow
+   and recoverable.
+
+   *Option B — bounded ack round-trip.* Restore the synchronous guarantee
+   cross-instance: the publishing endpoint (B) **subscribes to an ack channel
+   `{key_prefix}:control:ack` (or a per-run ack key) BEFORE publishing the
+   cancel** (subscribe-before-publish, else A's ack could fire before B is
+   listening and be missed), publishes the cancel, then `await
+   asyncio.wait_for(ack, timeout≈2–3s)`. After A's `cancel_run` cleanup
+   completes (key cleared), A publishes the ack `{run_id}`. B returns
+   `cancelled` (200) on ack — safe to resend — or `published` (202) on timeout
+   (best-effort; A slow or gone). Cost: B holds a subscriber wait per
+   cross-instance cancel (fine at this rate) and A emits one extra publish on
+   cleanup. Surgical, cancel-only, and it preserves today's behavior exactly
+   when the owner is responsive.
+
+   *UX difference (this is the deciding lens).* In almost every interaction A
+   and B are indistinguishable — they differ ONLY in the corner "multi-instance
+   deployment + user clicks Stop then **immediately** sends a new message,
+   landing inside the owner's teardown window (sub-second to a couple seconds)."
+   Single-instance (local fast-path) and all of `steer` behave identically under
+   both.
+
+   | User action | Option A (202, no ack) | Option B (bounded ack) |
+   |---|---|---|
+   | Click Stop | UI flips to "stopped" instantly (optimistic, backend-independent) — same both | same |
+   | Stop, **pause** (read/think/type ≥1–2s), then send | window already closed → send works | send works |
+   | Stop, **instantly** send | `create_run` hits the still-held active-run lock → **409**. Without client mitigation: a confusing "send failed / HTTP 409", user thinks the message was lost, must resend. With mitigation (retry-on-409 / poll `active_run`→null): no error, but the resend spins for a few hundred ms–seconds | "cancel response ⇒ safe" contract holds; gate resend on the cancel call → **send just works, no error, no delay perceived** |
+   | Cancelled turn's partial output | preserved (finalize-on-cancel; independent of A/B) | same |
+
+   Engineering implication: **B needs ~no frontend change** (keeps the existing
+   "await cancel ⇒ safe to resend" contract); **A pushes work to the frontend**
+   (must add 409-retry or active-run polling) and still leaves a corner error if
+   that mitigation is skipped.
+
+   *Decision: **Option B.*** "Stop, then immediately rephrase and resend" is a
+   common agent-chat interaction (user interrupts, redirects), so the one
+   regression A introduces is worth removing outright. B's cost is a small,
+   cancel-only ack round-trip on the backend; in return the UX matches
+   single-instance exactly and the frontend is untouched. (`steer` still needs
+   no ack.)
+
+3. **Response shape — DECIDED: adopt the unified `status` field for BOTH
+   `cancel` and `steer`, replacing today's booleans.**
+
+   *Why a boolean is no longer enough.* Today `cancel` returns
+   `{cancelled: bool, run_id}` and `steer` returns `{steered: bool, run_id}`.
+   Once cross-instance exists, each control action has **three** distinct
+   outcomes that a boolean can't express without overloading:
+   - acted locally / confirmed (run is definitively handled here, or — for
+     cancel under Option B — ack-confirmed cleaned up),
+   - published to the owner but **not confirmed** (cross-instance; for cancel
+     under B this is the ack-timeout case, for steer it's always the
+     cross-instance case),
+   - there was **no active run** to act on.
+
+   Cramming "published-but-unconfirmed" into `cancelled: false` would make it
+   indistinguishable from "no active run," and the frontend can't then tell
+   "safe to resend now" from "still settling." So we move both to:
+
+   ```json
+   // steer
+   { "status": "steered"  | "published" | "no_active_run", "run_id": "<id|null>" }
+   // cancel
+   { "status": "cancelled" | "published" | "no_active_run", "run_id": "<id|null>" }
+   ```
+
+   *Status meanings.*
+   - `steered` / `cancelled` — local fast-path, or (cancel + Option B)
+     ack-confirmed. Authoritative; for cancel, resend is safe.
+   - `published` — broadcast to the owner, consumption not confirmed (steer
+     cross-instance always; cancel cross-instance only on ack timeout).
+   - `no_active_run` — nothing to act on.
+
+   HTTP: `202` for `steered`/`cancelled`/`published`; `200` for `no_active_run`.
+
+   *Frontend use (ties OQ#3 to OQ#2/B).*
+   - steer: keep the optimistic bubble for `steered` **and** `published`; roll it
+     back only on `no_active_run`.
+   - cancel: gate "safe to resend immediately" on `status === "cancelled"`; on
+     `published` (B ack timeout) fall back to the active-run poll / retry-on-409
+     before resending. This is exactly the signal Option B provides.
+
+   *Migration.* Single repo, frontend + backend land together; cubebox hasn't
+   shipped publicly, so cut the booleans (`cancelled` / `steered`) over cleanly
+   to `status` — no back-compat shim. Touch points: backend `cancel_active_run`
+   + `steer_active_run`; `@cubebox/core` `CancelRunResponse` / `SteerRunResponse`
+   types + `cancelStream` / `steer` store actions (the steer rollback rule and
+   the cancel resend-gating above).

--- a/docs/dev/specs/2026-05-25-multi-instance-run-control-design.md
+++ b/docs/dev/specs/2026-05-25-multi-instance-run-control-design.md
@@ -210,12 +210,13 @@ Pin the ack design so it doesn't hold a subscriber connection per request:
   present; unknown `run_id`s are ignored (the requester is on another instance
   or already timed out).
 - Future resolved → endpoint returns `cancelled`; `wait_for` timeout → returns
-  `published` (owner slow or gone). `run_id` is a unique uuid7, so two concurrent
-  cancels of the same run both wait on… (note) two different `Future`s only if
-  they're on the same instance keyed by the same `run_id` — use a small list /
-  resolve-all, or accept that concurrent same-run cancels on one instance are
-  rare; simplest correct choice: store a list of waiters per `run_id` and resolve
-  all. No per-request Redis subscription is created.
+  `published` (owner slow or gone).
+- **Waiter map = `run_id → list[Future]`** (a list, so two concurrent cancels of
+  the same `run_id` on one instance each get their own future; one ack resolves
+  all). **Cleanup removes only this request's future**, and pops the `run_id`
+  key only when its list becomes empty — a timed-out waiter must NOT erase the
+  whole entry (that would orphan sibling waiters / a later valid ack). No
+  per-request Redis subscription is created.
 
 This keeps cross-instance cancel to **two extra pub/sub messages** (cancel +
 ack) and zero per-request connections.
@@ -225,11 +226,24 @@ ack) and zero per-request connections.
 The control listener and the ack listener are long-lived pub/sub subscribers. A
 dropped Redis connection must **reconnect and re-subscribe** — otherwise an
 instance silently goes deaf to control/acks after a blip while still serving
-traffic (a production multi-instance hazard). The listeners run as supervised
-tasks that, on connection error, reconnect with backoff and re-issue
-`SUBSCRIBE` before resuming. Tie their lifecycle to the app lifespan: start on
-startup; on shutdown, stop them **after** in-flight runs drain (so graceful
-drain can still receive controls).
+traffic (a production multi-instance hazard). Requirements:
+
+- **Reconnect with backoff + re-`SUBSCRIBE`** on any connection error, then
+  resume the read loop.
+- **Per-message exception containment:** wrap each message's decode + handler in
+  `try/except` so one bad payload (malformed JSON, schema drift) or a handler
+  fault logs and is skipped — it must NOT break out of the read loop and kill
+  the long-lived listener (which would silently deafen the instance until
+  restart). Only connection-level errors trigger the reconnect path.
+- **Await readiness on startup:** `start_control_listeners` must not return until
+  the first `SUBSCRIBE` for **both** channels has completed (each loop signals an
+  `asyncio.Event` after subscribing; startup awaits both, **bounded** by a short
+  timeout so a Redis hiccup can't hang boot). Otherwise the listeners are
+  fire-and-forget and a control published in the gap between "app ready" and
+  "subscriber live" is silently lost.
+- **Lifecycle = app lifespan:** start on startup (after readiness); on shutdown,
+  stop them **after** in-flight runs drain (so graceful drain can still receive
+  controls).
 
 ## Failure modes & edge cases
 
@@ -257,8 +271,20 @@ drain can still receive controls).
   puts the task into `_tasks` immediately, but `_agents[run_id]` is only set deep
   in `_run_cubepi_path` after the agent (LLM + tools + sandbox) is built — a
   multi-second gap during which the run is already "active" in Redis. So a
-  control arriving in that window: **cancel works** (owner has `_tasks[run_id]`),
-  but **steer is dropped** (owner has no `_agents[run_id]` yet → filter misses).
+  control arriving in that window: **cancel works**, but **steer is dropped**
+  (owner has no `_agents[run_id]` yet → filter misses).
+
+  Why cancel is safe even though `create_run` commits the active-run key
+  *before* the `_tasks` assignment (`run_manager.py:462-493`): on the owner's
+  single event loop there is **no `await` between** `create_run` resolving and
+  `self._tasks[run_id] = task`, so that assignment completes in the same
+  synchronous slice — the control listener (another task on the same loop)
+  cannot run until `start_run` next yields, by which point `_tasks` already has
+  the id. A cross-instance cancel can only reach the owner after a Redis
+  round-trip (B observes the key → publish → owner listener), which necessarily
+  happens after that slice. So the owner never processes a cancel while `_tasks`
+  lacks the run. (`_agents` is different: it's set deep inside `_run_cubepi_path`
+  after many awaits, hence the steer window is real.)
   This is not multi-instance-specific — single-instance steer in this window also
   no-ops via the fast-path (`steered:false` → `no_active_run`/`published`); there
   is simply no agent to steer yet. Documented, not fixed: the frontend treats it
@@ -367,16 +393,15 @@ B2's targeted delivery removes it.
    and recoverable.
 
    *Option B — bounded ack round-trip.* Restore the synchronous guarantee
-   cross-instance: the publishing endpoint (B) **subscribes to an ack channel
-   `{key_prefix}:control:ack` (or a per-run ack key) BEFORE publishing the
-   cancel** (subscribe-before-publish, else A's ack could fire before B is
-   listening and be missed), publishes the cancel, then `await
-   asyncio.wait_for(ack, timeout≈2–3s)`. After A's `cancel_run` cleanup
-   completes (key cleared), A publishes the ack `{run_id}`. B returns
-   `cancelled` (200) on ack — safe to resend — or `published` (202) on timeout
-   (best-effort; A slow or gone). Cost: B holds a subscriber wait per
-   cross-instance cancel (fine at this rate) and A emits one extra publish on
-   cleanup. Surgical, cancel-only, and it preserves today's behavior exactly
+   cross-instance. The mechanics are pinned in "Cross-instance cancel ack" above
+   (one **startup** ack subscriber per instance + a `run_id → list[Future]` map;
+   the endpoint **registers a future before publishing**, publishes the cancel,
+   then `await asyncio.wait_for(future, timeout≈2–3s)`; the owner publishes the
+   ack after its `cancel_run` cleanup clears the active-run key). B returns
+   `cancelled` on ack — safe to resend — or `published` on timeout (best-effort;
+   owner slow or gone); both are HTTP `202` (`200` is only `no_active_run`). Cost
+   is two extra pub/sub messages per cross-instance cancel and **no** per-request
+   subscription. Surgical, cancel-only, and it preserves today's behavior exactly
    when the owner is responsive.
 
    *UX difference (this is the deciding lens).* In almost every interaction A

--- a/frontend/packages/core/__tests__/stores/messageStoreCancel.test.ts
+++ b/frontend/packages/core/__tests__/stores/messageStoreCancel.test.ts
@@ -6,7 +6,7 @@ vi.mock('../../src/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/api')>()
   return {
     ...actual,
-    cancelActiveRun: vi.fn().mockResolvedValue({ cancelled: true, run_id: 'r1' }),
+    cancelActiveRun: vi.fn().mockResolvedValue({ status: 'cancelled', run_id: 'r1' }),
   }
 })
 

--- a/frontend/packages/core/__tests__/stores/messageStoreSteer.test.ts
+++ b/frontend/packages/core/__tests__/stores/messageStoreSteer.test.ts
@@ -5,7 +5,7 @@ vi.mock('../../src/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/api')>()
   return {
     ...actual,
-    steerRun: vi.fn().mockResolvedValue({ steered: true, run_id: 'r1' }),
+    steerRun: vi.fn().mockResolvedValue({ status: 'steered', run_id: 'r1' }),
   }
 })
 
@@ -60,10 +60,19 @@ describe('messageStore.steer', () => {
 
   it('rolls back the optimistic bubble when the run was not steered', async () => {
     ;(steerRun as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      steered: false,
+      status: 'no_active_run',
       run_id: null,
     })
     await useMessageStore.getState().steer(fakeClient, 'conv1', 'too late')
     expect(useMessageStore.getState().messages.conv1).toHaveLength(0)
+  })
+
+  it('keeps the optimistic bubble when status is published', async () => {
+    ;(steerRun as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 'published',
+      run_id: 'r1',
+    })
+    await useMessageStore.getState().steer(fakeClient, 'conv1', 'cross-instance steer')
+    expect(useMessageStore.getState().messages.conv1).toHaveLength(1)
   })
 })

--- a/frontend/packages/core/src/api/stream.ts
+++ b/frontend/packages/core/src/api/stream.ts
@@ -4,7 +4,7 @@ import { CSRF_COOKIE_NAME } from './cookieNames'
 import { streamRun } from './runStreams'
 
 export interface CancelRunResponse {
-  cancelled: boolean
+  status: 'cancelled' | 'published' | 'no_active_run'
   run_id: string | null
 }
 
@@ -20,7 +20,7 @@ export async function cancelActiveRun(
 }
 
 export interface SteerRunResponse {
-  steered: boolean
+  status: 'steered' | 'published' | 'no_active_run'
   run_id: string | null
 }
 

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -871,65 +871,83 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
     const controller = new AbortController()
     activeStreamController = controller
 
+    let retried = false
+    let streamSource = streamMessages(
+      client,
+      conversationId,
+      content,
+      attachmentIds,
+      controller.signal,
+    )
+
     try {
-      for await (const event of streamMessages(
-        client,
-        conversationId,
-        content,
-        attachmentIds,
-        controller.signal,
-      )) {
-        if (event.event_id && get().lastAppliedEventId) {
-          if (compareEventIds(event.event_id, get().lastAppliedEventId!) <= 0) continue
-        }
+      outer: for (;;) {
+        for await (const event of streamSource) {
+          if (event.event_id && get().lastAppliedEventId) {
+            if (compareEventIds(event.event_id, get().lastAppliedEventId!) <= 0) continue
+          }
 
-        if (event.type === 'artifact') {
-          const artifactData = event.data as unknown as ArtifactEventData
-          if (artifactData.artifact) {
-            const { useArtifactStore } = await import('./artifactStore')
-            useArtifactStore.getState().addOrUpdate(conversationId, artifactData.artifact)
-          }
-        } else if (event.type === 'citation') {
-          const citationData = event.data as unknown as import('../types').CitationData
-          useCitationStore.getState().addCitation(conversationId, citationData)
-        } else if (event.type === 'error') {
-          const errData = event.data as { message: string; details?: string }
-          set({
-            error: errData.details || errData.message,
-            isStreaming: false,
-            streamingConversationId: null,
-            currentRunId: null,
-            statusPhase: null,
-            lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
-          })
-          break
-        } else if (event.type === 'done') {
-          const usage = (event.data as Record<string, unknown>).usage as
-            | import('../types').UsageSummary
-            | undefined
-          const usageUpdate: Partial<MessageStore> = {
-            lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
-          }
-          if (usage) {
-            usageUpdate.turnUsage = {
-              ...get().turnUsage,
-              [conversationId]: usage.turn,
+          if (event.type === 'artifact') {
+            const artifactData = event.data as unknown as ArtifactEventData
+            if (artifactData.artifact) {
+              const { useArtifactStore } = await import('./artifactStore')
+              useArtifactStore.getState().addOrUpdate(conversationId, artifactData.artifact)
             }
-            usageUpdate.sessionUsage = {
-              ...get().sessionUsage,
-              [conversationId]: usage.session,
+          } else if (event.type === 'citation') {
+            const citationData = event.data as unknown as import('../types').CitationData
+            useCitationStore.getState().addCitation(conversationId, citationData)
+          } else if (event.type === 'error') {
+            const errData = event.data as { message: string; details?: string }
+            if (!retried && !sawDone && errData.message.includes('409')) {
+              retried = true
+              await new Promise((r) => setTimeout(r, 400))
+              streamSource = streamMessages(
+                client,
+                conversationId,
+                content,
+                attachmentIds,
+                controller.signal,
+              )
+              continue outer
             }
-            usageUpdate.contextWindow = {
-              ...get().contextWindow,
-              [conversationId]: usage.context_window,
+            set({
+              error: errData.details || errData.message,
+              isStreaming: false,
+              streamingConversationId: null,
+              currentRunId: null,
+              statusPhase: null,
+              lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
+            })
+            break outer
+          } else if (event.type === 'done') {
+            const usage = (event.data as Record<string, unknown>).usage as
+              | import('../types').UsageSummary
+              | undefined
+            const usageUpdate: Partial<MessageStore> = {
+              lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
             }
+            if (usage) {
+              usageUpdate.turnUsage = {
+                ...get().turnUsage,
+                [conversationId]: usage.turn,
+              }
+              usageUpdate.sessionUsage = {
+                ...get().sessionUsage,
+                [conversationId]: usage.session,
+              }
+              usageUpdate.contextWindow = {
+                ...get().contextWindow,
+                [conversationId]: usage.context_window,
+              }
+            }
+            set(usageUpdate)
+            sawDone = true
+            break outer
           }
-          set(usageUpdate)
-          sawDone = true
-          break
-        }
 
-        batchedSet((s) => applyStreamEvent(s, event))
+          batchedSet((s) => applyStreamEvent(s, event))
+        }
+        break outer
       }
     } catch (err) {
       set({
@@ -992,7 +1010,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
 
     try {
       const res = await steerRun(client, conversationId, text)
-      if (!res.steered) rollback()
+      if (res.status === 'no_active_run') rollback()
     } catch (err) {
       console.error('Failed to steer run:', err)
       rollback()


### PR DESCRIPTION
## Summary
Makes `cancel` and `steer` work across backend instances. Today both find the live run handle in a process-local dict on `RunManager`, so a control request landing on a different instance than the one running the agent is a no-op. This adds a Redis pub/sub control path with a local fast-path.

- **Transport (B1):** one shared channel `{key_prefix}:control`; every instance subscribes once at startup and filters by whether it owns the `run_id` (`_tasks`/`_agents`). Listeners reconnect + re-subscribe on drop, contain per-message exceptions, and startup waits for the first SUBSCRIBE.
- **Endpoints:** local fast-path (act directly if the run is here) → else PUBLISH. Unified `{status, run_id}` response (steer: `steered|published|no_active_run`; cancel: `cancelled|published|no_active_run`).
- **Cross-instance cancel = bounded ack:** one per-instance ack subscriber + `run_id → list[Future]` map; endpoint registers the future before publishing, waits ~3s; owner publishes the ack after its cleanup clears the active-run key → `cancelled`, or timeout → `published`. Preserves the "cancel response ⇒ safe to resend" contract.
- **Frontend:** `{status}` response types; steer keeps the optimistic bubble for `steered`+`published` (rolls back only `no_active_run`); `send` retries once on a 409 (resend-after-cancel race).

Single-instance behavior is unchanged (fast-path only). No schema/migration changes; no new dependency (Redis already required).

Design: `docs/dev/specs/2026-05-25-multi-instance-run-control-design.md` (independently codex-reviewed). Plan: `docs/dev/plans/2026-05-25-multi-instance-run-control.md`.

## Test plan
- [x] `test_run_control_pubsub.py` (6) — dispatch local/remote, `_handle_control`/`_handle_ack`, cancel-ack timeout (fakeredis).
- [x] `test_run_control_crossinstance.py` (2) — two `RunManager`s on one fakeredis: cross-instance steer delivery + cancel-ack round-trip through the real pub/sub path.
- [x] `test_run_manager_steer.py` (2) — registry + steer_run.
- [x] Frontend core vitest (61) — status-based rollback + published-kept case.
- [x] real-LLM E2E `test_steer_endpoint.py` — local fast-path returns `status: "steered"`, steered marker lands in history.
- [x] `make check-ci` green (backend ruff+mypy+unit, frontend build+lint+type-check+vitest+next build).

## Known v1 limitations (in the spec)
- Cross-instance `steer` is `202 published` (delivery, not consumption guarantee); a steer in the agent-build readiness window is a no-op (cancel is unaffected — `_tasks` is registered synchronously).
- Owner crash blocks the conversation until stale-detection (`lifecycle.stale_run_threshold_seconds`, default 120s).