### PR TITLE
fix(sandbox): separate create timeout + 503 on provider failure

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -114,10 +114,15 @@ default:
     # ready_timeout: Maximum time to wait for sandbox to become ready after creation
     #   Used only during sandbox initialization. If the sandbox doesn't respond to
     #   health checks within this time, creation fails.
-    ready_timeout: 60 # 60 seconds
+    ready_timeout: 300 # 5 minutes — must cover a cold image pull
     # request_timeout: HTTP request timeout for sandbox API calls
     #   Timeout for individual commands (execute, upload, download, etc.)
     request_timeout: 60 # 60 seconds
+    # create_timeout: HTTP timeout for the synchronous create call only. The server
+    #   holds POST /sandboxes open until the pod is ready, so a cold image pull
+    #   (minutes) blows past request_timeout. Kept separate so ordinary commands
+    #   aren't forced to tolerate multi-minute hangs.
+    create_timeout: 300 # 5 minutes
     # ttl: Sandbox idle timeout (time since last activity before cleanup)
     #   SandboxManager's background cleanup task periodically checks for sandboxes
     #   that have been inactive (no commands) for this duration and terminates them.

--- a/backend/cubebox/api/routes/v1/ws_browser.py
+++ b/backend/cubebox/api/routes/v1/ws_browser.py
@@ -12,6 +12,8 @@ from typing import Annotated
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from loguru import logger
+from opensandbox.exceptions import SandboxException
 from pydantic import BaseModel
 
 from cubebox.auth.context import RequestContext
@@ -51,17 +53,27 @@ async def get_live_view(
     """Resolve the caller's sandbox, ensure the browser stack is running, and
     return an embeddable live-view URL."""
     manager = get_sandbox_manager()
-    sandbox = await manager.get_or_create(
-        ctx.user.id,
-        org_id=ctx.org_id,
-        workspace_id=ctx.workspace_id,
-    )
-    await sandbox.start_browser()
-    # Live-view / takeover traffic goes straight to Neko and bypasses the normal
-    # per-tool activity updates, so mark the sandbox active here too (the
-    # frontend also pings /keepalive while the view is open).
-    await manager.touch(sandbox.id, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
-    endpoint = await sandbox.get_browser_endpoint()
+    try:
+        sandbox = await manager.get_or_create(
+            ctx.user.id,
+            org_id=ctx.org_id,
+            workspace_id=ctx.workspace_id,
+        )
+        await sandbox.start_browser()
+        # Live-view / takeover traffic goes straight to Neko and bypasses the normal
+        # per-tool activity updates, so mark the sandbox active here too (the
+        # frontend also pings /keepalive while the view is open).
+        await manager.touch(sandbox.id, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
+        endpoint = await sandbox.get_browser_endpoint()
+    except SandboxException as exc:
+        # Provisioning the sandbox (or its browser) failed — e.g. the provider
+        # timed out waiting for a cold-starting pod. Surface a retryable 503 with a
+        # clear reason instead of a bare 500.
+        logger.warning("browser live-view unavailable for workspace {}: {}", ctx.workspace_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="sandbox is starting up or temporarily unavailable; please retry shortly",
+        ) from exc
     if endpoint.headers:
         # The endpoint requires request headers a browser cannot attach to an
         # iframe navigation. A same-origin reverse proxy is the planned path; do

--- a/backend/cubebox/api/routes/v1/ws_browser.py
+++ b/backend/cubebox/api/routes/v1/ws_browser.py
@@ -13,11 +13,11 @@ from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from loguru import logger
-from opensandbox.exceptions import SandboxException
 from pydantic import BaseModel
 
 from cubebox.auth.context import RequestContext
 from cubebox.auth.dependencies import require_member
+from cubebox.sandbox import SandboxError
 from cubebox.sandbox.manager import get_sandbox_manager
 
 router = APIRouter(prefix="/ws/{workspace_id}/browser", tags=["ws-browser"])
@@ -65,7 +65,7 @@ async def get_live_view(
         # frontend also pings /keepalive while the view is open).
         await manager.touch(sandbox.id, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
         endpoint = await sandbox.get_browser_endpoint()
-    except SandboxException as exc:
+    except SandboxError as exc:
         # Provisioning the sandbox (or its browser) failed — e.g. the provider
         # timed out waiting for a cold-starting pod. Surface a retryable 503 with a
         # clear reason instead of a bare 500.

--- a/backend/cubebox/sandbox/__init__.py
+++ b/backend/cubebox/sandbox/__init__.py
@@ -1,8 +1,9 @@
 """Sandbox execution module"""
 
+from cubebox.sandbox.base import SandboxError
 from cubebox.sandbox.opensandbox import OpenSandbox
 
-__all__ = ["OpenSandbox"]
+__all__ = ["OpenSandbox", "SandboxError"]
 
 # SandboxManager is imported lazily to avoid circular imports.
 # Use cubebox.sandbox.manager.get_sandbox_manager() to access.

--- a/backend/cubebox/sandbox/base.py
+++ b/backend/cubebox/sandbox/base.py
@@ -10,6 +10,16 @@ if TYPE_CHECKING:
     from cubebox.parsers import FileReadOutput, ParseOptions
 
 
+class SandboxError(Exception):
+    """Driver-agnostic sandbox failure.
+
+    Each backend driver translates its own provider-specific exceptions into
+    this type so callers above the driver layer (API routes, services) can
+    react to sandbox failures without importing or depending on a particular
+    driver (OpenSandbox, ...).
+    """
+
+
 @dataclass
 class ExecuteResult:
     """Result of a shell command execution."""

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -39,6 +39,10 @@ class SandboxManager:
         self._image: str = config.get("sandbox.image", "ubuntu:22.04")
         self._api_key: str | None = config.get("sandbox.api_key", None)
         self._request_timeout: int = config.get("sandbox.request_timeout", 60)
+        # Separate, longer budget for the synchronous create call: the server holds
+        # the POST /sandboxes open until the pod is ready, so a cold image pull can
+        # take minutes — far longer than the per-command request_timeout.
+        self._create_timeout: int = config.get("sandbox.create_timeout", 300)
         self._ttl: int = config.get("sandbox.ttl", 600)
         self._touch_interval: int = config.get("sandbox.touch_interval", 60)
         self._ready_timeout: int = config.get("sandbox.ready_timeout", 60)
@@ -60,12 +64,16 @@ class SandboxManager:
         self._volume_mount_path: str = config.get("sandbox.volume.mount_path", "/workspace")
         self._volume_pvc_prefix: str = config.get("sandbox.volume.pvc_prefix", "cubebox-user")
 
-    def _build_connection_config(self) -> ConnectionConfig:
-        """Build OpenSandbox ConnectionConfig from app config."""
+    def _build_connection_config(self, *, request_timeout: int | None = None) -> ConnectionConfig:
+        """Build OpenSandbox ConnectionConfig from app config.
+
+        ``request_timeout`` overrides the per-command HTTP timeout — used to give
+        the synchronous create call a longer budget than ordinary commands.
+        """
         return ConnectionConfig(
             domain=self._domain,
             api_key=self._api_key,
-            request_timeout=timedelta(seconds=self._request_timeout),
+            request_timeout=timedelta(seconds=request_timeout or self._request_timeout),
             use_server_proxy=self._use_server_proxy,
         )
 
@@ -158,9 +166,13 @@ class SandboxManager:
             else:
                 logger.info("Creating new sandbox for user {}", user_id)
 
+            # Use the longer create budget for the create call only; ordinary
+            # commands on the returned sandbox keep the normal request_timeout via
+            # the reuse/connect path on subsequent turns.
+            create_conn_config = self._build_connection_config(request_timeout=self._create_timeout)
             raw_sandbox = await opensandbox.Sandbox.create(
                 self._image,
-                connection_config=conn_config,
+                connection_config=create_conn_config,
                 timeout=None,
                 ready_timeout=timedelta(seconds=self._ready_timeout),
                 volumes=volumes,

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -195,10 +195,13 @@ class SandboxManager:
             # Rebind to the default per-command timeout: the create call's adapters
             # captured the longer create_timeout, but ordinary commands on this
             # sandbox must use request_timeout, not create_timeout. Reconnecting
-            # rebuilds the HTTP clients with the default budget.
+            # rebuilds the HTTP clients with the default budget. Skip the health
+            # check — create already gated on readiness (ready_timeout), so a second
+            # readiness probe here would only add a redundant failure path.
             raw_sandbox = await opensandbox.Sandbox.connect(
                 sandbox_id,
                 connection_config=conn_config,
+                skip_health_check=True,
             )
             return OpenSandbox(sandbox=raw_sandbox, workdir=self._workdir)
 

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -166,9 +166,10 @@ class SandboxManager:
             else:
                 logger.info("Creating new sandbox for user {}", user_id)
 
-            # Use the longer create budget for the create call only; ordinary
-            # commands on the returned sandbox keep the normal request_timeout via
-            # the reuse/connect path on subsequent turns.
+            # Give only the create call the longer budget: the create POST is held
+            # open server-side until the pod is ready, so it must survive a cold
+            # image pull. ``create_conn_config`` is otherwise identical to the
+            # default.
             create_conn_config = self._build_connection_config(request_timeout=self._create_timeout)
             raw_sandbox = await opensandbox.Sandbox.create(
                 self._image,
@@ -178,21 +179,28 @@ class SandboxManager:
                 volumes=volumes,
                 resource={"cpu": self._resource_cpu, "memory": self._resource_memory},
             )
+            sandbox_id = raw_sandbox.id
+            logger.info("Sandbox created: {}", sandbox_id)
 
-            backend = OpenSandbox(sandbox=raw_sandbox, workdir=self._workdir)
-            logger.info("Sandbox created: {}", backend.id)
-
+            # Persist before rebinding so a reconnect failure can't orphan the
+            # sandbox — the reuse path will find and health-check it next turn.
             # Skill sync is the LazySandbox's responsibility post-M3.
-
-            # Persist to DB
             await repo.create(
                 user_id=user_id,
-                sandbox_id=raw_sandbox.id,
+                sandbox_id=sandbox_id,
                 image=self._image,
                 ttl_seconds=self._ttl,
             )
 
-            return backend
+            # Rebind to the default per-command timeout: the create call's adapters
+            # captured the longer create_timeout, but ordinary commands on this
+            # sandbox must use request_timeout, not create_timeout. Reconnecting
+            # rebuilds the HTTP clients with the default budget.
+            raw_sandbox = await opensandbox.Sandbox.connect(
+                sandbox_id,
+                connection_config=conn_config,
+            )
+            return OpenSandbox(sandbox=raw_sandbox, workdir=self._workdir)
 
     async def release(
         self,

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -19,12 +19,13 @@ from datetime import UTC, datetime, timedelta
 import opensandbox
 from loguru import logger
 from opensandbox.config import ConnectionConfig
+from opensandbox.exceptions import SandboxException as ProviderSandboxError
 from opensandbox.models.sandboxes import PVC, Volume
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from cubebox.config import config
 from cubebox.repositories.user_sandbox import UserSandboxRepository
-from cubebox.sandbox.base import Sandbox
+from cubebox.sandbox.base import Sandbox, SandboxError
 from cubebox.sandbox.opensandbox import OpenSandbox
 
 
@@ -171,38 +172,42 @@ class SandboxManager:
             # image pull. ``create_conn_config`` is otherwise identical to the
             # default.
             create_conn_config = self._build_connection_config(request_timeout=self._create_timeout)
-            raw_sandbox = await opensandbox.Sandbox.create(
-                self._image,
-                connection_config=create_conn_config,
-                timeout=None,
-                ready_timeout=timedelta(seconds=self._ready_timeout),
-                volumes=volumes,
-                resource={"cpu": self._resource_cpu, "memory": self._resource_memory},
-            )
-            sandbox_id = raw_sandbox.id
-            logger.info("Sandbox created: {}", sandbox_id)
+            try:
+                raw_sandbox = await opensandbox.Sandbox.create(
+                    self._image,
+                    connection_config=create_conn_config,
+                    timeout=None,
+                    ready_timeout=timedelta(seconds=self._ready_timeout),
+                    volumes=volumes,
+                    resource={"cpu": self._resource_cpu, "memory": self._resource_memory},
+                )
+                sandbox_id = raw_sandbox.id
+                logger.info("Sandbox created: {}", sandbox_id)
 
-            # Persist before rebinding so a reconnect failure can't orphan the
-            # sandbox — the reuse path will find and health-check it next turn.
-            # Skill sync is the LazySandbox's responsibility post-M3.
-            await repo.create(
-                user_id=user_id,
-                sandbox_id=sandbox_id,
-                image=self._image,
-                ttl_seconds=self._ttl,
-            )
+                # Persist before rebinding so a reconnect failure can't orphan the
+                # sandbox — the reuse path will find and health-check it next turn.
+                # Skill sync is the LazySandbox's responsibility post-M3.
+                await repo.create(
+                    user_id=user_id,
+                    sandbox_id=sandbox_id,
+                    image=self._image,
+                    ttl_seconds=self._ttl,
+                )
 
-            # Rebind to the default per-command timeout: the create call's adapters
-            # captured the longer create_timeout, but ordinary commands on this
-            # sandbox must use request_timeout, not create_timeout. Reconnecting
-            # rebuilds the HTTP clients with the default budget. Skip the health
-            # check — create already gated on readiness (ready_timeout), so a second
-            # readiness probe here would only add a redundant failure path.
-            raw_sandbox = await opensandbox.Sandbox.connect(
-                sandbox_id,
-                connection_config=conn_config,
-                skip_health_check=True,
-            )
+                # Rebind to the default per-command timeout: the create call's adapters
+                # captured the longer create_timeout, but ordinary commands on this
+                # sandbox must use request_timeout, not create_timeout. Reconnecting
+                # rebuilds the HTTP clients with the default budget. Skip the health
+                # check — create already gated on readiness (ready_timeout), so a
+                # second readiness probe here would only add a redundant failure path.
+                raw_sandbox = await opensandbox.Sandbox.connect(
+                    sandbox_id,
+                    connection_config=conn_config,
+                    skip_health_check=True,
+                )
+            except ProviderSandboxError as exc:
+                # Don't leak the opensandbox driver's exception type to callers.
+                raise SandboxError(str(exc)) from exc
             return OpenSandbox(sandbox=raw_sandbox, workdir=self._workdir)
 
     async def release(

--- a/backend/cubebox/sandbox/opensandbox.py
+++ b/backend/cubebox/sandbox/opensandbox.py
@@ -1,11 +1,24 @@
 """OpenSandbox implementation of the Sandbox base class."""
 
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import opensandbox
 from loguru import logger
+from opensandbox.exceptions import SandboxException as _ProviderError
 
-from cubebox.sandbox.base import BrowserEndpoint, ExecuteResult, Sandbox
+from cubebox.sandbox.base import BrowserEndpoint, ExecuteResult, Sandbox, SandboxError
+
+
+@contextmanager
+def _as_sandbox_error() -> Iterator[None]:
+    """Translate the OpenSandbox provider's exceptions into a driver-agnostic
+    SandboxError, so the opensandbox dependency never leaks past this driver."""
+    try:
+        yield
+    except _ProviderError as exc:
+        raise SandboxError(str(exc)) from exc
 
 
 class OpenSandbox(Sandbox):
@@ -24,56 +37,60 @@ class OpenSandbox(Sandbox):
         return self._workdir
 
     async def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResult:
-        execution = await self._sandbox.commands.run(command)
+        with _as_sandbox_error():
+            execution = await self._sandbox.commands.run(command)
 
-        output_lines: list[str] = []
-        for msg in execution.logs.stdout:
-            output_lines.append(msg.text)
-        for msg in execution.logs.stderr:
-            output_lines.append(msg.text)
-        output = "\n".join(output_lines) if output_lines else ""
+            output_lines: list[str] = []
+            for msg in execution.logs.stdout:
+                output_lines.append(msg.text)
+            for msg in execution.logs.stderr:
+                output_lines.append(msg.text)
+            output = "\n".join(output_lines) if output_lines else ""
 
-        exit_code: int | None = None
-        if execution.id:
-            try:
-                status = await self._sandbox.commands.get_command_status(execution.id)
-                exit_code = status.exit_code
-            except Exception as e:
-                logger.warning("Could not get exit code for command: {}", e)
+            exit_code: int | None = None
+            if execution.id:
+                try:
+                    status = await self._sandbox.commands.get_command_status(execution.id)
+                    exit_code = status.exit_code
+                except Exception as e:
+                    logger.warning("Could not get exit code for command: {}", e)
 
-        return ExecuteResult(output=output, exit_code=exit_code)
+            return ExecuteResult(output=output, exit_code=exit_code)
 
     async def upload(self, files: list[tuple[str, bytes]]) -> None:
-        for path, content in files:
-            await self._sandbox.files.write_file(path, content)
+        with _as_sandbox_error():
+            for path, content in files:
+                await self._sandbox.files.write_file(path, content)
 
     async def download(self, paths: list[str]) -> list[tuple[str, bytes]]:
-        result = []
-        for path in paths:
-            try:
-                content = await self._sandbox.files.read_bytes(path)
-            except Exception as exc:
-                if "404" in str(exc):
-                    raise FileNotFoundError(path) from exc
-                raise
-            result.append((path, content))
-        return result
+        with _as_sandbox_error():
+            result = []
+            for path in paths:
+                try:
+                    content = await self._sandbox.files.read_bytes(path)
+                except Exception as exc:
+                    if "404" in str(exc):
+                        raise FileNotFoundError(path) from exc
+                    raise
+                result.append((path, content))
+            return result
 
     async def get_browser_endpoint(self, *, expires_in: int = 3600) -> BrowserEndpoint:
-        expires = int(time.time()) + expires_in
-        endpoint = await self._sandbox.get_signed_endpoint(self.BROWSER_PORT, expires)
-        url = endpoint.endpoint
-        # OpenSandbox returns a scheme-less host/path; an iframe needs a full URL.
-        if not url.startswith(("http://", "https://")):
-            protocol = getattr(self._sandbox.connection_config, "protocol", "http")
-            url = f"{protocol}://{url}"
-        # A trailing slash after the .../proxy/<port> path is REQUIRED: the Neko
-        # client uses relative asset/WS paths, so without it they resolve against
-        # .../proxy/ (dropping the port) and the proxy returns 401 — the client JS
-        # never loads and only the static login shell shows.
-        if not url.endswith("/"):
-            url += "/"
-        return BrowserEndpoint(url=url, headers=dict(endpoint.headers or {}))
+        with _as_sandbox_error():
+            expires = int(time.time()) + expires_in
+            endpoint = await self._sandbox.get_signed_endpoint(self.BROWSER_PORT, expires)
+            url = endpoint.endpoint
+            # OpenSandbox returns a scheme-less host/path; an iframe needs a full URL.
+            if not url.startswith(("http://", "https://")):
+                protocol = getattr(self._sandbox.connection_config, "protocol", "http")
+                url = f"{protocol}://{url}"
+            # A trailing slash after the .../proxy/<port> path is REQUIRED: the Neko
+            # client uses relative asset/WS paths, so without it they resolve against
+            # .../proxy/ (dropping the port) and the proxy returns 401 — the client JS
+            # never loads and only the static login shell shows.
+            if not url.endswith("/"):
+                url += "/"
+            return BrowserEndpoint(url=url, headers=dict(endpoint.headers or {}))
 
     async def close(self) -> None:
         pass

--- a/backend/tests/unit/test_sandbox_browser.py
+++ b/backend/tests/unit/test_sandbox_browser.py
@@ -106,18 +106,41 @@ async def test_opensandbox_browser_endpoint_uses_signed_endpoint() -> None:
 
 
 @pytest.mark.asyncio
+async def test_opensandbox_translates_provider_error_to_sandbox_error() -> None:
+    """The driver must not leak opensandbox's own exception type to callers."""
+    from opensandbox.exceptions.sandbox import SandboxInternalException
+
+    from cubebox.sandbox.base import SandboxError
+    from cubebox.sandbox.opensandbox import OpenSandbox
+
+    class _FailingInner:
+        id = "sb-1"
+
+        async def get_signed_endpoint(self, port: int, expires: int):
+            raise SandboxInternalException("Network connectivity error")
+
+    sb = OpenSandbox(sandbox=_FailingInner())  # type: ignore[arg-type]
+    with pytest.raises(SandboxError):
+        await sb.get_browser_endpoint()
+
+
+@pytest.mark.asyncio
 async def test_live_view_returns_503_when_sandbox_unavailable(monkeypatch) -> None:
-    """A provider failure (e.g. create timeout) surfaces as 503, not a bare 500."""
+    """A provider failure (e.g. create timeout) surfaces as 503, not a bare 500.
+
+    The route depends only on the driver-agnostic ``SandboxError`` — never on a
+    specific backend driver's exception types.
+    """
     from types import SimpleNamespace
 
     from fastapi import HTTPException
-    from opensandbox.exceptions.sandbox import SandboxInternalException
 
     from cubebox.api.routes.v1 import ws_browser
+    from cubebox.sandbox import SandboxError
 
     class _Manager:
         async def get_or_create(self, *args, **kwargs):
-            raise SandboxInternalException("Network connectivity error")
+            raise SandboxError("sandbox provider timed out")
 
     monkeypatch.setattr(ws_browser, "get_sandbox_manager", lambda: _Manager())
     ctx = SimpleNamespace(user=SimpleNamespace(id="usr-1"), org_id="org-1", workspace_id="ws-1")

--- a/backend/tests/unit/test_sandbox_browser.py
+++ b/backend/tests/unit/test_sandbox_browser.py
@@ -103,3 +103,26 @@ async def test_opensandbox_browser_endpoint_uses_signed_endpoint() -> None:
     assert len(inner.calls) == 1
     port, _expires = inner.calls[0]
     assert port == 8080
+
+
+@pytest.mark.asyncio
+async def test_live_view_returns_503_when_sandbox_unavailable(monkeypatch) -> None:
+    """A provider failure (e.g. create timeout) surfaces as 503, not a bare 500."""
+    from types import SimpleNamespace
+
+    from fastapi import HTTPException
+    from opensandbox.exceptions.sandbox import SandboxInternalException
+
+    from cubebox.api.routes.v1 import ws_browser
+
+    class _Manager:
+        async def get_or_create(self, *args, **kwargs):
+            raise SandboxInternalException("Network connectivity error")
+
+    monkeypatch.setattr(ws_browser, "get_sandbox_manager", lambda: _Manager())
+    ctx = SimpleNamespace(user=SimpleNamespace(id="usr-1"), org_id="org-1", workspace_id="ws-1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await ws_browser.get_live_view(ctx)  # type: ignore[arg-type]
+
+    assert exc_info.value.status_code == 503

--- a/backend/tests/unit/test_sandbox_manager.py
+++ b/backend/tests/unit/test_sandbox_manager.py
@@ -16,3 +16,16 @@ def test_build_user_volume_uses_stable_non_colliding_name():
     assert first.pvc.claim_name == repeated.pvc.claim_name
     assert first.pvc.claim_name != second.pvc.claim_name
     assert first.pvc.claim_name.startswith("cubebox-user-")
+
+
+def test_create_timeout_overrides_request_timeout_for_create_only():
+    manager = SandboxManager(MagicMock())
+
+    default = manager._build_connection_config()
+    create = manager._build_connection_config(request_timeout=manager._create_timeout)
+
+    # Ordinary commands keep the short per-command budget; the create call gets the
+    # longer budget so a cold image pull doesn't time out before the pod is ready.
+    assert default.request_timeout.total_seconds() == manager._request_timeout
+    assert create.request_timeout.total_seconds() == manager._create_timeout
+    assert manager._create_timeout > manager._request_timeout


### PR DESCRIPTION
## Summary

`/api/v1/ws/{ws}/browser/live-view` returned a bare **500** when the sandbox couldn't be provisioned. Root cause (traced through cubebox logs → opensandbox-server → k8s):

- Sandbox creation is a **synchronous** `POST /v1/sandboxes` that the opensandbox server holds open until the pod is Ready.
- A cold pull of the new `cubebox-sandbox:24.04-20260525` image took **~3 minutes** on the node, but the SDK's single `request_timeout` (60s, shared with every `execute`/`upload`) cut the POST off → `httpx.ReadTimeout` → `SandboxInternalException` → uncaught → **500**. The half-created `BatchSandbox` was then torn down server-side on client disconnect, which is why nothing was left visible in k8s.

This PR hardens the cubebox side. (The cluster being CPU-saturated — `FailedScheduling: Insufficient cpu` — is a separate, infra-side cause not addressed here.)

## Changes

- **Separate create timeout.** New `sandbox.create_timeout` (default **300s**) applied **only** to the create call. `request_timeout` stays 60s so ordinary commands aren't forced to tolerate multi-minute hangs (it's a global httpx timeout in the SDK). `ready_timeout` raised 60s → 300s to match the cold-pull budget.
- **Graceful failure.** `/live-view` now catches `SandboxException` (base of all provider errors, incl. the timeout), logs a warning, and returns a retryable **503** with a clear reason instead of a 500.

## Test plan

- [x] `uv run pytest tests/unit/test_sandbox_manager.py tests/unit/test_sandbox_browser.py` — 9 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] pre-commit (mypy strict, ruff, frontend CI) passed on commit + push
- [ ] Verify against a real cold pull once the new image is pre-pulled / CPU freed on the cluster