### PR TITLE
fix(streams): restore live tool_call_delta streaming + fresh-checkout reload crash

### DIFF
--- a/backend/cubebox/agents/stream.py
+++ b/backend/cubebox/agents/stream.py
@@ -78,7 +78,20 @@ def convert_event_to_sse(evt: StreamEvent) -> list[dict[str, Any]]:
         return [{"type": "reasoning", "delta": evt.delta or ""}]
 
     if t == "toolcall_delta":
-        return [{"type": "tool_call_delta", "delta": evt.delta or ""}]
+        out: dict[str, Any] = {
+            "type": "tool_call_delta",
+            "delta": evt.delta or "",
+            "index": evt.content_index,
+        }
+        if evt.partial is not None and evt.content_index is not None:
+            try:
+                block = evt.partial.content[evt.content_index]
+            except (IndexError, TypeError):
+                block = None
+            if isinstance(block, ToolCall):
+                out["id"] = block.id
+                out["name"] = block.name
+        return [out]
 
     if t == "toolcall_end":
         if evt.partial is None or evt.content_index is None:

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -245,14 +245,14 @@ def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent 
     into a typed cubebox ``AgentEvent``.
 
     Returns ``None`` for dicts that should be silently dropped at this layer
-    (tool_call_delta — frontend only consumes complete tool_call; done — the
-    caller emits done with usage data; unknown types).
+    (done — the caller emits done with usage data; unknown types).
     """
     from cubebox.agents.schemas import (
         ErrorEvent,
         InjectedMessageEvent,
         ReasoningEvent,
         TextDeltaEvent,
+        ToolCallDeltaEvent,
         ToolCallEvent,
         ToolResultEvent,
         UsageEvent,
@@ -273,6 +273,16 @@ def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent 
         return ReasoningEvent(
             timestamp=timestamp,
             data={"content": d.get("delta", "")},
+        )
+    if t == "tool_call_delta":
+        return ToolCallDeltaEvent(
+            timestamp=timestamp,
+            data={
+                "tool_call_id": d.get("id"),
+                "name": d.get("name"),
+                "args_delta": d.get("delta", ""),
+                "index": d.get("index"),
+            },
         )
     if t == "tool_call":
         return ToolCallEvent(

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,15 +19,21 @@ if __name__ == "__main__":
         # exclude as a whole-subtree skip when it's an existing absolute dir
         # (it checks `dir in path.parents`); a glob like ".venv/*" only matches
         # one level and misses .venv/lib64/.../x.py, so anchor to absolute paths.
+        #
+        # An absolute exclude that doesn't exist yet is fatal, not ignored:
+        # uvicorn falls back to `Path.cwd().glob(pattern)`, and pathlib refuses
+        # an absolute glob pattern (NotImplementedError on 3.13). cubepi-traces
+        # is gitignored and created lazily on the first agent run, so a fresh
+        # checkout / worktree would crash on `python main.py` before it exists.
+        # mkdir it up front so the existing-dir short-circuit always applies.
         backend_dir = Path(__file__).resolve().parent
+        excluded_dirs = [backend_dir / ".venv", backend_dir / "cubepi-traces"]
+        for d in excluded_dirs:
+            d.mkdir(parents=True, exist_ok=True)
         reload_kwargs = {
             "reload_dirs": [str(backend_dir)],
             "reload_includes": ["*.py", "config*.yaml", ".env"],
-            "reload_excludes": [
-                str(backend_dir / ".venv"),
-                str(backend_dir / "cubepi-traces"),
-                "*.py[cod]",
-            ],
+            "reload_excludes": [str(d) for d in excluded_dirs] + ["*.py[cod]"],
         }
 
     uvicorn.run(

--- a/backend/tests/unit/test_run_manager_cubepi_dict_to_event.py
+++ b/backend/tests/unit/test_run_manager_cubepi_dict_to_event.py
@@ -13,6 +13,7 @@ from cubebox.agents.schemas import (
     ErrorEvent,
     ReasoningEvent,
     TextDeltaEvent,
+    ToolCallDeltaEvent,
     ToolCallEvent,
     ToolResultEvent,
     UsageEvent,
@@ -126,10 +127,41 @@ def test_done_dict_returns_none() -> None:
     assert cubepi_dict_to_agent_event({"type": "done"}, TS) is None
 
 
-def test_tool_call_delta_dict_returns_none() -> None:
-    """``tool_call_delta`` dicts are dropped — the frontend consumes the
-    complete ``tool_call`` once toolcall_end arrives."""
-    assert cubepi_dict_to_agent_event({"type": "tool_call_delta", "delta": "{"}, TS) is None
+def test_tool_call_delta_dict_maps_to_tool_call_delta_event() -> None:
+    """``tool_call_delta`` carries the streaming arg chunk plus the identity
+    (index/id/name) the frontend needs to route it to the right card so the
+    file_write / subagent preview streams live instead of appearing only at
+    toolcall_end."""
+    evt = cubepi_dict_to_agent_event(
+        {
+            "type": "tool_call_delta",
+            "delta": '{"path": "a.txt"',
+            "index": 2,
+            "id": "tc_1",
+            "name": "file_write",
+        },
+        TS,
+    )
+    assert isinstance(evt, ToolCallDeltaEvent)
+    assert evt.data == {
+        "tool_call_id": "tc_1",
+        "name": "file_write",
+        "args_delta": '{"path": "a.txt"',
+        "index": 2,
+    }
+
+
+def test_tool_call_delta_dict_without_identity_is_tolerated() -> None:
+    """Mid-stream chunks may omit id/name (only the first chunk carries them);
+    the event still maps, with nulls the frontend backfills by index."""
+    evt = cubepi_dict_to_agent_event({"type": "tool_call_delta", "delta": ": 1}", "index": 2}, TS)
+    assert isinstance(evt, ToolCallDeltaEvent)
+    assert evt.data == {
+        "tool_call_id": None,
+        "name": None,
+        "args_delta": ": 1}",
+        "index": 2,
+    }
 
 
 def test_unknown_type_returns_none() -> None:

--- a/backend/tests/unit/test_stream.py
+++ b/backend/tests/unit/test_stream.py
@@ -65,6 +65,43 @@ def test_toolcall_delta_emits_tool_call_delta() -> None:
     out = convert_event_to_sse(evt)
     assert out[0]["type"] == "tool_call_delta"
     assert out[0]["delta"] == '{"q": "x"'
+    # identity carried so the live SSE path can route the chunk to its card
+    assert out[0]["index"] == 0
+    assert out[0]["id"] == "tc1"
+    assert out[0]["name"] == "search"
+
+
+def test_live_chain_toolcall_delta_reaches_frontend_shape() -> None:
+    """End-to-end live seam: a streamed ``toolcall_delta`` must survive both
+    translation hops (``convert_agent_event_to_sse`` then
+    ``cubepi_dict_to_agent_event``) and arrive as a ``ToolCallDeltaEvent`` in
+    the exact shape the frontend reducer consumes. This is the regression that
+    broke during the langgraph→cubepi migration: the live drainer dropped
+    tool_call_delta, so file_write / subagent previews only appeared at
+    toolcall_end instead of streaming."""
+    from cubepi.agent.types import MessageUpdateEvent
+
+    from cubebox.agents.schemas import ToolCallDeltaEvent
+    from cubebox.streams.run_manager import cubepi_dict_to_agent_event
+
+    partial = _mk_assistant(tool_calls=[ToolCall(id="tc1", name="file_write", arguments={})])
+    stream_evt = StreamEvent(
+        type="toolcall_delta",
+        delta='{"path": "a.txt"',
+        partial=partial,
+        content_index=0,
+    )
+    dicts = convert_agent_event_to_sse(MessageUpdateEvent(message=partial, stream_event=stream_evt))
+    assert len(dicts) == 1
+
+    evt = cubepi_dict_to_agent_event(dicts[0], "2026-05-27T00:00:00+00:00")
+    assert isinstance(evt, ToolCallDeltaEvent)
+    assert evt.data == {
+        "tool_call_id": "tc1",
+        "name": "file_write",
+        "args_delta": '{"path": "a.txt"',
+        "index": 0,
+    }
 
 
 def test_done_translates_to_done() -> None:


### PR DESCRIPTION
## Summary

Two backend fixes, both surfaced while diagnosing why kimi-k2.6 tool-call previews (file_write, spawn subagent) stopped streaming.

### 1. Live `tool_call_delta` streaming (the reported regression)

The langgraph→cubepi migration routed the live SSE path through `cubepi_dict_to_agent_event`, which had **no `tool_call_delta` branch** and dropped every streaming arg chunk. The frontend builds its tool-call preview (`tool_call_streaming.args_text`) **solely** from `tool_call_delta`, so file_write / subagent previews only appeared in one batch at `toolcall_end` instead of streaming live. Provider-agnostic — affected every model, not just kimi.

- `agents/stream.py`: `toolcall_delta` now carries identity (`index`/`id`/`name` from the partial `ToolCall`) so the live path can route each chunk to its card.
- `streams/run_manager.py`: `cubepi_dict_to_agent_event` maps `tool_call_delta` → `ToolCallDeltaEvent` in the exact shape the frontend reducer consumes; removed the stale "frontend only consumes complete tool_call" comment.
- Frontend unchanged — it already expected this shape.

### 2. Fresh-checkout reload crash (found while bringing up the stack)

`main.py` passed **absolute** `reload_excludes`. uvicorn only short-circuits an absolute exclude when it's an *existing* dir; otherwise it falls back to `Path.cwd().glob(pattern)`, and pathlib rejects an absolute glob pattern (`NotImplementedError` on 3.13, `ValueError` earlier). `cubepi-traces` is gitignored and created lazily on the first agent run, so `python main.py` crashed on any fresh worktree/clone with reload enabled, before the first run. Fix: `mkdir(exist_ok=True)` the excluded dirs up front. (main.py isn't type-checked by CI; its pre-existing mypy notes are unrelated.)

## Test plan

- [x] New `test_live_chain_toolcall_delta_reaches_frontend_shape` drives the full live seam (`MessageUpdateEvent(toolcall_delta)` → `convert_agent_event_to_sse` → `cubepi_dict_to_agent_event` → typed `ToolCallDeltaEvent`).
- [x] Updated the test that previously froze the buggy drop behavior; added mid-stream (no-identity) chunk coverage.
- [x] Full backend unit suite green (851 passed); `mypy cubebox/` clean.
- [x] Reload fix verified by reproducing the exact `NotImplementedError` against the old exclude list and a clean boot (reload on, traces dir absent) with the new one.
- [x] **Live browser run** (kimi-k2.6, worktree stack): write_file preview grows progressively mid-stream — body text +~80–90 chars/1.5s, tail advancing through the essay — confirming `tool_call_delta` reaches the UI live.