### PR TITLE
feat(tracing): stamp conversation/user/org/workspace on trace spans

### DIFF
--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1469,16 +1469,30 @@ class RunManager:
             # best-effort scope: it swallows every tracing fault (attach,
             # detach, flush) so tracing can never break the run, and is a
             # no-op when tracing is disabled (tracer is None).
-            from cubepi.tracing import trace
+            from cubepi.tracing import trace, tracing_context
 
             from cubebox.llm.runtime_writeback import (
                 schedule_runtime_status_writeback as _schedule_writeback,
             )
 
             tracer = getattr(self._app.state, "tracer", None)
+            # Stamp the run's identity onto the trace spans (recorder writes
+            # these as cubepi.metadata.* on the invoke_agent span). Skip None
+            # and stringify so OTel attribute typing is always satisfied.
+            _trace_meta = {
+                k: str(v)
+                for k, v in (
+                    ("conversation_id", conversation_id),
+                    ("user_id", ctx.user_id),
+                    ("org_id", ctx.org_id),
+                    ("workspace_id", ctx.workspace_id),
+                )
+                if v is not None
+            }
             try:
-                async with trace(tracer, agent):
-                    await agent.prompt(_user_msg)
+                with tracing_context(metadata=_trace_meta):
+                    async with trace(tracer, agent):
+                        await agent.prompt(_user_msg)
             except BaseException as _run_exc:
                 # Out-of-band, best-effort: a 401/403 flips provider liveness to
                 # "fail"; a model_not_found flips this model to "unavailable".


### PR DESCRIPTION
## Summary
Agent runs were attached to the Tracer with a bare best-effort scope, so trace spans carried only the auto-generated `cubepi.run_id` — there was no way to locate a trace by conversation or user. Wrap the run in `tracing_context(metadata=…)` so the recorder stamps the run's identity onto the `invoke_agent` span.

- `run_manager.py`: build a metadata dict from `conversation_id`, `ctx.user_id`, `ctx.org_id`, `ctx.workspace_id` (skip `None`, stringified) and wrap the existing `async with trace(tracer, agent)` in `with tracing_context(metadata=…)`.
- The recorder writes these as `cubepi.metadata.{conversation_id,user_id,org_id,workspace_id}` on the `invoke_agent` span (visible in `cubepi trace view -v`). No effect when tracing is disabled.

## Test plan
- [x] Verified the mechanism end-to-end locally: `tracing_context(metadata=…)` → the four `cubepi.metadata.*` attributes land on the `invoke_agent` span (real `Tracer` + `Agent` + recorder).
- [x] `ruff` + `mypy` (strict) clean; in-scope names (`ctx.user_id/org_id/workspace_id`, `conversation_id`) type-check.
- [ ] CI (`/ci`).

Note: no full `run_manager.run()` integration test — that path needs the whole run pipeline (DB, provider, app state) and the suite has no traced-run harness; the wiring is a thin, type-checked change over a mechanism verified above.