### PR TITLE
feat: steer message display — pending chip → inline commit, with cancel

### DIFF
--- a/backend/cubebox/agents/schemas.py
+++ b/backend/cubebox/agents/schemas.py
@@ -160,3 +160,13 @@ class UsageEvent(AgentEvent):
             "Usage payload: input_tokens, output_tokens, cache_read_tokens, cache_write_tokens"
         )
     )
+
+
+class InjectedMessageEvent(AgentEvent):
+    """A user message injected mid-run (a steer) that cubepi has now drained
+    into the thread. Carries the join key so the frontend can match it to a
+    pending chip and commit it at the real transcript position.
+    """
+
+    type: Literal["injected_message"] = "injected_message"
+    data: dict[str, Any] = Field(description="Event data with content and steer_id")

--- a/backend/cubebox/agents/stream.py
+++ b/backend/cubebox/agents/stream.py
@@ -27,7 +27,13 @@ from cubepi.agent.types import (
     MessageUpdateEvent,
     ToolExecutionEndEvent,
 )
-from cubepi.providers.base import AssistantMessage, StreamEvent, TextContent, ToolCall
+from cubepi.providers.base import (
+    AssistantMessage,
+    StreamEvent,
+    TextContent,
+    ToolCall,
+    UserMessage,
+)
 
 
 def _stringify_tool_result(result: Any) -> tuple[str, Any]:
@@ -145,6 +151,12 @@ def convert_agent_event_to_sse(evt: AgentEvent) -> list[dict[str, Any]]:
                     "cache_write_tokens": msg.usage.cache_write_tokens or 0,
                 }
             ]
+
+    if isinstance(evt, MessageEndEvent) and isinstance(evt.message, UserMessage):
+        steer_id = evt.message.metadata.get("steer_id")
+        if steer_id:
+            text = "".join(c.text for c in evt.message.content if isinstance(c, TextContent))
+            return [{"type": "injected_message", "content": text, "steer_id": steer_id}]
 
     # Silently drop all other AgentEvent types:
     # AgentStartEvent, AgentEndEvent (done is emitted by run_manager with usage),

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -271,6 +271,13 @@ class SteerMessageRequest(BaseModel):
     """Request body for steering an in-flight run."""
 
     content: str
+    steer_id: str
+
+
+class CancelSteerRequest(BaseModel):
+    """Request body for cancelling a not-yet-drained steer."""
+
+    steer_id: str
 
 
 class SendMessageRequest(BaseModel):
@@ -862,5 +869,41 @@ async def steer_active_run(
         return {"status": "no_active_run", "run_id": None}
 
     run_manager = raw_request.app.state.run_manager
-    dispatch_status = await run_manager.dispatch_steer(active_run.run_id, body.content)
+    dispatch_status = await run_manager.dispatch_steer(
+        active_run.run_id, body.content, steer_id=body.steer_id
+    )
+    return {"status": dispatch_status, "run_id": active_run.run_id}
+
+
+@router.post("/{conversation_id}/steer/cancel", status_code=status.HTTP_202_ACCEPTED)
+async def cancel_steer(
+    conversation_id: str,
+    body: CancelSteerRequest,
+    raw_request: Request,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    ctx: Annotated[RequestContext, Depends(require_member)],
+    rds: Annotated[RedisHandle, Depends(redis_dep)],
+) -> dict[str, object]:
+    """Best-effort cancel of a not-yet-drained steer on the active run."""
+    conv_repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
+    conversation = await conv_repo.get_by_id(conversation_id)
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Conversation {conversation_id} not found",
+        )
+
+    active_run = await get_active_run(
+        rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
+    )
+    if active_run is None or active_run.status != "running":
+        return {"status": "no_active_run", "run_id": None}
+
+    run_manager = raw_request.app.state.run_manager
+    dispatch_status = await run_manager.dispatch_cancel_steer(active_run.run_id, body.steer_id)
     return {"status": dispatch_status, "run_id": active_run.run_id}

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -547,12 +547,20 @@ class RunManager:
         agent.steer(UserMessage(content=[TextContent(text=content)]))
         return True
 
-    async def _publish_control(self, run_id: str, type_: str, content: str | None = None) -> None:
+    async def _publish_control(
+        self,
+        run_id: str,
+        type_: str,
+        content: str | None = None,
+        steer_id: str | None = None,
+    ) -> None:
         import json
 
         payload: dict[str, Any] = {"run_id": run_id, "type": type_}
         if content is not None:
             payload["content"] = content
+        if steer_id is not None:
+            payload["steer_id"] = steer_id
         await self._redis.publish(self._control_channel, json.dumps(payload))
 
     async def _publish_ack(self, run_id: str) -> None:
@@ -560,14 +568,27 @@ class RunManager:
 
         await self._redis.publish(self._ack_channel, json.dumps({"run_id": run_id}))
 
-    async def dispatch_steer(self, run_id: str, content: str) -> str:
+    async def dispatch_steer(self, run_id: str, content: str, steer_id: str) -> str:
         agent = self._agents.get(run_id)
         if agent is not None:
             from cubepi.providers.base import TextContent, UserMessage
 
-            agent.steer(UserMessage(content=[TextContent(text=content)]))
+            agent.steer(
+                UserMessage(
+                    content=[TextContent(text=content)],
+                    metadata={"steer_id": steer_id},
+                )
+            )
             return "steered"
-        await self._publish_control(run_id, "steer", content)
+        await self._publish_control(run_id, "steer", content, steer_id=steer_id)
+        return "published"
+
+    async def dispatch_cancel_steer(self, run_id: str, steer_id: str) -> str:
+        agent = self._agents.get(run_id)
+        if agent is not None:
+            removed = agent.cancel_steer(steer_id)
+            return "cancelled" if removed else "not_found"
+        await self._publish_control(run_id, "cancel_steer", steer_id=steer_id)
         return "published"
 
     async def dispatch_cancel(self, run_id: str, ack_timeout: float = 3.0) -> str:
@@ -604,7 +625,16 @@ class RunManager:
             if agent is not None:
                 from cubepi.providers.base import TextContent, UserMessage
 
-                agent.steer(UserMessage(content=[TextContent(text=data.get("content") or "")]))
+                agent.steer(
+                    UserMessage(
+                        content=[TextContent(text=data.get("content") or "")],
+                        metadata={"steer_id": data.get("steer_id") or ""},
+                    )
+                )
+        elif type_ == "cancel_steer":
+            agent = self._agents.get(run_id)
+            if agent is not None:
+                agent.cancel_steer(data.get("steer_id") or "")
 
     async def _handle_ack(self, data: dict[str, Any]) -> None:
         run_id = data.get("run_id")

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -250,6 +250,7 @@ def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent 
     """
     from cubebox.agents.schemas import (
         ErrorEvent,
+        InjectedMessageEvent,
         ReasoningEvent,
         TextDeltaEvent,
         ToolCallEvent,
@@ -258,6 +259,11 @@ def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent 
     )
 
     t = d.get("type")
+    if t == "injected_message":
+        return InjectedMessageEvent(
+            timestamp=timestamp,
+            data={"content": d.get("content", ""), "steer_id": d.get("steer_id", "")},
+        )
     if t == "text_delta":
         return TextDeltaEvent(
             timestamp=timestamp,
@@ -1337,10 +1343,20 @@ class RunManager:
             # skills / todo middleware can read and write persistent state.
             extra_ref_holder["extra"] = agent._extra
 
+            from cubepi.agent.types import MessageEndEvent as _MsgEndEvent
+            from cubepi.providers.base import UserMessage as _UserMsg
+
+            _user_msg_seen = 0
+
             def _on_event(evt: Any, _signal: Any = None) -> None:
                 # Runs on the same event loop as _run_cubepi_path, so
                 # put_nowait is safe.  If we ever invoke the agent from a
                 # background thread, swap to loop.call_soon_threadsafe.
+                nonlocal _user_msg_seen
+                if isinstance(evt, _MsgEndEvent) and isinstance(evt.message, _UserMsg):
+                    _user_msg_seen += 1
+                    if _user_msg_seen == 1:
+                        return  # seed prompt — already shown optimistically
                 for d in convert_agent_event_to_sse(evt):
                     sse_queue.put_nowait(d)
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -158,11 +158,10 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-# TEMPORARY: pinned to the feat/cancel-steer branch commit (cubepi PR #120),
-# which adds Agent.cancel_steer / _MessageQueue.remove for the steer-cancel
-# feature. Re-pin to main once #120 merges, and before merging this cubebox
-# branch. Built on #117 (turn-boundary steering drain) + #116.
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "9533540" }
+# da9d792 is cubepi main HEAD: adds Agent.cancel_steer / _MessageQueue.remove
+# (#120) for the steer-cancel feature, on top of turn-boundary steering drain
+# (#117) + the cancel-orphan-tool-results fix (#116).
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "da9d792" }
 
 [dependency-groups]
 dev = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -158,10 +158,11 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-# 8e9e4b9 is cubepi main HEAD: adds turn-boundary steering drain (#117) on top
-# of the cancel-orphan-tool-results fix (#116). The steer-during-run feature
-# relies on tail steering being honored during a final/tool-less turn.
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "8e9e4b9" }
+# TEMPORARY: pinned to the feat/cancel-steer branch commit (cubepi PR #120),
+# which adds Agent.cancel_steer / _MessageQueue.remove for the steer-cancel
+# feature. Re-pin to main once #120 merges, and before merging this cubebox
+# branch. Built on #117 (turn-boundary steering drain) + #116.
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "9533540" }
 
 [dependency-groups]
 dev = [

--- a/backend/tests/e2e/test_steer_endpoint.py
+++ b/backend/tests/e2e/test_steer_endpoint.py
@@ -35,7 +35,10 @@ async def test_steer_injects_user_message_into_active_run(member_client) -> None
         if b.json().get("active_run"):
             s = await client.post(
                 f"/api/v1/ws/{ws_id}/conversations/{conv_id}/steer",
-                json={"content": "STEER_MARKER_42: also print 'hello from steer'"},
+                json={
+                    "content": "STEER_MARKER_42: also print 'hello from steer'",
+                    "steer_id": "steer-e2e-1",
+                },
             )
             assert s.status_code == 202
             steered = s.json()["status"] == "steered"

--- a/backend/tests/unit/test_run_control_crossinstance.py
+++ b/backend/tests/unit/test_run_control_crossinstance.py
@@ -22,10 +22,10 @@ def _mgr(redis: fakeredis.aioredis.FakeRedis) -> RunManager:
 
 class _FakeAgent:
     def __init__(self) -> None:
-        self.steered: list[str] = []
+        self.steered: list = []
 
     def steer(self, message) -> None:  # noqa: ANN001
-        self.steered.append(message.content[0].text)
+        self.steered.append(message)
 
 
 @pytest.mark.asyncio
@@ -39,12 +39,13 @@ async def test_cross_instance_steer() -> None:
     a._agents["r1"] = agent  # owner is A
     await a.start_control_listeners()
     try:
-        assert await b.dispatch_steer("r1", "redirect") == "published"
+        assert await b.dispatch_steer("r1", "redirect", steer_id="s1") == "published"
         for _ in range(50):
             if agent.steered:
                 break
             await asyncio.sleep(0.05)
-        assert agent.steered == ["redirect"]
+        assert agent.steered[0].content[0].text == "redirect"
+        assert agent.steered[0].metadata["steer_id"] == "s1"
     finally:
         await a.stop_control_listeners()
 

--- a/backend/tests/unit/test_run_control_pubsub.py
+++ b/backend/tests/unit/test_run_control_pubsub.py
@@ -23,10 +23,10 @@ def _mgr(redis) -> RunManager:
 
 class _FakeAgent:
     def __init__(self) -> None:
-        self.steered: list[str] = []
+        self.steered: list = []
 
     def steer(self, message) -> None:  # noqa: ANN001
-        self.steered.append(message.content[0].text)
+        self.steered.append(message)
 
 
 @pytest.fixture
@@ -39,8 +39,9 @@ async def test_dispatch_steer_local_calls_agent(redis):
     m = _mgr(redis)
     agent = _FakeAgent()
     m._agents["r1"] = agent
-    assert await m.dispatch_steer("r1", "go left") == "steered"
-    assert agent.steered == ["go left"]
+    assert await m.dispatch_steer("r1", "go left", steer_id="s1") == "steered"
+    assert agent.steered[0].content[0].text == "go left"
+    assert agent.steered[0].metadata["steer_id"] == "s1"
 
 
 @pytest.mark.asyncio
@@ -49,14 +50,19 @@ async def test_dispatch_steer_remote_publishes(redis):
     pubsub = redis.pubsub()
     await pubsub.subscribe("t:control")
     await asyncio.sleep(0)
-    assert await m.dispatch_steer("r-remote", "hello") == "published"
+    assert await m.dispatch_steer("r-remote", "hello", steer_id="s1") == "published"
     got = None
     for _ in range(20):
         msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.1)
         if msg:
             got = json.loads(msg["data"])
             break
-    assert got == {"run_id": "r-remote", "type": "steer", "content": "hello"}
+    assert got == {
+        "run_id": "r-remote",
+        "type": "steer",
+        "content": "hello",
+        "steer_id": "s1",
+    }
 
 
 @pytest.mark.asyncio
@@ -65,7 +71,7 @@ async def test_handle_control_steer_dispatches_locally(redis):
     agent = _FakeAgent()
     m._agents["r1"] = agent
     await m._handle_control({"run_id": "r1", "type": "steer", "content": "x"})
-    assert agent.steered == ["x"]
+    assert agent.steered[0].content[0].text == "x"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_run_manager_steer.py
+++ b/backend/tests/unit/test_run_manager_steer.py
@@ -7,10 +7,23 @@ from cubebox.streams.run_manager import RunManager
 
 class _FakeAgent:
     def __init__(self) -> None:
-        self.steered: list[str] = []
+        self.steered: list = []
+        self.cancelled: list[str] = []
 
     def steer(self, message) -> None:  # noqa: ANN001 - cubepi Message
-        self.steered.append(message.content[0].text)
+        self.steered.append(message)
+
+    def cancel_steer(self, steer_id: str) -> bool:  # noqa: ANN001
+        self.cancelled.append(steer_id)
+        return True
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.published: list[str] = []
+
+    async def publish(self, channel: str, payload: str) -> None:
+        self.published.append(payload)
 
 
 def _make_manager() -> RunManager:
@@ -28,7 +41,7 @@ async def test_steer_run_calls_agent_steer_for_registered_run() -> None:
     steered = await mgr.steer_run("run-1", "go left instead")
 
     assert steered is True
-    assert agent.steered == ["go left instead"]
+    assert agent.steered[0].content[0].text == "go left instead"
 
 
 @pytest.mark.asyncio
@@ -39,3 +52,35 @@ async def test_steer_run_returns_false_when_no_agent() -> None:
     steered = await mgr.steer_run("missing", "hello")
 
     assert steered is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_steer_threads_steer_id_into_metadata() -> None:
+    mgr = _make_manager()
+    mgr._agents = {}
+    agent = _FakeAgent()
+    mgr._agents["run-1"] = agent
+    status = await mgr.dispatch_steer("run-1", "do X", steer_id="s1")
+    assert status == "steered"
+    assert agent.steered[0].metadata["steer_id"] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_cancel_steer_calls_agent() -> None:
+    mgr = _make_manager()
+    mgr._agents = {}
+    agent = _FakeAgent()
+    mgr._agents["run-1"] = agent
+    status = await mgr.dispatch_cancel_steer("run-1", "s1")
+    assert status == "cancelled"
+    assert agent.cancelled == ["s1"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_cancel_steer_no_local_agent_publishes() -> None:
+    mgr = _make_manager()
+    mgr._agents = {}
+    mgr._redis = _FakeRedis()
+    mgr._control_channel = "ctrl"
+    status = await mgr.dispatch_cancel_steer("missing-run", "s1")
+    assert status == "published"

--- a/backend/tests/unit/test_run_manager_translate.py
+++ b/backend/tests/unit/test_run_manager_translate.py
@@ -1,0 +1,11 @@
+from cubebox.agents.schemas import InjectedMessageEvent
+from cubebox.streams.run_manager import cubepi_dict_to_agent_event
+
+
+def test_injected_message_dict_becomes_typed_event():
+    evt = cubepi_dict_to_agent_event(
+        {"type": "injected_message", "content": "do X", "steer_id": "s1"},
+        "2026-05-25T00:00:00+00:00",
+    )
+    assert isinstance(evt, InjectedMessageEvent)
+    assert evt.data == {"content": "do X", "steer_id": "s1"}

--- a/backend/tests/unit/test_stream.py
+++ b/backend/tests/unit/test_stream.py
@@ -8,6 +8,7 @@ from cubepi.providers.base import (
     TextContent,
     ToolCall,
     Usage,
+    UserMessage,
 )
 
 from cubebox.agents.stream import convert_agent_event_to_sse, convert_event_to_sse
@@ -233,3 +234,18 @@ def test_tool_result_prefers_details_original_content_for_sse() -> None:
     out = convert_agent_event_to_sse(evt)
     assert out[0]["result"] == '{"query":"q","results":[{"url":"http://x","title":"X"}]}'
     assert out[0]["details"]["citations"] == [{"citation_id": 1}]
+
+
+# ---------------------------------------------------------------------------
+# convert_agent_event_to_sse — injected steer UserMessage → injected_message
+
+
+def test_injected_user_message_becomes_injected_message_dict() -> None:
+    msg = UserMessage(content=[TextContent(text="do X instead")], metadata={"steer_id": "s1"})
+    out = convert_agent_event_to_sse(MessageEndEvent(message=msg))
+    assert out == [{"type": "injected_message", "content": "do X instead", "steer_id": "s1"}]
+
+
+def test_injected_user_message_without_steer_id_is_dropped() -> None:
+    msg = UserMessage(content=[TextContent(text="seed prompt")])
+    assert convert_agent_event_to_sse(MessageEndEvent(message=msg)) == []

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -841,7 +841,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "tracing", "tracing-otlp", "trace-cli"], git = "https://github.com/cubeplexai/cubepi.git?rev=9533540" },
+    { name = "cubepi", extras = ["mcp", "postgres", "tracing", "tracing-otlp", "trace-cli"], git = "https://github.com/cubeplexai/cubepi.git?rev=da9d792" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -885,7 +885,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.5.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=9533540#95335406fb052ff3fb0715896ef52b5fc8438cfb" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=da9d792#da9d7925d6c2eef3eea9dacada4e0613cd4223b1" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -841,7 +841,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "tracing", "tracing-otlp", "trace-cli"], git = "https://github.com/cubeplexai/cubepi.git?rev=8e9e4b9" },
+    { name = "cubepi", extras = ["mcp", "postgres", "tracing", "tracing-otlp", "trace-cli"], git = "https://github.com/cubeplexai/cubepi.git?rev=9533540" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -885,7 +885,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.5.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=8e9e4b9#8e9e4b90b2de11c88b315a7c14422e1df68ab4c1" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=9533540#95335406fb052ff3fb0715896ef52b5fc8438cfb" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },

--- a/docs/dev/plans/2026-05-25-steer-message-display.md
+++ b/docs/dev/plans/2026-05-25-steer-message-display.md
@@ -1,0 +1,1158 @@
+# Steer Message Display Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a sent-but-not-yet-injected steer message as a dimmed "pending" chip above the input box, then commit it inline into the transcript at the real injection point (so reload doesn't move it), with best-effort cancel.
+
+**Architecture:** A client-minted `steer_id` is the join key across the whole flow (carried in `UserMessage.metadata`). cubepi gains queue-removal for cancel. cubebox forwards a new `injected_message` SSE event when cubepi actually injects the steer, threaded through *both* backend translation layers. The frontend store holds pending steers outside the transcript, commits the current streaming bubble + the steer message on the SSE signal, and exposes cancel.
+
+**Tech Stack:** Python (FastAPI, pydantic, pytest, redis pub/sub), cubepi agent runtime, TypeScript (Zustand, vitest), Next.js/React, Playwright.
+
+**Spec:** `docs/dev/specs/2026-05-25-steer-message-display-design.md`
+
+**Worktree:** `/home/chris/cubebox/.worktrees/feat/steer-message-display` (ports 8059/3059 — see `.worktree.env`). cubepi lives at `/home/chris/cubepi` (separate repo; commit there separately).
+
+---
+
+## File Structure
+
+| Area | File | Responsibility |
+|---|---|---|
+| cubepi | `cubepi/agent/agent.py` | `_MessageQueue.remove(steer_id)`, `Agent.cancel_steer(steer_id)` |
+| cubepi test | `tests/agent/test_agent.py` | queue removal + cancel_steer unit tests |
+| backend | `cubebox/agents/schemas.py` | `InjectedMessageEvent` typed event |
+| backend | `cubebox/agents/stream.py` | translate injected `UserMessage` MessageEnd → wire dict |
+| backend | `cubebox/streams/run_manager.py` | `cubepi_dict_to_agent_event` branch, `_on_event` seed-skip, `steer_id` threading, `dispatch_cancel_steer`, control type |
+| backend | `cubebox/api/routes/v1/conversations.py` | `steer_id` on steer request, `POST /steer/cancel` route |
+| core | `src/types/events.ts` | `InjectedMessageEvent` + union member |
+| core | `src/api/stream.ts` | `steerRun(..., steerId)`, `cancelSteer(...)` |
+| core | `src/stores/messageStore.ts` | `pendingSteers`, `steer`/`cancelSteer`, `buildTurnMessages`, `commitTurnAndInject`, cleanup |
+| web | `components/layout/PendingSteers.tsx` | dimmed pending chip list + cancel |
+| web | `components/layout/InputBar.tsx` | render `<PendingSteers>` above textarea |
+| web | `components/chat/MessageList.tsx` | (no change — committed steer is a normal user message) |
+
+---
+
+## Phase 1 — cubepi (upstream): cancel support
+
+> Commit these in the cubepi repo (`/home/chris/cubepi`), not cubebox.
+
+### Task 1: Queue removal + `Agent.cancel_steer`
+
+**Files:**
+- Modify: `/home/chris/cubepi/cubepi/agent/agent.py` (`_MessageQueue` ~line 42, `Agent` ~line 181)
+- Test: `/home/chris/cubepi/tests/agent/test_agent.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/agent/test_agent.py
+from cubepi.agent.agent import _MessageQueue
+from cubepi.providers.base import TextContent, UserMessage
+
+
+def _steer_msg(text: str, steer_id: str) -> UserMessage:
+    return UserMessage(content=[TextContent(text=text)], metadata={"steer_id": steer_id})
+
+
+def test_message_queue_remove_by_steer_id():
+    q = _MessageQueue(mode="all")
+    q.enqueue(_steer_msg("a", "s1"))
+    q.enqueue(_steer_msg("b", "s2"))
+    assert q.remove("s1") is True
+    assert [m.content[0].text for m in q.drain()] == ["b"]
+
+
+def test_message_queue_remove_missing_returns_false():
+    q = _MessageQueue(mode="all")
+    q.enqueue(_steer_msg("a", "s1"))
+    assert q.remove("nope") is False
+    assert len(q.drain()) == 1
+
+
+def test_message_queue_remove_ignores_messages_without_steer_id():
+    q = _MessageQueue(mode="all")
+    q.enqueue(UserMessage(content=[TextContent(text="x")]))  # no metadata.steer_id
+    assert q.remove("s1") is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/chris/cubepi && uv run pytest tests/agent/test_agent.py -k "message_queue_remove" -v`
+Expected: FAIL with `AttributeError: '_MessageQueue' object has no attribute 'remove'`
+
+- [ ] **Step 3: Implement `_MessageQueue.remove`**
+
+Add to `_MessageQueue` (after `drain`, before `clear`):
+
+```python
+    def remove(self, steer_id: str) -> bool:
+        kept = [
+            m
+            for m in self._messages
+            if getattr(m, "metadata", {}).get("steer_id") != steer_id
+        ]
+        removed = len(kept) != len(self._messages)
+        self._messages = kept
+        return removed
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/chris/cubepi && uv run pytest tests/agent/test_agent.py -k "message_queue_remove" -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Write the failing test for `Agent.cancel_steer`**
+
+```python
+# tests/agent/test_agent.py — add this test
+import pytest
+from cubepi.agent.agent import Agent
+from cubepi.providers.base import Model
+
+
+@pytest.mark.asyncio
+async def test_agent_cancel_steer_removes_queued_steer():
+    agent = Agent(provider=DummyProvider(), model=Model(id="m", provider="p"))
+    agent.steer(_steer_msg("hi", "s1"))
+    assert agent.cancel_steer("s1") is True
+    assert agent.cancel_steer("s1") is False
+```
+
+> Reuse the existing test's provider double for `DummyProvider`. If none exists in this file, copy the minimal provider stub already used by other `Agent` tests in `tests/agent/`.
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `cd /home/chris/cubepi && uv run pytest tests/agent/test_agent.py -k "cancel_steer" -v`
+Expected: FAIL with `AttributeError: 'Agent' object has no attribute 'cancel_steer'`
+
+- [ ] **Step 7: Implement `Agent.cancel_steer`**
+
+Add to `Agent` right after `steer` (~line 182):
+
+```python
+    def cancel_steer(self, steer_id: str) -> bool:
+        """Remove a not-yet-drained steering message by its steer_id.
+
+        Returns True if a queued message was removed; False if it was already
+        drained or never queued (best-effort cancel).
+        """
+        return self._steering_queue.remove(steer_id)
+```
+
+- [ ] **Step 8: Run to verify it passes**
+
+Run: `cd /home/chris/cubepi && uv run pytest tests/agent/test_agent.py -k "cancel_steer or message_queue_remove" -v`
+Expected: PASS
+
+- [ ] **Step 9: Commit (in cubepi repo)**
+
+```bash
+cd /home/chris/cubepi
+git add cubepi/agent/agent.py tests/agent/test_agent.py
+git commit -m "feat(agent): cancel a not-yet-drained steering message by steer_id"
+```
+
+---
+
+## Phase 2 — cubebox backend
+
+### Task 2: `InjectedMessageEvent` schema + stream.py converter
+
+**Files:**
+- Modify: `backend/cubebox/agents/schemas.py` (after `UsageEvent` ~line 158)
+- Modify: `backend/cubebox/agents/stream.py` (`convert_agent_event_to_sse` ~line 136)
+- Test: `backend/tests/agents/test_stream.py` (create if absent)
+
+- [ ] **Step 1: Add the schema**
+
+In `cubebox/agents/schemas.py`, after `UsageEvent`:
+
+```python
+class InjectedMessageEvent(AgentEvent):
+    """A user message injected mid-run (a steer) that cubepi has now drained
+    into the thread. Carries the join key so the frontend can match it to a
+    pending chip and commit it at the real transcript position.
+    """
+
+    type: Literal["injected_message"] = "injected_message"
+    data: dict[str, Any] = Field(description="Event data with content and steer_id")
+```
+
+- [ ] **Step 2: Write the failing converter test**
+
+```python
+# backend/tests/agents/test_stream.py
+from cubepi.agent.events import MessageEndEvent
+from cubepi.providers.base import TextContent, UserMessage
+from cubebox.agents.stream import convert_agent_event_to_sse
+
+
+def test_injected_user_message_becomes_injected_message_dict():
+    msg = UserMessage(content=[TextContent(text="do X instead")], metadata={"steer_id": "s1"})
+    out = convert_agent_event_to_sse(MessageEndEvent(message=msg))
+    assert out == [{"type": "injected_message", "content": "do X instead", "steer_id": "s1"}]
+
+
+def test_injected_user_message_without_steer_id_is_dropped():
+    msg = UserMessage(content=[TextContent(text="seed prompt")])
+    assert convert_agent_event_to_sse(MessageEndEvent(message=msg)) == []
+```
+
+> Verify the `MessageEndEvent` import path against the existing assistant-usage path in `stream.py` (it already imports `MessageEndEvent`); match that import.
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cd /home/chris/cubebox/.worktrees/feat/steer-message-display/backend && uv run pytest tests/agents/test_stream.py -v`
+Expected: FAIL (returns `[]`, not the injected_message dict)
+
+- [ ] **Step 4: Implement the converter branch**
+
+In `stream.py`, add `UserMessage` to the existing cubepi imports, then insert this branch *before* the final `return []` (after the AssistantMessage usage branch ~line 147):
+
+```python
+    if isinstance(evt, MessageEndEvent) and isinstance(evt.message, UserMessage):
+        steer_id = evt.message.metadata.get("steer_id")
+        if steer_id:
+            text = "".join(
+                c.text for c in evt.message.content if isinstance(c, TextContent)
+            )
+            return [{"type": "injected_message", "content": text, "steer_id": steer_id}]
+```
+
+> `TextContent` is already imported in `stream.py` (used by `_stringify_tool_result`); add `UserMessage` to that import line.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd .../backend && uv run pytest tests/agents/test_stream.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/agents/schemas.py backend/cubebox/agents/stream.py backend/tests/agents/test_stream.py
+git commit -m "feat(agents): translate injected steer UserMessage into injected_message SSE dict"
+```
+
+### Task 3: `cubepi_dict_to_agent_event` branch + `_on_event` seed-skip
+
+**Files:**
+- Modify: `backend/cubebox/streams/run_manager.py` (`cubepi_dict_to_agent_event` ~line 243; `_on_event` ~line 1340)
+- Test: `backend/tests/streams/test_run_manager_translate.py` (create if absent)
+
+- [ ] **Step 1: Write the failing translator test**
+
+```python
+# backend/tests/streams/test_run_manager_translate.py
+from cubebox.streams.run_manager import cubepi_dict_to_agent_event
+from cubebox.agents.schemas import InjectedMessageEvent
+
+
+def test_injected_message_dict_becomes_typed_event():
+    evt = cubepi_dict_to_agent_event(
+        {"type": "injected_message", "content": "do X", "steer_id": "s1"},
+        "2026-05-25T00:00:00+00:00",
+    )
+    assert isinstance(evt, InjectedMessageEvent)
+    assert evt.data == {"content": "do X", "steer_id": "s1"}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd .../backend && uv run pytest tests/streams/test_run_manager_translate.py -v`
+Expected: FAIL (`cubepi_dict_to_agent_event` returns `None` for the unknown type)
+
+- [ ] **Step 3: Implement the translator branch**
+
+In `cubepi_dict_to_agent_event`, add `InjectedMessageEvent` to the local schema import, then add this branch (alongside the other `if t == ...` branches):
+
+```python
+    if t == "injected_message":
+        return InjectedMessageEvent(
+            timestamp=timestamp,
+            data={"content": d.get("content", ""), "steer_id": d.get("steer_id", "")},
+        )
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd .../backend && uv run pytest tests/streams/test_run_manager_translate.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Implement `_on_event` seed-skip**
+
+In `_run_cubepi_path`, just before the `_on_event` definition (~line 1340), add a counter, and skip the first user-message `MessageEnd`:
+
+```python
+            from cubepi.agent.events import MessageEndEvent as _MsgEndEvent
+            from cubepi.providers.base import UserMessage as _UserMsg
+
+            _user_msg_seen = 0
+
+            def _on_event(evt: Any, _signal: Any = None) -> None:
+                nonlocal _user_msg_seen
+                if isinstance(evt, _MsgEndEvent) and isinstance(evt.message, _UserMsg):
+                    _user_msg_seen += 1
+                    if _user_msg_seen == 1:
+                        return  # seed prompt — already shown optimistically
+                for d in convert_agent_event_to_sse(evt):
+                    sse_queue.put_nowait(d)
+```
+
+> This replaces the existing `_on_event` body. Keep the existing `convert_agent_event_to_sse` loop. Seed-dedup lives ONLY here.
+
+- [ ] **Step 6: Verify backend still imports/lints**
+
+Run: `cd .../backend && uv run mypy cubebox/streams/run_manager.py && uv run ruff check cubebox/streams/run_manager.py`
+Expected: no errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/cubebox/streams/run_manager.py backend/tests/streams/test_run_manager_translate.py
+git commit -m "feat(streams): forward injected_message through translator; skip seed user message"
+```
+
+### Task 4: `steer_id` threading + cancel endpoint + control plane
+
+**Files:**
+- Modify: `backend/cubebox/api/routes/v1/conversations.py` (`SteerMessageRequest` ~line 270; steer route ~line 829; add cancel route)
+- Modify: `backend/cubebox/streams/run_manager.py` (`dispatch_steer`, `_publish_control`, `_handle_control`, add `dispatch_cancel_steer`)
+- Test: `backend/tests/streams/test_run_manager_steer.py` (create if absent)
+
+- [ ] **Step 1: Write the failing dispatch test**
+
+```python
+# backend/tests/streams/test_run_manager_steer.py
+import pytest
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.steered = []
+        self.cancelled = []
+
+    def steer(self, msg):
+        self.steered.append(msg)
+
+    def cancel_steer(self, steer_id):
+        self.cancelled.append(steer_id)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_steer_threads_steer_id_into_metadata(run_manager_with_agent):
+    rm, agent, run_id = run_manager_with_agent
+    status = await rm.dispatch_steer(run_id, "do X", steer_id="s1")
+    assert status == "steered"
+    assert agent.steered[0].metadata["steer_id"] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_cancel_steer_calls_agent(run_manager_with_agent):
+    rm, agent, run_id = run_manager_with_agent
+    status = await rm.dispatch_cancel_steer(run_id, "s1")
+    assert status == "cancelled"
+    assert agent.cancelled == ["s1"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_cancel_steer_no_local_agent_publishes(run_manager_no_agent):
+    rm = run_manager_no_agent
+    status = await rm.dispatch_cancel_steer("missing-run", "s1")
+    assert status == "published"
+```
+
+> Add `run_manager_with_agent` / `run_manager_no_agent` fixtures: construct the `RunManager` the way existing run_manager tests do (check `backend/tests/streams/` for an existing fixture to copy), inject a `_FakeAgent` into `rm._agents[run_id]`, and stub `rm._redis` with an object whose `publish` is an async no-op.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd .../backend && uv run pytest tests/streams/test_run_manager_steer.py -v`
+Expected: FAIL (`dispatch_steer` has no `steer_id` kwarg; no `dispatch_cancel_steer`)
+
+- [ ] **Step 3: Thread `steer_id` through `dispatch_steer` + control**
+
+Replace `dispatch_steer` and extend `_publish_control` / `_handle_control` in `run_manager.py`:
+
+```python
+    async def _publish_control(
+        self,
+        run_id: str,
+        type_: str,
+        content: str | None = None,
+        steer_id: str | None = None,
+    ) -> None:
+        import json
+
+        payload: dict[str, Any] = {"run_id": run_id, "type": type_}
+        if content is not None:
+            payload["content"] = content
+        if steer_id is not None:
+            payload["steer_id"] = steer_id
+        await self._redis.publish(self._control_channel, json.dumps(payload))
+
+    async def dispatch_steer(self, run_id: str, content: str, steer_id: str) -> str:
+        agent = self._agents.get(run_id)
+        if agent is not None:
+            from cubepi.providers.base import TextContent, UserMessage
+
+            agent.steer(
+                UserMessage(
+                    content=[TextContent(text=content)],
+                    metadata={"steer_id": steer_id},
+                )
+            )
+            return "steered"
+        await self._publish_control(run_id, "steer", content, steer_id=steer_id)
+        return "published"
+
+    async def dispatch_cancel_steer(self, run_id: str, steer_id: str) -> str:
+        agent = self._agents.get(run_id)
+        if agent is not None:
+            removed = agent.cancel_steer(steer_id)
+            return "cancelled" if removed else "not_found"
+        await self._publish_control(run_id, "cancel_steer", steer_id=steer_id)
+        return "published"
+```
+
+Then extend `_handle_control` (add `steer_id` to the steer branch and a new `cancel_steer` branch):
+
+```python
+        elif type_ == "steer":
+            agent = self._agents.get(run_id)
+            if agent is not None:
+                from cubepi.providers.base import TextContent, UserMessage
+
+                agent.steer(
+                    UserMessage(
+                        content=[TextContent(text=data.get("content") or "")],
+                        metadata={"steer_id": data.get("steer_id") or ""},
+                    )
+                )
+        elif type_ == "cancel_steer":
+            agent = self._agents.get(run_id)
+            if agent is not None:
+                agent.cancel_steer(data.get("steer_id") or "")
+```
+
+> Delete the now-redundant older `steer_run` method (line ~527) only if nothing references it — grep first: `grep -rn "steer_run" backend/cubebox`. If referenced, leave it.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd .../backend && uv run pytest tests/streams/test_run_manager_steer.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Add `steer_id` to the request model + steer route + cancel route**
+
+In `conversations.py`, update `SteerMessageRequest`:
+
+```python
+class SteerMessageRequest(BaseModel):
+    """Request body for steering an in-flight run."""
+
+    content: str
+    steer_id: str
+
+
+class CancelSteerRequest(BaseModel):
+    """Request body for cancelling a not-yet-drained steer."""
+
+    steer_id: str
+```
+
+Update the steer route's dispatch call (line ~865):
+
+```python
+    dispatch_status = await run_manager.dispatch_steer(
+        active_run.run_id, body.content, steer_id=body.steer_id
+    )
+    return {"status": dispatch_status, "run_id": active_run.run_id}
+```
+
+Add a new route after `steer_active_run`:
+
+```python
+@router.post("/{conversation_id}/steer/cancel", status_code=status.HTTP_202_ACCEPTED)
+async def cancel_steer(
+    conversation_id: str,
+    body: CancelSteerRequest,
+    raw_request: Request,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    ctx: Annotated[RequestContext, Depends(require_member)],
+    rds: Annotated[RedisHandle, Depends(redis_dep)],
+) -> dict[str, object]:
+    """Best-effort cancel of a not-yet-drained steer on the active run."""
+    conv_repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
+    conversation = await conv_repo.get_by_id(conversation_id)
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Conversation {conversation_id} not found",
+        )
+
+    active_run = await get_active_run(
+        rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
+    )
+    if active_run is None or active_run.status != "running":
+        return {"status": "no_active_run", "run_id": None}
+
+    run_manager = raw_request.app.state.run_manager
+    dispatch_status = await run_manager.dispatch_cancel_steer(active_run.run_id, body.steer_id)
+    return {"status": dispatch_status, "run_id": active_run.run_id}
+```
+
+- [ ] **Step 6: Verify lint/type**
+
+Run: `cd .../backend && uv run mypy cubebox/ && uv run ruff check cubebox/`
+Expected: no errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/cubebox/streams/run_manager.py backend/cubebox/api/routes/v1/conversations.py backend/tests/streams/test_run_manager_steer.py
+git commit -m "feat(api): thread steer_id through steer; add best-effort cancel-steer endpoint"
+```
+
+---
+
+## Phase 3 — frontend core
+
+### Task 5: Types + API client
+
+**Files:**
+- Modify: `frontend/packages/core/src/types/events.ts` (union ~line 51; add interface ~line 163)
+- Modify: `frontend/packages/core/src/api/stream.ts`
+- Test: `frontend/packages/core/__tests__/api/stream.test.ts` (extend if exists, else create)
+
+- [ ] **Step 1: Add the event type**
+
+In `events.ts`, add `'injected_message'` to the `AgentEventType` union, and add the interface:
+
+```typescript
+export interface InjectedMessageEvent extends AgentEvent {
+  type: 'injected_message'
+  data: { content: string; steer_id: string }
+}
+```
+
+- [ ] **Step 2: Write the failing API test**
+
+```typescript
+// frontend/packages/core/__tests__/api/stream.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import { steerRun, cancelSteer } from '../../src/api/stream'
+
+function fakeClient(capture: { path?: string; body?: unknown }) {
+  return {
+    post: vi.fn(async (path: string, body: unknown) => {
+      capture.path = path
+      capture.body = body
+      return { ok: true, json: async () => ({ status: 'steered', run_id: 'r1' }) }
+    }),
+  } as never
+}
+
+describe('steer api', () => {
+  it('steerRun sends content + steer_id', async () => {
+    const cap: { path?: string; body?: unknown } = {}
+    await steerRun(fakeClient(cap), 'conv-1', 'do X', 's1')
+    expect(cap.path).toBe('/api/v1/conversations/conv-1/steer')
+    expect(cap.body).toEqual({ content: 'do X', steer_id: 's1' })
+  })
+
+  it('cancelSteer posts steer_id to the cancel route', async () => {
+    const cap: { path?: string; body?: unknown } = {}
+    await cancelSteer(fakeClient(cap), 'conv-1', 's1')
+    expect(cap.path).toBe('/api/v1/conversations/conv-1/steer/cancel')
+    expect(cap.body).toEqual({ steer_id: 's1' })
+  })
+})
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cd frontend/packages/core && npx vitest run __tests__/api/stream.test.ts`
+Expected: FAIL (`cancelSteer` not exported; `steerRun` ignores 4th arg)
+
+- [ ] **Step 4: Implement the API changes**
+
+In `stream.ts`, replace `steerRun` and add `cancelSteer`:
+
+```typescript
+export async function steerRun(
+  client: ApiClient,
+  conversationId: string,
+  content: string,
+  steerId: string,
+): Promise<SteerRunResponse> {
+  const res = await client.post(`/api/v1/conversations/${conversationId}/steer`, {
+    content,
+    steer_id: steerId,
+  })
+  if (!res.ok) {
+    throw new Error(`Failed to steer run: HTTP ${res.status}`)
+  }
+  return (await res.json()) as SteerRunResponse
+}
+
+export interface CancelSteerResponse {
+  status: 'cancelled' | 'not_found' | 'published' | 'no_active_run'
+  run_id: string | null
+}
+
+export async function cancelSteer(
+  client: ApiClient,
+  conversationId: string,
+  steerId: string,
+): Promise<CancelSteerResponse> {
+  const res = await client.post(`/api/v1/conversations/${conversationId}/steer/cancel`, {
+    steer_id: steerId,
+  })
+  if (!res.ok) {
+    throw new Error(`Failed to cancel steer: HTTP ${res.status}`)
+  }
+  return (await res.json()) as CancelSteerResponse
+}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd frontend/packages/core && npx vitest run __tests__/api/stream.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/packages/core/src/types/events.ts frontend/packages/core/src/api/stream.ts frontend/packages/core/__tests__/api/stream.test.ts
+git commit -m "feat(core): injected_message event type; steerRun steer_id + cancelSteer api"
+```
+
+### Task 6: `messageStore` — pending steers state + steer/cancelSteer actions
+
+**Files:**
+- Modify: `frontend/packages/core/src/stores/messageStore.ts`
+- Test: `frontend/packages/core/__tests__/stores/messageStorePendingSteer.test.ts` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// frontend/packages/core/__tests__/stores/messageStorePendingSteer.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useMessageStore } from '../../src/stores/messageStore'
+
+vi.mock('../../src/api', async (orig) => {
+  const actual = await (orig as () => Promise<Record<string, unknown>>)()
+  return {
+    ...actual,
+    steerRun: vi.fn(async () => ({ status: 'steered', run_id: 'r1' })),
+    cancelSteer: vi.fn(async () => ({ status: 'cancelled', run_id: 'r1' })),
+  }
+})
+
+const client = {} as never
+
+describe('pending steers', () => {
+  beforeEach(() => {
+    useMessageStore.setState({
+      messages: {},
+      pendingSteers: {},
+      isStreaming: true,
+      streamingConversationId: 'c1',
+    })
+  })
+
+  it('steer() adds to pendingSteers, not messages', async () => {
+    await useMessageStore.getState().steer(client, 'c1', 'do X')
+    const s = useMessageStore.getState()
+    expect(s.pendingSteers.c1).toHaveLength(1)
+    expect(s.pendingSteers.c1[0].text).toBe('do X')
+    expect(s.messages.c1 ?? []).toHaveLength(0)
+  })
+
+  it('cancelSteer() removes the pending entry', async () => {
+    await useMessageStore.getState().steer(client, 'c1', 'do X')
+    const id = useMessageStore.getState().pendingSteers.c1[0].steerId
+    await useMessageStore.getState().cancelSteer(client, 'c1', id)
+    expect(useMessageStore.getState().pendingSteers.c1 ?? []).toHaveLength(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd frontend/packages/core && npx vitest run __tests__/stores/messageStorePendingSteer.test.ts`
+Expected: FAIL (`pendingSteers` undefined; `cancelSteer` not a function)
+
+- [ ] **Step 3: Add state + interface members**
+
+In `MessageStore` interface add:
+
+```typescript
+  pendingSteers: Record<string, { steerId: string; text: string }[]>
+  cancelSteer(client: ApiClient, conversationId: string, steerId: string): Promise<void>
+```
+
+In the store initializer (alongside `messages: {}`) add `pendingSteers: {},`.
+Add `cancelSteer` and `steerRun` to the `../api` import (the file already imports `steerRun`; add `cancelSteer`).
+
+- [ ] **Step 4: Rewrite `steer()` to use pendingSteers**
+
+Replace the existing `steer` action body:
+
+```typescript
+  async steer(client, conversationId, content) {
+    const text = content.trim()
+    if (!text) return
+    const state = get()
+    if (!state.isStreaming || state.streamingConversationId !== conversationId) return
+
+    const steerId = nextMessageId('steer')
+    set((s) => ({
+      pendingSteers: {
+        ...s.pendingSteers,
+        [conversationId]: [
+          ...(s.pendingSteers[conversationId] ?? []),
+          { steerId, text },
+        ],
+      },
+    }))
+
+    const removePending = () =>
+      set((s) => ({
+        pendingSteers: {
+          ...s.pendingSteers,
+          [conversationId]: (s.pendingSteers[conversationId] ?? []).filter(
+            (p) => p.steerId !== steerId,
+          ),
+        },
+      }))
+
+    try {
+      const res = await steerRun(client, conversationId, text, steerId)
+      if (res.status === 'no_active_run') removePending()
+    } catch (err) {
+      console.error('Failed to steer run:', err)
+      removePending()
+    }
+  },
+
+  async cancelSteer(client, conversationId, steerId) {
+    set((s) => ({
+      pendingSteers: {
+        ...s.pendingSteers,
+        [conversationId]: (s.pendingSteers[conversationId] ?? []).filter(
+          (p) => p.steerId !== steerId,
+        ),
+      },
+    }))
+    try {
+      await cancelSteer(client, conversationId, steerId)
+    } catch (err) {
+      console.error('Failed to cancel steer:', err)
+    }
+  },
+```
+
+> This removes the old optimistic-`messages` append entirely.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd frontend/packages/core && npx vitest run __tests__/stores/messageStorePendingSteer.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Update the existing steer test**
+
+`__tests__/stores/messageStoreSteer.test.ts` asserts the old optimistic-message behavior. Update its assertions to expect `pendingSteers` instead of an appended message. Run:
+`cd frontend/packages/core && npx vitest run __tests__/stores/messageStoreSteer.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/packages/core/src/stores/messageStore.ts frontend/packages/core/__tests__/stores/messageStorePendingSteer.test.ts frontend/packages/core/__tests__/stores/messageStoreSteer.test.ts
+git commit -m "feat(core): hold steers in pendingSteers state with cancel, off the transcript"
+```
+
+### Task 7: `messageStore` — commit on injected_message + buildTurnMessages refactor + cleanup
+
+**Files:**
+- Modify: `frontend/packages/core/src/stores/messageStore.ts`
+- Test: `frontend/packages/core/__tests__/stores/messageStoreCommitSteer.test.ts` (create)
+
+- [ ] **Step 1: Extract `buildTurnMessages` (pure refactor, no behavior change)**
+
+Pull the message-building body out of `finalizeCompletedStream` into a module-level pure function. It takes the agents map + maps and returns the messages; `finalizeCompletedStream` then calls it. Signature:
+
+```typescript
+function buildTurnMessages(
+  agents: Record<string, AgentStream>,
+  toolResultMap: MessageStore['toolResultMap'],
+  turnUsage: import('../types').TurnUsage | null,
+): { assistantMessage: AssistantMessageType | null; toolMessages: ToolResultMessageType[] } {
+  const mainStream = agents[MAIN_AGENT_KEY]
+  if (!mainStream) return { assistantMessage: null, toolMessages: [] }
+  // ... existing finalBlocks / assistantMessage / toolMessages construction
+  // moved verbatim from finalizeCompletedStream, returning the pieces ...
+  return { assistantMessage, toolMessages }
+}
+```
+
+Refactor `finalizeCompletedStream` to call it and then `set(...)` the messages + clear streaming state exactly as before. Run the full core suite to confirm no regressions:
+`cd frontend/packages/core && npx vitest run`
+Expected: PASS (unchanged behavior)
+
+- [ ] **Step 2: Commit the refactor**
+
+```bash
+git add frontend/packages/core/src/stores/messageStore.ts
+git commit -m "refactor(core): extract buildTurnMessages from finalizeCompletedStream"
+```
+
+- [ ] **Step 3: Write the failing commit test**
+
+```typescript
+// frontend/packages/core/__tests__/stores/messageStoreCommitSteer.test.ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useMessageStore } from '../../src/stores/messageStore'
+
+function applyInjected(convId: string, content: string, steerId: string) {
+  // helper invoked by the store's stream consumer; we test the handler directly
+  return useMessageStore.getState().__commitTurnAndInject(convId, {
+    content,
+    steer_id: steerId,
+  })
+}
+
+describe('commit on injected_message', () => {
+  beforeEach(() => {
+    useMessageStore.setState({
+      messages: { c1: [{ id: 'u1', role: 'user', content: [{ type: 'text', text: 'go' }], timestamp: 1, metadata: {} }] },
+      streamAgents: { main: { text: 'partial', toolCalls: [], toolResults: [], thinking: '', blocks: [{ type: 'text', text: 'partial' }], name: null } },
+      pendingSteers: { c1: [{ steerId: 's1', text: 'do X' }] },
+      toolResultMap: {},
+      turnUsage: { c1: null },
+      isStreaming: true,
+      streamingConversationId: 'c1',
+    })
+  })
+
+  it('finalizes the current bubble, inserts the steer user msg, resets streams, clears pending', () => {
+    applyInjected('c1', 'do X', 's1')
+    const s = useMessageStore.getState()
+    const msgs = s.messages.c1
+    const roles = msgs.map((m) => m.role)
+    expect(roles).toEqual(['user', 'assistant', 'user']) // original, finalized bubble, steer
+    expect(msgs[2].content[0]).toMatchObject({ type: 'text', text: 'do X' })
+    expect(msgs[2].metadata?.steer_id).toBe('s1')
+    expect(s.streamAgents.main.text).toBe('') // reset
+    expect(s.pendingSteers.c1 ?? []).toHaveLength(0)
+  })
+
+  it('skips the empty assistant bubble when the main stream has no content', () => {
+    useMessageStore.setState({
+      streamAgents: { main: { text: '', toolCalls: [], toolResults: [], thinking: '', blocks: [], name: null } },
+    })
+    applyInjected('c1', 'do X', 's1')
+    const roles = useMessageStore.getState().messages.c1.map((m) => m.role)
+    expect(roles).toEqual(['user', 'user']) // original, steer — no empty assistant
+  })
+})
+```
+
+> The test reaches a `__commitTurnAndInject(convId, data)` method exposed on the store for testability. The stream consumers call the same method.
+
+- [ ] **Step 4: Run to verify it fails**
+
+Run: `cd frontend/packages/core && npx vitest run __tests__/stores/messageStoreCommitSteer.test.ts`
+Expected: FAIL (`__commitTurnAndInject` not a function)
+
+- [ ] **Step 5: Implement `__commitTurnAndInject` + wire into both consumers**
+
+Add to the `MessageStore` interface:
+
+```typescript
+  __commitTurnAndInject(conversationId: string, data: { content: string; steer_id: string }): void
+```
+
+Implement in the store:
+
+```typescript
+  __commitTurnAndInject(conversationId, data) {
+    const state = get()
+    // Idempotency: if this steer is already committed, no-op (replay-safe).
+    const already = (state.messages[conversationId] ?? []).some(
+      (m) => m.role === 'user' && m.metadata?.steer_id === data.steer_id,
+    )
+    if (already) return
+
+    const { assistantMessage, toolMessages } = buildTurnMessages(
+      state.streamAgents,
+      state.toolResultMap,
+      state.turnUsage[conversationId] ?? null,
+    )
+    const mainHasContent =
+      !!assistantMessage && assistantMessage.content.length > 0
+
+    const steerMessage: UserMessageType = {
+      id: nextMessageId('user-steer'),
+      role: 'user',
+      content: [{ type: 'text', text: data.content }],
+      timestamp: Date.now() / 1000,
+      metadata: { steer_id: data.steer_id },
+    }
+
+    set((s) => ({
+      messages: {
+        ...s.messages,
+        [conversationId]: [
+          ...(s.messages[conversationId] ?? []),
+          ...(mainHasContent ? [assistantMessage as AssistantMessageType, ...toolMessages] : []),
+          steerMessage,
+        ],
+      },
+      streamAgents: { [MAIN_AGENT_KEY]: emptyStream() },
+      pendingSteers: {
+        ...s.pendingSteers,
+        [conversationId]: (s.pendingSteers[conversationId] ?? []).filter(
+          (p) => p.steerId !== data.steer_id,
+        ),
+      },
+    }))
+  },
+```
+
+Then, in BOTH stream consumers, handle the event. In `send()`'s event loop and in `consumeRunStream()`'s event loop, add a branch alongside the `artifact`/`citation`/`error`/`done` handling (after the `event_id` ordering guard, before `batchedSet`):
+
+```typescript
+          } else if (event.type === 'injected_message') {
+            const d = event.data as { content: string; steer_id: string }
+            set((s) => ({
+              lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
+            }))
+            get().__commitTurnAndInject(conversationId, d)
+            continue
+          }
+```
+
+> Place it so it shares the same `lastAppliedEventId` skip guard the loop already applies. In `consumeRunStream`, use the same shape.
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `cd frontend/packages/core && npx vitest run __tests__/stores/messageStoreCommitSteer.test.ts`
+Expected: PASS (2 tests)
+
+- [ ] **Step 7: Add pending cleanup on run-ending paths**
+
+In `loadMessages` (the big `set(...)` that resets state), add `pendingSteers: { ...get().pendingSteers, [conversationId]: [] },`. In `finalizeCompletedStream`'s final `set`, add the same clear. In the `error` branches of `send()` and `consumeRunStream()`, in `cancelStream`, and in `clearStream()`, clear `pendingSteers` for the conversation (in `clearStream`, reset to `{}`). Write a quick test:
+
+```typescript
+// append to messageStoreCommitSteer.test.ts
+it('clears pending steers on finalize', () => {
+  useMessageStore.setState({
+    streamAgents: { main: { text: 'x', toolCalls: [], toolResults: [], thinking: '', blocks: [{ type: 'text', text: 'x' }], name: null } },
+    pendingSteers: { c1: [{ steerId: 's1', text: 'do X' }] },
+  })
+  // finalizeCompletedStream is module-internal; trigger via the exported path used in send().
+  // Instead assert via clearStream which is public:
+  useMessageStore.getState().clearStream()
+  expect(useMessageStore.getState().pendingSteers).toEqual({})
+})
+```
+
+Run: `cd frontend/packages/core && npx vitest run __tests__/stores/messageStoreCommitSteer.test.ts`
+Expected: PASS
+
+- [ ] **Step 8: Run the full core suite + build**
+
+Run: `cd frontend/packages/core && npx vitest run && pnpm build`
+Expected: PASS + clean build (so `@cubebox/web` sees the new types).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/packages/core/src/stores/messageStore.ts frontend/packages/core/__tests__/stores/messageStoreCommitSteer.test.ts
+git commit -m "feat(core): commit steer into transcript on injected_message; clear pending on run end"
+```
+
+---
+
+## Phase 4 — frontend web
+
+### Task 8: Pending steer chips above the input + remove optimistic transcript path
+
+**Files:**
+- Create: `frontend/packages/web/components/layout/PendingSteers.tsx`
+- Modify: `frontend/packages/web/components/layout/InputBar.tsx`
+- Test: `frontend/packages/web/__tests__/components/PendingSteers.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing component test**
+
+```tsx
+// frontend/packages/web/__tests__/components/PendingSteers.test.tsx
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PendingSteers } from '../../components/layout/PendingSteers'
+
+const mocks = vi.hoisted(() => ({
+  cancelSteer: vi.fn(),
+  setWorkspaceId: vi.fn(),
+  pending: [] as { steerId: string; text: string }[],
+}))
+
+vi.mock('@cubebox/core', () => ({
+  createApiClient: () => ({ setWorkspaceId: mocks.setWorkspaceId }),
+  useMessageStore: (sel: (s: { pendingSteers: Record<string, unknown>; cancelSteer: typeof mocks.cancelSteer }) => unknown) =>
+    sel({ pendingSteers: { 'conv-1': mocks.pending }, cancelSteer: mocks.cancelSteer }),
+}))
+vi.mock('@/hooks/useWorkspaceContext', () => ({ useWorkspaceContext: () => ({ workspaceId: 'ws-1' }) }))
+
+describe('PendingSteers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.pending = [{ steerId: 's1', text: 'do X instead' }]
+  })
+
+  it('renders pending steer text and cancels on click', () => {
+    render(<PendingSteers conversationId="conv-1" />)
+    expect(screen.getByText('do X instead')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(mocks.cancelSteer).toHaveBeenCalledWith(expect.anything(), 'conv-1', 's1')
+  })
+
+  it('renders nothing when there are no pending steers', () => {
+    mocks.pending = []
+    const { container } = render(<PendingSteers conversationId="conv-1" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd frontend/packages/web && npx vitest run __tests__/components/PendingSteers.test.tsx`
+Expected: FAIL (module not found)
+
+- [ ] **Step 3: Implement `PendingSteers.tsx`**
+
+```tsx
+'use client'
+
+import { useMessageStore, createApiClient } from '@cubebox/core'
+import { X } from 'lucide-react'
+import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
+
+interface PendingSteersProps {
+  conversationId: string
+}
+
+export function PendingSteers({ conversationId }: PendingSteersProps): React.ReactElement | null {
+  const pending = useMessageStore((s) => s.pendingSteers[conversationId] ?? [])
+  const cancelSteer = useMessageStore((s) => s.cancelSteer)
+  const { workspaceId } = useWorkspaceContext()
+
+  if (pending.length === 0) return null
+
+  const onCancel = (steerId: string): void => {
+    const client = createApiClient('')
+    if (workspaceId) client.setWorkspaceId(workspaceId)
+    void cancelSteer(client, conversationId, steerId)
+  }
+
+  return (
+    <div className="mb-2 flex flex-col gap-1.5">
+      {pending.map((p) => (
+        <div
+          key={p.steerId}
+          className="flex items-center gap-2 rounded-lg border border-border/60 bg-muted/40 px-3 py-1.5 text-sm text-muted-foreground"
+        >
+          <span className="flex-1 truncate opacity-70">{p.text}</span>
+          <span className="text-[10px] uppercase tracking-wide opacity-50">steering…</span>
+          <button
+            type="button"
+            aria-label="Cancel pending steer"
+            onClick={() => onCancel(p.steerId)}
+            className="grid size-5 place-items-center rounded hover:bg-muted"
+          >
+            <X className="size-3" />
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd frontend/packages/web && npx vitest run __tests__/components/PendingSteers.test.tsx`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Render it in InputBar**
+
+In `InputBar.tsx`, import `PendingSteers` and render it inside the top-level wrapper, above the input shell (right after the opening `<div className="w-full max-w-3xl mx-auto">`):
+
+```tsx
+      {conversationId && <PendingSteers conversationId={conversationId} />}
+```
+
+- [ ] **Step 6: Verify web suite + typecheck**
+
+Run: `cd frontend/packages/web && npx vitest run __tests__/components && npx tsc --noEmit`
+Expected: PASS + no type errors. (The existing `InputBar.test.tsx` steer-path expectations still hold; the store mock there does not exercise pendingSteers.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/packages/web/components/layout/PendingSteers.tsx frontend/packages/web/components/layout/InputBar.tsx frontend/packages/web/__tests__/components/PendingSteers.test.tsx
+git commit -m "feat(web): dimmed pending-steer chips above the input with cancel"
+```
+
+---
+
+## Phase 5 — E2E
+
+### Task 9: Steer pending → commit → cancel E2E
+
+**Files:**
+- Modify/extend: the existing steer E2E under `frontend/packages/web/tests/e2e/` (find it: `grep -rln "steer" frontend/packages/web/tests`)
+- Prereq: copy `backend/.env` + `backend/config.development.local.yaml` into the worktree backend dir; start backend on 8059 and frontend on 3059 (see `.worktree.env`).
+
+- [ ] **Step 1: Write the E2E spec**
+
+Add a test that, against a real run:
+1. sends a first message and waits for streaming to start,
+2. types a steer + submits, asserts a `steering…` chip appears above the input (`getByText('steering…')` scoped to the input area),
+3. waits for the chip to disappear and the steer text to appear as a user message in the transcript **below** the first assistant bubble,
+4. reloads the page and asserts the steer user message is in the same position (no jump) — assert ordering of message roles is stable across reload,
+5. (separate case) sends a steer and immediately clicks cancel; asserts the chip disappears and — if cancelled before injection — the text never appears in the transcript.
+
+Model the harness/selectors on the existing steer E2E. Use the data-testids already in `InputBar.tsx` (`chat-input`, `send-button`). Add a `data-testid="pending-steer"` to the chip in `PendingSteers.tsx` to make selection robust.
+
+- [ ] **Step 2: Add the testid to the chip**
+
+In `PendingSteers.tsx`, add `data-testid="pending-steer"` to the chip `<div>`.
+
+- [ ] **Step 3: Run the E2E**
+
+Run (from worktree, with servers up): `cd frontend/packages/web && npx playwright test <steer-spec-file>`
+Expected: PASS. If the model/run timing is flaky, gate waits on conditions (chip present, chip absent, message present) rather than fixed timeouts.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/packages/web/components/layout/PendingSteers.tsx frontend/packages/web/tests/e2e/<steer-spec-file>
+git commit -m "test(e2e): steer pending chip → inline commit → reload-stable position → cancel"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** A=Task 1; B(schema+converter)=Task 2; B(translator+seed-skip)=Task 3; C=Task 4; D=Task 5; E(state/steer/cancel)=Task 6, E(commit/buildTurnMessages/cleanup)=Task 7; F=Task 8; Testing=Tasks 1–9 (E2E=Task 9). All spec sections mapped.
+- **Type consistency:** `pendingSteers: Record<string, { steerId; text }[]>`, `steer_id` (wire/metadata) vs `steerId` (TS), `__commitTurnAndInject`, `buildTurnMessages`, `cancelSteer`, `InjectedMessageEvent` used consistently across tasks.
+- **Cross-repo:** Task 1 commits in cubepi; Tasks 2–9 in cubebox. The cubebox steer feature depends on the cubepi `cancel_steer` for Task 4's cancel path — land cubepi first (or pin the local cubepi for dev).

--- a/docs/dev/plans/2026-05-25-steer-message-display.md
+++ b/docs/dev/plans/2026-05-25-steer-message-display.md
@@ -109,17 +109,18 @@ Expected: PASS (3 tests)
 import pytest
 from cubepi.agent.agent import Agent
 from cubepi.providers.base import Model
+from cubepi.providers.faux import FauxProvider  # already used by this test file
 
 
 @pytest.mark.asyncio
 async def test_agent_cancel_steer_removes_queued_steer():
-    agent = Agent(provider=DummyProvider(), model=Model(id="m", provider="p"))
+    agent = Agent(provider=FauxProvider(), model=Model(id="m", provider="p"))
     agent.steer(_steer_msg("hi", "s1"))
     assert agent.cancel_steer("s1") is True
     assert agent.cancel_steer("s1") is False
 ```
 
-> Reuse the existing test's provider double for `DummyProvider`. If none exists in this file, copy the minimal provider stub already used by other `Agent` tests in `tests/agent/`.
+> `FauxProvider` is imported from `cubepi.providers.faux` (the existing `test_agent.py` already uses it at line 13). Match how other `Agent` tests in this file construct the agent.
 
 - [ ] **Step 6: Run to verify it fails**
 
@@ -162,7 +163,7 @@ git commit -m "feat(agent): cancel a not-yet-drained steering message by steer_i
 **Files:**
 - Modify: `backend/cubebox/agents/schemas.py` (after `UsageEvent` ~line 158)
 - Modify: `backend/cubebox/agents/stream.py` (`convert_agent_event_to_sse` ~line 136)
-- Test: `backend/tests/agents/test_stream.py` (create if absent)
+- Test: add cases to the existing `backend/tests/unit/test_stream.py`
 
 - [ ] **Step 1: Add the schema**
 
@@ -182,8 +183,8 @@ class InjectedMessageEvent(AgentEvent):
 - [ ] **Step 2: Write the failing converter test**
 
 ```python
-# backend/tests/agents/test_stream.py
-from cubepi.agent.events import MessageEndEvent
+# backend/tests/unit/test_stream.py — add these cases
+from cubepi.agent.types import MessageEndEvent
 from cubepi.providers.base import TextContent, UserMessage
 from cubebox.agents.stream import convert_agent_event_to_sse
 
@@ -203,7 +204,7 @@ def test_injected_user_message_without_steer_id_is_dropped():
 
 - [ ] **Step 3: Run to verify it fails**
 
-Run: `cd /home/chris/cubebox/.worktrees/feat/steer-message-display/backend && uv run pytest tests/agents/test_stream.py -v`
+Run: `cd /home/chris/cubebox/.worktrees/feat/steer-message-display/backend && uv run pytest tests/unit/test_stream.py -v`
 Expected: FAIL (returns `[]`, not the injected_message dict)
 
 - [ ] **Step 4: Implement the converter branch**
@@ -224,13 +225,13 @@ In `stream.py`, add `UserMessage` to the existing cubepi imports, then insert th
 
 - [ ] **Step 5: Run to verify it passes**
 
-Run: `cd .../backend && uv run pytest tests/agents/test_stream.py -v`
+Run: `cd .../backend && uv run pytest tests/unit/test_stream.py -v`
 Expected: PASS (2 tests)
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add backend/cubebox/agents/schemas.py backend/cubebox/agents/stream.py backend/tests/agents/test_stream.py
+git add backend/cubebox/agents/schemas.py backend/cubebox/agents/stream.py backend/tests/unit/test_stream.py
 git commit -m "feat(agents): translate injected steer UserMessage into injected_message SSE dict"
 ```
 
@@ -238,12 +239,12 @@ git commit -m "feat(agents): translate injected steer UserMessage into injected_
 
 **Files:**
 - Modify: `backend/cubebox/streams/run_manager.py` (`cubepi_dict_to_agent_event` ~line 243; `_on_event` ~line 1340)
-- Test: `backend/tests/streams/test_run_manager_translate.py` (create if absent)
+- Test: `backend/tests/unit/test_run_manager_translate.py` (create if absent)
 
 - [ ] **Step 1: Write the failing translator test**
 
 ```python
-# backend/tests/streams/test_run_manager_translate.py
+# backend/tests/unit/test_run_manager_translate.py
 from cubebox.streams.run_manager import cubepi_dict_to_agent_event
 from cubebox.agents.schemas import InjectedMessageEvent
 
@@ -259,7 +260,7 @@ def test_injected_message_dict_becomes_typed_event():
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `cd .../backend && uv run pytest tests/streams/test_run_manager_translate.py -v`
+Run: `cd .../backend && uv run pytest tests/unit/test_run_manager_translate.py -v`
 Expected: FAIL (`cubepi_dict_to_agent_event` returns `None` for the unknown type)
 
 - [ ] **Step 3: Implement the translator branch**
@@ -276,7 +277,7 @@ In `cubepi_dict_to_agent_event`, add `InjectedMessageEvent` to the local schema 
 
 - [ ] **Step 4: Run to verify it passes**
 
-Run: `cd .../backend && uv run pytest tests/streams/test_run_manager_translate.py -v`
+Run: `cd .../backend && uv run pytest tests/unit/test_run_manager_translate.py -v`
 Expected: PASS
 
 - [ ] **Step 5: Implement `_on_event` seed-skip**
@@ -284,7 +285,7 @@ Expected: PASS
 In `_run_cubepi_path`, just before the `_on_event` definition (~line 1340), add a counter, and skip the first user-message `MessageEnd`:
 
 ```python
-            from cubepi.agent.events import MessageEndEvent as _MsgEndEvent
+            from cubepi.agent.types import MessageEndEvent as _MsgEndEvent
             from cubepi.providers.base import UserMessage as _UserMsg
 
             _user_msg_seen = 0
@@ -309,7 +310,7 @@ Expected: no errors
 - [ ] **Step 7: Commit**
 
 ```bash
-git add backend/cubebox/streams/run_manager.py backend/tests/streams/test_run_manager_translate.py
+git add backend/cubebox/streams/run_manager.py backend/tests/unit/test_run_manager_translate.py
 git commit -m "feat(streams): forward injected_message through translator; skip seed user message"
 ```
 
@@ -318,56 +319,79 @@ git commit -m "feat(streams): forward injected_message through translator; skip 
 **Files:**
 - Modify: `backend/cubebox/api/routes/v1/conversations.py` (`SteerMessageRequest` ~line 270; steer route ~line 829; add cancel route)
 - Modify: `backend/cubebox/streams/run_manager.py` (`dispatch_steer`, `_publish_control`, `_handle_control`, add `dispatch_cancel_steer`)
-- Test: `backend/tests/streams/test_run_manager_steer.py` (create if absent)
+- Test: extend the existing `backend/tests/unit/test_run_manager_steer.py`
 
-- [ ] **Step 1: Write the failing dispatch test**
+- [ ] **Step 1: Write the failing dispatch tests**
+
+The existing file already has a `_FakeAgent` (with `.steer`) and a `_make_manager()`
+helper using `RunManager.__new__(RunManager)`. Extend `_FakeAgent` with
+`cancel_steer`, and add a tiny redis stub for the publish path:
 
 ```python
-# backend/tests/streams/test_run_manager_steer.py
-import pytest
-
-
+# backend/tests/unit/test_run_manager_steer.py — extend the existing _FakeAgent
 class _FakeAgent:
-    def __init__(self):
-        self.steered = []
-        self.cancelled = []
+    def __init__(self) -> None:
+        self.steered: list = []
+        self.cancelled: list[str] = []
 
-    def steer(self, msg):
-        self.steered.append(msg)
+    def steer(self, message) -> None:  # noqa: ANN001
+        self.steered.append(message)
 
-    def cancel_steer(self, steer_id):
+    def cancel_steer(self, steer_id: str) -> bool:  # noqa: ANN001
         self.cancelled.append(steer_id)
         return True
 
 
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.published: list[str] = []
+
+    async def publish(self, channel: str, payload: str) -> None:
+        self.published.append(payload)
+
+
+# add these tests to the file
 @pytest.mark.asyncio
-async def test_dispatch_steer_threads_steer_id_into_metadata(run_manager_with_agent):
-    rm, agent, run_id = run_manager_with_agent
-    status = await rm.dispatch_steer(run_id, "do X", steer_id="s1")
+async def test_dispatch_steer_threads_steer_id_into_metadata() -> None:
+    mgr = _make_manager()
+    mgr._agents = {}
+    agent = _FakeAgent()
+    mgr._agents["run-1"] = agent
+    status = await mgr.dispatch_steer("run-1", "do X", steer_id="s1")
     assert status == "steered"
     assert agent.steered[0].metadata["steer_id"] == "s1"
 
 
 @pytest.mark.asyncio
-async def test_dispatch_cancel_steer_calls_agent(run_manager_with_agent):
-    rm, agent, run_id = run_manager_with_agent
-    status = await rm.dispatch_cancel_steer(run_id, "s1")
+async def test_dispatch_cancel_steer_calls_agent() -> None:
+    mgr = _make_manager()
+    mgr._agents = {}
+    agent = _FakeAgent()
+    mgr._agents["run-1"] = agent
+    status = await mgr.dispatch_cancel_steer("run-1", "s1")
     assert status == "cancelled"
     assert agent.cancelled == ["s1"]
 
 
 @pytest.mark.asyncio
-async def test_dispatch_cancel_steer_no_local_agent_publishes(run_manager_no_agent):
-    rm = run_manager_no_agent
-    status = await rm.dispatch_cancel_steer("missing-run", "s1")
+async def test_dispatch_cancel_steer_no_local_agent_publishes() -> None:
+    mgr = _make_manager()
+    mgr._agents = {}
+    mgr._redis = _FakeRedis()
+    mgr._control_channel = "ctrl"
+    status = await mgr.dispatch_cancel_steer("missing-run", "s1")
     assert status == "published"
 ```
 
-> Add `run_manager_with_agent` / `run_manager_no_agent` fixtures: construct the `RunManager` the way existing run_manager tests do (check `backend/tests/streams/` for an existing fixture to copy), inject a `_FakeAgent` into `rm._agents[run_id]`, and stub `rm._redis` with an object whose `publish` is an async no-op.
+> The existing `_FakeAgent` in this file currently records `message.content[0].text`
+> in `steered`; change it to append the whole `message` (as shown) so the metadata
+> assertion works, and update the pre-existing `steer_run` tests' assertions
+> accordingly (they read `agent.steered == ["..."]` → change to
+> `agent.steered[0].content[0].text == "..."`).
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `cd .../backend && uv run pytest tests/streams/test_run_manager_steer.py -v`
+Run: `cd .../backend && uv run pytest tests/unit/test_run_manager_steer.py -v`
 Expected: FAIL (`dispatch_steer` has no `steer_id` kwarg; no `dispatch_cancel_steer`)
 
 - [ ] **Step 3: Thread `steer_id` through `dispatch_steer` + control**
@@ -435,11 +459,13 @@ Then extend `_handle_control` (add `steer_id` to the steer branch and a new `can
                 agent.cancel_steer(data.get("steer_id") or "")
 ```
 
-> Delete the now-redundant older `steer_run` method (line ~527) only if nothing references it — grep first: `grep -rn "steer_run" backend/cubebox`. If referenced, leave it.
+> Leave the older `steer_run` method (line ~527) in place — it is still covered by
+> the existing tests in `test_run_manager_steer.py`. Only `dispatch_steer` (used by
+> the route) needs the `steer_id` change. Do not delete `steer_run`.
 
 - [ ] **Step 4: Run to verify it passes**
 
-Run: `cd .../backend && uv run pytest tests/streams/test_run_manager_steer.py -v`
+Run: `cd .../backend && uv run pytest tests/unit/test_run_manager_steer.py -v`
 Expected: PASS (3 tests)
 
 - [ ] **Step 5: Add `steer_id` to the request model + steer route + cancel route**
@@ -514,7 +540,7 @@ Expected: no errors
 - [ ] **Step 7: Commit**
 
 ```bash
-git add backend/cubebox/streams/run_manager.py backend/cubebox/api/routes/v1/conversations.py backend/tests/streams/test_run_manager_steer.py
+git add backend/cubebox/streams/run_manager.py backend/cubebox/api/routes/v1/conversations.py backend/tests/unit/test_run_manager_steer.py
 git commit -m "feat(api): thread steer_id through steer; add best-effort cancel-steer endpoint"
 ```
 
@@ -576,7 +602,7 @@ describe('steer api', () => {
 
 - [ ] **Step 3: Run to verify it fails**
 
-Run: `cd frontend/packages/core && npx vitest run __tests__/api/stream.test.ts`
+Run: `cd frontend/packages/core && pnpm exec vitest run __tests__/api/stream.test.ts`
 Expected: FAIL (`cancelSteer` not exported; `steerRun` ignores 4th arg)
 
 - [ ] **Step 4: Implement the API changes**
@@ -622,7 +648,7 @@ export async function cancelSteer(
 
 - [ ] **Step 5: Run to verify it passes**
 
-Run: `cd frontend/packages/core && npx vitest run __tests__/api/stream.test.ts`
+Run: `cd frontend/packages/core && pnpm exec vitest run __tests__/api/stream.test.ts`
 Expected: PASS
 
 - [ ] **Step 6: Commit**
@@ -685,7 +711,7 @@ describe('pending steers', () => {
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `cd frontend/packages/core && npx vitest run __tests__/stores/messageStorePendingSteer.test.ts`
+Run: `cd frontend/packages/core && pnpm exec vitest run __tests__/stores/messageStorePendingSteer.test.ts`
 Expected: FAIL (`pendingSteers` undefined; `cancelSteer` not a function)
 
 - [ ] **Step 3: Add state + interface members**
@@ -762,13 +788,13 @@ Replace the existing `steer` action body:
 
 - [ ] **Step 5: Run to verify it passes**
 
-Run: `cd frontend/packages/core && npx vitest run __tests__/stores/messageStorePendingSteer.test.ts`
+Run: `cd frontend/packages/core && pnpm exec vitest run __tests__/stores/messageStorePendingSteer.test.ts`
 Expected: PASS
 
 - [ ] **Step 6: Update the existing steer test**
 
 `__tests__/stores/messageStoreSteer.test.ts` asserts the old optimistic-message behavior. Update its assertions to expect `pendingSteers` instead of an appended message. Run:
-`cd frontend/packages/core && npx vitest run __tests__/stores/messageStoreSteer.test.ts`
+`cd frontend/packages/core && pnpm exec vitest run __tests__/stores/messageStoreSteer.test.ts`
 Expected: PASS
 
 - [ ] **Step 7: Commit**
@@ -803,7 +829,7 @@ function buildTurnMessages(
 ```
 
 Refactor `finalizeCompletedStream` to call it and then `set(...)` the messages + clear streaming state exactly as before. Run the full core suite to confirm no regressions:
-`cd frontend/packages/core && npx vitest run`
+`cd frontend/packages/core && pnpm exec vitest run`
 Expected: PASS (unchanged behavior)
 
 - [ ] **Step 2: Commit the refactor**
@@ -868,7 +894,7 @@ describe('commit on injected_message', () => {
 
 - [ ] **Step 4: Run to verify it fails**
 
-Run: `cd frontend/packages/core && npx vitest run __tests__/stores/messageStoreCommitSteer.test.ts`
+Run: `cd frontend/packages/core && pnpm exec vitest run __tests__/stores/messageStoreCommitSteer.test.ts`
 Expected: FAIL (`__commitTurnAndInject` not a function)
 
 - [ ] **Step 5: Implement `__commitTurnAndInject` + wire into both consumers**
@@ -931,6 +957,10 @@ Then, in BOTH stream consumers, handle the event. In `send()`'s event loop and i
 ```typescript
           } else if (event.type === 'injected_message') {
             const d = event.data as { content: string; steer_id: string }
+            // Both consumers buffer mutations through createBatcher (batchedSet);
+            // flush so __commitTurnAndInject reads the fully-applied streamAgents,
+            // not a stale snapshot with pending batched deltas.
+            flush()
             set((s) => ({
               lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
             }))
@@ -939,16 +969,21 @@ Then, in BOTH stream consumers, handle the event. In `send()`'s event loop and i
           }
 ```
 
-> Place it so it shares the same `lastAppliedEventId` skip guard the loop already applies. In `consumeRunStream`, use the same shape.
+> `flush` is the function returned by `createBatcher` in each consumer (`send()` and
+> `consumeRunStream()` both destructure `{ batchedSet, flush }`). Calling it here is
+> mandatory — the commit reads `streamAgents` synchronously, and unflushed
+> `batchedSet` deltas would otherwise be dropped/reordered relative to the commit.
+> Place the branch so it shares the same `lastAppliedEventId` skip guard the loop
+> already applies. In `consumeRunStream`, use the same shape.
 
 - [ ] **Step 6: Run to verify it passes**
 
-Run: `cd frontend/packages/core && npx vitest run __tests__/stores/messageStoreCommitSteer.test.ts`
+Run: `cd frontend/packages/core && pnpm exec vitest run __tests__/stores/messageStoreCommitSteer.test.ts`
 Expected: PASS (2 tests)
 
 - [ ] **Step 7: Add pending cleanup on run-ending paths**
 
-In `loadMessages` (the big `set(...)` that resets state), add `pendingSteers: { ...get().pendingSteers, [conversationId]: [] },`. In `finalizeCompletedStream`'s final `set`, add the same clear. In the `error` branches of `send()` and `consumeRunStream()`, in `cancelStream`, and in `clearStream()`, clear `pendingSteers` for the conversation (in `clearStream`, reset to `{}`). Write a quick test:
+In `loadMessages` (the big `set(...)` that resets state), add `pendingSteers: { ...get().pendingSteers, [conversationId]: [] },`. In `finalizeCompletedStream` clear the same — note it has **two** `set(...)` exit points: the early-return branch when `mainStream` is absent (~line 522) AND the final `set` (~line 628); add the clear to **both**. In the `error` branches of `send()` and `consumeRunStream()`, in `cancelStream`, and in `clearStream()`, clear `pendingSteers` for the conversation (in `clearStream`, reset to `{}`). Write a quick test:
 
 ```typescript
 // append to messageStoreCommitSteer.test.ts
@@ -964,12 +999,12 @@ it('clears pending steers on finalize', () => {
 })
 ```
 
-Run: `cd frontend/packages/core && npx vitest run __tests__/stores/messageStoreCommitSteer.test.ts`
+Run: `cd frontend/packages/core && pnpm exec vitest run __tests__/stores/messageStoreCommitSteer.test.ts`
 Expected: PASS
 
 - [ ] **Step 8: Run the full core suite + build**
 
-Run: `cd frontend/packages/core && npx vitest run && pnpm build`
+Run: `cd frontend/packages/core && pnpm exec vitest run && pnpm build`
 Expected: PASS + clean build (so `@cubebox/web` sees the new types).
 
 - [ ] **Step 9: Commit**
@@ -1034,7 +1069,7 @@ describe('PendingSteers', () => {
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `cd frontend/packages/web && npx vitest run __tests__/components/PendingSteers.test.tsx`
+Run: `cd frontend/packages/web && pnpm exec vitest run __tests__/components/PendingSteers.test.tsx`
 Expected: FAIL (module not found)
 
 - [ ] **Step 3: Implement `PendingSteers.tsx`**
@@ -1089,7 +1124,7 @@ export function PendingSteers({ conversationId }: PendingSteersProps): React.Rea
 
 - [ ] **Step 4: Run to verify it passes**
 
-Run: `cd frontend/packages/web && npx vitest run __tests__/components/PendingSteers.test.tsx`
+Run: `cd frontend/packages/web && pnpm exec vitest run __tests__/components/PendingSteers.test.tsx`
 Expected: PASS (2 tests)
 
 - [ ] **Step 5: Render it in InputBar**
@@ -1100,15 +1135,36 @@ In `InputBar.tsx`, import `PendingSteers` and render it inside the top-level wra
       {conversationId && <PendingSteers conversationId={conversationId} />}
 ```
 
-- [ ] **Step 6: Verify web suite + typecheck**
+- [ ] **Step 6: Fix the existing `InputBar.test.tsx` mock (it will otherwise crash)**
 
-Run: `cd frontend/packages/web && npx vitest run __tests__/components && npx tsc --noEmit`
-Expected: PASS + no type errors. (The existing `InputBar.test.tsx` steer-path expectations still hold; the store mock there does not exercise pendingSteers.)
+`InputBar` now renders `<PendingSteers>`, which selects `s.pendingSteers[conversationId]`
+and `s.cancelSteer`. The existing `InputBar.test.tsx` `useMessageStore` mock returns a
+fixed object without those keys, so `s.pendingSteers` is `undefined` and the render
+throws. Add the two keys to that mock's `selector({...})` call:
 
-- [ ] **Step 7: Commit**
+```typescript
+    selector({
+      send: storeMocks.send,
+      steer: storeMocks.steer,
+      cancelStream: storeMocks.cancelStream,
+      cancelSteer: storeMocks.cancelSteer ?? (() => {}),
+      pendingSteers: {},
+      isStreaming: storeMocks.state.isStreaming,
+      streamingConversationId: storeMocks.state.streamingConversationId,
+    }),
+```
+
+(Add `cancelSteer: vi.fn()` to the `storeMocks` hoisted object too.)
+
+- [ ] **Step 7: Verify web suite + typecheck**
+
+Run: `cd frontend/packages/web && pnpm exec vitest run __tests__/components && pnpm exec tsc --noEmit`
+Expected: PASS + no type errors.
+
+- [ ] **Step 8: Commit**
 
 ```bash
-git add frontend/packages/web/components/layout/PendingSteers.tsx frontend/packages/web/components/layout/InputBar.tsx frontend/packages/web/__tests__/components/PendingSteers.test.tsx
+git add frontend/packages/web/components/layout/PendingSteers.tsx frontend/packages/web/components/layout/InputBar.tsx frontend/packages/web/__tests__/components/PendingSteers.test.tsx frontend/packages/web/__tests__/components/InputBar.test.tsx
 git commit -m "feat(web): dimmed pending-steer chips above the input with cancel"
 ```
 
@@ -1119,7 +1175,7 @@ git commit -m "feat(web): dimmed pending-steer chips above the input with cancel
 ### Task 9: Steer pending → commit → cancel E2E
 
 **Files:**
-- Modify/extend: the existing steer E2E under `frontend/packages/web/tests/e2e/` (find it: `grep -rln "steer" frontend/packages/web/tests`)
+- Modify/extend: the existing steer E2E under `frontend/packages/web/__tests__/e2e/` (find it: `grep -rln "steer" frontend/packages/web/__tests__/e2e`)
 - Prereq: copy `backend/.env` + `backend/config.development.local.yaml` into the worktree backend dir; start backend on 8059 and frontend on 3059 (see `.worktree.env`).
 
 - [ ] **Step 1: Write the E2E spec**
@@ -1139,13 +1195,13 @@ In `PendingSteers.tsx`, add `data-testid="pending-steer"` to the chip `<div>`.
 
 - [ ] **Step 3: Run the E2E**
 
-Run (from worktree, with servers up): `cd frontend/packages/web && npx playwright test <steer-spec-file>`
+Run (from worktree, with servers up): `cd frontend/packages/web && pnpm exec playwright test <steer-spec-file>`
 Expected: PASS. If the model/run timing is flaky, gate waits on conditions (chip present, chip absent, message present) rather than fixed timeouts.
 
 - [ ] **Step 4: Commit**
 
 ```bash
-git add frontend/packages/web/components/layout/PendingSteers.tsx frontend/packages/web/tests/e2e/<steer-spec-file>
+git add frontend/packages/web/components/layout/PendingSteers.tsx frontend/packages/web/__tests__/e2e/<steer-spec-file>
 git commit -m "test(e2e): steer pending chip → inline commit → reload-stable position → cancel"
 ```
 

--- a/docs/dev/specs/2026-05-25-steer-message-display-design.md
+++ b/docs/dev/specs/2026-05-25-steer-message-display-design.md
@@ -1,0 +1,253 @@
+# Steer message display: pending → committed
+
+**Date:** 2026-05-25
+**Status:** Design (approved in brainstorming, pending spec review)
+**Branch:** `feat/steer-message-display`
+
+## Problem
+
+When a user steers a running agent (types a mid-run instruction), the steer
+message is shown optimistically as a normal user bubble appended to the end of
+the in-memory message list. During an active run, the live assistant output
+lives in a single streaming bubble (`streamAgents['main']`) that has not yet
+been split into per-turn messages. So the optimistic steer bubble renders
+*above* the still-streaming assistant output.
+
+cubepi actually injects the steer `UserMessage` into the thread at the next
+safe point — after the current tool batch completes, before the next assistant
+turn (`cubepi/agent/loop.py:321-328` and `:334-341`). On reload, the
+checkpointer returns the thread with the steer message **interleaved between
+assistant turns**, not at the top or bottom of one merged bubble. Result: the
+steer message visibly **jumps position** on refresh.
+
+Root cause of the jump: the frontend commits the steer message to a *guessed*
+transcript position before it knows the real injection point. cubebox also does
+not forward any SSE event when cubepi injects the message
+(`backend/cubebox/agents/stream.py:120-153` drops `MessageStart`/`MessageEnd`
+for non-assistant messages), so the frontend has no live signal of the real
+position.
+
+## Goal
+
+Adopt Claude Code's queued-message model:
+
+1. **Pending state** — a sent-but-not-yet-injected steer shows as a distinct,
+   dimmed item pinned **above the input box**, not in the transcript. The
+   transcript stream stays clean; no position is ever claimed and then revoked.
+2. **Committed state** — when cubepi actually injects the message, the backend
+   emits a new SSE event. The frontend finalizes the current streaming bubble
+   into a history assistant message, inserts the steer user message at that
+   point, resets the streaming bubble, and removes the pending item. The live
+   position now matches what a reload shows — **no jump**.
+3. **Cancel** — a pending steer can be cancelled (best-effort) before cubepi
+   drains it, via an X on the pending item.
+
+Multiple steers may be pending at once; they stack as a vertical list above the
+input box.
+
+## Non-goals
+
+- Follow-up messages (`get_follow_up_messages`) — cubebox does not use them.
+  The backend event mechanism is generic enough to cover them later, but no UI
+  is built for them now.
+- Editing a pending steer in place. Cancel + retype only.
+
+## Join key: `steer_id`
+
+A client-generated `steer_id` (UUID-ish, minted when the user sends the steer)
+is the single join key across the whole flow:
+
+- Sent on the steer request; cubebox puts it in the injected
+  `UserMessage.metadata["steer_id"]`. cubepi's `UserMessage` has no `id` field
+  but does carry a `metadata: dict`, so this avoids a Message-schema change
+  upstream and follows the existing "cubebox extras ride in metadata"
+  convention.
+- The `injected_message` SSE event echoes `steer_id`, so the frontend can match
+  the committed message to the pending item and remove it.
+- Cancel targets a `steer_id`; cubepi's steering queue removes the queued
+  message whose `metadata["steer_id"]` matches.
+
+The persisted message id (assigned by cubebox when it stores history) and the
+live committed message id may differ; this is fine — `steer_id` is the live
+join key, and a reload does a full re-render from authoritative history.
+
+## Architecture & changes
+
+### A. cubepi (upstream) — cancel support
+
+`cubepi/agent/agent.py`:
+
+- `_MessageQueue.remove(steer_id: str) -> bool` — drop queued message(s) whose
+  `metadata.get("steer_id") == steer_id`; return whether anything was removed.
+- `Agent.cancel_steer(steer_id: str) -> bool` — delegate to
+  `self._steering_queue.remove(steer_id)`.
+
+No change to the `UserMessage` schema. No change to drain/injection behavior.
+
+### B. cubebox backend — `injected_message` SSE event
+
+`backend/cubebox/agents/stream.py` (`convert_agent_event_to_sse`) +
+`backend/cubebox/streams/run_manager.py` (`_on_event`):
+
+- When a `MessageEndEvent` wraps a `UserMessage`, emit:
+  ```json
+  {"type": "injected_message", "role": "user",
+   "content": "<text>", "steer_id": "<from metadata>"}
+  ```
+  (Text extracted from `TextContent` blocks; steer is text-only.)
+- **Seed-message dedup:** cubepi emits `MessageStart`/`MessageEnd` for the
+  run's seed prompt at loop start (`cubepi/agent/loop.py:62-64`). cubebox sends
+  exactly one seed user message per run, and the frontend already shows it
+  optimistically. `_on_event` keeps a per-run counter and **skips the first
+  user-message event**, forwarding only subsequent injected ones. (A steer
+  drained by the start-poll before the first assistant turn is the 2nd
+  user-message event → forwarded correctly.)
+
+### C. cubebox backend — cancel-steer endpoint + control plane
+
+`backend/cubebox/api/routes/v1/conversations.py`:
+
+- `SteerMessageRequest` gains `steer_id: str` (client-generated, required).
+- New route `POST /{conversation_id}/steer/cancel` with body `{steer_id}`,
+  returning a status (`cancelled` | `not_found`). `not_found` = already drained
+  or unknown id.
+
+`backend/cubebox/streams/run_manager.py`:
+
+- `dispatch_steer` already forwards `content`; thread `steer_id` through so the
+  injected `UserMessage` carries `metadata["steer_id"]`.
+- Add `dispatch_cancel_steer(run_id, steer_id)` mirroring the existing
+  steer/cancel multi-instance plumbing (local agent call + Redis pub/sub
+  control message `cancel_steer` for cross-instance, alongside the existing
+  `steer`/`cancel` control types at `run_manager.py:596`).
+
+### D. frontend core — types + parsing
+
+- Add `InjectedMessageEvent` to the `AgentEvent` union (`types`), and parse the
+  `injected_message` SSE type in `frontend/packages/core/src/api/stream.ts`.
+- `steerRun(client, conversationId, content, steerId)` — send `steer_id`.
+- New `cancelSteer(client, conversationId, steerId)` API call.
+
+### E. frontend core — `messageStore`
+
+`frontend/packages/core/src/stores/messageStore.ts`:
+
+- New state: `pendingSteers: Record<conversationId, { steerId: string; text: string }[]>`.
+- `steer()`:
+  - mint `steerId`, push `{steerId, text}` into `pendingSteers[convId]`
+    (instead of appending to `messages`).
+  - call `steerRun(..., steerId)`. On `no_active_run` or error → remove that
+    `steerId` from `pendingSteers` (rollback).
+- New `cancelSteer(client, conversationId, steerId)` store action:
+  - optimistically remove from `pendingSteers`; call the cancel API. If the API
+    reports `not_found` (already drained), the upcoming `injected_message` will
+    commit it normally — acceptable best-effort behavior.
+- Handle `injected_message` in **both** stream consumers (`send()` loop and
+  `consumeRunStream()`), via a shared helper `commitTurnAndInject(injected)`:
+  1. Build the current main turn's messages from `streamAgents['main']` using a
+     pure helper `buildTurnMessages(agents, toolResultMap, turnUsage)` extracted
+     from `finalizeCompletedStream` (so assistant + tool_result + subagent
+     handling is identical), append them to `messages[convId]`.
+  2. Append the injected steer user message (id derived from `steer_id`).
+  3. Reset `streamAgents['main']` to empty so subsequent deltas form a fresh
+     bubble. Leave `toolResultMap`/`toolStartedMap` intact (keyed globally by
+     tool_call_id).
+  4. Remove the matching `steerId` from `pendingSteers`.
+- `finalizeCompletedStream()` — refactor to reuse `buildTurnMessages`. On run
+  finalize, clear `pendingSteers[convId]` (run is over; any still-pending were
+  not injected, and reload is authoritative if that's wrong).
+- `loadMessages()` — clear `pendingSteers[convId]` on (re)load; committed steers
+  come back from checkpointer history naturally → no transcript duplication.
+
+### F. frontend web — UI
+
+- New pending area rendered **above the textarea** in/near
+  `components/layout/InputBar.tsx`: maps `pendingSteers[convId]` to a vertical
+  stack of dimmed chips, each with the steer text and a cancel (X) button. Style
+  borrows Claude Code's `QueuedMessageProvider` dimmed treatment (own component,
+  not a `mode` prop — per the repo's module-reuse rule).
+- Remove the old optimistic steer bubble from the transcript (no longer appended
+  to `messages`).
+- `components/chat/MessageList.tsx` — no special case needed: a committed steer
+  is a normal `role==='user'` message in `messages[]` at the correct position.
+
+## Data flow (happy path)
+
+```
+user types mid-run, hits Enter
+  → store.steer(): mint steer_id, push to pendingSteers, POST /steer {content, steer_id}
+  → pending chip appears above input (dimmed)
+... agent finishes current tool batch ...
+cubepi drains steering queue → injects UserMessage(metadata.steer_id) → MessageEnd(UserMessage)
+  → cubebox _on_event (past seed) → SSE injected_message {content, steer_id}
+  → store: commitTurnAndInject:
+       finalize current main bubble → append to messages[]
+       append steer user message at this point
+       reset streamAgents.main
+       remove steer_id from pendingSteers   (chip disappears)
+  → next deltas build the next assistant bubble below the steer message
+reload → checkpointer history has the same interleaving → identical position
+```
+
+## Cancel flow
+
+```
+user clicks X on a pending chip
+  → store.cancelSteer(steer_id): remove from pendingSteers, POST /steer/cancel {steer_id}
+  → run_manager.dispatch_cancel_steer → agent.cancel_steer(steer_id)
+       → queue.remove(steer_id)
+  → cancelled  : never injected, no injected_message ever arrives. Done.
+  → not_found  : already drained → injected_message will arrive and commit it
+                 into the transcript (best-effort cancel lost the race). Acceptable.
+```
+
+## Error handling & edges
+
+- **steer arrives too late** (run finishing a tool-less final turn): cubepi's
+  tail drain (`loop.py:334-341`) still injects it → `injected_message` fires →
+  committed. No special handling.
+- **run dies before injection**: pending chip lingers; cleared on
+  `finalizeCompletedStream` / next `loadMessages`. Reload is authoritative.
+- **identical-text steers**: disambiguated by `steer_id`, not text.
+- **multi-instance**: cancel uses the same Redis control channel as steer/cancel
+  so it works when the run lives on another API instance.
+- **reconnect mid-run** (`consumeRunStream` replay): `injected_message` events
+  carry `event_id` and flow through the same de-dup/ordering as other events;
+  the commit helper is idempotent w.r.t. already-applied event ids.
+
+## Testing
+
+- **cubepi unit:** `_MessageQueue.remove` (match/no-match, mode=all & one);
+  `Agent.cancel_steer` returns correct bool.
+- **cubebox backend unit:** `convert_agent_event_to_sse` emits
+  `injected_message` for an injected UserMessage and **not** for the seed;
+  `_on_event` seed-skip counter; cancel endpoint status mapping.
+- **frontend core unit (vitest):** `steer()` writes to `pendingSteers` not
+  `messages`; `injected_message` commits the current turn, inserts the user
+  message, resets `main`, removes the pending entry; `cancelSteer` removes
+  optimistically; `loadMessages`/`finalize` clear pending.
+- **frontend web unit:** pending list renders chips + cancel; chip clears on
+  commit.
+- **E2E (priority, per repo discipline):** real run, steer mid-run →
+  - pending chip appears above input,
+  - chip moves into the transcript at the correct interleaved position once
+    injected,
+  - reload → identical position (no jump),
+  - cancel before injection → message never enters the transcript.
+  Extends the existing steer E2E. Needs a real agent run (the multi-instance
+  run-control work already exercises live steer).
+
+## Files touched
+
+| Area | File |
+|---|---|
+| cubepi | `cubepi/agent/agent.py` (`_MessageQueue.remove`, `Agent.cancel_steer`) |
+| backend | `cubebox/agents/stream.py`, `cubebox/streams/run_manager.py`, `cubebox/api/routes/v1/conversations.py` |
+| core | `src/types`, `src/api/stream.ts`, `src/stores/messageStore.ts` |
+| web | `components/layout/InputBar.tsx` (+ new pending component), `components/chat/MessageList.tsx` (remove optimistic), tests |
+
+## PR split
+
+cubepi change ships first (upstream), then the cubebox backend + frontend land
+together (they are tightly coupled through the `injected_message` event and the
+cancel endpoint). Revisit at plan time.

--- a/docs/dev/specs/2026-05-25-steer-message-display-design.md
+++ b/docs/dev/specs/2026-05-25-steer-message-display-design.md
@@ -67,9 +67,12 @@ is the single join key across the whole flow:
 - Cancel targets a `steer_id`; cubepi's steering queue removes the queued
   message whose `metadata["steer_id"]` matches.
 
-The persisted message id (assigned by cubebox when it stores history) and the
-live committed message id may differ; this is fine — `steer_id` is the live
-join key, and a reload does a full re-render from authoritative history.
+cubepi messages have no id and cubebox does not assign one — history is the raw
+`model_dump()` of each message (`conversations.py:602`), and the frontend
+synthesizes a React-key id locally when one is missing (`messageStore.ts:124`).
+So the live committed message id and the post-reload synthesized id will differ;
+this is fine — `steer_id` (carried in `metadata`, which *is* persisted) is the
+durable join key, and a reload does a full re-render from authoritative history.
 
 ## Architecture & changes
 
@@ -86,22 +89,42 @@ No change to the `UserMessage` schema. No change to drain/injection behavior.
 
 ### B. cubebox backend — `injected_message` SSE event
 
-`backend/cubebox/agents/stream.py` (`convert_agent_event_to_sse`) +
-`backend/cubebox/streams/run_manager.py` (`_on_event`):
+There are **two** translation layers; the event must be wired through both, or
+it is silently dropped:
 
-- When a `MessageEndEvent` wraps a `UserMessage`, emit:
+1. `backend/cubebox/agents/stream.py` — `convert_agent_event_to_sse(evt)` turns
+   a cubepi `AgentEvent` into a wire dict.
+2. `backend/cubebox/streams/run_manager.py:243` — `cubepi_dict_to_agent_event(d)`
+   turns that dict into a typed cubebox `AgentEvent` (from
+   `cubebox/agents/schemas.py`) before it reaches `publish_stream_event`. It
+   returns `None` for unknown `type`, so an unhandled `injected_message` is
+   dropped here.
+
+Changes:
+
+- **`cubebox/agents/schemas.py`** — add `InjectedMessageEvent` with
+  `type="injected_message"` and the same `timestamp` / `data` envelope every
+  other event uses (events are NOT flat — they carry `data: {...}`):
   ```json
-  {"type": "injected_message", "role": "user",
-   "content": "<text>", "steer_id": "<from metadata>"}
+  {"type": "injected_message", "timestamp": "...",
+   "data": {"content": "<text>", "steer_id": "<from metadata>"}}
   ```
-  (Text extracted from `TextContent` blocks; steer is text-only.)
-- **Seed-message dedup:** cubepi emits `MessageStart`/`MessageEnd` for the
-  run's seed prompt at loop start (`cubepi/agent/loop.py:62-64`). cubebox sends
-  exactly one seed user message per run, and the frontend already shows it
-  optimistically. `_on_event` keeps a per-run counter and **skips the first
-  user-message event**, forwarding only subsequent injected ones. (A steer
-  drained by the start-poll before the first assistant turn is the 2nd
-  user-message event → forwarded correctly.)
+- **`convert_agent_event_to_sse`** — add a branch: a `MessageEndEvent` whose
+  `message` is a `UserMessage` → wire dict
+  `{"type": "injected_message", "content": <text>, "steer_id": <metadata.steer_id>}`
+  (text from `TextContent` blocks; steer is text-only).
+- **`cubepi_dict_to_agent_event`** — add a `type == "injected_message"` branch
+  that builds `InjectedMessageEvent`.
+- **Seed-message dedup lives in ONE place: `_on_event`** (the only layer with
+  per-run state). cubepi emits `MessageStart`/`MessageEnd` for the run's seed
+  prompt at loop start (`cubepi/agent/loop.py:62-64`) using the same shape as an
+  injected steer. cubebox sends exactly one seed user message per run, and the
+  frontend already shows it optimistically. `_on_event` keeps a per-run
+  user-message counter and **suppresses the first** user-message `MessageEnd`
+  before it is converted/forwarded; subsequent ones are injected steers. (A
+  steer drained by the start-poll before the first assistant turn is the 2nd
+  user-message event → forwarded correctly.) The pure converters do NOT do
+  seed-dedup — they have no run state.
 
 ### C. cubebox backend — cancel-steer endpoint + control plane
 
@@ -144,18 +167,35 @@ No change to the `UserMessage` schema. No change to drain/injection behavior.
     commit it normally — acceptable best-effort behavior.
 - Handle `injected_message` in **both** stream consumers (`send()` loop and
   `consumeRunStream()`), via a shared helper `commitTurnAndInject(injected)`:
-  1. Build the current main turn's messages from `streamAgents['main']` using a
-     pure helper `buildTurnMessages(agents, toolResultMap, turnUsage)` extracted
-     from `finalizeCompletedStream` (so assistant + tool_result + subagent
-     handling is identical), append them to `messages[convId]`.
-  2. Append the injected steer user message (id derived from `steer_id`).
-  3. Reset `streamAgents['main']` to empty so subsequent deltas form a fresh
-     bubble. Leave `toolResultMap`/`toolStartedMap` intact (keyed globally by
-     tool_call_id).
-  4. Remove the matching `steerId` from `pendingSteers`.
+  1. **Idempotency:** `injected_message` carries `event_id` and goes through the
+     same `lastAppliedEventId` ordering/skip guard the consumers already apply to
+     `done`/`error` (those are handled outside `applyStreamEvent`, so the guard
+     is inline in each consumer). Additionally, if `steer_id` is already present
+     in `messages[convId]` (matched via `metadata.steer_id`), the commit is a
+     no-op — this makes replay on reconnect safe.
+  2. **Empty-turn guard:** build the current turn's messages from *all*
+     `streamAgents` buckets via a pure helper
+     `buildTurnMessages(agents, toolResultMap, turnUsage)` extracted from
+     `finalizeCompletedStream` (identical assistant + tool_result + subagent
+     handling), append to `messages[convId]`. If the current main bucket has **no
+     content** (e.g. a steer drained by the start-poll at `loop.py:165` before
+     any assistant output), skip building an assistant message entirely — do not
+     append an empty bubble.
+  3. Append the injected steer user message (carrying `metadata.steer_id`; id
+     synthesized locally).
+  4. Reset **all** `streamAgents` buckets to a fresh `{main: empty}` — not just
+     `main` — so any settled subagent streams are cleared along with the main
+     bubble (they were just persisted in step 2). Leave
+     `toolResultMap`/`toolStartedMap` intact (keyed globally by tool_call_id).
+  5. Remove the matching `steerId` from `pendingSteers`.
 - `finalizeCompletedStream()` — refactor to reuse `buildTurnMessages`. On run
   finalize, clear `pendingSteers[convId]` (run is over; any still-pending were
   not injected, and reload is authoritative if that's wrong).
+- **Pending cleanup on every run-ending path:** the error branches in `send()`
+  and `consumeRunStream()` (`messageStore.ts:679,913`), `cancelStream()`, and
+  `clearStream()` currently touch only stream fields — each must also clear
+  `pendingSteers[convId]`, or a chip is stranded when a run errors/aborts
+  mid-steer.
 - `loadMessages()` — clear `pendingSteers[convId]` on (re)load; committed steers
   come back from checkpointer history naturally → no transcript duplication.
 
@@ -219,9 +259,12 @@ user clicks X on a pending chip
 
 - **cubepi unit:** `_MessageQueue.remove` (match/no-match, mode=all & one);
   `Agent.cancel_steer` returns correct bool.
-- **cubebox backend unit:** `convert_agent_event_to_sse` emits
-  `injected_message` for an injected UserMessage and **not** for the seed;
-  `_on_event` seed-skip counter; cancel endpoint status mapping.
+- **cubebox backend unit:** `convert_agent_event_to_sse` emits the
+  `injected_message` wire dict for a UserMessage `MessageEndEvent`;
+  `cubepi_dict_to_agent_event` maps that dict to `InjectedMessageEvent`;
+  `_on_event` suppresses the first (seed) user-message event and forwards
+  subsequent ones (seed-dedup is asserted here, NOT in the pure converter);
+  cancel endpoint status mapping (`cancelled` / `not_found`).
 - **frontend core unit (vitest):** `steer()` writes to `pendingSteers` not
   `messages`; `injected_message` commits the current turn, inserts the user
   message, resets `main`, removes the pending entry; `cancelSteer` removes
@@ -242,7 +285,7 @@ user clicks X on a pending chip
 | Area | File |
 |---|---|
 | cubepi | `cubepi/agent/agent.py` (`_MessageQueue.remove`, `Agent.cancel_steer`) |
-| backend | `cubebox/agents/stream.py`, `cubebox/streams/run_manager.py`, `cubebox/api/routes/v1/conversations.py` |
+| backend | `cubebox/agents/schemas.py` (`InjectedMessageEvent`), `cubebox/agents/stream.py`, `cubebox/streams/run_manager.py` (`cubepi_dict_to_agent_event` + `_on_event`), `cubebox/api/routes/v1/conversations.py` |
 | core | `src/types`, `src/api/stream.ts`, `src/stores/messageStore.ts` |
 | web | `components/layout/InputBar.tsx` (+ new pending component), `components/chat/MessageList.tsx` (remove optimistic), tests |
 

--- a/frontend/packages/core/__tests__/api/stream.test.ts
+++ b/frontend/packages/core/__tests__/api/stream.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest'
+import { steerRun, cancelSteer } from '../../src/api/stream'
+
+function fakeClient(capture: { path?: string; body?: unknown }) {
+  return {
+    post: vi.fn(async (path: string, body: unknown) => {
+      capture.path = path
+      capture.body = body
+      return { ok: true, json: async () => ({ status: 'steered', run_id: 'r1' }) }
+    }),
+  } as never
+}
+
+describe('steer api', () => {
+  it('steerRun sends content + steer_id', async () => {
+    const cap: { path?: string; body?: unknown } = {}
+    await steerRun(fakeClient(cap), 'conv-1', 'do X', 's1')
+    expect(cap.path).toBe('/api/v1/conversations/conv-1/steer')
+    expect(cap.body).toEqual({ content: 'do X', steer_id: 's1' })
+  })
+
+  it('cancelSteer posts steer_id to the cancel route', async () => {
+    const cap: { path?: string; body?: unknown } = {}
+    await cancelSteer(fakeClient(cap), 'conv-1', 's1')
+    expect(cap.path).toBe('/api/v1/conversations/conv-1/steer/cancel')
+    expect(cap.body).toEqual({ steer_id: 's1' })
+  })
+})

--- a/frontend/packages/core/__tests__/stores/messageStoreCommitSteer.test.ts
+++ b/frontend/packages/core/__tests__/stores/messageStoreCommitSteer.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useMessageStore } from '../../src/stores/messageStore'
+
+function applyInjected(convId: string, content: string, steerId: string) {
+  return useMessageStore.getState().__commitTurnAndInject(convId, {
+    content,
+    steer_id: steerId,
+  })
+}
+
+describe('commit on injected_message', () => {
+  beforeEach(() => {
+    useMessageStore.setState({
+      messages: {
+        c1: [
+          {
+            id: 'u1',
+            role: 'user',
+            content: [{ type: 'text', text: 'go' }],
+            timestamp: 1,
+            metadata: {},
+          },
+        ],
+      },
+      streamAgents: {
+        main: {
+          text: 'partial',
+          toolCalls: [],
+          toolResults: [],
+          thinking: '',
+          blocks: [{ type: 'text', text: 'partial' }],
+          name: null,
+        },
+      },
+      pendingSteers: { c1: [{ steerId: 's1', text: 'do X' }] },
+      toolResultMap: {},
+      turnUsage: { c1: null },
+      isStreaming: true,
+      streamingConversationId: 'c1',
+    })
+  })
+
+  it('finalizes the current bubble, inserts the steer user msg, resets streams, clears pending', () => {
+    applyInjected('c1', 'do X', 's1')
+    const s = useMessageStore.getState()
+    const roles = s.messages.c1.map((m) => m.role)
+    expect(roles).toEqual(['user', 'assistant', 'user'])
+    expect(s.messages.c1[2].content[0]).toMatchObject({ type: 'text', text: 'do X' })
+    expect(s.messages.c1[2].metadata?.steer_id).toBe('s1')
+    expect(s.streamAgents.main.text).toBe('')
+    expect(s.pendingSteers.c1 ?? []).toHaveLength(0)
+  })
+
+  it('skips the empty assistant bubble when the main stream has no content', () => {
+    useMessageStore.setState({
+      streamAgents: {
+        main: { text: '', toolCalls: [], toolResults: [], thinking: '', blocks: [], name: null },
+      },
+    })
+    applyInjected('c1', 'do X', 's1')
+    const roles = useMessageStore.getState().messages.c1.map((m) => m.role)
+    expect(roles).toEqual(['user', 'user'])
+  })
+
+  it('is idempotent — re-applying the same steer_id is a no-op', () => {
+    applyInjected('c1', 'do X', 's1')
+    const before = useMessageStore.getState().messages.c1.length
+    applyInjected('c1', 'do X', 's1')
+    expect(useMessageStore.getState().messages.c1.length).toBe(before)
+  })
+
+  it('clearStream clears all pending steers', () => {
+    useMessageStore.setState({ pendingSteers: { c1: [{ steerId: 's1', text: 'do X' }] } })
+    useMessageStore.getState().clearStream()
+    expect(useMessageStore.getState().pendingSteers).toEqual({})
+  })
+})

--- a/frontend/packages/core/__tests__/stores/messageStorePendingSteer.test.ts
+++ b/frontend/packages/core/__tests__/stores/messageStorePendingSteer.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useMessageStore } from '../../src/stores/messageStore'
+
+vi.mock('../../src/api', async (orig) => {
+  const actual = await (orig as () => Promise<Record<string, unknown>>)()
+  return {
+    ...actual,
+    steerRun: vi.fn(async () => ({ status: 'steered', run_id: 'r1' })),
+    cancelSteer: vi.fn(async () => ({ status: 'cancelled', run_id: 'r1' })),
+  }
+})
+
+const client = {} as never
+
+describe('pending steers', () => {
+  beforeEach(() => {
+    useMessageStore.setState({
+      messages: {},
+      pendingSteers: {},
+      isStreaming: true,
+      streamingConversationId: 'c1',
+    })
+  })
+
+  it('steer() adds to pendingSteers, not messages', async () => {
+    await useMessageStore.getState().steer(client, 'c1', 'do X')
+    const s = useMessageStore.getState()
+    expect(s.pendingSteers.c1).toHaveLength(1)
+    expect(s.pendingSteers.c1[0].text).toBe('do X')
+    expect(s.messages.c1 ?? []).toHaveLength(0)
+  })
+
+  it('cancelSteer() removes the pending entry', async () => {
+    await useMessageStore.getState().steer(client, 'c1', 'do X')
+    const id = useMessageStore.getState().pendingSteers.c1[0].steerId
+    await useMessageStore.getState().cancelSteer(client, 'c1', id)
+    expect(useMessageStore.getState().pendingSteers.c1 ?? []).toHaveLength(0)
+  })
+})

--- a/frontend/packages/core/__tests__/stores/messageStoreSteer.test.ts
+++ b/frontend/packages/core/__tests__/stores/messageStoreSteer.test.ts
@@ -18,6 +18,7 @@ describe('messageStore.steer', () => {
     vi.clearAllMocks()
     useMessageStore.setState({
       messages: { conv1: [] },
+      pendingSteers: {},
       streamAgents: {
         main: {
           text: 'partial',
@@ -34,20 +35,20 @@ describe('messageStore.steer', () => {
     })
   })
 
-  it('optimistically appends the user message and calls steerRun', async () => {
+  it('adds the steer to pendingSteers (not messages) and calls steerRun', async () => {
     await useMessageStore.getState().steer(fakeClient, 'conv1', 'go left instead')
     const state = useMessageStore.getState()
     expect(state.isStreaming).toBe(true)
     expect(state.streamingConversationId).toBe('conv1')
-    const msgs = state.messages.conv1
-    expect(msgs).toHaveLength(1)
-    expect(msgs[0].role).toBe('user')
-    expect(msgs[0].content).toEqual([{ type: 'text', text: 'go left instead' }])
+    expect(state.messages.conv1).toHaveLength(0)
+    const pending = state.pendingSteers.conv1
+    expect(pending).toHaveLength(1)
+    expect(pending[0].text).toBe('go left instead')
     expect(steerRun).toHaveBeenCalledWith(
       fakeClient,
       'conv1',
       'go left instead',
-      expect.any(String),
+      pending[0].steerId,
     )
   })
 
@@ -55,29 +56,33 @@ describe('messageStore.steer', () => {
     await useMessageStore.getState().steer(fakeClient, 'conv1', '   ')
     expect(steerRun).not.toHaveBeenCalled()
     expect(useMessageStore.getState().messages.conv1).toHaveLength(0)
+    expect(useMessageStore.getState().pendingSteers.conv1 ?? []).toHaveLength(0)
   })
 
   it('does nothing when not streaming the given conversation', async () => {
     useMessageStore.setState({ isStreaming: false, streamingConversationId: null })
     await useMessageStore.getState().steer(fakeClient, 'conv1', 'hi')
     expect(steerRun).not.toHaveBeenCalled()
+    expect(useMessageStore.getState().pendingSteers.conv1 ?? []).toHaveLength(0)
   })
 
-  it('rolls back the optimistic bubble when the run was not steered', async () => {
+  it('removes the pending steer when the run was not steered', async () => {
     ;(steerRun as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       status: 'no_active_run',
       run_id: null,
     })
     await useMessageStore.getState().steer(fakeClient, 'conv1', 'too late')
+    expect(useMessageStore.getState().pendingSteers.conv1 ?? []).toHaveLength(0)
     expect(useMessageStore.getState().messages.conv1).toHaveLength(0)
   })
 
-  it('keeps the optimistic bubble when status is published', async () => {
+  it('keeps the pending steer when status is published', async () => {
     ;(steerRun as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       status: 'published',
       run_id: 'r1',
     })
     await useMessageStore.getState().steer(fakeClient, 'conv1', 'cross-instance steer')
-    expect(useMessageStore.getState().messages.conv1).toHaveLength(1)
+    expect(useMessageStore.getState().pendingSteers.conv1).toHaveLength(1)
+    expect(useMessageStore.getState().messages.conv1).toHaveLength(0)
   })
 })

--- a/frontend/packages/core/__tests__/stores/messageStoreSteer.test.ts
+++ b/frontend/packages/core/__tests__/stores/messageStoreSteer.test.ts
@@ -43,7 +43,12 @@ describe('messageStore.steer', () => {
     expect(msgs).toHaveLength(1)
     expect(msgs[0].role).toBe('user')
     expect(msgs[0].content).toEqual([{ type: 'text', text: 'go left instead' }])
-    expect(steerRun).toHaveBeenCalledWith(fakeClient, 'conv1', 'go left instead')
+    expect(steerRun).toHaveBeenCalledWith(
+      fakeClient,
+      'conv1',
+      'go left instead',
+      expect.any(String),
+    )
   })
 
   it('is a no-op for empty content', async () => {

--- a/frontend/packages/core/src/api/stream.ts
+++ b/frontend/packages/core/src/api/stream.ts
@@ -28,12 +28,35 @@ export async function steerRun(
   client: ApiClient,
   conversationId: string,
   content: string,
+  steerId: string,
 ): Promise<SteerRunResponse> {
-  const res = await client.post(`/api/v1/conversations/${conversationId}/steer`, { content })
+  const res = await client.post(`/api/v1/conversations/${conversationId}/steer`, {
+    content,
+    steer_id: steerId,
+  })
   if (!res.ok) {
     throw new Error(`Failed to steer run: HTTP ${res.status}`)
   }
   return (await res.json()) as SteerRunResponse
+}
+
+export interface CancelSteerResponse {
+  status: 'cancelled' | 'not_found' | 'published' | 'no_active_run'
+  run_id: string | null
+}
+
+export async function cancelSteer(
+  client: ApiClient,
+  conversationId: string,
+  steerId: string,
+): Promise<CancelSteerResponse> {
+  const res = await client.post(`/api/v1/conversations/${conversationId}/steer/cancel`, {
+    steer_id: steerId,
+  })
+  if (!res.ok) {
+    throw new Error(`Failed to cancel steer: HTTP ${res.status}`)
+  }
+  return (await res.json()) as CancelSteerResponse
 }
 
 async function* readLines(reader: ReadableStreamDefaultReader<Uint8Array>): AsyncGenerator<string> {

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -1009,7 +1009,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       }))
 
     try {
-      const res = await steerRun(client, conversationId, text)
+      const res = await steerRun(client, conversationId, text, crypto.randomUUID())
       if (res.status === 'no_active_run') rollback()
     } catch (err) {
       console.error('Failed to steer run:', err)

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -25,6 +25,7 @@ import { getTextContent } from '../types'
 import type { ApiClient } from '../api'
 import {
   cancelActiveRun,
+  cancelSteer,
   getConversationBootstrap,
   steerRun,
   streamMessages,
@@ -44,6 +45,7 @@ export interface AgentStream {
 
 export interface MessageStore {
   messages: Record<string, Message[]>
+  pendingSteers: Record<string, { steerId: string; text: string }[]>
   streamAgents: Record<string, AgentStream> // "main" or "subagent:xxx"
   isStreaming: boolean
   streamingConversationId: string | null
@@ -72,6 +74,7 @@ export interface MessageStore {
   ): Promise<void>
   cancelStream(client: ApiClient, conversationId: string): Promise<void>
   steer(client: ApiClient, conversationId: string, content: string): Promise<void>
+  cancelSteer(client: ApiClient, conversationId: string, steerId: string): Promise<void>
   clearStream(): void
   clearLastRunStatus(): void
 }
@@ -727,6 +730,7 @@ async function consumeRunStream(
 
 export const useMessageStore = create<MessageStore>((set, get) => ({
   messages: {},
+  pendingSteers: {},
   streamAgents: {},
   isStreaming: false,
   streamingConversationId: null,
@@ -978,42 +982,53 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
     const state = get()
     if (!state.isStreaming || state.streamingConversationId !== conversationId) return
 
-    // Optimistically show the steered user message immediately for responsive
-    // feedback. cubepi emits the injected message to the checkpointer (not as
-    // SSE deltas), so this in-memory bubble is the live display; a reload after
-    // the run completes re-reads it from history. Streaming state is left
-    // untouched — the run keeps going and the model picks the message up at its
-    // next safe point. If the endpoint reports the run was NOT steered (already
-    // finished / not in this process), roll the bubble back.
-    const optimisticId = nextMessageId('user-steer')
-    const userMessage: UserMessageType = {
-      id: optimisticId,
-      role: 'user',
-      content: [{ type: 'text', text }],
-      timestamp: Date.now() / 1000,
-      metadata: {},
-    }
+    // A sent-but-not-yet-injected steer is held in pendingSteers (rendered as a
+    // chip above the input box), NOT in the transcript. cubepi injects it into
+    // history at its next safe point and emits an injected_message SSE event,
+    // at which point it gets committed into messages (handled elsewhere).
+    // Streaming state is left untouched — the run keeps going. If the endpoint
+    // reports the run was NOT steered (already finished / not in this process),
+    // remove the pending entry.
+    const steerId = nextMessageId('steer')
     set((s) => ({
-      messages: {
-        ...s.messages,
-        [conversationId]: [...(s.messages[conversationId] ?? []), userMessage],
+      pendingSteers: {
+        ...s.pendingSteers,
+        [conversationId]: [...(s.pendingSteers[conversationId] ?? []), { steerId, text }],
       },
     }))
 
-    const rollback = () =>
+    const removePending = () =>
       set((s) => ({
-        messages: {
-          ...s.messages,
-          [conversationId]: (s.messages[conversationId] ?? []).filter((m) => m.id !== optimisticId),
+        pendingSteers: {
+          ...s.pendingSteers,
+          [conversationId]: (s.pendingSteers[conversationId] ?? []).filter(
+            (p) => p.steerId !== steerId,
+          ),
         },
       }))
 
     try {
-      const res = await steerRun(client, conversationId, text, crypto.randomUUID())
-      if (res.status === 'no_active_run') rollback()
+      const res = await steerRun(client, conversationId, text, steerId)
+      if (res.status === 'no_active_run') removePending()
     } catch (err) {
       console.error('Failed to steer run:', err)
-      rollback()
+      removePending()
+    }
+  },
+
+  async cancelSteer(client, conversationId, steerId) {
+    set((s) => ({
+      pendingSteers: {
+        ...s.pendingSteers,
+        [conversationId]: (s.pendingSteers[conversationId] ?? []).filter(
+          (p) => p.steerId !== steerId,
+        ),
+      },
+    }))
+    try {
+      await cancelSteer(client, conversationId, steerId)
+    } catch (err) {
+      console.error('Failed to cancel steer:', err)
     }
   },
 

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -75,6 +75,7 @@ export interface MessageStore {
   cancelStream(client: ApiClient, conversationId: string): Promise<void>
   steer(client: ApiClient, conversationId: string, content: string): Promise<void>
   cancelSteer(client: ApiClient, conversationId: string, steerId: string): Promise<void>
+  __commitTurnAndInject(conversationId: string, data: { content: string; steer_id: string }): void
   clearStream(): void
   clearLastRunStatus(): void
 }
@@ -639,12 +640,13 @@ async function finalizeCompletedStream(
   )
 
   if (!assistantMessage) {
-    set({
+    set((state) => ({
       isStreaming: false,
       streamingConversationId: null,
       currentRunId: null,
       statusPhase: null,
-    })
+      pendingSteers: { ...state.pendingSteers, [conversationId]: [] },
+    }))
     return
   }
 
@@ -661,6 +663,7 @@ async function finalizeCompletedStream(
     streamingConversationId: null,
     currentRunId: null,
     statusPhase: null,
+    pendingSteers: { ...state.pendingSteers, [conversationId]: [] },
   }))
 }
 
@@ -701,14 +704,15 @@ async function consumeRunStream(
         useCitationStore.getState().addCitation(conversationId, citationData)
       } else if (event.type === 'error') {
         const errData = event.data as { message: string; details?: string }
-        set({
+        set((s) => ({
           error: errData.details || errData.message,
           isStreaming: false,
           streamingConversationId: null,
           currentRunId: null,
           statusPhase: null,
-          lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
-        })
+          lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
+          pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
+        }))
         break
       } else if (event.type === 'done') {
         const usage = (event.data as Record<string, unknown>).usage as
@@ -734,6 +738,16 @@ async function consumeRunStream(
         set(usageUpdate)
         sawDone = true
         break
+      } else if (event.type === 'injected_message') {
+        const d = event.data as { content: string; steer_id: string }
+        // Flush batched stream mutations so the commit reads fully-applied
+        // streamAgents, not a stale snapshot.
+        flush()
+        set((s) => ({
+          lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
+        }))
+        get().__commitTurnAndInject(conversationId, d)
+        continue
       }
 
       batchedSet((s) => applyStreamEvent(s, event))
@@ -810,6 +824,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
         error: null,
         lastRunStatus: bootstrap.last_run_status ?? null,
         streamAgents: nextStreamAgents,
+        pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
         toolStartedMap: {},
         toolResultMap: {},
         isStreaming: !!bootstrap.active_run,
@@ -934,14 +949,15 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
               )
               continue outer
             }
-            set({
+            set((s) => ({
               error: errData.details || errData.message,
               isStreaming: false,
               streamingConversationId: null,
               currentRunId: null,
               statusPhase: null,
-              lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
-            })
+              lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
+              pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
+            }))
             break outer
           } else if (event.type === 'done') {
             const usage = (event.data as Record<string, unknown>).usage as
@@ -967,6 +983,16 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
             set(usageUpdate)
             sawDone = true
             break outer
+          } else if (event.type === 'injected_message') {
+            const d = event.data as { content: string; steer_id: string }
+            // Flush batched stream mutations so the commit reads fully-applied
+            // streamAgents, not a stale snapshot.
+            flush()
+            set((s) => ({
+              lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
+            }))
+            get().__commitTurnAndInject(conversationId, d)
+            continue
           }
 
           batchedSet((s) => applyStreamEvent(s, event))
@@ -974,12 +1000,13 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
         break outer
       }
     } catch (err) {
-      set({
+      set((s) => ({
         error: (err as Error).message,
         isStreaming: false,
         streamingConversationId: null,
         currentRunId: null,
-      })
+        pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
+      }))
       return
     } finally {
       flush()
@@ -1052,6 +1079,53 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
     }
   },
 
+  // Commit the in-flight assistant turn into history at the point cubepi
+  // injected the steer, then append the steer user message right after, reset
+  // the streaming buckets so subsequent deltas form a fresh bubble, and drop the
+  // matching pending entry. This keeps the live transcript ordering identical to
+  // a reload from the checkpointer (steer interleaved between assistant turns).
+  __commitTurnAndInject(conversationId, data) {
+    const state = get()
+    // Idempotency: if this steer is already committed, no-op (replay-safe).
+    const already = (state.messages[conversationId] ?? []).some(
+      (m) => m.role === 'user' && m.metadata?.steer_id === data.steer_id,
+    )
+    if (already) return
+
+    const { assistantMessage, toolMessages } = buildTurnMessages(
+      state.streamAgents,
+      state.toolResultMap,
+      state.turnUsage[conversationId] ?? null,
+    )
+    const mainHasContent = !!assistantMessage && assistantMessage.content.length > 0
+
+    const steerMessage: UserMessageType = {
+      id: nextMessageId('user-steer'),
+      role: 'user',
+      content: [{ type: 'text', text: data.content }],
+      timestamp: Date.now() / 1000,
+      metadata: { steer_id: data.steer_id },
+    }
+
+    set((s) => ({
+      messages: {
+        ...s.messages,
+        [conversationId]: [
+          ...(s.messages[conversationId] ?? []),
+          ...(mainHasContent ? [assistantMessage as AssistantMessageType, ...toolMessages] : []),
+          steerMessage,
+        ],
+      },
+      streamAgents: { [MAIN_AGENT_KEY]: emptyStream() },
+      pendingSteers: {
+        ...s.pendingSteers,
+        [conversationId]: (s.pendingSteers[conversationId] ?? []).filter(
+          (p) => p.steerId !== data.steer_id,
+        ),
+      },
+    }))
+  },
+
   async cancelStream(client, conversationId) {
     const state = get()
     if (!state.isStreaming || state.streamingConversationId !== conversationId) return
@@ -1077,12 +1151,13 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
     if (hasContent) {
       await finalizeCompletedStream(get, set, conversationId, 'aborted')
     } else {
-      set({
+      set((s) => ({
         isStreaming: false,
         streamingConversationId: null,
         currentRunId: null,
         statusPhase: null,
-      })
+        pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
+      }))
     }
 
     try {
@@ -1095,6 +1170,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
   clearStream() {
     set({
       streamAgents: {},
+      pendingSteers: {},
       isStreaming: false,
       streamingConversationId: null,
       currentRunId: null,

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -513,30 +513,26 @@ function applyStreamEvent(state: MessageStore, event: AgentEvent): Partial<Messa
   return base
 }
 
-async function finalizeCompletedStream(
-  get: () => MessageStore,
-  set: (partial: Partial<MessageStore> | ((state: MessageStore) => Partial<MessageStore>)) => void,
-  conversationId: string,
+/**
+ * Build the assistant (+ tool) messages for a finished/interrupted turn from the
+ * current streaming buckets. Pure — reads its inputs, allocates message ids, and
+ * returns the pieces; the caller decides how to append them and clear state.
+ * Returns `assistantMessage: null` when there is no main stream to finalize.
+ */
+function buildTurnMessages(
+  agents: Record<string, AgentStream>,
+  toolResultMap: MessageStore['toolResultMap'],
+  turnUsage: import('../types').TurnUsage | null,
   stopReason: AssistantMessageType['stop_reason'] = 'stop',
-): Promise<void> {
-  const agents = get().streamAgents
+): { assistantMessage: AssistantMessageType | null; toolMessages: ToolResultMessageType[] } {
   const mainStream = agents[MAIN_AGENT_KEY]
-
-  if (!mainStream) {
-    set({
-      isStreaming: false,
-      streamingConversationId: null,
-      currentRunId: null,
-      statusPhase: null,
-    })
-    return
-  }
+  if (!mainStream) return { assistantMessage: null, toolMessages: [] }
 
   const finalBlocks = finalizeLastThinking(mainStream.blocks).filter(
     (block) => block.type !== 'tool_call_streaming',
   )
 
-  const usage = get().turnUsage[conversationId]
+  const usage = turnUsage
   const assistantMessage: AssistantMessageType = {
     id: nextMessageId('assistant'),
     role: 'assistant',
@@ -568,11 +564,10 @@ async function finalizeCompletedStream(
   // Persist main-agent tool results into history so the just-finished message
   // remains interactive after streamingConversationId clears. Skip subagent
   // tool results — those get richer messages from the loop below.
-  const mainToolResultMap = get().toolResultMap
   for (const tr of mainStream.toolResults) {
     const tcId = tr.data.tool_call_id
     if (!tcId || tr.data.tool_name === 'subagent') continue
-    const mapEntry = mainToolResultMap[tcId]
+    const mapEntry = toolResultMap[tcId]
     const receivedAtMs =
       mapEntry?.receivedAt ?? (tr.timestamp ? new Date(tr.timestamp).getTime() : Date.now())
     toolMessages.push({
@@ -590,7 +585,6 @@ async function finalizeCompletedStream(
     if (key === MAIN_AGENT_KEY) continue
     const toolCallId = key.startsWith('subagent:') ? key.slice(9) : key
     const args = subagentArgs[key]
-    const currentToolResultMap = get().toolResultMap
     toolMessages.push({
       id: nextMessageId('tool'),
       role: 'tool_result',
@@ -609,7 +603,7 @@ async function finalizeCompletedStream(
           })),
           tool_results: agentStream.toolResults
             .map((tr) => {
-              const mapEntry = currentToolResultMap[tr.data.tool_call_id ?? '']
+              const mapEntry = toolResultMap[tr.data.tool_call_id ?? '']
               return {
                 tool_name: tr.data.tool_name ?? '',
                 tool_call_id: tr.data.tool_call_id ?? '',
@@ -626,6 +620,32 @@ async function finalizeCompletedStream(
         },
       },
     })
+  }
+
+  return { assistantMessage, toolMessages }
+}
+
+async function finalizeCompletedStream(
+  get: () => MessageStore,
+  set: (partial: Partial<MessageStore> | ((state: MessageStore) => Partial<MessageStore>)) => void,
+  conversationId: string,
+  stopReason: AssistantMessageType['stop_reason'] = 'stop',
+): Promise<void> {
+  const { assistantMessage, toolMessages } = buildTurnMessages(
+    get().streamAgents,
+    get().toolResultMap,
+    get().turnUsage[conversationId] ?? null,
+    stopReason,
+  )
+
+  if (!assistantMessage) {
+    set({
+      isStreaming: false,
+      streamingConversationId: null,
+      currentRunId: null,
+      statusPhase: null,
+    })
+    return
   }
 
   set((state) => ({

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -1112,7 +1112,12 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
         ...s.messages,
         [conversationId]: [
           ...(s.messages[conversationId] ?? []),
-          ...(mainHasContent ? [assistantMessage as AssistantMessageType, ...toolMessages] : []),
+          // Only the assistant bubble is gated on having content (avoid an empty
+          // bubble when a steer drains before any text). Tool results always
+          // commit — they must not be lost from the live view if a steer lands
+          // right after a tool boundary.
+          ...(mainHasContent ? [assistantMessage as AssistantMessageType] : []),
+          ...toolMessages,
           steerMessage,
         ],
       },

--- a/frontend/packages/core/src/types/events.ts
+++ b/frontend/packages/core/src/types/events.ts
@@ -60,6 +60,7 @@ export type AgentEventType =
   | 'citation'
   | 'status'
   | 'usage'
+  | 'injected_message'
 
 export interface AgentEvent {
   type: AgentEventType
@@ -156,6 +157,11 @@ export interface ErrorEvent extends AgentEvent {
 export interface DoneEvent extends AgentEvent {
   type: 'done'
   data: Record<string, unknown>
+}
+
+export interface InjectedMessageEvent extends AgentEvent {
+  type: 'injected_message'
+  data: { content: string; steer_id: string }
 }
 
 export type StatusPhase = 'sandbox_creating' | 'sandbox_ready' | 'sandbox_failed'

--- a/frontend/packages/core/src/types/message.ts
+++ b/frontend/packages/core/src/types/message.ts
@@ -62,6 +62,8 @@ interface MessageBase {
     memory_snapshot?: unknown
     citations?: CitationData[]
     subagent_events?: SubagentSummary
+    // Set on a steer user message committed mid-run; used for replay idempotency.
+    steer_id?: string
   }
 }
 

--- a/frontend/packages/web/__tests__/components/InputBar.test.tsx
+++ b/frontend/packages/web/__tests__/components/InputBar.test.tsx
@@ -8,6 +8,7 @@ const storeMocks = vi.hoisted(() => ({
   send: vi.fn(),
   steer: vi.fn(),
   cancelStream: vi.fn(),
+  cancelSteer: vi.fn(),
   upload: vi.fn(),
   clear: vi.fn(),
   hydrate: vi.fn(),
@@ -24,6 +25,8 @@ vi.mock('@cubebox/core', () => ({
       send: typeof storeMocks.send
       steer: typeof storeMocks.steer
       cancelStream: typeof storeMocks.cancelStream
+      cancelSteer: typeof storeMocks.cancelSteer
+      pendingSteers: Record<string, unknown[]>
       isStreaming: boolean
       streamingConversationId: string | null
     }) => unknown,
@@ -32,6 +35,8 @@ vi.mock('@cubebox/core', () => ({
       send: storeMocks.send,
       steer: storeMocks.steer,
       cancelStream: storeMocks.cancelStream,
+      cancelSteer: storeMocks.cancelSteer,
+      pendingSteers: {},
       isStreaming: storeMocks.state.isStreaming,
       streamingConversationId: storeMocks.state.streamingConversationId,
     }),

--- a/frontend/packages/web/__tests__/components/PendingSteers.test.tsx
+++ b/frontend/packages/web/__tests__/components/PendingSteers.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PendingSteers } from '../../components/layout/PendingSteers'
+
+const mocks = vi.hoisted(() => ({
+  cancelSteer: vi.fn(),
+  setWorkspaceId: vi.fn(),
+  pending: [] as { steerId: string; text: string }[],
+}))
+
+vi.mock('@cubebox/core', () => ({
+  createApiClient: () => ({ setWorkspaceId: mocks.setWorkspaceId }),
+  useMessageStore: (
+    sel: (s: {
+      pendingSteers: Record<string, unknown>
+      cancelSteer: typeof mocks.cancelSteer
+    }) => unknown,
+  ) => sel({ pendingSteers: { 'conv-1': mocks.pending }, cancelSteer: mocks.cancelSteer }),
+}))
+vi.mock('@/hooks/useWorkspaceContext', () => ({
+  useWorkspaceContext: () => ({ workspaceId: 'ws-1' }),
+}))
+
+describe('PendingSteers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.pending = [{ steerId: 's1', text: 'do X instead' }]
+  })
+
+  it('renders pending steer text and cancels on click', () => {
+    render(<PendingSteers conversationId="conv-1" />)
+    expect(screen.getByText('do X instead')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(mocks.cancelSteer).toHaveBeenCalledWith(expect.anything(), 'conv-1', 's1')
+  })
+
+  it('renders nothing when there are no pending steers', () => {
+    mocks.pending = []
+    const { container } = render(<PendingSteers conversationId="conv-1" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/packages/web/__tests__/components/WorkspaceHomePage.test.tsx
+++ b/frontend/packages/web/__tests__/components/WorkspaceHomePage.test.tsx
@@ -11,6 +11,7 @@ const storeMocks = vi.hoisted(() => ({
   setConversationState: vi.fn(),
   renameConversation: vi.fn(),
   send: vi.fn(),
+  cancelSteer: vi.fn(),
   upload: vi.fn(),
   clear: vi.fn(),
   hydrate: vi.fn(),
@@ -59,12 +60,16 @@ vi.mock('@cubebox/core', () => {
     useMessageStore: (
       selector: (state: {
         send: typeof storeMocks.send
+        cancelSteer: typeof storeMocks.cancelSteer
+        pendingSteers: Record<string, unknown[]>
         isStreaming: boolean
         streamingConversationId: string | null
       }) => unknown,
     ) =>
       selector({
         send: storeMocks.send,
+        cancelSteer: storeMocks.cancelSteer,
+        pendingSteers: {},
         isStreaming: false,
         streamingConversationId: null,
       }),

--- a/frontend/packages/web/__tests__/e2e/steering.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/steering.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, type Page } from '@playwright/test'
+
+const PASSWORD = 'correcthorsebatterystaple'
+
+async function registerAndLand(page: Page): Promise<void> {
+  const email = `u-${Date.now()}-${Math.random().toString(16).slice(2, 6)}@example.com`
+  await page.goto('/register')
+  await page.getByLabel('Email').fill(email)
+  await page.getByLabel('Password').fill(PASSWORD)
+  await page.getByRole('button', { name: /create account/i }).click()
+  await expect(page).toHaveURL(/\/w\/[^/]+$/, { timeout: 10_000 })
+}
+
+async function startRun(page: Page, prompt: string): Promise<void> {
+  const input = page.getByPlaceholder('How can I help you?')
+  await input.fill(prompt)
+  await input.press('Enter')
+  await expect(page).toHaveURL(/\/w\/[^/]+\/conversations\//)
+  await expect(page.getByTestId('loading-indicator')).toBeVisible({ timeout: 10_000 })
+}
+
+test('steer shows a pending chip, then commits into the transcript at a stable position', async ({
+  page,
+}) => {
+  await registerAndLand(page)
+  await startRun(page, 'Count slowly from 1 to 20, one number per line.')
+
+  // Type a steer while the run is streaming.
+  const input = page.getByPlaceholder('How can I help you?')
+  await input.fill('Actually, also say hello at the end.')
+  await input.press('Enter')
+
+  // Pending chip appears above the input (not yet in the transcript).
+  const chip = page.getByTestId('pending-steer')
+  await expect(chip).toBeVisible({ timeout: 5_000 })
+  await expect(chip).toContainText('Actually, also say hello at the end.')
+
+  // Once cubepi drains the steer, the chip disappears and the steer becomes a
+  // real user message in the transcript.
+  await expect(chip).toBeHidden({ timeout: 50_000 })
+  const steerInTranscript = page
+    .locator('[data-role="user"]')
+    .filter({ hasText: 'Actually, also say hello at the end.' })
+  await expect(steerInTranscript).toBeVisible()
+
+  // Capture the ordered role sequence, then reload and assert it is unchanged
+  // (the committed steer must not jump position on refresh).
+  await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 50_000 })
+  const rolesBefore = await page
+    .locator('[data-role]')
+    .evaluateAll((els) => els.map((e) => e.getAttribute('data-role')))
+
+  await page.reload()
+  await expect(page.locator('[data-role="user"]').first()).toBeVisible({ timeout: 10_000 })
+  const rolesAfter = await page
+    .locator('[data-role]')
+    .evaluateAll((els) => els.map((e) => e.getAttribute('data-role')))
+  expect(rolesAfter).toEqual(rolesBefore)
+})
+
+test('cancelling a pending steer removes the chip before it is injected', async ({ page }) => {
+  await registerAndLand(page)
+  await startRun(page, 'Count slowly from 1 to 30, one number per line.')
+
+  const input = page.getByPlaceholder('How can I help you?')
+  await input.fill('Never mind this instruction.')
+  await input.press('Enter')
+
+  const chip = page.getByTestId('pending-steer')
+  await expect(chip).toBeVisible({ timeout: 5_000 })
+
+  // Cancel before the agent drains it.
+  await chip.getByRole('button', { name: /cancel/i }).click()
+  await expect(chip).toBeHidden({ timeout: 5_000 })
+
+  // It must never appear as a committed user message in the transcript.
+  await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 50_000 })
+  await expect(
+    page.locator('[data-role="user"]').filter({ hasText: 'Never mind this instruction.' }),
+  ).toHaveCount(0)
+})

--- a/frontend/packages/web/__tests__/e2e/steering.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/steering.spec.ts
@@ -16,14 +16,22 @@ async function startRun(page: Page, prompt: string): Promise<void> {
   await input.fill(prompt)
   await input.press('Enter')
   await expect(page).toHaveURL(/\/w\/[^/]+\/conversations\//)
-  await expect(page.getByTestId('loading-indicator')).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByTestId('loading-indicator')).toBeVisible({ timeout: 20_000 })
 }
+
+// A prompt that streams steadily for a clear mid-run window but still finishes
+// well within the test budget — and is purely conversational so it won't pull
+// in tools (the E2E env has no sandbox). The steer drains at the run's tail.
+const STREAMY_PROMPT =
+  'Tell me a slow, gentle bedtime story about a small robot exploring a ' +
+  'quiet forest. At least 400 words. Do not use any tools — just write prose.'
 
 test('steer shows a pending chip, then commits into the transcript at a stable position', async ({
   page,
 }) => {
+  test.setTimeout(240_000)
   await registerAndLand(page)
-  await startRun(page, 'Count slowly from 1 to 20, one number per line.')
+  await startRun(page, STREAMY_PROMPT)
 
   // Type a steer while the run is streaming.
   const input = page.getByPlaceholder('How can I help you?')
@@ -37,7 +45,7 @@ test('steer shows a pending chip, then commits into the transcript at a stable p
 
   // Once cubepi drains the steer, the chip disappears and the steer becomes a
   // real user message in the transcript.
-  await expect(chip).toBeHidden({ timeout: 50_000 })
+  await expect(chip).toBeHidden({ timeout: 150_000 })
   const steerInTranscript = page
     .locator('[data-role="user"]')
     .filter({ hasText: 'Actually, also say hello at the end.' })
@@ -45,7 +53,7 @@ test('steer shows a pending chip, then commits into the transcript at a stable p
 
   // Capture the ordered role sequence, then reload and assert it is unchanged
   // (the committed steer must not jump position on refresh).
-  await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 50_000 })
+  await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 150_000 })
   const rolesBefore = await page
     .locator('[data-role]')
     .evaluateAll((els) => els.map((e) => e.getAttribute('data-role')))
@@ -59,8 +67,9 @@ test('steer shows a pending chip, then commits into the transcript at a stable p
 })
 
 test('cancelling a pending steer removes the chip before it is injected', async ({ page }) => {
+  test.setTimeout(240_000)
   await registerAndLand(page)
-  await startRun(page, 'Count slowly from 1 to 30, one number per line.')
+  await startRun(page, STREAMY_PROMPT)
 
   const input = page.getByPlaceholder('How can I help you?')
   await input.fill('Never mind this instruction.')
@@ -74,7 +83,7 @@ test('cancelling a pending steer removes the chip before it is injected', async 
   await expect(chip).toBeHidden({ timeout: 5_000 })
 
   // It must never appear as a committed user message in the transcript.
-  await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 50_000 })
+  await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 150_000 })
   await expect(
     page.locator('[data-role="user"]').filter({ hasText: 'Never mind this instruction.' }),
   ).toHaveCount(0)

--- a/frontend/packages/web/__tests__/e2e/streaming.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/streaming.spec.ts
@@ -28,7 +28,7 @@ test('loading animation appears while streaming', async ({ page }) => {
   expect(text!.length).toBeGreaterThan(20)
 })
 
-test('input is disabled while streaming', async ({ page }) => {
+test('input stays editable while streaming (so the user can steer)', async ({ page }) => {
   await registerAndLand(page)
 
   const input = page.getByPlaceholder('How can I help you?')
@@ -37,7 +37,10 @@ test('input is disabled while streaming', async ({ page }) => {
 
   await expect(page).toHaveURL(/\/w\/[^/]+\/conversations\//)
 
-  await expect(page.getByPlaceholder('How can I help you?')).toBeDisabled({ timeout: 5_000 })
+  // While the run streams, the composer must remain enabled — steering needs
+  // the user to type mid-run. (Previously the box was locked during streaming.)
+  await expect(page.getByTestId('loading-indicator')).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByPlaceholder('How can I help you?')).toBeEnabled()
 
   await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 50_000 })
 

--- a/frontend/packages/web/components/chat/UserMessage.tsx
+++ b/frontend/packages/web/components/chat/UserMessage.tsx
@@ -4,7 +4,7 @@ interface UserMessageProps {
 
 export function UserMessage({ content }: UserMessageProps) {
   return (
-    <div className="flex justify-end">
+    <div data-role="user" className="flex justify-end">
       <div className="max-w-[72%] bg-primary text-white rounded-2xl rounded-br-sm px-3.5 py-2.5 text-sm leading-relaxed">
         {content}
       </div>

--- a/frontend/packages/web/components/layout/InputBar.tsx
+++ b/frontend/packages/web/components/layout/InputBar.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils'
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
 import { AttachmentChips } from '@/components/chat/AttachmentChips'
 import { UploadDropzone } from '@/components/chat/UploadDropzone'
+import { PendingSteers } from '@/components/layout/PendingSteers'
 
 interface InputBarProps {
   conversationId?: string
@@ -199,6 +200,7 @@ export function InputBar({
 
   return (
     <div className="w-full max-w-3xl mx-auto">
+      {conversationId && <PendingSteers conversationId={conversationId} />}
       {conversationId && <UploadDropzone conversationId={conversationId} />}
       {conversationId && <AttachmentChips conversationId={conversationId} />}
       <input

--- a/frontend/packages/web/components/layout/PendingSteers.tsx
+++ b/frontend/packages/web/components/layout/PendingSteers.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useMessageStore, createApiClient } from '@cubebox/core'
+import { X } from 'lucide-react'
+import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
+
+interface PendingSteersProps {
+  conversationId: string
+}
+
+export function PendingSteers({ conversationId }: PendingSteersProps): React.ReactElement | null {
+  const pending = useMessageStore((s) => s.pendingSteers[conversationId] ?? [])
+  const cancelSteer = useMessageStore((s) => s.cancelSteer)
+  const { workspaceId } = useWorkspaceContext()
+
+  if (pending.length === 0) return null
+
+  const onCancel = (steerId: string): void => {
+    const client = createApiClient('')
+    if (workspaceId) client.setWorkspaceId(workspaceId)
+    void cancelSteer(client, conversationId, steerId)
+  }
+
+  return (
+    <div className="mb-2 flex flex-col gap-1.5">
+      {pending.map((p) => (
+        <div
+          key={p.steerId}
+          data-testid="pending-steer"
+          className="flex items-center gap-2 rounded-lg border border-dashed border-border/60 bg-muted/40 px-3 py-1.5 text-sm text-muted-foreground"
+        >
+          <span className="flex-1 truncate opacity-70">{p.text}</span>
+          <span className="text-[10px] uppercase tracking-wide opacity-50">steering…</span>
+          <button
+            type="button"
+            aria-label="Cancel pending steer"
+            onClick={() => onCancel(p.steerId)}
+            className="grid size-5 place-items-center rounded text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <X className="size-3" />
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Reworks how a mid-run "steer" message is shown so it never jumps position on reload, and adds the ability to cancel a not-yet-injected steer.

- **Pending state:** a sent steer shows as a dimmed chip above the input box (not in the transcript), held in a new `pendingSteers` store field. Multiple steers stack.
- **Commit state:** when cubepi actually injects the steer, the backend emits a new `injected_message` SSE event; the frontend finalizes the current streaming bubble into the transcript, inserts the steer user message at that exact point, and clears the chip — so the live position matches what a reload from the checkpointer shows (no jump).
- **Cancel:** a pending chip has an X that best-effort cancels the steer (cubepi `Agent.cancel_steer` removes it from the queue if not yet drained; if already drained, it commits normally).
- Also fixes the composer staying disabled during streaming (it must stay editable so the user can steer) and tags user messages with `data-role="user"`.

### Cross-repo
Depends on cubepi PR #120 (`Agent.cancel_steer` / `_MessageQueue.remove`), **merged**; cubebox is pinned to cubepi `main` (`da9d792`).

### Key design points
- `steer_id` (client-minted, carried in `UserMessage.metadata`) is the join key end-to-end: pending chip ↔ `injected_message` echo ↔ commit/idempotency ↔ cancel.
- Seed-message dedup lives only in `_on_event` (suppresses the run's first user-message event so only injected steers are forwarded).
- `injected_message` wired through both backend translation layers (`convert_agent_event_to_sse` → `cubepi_dict_to_agent_event`).
- Commit is idempotent by `steer_id` (replay-safe), flushes batched stream mutations first, gates only the empty assistant bubble (tool results always commit), and clears pending on every run-ending path.

Spec + plan in `docs/dev/`; both went through codex review, as did the final diff.

## Test plan
- [x] Backend unit (changed areas): 36 pass
- [x] Core (vitest): 69 pass
- [x] Web component (vitest): 118 pass
- [x] E2E (Playwright, live run): 4/4 — pending chip → inline commit at stable position across reload, cancel, + 2 streaming