### PR TITLE
fix(stream): coalesce + chunk reconnect replay to stop refresh freeze

### DIFF
--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -20,17 +20,22 @@ from cubebox.db import get_session
 from cubebox.db.engine import _build_database_url, async_session_maker
 from cubebox.models import Conversation
 from cubebox.repositories import ConversationRepository
+from cubebox.streams.replay_coalescer import ReplayCoalescer
 from cubebox.streams.run_events import (
     get_active_run,
     get_latest_event_id,
     get_run_meta,
     is_stale_meta,
-    iter_run_events,
+    iter_run_events_chunked,
     mark_run_stale,
     read_run_events_after,
 )
 from cubebox.streams.run_manager import RunContext
 from cubebox.utils.time import utc_isoformat
+
+# Replay backlog is read in bounded batches so a large reconnect never stalls
+# the event loop. Tunable; ~1000 keeps each XRANGE + JSON decode cheap.
+REPLAY_CHUNK_SIZE = 1000
 
 router = APIRouter(prefix="/ws/{workspace_id}/conversations", tags=["conversations"])
 
@@ -324,15 +329,24 @@ def _build_run_streaming_response(
         replay_cursor = last_event_id
 
         if target_event_id is not None:
-            replay_events = await iter_run_events(
+            coalescer = ReplayCoalescer()
+            async for batch in iter_run_events_chunked(
                 redis,
                 prefix=prefix,
                 run_id=run_id,
                 start=replay_start,
                 stop=target_event_id,
-            )
-            for event in replay_events:
-                replay_cursor = event.event_id
+                count=REPLAY_CHUNK_SIZE,
+            ):
+                for event in coalescer.feed(batch):
+                    yield _format_sse_event(event.event_id, event.payload)
+                    if event.payload.get("type") in {"done", "error"}:
+                        return
+                # Advance the live-tail cursor by the ORIGINAL last id of the
+                # batch — coalesced events carry a synthetic (last-merged) id,
+                # so the original id is what keeps the tail gap-free.
+                replay_cursor = batch[-1].event_id
+            for event in coalescer.flush():
                 yield _format_sse_event(event.event_id, event.payload)
                 if event.payload.get("type") in {"done", "error"}:
                     return

--- a/backend/cubebox/streams/replay_coalescer.py
+++ b/backend/cubebox/streams/replay_coalescer.py
@@ -1,0 +1,141 @@
+"""Fold a run's replayed event backlog into a compact, order-preserving set.
+
+On reconnect the backend replays the whole Redis event stream for the active
+run. A long run emits tens of thousands of 1-character ``text_delta`` /
+``tool_call_delta`` events, which the frontend folds O(N²) on the main thread
+— the cause of the freeze-on-reload. This coalescer merges *adjacent*
+same-key deltas so the replayed payload shrinks to roughly message
+granularity, while preserving SSE order (the frontend applies replayed events
+in order and dedups by ``event_id``).
+
+Two performance invariants:
+- Accumulation is O(N): delta pieces go into a list and are ``"".join()``ed
+  once when the run is emitted — never ``s = s + delta`` per event (that
+  copies the whole growing string each time, re-introducing the backend stall).
+- A run is also flushed when it reaches ``MAX_COALESCED_CHARS``, so one
+  enormous message becomes several bounded ``text_delta`` events. This keeps
+  each join + each frontend reducer/render step bounded and lets the
+  frontend's count-based yield fire (a single huge event would slip it).
+
+Streaming and stateful so it can fold across read chunks without holding the
+whole backlog in memory. Pure (no IO).
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from dataclasses import field as dc_field
+from typing import Any
+
+from cubebox.streams.run_events import RunEvent
+
+# Max accumulated characters in one coalesced delta before it is flushed and a
+# fresh same-key run continues. ~64 KiB: large enough that normal messages
+# stay a single event, small enough that each join/render step is cheap.
+MAX_COALESCED_CHARS = 65536
+
+# Mergeable event type -> the data field whose value accumulates.
+_DELTA_FIELD = {
+    "text_delta": "content",
+    "reasoning": "content",
+    "tool_call_delta": "args_delta",
+}
+
+
+def _merge_key(event: RunEvent) -> tuple[Any, ...] | None:
+    """Coalescing key for a mergeable event, or None when not mergeable."""
+    payload = event.payload
+    etype = payload.get("type")
+    if etype in ("text_delta", "reasoning"):
+        return (etype, payload.get("agent_id"))
+    if etype == "tool_call_delta":
+        data = payload.get("data") or {}
+        return (etype, payload.get("agent_id"), data.get("index"))
+    return None
+
+
+@dataclass(slots=True)
+class _Pending:
+    """An in-progress coalesced run. ``pieces`` are joined once at emit time."""
+
+    key: tuple[Any, ...]
+    payload: dict[str, Any]  # mutable copy of the first event's payload
+    field: str  # "content" | "args_delta"
+    pieces: list[str] = dc_field(default_factory=list)
+    size: int = 0
+    last_event_id: str = ""
+
+
+class ReplayCoalescer:
+    """Folds adjacent same-key deltas; flushes on key change or size cap.
+
+    Holds at most one pending mergeable run. ``feed`` returns the events that
+    are now complete (the pending run is held back until a differing event, or
+    the size cap, forces a flush); ``flush`` emits whatever remains at end of
+    replay.
+    """
+
+    def __init__(self, max_chars: int = MAX_COALESCED_CHARS) -> None:
+        self._max_chars = max_chars
+        self._pending: _Pending | None = None
+
+    def feed(self, events: list[RunEvent]) -> list[RunEvent]:
+        out: list[RunEvent] = []
+        for event in events:
+            key = _merge_key(event)
+            if self._pending is not None and key == self._pending.key:
+                self._absorb(event)
+                if self._pending.size >= self._max_chars:
+                    out.append(self._finish())  # emit a bounded chunk
+                continue
+            # Different key (or non-mergeable): flush the pending run first so
+            # nothing is emitted out of stream order.
+            if self._pending is not None:
+                out.append(self._finish())
+            if key is not None:
+                self._start(event, key)
+            else:
+                out.append(event)
+        return out
+
+    def flush(self) -> list[RunEvent]:
+        return [self._finish()] if self._pending is not None else []
+
+    def _start(self, event: RunEvent, key: tuple[Any, ...]) -> None:
+        payload = deepcopy(event.payload)
+        fld = _DELTA_FIELD[payload["type"]]
+        data = payload.setdefault("data", {})
+        piece = data.get(fld) or ""
+        self._pending = _Pending(
+            key=key,
+            payload=payload,
+            field=fld,
+            pieces=[piece],
+            size=len(piece),
+            last_event_id=event.event_id,
+        )
+
+    def _absorb(self, event: RunEvent) -> None:
+        assert self._pending is not None
+        edata = event.payload.get("data") or {}
+        piece = edata.get(self._pending.field) or ""
+        self._pending.pieces.append(piece)
+        self._pending.size += len(piece)
+        self._pending.last_event_id = event.event_id
+        if self._pending.payload["type"] == "tool_call_delta":
+            # Latest non-None identity wins (mirrors the route-level backfill).
+            pdata = self._pending.payload["data"]
+            if edata.get("tool_call_id") is not None:
+                pdata["tool_call_id"] = edata["tool_call_id"]
+            if edata.get("name") is not None:
+                pdata["name"] = edata["name"]
+
+    def _finish(self) -> RunEvent:
+        assert self._pending is not None
+        p = self._pending
+        p.payload["data"][p.field] = "".join(p.pieces)
+        # Stamp the last merged original id so frontend dedup stays monotonic.
+        result = RunEvent(p.last_event_id, p.payload)
+        self._pending = None
+        return result

--- a/backend/cubebox/streams/run_events.py
+++ b/backend/cubebox/streams/run_events.py
@@ -17,6 +17,7 @@ meta field updates.
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncIterator
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from typing import Any, cast
@@ -418,6 +419,35 @@ async def iter_run_events(
     max_id = stop or "+"
     entries = await redis.xrange(stream_key, min=min_id, max=max_id)
     return _decode_stream_entries(entries)
+
+
+async def iter_run_events_chunked(
+    redis: Redis,
+    *,
+    prefix: str,
+    run_id: str,
+    start: str | None = None,
+    stop: str | None = None,
+    count: int = 1000,
+) -> AsyncIterator[list[RunEvent]]:
+    """Yield decoded run events in ``[start, stop]`` in batches of ~``count``.
+
+    Paginates with ``XRANGE`` using a ``(<id>`` exclusive cursor between pages,
+    so each ``await`` hands control back to the event loop and memory stays
+    bounded to one batch. ``start`` may be None (from the beginning), a bare
+    id, or an already-exclusive ``(<id>`` form. ``stop`` is inclusive.
+    """
+    stream_key = _run_events_key(prefix, run_id)
+    min_id = start if start is not None else "-"
+    max_id = stop if stop is not None else "+"
+    while True:
+        entries = await redis.xrange(stream_key, min=min_id, max=max_id, count=count)
+        if not entries:
+            return
+        yield _decode_stream_entries(entries)
+        if len(entries) < count:
+            return
+        min_id = f"({entries[-1][0]}"
 
 
 async def read_run_events_after(

--- a/backend/tests/unit/test_iter_run_events_chunked.py
+++ b/backend/tests/unit/test_iter_run_events_chunked.py
@@ -1,0 +1,75 @@
+import json
+
+import fakeredis.aioredis
+import pytest
+
+from cubebox.streams.run_events import (
+    _run_events_key,
+    iter_run_events_chunked,
+)
+
+PREFIX = "test-chunked"
+
+
+@pytest.fixture
+def redis():
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+async def _seed(redis, run_id: str, n: int) -> list[str]:
+    key = _run_events_key(PREFIX, run_id)
+    ids = []
+    for i in range(n):
+        payload = json.dumps(
+            {
+                "type": "text_delta",
+                "timestamp": "",
+                "data": {"content": str(i)},
+                "agent_id": None,
+                "agent_name": None,
+            }
+        )
+        ids.append(await redis.xadd(key, {"payload": payload}))
+    return ids
+
+
+@pytest.mark.asyncio
+async def test_chunked_reads_all_events_in_order(redis):
+    ids = await _seed(redis, "run-chunk-1", 25)
+
+    batches = []
+    async for batch in iter_run_events_chunked(
+        redis, prefix=PREFIX, run_id="run-chunk-1", start=None, stop="+", count=10
+    ):
+        batches.append(batch)
+
+    # 25 events / count 10 -> 3 batches (10, 10, 5)
+    assert [len(b) for b in batches] == [10, 10, 5]
+    flat = [e.event_id for b in batches for e in b]
+    assert flat == ids
+    assert [e.payload["data"]["content"] for b in batches for e in b] == [str(i) for i in range(25)]
+
+
+@pytest.mark.asyncio
+async def test_chunked_honors_exclusive_start(redis):
+    ids = await _seed(redis, "run-chunk-2", 5)
+
+    flat = []
+    async for batch in iter_run_events_chunked(
+        redis, prefix=PREFIX, run_id="run-chunk-2", start=f"({ids[1]}", stop="+", count=10
+    ):
+        flat.extend(e.event_id for e in batch)
+
+    # Exclusive of ids[1] -> starts at ids[2].
+    assert flat == ids[2:]
+
+
+@pytest.mark.asyncio
+async def test_chunked_empty_stream(redis):
+    batches = [
+        b
+        async for b in iter_run_events_chunked(
+            redis, prefix=PREFIX, run_id="run-none", start=None, stop="+", count=10
+        )
+    ]
+    assert batches == []

--- a/backend/tests/unit/test_replay_coalescer.py
+++ b/backend/tests/unit/test_replay_coalescer.py
@@ -1,0 +1,163 @@
+from cubebox.streams.replay_coalescer import ReplayCoalescer
+from cubebox.streams.run_events import RunEvent
+
+
+def _ev(event_id: str, etype: str, *, data=None, agent_id=None) -> RunEvent:
+    return RunEvent(
+        event_id=event_id,
+        payload={
+            "type": etype,
+            "timestamp": "",
+            "data": data or {},
+            "agent_id": agent_id,
+            "agent_name": None,
+        },
+    )
+
+
+def _run(events):
+    c = ReplayCoalescer()
+    out = c.feed(events)
+    out += c.flush()
+    return out
+
+
+def test_consecutive_text_delta_same_agent_merges():
+    out = _run(
+        [
+            _ev("1-0", "text_delta", data={"content": "Hel"}),
+            _ev("2-0", "text_delta", data={"content": "lo"}),
+        ]
+    )
+    assert len(out) == 1
+    assert out[0].payload["data"]["content"] == "Hello"
+    assert out[0].event_id == "2-0"  # last merged id
+
+
+def test_consecutive_reasoning_same_agent_merges():
+    out = _run(
+        [
+            _ev("1-0", "reasoning", data={"content": "th"}),
+            _ev("2-0", "reasoning", data={"content": "ink"}),
+        ]
+    )
+    assert len(out) == 1
+    assert out[0].payload["data"]["content"] == "think"
+
+
+def test_tool_call_delta_merges_per_index_keeps_type():
+    out = _run(
+        [
+            _ev(
+                "1-0",
+                "tool_call_delta",
+                data={"index": 0, "args_delta": '{"a"', "name": "calc", "tool_call_id": "t1"},
+            ),
+            _ev(
+                "2-0",
+                "tool_call_delta",
+                data={"index": 0, "args_delta": ":1}", "name": None, "tool_call_id": None},
+            ),
+        ]
+    )
+    assert len(out) == 1
+    assert out[0].payload["type"] == "tool_call_delta"
+    assert out[0].payload["data"]["args_delta"] == '{"a":1}'
+    assert out[0].payload["data"]["tool_call_id"] == "t1"
+    assert out[0].payload["data"]["name"] == "calc"
+
+
+def test_structural_events_pass_through():
+    events = [
+        _ev("1-0", "tool_call", data={"tool_call_id": "t1", "name": "calc", "arguments": {}}),
+        _ev("2-0", "tool_result", data={"tool_call_id": "t1", "content": "1"}),
+        _ev("3-0", "usage", data={"input_tokens": 1}),
+        _ev("4-0", "citation", data={}),
+        _ev("5-0", "artifact", data={}),
+        _ev("6-0", "injected_message", data={"content": "x", "steer_id": "s"}),
+        _ev("7-0", "status", data={"phase": "x"}),
+    ]
+    out = _run(events)
+    assert [e.event_id for e in out] == ["1-0", "2-0", "3-0", "4-0", "5-0", "6-0", "7-0"]
+
+
+def test_interleave_preserves_stream_order():
+    # main e1, subagent e2, main e3 -> e1, e2, e3 (never e1+e3 around e2)
+    out = _run(
+        [
+            _ev("1-0", "text_delta", data={"content": "A"}, agent_id=None),
+            _ev("2-0", "text_delta", data={"content": "B"}, agent_id="subagent:t1"),
+            _ev("3-0", "text_delta", data={"content": "C"}, agent_id=None),
+        ]
+    )
+    assert [e.event_id for e in out] == ["1-0", "2-0", "3-0"]
+    assert out[0].payload["data"]["content"] == "A"
+    assert out[1].payload["data"]["content"] == "B"
+    assert out[2].payload["data"]["content"] == "C"
+
+
+def test_text_interrupted_by_tool_call_splits():
+    out = _run(
+        [
+            _ev("1-0", "text_delta", data={"content": "before"}),
+            _ev("2-0", "tool_call", data={"tool_call_id": "t1", "name": "calc", "arguments": {}}),
+            _ev("3-0", "text_delta", data={"content": "after"}),
+        ]
+    )
+    assert [e.payload["type"] for e in out] == ["text_delta", "tool_call", "text_delta"]
+    assert out[0].payload["data"]["content"] == "before"
+    assert out[2].payload["data"]["content"] == "after"
+
+
+def test_done_flushes_pending_then_passes_through():
+    out = _run(
+        [
+            _ev("1-0", "text_delta", data={"content": "hi"}),
+            _ev("2-0", "done", data={}),
+        ]
+    )
+    assert [e.payload["type"] for e in out] == ["text_delta", "done"]
+    assert out[0].payload["data"]["content"] == "hi"
+
+
+def test_empty_input():
+    assert _run([]) == []
+
+
+def test_chunk_boundary_invariance():
+    events = [
+        _ev("1-0", "text_delta", data={"content": "A"}),
+        _ev("2-0", "text_delta", data={"content": "B"}),
+        _ev(
+            "3-0",
+            "tool_call_delta",
+            data={"index": 0, "args_delta": "{", "name": "c", "tool_call_id": "t"},
+        ),
+        _ev(
+            "4-0",
+            "tool_call_delta",
+            data={"index": 0, "args_delta": "}", "name": None, "tool_call_id": None},
+        ),
+        _ev("5-0", "done", data={}),
+    ]
+    whole = _run(events)
+    # Feed split at every boundary; output must be identical.
+    for split in range(len(events) + 1):
+        c = ReplayCoalescer()
+        chunked = c.feed(events[:split]) + c.feed(events[split:]) + c.flush()
+        assert [(e.event_id, e.payload["type"], e.payload["data"]) for e in chunked] == [
+            (e.event_id, e.payload["type"], e.payload["data"]) for e in whole
+        ]
+
+
+def test_size_cap_splits_huge_run_into_bounded_events():
+    # 6 deltas of 4 chars (24 total) with a 10-char cap -> multiple bounded
+    # text_delta events whose contents concatenate back to the original.
+    c = ReplayCoalescer(max_chars=10)
+    events = [_ev(f"{i}-0", "text_delta", data={"content": "abcd"}) for i in range(6)]
+    out = c.feed(events) + c.flush()
+    assert len(out) >= 2
+    assert all(e.payload["type"] == "text_delta" for e in out)
+    assert "".join(e.payload["data"]["content"] for e in out) == "abcd" * 6
+    # No emitted chunk grossly exceeds the cap (cap + at most one delta).
+    assert all(len(e.payload["data"]["content"]) <= 10 + 4 for e in out)

--- a/docs/dev/plans/2026-05-26-reconnect-replay-coalescing.md
+++ b/docs/dev/plans/2026-05-26-reconnect-replay-coalescing.md
@@ -1,0 +1,694 @@
+# Reconnect Replay Coalescing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the browser freezing when the page is refreshed during a busy agent run, by folding the replayed event backlog server-side and yielding to the event loop in the frontend consume loops.
+
+**Architecture:** On reconnect the backend currently replays every fine-grained SSE event (tens of thousands of 1-character `text_delta` / `tool_call_delta`) from the Redis stream, which the frontend folds O(N²) on the main thread. We add a stateful `ReplayCoalescer` that merges adjacent same-key deltas in strict stream order, read the backlog in bounded chunks (so the asyncio loop never stalls), and add a periodic yield in the two frontend consume loops as a safety net. Live tail stays fine-grained for smooth streaming. No cubepi changes, no checkpoint correlation.
+
+**Tech Stack:** Python (FastAPI, redis.asyncio, pytest), TypeScript (Zustand store, Vitest).
+
+**Spec:** `docs/dev/specs/2026-05-26-reconnect-replay-coalescing-design.md`
+
+---
+
+## File Structure
+
+- **Create** `backend/cubebox/streams/replay_coalescer.py` — the pure, stateful `ReplayCoalescer` (no IO). One responsibility: fold a stream of `RunEvent` into a compact, order-preserving equivalent.
+- **Create** `backend/tests/unit/test_replay_coalescer.py` — unit tests for the coalescer.
+- **Modify** `backend/cubebox/streams/run_events.py` — add `iter_run_events_chunked` (cursor-paginated batch reader). Leave `iter_run_events` and its callers untouched.
+- **Create** `backend/tests/unit/test_iter_run_events_chunked.py` — test for the chunked reader. Uses an inline `fakeredis` fixture with `decode_responses=True` (matches production `app.py:141` and the convention in `tests/unit/test_run_control_pubsub.py`).
+- **Modify** `backend/cubebox/api/routes/v1/conversations.py` — replay segment of `event_generator` uses the chunked reader + coalescer.
+- **Modify** `frontend/packages/core/src/stores/messageStore.ts` — periodic yield in both consume loops (`consumeRunStream`, `send`).
+- **Create** `frontend/packages/web/__tests__/stores/messageStore.yield.test.ts` — asserts the yield fires for large event counts.
+
+---
+
+## Task 1: ReplayCoalescer (pure, streaming)
+
+**Files:**
+- Create: `backend/cubebox/streams/replay_coalescer.py`
+- Test: `backend/tests/unit/test_replay_coalescer.py`
+
+The coalescer holds **at most one** pending mergeable run at a time. When an event arrives whose key differs from the pending run's key (or is non-mergeable), the pending run is flushed first — this is what preserves SSE order and event-id dedup monotonicity on the frontend.
+
+Merge keys:
+- `text_delta` → `("text_delta", agent_id)`
+- `reasoning` → `("reasoning", agent_id)`
+- `tool_call_delta` → `("tool_call_delta", agent_id, index)`
+
+Every other event type is non-mergeable (pass-through). A coalesced event keeps the `event_id` of the **last** original event it merged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_replay_coalescer.py`:
+
+```python
+from cubebox.streams.replay_coalescer import ReplayCoalescer
+from cubebox.streams.run_events import RunEvent
+
+
+def _ev(event_id: str, etype: str, *, data=None, agent_id=None) -> RunEvent:
+    return RunEvent(
+        event_id=event_id,
+        payload={
+            "type": etype,
+            "timestamp": "",
+            "data": data or {},
+            "agent_id": agent_id,
+            "agent_name": None,
+        },
+    )
+
+
+def _run(events):
+    c = ReplayCoalescer()
+    out = c.feed(events)
+    out += c.flush()
+    return out
+
+
+def test_consecutive_text_delta_same_agent_merges():
+    out = _run([
+        _ev("1-0", "text_delta", data={"content": "Hel"}),
+        _ev("2-0", "text_delta", data={"content": "lo"}),
+    ])
+    assert len(out) == 1
+    assert out[0].payload["data"]["content"] == "Hello"
+    assert out[0].event_id == "2-0"  # last merged id
+
+
+def test_consecutive_reasoning_same_agent_merges():
+    out = _run([
+        _ev("1-0", "reasoning", data={"content": "th"}),
+        _ev("2-0", "reasoning", data={"content": "ink"}),
+    ])
+    assert len(out) == 1
+    assert out[0].payload["data"]["content"] == "think"
+
+
+def test_tool_call_delta_merges_per_index_keeps_type():
+    out = _run([
+        _ev("1-0", "tool_call_delta", data={"index": 0, "args_delta": '{"a"', "name": "calc", "tool_call_id": "t1"}),
+        _ev("2-0", "tool_call_delta", data={"index": 0, "args_delta": ":1}", "name": None, "tool_call_id": None}),
+    ])
+    assert len(out) == 1
+    assert out[0].payload["type"] == "tool_call_delta"
+    assert out[0].payload["data"]["args_delta"] == '{"a":1}'
+    assert out[0].payload["data"]["tool_call_id"] == "t1"
+    assert out[0].payload["data"]["name"] == "calc"
+
+
+def test_structural_events_pass_through():
+    events = [
+        _ev("1-0", "tool_call", data={"tool_call_id": "t1", "name": "calc", "arguments": {}}),
+        _ev("2-0", "tool_result", data={"tool_call_id": "t1", "content": "1"}),
+        _ev("3-0", "usage", data={"input_tokens": 1}),
+        _ev("4-0", "citation", data={}),
+        _ev("5-0", "artifact", data={}),
+        _ev("6-0", "injected_message", data={"content": "x", "steer_id": "s"}),
+        _ev("7-0", "status", data={"phase": "x"}),
+    ]
+    out = _run(events)
+    assert [e.event_id for e in out] == ["1-0", "2-0", "3-0", "4-0", "5-0", "6-0", "7-0"]
+
+
+def test_interleave_preserves_stream_order():
+    # main e1, subagent e2, main e3 -> e1, e2, e3 (never e1+e3 around e2)
+    out = _run([
+        _ev("1-0", "text_delta", data={"content": "A"}, agent_id=None),
+        _ev("2-0", "text_delta", data={"content": "B"}, agent_id="subagent:t1"),
+        _ev("3-0", "text_delta", data={"content": "C"}, agent_id=None),
+    ])
+    assert [e.event_id for e in out] == ["1-0", "2-0", "3-0"]
+    assert out[0].payload["data"]["content"] == "A"
+    assert out[1].payload["data"]["content"] == "B"
+    assert out[2].payload["data"]["content"] == "C"
+
+
+def test_text_interrupted_by_tool_call_splits():
+    out = _run([
+        _ev("1-0", "text_delta", data={"content": "before"}),
+        _ev("2-0", "tool_call", data={"tool_call_id": "t1", "name": "calc", "arguments": {}}),
+        _ev("3-0", "text_delta", data={"content": "after"}),
+    ])
+    assert [e.payload["type"] for e in out] == ["text_delta", "tool_call", "text_delta"]
+    assert out[0].payload["data"]["content"] == "before"
+    assert out[2].payload["data"]["content"] == "after"
+
+
+def test_done_flushes_pending_then_passes_through():
+    out = _run([
+        _ev("1-0", "text_delta", data={"content": "hi"}),
+        _ev("2-0", "done", data={}),
+    ])
+    assert [e.payload["type"] for e in out] == ["text_delta", "done"]
+    assert out[0].payload["data"]["content"] == "hi"
+
+
+def test_empty_input():
+    assert _run([]) == []
+
+
+def test_chunk_boundary_invariance():
+    events = [
+        _ev("1-0", "text_delta", data={"content": "A"}),
+        _ev("2-0", "text_delta", data={"content": "B"}),
+        _ev("3-0", "tool_call_delta", data={"index": 0, "args_delta": "{", "name": "c", "tool_call_id": "t"}),
+        _ev("4-0", "tool_call_delta", data={"index": 0, "args_delta": "}", "name": None, "tool_call_id": None}),
+        _ev("5-0", "done", data={}),
+    ]
+    whole = _run(events)
+    # Feed split at every boundary; output must be identical.
+    for split in range(len(events) + 1):
+        c = ReplayCoalescer()
+        chunked = c.feed(events[:split]) + c.feed(events[split:]) + c.flush()
+        assert [(e.event_id, e.payload["type"], e.payload["data"]) for e in chunked] == \
+               [(e.event_id, e.payload["type"], e.payload["data"]) for e in whole]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/unit/test_replay_coalescer.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'cubebox.streams.replay_coalescer'`
+
+- [ ] **Step 3: Implement the coalescer**
+
+Create `backend/cubebox/streams/replay_coalescer.py`:
+
+```python
+"""Fold a run's replayed event backlog into a compact, order-preserving set.
+
+On reconnect the backend replays the whole Redis event stream for the active
+run. A long run emits tens of thousands of 1-character ``text_delta`` /
+``tool_call_delta`` events, which the frontend folds O(N²) on the main thread
+— the cause of the freeze-on-reload. This coalescer merges *adjacent*
+same-key deltas so the replayed payload shrinks to roughly message
+granularity, while preserving SSE order (the frontend applies replayed events
+in order and dedups by ``event_id``).
+
+Streaming and stateful so it can fold across read chunks without holding the
+whole backlog in memory. Pure (no IO).
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from cubebox.streams.run_events import RunEvent
+
+_MERGEABLE = {"text_delta", "reasoning", "tool_call_delta"}
+
+
+def _merge_key(event: RunEvent) -> tuple[Any, ...] | None:
+    """Coalescing key for a mergeable event, or None when not mergeable."""
+    payload = event.payload
+    etype = payload.get("type")
+    if etype in ("text_delta", "reasoning"):
+        return (etype, payload.get("agent_id"))
+    if etype == "tool_call_delta":
+        data = payload.get("data") or {}
+        return (etype, payload.get("agent_id"), data.get("index"))
+    return None
+
+
+class ReplayCoalescer:
+    """Folds adjacent same-key deltas; flushes on any key change (strict order).
+
+    Holds at most one pending mergeable run. ``feed`` returns the events that
+    are now complete (the pending run is held back until a differing event
+    forces a flush); ``flush`` emits whatever remains at end of replay.
+    """
+
+    def __init__(self) -> None:
+        self._pending: RunEvent | None = None
+        self._pending_key: tuple[Any, ...] | None = None
+
+    def feed(self, events: list[RunEvent]) -> list[RunEvent]:
+        out: list[RunEvent] = []
+        for event in events:
+            key = _merge_key(event)
+            if key is not None and key == self._pending_key:
+                self._absorb(event)
+                continue
+            # Different key (or non-mergeable): flush the pending run first so
+            # nothing is emitted out of stream order.
+            if self._pending is not None:
+                out.append(self._pending)
+                self._pending = None
+                self._pending_key = None
+            if key is not None:
+                # Start a fresh pending run from a copy we can mutate.
+                self._pending = RunEvent(event.event_id, deepcopy(event.payload))
+                self._pending_key = key
+            else:
+                out.append(event)
+        return out
+
+    def flush(self) -> list[RunEvent]:
+        if self._pending is None:
+            return []
+        out = [self._pending]
+        self._pending = None
+        self._pending_key = None
+        return out
+
+    def _absorb(self, event: RunEvent) -> None:
+        assert self._pending is not None
+        etype = self._pending.payload.get("type")
+        pdata: dict[str, Any] = self._pending.payload.setdefault("data", {})
+        edata = event.payload.get("data") or {}
+        if etype in ("text_delta", "reasoning"):
+            pdata["content"] = (pdata.get("content") or "") + (edata.get("content") or "")
+        elif etype == "tool_call_delta":
+            pdata["args_delta"] = (pdata.get("args_delta") or "") + (edata.get("args_delta") or "")
+            # Latest non-None identity wins (mirrors the route-level backfill).
+            if edata.get("tool_call_id") is not None:
+                pdata["tool_call_id"] = edata["tool_call_id"]
+            if edata.get("name") is not None:
+                pdata["name"] = edata["name"]
+        # Stamp the last merged original id so frontend dedup stays monotonic.
+        self._pending.event_id = event.event_id
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/unit/test_replay_coalescer.py -v`
+Expected: PASS (all 9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/streams/replay_coalescer.py backend/tests/unit/test_replay_coalescer.py
+git commit -m "feat(streams): add ReplayCoalescer for reconnect replay folding"
+```
+
+---
+
+## Task 2: Chunked run-event reader
+
+**Files:**
+- Modify: `backend/cubebox/streams/run_events.py` (add `iter_run_events_chunked`; leave `iter_run_events` untouched)
+- Test: `backend/tests/unit/test_iter_run_events_chunked.py`
+
+Reads `[start, stop]` in batches of ~`count` using a `(<id>` exclusive cursor for pagination, so each `await xrange` returns control to the event loop and memory stays bounded to one batch. `start` may be `None` (read from the beginning), a bare id, or an exclusive `(<id>` form (as the route passes when a `Last-Event-ID` header is present).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/test_iter_run_events_chunked.py`. It seeds the
+stream directly via `xadd` (no `append_run_event` Lua dependency) and reads
+through the real `iter_run_events_chunked`. The fixture uses
+`decode_responses=True` so `_decode_stream_entries` (which indexes the `str`
+key `"payload"`) works exactly as in production:
+
+```python
+import json
+
+import fakeredis.aioredis
+import pytest
+
+from cubebox.streams.run_events import (
+    _run_events_key,
+    iter_run_events_chunked,
+)
+
+PREFIX = "test-chunked"
+
+
+@pytest.fixture
+def redis():
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+async def _seed(redis, run_id: str, n: int) -> list[str]:
+    key = _run_events_key(PREFIX, run_id)
+    ids = []
+    for i in range(n):
+        payload = json.dumps(
+            {"type": "text_delta", "timestamp": "", "data": {"content": str(i)},
+             "agent_id": None, "agent_name": None}
+        )
+        ids.append(await redis.xadd(key, {"payload": payload}))
+    return ids
+
+
+@pytest.mark.asyncio
+async def test_chunked_reads_all_events_in_order(redis):
+    ids = await _seed(redis, "run-chunk-1", 25)
+
+    batches = []
+    async for batch in iter_run_events_chunked(
+        redis, prefix=PREFIX, run_id="run-chunk-1", start=None, stop="+", count=10
+    ):
+        batches.append(batch)
+
+    # 25 events / count 10 -> 3 batches (10, 10, 5)
+    assert [len(b) for b in batches] == [10, 10, 5]
+    flat = [e.event_id for b in batches for e in b]
+    assert flat == ids
+    # Payload is decoded into a dict, content preserved in order.
+    assert [e.payload["data"]["content"] for b in batches for e in b] == [str(i) for i in range(25)]
+
+
+@pytest.mark.asyncio
+async def test_chunked_honors_exclusive_start(redis):
+    ids = await _seed(redis, "run-chunk-2", 5)
+
+    flat = []
+    async for batch in iter_run_events_chunked(
+        redis, prefix=PREFIX, run_id="run-chunk-2", start=f"({ids[1]}", stop="+", count=10
+    ):
+        flat.extend(e.event_id for e in batch)
+
+    # Exclusive of ids[1] -> starts at ids[2].
+    assert flat == ids[2:]
+
+
+@pytest.mark.asyncio
+async def test_chunked_empty_stream(redis):
+    batches = [
+        b
+        async for b in iter_run_events_chunked(
+            redis, prefix=PREFIX, run_id="run-none", start=None, stop="+", count=10
+        )
+    ]
+    assert batches == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/test_iter_run_events_chunked.py -v`
+Expected: FAIL with `ImportError: cannot import name 'iter_run_events_chunked'`
+
+- [ ] **Step 3: Implement the chunked reader**
+
+In `backend/cubebox/streams/run_events.py`, add the import at the top of the file (with the other typing imports) if not present:
+
+```python
+from collections.abc import AsyncIterator
+```
+
+Then add this function directly after `iter_run_events`:
+
+```python
+async def iter_run_events_chunked(
+    redis: Redis,
+    *,
+    prefix: str,
+    run_id: str,
+    start: str | None = None,
+    stop: str | None = None,
+    count: int = 1000,
+) -> AsyncIterator[list[RunEvent]]:
+    """Yield decoded run events in ``[start, stop]`` in batches of ~``count``.
+
+    Paginates with ``XRANGE`` using a ``(<id>`` exclusive cursor between pages,
+    so each ``await`` hands control back to the event loop and memory stays
+    bounded to one batch. ``start`` may be None (from the beginning), a bare
+    id, or an already-exclusive ``(<id>`` form. ``stop`` is inclusive.
+    """
+    stream_key = _run_events_key(prefix, run_id)
+    min_id = start if start is not None else "-"
+    max_id = stop if stop is not None else "+"
+    while True:
+        entries = await redis.xrange(stream_key, min=min_id, max=max_id, count=count)
+        if not entries:
+            return
+        yield _decode_stream_entries(entries)
+        if len(entries) < count:
+            return
+        min_id = f"({entries[-1][0]}"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/test_iter_run_events_chunked.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/streams/run_events.py backend/tests/unit/test_iter_run_events_chunked.py
+git commit -m "feat(streams): add chunked run-event reader for bounded replay"
+```
+
+---
+
+## Task 3: Wire coalescer + chunked reader into the stream route
+
+**Files:**
+- Modify: `backend/cubebox/api/routes/v1/conversations.py` (replay segment of `event_generator`, around lines 321-340)
+
+The replay segment is replaced so it reads in chunks, folds each batch through the coalescer, and advances the live-tail cursor by the **original** last id of each batch (not the synthetic coalesced id). The live tail segment (the `while True` loop) and the `done`/`error` early-return are unchanged.
+
+- [ ] **Step 1: Read the current replay segment**
+
+Run: `cd backend && sed -n '305,345p' cubebox/api/routes/v1/conversations.py`
+Expected: see `target_event_id = await get_latest_event_id(...)`, `replay_start = ...`, the `iter_run_events(...)` call, and the replay `for` loop.
+
+- [ ] **Step 2: Add imports + chunk-size constant**
+
+Near the existing imports from `cubebox.streams.run_events` in `conversations.py`, add `iter_run_events_chunked` to that import list, and import the coalescer:
+
+```python
+from cubebox.streams.replay_coalescer import ReplayCoalescer
+```
+
+Add a module-level constant near the top of the file (after imports):
+
+```python
+# Replay backlog is read in bounded batches so a large reconnect never stalls
+# the event loop. Tunable; ~1000 keeps each XRANGE + JSON decode cheap.
+REPLAY_CHUNK_SIZE = 1000
+```
+
+- [ ] **Step 3: Replace the replay segment**
+
+Replace this block (currently `conversations.py:326-340`):
+
+```python
+        if target_event_id is not None:
+            replay_events = await iter_run_events(
+                redis,
+                prefix=prefix,
+                run_id=run_id,
+                start=replay_start,
+                stop=target_event_id,
+            )
+            for event in replay_events:
+                replay_cursor = event.event_id
+                yield _format_sse_event(event.event_id, event.payload)
+                if event.payload.get("type") in {"done", "error"}:
+                    return
+
+        live_cursor = replay_cursor or target_event_id or "$"
+```
+
+with:
+
+```python
+        if target_event_id is not None:
+            coalescer = ReplayCoalescer()
+            async for batch in iter_run_events_chunked(
+                redis,
+                prefix=prefix,
+                run_id=run_id,
+                start=replay_start,
+                stop=target_event_id,
+                count=REPLAY_CHUNK_SIZE,
+            ):
+                for event in coalescer.feed(batch):
+                    yield _format_sse_event(event.event_id, event.payload)
+                    if event.payload.get("type") in {"done", "error"}:
+                        return
+                # Advance the live-tail cursor by the ORIGINAL last id of the
+                # batch — coalesced events carry a synthetic (last-merged) id,
+                # so the original id is what keeps the tail gap-free.
+                replay_cursor = batch[-1].event_id
+            for event in coalescer.flush():
+                yield _format_sse_event(event.event_id, event.payload)
+                if event.payload.get("type") in {"done", "error"}:
+                    return
+
+        live_cursor = replay_cursor or target_event_id or "$"
+```
+
+> If `iter_run_events` is now unused in `conversations.py`, remove it from the import to keep the linter happy. Grep first: `grep -n iter_run_events cubebox/api/routes/v1/conversations.py`.
+
+- [ ] **Step 4: Verify type-check and lint pass**
+
+Run: `cd backend && uv run mypy cubebox/api/routes/v1/conversations.py && uv run ruff check cubebox/api/routes/v1/conversations.py`
+Expected: no errors.
+
+- [ ] **Step 5: Run the existing conversations route tests**
+
+Run: `cd backend && uv run pytest tests/ -k "stream or conversation or replay" -v`
+Expected: PASS (no regressions in existing stream/replay tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/api/routes/v1/conversations.py
+git commit -m "feat(stream): coalesce + chunk replay on reconnect"
+```
+
+---
+
+## Task 4: Frontend yield in consume loops
+
+**Files:**
+- Modify: `frontend/packages/core/src/stores/messageStore.ts`
+- Test: `frontend/packages/web/__tests__/stores/messageStore.yield.test.ts`
+
+Add a periodic yield so a large event batch can never pin the main thread. After coalescing this rarely triggers, but it caps the worst case (a single huge coalesced message) at "slow" instead of "frozen".
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/packages/web/__tests__/stores/messageStore.yield.test.ts`:
+
+```typescript
+import { act } from '@testing-library/react'
+import { useMessageStore } from '@cubebox/core'
+
+const CONV_ID = 'conv-yield'
+
+function mockSSEResponse(events: object[]) {
+  const lines = events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join('')
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(lines))
+      controller.close()
+    },
+  })
+  return new Response(stream, { headers: { 'content-type': 'text/event-stream' } })
+}
+
+const mockClient = { baseUrl: '', get: vi.fn(), post: vi.fn(), resolvePath: (p: string) => p }
+
+beforeEach(() => {
+  vi.useRealTimers()
+  useMessageStore.setState({
+    messages: {},
+    streamAgents: {},
+    isStreaming: false,
+    streamingConversationId: null,
+    currentRunId: null,
+    lastAppliedEventId: null,
+    statusPhase: null,
+    error: null,
+    todos: [],
+    toolStartedMap: {},
+    toolResultMap: {},
+  })
+})
+
+it('yields to the event loop when processing many events', async () => {
+  // 250 text deltas (> YIELD_EVERY=200) then done.
+  const events = Array.from({ length: 250 }, (_, i) => ({
+    type: 'text_delta',
+    data: { content: 'x' },
+    agent_id: null,
+    agent_name: null,
+    timestamp: '',
+    event_id: `${i + 1}-0`,
+  }))
+  events.push({ type: 'done', data: {}, agent_id: null, agent_name: null, timestamp: '' } as never)
+
+  vi.stubGlobal('fetch', vi.fn(() => mockSSEResponse(events)))
+  // Force the setTimeout fallback path (no scheduler.yield in jsdom).
+  vi.stubGlobal('scheduler', undefined)
+  const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+
+  await act(async () => {
+    await useMessageStore.getState().send(mockClient as never, CONV_ID, 'hi')
+  })
+
+  expect(setTimeoutSpy).toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && pnpm --filter @cubebox/web test -- messageStore.yield`
+Expected: FAIL — `setTimeoutSpy` not called (no yield exists yet).
+
+- [ ] **Step 3: Add the yield helper + constant**
+
+In `frontend/packages/core/src/stores/messageStore.ts`, after the imports (near the top, before `export interface AgentStream`), add:
+
+```typescript
+const YIELD_EVERY = 200
+
+function yieldToEventLoop(): Promise<void> {
+  const sched = (globalThis as { scheduler?: { yield?: () => Promise<void> } }).scheduler
+  if (sched && typeof sched.yield === 'function') return sched.yield()
+  return new Promise((resolve) => setTimeout(resolve))
+}
+```
+
+- [ ] **Step 4: Add the yield to `consumeRunStream`**
+
+In `consumeRunStream`, the loop is `for await (const event of streamRun(...)) { ... batchedSet((s) => applyStreamEvent(s, event)) }`. Add a counter declared just before the loop:
+
+```typescript
+  let processed = 0
+```
+
+and replace the trailing `batchedSet((s) => applyStreamEvent(s, event))` (the last statement inside the loop, after all the `if/else if` branches) with:
+
+```typescript
+      batchedSet((s) => applyStreamEvent(s, event))
+      if (++processed % YIELD_EVERY === 0) {
+        await yieldToEventLoop()
+      }
+```
+
+- [ ] **Step 5: Add the same yield to `send`**
+
+In `send`, the inner `for await (const event of streamSource)` loop ends with the same `batchedSet((s) => applyStreamEvent(s, event))`. Declare `let processed = 0` just before the `outer:` loop, and replace that trailing `batchedSet(...)` with the identical block:
+
+```typescript
+          batchedSet((s) => applyStreamEvent(s, event))
+          if (++processed % YIELD_EVERY === 0) {
+            await yieldToEventLoop()
+          }
+```
+
+> Both loops have `continue` in the `injected_message` branch (before `batchedSet`), so the counter only advances on the batched path — the `flush()` → `__commitTurnAndInject` ordering is never split by a yield.
+
+- [ ] **Step 6: Build core and run the test**
+
+Run: `cd frontend && pnpm --filter @cubebox/core build && pnpm --filter @cubebox/web test -- messageStore.yield`
+Expected: PASS.
+
+- [ ] **Step 7: Run the existing messageStore tests for regressions**
+
+Run: `cd frontend && pnpm --filter @cubebox/web test -- useMessages`
+Expected: PASS (no regressions).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/packages/core/src/stores/messageStore.ts frontend/packages/web/__tests__/stores/messageStore.yield.test.ts
+git commit -m "feat(messageStore): yield to event loop during large stream consumption"
+```
+
+---
+
+## Final verification
+
+- [ ] **Backend full module sweep**
+
+Run: `cd backend && uv run pytest tests/unit/test_replay_coalescer.py tests/unit/test_iter_run_events_chunked.py && uv run pytest tests/ -k "stream or conversation or replay" -q`
+Expected: all PASS.
+
+- [ ] **Frontend type-check + lint**
+
+Run: `cd frontend && pnpm --filter @cubebox/core build && pnpm --filter @cubebox/web lint`
+Expected: clean.
+
+- [ ] **Manual self-test (user)**
+
+Start a run that produces a lot of output; mid-stream, reload the page. Confirm: the page becomes interactive within a moment (clickable, scrollable), the transcript is complete, and streaming continues to completion. (E2E intentionally skipped per spec.)

--- a/docs/dev/plans/2026-05-26-reconnect-replay-coalescing.md
+++ b/docs/dev/plans/2026-05-26-reconnect-replay-coalescing.md
@@ -165,6 +165,19 @@ def test_chunk_boundary_invariance():
         chunked = c.feed(events[:split]) + c.feed(events[split:]) + c.flush()
         assert [(e.event_id, e.payload["type"], e.payload["data"]) for e in chunked] == \
                [(e.event_id, e.payload["type"], e.payload["data"]) for e in whole]
+
+
+def test_size_cap_splits_huge_run_into_bounded_events():
+    # 6 deltas of 4 chars (24 total) with a 10-char cap -> multiple bounded
+    # text_delta events whose contents concatenate back to the original.
+    c = ReplayCoalescer(max_chars=10)
+    events = [_ev(f"{i}-0", "text_delta", data={"content": "abcd"}) for i in range(6)]
+    out = c.feed(events) + c.flush()
+    assert len(out) >= 2
+    assert all(e.payload["type"] == "text_delta" for e in out)
+    assert "".join(e.payload["data"]["content"] for e in out) == "abcd" * 6
+    # No emitted chunk grossly exceeds the cap (cap + at most one delta).
+    assert all(len(e.payload["data"]["content"]) <= 10 + 4 for e in out)
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -187,6 +200,15 @@ same-key deltas so the replayed payload shrinks to roughly message
 granularity, while preserving SSE order (the frontend applies replayed events
 in order and dedups by ``event_id``).
 
+Two performance invariants:
+- Accumulation is O(N): delta pieces go into a list and are ``"".join()``ed
+  once when the run is emitted — never ``s = s + delta`` per event (that
+  copies the whole growing string each time, re-introducing the backend stall).
+- A run is also flushed when it reaches ``MAX_COALESCED_CHARS``, so one
+  enormous message becomes several bounded ``text_delta`` events. This keeps
+  each join + each frontend reducer/render step bounded and lets the
+  frontend's count-based yield fire (a single huge event would slip it).
+
 Streaming and stateful so it can fold across read chunks without holding the
 whole backlog in memory. Pure (no IO).
 """
@@ -194,11 +216,22 @@ whole backlog in memory. Pure (no IO).
 from __future__ import annotations
 
 from copy import deepcopy
+from dataclasses import dataclass, field
 from typing import Any
 
 from cubebox.streams.run_events import RunEvent
 
-_MERGEABLE = {"text_delta", "reasoning", "tool_call_delta"}
+# Max accumulated characters in one coalesced delta before it is flushed and a
+# fresh same-key run continues. ~64 KiB: large enough that normal messages
+# stay a single event, small enough that each join/render step is cheap.
+MAX_COALESCED_CHARS = 65536
+
+# Mergeable event type -> the data field whose value accumulates.
+_DELTA_FIELD = {
+    "text_delta": "content",
+    "reasoning": "content",
+    "tool_call_delta": "args_delta",
+}
 
 
 def _merge_key(event: RunEvent) -> tuple[Any, ...] | None:
@@ -213,69 +246,96 @@ def _merge_key(event: RunEvent) -> tuple[Any, ...] | None:
     return None
 
 
+@dataclass(slots=True)
+class _Pending:
+    """An in-progress coalesced run. ``pieces`` are joined once at emit time."""
+
+    key: tuple[Any, ...]
+    payload: dict[str, Any]  # mutable copy of the first event's payload
+    field: str  # "content" | "args_delta"
+    pieces: list[str] = field(default_factory=list)
+    size: int = 0
+    last_event_id: str = ""
+
+
 class ReplayCoalescer:
-    """Folds adjacent same-key deltas; flushes on any key change (strict order).
+    """Folds adjacent same-key deltas; flushes on key change or size cap.
 
     Holds at most one pending mergeable run. ``feed`` returns the events that
-    are now complete (the pending run is held back until a differing event
-    forces a flush); ``flush`` emits whatever remains at end of replay.
+    are now complete (the pending run is held back until a differing event, or
+    the size cap, forces a flush); ``flush`` emits whatever remains at end of
+    replay.
     """
 
-    def __init__(self) -> None:
-        self._pending: RunEvent | None = None
-        self._pending_key: tuple[Any, ...] | None = None
+    def __init__(self, max_chars: int = MAX_COALESCED_CHARS) -> None:
+        self._max_chars = max_chars
+        self._pending: _Pending | None = None
 
     def feed(self, events: list[RunEvent]) -> list[RunEvent]:
         out: list[RunEvent] = []
         for event in events:
             key = _merge_key(event)
-            if key is not None and key == self._pending_key:
+            if self._pending is not None and key == self._pending.key:
                 self._absorb(event)
+                if self._pending.size >= self._max_chars:
+                    out.append(self._finish())  # emit a bounded chunk
                 continue
             # Different key (or non-mergeable): flush the pending run first so
             # nothing is emitted out of stream order.
             if self._pending is not None:
-                out.append(self._pending)
-                self._pending = None
-                self._pending_key = None
+                out.append(self._finish())
             if key is not None:
-                # Start a fresh pending run from a copy we can mutate.
-                self._pending = RunEvent(event.event_id, deepcopy(event.payload))
-                self._pending_key = key
+                self._start(event, key)
             else:
                 out.append(event)
         return out
 
     def flush(self) -> list[RunEvent]:
-        if self._pending is None:
-            return []
-        out = [self._pending]
-        self._pending = None
-        self._pending_key = None
-        return out
+        return [self._finish()] if self._pending is not None else []
+
+    def _start(self, event: RunEvent, key: tuple[Any, ...]) -> None:
+        payload = deepcopy(event.payload)
+        fld = _DELTA_FIELD[payload["type"]]
+        data = payload.setdefault("data", {})
+        piece = data.get(fld) or ""
+        self._pending = _Pending(
+            key=key,
+            payload=payload,
+            field=fld,
+            pieces=[piece],
+            size=len(piece),
+            last_event_id=event.event_id,
+        )
 
     def _absorb(self, event: RunEvent) -> None:
         assert self._pending is not None
-        etype = self._pending.payload.get("type")
-        pdata: dict[str, Any] = self._pending.payload.setdefault("data", {})
         edata = event.payload.get("data") or {}
-        if etype in ("text_delta", "reasoning"):
-            pdata["content"] = (pdata.get("content") or "") + (edata.get("content") or "")
-        elif etype == "tool_call_delta":
-            pdata["args_delta"] = (pdata.get("args_delta") or "") + (edata.get("args_delta") or "")
+        piece = edata.get(self._pending.field) or ""
+        self._pending.pieces.append(piece)
+        self._pending.size += len(piece)
+        self._pending.last_event_id = event.event_id
+        if self._pending.payload["type"] == "tool_call_delta":
             # Latest non-None identity wins (mirrors the route-level backfill).
+            pdata = self._pending.payload["data"]
             if edata.get("tool_call_id") is not None:
                 pdata["tool_call_id"] = edata["tool_call_id"]
             if edata.get("name") is not None:
                 pdata["name"] = edata["name"]
+
+    def _finish(self) -> RunEvent:
+        assert self._pending is not None
+        p = self._pending
+        p.payload["data"][p.field] = "".join(p.pieces)
         # Stamp the last merged original id so frontend dedup stays monotonic.
-        self._pending.event_id = event.event_id
+        result = RunEvent(p.last_event_id, p.payload)
+        self._pending = None
+        return result
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
 
 Run: `cd backend && uv run pytest tests/unit/test_replay_coalescer.py -v`
-Expected: PASS (all 9 tests)
+Expected: PASS (all 10 tests)
 
 - [ ] **Step 5: Commit**
 

--- a/docs/dev/specs/2026-05-26-reconnect-replay-coalescing-design.md
+++ b/docs/dev/specs/2026-05-26-reconnect-replay-coalescing-design.md
@@ -1,0 +1,252 @@
+# Reconnect replay coalescing — design
+
+Date: 2026-05-26
+Status: approved (brainstorming), pending implementation plan
+
+## Problem
+
+When an agent run is producing a lot of output and the user refreshes the
+page mid-run, the browser freezes: it pops the "Page Unresponsive" dialog,
+and clicking "Wait" leaves the page stuck — clicks do nothing.
+
+### Root cause
+
+On refresh the frontend reconnects to the active run and **replays the entire
+event log from event 0**:
+
+- `messageStore.loadMessages` finds `active_run` in the bootstrap response and
+  reconnects via `consumeRunStream(..., lastEventId=undefined, ...)`
+  (`frontend/packages/core/src/stores/messageStore.ts:846`), resetting
+  `lastAppliedEventId` to `null` (`messageStore.ts:833`). bootstrap returns
+  `active_run.last_event_id` but it is **not used** — full replay is
+  intentional, because the in-flight assistant turn is not in the trimmed
+  bootstrap history (`trimHistoryForActiveRun`, `messageStore.ts:255`).
+- A long run emits tens of thousands of fine-grained `text_delta` /
+  `tool_call_delta` events. Each is folded by `applyStreamEvent` with
+  immutable spreads (`appendTextBlock` copies the blocks array,
+  `{...state.streamAgents}`, `{...toolResultMap}` —
+  `messageStore.ts:357-501`). Total client cost is **O(N²)** in event count,
+  plus a giant React re-render of the accumulated transcript.
+- The backend amplifies this: `iter_run_events` does a single
+  `redis.xrange(min, max)` over the whole stream (up to 1,000,000 events,
+  `run_manager.py:439`) and the replay loop yields every event with no pacing
+  (`conversations.py:327-338`).
+- The consume loop never yields to the event loop, so input/paint handlers
+  never run → the page is pinned → "Wait" re-enters the same blocked task.
+
+### What we are NOT doing (and why)
+
+An earlier idea was to render completed messages from the checkpointer and
+tail Redis from a cursor stamped into each checkpointed message (requiring a
+cubepi-generated run-scoped event id, an explicit-`XADD`-id scheme or a
+`token → stream-id` map, and special handling for compaction / synthetic /
+pre-migration messages). That precisely avoids *re-sending* completed content,
+but the freeze is not caused by re-sending — it is caused by re-sending
+**tens of thousands of 1-character deltas** and folding them O(N²) on the
+client. Coalescing the replayed events server-side removes the root cause with
+no cubepi change, no migration, and no checkpoint correlation. The
+checkpoint-cursor architecture is dropped.
+
+## Approach
+
+Two changes, server-side coalescing as the core fix and a frontend yield as a
+safety net.
+
+1. **Server-side replay coalescing (core).** When replaying the historical
+   backlog on reconnect, fold the fine-grained events into a compact set
+   before sending. Consecutive `text_delta` / `reasoning` per agent collapse
+   into one event; `tool_call_delta` per `(agent_id, index)` collapses into a
+   single `tool_call_streaming`; structural events pass through unchanged. The
+   replayed payload shrinks from tens of thousands of events to a few dozen.
+   The **live tail** (events after the reconnect snapshot point) stays
+   fine-grained so streaming feels smooth.
+
+2. **Frontend yield (safety net).** The consume loops yield to the event loop
+   periodically so the browser never shows "Page Unresponsive", even if a
+   single coalesced message is still very large.
+
+The replay read is **chunked and incremental** so the backend never blocks the
+asyncio event loop while handling a large backlog.
+
+## Component 1 — server-side replay coalescing
+
+### Where
+
+Only the **replay segment** of `event_generator`
+(`backend/cubebox/api/routes/v1/conversations.py:321-365`). The **live tail**
+segment (lines 341-365) is unchanged. The `done`/`error` short-circuit
+(`conversations.py:337`) is preserved.
+
+### `ReplayCoalescer` — stateful streaming folder
+
+A new pure (no IO) helper at `backend/cubebox/streams/replay_coalescer.py`,
+unit-testable in isolation. It is **streaming** (not list-in/list-out) so it can fold across
+read chunks without holding the whole backlog in memory:
+
+- `feed(events: list[RunEvent]) -> list[RunEvent]` — accept a chunk, return
+  the coalesced events that are now complete; hold in-progress runs in a
+  pending buffer.
+- `flush() -> list[RunEvent]` — emit everything still buffered (end of
+  replay).
+
+Pure-function equivalence holds: `feed(all) + flush()` produces the same
+output regardless of how `all` is split across `feed` calls.
+
+### Coalescing rules
+
+| Event type | Rule |
+|---|---|
+| `text_delta` | Per `agent_id`, concatenate `data.content` of a consecutive run into one event. |
+| `reasoning` | Per `agent_id`, concatenate `data.content` of a consecutive run into one event. |
+| `tool_call_delta` | Per `(agent_id, index)`, concatenate `data.args_delta` into one `tool_call_streaming`-shaped event (keeps a tool call that was mid-stream at the snapshot point visible). |
+| `tool_call`, `tool_result`, `usage`, `done`, `error`, `citation`, `artifact`, `injected_message`, `status` | Pass through unchanged. |
+
+A pending text/thinking run for an agent is flushed when a non-matching event
+for that agent arrives (different block type, or a structural event), or at
+`flush()`. A pending `tool_call_streaming` is flushed likewise.
+
+### Correctness
+
+1. Folding happens in stream order.
+2. The frontend already merges deltas into the **last block** of the agent's
+   stream (`appendTextBlock` / `appendThinkingBlock`,
+   `messageStore.ts:155-180`), so a few large coalesced events render
+   **identically** to many small ones. No frontend change in this component.
+3. Multi-agent interleaving: text/thinking runs accumulate **per `agent_id`**;
+   different agents never merge; relative order is preserved. Subagent events
+   (`agent_id="subagent:<tool_call_id>"`) fold independently from the main
+   agent.
+
+### Synthetic event ids
+
+Coalesced events have no real Redis entry id. Each emitted coalesced event is
+stamped with the `event_id` of the **last original event it merged**. This
+keeps the frontend's `compareEventIds` dedup monotonic
+(`messageStore.ts:95-106`): the first live-tail event's id is strictly greater
+than the last coalesced event's id, so nothing is wrongly deduped.
+
+### `done` / `error` in the replay segment
+
+The coalescer terminates immediately on `done`/`error`, emitting it as the
+final event; nothing after it is folded in. The route keeps its existing
+short-circuit `return`.
+
+### Chunked / incremental read (do not block the event loop)
+
+The current path loads the whole backlog at once: `iter_run_events` →
+`redis.xrange(min, max)` → `_decode_stream_entries` JSON-parses every entry
+synchronously (`run_events.py:413-421, 383-388`). For tens of thousands of
+events this is one large synchronous block that stalls the asyncio event loop
+and every other request on the worker.
+
+Change the replay segment to read in cursor-paginated chunks:
+
+- Add a chunked reader (e.g. `iter_run_events_chunked`) that pages with
+  `XRANGE (last_id <stop> COUNT N`, yielding one decoded batch at a time.
+  Do **not** change `iter_run_events` or its other callers.
+- Loop: read a chunk → `coalescer.feed(chunk)` → `yield` coalesced events →
+  advance cursor → repeat until the snapshot `target_event_id` is reached →
+  `coalescer.flush()` → `yield` remainder. Each `await xrange` returns control
+  to the event loop; memory is bounded to one chunk; the client starts
+  receiving coalesced output sooner.
+- `N` (chunk size) is a named constant, ≈1000, tunable.
+- The replay cursor advances by the **original** last event id seen (not a
+  synthetic coalesced id), so the live tail picks up exactly where the
+  snapshot ended — no gap, no duplicate.
+
+## Component 2 — frontend yield (safety net)
+
+### Where
+
+Both consume loops in `frontend/packages/core/src/stores/messageStore.ts`:
+`consumeRunStream` (`messageStore.ts:686`) and `send` (`messageStore.ts:924`).
+
+### Behavior
+
+Count processed events; every `YIELD_EVERY` events, yield to the event loop:
+
+```ts
+let processed = 0
+for await (const event of streamRun(...)) {
+  // existing artifact / citation / error / done / injected_message branches unchanged
+  batchedSet((s) => applyStreamEvent(s, event))
+  if (++processed % YIELD_EVERY === 0) {
+    await (globalThis.scheduler?.yield?.() ?? new Promise((r) => setTimeout(r)))
+  }
+}
+```
+
+- `YIELD_EVERY = 200` (named constant, tunable).
+- Prefer `scheduler.yield()` (less likely to be deprioritized); fall back to
+  `setTimeout(0)`.
+- The yield point sits **after** `batchedSet`, and must not split the
+  `injected_message` `flush()` → `__commitTurnAndInject` sequence
+  (`messageStore.ts:741-751`). Only yield between ordinary batched events.
+
+### Relationship to coalescing
+
+After coalescing, the normal case has few events and rarely reaches a yield
+point. The yield only matters when a single coalesced message is still very
+large (e.g. hundreds of thousands of characters) — then the worst case is
+"slow", not "frozen / unclickable". `send` gets the same treatment for
+consistency (zero cost; no backlog on a fresh turn).
+
+## Edge cases
+
+1. **Tool call mid-stream at reconnect.** Replay folds the arrived
+   `tool_call_delta`s into one `tool_call_streaming` (partial args); the live
+   tail continues the rest; the final `tool_call` event makes the frontend
+   replace the streaming block with the complete call
+   (`appendToolCallBlock`, `messageStore.ts:182-209`). No loss, eventually
+   consistent.
+2. **Empty stream / empty coalescer output.** `feed`/`flush` on no input
+   return nothing; existing live-tail / heartbeat logic runs unchanged.
+3. **compaction summary / synthetic / pre-migration messages.** Not special —
+   the replay reads the raw Redis stream and never correlates with the
+   checkpointer, so these "just work".
+4. **Chunk boundary splits a run.** Handled by the stateful coalescer: a
+   text/thinking run or a `tool_call_streaming` that spans chunks is held in
+   the pending buffer across `feed` calls and flushed at the right boundary.
+
+## Testing
+
+Per CLAUDE.md (E2E priority, incremental per-module tests). The reconnect E2E
+is intentionally **skipped** — the user will self-test the freeze-on-reload
+path manually.
+
+### Backend — `ReplayCoalescer` unit tests (primary)
+
+1. Consecutive `text_delta` (same agent) → one event, content concatenated.
+2. Consecutive `reasoning` (same agent) → one event, content concatenated.
+3. `tool_call_delta` per `(agent_id, index)` → one `tool_call_streaming`,
+   args concatenated (mid-stream tool call).
+4. `tool_call` / `tool_result` / `usage` / `done` / `error` / `citation` /
+   `artifact` / `injected_message` / `status` pass through unchanged.
+5. Multi-agent interleave: main + `subagent:<id>` fold independently, relative
+   order preserved.
+6. Coalesced event id = id of the last original event it merged (dedup
+   monotonicity).
+7. `done` / `error` terminates immediately and is the final event.
+8. Empty input → empty output.
+9. Text interrupted by a tool call → two separate text blocks (tool_call in
+   between).
+10. **Chunk-boundary invariance:** for the same event sequence, `feed`/`flush`
+    with arbitrary chunk splits yields the same output as feeding all at once
+    (especially text runs and `tool_call_streaming` spanning a boundary).
+
+### Frontend — yield loop unit test
+
+`consumeRunStream` processing more than `YIELD_EVERY` events hits a yield
+point (assert `scheduler.yield` / `setTimeout` invoked), and the yield does
+not break the `injected_message` flush/commit ordering.
+
+## Files touched
+
+- `backend/cubebox/streams/replay_coalescer.py` — `ReplayCoalescer` (new).
+- `backend/cubebox/streams/run_events.py` — add chunked reader; leave
+  `iter_run_events` and callers untouched.
+- `backend/cubebox/api/routes/v1/conversations.py` — replay segment of
+  `event_generator` uses the chunked reader + coalescer.
+- `frontend/packages/core/src/stores/messageStore.ts` — yield in both consume
+  loops.
+- Backend + frontend unit tests as above.

--- a/docs/dev/specs/2026-05-26-reconnect-replay-coalescing-design.md
+++ b/docs/dev/specs/2026-05-26-reconnect-replay-coalescing-design.md
@@ -137,6 +137,31 @@ arrives.
    preserved exactly. Subagent events (`agent_id="subagent:<tool_call_id>"`)
    thus fold independently from the main agent without ever reordering across
    each other.
+4. The accumulation itself must be O(N), not O(N²). A pending run holds its
+   delta pieces in a **list** and `"".join()`s once when the run is emitted —
+   never `accumulated = accumulated + delta` per event (that copies the whole
+   growing string each time and would re-introduce the very backend stall we
+   are removing).
+
+### Bounded coalesced size
+
+A pending text/thinking/tool-arg run is also flushed when its accumulated
+length reaches `MAX_COALESCED_CHARS` (a module constant, ~64 KiB), then a fresh
+run with the same key continues. So a single enormous message is emitted as a
+handful of bounded `text_delta` events rather than one giant one. This matters
+for two reasons:
+
+- It keeps each `"".join()` and each frontend reducer/render step bounded, and
+- it keeps the **frontend yield** (Component 2) effective: the yield is
+  count-based, so it only fires across multiple events. A single multi-hundred-
+  KB coalesced event would slip the net and still pin the main thread in one
+  `applyStreamEvent` + render. Capping size on the backend guarantees the
+  frontend always sees multiple bounded events for a large message.
+
+The split is invisible in the rendered transcript: the frontend merges
+consecutive same-agent `text_delta`s into the same block
+(`appendTextBlock`, `messageStore.ts:155-180`), so N bounded deltas render
+identically to one.
 
 ### Synthetic event ids
 
@@ -207,8 +232,11 @@ for await (const event of streamRun(...)) {
 ### Relationship to coalescing
 
 After coalescing, the normal case has few events and rarely reaches a yield
-point. The yield only matters when a single coalesced message is still very
-large (e.g. hundreds of thousands of characters) — then the worst case is
+point. The yield's effectiveness **depends on the backend size cap** (see
+"Bounded coalesced size"): because the yield is count-based, a single huge
+coalesced event would never trigger it. The cap guarantees a large message
+arrives as multiple bounded `text_delta`s, so the count yield fires between
+them and each `applyStreamEvent` + render step stays bounded — worst case is
 "slow", not "frozen / unclickable". `send` gets the same treatment for
 consistency (zero cost; no backlog on a fresh turn).
 
@@ -258,6 +286,10 @@ path manually.
     with arbitrary chunk splits yields the same output as feeding all at once
     (especially text runs and `tool_call_delta` accumulations spanning a
     boundary).
+11. **Size cap splits a huge run:** a single run far exceeding
+    `MAX_COALESCED_CHARS` is emitted as multiple bounded `text_delta` events
+    (each ≤ ~cap + one delta), and concatenating their content reproduces the
+    original — the one-huge-event case the frontend yield can't handle alone.
 
 ### Frontend — yield loop unit test
 

--- a/docs/dev/specs/2026-05-26-reconnect-replay-coalescing-design.md
+++ b/docs/dev/specs/2026-05-26-reconnect-replay-coalescing-design.md
@@ -56,7 +56,8 @@ safety net.
    backlog on reconnect, fold the fine-grained events into a compact set
    before sending. Consecutive `text_delta` / `reasoning` per agent collapse
    into one event; `tool_call_delta` per `(agent_id, index)` collapses into a
-   single `tool_call_streaming`; structural events pass through unchanged. The
+   single `tool_call_delta` (concatenated args); structural events pass
+   through unchanged. The
    replayed payload shrinks from tens of thousands of events to a few dozen.
    The **live tail** (events after the reconnect snapshot point) stays
    fine-grained so streaming feels smooth.
@@ -98,12 +99,30 @@ output regardless of how `all` is split across `feed` calls.
 |---|---|
 | `text_delta` | Per `agent_id`, concatenate `data.content` of a consecutive run into one event. |
 | `reasoning` | Per `agent_id`, concatenate `data.content` of a consecutive run into one event. |
-| `tool_call_delta` | Per `(agent_id, index)`, concatenate `data.args_delta` into one `tool_call_streaming`-shaped event (keeps a tool call that was mid-stream at the snapshot point visible). |
+| `tool_call_delta` | Per `(agent_id, index)`, concatenate `data.args_delta` into one event that stays `type: "tool_call_delta"` (keeps a tool call that was mid-stream at the snapshot point visible). **Not** `tool_call_streaming` — see below. |
 | `tool_call`, `tool_result`, `usage`, `done`, `error`, `citation`, `artifact`, `injected_message`, `status` | Pass through unchanged. |
 
-A pending text/thinking run for an agent is flushed when a non-matching event
-for that agent arrives (different block type, or a structural event), or at
-`flush()`. A pending `tool_call_streaming` is flushed likewise.
+**Flush is strictly stream-order, not per-agent.** A pending run (text /
+thinking for an agent, or a `tool_call_delta` accumulation for an
+`(agent_id, index)`) is flushed **before emitting any later event that would
+pass it in stream order** — i.e. coalesce only *adjacent* same-key deltas,
+never across an intervening event belonging to a different agent or key. This
+is the critical correctness rule: the frontend applies replayed events in SSE
+order and dedups by `event_id`, so merging a run *across* an intervening event
+would reorder or drop visible content. Concretely, for `main e1`, `subagent
+e2`, `main e3`, the coalescer flushes the `main` pending run (`e1`) before
+emitting `e2`, then starts a fresh `main` run for `e3` — yielding `e1`, `e2`,
+`e3` in order, never `e1+e3` around `e2`. All pending runs are also flushed at
+`flush()`.
+
+The `tool_call_delta` coalescing keeps the SSE `type` as `tool_call_delta`
+(with concatenated `args_delta`), **not** `tool_call_streaming`.
+`tool_call_streaming` is a frontend *content-block* type, not an SSE event
+type — `applyStreamEvent` only consumes `tool_call_delta` and builds the
+`tool_call_streaming` block locally (`messageStore.ts:422`). Emitting a
+`tool_call_streaming` event would be ignored by the frontend, so the
+already-streamed args prefix would not render until the final `tool_call`
+arrives.
 
 ### Correctness
 
@@ -112,10 +131,12 @@ for that agent arrives (different block type, or a structural event), or at
    stream (`appendTextBlock` / `appendThinkingBlock`,
    `messageStore.ts:155-180`), so a few large coalesced events render
    **identically** to many small ones. No frontend change in this component.
-3. Multi-agent interleaving: text/thinking runs accumulate **per `agent_id`**;
-   different agents never merge; relative order is preserved. Subagent events
-   (`agent_id="subagent:<tool_call_id>"`) fold independently from the main
-   agent.
+3. Multi-agent interleaving: a pending run is keyed per `agent_id`, but is
+   flushed the moment any event of a different key arrives (the strict
+   stream-order rule above), so different agents never merge and SSE order is
+   preserved exactly. Subagent events (`agent_id="subagent:<tool_call_id>"`)
+   thus fold independently from the main agent without ever reordering across
+   each other.
 
 ### Synthetic event ids
 
@@ -194,19 +215,21 @@ consistency (zero cost; no backlog on a fresh turn).
 ## Edge cases
 
 1. **Tool call mid-stream at reconnect.** Replay folds the arrived
-   `tool_call_delta`s into one `tool_call_streaming` (partial args); the live
-   tail continues the rest; the final `tool_call` event makes the frontend
-   replace the streaming block with the complete call
-   (`appendToolCallBlock`, `messageStore.ts:182-209`). No loss, eventually
-   consistent.
+   `tool_call_delta`s into one `tool_call_delta` event (concatenated
+   `args_delta`, same `type`); the frontend builds the `tool_call_streaming`
+   block locally from it; the live tail continues the rest; the final
+   `tool_call` event makes the frontend replace the streaming block with the
+   complete call (`appendToolCallBlock`, `messageStore.ts:182-209`). No loss,
+   eventually consistent.
 2. **Empty stream / empty coalescer output.** `feed`/`flush` on no input
    return nothing; existing live-tail / heartbeat logic runs unchanged.
 3. **compaction summary / synthetic / pre-migration messages.** Not special —
    the replay reads the raw Redis stream and never correlates with the
    checkpointer, so these "just work".
 4. **Chunk boundary splits a run.** Handled by the stateful coalescer: a
-   text/thinking run or a `tool_call_streaming` that spans chunks is held in
-   the pending buffer across `feed` calls and flushed at the right boundary.
+   text/thinking run or a `tool_call_delta` accumulation that spans chunks is
+   held in the pending buffer across `feed` calls and flushed at the right
+   boundary.
 
 ## Testing
 
@@ -218,12 +241,13 @@ path manually.
 
 1. Consecutive `text_delta` (same agent) → one event, content concatenated.
 2. Consecutive `reasoning` (same agent) → one event, content concatenated.
-3. `tool_call_delta` per `(agent_id, index)` → one `tool_call_streaming`,
-   args concatenated (mid-stream tool call).
+3. `tool_call_delta` per `(agent_id, index)` → one `tool_call_delta` (same
+   `type`), `args_delta` concatenated (mid-stream tool call).
 4. `tool_call` / `tool_result` / `usage` / `done` / `error` / `citation` /
    `artifact` / `injected_message` / `status` pass through unchanged.
-5. Multi-agent interleave: main + `subagent:<id>` fold independently, relative
-   order preserved.
+5. Multi-agent interleave preserves stream order: `main e1`, `subagent e2`,
+   `main e3` → emits `e1`, `e2`, `e3` (the `main` run is flushed before `e2`),
+   **never** `e1+e3` merged around or after `e2`.
 6. Coalesced event id = id of the last original event it merged (dedup
    monotonicity).
 7. `done` / `error` terminates immediately and is the final event.
@@ -232,7 +256,8 @@ path manually.
    between).
 10. **Chunk-boundary invariance:** for the same event sequence, `feed`/`flush`
     with arbitrary chunk splits yields the same output as feeding all at once
-    (especially text runs and `tool_call_streaming` spanning a boundary).
+    (especially text runs and `tool_call_delta` accumulations spanning a
+    boundary).
 
 ### Frontend — yield loop unit test
 

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -34,6 +34,14 @@ import {
 import { useCitationStore } from './citationStore'
 import { useConversationStore } from './conversationStore'
 
+const YIELD_EVERY = 200
+
+function yieldToEventLoop(): Promise<void> {
+  const sched = (globalThis as { scheduler?: { yield?: () => Promise<void> } }).scheduler
+  if (sched && typeof sched.yield === 'function') return sched.yield()
+  return new Promise((resolve) => setTimeout(resolve))
+}
+
 export interface AgentStream {
   text: string
   toolCalls: ToolCallEvent[]
@@ -681,6 +689,7 @@ async function consumeRunStream(
   )
   let shouldFinalize = true
   let sawDone = false
+  let processed = 0
 
   try {
     for await (const event of streamRun(client, conversationId, runId, lastEventId, signal)) {
@@ -751,6 +760,9 @@ async function consumeRunStream(
       }
 
       batchedSet((s) => applyStreamEvent(s, event))
+      if (++processed % YIELD_EVERY === 0) {
+        await yieldToEventLoop()
+      }
     }
   } catch (err) {
     set({ error: (err as Error).message })
@@ -919,6 +931,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       controller.signal,
     )
 
+    let processed = 0
     try {
       outer: for (;;) {
         for await (const event of streamSource) {
@@ -996,6 +1009,9 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
           }
 
           batchedSet((s) => applyStreamEvent(s, event))
+          if (++processed % YIELD_EVERY === 0) {
+            await yieldToEventLoop()
+          }
         }
         break outer
       }

--- a/frontend/packages/web/__tests__/stores/messageStore.yield.test.ts
+++ b/frontend/packages/web/__tests__/stores/messageStore.yield.test.ts
@@ -1,0 +1,61 @@
+import { act } from '@testing-library/react'
+import { useMessageStore } from '@cubebox/core'
+
+const CONV_ID = 'conv-yield'
+
+function mockSSEResponse(events: object[]) {
+  const lines = events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join('')
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(lines))
+      controller.close()
+    },
+  })
+  return new Response(stream, { headers: { 'content-type': 'text/event-stream' } })
+}
+
+const mockClient = { baseUrl: '', get: vi.fn(), post: vi.fn(), resolvePath: (p: string) => p }
+
+beforeEach(() => {
+  vi.useRealTimers()
+  useMessageStore.setState({
+    messages: {},
+    streamAgents: {},
+    isStreaming: false,
+    streamingConversationId: null,
+    currentRunId: null,
+    lastAppliedEventId: null,
+    statusPhase: null,
+    error: null,
+    todos: [],
+    toolStartedMap: {},
+    toolResultMap: {},
+  })
+})
+
+it('yields to the event loop when processing many events', async () => {
+  const events: object[] = Array.from({ length: 250 }, (_, i) => ({
+    type: 'text_delta',
+    data: { content: 'x' },
+    agent_id: null,
+    agent_name: null,
+    timestamp: '',
+    event_id: `${i + 1}-0`,
+  }))
+  events.push({ type: 'done', data: {}, agent_id: null, agent_name: null, timestamp: '' })
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => mockSSEResponse(events)),
+  )
+  // Force the setTimeout fallback path (no scheduler.yield in jsdom).
+  vi.stubGlobal('scheduler', undefined)
+  const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+
+  await act(async () => {
+    await useMessageStore.getState().send(mockClient as never, CONV_ID, 'hi')
+  })
+
+  expect(setTimeoutSpy).toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary

Refreshing the page mid-run during a busy agent run froze the browser ("Page Unresponsive"; clicking Wait left it stuck). On reconnect the backend replayed the entire Redis event stream (tens of thousands of 1-char `text_delta`/`tool_call_delta`) and the frontend folded them O(N²) on the main thread.

This PR fixes the root cause server-side and adds a frontend safety net:

- **`ReplayCoalescer`** (`backend/cubebox/streams/replay_coalescer.py`) — folds adjacent same-key delta events (per `agent_id`; `tool_call_delta` per `(agent_id, index)`) into a compact, stream-order-preserving set. O(N) (list + single join), with a `MAX_COALESCED_CHARS` cap so one huge message becomes several bounded `text_delta`s. Structural events pass through; coalesced events keep the last-merged `event_id` for frontend dedup.
- **`iter_run_events_chunked`** (`backend/cubebox/streams/run_events.py`) — paginated batch reader so the replay no longer loads the whole backlog at once and never stalls the asyncio loop.
- **Stream route** (`conversations.py`) — replay segment now reads in chunks and feeds the coalescer; live tail unchanged; cursor advances by the original last id per batch.
- **Frontend yield** (`messageStore.ts`) — both consume loops yield to the event loop every 200 events (`scheduler.yield()` → `setTimeout` fallback), so the worst case is "slow", not "frozen".

No cubepi changes, no checkpoint correlation, no migration. compaction/synthetic/old-run cases need no special handling because we read the raw Redis stream.

Spec: `docs/dev/specs/2026-05-26-reconnect-replay-coalescing-design.md`
Plan: `docs/dev/plans/2026-05-26-reconnect-replay-coalescing.md`

## Test plan

- [x] `ReplayCoalescer` unit tests (10): merge text/reasoning/tool-arg, structural pass-through, interleave order, chunk-boundary invariance, size-cap split, done/error, empty
- [x] `iter_run_events_chunked` tests (3): paginated order, exclusive start, empty
- [x] frontend yield test: >200 events triggers a yield; existing `useMessages` tests green
- [x] mypy + ruff clean on changed backend files
- [ ] Manual self-test: reload mid-run, confirm page stays interactive and transcript completes (E2E intentionally skipped per spec)