### PR TITLE
fix(subagents): attach Tracer to inner agent + bump cubepi for nested traces

### DIFF
--- a/backend/cubebox/middleware/subagents.py
+++ b/backend/cubebox/middleware/subagents.py
@@ -92,6 +92,7 @@ class SubAgentMiddleware(Middleware):
         default_provider_name: str,
         shared_tools: Sequence[AgentTool[Any]] = (),
         inherited_middleware: Sequence[Any] = (),
+        tracer: Any = None,
     ) -> None:
         # Ensure general-purpose fallback is always available
         if "general-purpose" not in subagent_map:
@@ -113,6 +114,7 @@ class SubAgentMiddleware(Middleware):
             t for t in shared_tools if t.name not in _excluded
         )
         self._inherited_middleware: tuple[Any, ...] = tuple(inherited_middleware)
+        self._tracer = tracer
 
         self.tools: list[AgentTool[Any]] = [self._make_subagent_tool()]
 
@@ -232,25 +234,44 @@ class SubAgentMiddleware(Middleware):
 
             inner.subscribe(_listener)
 
-            try:
-                await inner.prompt(args.prompt)
-            except Exception as exc:
-                logger.error(
-                    "Subagent '{}' failed (tool_call_id={}): {}",
-                    args.subagent_type,
-                    tool_call_id,
-                    exc,
-                )
-                return AgentToolResult(
-                    content=[TextContent(text=f"[error: {exc}]")],
-                    is_error=True,
-                )
+            # Attach the process-level Tracer so the inner subagent run is
+            # recorded. Best-effort: tracing must never break the run.
+            detach: Any = None
+            if self._tracer is not None:
+                try:
+                    detach = self._tracer.attach(inner)
+                except Exception as exc:
+                    logger.debug("subagent tracer.attach failed: {}", exc)
+                    detach = None
 
-            final_content = "".join(last_ai_text) or "[subagent produced no output]"
-            return AgentToolResult(
-                content=[TextContent(text=final_content)],
-                details={"subagent_events": subagent_events},
-            )
+            try:
+                try:
+                    await inner.prompt(args.prompt)
+                except Exception as exc:
+                    logger.error(
+                        "Subagent '{}' failed (tool_call_id={}): {}",
+                        args.subagent_type,
+                        tool_call_id,
+                        exc,
+                    )
+                    return AgentToolResult(
+                        content=[TextContent(text=f"[error: {exc}]")],
+                        is_error=True,
+                    )
+
+                final_content = "".join(last_ai_text) or "[subagent produced no output]"
+                return AgentToolResult(
+                    content=[TextContent(text=final_content)],
+                    details={"subagent_events": subagent_events},
+                )
+            finally:
+                if detach is not None:
+                    try:
+                        res = detach()
+                        if res is not None:
+                            await res
+                    except Exception as exc:
+                        logger.debug("subagent tracer.detach failed: {}", exc)
 
         return AgentTool(
             name="subagent",

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1298,6 +1298,7 @@ class RunManager:
                 # as shared tools for subagent spawning.
                 shared_tools=_sandbox_tools + _artifact_tools + _builtin_tools,
                 inherited_middleware=_cost_mw_for_inherit,
+                tracer=getattr(self._app.state, "tracer", None),
             )
             cubepi_middleware.append(subagent_mw)
             _subagent_tools.extend(subagent_mw.tools)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -161,10 +161,11 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-# da9d792 is cubepi main HEAD: adds Agent.cancel_steer / _MessageQueue.remove
-# (#120) for the steer-cancel feature, on top of turn-boundary steering drain
-# (#117) + the cancel-orphan-tool-results fix (#116).
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "da9d792" }
+# 9cb6817 is cubepi main HEAD: subagent runs now nest under their
+# execute_tool span (#122 — per-task active-run gate, invoke_agent parented at
+# the active tool span, JSONL sharded by trace_id) + span_id in trace view
+# (#121), on top of the steer-cancel feature (#120).
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "9cb6817" }
 
 [dependency-groups]
 dev = [

--- a/backend/tests/unit/test_subagent_trace.py
+++ b/backend/tests/unit/test_subagent_trace.py
@@ -1,0 +1,170 @@
+"""Unit tests for SubAgentMiddleware tracer attach/detach wiring (Task 4).
+
+The middleware spawns an inner cubepi.Agent and runs ``await inner.prompt``.
+A process-level ``Tracer`` is threaded in via the ``tracer=`` kwarg; the
+middleware must ``tracer.attach(inner)`` around the inner run and always
+detach in ``finally`` — best-effort, so tracing can never break the run.
+
+These tests use a ``_FakeTracer`` and reuse the construction/invocation
+pattern from ``test_subagents.py``. They do NOT depend on the cubepi-side
+run-nesting changes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from cubepi.providers.faux import FauxProvider, faux_assistant_message
+
+from cubebox.middleware.subagents import SubAgent, SubAgentMiddleware
+
+
+class _FakeTracer:
+    def __init__(self) -> None:
+        self.attached: list[Any] = []
+        self.detached = 0
+
+    def attach(self, agent: Any) -> Any:
+        self.attached.append(agent)
+
+        def _detach() -> None:  # mirror cubepi Tracer.attach: sync, may return awaitable
+            self.detached += 1
+            return None
+
+        return _detach
+
+
+def _make_mw(
+    tracer: Any,
+    *,
+    provider: FauxProvider | None = None,
+) -> SubAgentMiddleware:
+    if provider is None:
+        provider = FauxProvider()
+    subagent_map = {
+        "general-purpose": SubAgent(
+            name="general-purpose",
+            description="general",
+            system_prompt="You are a sub.",
+        )
+    }
+    return SubAgentMiddleware(
+        subagent_map=subagent_map,
+        default_provider=provider,
+        default_model_id="test-model",
+        default_provider_name="faux",
+        tracer=tracer,
+    )
+
+
+def _args(sub_tool: Any, prompt: str) -> Any:
+    return sub_tool.parameters(
+        name="x",
+        role="r",
+        task="t",
+        prompt=prompt,
+        subagent_type="general-purpose",
+    )
+
+
+@pytest.mark.asyncio
+async def test_subagent_attaches_and_detaches_tracer_on_success() -> None:
+    """Inner run completes normally: tracer attached once, detached once."""
+    tracer = _FakeTracer()
+    provider = FauxProvider()
+    provider.set_responses([faux_assistant_message("subagent reply")])
+
+    mw = _make_mw(tracer, provider=provider)
+    [sub_tool] = mw.tools
+
+    result = await sub_tool.execute(
+        "tc-1", _args(sub_tool, "please reply"), signal=None, on_update=None
+    )
+
+    assert not result.is_error
+    assert len(tracer.attached) == 1
+    assert tracer.detached == 1
+
+
+@pytest.mark.asyncio
+async def test_subagent_detaches_tracer_when_inner_run_fails() -> None:
+    """Inner run raises a normal Exception: tool returns is_error, still detaches."""
+    tracer = _FakeTracer()
+    provider = FauxProvider()
+    mw = _make_mw(tracer, provider=provider)
+    [sub_tool] = mw.tools
+
+    with patch("cubebox.agents.graph.create_cubebox_agent") as mock_factory:
+        mock_agent = AsyncMock()
+        mock_agent.subscribe = lambda listener: lambda: None
+        mock_agent.prompt = AsyncMock(side_effect=RuntimeError("inner boom"))
+        mock_factory.return_value = mock_agent
+
+        result = await sub_tool.execute(
+            "tc-2", _args(sub_tool, "break please"), signal=None, on_update=None
+        )
+
+    assert result.is_error is True
+    assert "inner boom" in result.content[0].text
+    assert len(tracer.attached) == 1
+    assert tracer.detached == 1
+
+
+@pytest.mark.asyncio
+async def test_subagent_detaches_tracer_when_inner_run_cancelled() -> None:
+    """Inner run raises CancelledError (BaseException): propagates but finally detaches."""
+    tracer = _FakeTracer()
+    provider = FauxProvider()
+    mw = _make_mw(tracer, provider=provider)
+    [sub_tool] = mw.tools
+
+    with patch("cubebox.agents.graph.create_cubebox_agent") as mock_factory:
+        mock_agent = AsyncMock()
+        mock_agent.subscribe = lambda listener: lambda: None
+        mock_agent.prompt = AsyncMock(side_effect=asyncio.CancelledError())
+        mock_factory.return_value = mock_agent
+
+        with pytest.raises(asyncio.CancelledError):
+            await sub_tool.execute(
+                "tc-3", _args(sub_tool, "cancel please"), signal=None, on_update=None
+            )
+
+    assert len(tracer.attached) == 1
+    assert tracer.detached == 1
+
+
+def test_run_manager_passes_process_tracer_to_subagent_middleware() -> None:
+    """The process Tracer read off ``app.state.tracer`` reaches the middleware.
+
+    Fully driving run_manager's construction site requires standing up the
+    whole run pipeline (provider resolution, tool collection, conversation
+    context), so per the task fallback we assert narrowly: a tracer read via
+    the same ``getattr(app.state, "tracer", None)`` pattern run_manager uses
+    flows through the ``tracer=`` kwarg into ``SubAgentMiddleware._tracer``.
+    This guards the kwarg name and storage; the literal run_manager line is
+    covered by inspection (see report).
+    """
+    sentinel = object()
+
+    class _State:
+        tracer = sentinel
+
+    class _App:
+        state = _State()
+
+    app = _App()
+
+    mw = SubAgentMiddleware(
+        subagent_map={},
+        default_provider=FauxProvider(),
+        default_model_id="test-model",
+        default_provider_name="faux",
+        shared_tools=[],
+        inherited_middleware=[],
+        tracer=getattr(app.state, "tracer", None),
+    )
+
+    assert mw._tracer is sentinel

--- a/backend/tests/unit/test_subagent_trace.py
+++ b/backend/tests/unit/test_subagent_trace.py
@@ -30,9 +30,34 @@ class _FakeTracer:
     def attach(self, agent: Any) -> Any:
         self.attached.append(agent)
 
-        def _detach() -> None:  # mirror cubepi Tracer.attach: sync, may return awaitable
+        def _detach() -> None:  # this fake's detach is sync (returns None)
             self.detached += 1
             return None
+
+        return _detach
+
+
+class _AwaitableDetachTracer:
+    """Fake whose ``detach()`` returns an awaitable — mirrors the real
+    cubepi ``Tracer.attach`` contract, where ``detach()`` runs sync cleanup
+    then returns the scheduled-flush ``asyncio.Task``. Exercises the
+    ``if res is not None: await res`` branch in the middleware's finally."""
+
+    def __init__(self) -> None:
+        self.attached: list[Any] = []
+        self.detached = 0
+        self.awaited = False
+
+    def attach(self, agent: Any) -> Any:
+        self.attached.append(agent)
+
+        def _detach() -> Any:
+            self.detached += 1
+
+            async def _flush() -> None:
+                self.awaited = True
+
+            return _flush()
 
         return _detach
 
@@ -90,6 +115,26 @@ async def test_subagent_attaches_and_detaches_tracer_on_success() -> None:
 
 
 @pytest.mark.asyncio
+async def test_subagent_awaits_awaitable_detach() -> None:
+    """When detach() returns an awaitable (the real Tracer schedules a flush
+    Task), the middleware awaits it in finally."""
+    tracer = _AwaitableDetachTracer()
+    provider = FauxProvider()
+    provider.set_responses([faux_assistant_message("subagent reply")])
+
+    mw = _make_mw(tracer, provider=provider)
+    [sub_tool] = mw.tools
+
+    result = await sub_tool.execute(
+        "tc-await", _args(sub_tool, "please reply"), signal=None, on_update=None
+    )
+
+    assert not result.is_error
+    assert tracer.detached == 1
+    assert tracer.awaited is True, "awaitable returned by detach() was not awaited"
+
+
+@pytest.mark.asyncio
 async def test_subagent_detaches_tracer_when_inner_run_fails() -> None:
     """Inner run raises a normal Exception: tool returns is_error, still detaches."""
     tracer = _FakeTracer()
@@ -139,13 +184,15 @@ async def test_subagent_detaches_tracer_when_inner_run_cancelled() -> None:
 def test_run_manager_passes_process_tracer_to_subagent_middleware() -> None:
     """The process Tracer read off ``app.state.tracer`` reaches the middleware.
 
-    Fully driving run_manager's construction site requires standing up the
-    whole run pipeline (provider resolution, tool collection, conversation
-    context), so per the task fallback we assert narrowly: a tracer read via
-    the same ``getattr(app.state, "tracer", None)`` pattern run_manager uses
-    flows through the ``tracer=`` kwarg into ``SubAgentMiddleware._tracer``.
-    This guards the kwarg name and storage; the literal run_manager line is
-    covered by inspection (see report).
+    Driving run_manager's real construction site is impractical because the
+    surrounding setup (provider resolution, tool collection, conversation
+    context) is heavy to stand up in a unit test — not because of the lazy
+    import (that re-resolves the module-level class and is patchable). So we
+    assert narrowly: a tracer read via the same
+    ``getattr(app.state, "tracer", None)`` pattern run_manager uses flows
+    through the ``tracer=`` kwarg into ``SubAgentMiddleware._tracer``. This
+    guards the kwarg name and storage; the literal run_manager line is covered
+    by inspection.
     """
     sentinel = object()
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -844,7 +844,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "tracing", "tracing-otlp", "trace-cli"], git = "https://github.com/cubeplexai/cubepi.git?rev=da9d792" },
+    { name = "cubepi", extras = ["mcp", "postgres", "tracing", "tracing-otlp", "trace-cli"], git = "https://github.com/cubeplexai/cubepi.git?rev=9cb6817" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -891,7 +891,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.5.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=da9d792#da9d7925d6c2eef3eea9dacada4e0613cd4223b1" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=9cb6817#9cb6817168a578026eda94b1982b08f1a938ea01" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },


### PR DESCRIPTION
## Summary
Subagent runs were invisible to tracing: the inner `cubepi.Agent` spawned by `SubAgentMiddleware` was never attached to the process Tracer, so its turn/tool spans were missing and its chat spans leaked flat onto the parent's turn. This attaches the active Tracer to the inner agent and bumps the cubepi pin to the merged fix so the inner run nests under its `execute_tool subagent` span.

- **`SubAgentMiddleware`** now accepts a `tracer` and, in the subagent tool's `_execute`, attaches it to the inner agent (best-effort — tracing can never break the run) and detaches in `finally`. Success, normal-exception (returns `is_error`), and `CancelledError` (propagates) paths all detach.
- **`run_manager`** threads `getattr(self._app.state, "tracer", None)` into the construction.
- **cubepi pin → `9cb6817`**: brings in cubeplexai/cubepi#122 (per-task active-run gate so a shared provider doesn't double-mint the inner chat span; `invoke_agent` parented at the active `execute_tool` span; JSONL sharded by `trace_id` so the whole run is one trace file) + #121 (span_id in `trace view`).

## Test plan
- [x] `tests/unit/test_subagent_trace.py`: attach+detach on success / normal-failure / cancellation paths; awaitable-detach awaited; run_manager threads `app.state.tracer`.
- [x] `tests/unit/test_subagents.py` regression green.
- [x] E2E (local, scripted FauxProvider through the real `SubAgentMiddleware` + `create_cubebox_agent` + Tracer/JSONL + `cubepi trace view`): one trace file, `execute_tool subagent → invoke_agent → cubepi.turn → {chat, execute_tool inner_tool}` nesting, no duplicate chat spans.
- [x] pre-commit (ruff + mypy strict, 266 files) clean.