### PR TITLE
feat(widget): inline streaming generative-UI widgets (show_widget)

### DIFF
--- a/backend/cubebox/prompts/widget.py
+++ b/backend/cubebox/prompts/widget.py
@@ -1,0 +1,35 @@
+"""Design guidelines + tool description for the show_widget generative-UI tool.
+
+Self-authored (informed by, not copied from, Claude's artifact guidelines).
+Keep this string stable: it is appended to the system prompt and is
+cache-sensitive (see backend/docs/prompt-cache-discipline.md).
+"""
+
+WIDGET_TOOL_DESCRIPTION = (
+    "Render an interactive HTML widget inline in the conversation. Use for "
+    "visual/explanatory answers: charts, diagrams, sliders, animations. "
+    "widget_code is an HTML fragment (no <html>/<body>); it renders in a "
+    "sandboxed iframe. It cannot fetch/XHR/WebSocket (no data fetching) and "
+    "cannot use localStorage, but it MAY load JS libraries from the allowed CDNs."
+)
+
+WIDGET_GUIDELINES = """\
+## Rendering interactive widgets (show_widget)
+
+When a visual or interactive explanation is clearly better than text, call
+`show_widget`. Rules for `widget_code`:
+
+- It is an HTML fragment injected into a `<div id="root">`. Do NOT include
+  `<!DOCTYPE>`, `<html>`, `<head>`, or `<body>`.
+- Order content for streaming: `<style>` (short) first, then visible HTML,
+  then `<script>` last. Scripts run only after the widget finishes streaming.
+- No data fetching: fetch/XHR/WebSocket are blocked (CSP `connect-src 'none'`).
+  Embed all data directly in the code. (Loading JS libraries from the allowed
+  CDNs below IS permitted - that is `script-src`, not `connect-src`.)
+- No `localStorage`/`sessionStorage` (they throw). Use in-memory variables.
+- Use CSS variables for colors; support a dark background (#1a1a1a-ish).
+  Two font weights max (400, 500). Avoid gradients, shadows, and blur.
+- Libraries may be loaded only from: cdnjs.cloudflare.com, cdn.jsdelivr.net,
+  unpkg.com, esm.sh.
+- Keep total `widget_code` under ~256KB.
+"""

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -41,6 +41,16 @@ def _ns_to_agent_id(ns: tuple[Any, ...]) -> str | None:
     return ":".join(str(part) for part in ns)
 
 
+def _subagent_shared_tools(tools: list[Any]) -> list[Any]:
+    """Tools shared into subagents. show_widget is top-level only (v1).
+
+    Annotated ``list[Any]`` to match this module's convention (it builds tools
+    via lazy imports inside functions and does not import ``AgentTool`` at module
+    level). The helper only reads ``t.name``.
+    """
+    return [t for t in tools if t.name != "show_widget"]
+
+
 def _backfill_tool_call_delta_identity(
     evt_dict: dict[str, Any],
     delta_context: dict[tuple[str | None, int], dict[str, Any]],
@@ -993,6 +1003,15 @@ class RunManager:
         except Exception as _exc:
             logger.warning("view_images unavailable for cubepi run: {}", _exc)
 
+        # show_widget — UI-only tool; no DI. Fixed position in the builtin tool
+        # order to keep the prompt-cache prefix stable.
+        try:
+            from cubebox.tools.builtin.show_widget import make_show_widget_tool
+
+            _builtin_tools.append(make_show_widget_tool())
+        except Exception as _exc:
+            logger.warning("show_widget unavailable for cubepi run: {}", _exc)
+
         # generate_image — sandbox-gated; enabled only when image_generation config is active.
         # Builds a per-run provider instance via create_images_provider — never the global registry.
         if sandbox is not None:
@@ -1295,8 +1314,11 @@ class RunManager:
                 default_model_id=model_id,
                 default_provider_name=provider_name,
                 # Pass all tools (sandbox + artifact + builtin) collected so far
-                # as shared tools for subagent spawning.
-                shared_tools=_sandbox_tools + _artifact_tools + _builtin_tools,
+                # as shared tools for subagent spawning, minus show_widget
+                # (top-level only in v1).
+                shared_tools=_subagent_shared_tools(
+                    _sandbox_tools + _artifact_tools + _builtin_tools
+                ),
                 inherited_middleware=_cost_mw_for_inherit,
                 tracer=getattr(self._app.state, "tracer", None),
             )
@@ -1818,6 +1840,13 @@ class RunManager:
                         )
             except Exception as exc:
                 logger.warning("Failed to inject available-skills list: {}", exc)
+
+            # show_widget guidelines — appended unconditionally at a fixed spot
+            # so the cache prefix stays deterministic (the tool is always
+            # registered). See backend/docs/prompt-cache-discipline.md.
+            from cubebox.prompts.widget import WIDGET_GUIDELINES
+
+            effective_system_prompt += "\n\n" + WIDGET_GUIDELINES
 
             await self._run_cubepi_path(
                 ctx=ctx,

--- a/backend/cubebox/tools/builtin/show_widget.py
+++ b/backend/cubebox/tools/builtin/show_widget.py
@@ -1,0 +1,39 @@
+"""show_widget builtin tool.
+
+Declares the schema so the model can stream an HTML widget. execute() does no
+real work - rendering happens entirely in the frontend, which reads the
+streamed widget_code from tool_call_delta events. The ack just closes the
+tool call in message history.
+"""
+
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import TextContent
+from pydantic import BaseModel, Field
+
+from cubebox.prompts.widget import WIDGET_TOOL_DESCRIPTION
+
+
+class _ShowWidgetArgs(BaseModel):
+    title: str = Field(description="Short snake_case identifier for the widget.")
+    widget_code: str = Field(description="HTML fragment to render (no <html>/<body>).")
+    width: int | None = Field(default=None, description="Optional preferred width in px.")
+    height: int | None = Field(default=None, description="Optional preferred height in px.")
+
+
+def make_show_widget_tool() -> AgentTool[_ShowWidgetArgs]:
+    async def _show_widget(
+        tool_call_id: str,
+        args: _ShowWidgetArgs,
+        *,
+        signal: object = None,
+        on_update: object = None,
+    ) -> AgentToolResult:
+        del tool_call_id, args, signal, on_update
+        return AgentToolResult(content=[TextContent(text="Widget rendered.")])
+
+    return AgentTool(
+        name="show_widget",
+        description=WIDGET_TOOL_DESCRIPTION,
+        parameters=_ShowWidgetArgs,
+        execute=_show_widget,
+    )

--- a/backend/tests/unit/test_show_widget.py
+++ b/backend/tests/unit/test_show_widget.py
@@ -1,0 +1,44 @@
+"""show_widget builtin tool + subagent-scope helper — unit tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from cubebox.prompts.widget import WIDGET_GUIDELINES
+from cubebox.streams.run_manager import _subagent_shared_tools
+from cubebox.tools.builtin.show_widget import _ShowWidgetArgs, make_show_widget_tool
+
+
+def test_tool_metadata() -> None:
+    tool = make_show_widget_tool()
+    assert tool.name == "show_widget"
+    assert tool.parameters is _ShowWidgetArgs
+
+
+@pytest.mark.asyncio
+async def test_execute_returns_light_ack() -> None:
+    tool = make_show_widget_tool()
+    result = await tool.execute(
+        "call_1",
+        _ShowWidgetArgs(title="demo", widget_code="<div>hi</div>"),
+        signal=None,
+        on_update=None,
+    )
+    text = "".join(c.text for c in result.content)
+    assert "rendered" in text.lower()
+
+
+def test_guidelines_mention_tool_and_constraints() -> None:
+    assert "show_widget" in WIDGET_GUIDELINES
+    assert "fetch" in WIDGET_GUIDELINES  # network-blocked note
+    assert "localStorage" in WIDGET_GUIDELINES
+
+
+def test_subagent_shared_tools_drops_show_widget() -> None:
+    sw = make_show_widget_tool()
+    keep = SimpleNamespace(name="execute")  # helper only reads .name
+    result = _subagent_shared_tools([sw, keep])  # type: ignore[list-item]
+    assert sw not in result  # show_widget removed
+    assert keep in result  # other tools retained

--- a/docs/dev/plans/2026-05-27-generative-ui-widgets.md
+++ b/docs/dev/plans/2026-05-27-generative-ui-widgets.md
@@ -12,7 +12,7 @@
 
 **Read before touching:** `backend/docs/prompt-cache-discipline.md` (tool order + system-prompt injection are cache-sensitive), `backend/docs/agent-system-design.md` (tool/middleware assembly).
 
-**Worktree:** `/home/chris/cubebox/.worktrees/feat/generative-ui-widgets` (ports 8075/3075). `cat .worktree.env` first. Backend tests: `uv run pytest`. Frontend unit: `pnpm --filter web test`. E2E: `pnpm --filter web test:e2e` (or the repo's Playwright command).
+**Worktree:** `/home/chris/cubebox/.worktrees/feat/generative-ui-widgets` (ports 8075/3075). `cat .worktree.env` first. Backend tests: `uv run pytest`. Frontend unit: `pnpm --filter web test`. E2E: `cd frontend && pnpm test:e2e` (the `test:e2e` script lives in `frontend/package.json`; `packages/web/package.json` has no such script).
 
 ---
 
@@ -37,7 +37,8 @@
 **Tests (create):**
 - `backend/tests/tools/test_show_widget.py`
 - `frontend/packages/web/lib/__tests__/partialJson.test.ts`
-- `frontend/packages/web/__tests__/e2e/generative-ui-widgets.spec.ts`
+- `frontend/packages/web/__tests__/e2e/widget-shell.spec.ts` (shell protocol, Playwright)
+- `frontend/packages/web/components/chat/widget/__tests__/WidgetView.test.tsx` (vitest)
 
 ---
 
@@ -93,7 +94,8 @@ WIDGET_TOOL_DESCRIPTION = (
     "Render an interactive HTML widget inline in the conversation. Use for "
     "visual/explanatory answers: charts, diagrams, sliders, animations. "
     "widget_code is an HTML fragment (no <html>/<body>); it renders in a "
-    "sandboxed iframe with no network access and no localStorage."
+    "sandboxed iframe. It cannot fetch/XHR/WebSocket (no data fetching) and "
+    "cannot use localStorage, but it MAY load JS libraries from the allowed CDNs."
 )
 
 WIDGET_GUIDELINES = """\
@@ -106,8 +108,9 @@ When a visual or interactive explanation is clearly better than text, call
   `<!DOCTYPE>`, `<html>`, `<head>`, or `<body>`.
 - Order content for streaming: `<style>` (short) first, then visible HTML,
   then `<script>` last. Scripts run only after the widget finishes streaming.
-- No network requests (fetch/XHR/WebSocket are blocked). Embed all data
-  directly in the code.
+- No data fetching: fetch/XHR/WebSocket are blocked (CSP `connect-src 'none'`).
+  Embed all data directly in the code. (Loading JS libraries from the allowed
+  CDNs below IS permitted — that is `script-src`, not `connect-src`.)
 - No `localStorage`/`sessionStorage` (they throw). Use in-memory variables.
 - Use CSS variables for colors; support a dark background (#1a1a1a-ish).
   Two font weights max (400, 500). Avoid gradients, shadows, and blur.
@@ -414,10 +417,11 @@ body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;backgr
 <body><div id="root"></div>
 <script>
 (function(){
-  // WidgetView injects the real id by replacing the __WIDGET_ID__ token in the
-  // srcDoc at mount, so the shell knows its identity from the start (no
-  // learn-from-first-message handshake → no deadlock).
-  var WIDGET_ID = "__WIDGET_ID__";
+  // WidgetView replaces the placeholder below with the real id at mount, so the
+  // shell knows its identity from the start (no learn-from-first-message
+  // handshake -> no deadlock). The placeholder appears exactly ONCE in this
+  // whole srcDoc string (here), so a single string replace is unambiguous.
+  var WIDGET_ID = "%%WIDGET_ID%%";
   var lastSeq = -1;
   var finalized = false;
 
@@ -481,9 +485,11 @@ body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;backgr
 ```
 
 > The CSP `meta` is the first `<head>` child, before the inline `<style>`/`<script>`.
-> `__WIDGET_ID__` is a literal placeholder that `WidgetView` replaces with the
-> real id at mount (Task 5). `ready` fires only after morphdom loads, and the
-> parent sends nothing before `ready`, so no pre-ready buffering is needed.
+> `%%WIDGET_ID%%` is a literal placeholder appearing exactly once in the string
+> (in the `var WIDGET_ID` assignment, not in any comment), so `WidgetView`'s
+> single `.replace('%%WIDGET_ID%%', widgetId)` is unambiguous. `ready` fires only
+> after morphdom loads, and the parent sends nothing before `ready`, so no
+> pre-ready buffering is needed.
 
 - [ ] **Step 2: Type-check**
 
@@ -542,8 +548,9 @@ export function WidgetView({
   const latestRef = useRef('')
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Inject the real id into the shell (stable per widgetId).
-  const srcDoc = useMemo(() => WIDGET_SHELL_HTML.replace('__WIDGET_ID__', widgetId), [widgetId])
+  // Inject the real id into the shell (stable per widgetId). The placeholder
+  // appears exactly once in WIDGET_SHELL_HTML, so a single replace is safe.
+  const srcDoc = useMemo(() => WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', widgetId), [widgetId])
 
   const tooBig = new Blob([widgetCode]).size > MAX_CODE_BYTES
   latestRef.current = widgetCode
@@ -652,15 +659,22 @@ generic `write_file` handling, add:
 
 ```tsx
   if (block.type === 'tool_call_streaming' && block.name === 'show_widget') {
+    const title = extractJsonStringPrefix(block.args_text, 'title') || undefined
     return (
       <WidgetView
         widgetId={block.tool_call_id ?? `idx-${block.index}`}
         widgetCode={extractWidgetCode(block.args_text)}
         status="streaming"
+        title={title}
       />
     )
   }
 ```
+
+> `width`/`height` are integers that may not have streamed yet mid-call; they
+> are left `undefined` during streaming and applied when the completed branch
+> re-renders the same widget (same `widgetId` → same iframe, no remount). Only
+> `title` (a leading string field) is cheap to extract live.
 
 - [ ] **Step 2: Exclude `show_widget` from `groupBlocks` (REQUIRED — the real fix)**
 
@@ -713,7 +727,7 @@ and renders as a widget instead of collapsing into the tool-call list.
 
 ```tsx
 import { WidgetView } from '@/components/chat/widget/WidgetView'
-import { extractWidgetCode } from '@/lib/partialJson'
+import { extractWidgetCode, extractJsonStringPrefix } from '@/lib/partialJson'
 ```
 
 - [ ] **Step 5: Type-check + existing component tests**
@@ -733,29 +747,43 @@ git commit -m "feat(widget): mount WidgetView for streaming + completed show_wid
 
 ## Task 7: Subagent scope — exclude `show_widget` from subagent tools (v1)
 
-**Context:** `SubAgentMiddleware` shares the same `_builtin_tools` list
-(`run_manager.py:1292-1300`), so registering `show_widget` in builtins makes it
-callable from inside subagents too. Rendering widgets inside `SubAgentCard.tsx`
+**Context:** `SubAgentMiddleware` is constructed with
+`shared_tools=_sandbox_tools + _artifact_tools + _builtin_tools`
+(`run_manager.py:1299`), so registering `show_widget` in `_builtin_tools` makes
+it callable from inside subagents too. Rendering widgets inside `SubAgentCard.tsx`
 (which has its own block-rendering path) is extra surface we don't want in v1.
 
 **v1 decision:** keep widgets a **top-level assistant feature only**. The
-cleanest way is to **not expose `show_widget` to subagents**, so subagent output
-can never contain a widget block to render.
+cleanest way is to **not pass `show_widget` to subagents** via `shared_tools`, so
+subagent output can never contain a widget block to render. (The top-level run
+still includes it from `_builtin_tools`.)
 
 **Files:**
-- Modify: `backend/cubebox/streams/run_manager.py` (subagent tool assembly, ~`:1292-1303`)
+- Modify: `backend/cubebox/streams/run_manager.py` (SubAgentMiddleware construction, `:1292-1300`)
 
-- [ ] **Step 1: Exclude `show_widget` from the subagent tool set**
+- [ ] **Step 1: Exclude `show_widget` from the subagent `shared_tools`**
 
-Where `_subagent_tools` / the SubAgentMiddleware tool list is built from the
-shared builtins (~`:1292-1303`), filter it out:
+At the `SubAgentMiddleware(...)` construction (`:1299`), filter the
+`shared_tools` argument:
 
 ```python
-        _subagent_tools = [t for t in _subagent_tools if t.name != "show_widget"]
+            subagent_mw = SubAgentMiddleware(
+                subagent_map={},
+                default_provider=provider,
+                default_model_id=model_id,
+                default_provider_name=provider_name,
+                shared_tools=[
+                    t
+                    for t in (_sandbox_tools + _artifact_tools + _builtin_tools)
+                    if t.name != "show_widget"
+                ],
+                inherited_middleware=_cost_mw_for_inherit,
+            )
 ```
 
-> Verify the exact variable that feeds `SubAgentMiddleware` and filter that one.
-> The goal: the top-level run includes `show_widget`; subagent runs do not.
+> This is the list actually handed to subagents. (`SubAgentMiddleware` already
+> drops self-referential tools internally, but `show_widget` isn't one of those,
+> so we exclude it here.)
 
 - [ ] **Step 2: Add a backend test**
 
@@ -783,104 +811,157 @@ git commit -m "feat(widget): keep show_widget out of subagent tool set (v1 top-l
 
 ---
 
-## Task 8: E2E — streaming, latest-wins, reload, fallback, multi, security
+## Task 8: Deterministic widget tests (shell + WidgetView)
+
+**Why not a model-driven E2E:** the frontend E2E harness drives a **real model**
+(`streaming.spec.ts` registers a user and waits up to 50s for a real haiku) — it
+does not use the faux provider. A real model will not reliably emit a
+`show_widget` call, so a model-driven assertion would be flaky. Instead we test
+the widget machinery directly and deterministically, and leave the true
+model→widget path to manual verification (Task 9).
+
+Two layers:
+- **8A — shell** (Playwright via `setContent` + a real `<iframe srcdoc>`): drives
+  the postMessage protocol against a real browser/morphdom. Covers ready,
+  morph, latest-wins, finalize-once, opaque-origin, `connect-src 'none'`.
+- **8B — WidgetView** (vitest + jsdom, the repo's component-test setup): the
+  parent-side logic — ready-timeout fallback, size-cap fallback, posts-after-ready,
+  forged-source rejection.
 
 **Files:**
-- Create: `frontend/packages/web/__tests__/e2e/generative-ui-widgets.spec.ts`
+- Create: `frontend/packages/web/__tests__/e2e/widget-shell.spec.ts`
+- Create: `frontend/packages/web/components/chat/widget/__tests__/WidgetView.test.tsx`
 
-> Verified repo layout: frontend E2E specs live in
-> `frontend/packages/web/__tests__/e2e/` (e.g. `admin-settings.spec.ts`), and the
-> Playwright runner is `test:e2e` in **`frontend/package.json`** (`playwright test`),
-> run as `cd frontend && pnpm test:e2e`. There is no `test:e2e` in
-> `packages/web/package.json` (that only has `test` = vitest).
-
-Uses the faux provider (`cubepi/providers/faux.py`) to script a `show_widget`
-tool call streamed across frames. Wire the faux script via the existing E2E
-config switch (match how a sibling spec in `__tests__/e2e/` selects faux and
-sends a prompt — reuse those exact helpers; do not invent harness APIs).
-
-- [ ] **Step 1: Write the E2E spec**
+- [ ] **Step 1: Write the shell Playwright spec (8A)**
 
 ```typescript
-// frontend/packages/web/__tests__/e2e/generative-ui-widgets.spec.ts
-import { test, expect } from '@playwright/test'
+// frontend/packages/web/__tests__/e2e/widget-shell.spec.ts
+import { test, expect, type Page } from '@playwright/test'
+import { WIDGET_SHELL_HTML } from '../../components/chat/widget/widgetShell'
 
-// Helper: the faux script emits a show_widget tool call whose widget_code is:
-//   <style>...</style><p id="w">hi</p><script>window.__c=(window.__c||0)+1;
-//     document.getElementById('w').textContent='done'+window.__c;</script>
-// streamed across several deltas. (See faux fixture wiring.)
+const WIDGET_ID = 'w-test'
+const SHELL = WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', WIDGET_ID)
 
-test('streams a widget and finalizes scripts once', async ({ page }) => {
-  await page.goto('/')             // adjust to the conversation URL the suite uses
-  // ...send the prompt that triggers the faux show_widget script...
-  const frame = page.frameLocator('iframe[title]')
-  // sandbox attribute is hardened
-  const sandbox = await page.locator('iframe[title]').getAttribute('sandbox')
-  expect(sandbox).toBe('allow-scripts')
-  // mid-stream partial node appears
-  await expect(frame.locator('#w')).toBeVisible()
-  // after finalize the script ran exactly once
-  await expect(frame.locator('#w')).toHaveText('done1')
+async function mountShell(page: Page) {
+  await page.setContent('<div id="host"></div>')
+  await page.evaluate((srcdoc) => {
+    ;(window as unknown as { __ready: boolean }).__ready = false
+    window.addEventListener('message', (e) => {
+      if ((e.data || {}).type === 'ready') (window as unknown as { __ready: boolean }).__ready = true
+    })
+    const f = document.createElement('iframe')
+    f.id = 'wf'
+    f.setAttribute('sandbox', 'allow-scripts')
+    f.srcdoc = srcdoc
+    document.getElementById('host')!.appendChild(f)
+  }, SHELL)
+  await page.waitForFunction(() => (window as unknown as { __ready: boolean }).__ready === true, {
+    timeout: 15_000,
+  })
+}
+
+async function send(page: Page, msg: Record<string, unknown>) {
+  await page.evaluate((m) => {
+    ;(document.getElementById('wf') as HTMLIFrameElement).contentWindow!.postMessage(m, '*')
+  }, msg)
+}
+
+test('morph applies, then finalize runs scripts exactly once', async ({ page }) => {
+  await mountShell(page)
+  const frame = page.frameLocator('#wf')
+  await send(page, {
+    widgetId: WIDGET_ID, seq: 1, type: 'morph',
+    html: '<p id="w">hi</p><script>window.__c=(window.__c||0)+1;document.getElementById("w").textContent="done"+window.__c;</script>',
+  })
+  await expect(frame.locator('#w')).toHaveText('hi')         // script not run yet
+  await send(page, { widgetId: WIDGET_ID, seq: 2, type: 'finalize' })
+  await expect(frame.locator('#w')).toHaveText('done1')      // ran once
 })
 
-test('reload renders finished widget without streaming', async ({ page }) => {
-  // ...after a completed widget exists, reload...
-  await page.reload()
-  const frame = page.frameLocator('iframe[title]')
-  await expect(frame.locator('#w')).toHaveText('done1')
+test('latest-wins: a stale lower-seq morph is ignored', async ({ page }) => {
+  await mountShell(page)
+  const frame = page.frameLocator('#wf')
+  await send(page, { widgetId: WIDGET_ID, seq: 5, type: 'morph', html: '<p id="w">new</p>' })
+  await expect(frame.locator('#w')).toHaveText('new')
+  await send(page, { widgetId: WIDGET_ID, seq: 2, type: 'morph', html: '<p id="w">stale</p>' })
+  await expect(frame.locator('#w')).toHaveText('new')        // unchanged
 })
 
-test('latest-wins: a late lower-seq morph does not regress', async ({ page }) => {
-  // Drive WidgetView with a complete widget, then inject a stale morph via
-  // page.evaluate(postMessage with seq=0); assert content unchanged.
-})
-
-test('readiness timeout falls back to source block', async ({ page }) => {
-  // Block the morphdom CDN (route.abort) so ready never fires; assert the
-  // <details> source fallback appears within ~6s, not a blank iframe body.
-})
-
-test('two widgets render in independent iframes', async ({ page }) => {
-  // faux emits two show_widget calls; assert two iframes, each with its content.
-})
-
-test('widget cannot reach parent or network', async ({ page }) => {
-  const frame = page.frameLocator('iframe[title]')
-  // inside the widget, reading parent.document throws (opaque origin);
-  // fetch() is blocked by connect-src 'none'. Assert via a widget that posts
-  // its probe result, or via console/network assertions.
-})
-
-test('parent ignores a forged-source message', async ({ page }) => {
-  // From the page (not the iframe), postMessage a {widgetId, type:'resize',
-  // height: 9999} directly to window. Because WidgetView checks
-  // e.source === iframe.contentWindow, the forged message (source = top window)
-  // must be ignored — assert the iframe height does NOT jump to 9999.
-})
-
-// Subagent scope (Task 7): a subagent prompt that would otherwise trigger a
-// widget produces NO iframe, since show_widget is excluded from subagent tools.
-test('subagents do not render widgets', async ({ page }) => {
-  // drive a faux subagent run that would call show_widget; assert no iframe[title].
+test('widget cannot reach parent (opaque origin) nor fetch (connect-src none)', async ({ page }) => {
+  await mountShell(page)
+  const frame = page.frameLocator('#wf')
+  await send(page, {
+    widgetId: WIDGET_ID, seq: 1, type: 'morph',
+    html: `<p id="probe"></p><script>
+      var r='';
+      try { void parent.document; r+='PARENT_OK'; } catch(e){ r+='PARENT_BLOCKED'; }
+      fetch('https://example.com').then(function(){document.getElementById('probe').textContent=r+' FETCH_OK';})
+        .catch(function(){document.getElementById('probe').textContent=r+' FETCH_BLOCKED';});
+    </script>`,
+  })
+  await send(page, { widgetId: WIDGET_ID, seq: 2, type: 'finalize' })
+  await expect(frame.locator('#probe')).toHaveText('PARENT_BLOCKED FETCH_BLOCKED')
 })
 ```
 
-> The exact navigation/prompt-send steps and faux wiring follow the patterns in
-> a sibling spec in `__tests__/e2e/`. Fill those in from that spec; do not
-> invent new harness APIs.
+> 8A loads morphdom from the real CDN (same as production). If CI has no network,
+> mark this spec to run only where outbound HTTPS to the CDN allowlist is
+> available; the CDN-failure path itself is covered in 8B by a timeout.
 
-- [ ] **Step 2: Run the E2E on worktree ports**
+- [ ] **Step 2: Write the WidgetView vitest spec (8B)**
 
-Run: `cd frontend && pnpm test:e2e generative-ui-widgets` (the `test:e2e` script
-is in `frontend/package.json`). Ensure backend (8075) + frontend (3075) are up
-via the worktree env (`cat .worktree.env`).
-Expected: all specs PASS.
+```tsx
+// frontend/packages/web/components/chat/widget/__tests__/WidgetView.test.tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { WidgetView } from '../WidgetView'
 
-- [ ] **Step 3: Commit**
+describe('WidgetView', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks() })
+
+  it('falls back to a source block when widget_code exceeds the size cap', () => {
+    const big = 'x'.repeat(256 * 1024 + 1)
+    render(<WidgetView widgetId="a" widgetCode={big} status="complete" />)
+    expect(screen.getByText(/too large/i)).toBeInTheDocument()
+  })
+
+  it('falls back when no ready arrives before the timeout', () => {
+    render(<WidgetView widgetId="a" widgetCode="<p>x</p>" status="complete" />)
+    act(() => { vi.advanceTimersByTime(5001) })
+    expect(screen.getByText(/failed to render/i)).toBeInTheDocument()
+  })
+
+  it('posts a morph only after a ready from the iframe', () => {
+    const { container } = render(<WidgetView widgetId="a" widgetCode="<p>x</p>" status="complete" />)
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement
+    const post = vi.spyOn(iframe.contentWindow as Window, 'postMessage')
+    // forged source (window, not the iframe) → ignored
+    act(() => { window.dispatchEvent(new MessageEvent('message', { data: { widgetId: 'a', type: 'ready' }, source: window })) })
+    expect(post).not.toHaveBeenCalled()
+    // real ready (source === iframe.contentWindow) → morph is sent
+    act(() => { window.dispatchEvent(new MessageEvent('message', { data: { widgetId: 'a', type: 'ready' }, source: iframe.contentWindow })) })
+    expect(post).toHaveBeenCalledWith(expect.objectContaining({ type: 'morph' }), '*')
+  })
+})
+```
+
+> `@testing-library/react` is already used by the repo's component tests; match
+> the existing test setup (jsdom env). jsdom does not execute the iframe's inline
+> scripts, which is fine — 8B verifies only WidgetView's parent-side behavior;
+> the in-iframe behavior is 8A's job.
+
+- [ ] **Step 3: Run both layers**
+
+Run: `pnpm --filter web test WidgetView`
+Run: `cd frontend && pnpm test:e2e widget-shell`  (backend not required — shell is self-contained)
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
 
 ```bash
-git add frontend/packages/web/__tests__/e2e/generative-ui-widgets.spec.ts
-git commit -m "test(widget): E2E for streaming, latest-wins, reload, fallback, security, subagent-scope"
+git add frontend/packages/web/__tests__/e2e/widget-shell.spec.ts frontend/packages/web/components/chat/widget/__tests__/WidgetView.test.tsx
+git commit -m "test(widget): deterministic shell (playwright) + WidgetView (vitest) tests"
 ```
 
 ---
@@ -891,7 +972,10 @@ git commit -m "test(widget): E2E for streaming, latest-wins, reload, fallback, s
   browser (bind 0.0.0.0; report IP:port — user is remote), trigger a real
   `show_widget` (e.g. "show me how compound interest works"). Confirm: it
   streams in, morphs smoothly, scripts run once, dark theme reads well, resize
-  fits. Check both light and dark app themes.
+  fits. Check both light and dark app themes. **Then reload the page** and
+  confirm the completed widget re-renders from message history (one-shot, no
+  streaming animation) — this is the reload path (deterministic E2E can't cover
+  it because it needs a real model-produced widget in history).
 - [ ] **Step 2:** Run changed-module tests:
   - `uv run pytest tests/tools/test_show_widget.py -v`
   - `pnpm --filter web test partialJson writeFilePreview`
@@ -903,12 +987,15 @@ git commit -m "test(widget): E2E for streaming, latest-wins, reload, fallback, s
 ## Self-Review
 
 - **Spec coverage:** tool (T1) + registration/prompt-injection-in-`_execute_run`
-  (T2) + extract reuse (T3) + shell with `__WIDGET_ID__` injection (T4) +
+  (T2) + extract reuse (T3) + shell with `%%WIDGET_ID%%` injection (T4) +
   WidgetView with id-injected srcDoc, seq/debounce/ready-timeout/fallback/limits,
   height applied (T5) + mount with `groupBlocks` exclusion + completed branch (T6)
-  + subagent exclusion (T7) + E2E incl. latest-wins/reload/fallback/multi/security/
-  forged-source/subagent-scope (T8) + manual + theme check (T9).
-  Interrupted-widget non-persistence is inherited behavior (no task needed).
+  + subagent exclusion via `shared_tools` (T7) + deterministic tests: shell
+  morph/latest-wins/finalize-once/opaque-origin/connect-src (8A) and WidgetView
+  size-cap/ready-timeout/forged-source/posts-after-ready (8B) + manual model→widget
+  + reload + theme check (T9). Multi-widget isolation is structural (one
+  `WidgetView`/iframe per `tool_call_streaming` block, keyed by `index`) — no
+  dedicated test needed. Interrupted-widget non-persistence is inherited behavior.
 - **Verified against real code:** cubepi imports (`cubepi.agent.types` /
   `cubepi.providers.base`), builtin registration order (`run_manager.py:977-996`),
   prompt site (`_execute_run` `:1760-1807`), `groupBlocks` name-exclusion

--- a/docs/dev/plans/2026-05-27-generative-ui-widgets.md
+++ b/docs/dev/plans/2026-05-27-generative-ui-widgets.md
@@ -1,0 +1,831 @@
+# Generative UI Widgets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the agent render live, interactive HTML/JS widgets inline in the chat stream via a `show_widget` tool, streamed token-by-token into a sandboxed iframe and morphed in place.
+
+**Architecture:** `show_widget` is a builtin tool whose `widget_code` HTML fragment rides the existing `tool_call_delta → args_text → extractJsonStringPrefix` streaming path (no streaming-pipeline change). The frontend extracts the in-progress HTML and `postMessage`s it into a `sandbox="allow-scripts"` iframe whose shell runs morphdom; scripts run once on finalize. Security = opaque-origin sandbox + CSP + `event.source` validation.
+
+**Tech Stack:** Python/FastAPI + cubepi (backend tool + prompt), React 19 / Next.js + TypeScript (frontend component, iframe shell), morphdom (CDN), Playwright + vitest (tests).
+
+**Spec:** `docs/dev/specs/2026-05-27-generative-ui-widgets-design.md` (read it first).
+
+**Read before touching:** `backend/docs/prompt-cache-discipline.md` (tool order + system-prompt injection are cache-sensitive), `backend/docs/agent-system-design.md` (tool/middleware assembly).
+
+**Worktree:** `/home/chris/cubebox/.worktrees/feat/generative-ui-widgets` (ports 8075/3075). `cat .worktree.env` first. Backend tests: `uv run pytest`. Frontend unit: `pnpm --filter web test`. E2E: `pnpm --filter web test:e2e` (or the repo's Playwright command).
+
+---
+
+## File Structure
+
+**Backend (create):**
+- `backend/cubebox/tools/builtin/show_widget.py` — `_ShowWidgetArgs` model + `make_show_widget_tool()` factory. The tool's `execute()` returns a light ack; rendering is entirely frontend.
+- `backend/cubebox/prompts/widget.py` — `WIDGET_GUIDELINES` string (self-authored design constraints) + `WIDGET_TOOL_DESCRIPTION`.
+
+**Backend (modify):**
+- `backend/cubebox/streams/run_manager.py` — register `make_show_widget_tool()` in `_builtin_tools` (fixed order) and append `WIDGET_GUIDELINES` to the system prompt when the tool is enabled.
+
+**Frontend (create):**
+- `frontend/packages/web/lib/partialJson.ts` — `extractJsonStringPrefix` (moved out of `writeFilePreview.ts`, exported) + `extractWidgetCode`.
+- `frontend/packages/web/components/chat/widget/widgetShell.ts` — exports `WIDGET_SHELL_HTML` (srcDoc string: CSP meta + morphdom runtime + postMessage listener).
+- `frontend/packages/web/components/chat/widget/WidgetView.tsx` — the sandboxed-iframe component.
+
+**Frontend (modify):**
+- `frontend/packages/web/lib/writeFilePreview.ts` — import `extractJsonStringPrefix` from `partialJson.ts` instead of defining it.
+- `frontend/packages/web/components/chat/AssistantMessage.tsx` — mount `<WidgetView>` for streaming + completed `show_widget` blocks; exclude completed `show_widget` from `ToolCallGroup`.
+
+**Tests (create):**
+- `backend/tests/tools/test_show_widget.py`
+- `frontend/packages/web/lib/__tests__/partialJson.test.ts`
+- `frontend/packages/web/tests/e2e/generative-ui-widgets.spec.ts`
+
+---
+
+## Task 1: Backend — `show_widget` tool
+
+**Files:**
+- Create: `backend/cubebox/tools/builtin/show_widget.py`
+- Create: `backend/cubebox/prompts/widget.py`
+- Test: `backend/tests/tools/test_show_widget.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/tools/test_show_widget.py
+import pytest
+from cubebox.tools.builtin.show_widget import make_show_widget_tool, _ShowWidgetArgs
+
+
+def test_tool_metadata():
+    tool = make_show_widget_tool()
+    assert tool.name == "show_widget"
+    assert tool.parameters is _ShowWidgetArgs
+
+
+@pytest.mark.asyncio
+async def test_execute_returns_light_ack():
+    tool = make_show_widget_tool()
+    result = await tool.execute(
+        "call_1",
+        _ShowWidgetArgs(title="demo", widget_code="<div>hi</div>"),
+    )
+    text = "".join(c.text for c in result.content)
+    assert "rendered" in text.lower()
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `uv run pytest tests/tools/test_show_widget.py -v`
+Expected: FAIL — `ModuleNotFoundError: cubebox.tools.builtin.show_widget`.
+
+- [ ] **Step 3: Write the prompt constants**
+
+```python
+# backend/cubebox/prompts/widget.py
+"""Design guidelines + tool description for the show_widget generative-UI tool.
+
+Self-authored (informed by, not copied from, Claude's artifact guidelines).
+Keep this string stable: it is appended to the system prompt and is
+cache-sensitive (see backend/docs/prompt-cache-discipline.md).
+"""
+
+WIDGET_TOOL_DESCRIPTION = (
+    "Render an interactive HTML widget inline in the conversation. Use for "
+    "visual/explanatory answers: charts, diagrams, sliders, animations. "
+    "widget_code is an HTML fragment (no <html>/<body>); it renders in a "
+    "sandboxed iframe with no network access and no localStorage."
+)
+
+WIDGET_GUIDELINES = """\
+## Rendering interactive widgets (show_widget)
+
+When a visual or interactive explanation is clearly better than text, call
+`show_widget`. Rules for `widget_code`:
+
+- It is an HTML fragment injected into a `<div id="root">`. Do NOT include
+  `<!DOCTYPE>`, `<html>`, `<head>`, or `<body>`.
+- Order content for streaming: `<style>` (short) first, then visible HTML,
+  then `<script>` last. Scripts run only after the widget finishes streaming.
+- No network requests (fetch/XHR/WebSocket are blocked). Embed all data
+  directly in the code.
+- No `localStorage`/`sessionStorage` (they throw). Use in-memory variables.
+- Use CSS variables for colors; support a dark background (#1a1a1a-ish).
+  Two font weights max (400, 500). Avoid gradients, shadows, and blur.
+- Libraries may be loaded only from: cdnjs.cloudflare.com, cdn.jsdelivr.net,
+  unpkg.com, esm.sh.
+- Keep total `widget_code` under ~256KB.
+"""
+```
+
+- [ ] **Step 4: Write the tool**
+
+```python
+# backend/cubebox/tools/builtin/show_widget.py
+"""show_widget builtin tool.
+
+Declares the schema so the model can stream an HTML widget. execute() does no
+real work — rendering happens entirely in the frontend, which reads the
+streamed widget_code from tool_call_delta events. The ack just closes the
+tool call in message history.
+"""
+
+from pydantic import BaseModel, Field
+
+from cubepi.providers.base import TextContent
+from cubepi.agent.tools import AgentTool, AgentToolResult
+
+from cubebox.prompts.widget import WIDGET_TOOL_DESCRIPTION
+
+
+class _ShowWidgetArgs(BaseModel):
+    title: str = Field(description="Short snake_case identifier for the widget.")
+    widget_code: str = Field(description="HTML fragment to render (no <html>/<body>).")
+    width: int | None = Field(default=None, description="Optional preferred width in px.")
+    height: int | None = Field(default=None, description="Optional preferred height in px.")
+
+
+def make_show_widget_tool() -> AgentTool[_ShowWidgetArgs]:
+    async def _show_widget(
+        tool_call_id: str,
+        args: _ShowWidgetArgs,
+        *,
+        signal: object = None,
+        on_update: object = None,
+    ) -> AgentToolResult:
+        del tool_call_id, signal, on_update
+        return AgentToolResult(content=[TextContent(text="Widget rendered.")])
+
+    return AgentTool(
+        name="show_widget",
+        description=WIDGET_TOOL_DESCRIPTION,
+        parameters=_ShowWidgetArgs,
+        execute=_show_widget,
+    )
+```
+
+> NOTE: confirm the exact import paths for `AgentTool`, `AgentToolResult`,
+> `TextContent` against `cubebox/middleware/sandbox.py` (it imports the same
+> symbols). Match that file's imports verbatim.
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `uv run pytest tests/tools/test_show_widget.py -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/tools/builtin/show_widget.py backend/cubebox/prompts/widget.py backend/tests/tools/test_show_widget.py
+git commit -m "feat(widget): add show_widget tool + design-guidelines prompt"
+```
+
+---
+
+## Task 2: Backend — register tool + inject guidelines
+
+**Files:**
+- Modify: `backend/cubebox/streams/run_manager.py` (builtin-tool assembly block, ~`:977`-`:994`; system-prompt assembly)
+- Test: `backend/tests/tools/test_show_widget.py` (add a registration assertion)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `backend/tests/tools/test_show_widget.py`:
+
+```python
+def test_guidelines_mention_tool_and_constraints():
+    from cubebox.prompts.widget import WIDGET_GUIDELINES
+    assert "show_widget" in WIDGET_GUIDELINES
+    assert "fetch" in WIDGET_GUIDELINES  # network-blocked note
+    assert "localStorage" in WIDGET_GUIDELINES
+```
+
+- [ ] **Step 2: Run it, verify it passes** (the prompt already exists from Task 1)
+
+Run: `uv run pytest tests/tools/test_show_widget.py::test_guidelines_mention_tool_and_constraints -v`
+Expected: PASS. (This locks the guideline content; the registration wiring below is verified by the Task 8 E2E, which exercises the full run path.)
+
+- [ ] **Step 3: Register the tool in run_manager**
+
+In `backend/cubebox/streams/run_manager.py`, after the `view_images` append block (~`:994`) and before `generate_image`, add:
+
+```python
+        # show_widget — UI-only tool; no DI. Fixed position in the builtin
+        # tool order to keep the prompt-cache prefix stable.
+        try:
+            from cubebox.tools.builtin.show_widget import make_show_widget_tool
+
+            _builtin_tools.append(make_show_widget_tool())
+        except Exception as _exc:
+            logger.warning("show_widget unavailable for cubepi run: {}", _exc)
+```
+
+> Placement matters for cache discipline: append at a *fixed* spot every run.
+> Do not gate it behind optional config that would make the tool list vary
+> run-to-run for the same workspace.
+
+- [ ] **Step 4: Inject the guidelines into the system prompt**
+
+Find where `run_manager` assembles the system prompt for the cubepi run (search `transform_system_prompt` consumers / where builtin-tool prompt sections are appended). Append `WIDGET_GUIDELINES` **once**, unconditionally whenever `show_widget` is in the tool list, at a fixed position relative to other appended sections:
+
+```python
+        from cubebox.prompts.widget import WIDGET_GUIDELINES
+        # appended after the other builtin-tool prompt sections, before sandbox
+        system_prompt = system_prompt + "\n\n" + WIDGET_GUIDELINES
+```
+
+> Read `backend/docs/prompt-cache-discipline.md` first and match the existing
+> append style/position used for other builtin tools. The exact insertion
+> point is whatever keeps a deterministic, cache-stable prefix.
+
+- [ ] **Step 5: Run the backend tool tests + a quick import smoke**
+
+Run: `uv run pytest tests/tools/test_show_widget.py -v`
+Run: `uv run python -c "import cubebox.streams.run_manager"`
+Expected: tests PASS; import succeeds with no error.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/streams/run_manager.py backend/tests/tools/test_show_widget.py
+git commit -m "feat(widget): register show_widget tool and inject guidelines prompt"
+```
+
+---
+
+## Task 3: Frontend — promote `extractJsonStringPrefix` + add `extractWidgetCode`
+
+**Files:**
+- Create: `frontend/packages/web/lib/partialJson.ts`
+- Modify: `frontend/packages/web/lib/writeFilePreview.ts`
+- Test: `frontend/packages/web/lib/__tests__/partialJson.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// frontend/packages/web/lib/__tests__/partialJson.test.ts
+import { describe, it, expect } from 'vitest'
+import { extractJsonStringPrefix, extractWidgetCode } from '@/lib/partialJson'
+
+describe('extractJsonStringPrefix', () => {
+  it('extracts a complete value', () => {
+    expect(extractJsonStringPrefix('{"content":"hello"}', 'content')).toBe('hello')
+  })
+  it('returns the prefix for an unterminated value', () => {
+    expect(extractJsonStringPrefix('{"content":"# Title\\nbody', 'content')).toBe('# Title\nbody')
+  })
+  it('decodes escapes', () => {
+    expect(extractJsonStringPrefix('{"c":"a\\tb\\"c\\u0041"}', 'c')).toBe('a\tb"cA')
+  })
+  it('does not end early on an escaped quote inside the value', () => {
+    expect(extractJsonStringPrefix('{"c":"say \\"hi\\" ok"}', 'c')).toBe('say "hi" ok')
+  })
+  it('returns empty when the key is absent', () => {
+    expect(extractJsonStringPrefix('{"other":"x"}', 'content')).toBe('')
+  })
+})
+
+describe('extractWidgetCode', () => {
+  it('pulls widget_code mid-stream', () => {
+    expect(extractWidgetCode('{"title":"t","widget_code":"<div>part')).toBe('<div>part')
+  })
+})
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `pnpm --filter web test partialJson`
+Expected: FAIL — `@/lib/partialJson` not found.
+
+- [ ] **Step 3: Create `partialJson.ts` by moving the existing function**
+
+Move `decodeEscapeSequence` and `extractJsonStringPrefix` **verbatim** from
+`writeFilePreview.ts` into a new file and export the prefix function, then add
+the widget wrapper:
+
+```typescript
+// frontend/packages/web/lib/partialJson.ts
+function decodeEscapeSequence(char: string): string {
+  switch (char) {
+    case 'n': return '\n'
+    case 'r': return '\r'
+    case 't': return '\t'
+    case 'b': return '\b'
+    case 'f': return '\f'
+    case '"': return '"'
+    case '\\': return '\\'
+    case '/': return '/'
+    default: return char
+  }
+}
+
+/** Tolerantly extract a JSON string field's value from possibly-incomplete JSON. */
+export function extractJsonStringPrefix(raw: string, key: string): string {
+  const keyMatch = new RegExp(`"${key}"\\s*:\\s*"`, 'm').exec(raw)
+  if (!keyMatch) return ''
+  let i = keyMatch.index + keyMatch[0].length
+  let value = ''
+  while (i < raw.length) {
+    const char = raw[i]
+    if (char === '"') break
+    if (char === '\\') {
+      const next = raw[i + 1]
+      if (!next) break
+      if (next === 'u') {
+        const hex = raw.slice(i + 2, i + 6)
+        if (hex.length < 4 || /[^0-9a-fA-F]/.test(hex)) break
+        value += String.fromCharCode(parseInt(hex, 16))
+        i += 6
+        continue
+      }
+      value += decodeEscapeSequence(next)
+      i += 2
+      continue
+    }
+    value += char
+    i++
+  }
+  return value
+}
+
+export function extractWidgetCode(rawArgsText: string): string {
+  return extractJsonStringPrefix(rawArgsText, 'widget_code')
+}
+```
+
+- [ ] **Step 4: Update `writeFilePreview.ts` to import the shared function**
+
+Delete the local `decodeEscapeSequence` + `extractJsonStringPrefix` definitions
+in `writeFilePreview.ts` and add at the top:
+
+```typescript
+import { extractJsonStringPrefix } from '@/lib/partialJson'
+```
+
+Leave the rest (`parseWriteFileArgs`, etc.) unchanged — they call
+`extractJsonStringPrefix` exactly as before.
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `pnpm --filter web test partialJson`
+Run: `pnpm --filter web test writeFilePreview`  (existing tests still green)
+Run: `pnpm --filter web type-check`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/packages/web/lib/partialJson.ts frontend/packages/web/lib/writeFilePreview.ts frontend/packages/web/lib/__tests__/partialJson.test.ts
+git commit -m "refactor(widget): extract shared partial-JSON parser + extractWidgetCode"
+```
+
+---
+
+## Task 4: Frontend — iframe shell runtime
+
+**Files:**
+- Create: `frontend/packages/web/components/chat/widget/widgetShell.ts`
+
+This is a static string; correctness is verified end-to-end by the Task 8 E2E.
+No isolated unit test (it only runs inside an iframe).
+
+- [ ] **Step 1: Write the shell string**
+
+```typescript
+// frontend/packages/web/components/chat/widget/widgetShell.ts
+// srcDoc for the widget iframe. CSP meta MUST be the first element in <head>.
+// Parent → child messages: {widgetId, seq, type:'morph', html} / {...type:'finalize'}.
+// Child → parent messages: {widgetId, type:'ready'|'error'|'resize', ...}.
+export const WIDGET_SHELL_HTML = `<!DOCTYPE html><html><head>
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; style-src 'unsafe-inline'; img-src data: https:; font-src data: https:; connect-src 'none'; base-uri 'none'; form-action 'none'; worker-src 'none'; frame-src 'none'; object-src 'none';">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<style>
+*{box-sizing:border-box}
+body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;background:#1a1a1a;color:#e0e0e0;}
+@keyframes _fadeIn{from{opacity:0;transform:translateY(4px);}to{opacity:1;transform:none;}}
+</style></head>
+<body><div id="root"></div>
+<script>
+(function(){
+  var WIDGET_ID = null;
+  var lastSeq = -1;
+  var finalized = false;
+  var morphReady = false;
+  var pending = null; // {seq, html}
+
+  function post(msg){ parent.postMessage(Object.assign({widgetId: WIDGET_ID}, msg), '*'); }
+
+  function applyMorph(html){
+    var root = document.getElementById('root');
+    var target = document.createElement('div');
+    target.id = 'root';
+    target.innerHTML = html;
+    window.morphdom(root, target, {
+      onBeforeElUpdated: function(from, to){ return !from.isEqualNode(to); },
+      onNodeAdded: function(node){
+        if (node.nodeType === 1 && node.tagName !== 'STYLE' && node.tagName !== 'SCRIPT') {
+          node.style.animation = '_fadeIn 0.3s ease both';
+        }
+        return node;
+      }
+    });
+    post({type:'resize', height: document.body.scrollHeight});
+  }
+
+  function runScripts(){
+    document.querySelectorAll('#root script').forEach(function(old){
+      var s = document.createElement('script');
+      if (old.src) { s.src = old.src; } else { s.textContent = old.textContent; }
+      old.parentNode.replaceChild(s, old);
+    });
+  }
+
+  window.addEventListener('message', function(e){
+    if (e.source !== parent) return;
+    var d = e.data || {};
+    if (WIDGET_ID === null && d.widgetId != null) WIDGET_ID = d.widgetId;
+    if (d.widgetId !== WIDGET_ID) return;
+    if (typeof d.seq !== 'number' || d.seq <= lastSeq) return; // latest-wins
+    lastSeq = d.seq;
+    try {
+      if (d.type === 'morph') {
+        if (finalized) return;
+        if (!morphReady) { pending = {seq:d.seq, html:d.html}; return; }
+        applyMorph(d.html);
+      } else if (d.type === 'finalize') {
+        if (finalized) return;
+        if (!morphReady) { pending = {seq:d.seq, html:null, finalize:true}; return; }
+        finalized = true;
+        runScripts();
+        post({type:'resize', height: document.body.scrollHeight});
+      }
+    } catch (err) {
+      post({type:'error', message: String(err && err.message || err).slice(0, 500)});
+    }
+  });
+
+  var s = document.createElement('script');
+  s.src = 'https://cdn.jsdelivr.net/npm/morphdom@2.7.4/dist/morphdom-umd.min.js';
+  s.onload = function(){
+    morphReady = true;
+    post({type:'ready'});
+    if (pending) {
+      if (pending.html != null) applyMorph(pending.html);
+      if (pending.finalize) { finalized = true; runScripts(); }
+      pending = null;
+    }
+  };
+  s.onerror = function(){ post({type:'error', message:'morphdom failed to load'}); };
+  document.head.appendChild(s);
+})();
+</script></body></html>`
+```
+
+> The CSP `meta` is the first `<head>` child, before the inline `<style>`/`<script>`.
+> The shell installs its message listener synchronously, but `WidgetView` still
+> waits for `ready` before sending (Task 5) — `pending` is belt-and-suspenders.
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm --filter web type-check`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/packages/web/components/chat/widget/widgetShell.ts
+git commit -m "feat(widget): iframe shell runtime (CSP + morphdom + postMessage)"
+```
+
+---
+
+## Task 5: Frontend — `WidgetView` component
+
+**Files:**
+- Create: `frontend/packages/web/components/chat/widget/WidgetView.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// frontend/packages/web/components/chat/widget/WidgetView.tsx
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { WIDGET_SHELL_HTML } from './widgetShell'
+
+const READY_TIMEOUT_MS = 5000
+const MAX_HEIGHT_PX = 4000
+const MAX_CODE_BYTES = 256 * 1024
+
+interface WidgetViewProps {
+  widgetCode: string
+  status: 'streaming' | 'complete'
+  widgetId: string
+  title?: string
+  width?: number
+  height?: number
+}
+
+export function WidgetView({ widgetCode, status, widgetId, title, width }: WidgetViewProps) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
+  const [ready, setReady] = useState(false)
+  const [failed, setFailed] = useState(false)
+  const [height, setHeight] = useState(120)
+  const seqRef = useRef(0)
+  const latestRef = useRef('')
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const tooBig = new Blob([widgetCode]).size > MAX_CODE_BYTES
+  latestRef.current = widgetCode
+
+  // child → parent listener (validate source + type)
+  useEffect(() => {
+    function onMessage(e: MessageEvent) {
+      if (e.source !== iframeRef.current?.contentWindow) return
+      const d = e.data as { widgetId?: string; type?: string; height?: number; message?: string }
+      if (d.widgetId !== widgetId) return
+      if (d.type === 'ready') setReady(true)
+      else if (d.type === 'error') setFailed(true)
+      else if (d.type === 'resize' && typeof d.height === 'number') {
+        setHeight(Math.min(Math.max(d.height, 40), MAX_HEIGHT_PX))
+      }
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [widgetId])
+
+  // readiness timeout → fallback
+  useEffect(() => {
+    if (ready || failed) return
+    const t = setTimeout(() => { if (!ready) setFailed(true) }, READY_TIMEOUT_MS)
+    return () => clearTimeout(t)
+  }, [ready, failed])
+
+  // push morph (debounced) once ready
+  useEffect(() => {
+    if (!ready || failed || tooBig) return
+    const send = (final: boolean) => {
+      const win = iframeRef.current?.contentWindow
+      if (!win) return
+      seqRef.current += 1
+      win.postMessage(
+        { widgetId, seq: seqRef.current, type: 'morph', html: latestRef.current },
+        '*',
+      )
+      if (final) {
+        seqRef.current += 1
+        win.postMessage({ widgetId, seq: seqRef.current, type: 'finalize' }, '*')
+      }
+    }
+    if (status === 'complete') {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      send(true)
+    } else {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      debounceRef.current = setTimeout(() => send(false), 120)
+    }
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current) }
+  }, [widgetCode, status, ready, failed, tooBig, widgetId])
+
+  if (failed || tooBig) {
+    return (
+      <details className="rounded-lg border border-border bg-muted p-2 text-sm">
+        <summary className="cursor-pointer text-muted-foreground">
+          {tooBig ? 'Widget too large — showing source' : 'Widget failed to render — showing source'}
+          {title ? ` (${title})` : ''}
+        </summary>
+        <pre className="overflow-auto text-xs"><code>{widgetCode}</code></pre>
+      </details>
+    )
+  }
+
+  return (
+    <iframe
+      ref={iframeRef}
+      title={title ?? 'widget'}
+      sandbox="allow-scripts"
+      srcDoc={WIDGET_SHELL_HTML}
+      style={{ width: width ? `${width}px` : '100%', height, border: 'none' }}
+      className="rounded-lg border border-border bg-muted"
+    />
+  )
+}
+```
+
+> `sandbox="allow-scripts"` only — never add `allow-same-origin`. `srcDoc` carries
+> the shell. The component holds `latestRef` so the first post after `ready` uses
+> the newest HTML.
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm --filter web type-check`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/packages/web/components/chat/widget/WidgetView.tsx
+git commit -m "feat(widget): WidgetView sandboxed-iframe component"
+```
+
+---
+
+## Task 6: Frontend — mount in `AssistantMessage`
+
+**Files:**
+- Modify: `frontend/packages/web/components/chat/AssistantMessage.tsx`
+
+- [ ] **Step 1: Add the streaming branch**
+
+In the `block.type === 'tool_call_streaming'` branch (~`:314`), before the
+generic `write_file` handling, add:
+
+```tsx
+  if (block.type === 'tool_call_streaming' && block.name === 'show_widget') {
+    return (
+      <WidgetView
+        widgetId={block.tool_call_id ?? `idx-${block.index}`}
+        widgetCode={extractWidgetCode(block.args_text)}
+        status="streaming"
+      />
+    )
+  }
+```
+
+- [ ] **Step 2: Add the completed branch (before ToolCallGroup)**
+
+Alongside the existing `subagent` (~`:230`) and `save_artifact` (~`:256`)
+special cases, before the generic `if (block.type === 'tool_call')` →
+`ToolCallGroup` (~`:303`), add:
+
+```tsx
+  if (block.type === 'tool_call' && block.name === 'show_widget') {
+    return (
+      <WidgetView
+        widgetId={block.id}
+        widgetCode={typeof block.arguments?.widget_code === 'string' ? block.arguments.widget_code : ''}
+        status="complete"
+        title={typeof block.arguments?.title === 'string' ? block.arguments.title : undefined}
+      />
+    )
+  }
+```
+
+This early return means a completed `show_widget` never reaches the generic
+`ToolCallGroup`, so it renders as a widget rather than collapsing into the
+tool-call list.
+
+- [ ] **Step 3: Add imports**
+
+```tsx
+import { WidgetView } from '@/components/chat/widget/WidgetView'
+import { extractWidgetCode } from '@/lib/partialJson'
+```
+
+- [ ] **Step 4: Type-check + existing component tests**
+
+Run: `pnpm --filter web type-check`
+Run: `pnpm --filter web test AssistantMessage` (if present)
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/packages/web/components/chat/AssistantMessage.tsx
+git commit -m "feat(widget): mount WidgetView for streaming + completed show_widget"
+```
+
+---
+
+## Task 7: Frontend — `SubAgentCard` parity (if widgets can appear in subagent output)
+
+**Files:**
+- Modify: `frontend/packages/web/components/chat/SubAgentCard.tsx`
+
+`SubAgentCard.tsx` also renders streamed tool blocks (it imports
+`getWriteFileSummary`). If subagents may emit widgets, mirror Task 6's two
+branches there.
+
+- [ ] **Step 1: Decide scope**
+
+If subagents are not expected to call `show_widget` in v1, **skip this task**
+and note it: widgets render only in top-level assistant messages for v1.
+Otherwise mirror the streaming + completed branches from Task 6.
+
+- [ ] **Step 2 (if applying): add the branches + imports, type-check, commit**
+
+```bash
+git add frontend/packages/web/components/chat/SubAgentCard.tsx
+git commit -m "feat(widget): render show_widget inside subagent cards"
+```
+
+---
+
+## Task 8: E2E — streaming, latest-wins, reload, fallback, multi, security
+
+**Files:**
+- Create: `frontend/packages/web/tests/e2e/generative-ui-widgets.spec.ts`
+
+Uses the faux provider (`cubepi/providers/faux.py`) to script a `show_widget`
+tool call streamed across frames. Wire the faux script via the existing E2E
+config switch (match how other E2E specs select faux — see existing specs in
+`tests/e2e/`).
+
+- [ ] **Step 1: Write the E2E spec**
+
+```typescript
+// frontend/packages/web/tests/e2e/generative-ui-widgets.spec.ts
+import { test, expect } from '@playwright/test'
+
+// Helper: the faux script emits a show_widget tool call whose widget_code is:
+//   <style>...</style><p id="w">hi</p><script>window.__c=(window.__c||0)+1;
+//     document.getElementById('w').textContent='done'+window.__c;</script>
+// streamed across several deltas. (See faux fixture wiring.)
+
+test('streams a widget and finalizes scripts once', async ({ page }) => {
+  await page.goto('/')             // adjust to the conversation URL the suite uses
+  // ...send the prompt that triggers the faux show_widget script...
+  const frame = page.frameLocator('iframe[title]')
+  // sandbox attribute is hardened
+  const sandbox = await page.locator('iframe[title]').getAttribute('sandbox')
+  expect(sandbox).toBe('allow-scripts')
+  // mid-stream partial node appears
+  await expect(frame.locator('#w')).toBeVisible()
+  // after finalize the script ran exactly once
+  await expect(frame.locator('#w')).toHaveText('done1')
+})
+
+test('reload renders finished widget without streaming', async ({ page }) => {
+  // ...after a completed widget exists, reload...
+  await page.reload()
+  const frame = page.frameLocator('iframe[title]')
+  await expect(frame.locator('#w')).toHaveText('done1')
+})
+
+test('latest-wins: a late lower-seq morph does not regress', async ({ page }) => {
+  // Drive WidgetView with a complete widget, then inject a stale morph via
+  // page.evaluate(postMessage with seq=0); assert content unchanged.
+})
+
+test('readiness timeout falls back to source block', async ({ page }) => {
+  // Block the morphdom CDN (route.abort) so ready never fires; assert the
+  // <details> source fallback appears within ~6s, not a blank iframe body.
+})
+
+test('two widgets render in independent iframes', async ({ page }) => {
+  // faux emits two show_widget calls; assert two iframes, each with its content.
+})
+
+test('widget cannot reach parent or network', async ({ page }) => {
+  const frame = page.frameLocator('iframe[title]')
+  // inside the widget, reading parent.document throws (opaque origin);
+  // fetch() is blocked by connect-src 'none'. Assert via a widget that posts
+  // its probe result, or via console/network assertions.
+})
+```
+
+> The exact navigation/prompt-send steps and faux wiring follow the patterns in
+> the existing `tests/e2e/` specs. Fill those in from a sibling spec; do not
+> invent new harness APIs.
+
+- [ ] **Step 2: Run the E2E on worktree ports**
+
+Run (from `frontend/`): the repo's Playwright command (e.g. `pnpm --filter web test:e2e generative-ui-widgets`). Ensure backend (8075) + frontend (3075) are up via the worktree env.
+Expected: all specs PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/packages/web/tests/e2e/generative-ui-widgets.spec.ts
+git commit -m "test(widget): E2E for streaming, latest-wins, reload, fallback, security"
+```
+
+---
+
+## Task 9: Manual browser verification + changed-module sweep
+
+- [ ] **Step 1:** Start backend (8075) + frontend (3075) via worktree env. In the
+  browser (bind 0.0.0.0; report IP:port — user is remote), trigger a real
+  `show_widget` (e.g. "show me how compound interest works"). Confirm: it
+  streams in, morphs smoothly, scripts run once, dark theme reads well, resize
+  fits. Check both light and dark app themes.
+- [ ] **Step 2:** Run changed-module tests:
+  - `uv run pytest tests/tools/test_show_widget.py -v`
+  - `pnpm --filter web test partialJson writeFilePreview`
+  - `pnpm --filter web type-check`
+- [ ] **Step 3:** Defer the full suite + `/ci` to the pre-PR / Stage-5 sweep.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** tool (T1) + registration/prompt (T2) + extract reuse (T3) +
+  shell (T4) + WidgetView with seq/debounce/ready-timeout/fallback/limits (T5) +
+  mount excluding ToolCallGroup (T6) + subagent parity decision (T7) + E2E incl.
+  latest-wins/reload/fallback/multi/security (T8) + manual + theme check (T9).
+  Interrupted-widget non-persistence is inherited behavior (no task needed).
+- **Placeholders:** the E2E navigation/faux-wiring steps intentionally defer to
+  sibling-spec patterns rather than inventing harness APIs; all code units have
+  complete implementations.
+- **Type consistency:** message shape `{widgetId, seq, type, html?}` (parent→child)
+  and `{widgetId, type, ...}` (child→parent) is identical in `widgetShell.ts` and
+  `WidgetView.tsx`; `extractWidgetCode` signature matches its callers.

--- a/docs/dev/plans/2026-05-27-generative-ui-widgets.md
+++ b/docs/dev/plans/2026-05-27-generative-ui-widgets.md
@@ -37,7 +37,7 @@
 **Tests (create):**
 - `backend/tests/tools/test_show_widget.py`
 - `frontend/packages/web/lib/__tests__/partialJson.test.ts`
-- `frontend/packages/web/tests/e2e/generative-ui-widgets.spec.ts`
+- `frontend/packages/web/__tests__/e2e/generative-ui-widgets.spec.ts`
 
 ---
 
@@ -131,8 +131,8 @@ tool call in message history.
 
 from pydantic import BaseModel, Field
 
+from cubepi.agent.types import AgentTool, AgentToolResult
 from cubepi.providers.base import TextContent
-from cubepi.agent.tools import AgentTool, AgentToolResult
 
 from cubebox.prompts.widget import WIDGET_TOOL_DESCRIPTION
 
@@ -163,9 +163,9 @@ def make_show_widget_tool() -> AgentTool[_ShowWidgetArgs]:
     )
 ```
 
-> NOTE: confirm the exact import paths for `AgentTool`, `AgentToolResult`,
-> `TextContent` against `cubebox/middleware/sandbox.py` (it imports the same
-> symbols). Match that file's imports verbatim.
+> Verified against `cubebox/middleware/sandbox.py:21-23`: `AgentTool` /
+> `AgentToolResult` come from `cubepi.agent.types`, `TextContent` from
+> `cubepi.providers.base`. (Not `cubepi.agent.tools` — that module does not exist.)
 
 - [ ] **Step 5: Run tests, verify pass**
 
@@ -225,17 +225,25 @@ In `backend/cubebox/streams/run_manager.py`, after the `view_images` append bloc
 
 - [ ] **Step 4: Inject the guidelines into the system prompt**
 
-Find where `run_manager` assembles the system prompt for the cubepi run (search `transform_system_prompt` consumers / where builtin-tool prompt sections are appended). Append `WIDGET_GUIDELINES` **once**, unconditionally whenever `show_widget` is in the tool list, at a fixed position relative to other appended sections:
+The system prompt is assembled in `_execute_run` as `effective_system_prompt`
+(`run_manager.py:1760-1801`) and **passed into** `_run_cubepi_path` as a
+parameter (`run_manager.py:824`, called at `:1807`). Inject there — not inside
+`_run_cubepi_path`. Append `WIDGET_GUIDELINES` **once**, at a fixed position
+after the existing appends (e.g. after the `SKILLS_PROMPT_TEMPLATE` block at
+`~:1801`, before the `_run_cubepi_path` call at `:1807`):
 
 ```python
+        # backend/cubebox/streams/run_manager.py, in _execute_run, after the
+        # SKILLS_PROMPT_TEMPLATE append (~:1801), before _run_cubepi_path(...)
         from cubebox.prompts.widget import WIDGET_GUIDELINES
-        # appended after the other builtin-tool prompt sections, before sandbox
-        system_prompt = system_prompt + "\n\n" + WIDGET_GUIDELINES
+
+        effective_system_prompt += "\n\n" + WIDGET_GUIDELINES
 ```
 
-> Read `backend/docs/prompt-cache-discipline.md` first and match the existing
-> append style/position used for other builtin tools. The exact insertion
-> point is whatever keeps a deterministic, cache-stable prefix.
+> Read `backend/docs/prompt-cache-discipline.md` first. Append at a fixed,
+> deterministic position so the cache prefix stays stable across runs. v1
+> appends unconditionally (the tool is always registered), which keeps the
+> prompt deterministic.
 
 - [ ] **Step 5: Run the backend tool tests + a quick import smoke**
 
@@ -406,11 +414,12 @@ body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;backgr
 <body><div id="root"></div>
 <script>
 (function(){
-  var WIDGET_ID = null;
+  // WidgetView injects the real id by replacing the __WIDGET_ID__ token in the
+  // srcDoc at mount, so the shell knows its identity from the start (no
+  // learn-from-first-message handshake → no deadlock).
+  var WIDGET_ID = "__WIDGET_ID__";
   var lastSeq = -1;
   var finalized = false;
-  var morphReady = false;
-  var pending = null; // {seq, html}
 
   function post(msg){ parent.postMessage(Object.assign({widgetId: WIDGET_ID}, msg), '*'); }
 
@@ -439,21 +448,20 @@ body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;backgr
     });
   }
 
+  // WidgetView only sends after it receives {type:'ready'} (sent below, after
+  // morphdom loads), so every inbound morph/finalize arrives morph-ready.
   window.addEventListener('message', function(e){
     if (e.source !== parent) return;
     var d = e.data || {};
-    if (WIDGET_ID === null && d.widgetId != null) WIDGET_ID = d.widgetId;
     if (d.widgetId !== WIDGET_ID) return;
     if (typeof d.seq !== 'number' || d.seq <= lastSeq) return; // latest-wins
     lastSeq = d.seq;
     try {
       if (d.type === 'morph') {
         if (finalized) return;
-        if (!morphReady) { pending = {seq:d.seq, html:d.html}; return; }
         applyMorph(d.html);
       } else if (d.type === 'finalize') {
         if (finalized) return;
-        if (!morphReady) { pending = {seq:d.seq, html:null, finalize:true}; return; }
         finalized = true;
         runScripts();
         post({type:'resize', height: document.body.scrollHeight});
@@ -465,15 +473,7 @@ body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;backgr
 
   var s = document.createElement('script');
   s.src = 'https://cdn.jsdelivr.net/npm/morphdom@2.7.4/dist/morphdom-umd.min.js';
-  s.onload = function(){
-    morphReady = true;
-    post({type:'ready'});
-    if (pending) {
-      if (pending.html != null) applyMorph(pending.html);
-      if (pending.finalize) { finalized = true; runScripts(); }
-      pending = null;
-    }
-  };
+  s.onload = function(){ post({type:'ready'}); };
   s.onerror = function(){ post({type:'error', message:'morphdom failed to load'}); };
   document.head.appendChild(s);
 })();
@@ -481,8 +481,9 @@ body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;backgr
 ```
 
 > The CSP `meta` is the first `<head>` child, before the inline `<style>`/`<script>`.
-> The shell installs its message listener synchronously, but `WidgetView` still
-> waits for `ready` before sending (Task 5) — `pending` is belt-and-suspenders.
+> `__WIDGET_ID__` is a literal placeholder that `WidgetView` replaces with the
+> real id at mount (Task 5). `ready` fires only after morphdom loads, and the
+> parent sends nothing before `ready`, so no pre-ready buffering is needed.
 
 - [ ] **Step 2: Type-check**
 
@@ -509,7 +510,7 @@ git commit -m "feat(widget): iframe shell runtime (CSP + morphdom + postMessage)
 // frontend/packages/web/components/chat/widget/WidgetView.tsx
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { WIDGET_SHELL_HTML } from './widgetShell'
 
 const READY_TIMEOUT_MS = 5000
@@ -525,14 +526,24 @@ interface WidgetViewProps {
   height?: number
 }
 
-export function WidgetView({ widgetCode, status, widgetId, title, width }: WidgetViewProps) {
+export function WidgetView({
+  widgetCode,
+  status,
+  widgetId,
+  title,
+  width,
+  height: initialHeight,
+}: WidgetViewProps) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
   const [ready, setReady] = useState(false)
   const [failed, setFailed] = useState(false)
-  const [height, setHeight] = useState(120)
+  const [height, setHeight] = useState(initialHeight ?? 120)
   const seqRef = useRef(0)
   const latestRef = useRef('')
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Inject the real id into the shell (stable per widgetId).
+  const srcDoc = useMemo(() => WIDGET_SHELL_HTML.replace('__WIDGET_ID__', widgetId), [widgetId])
 
   const tooBig = new Blob([widgetCode]).size > MAX_CODE_BYTES
   latestRef.current = widgetCode
@@ -603,7 +614,7 @@ export function WidgetView({ widgetCode, status, widgetId, title, width }: Widge
       ref={iframeRef}
       title={title ?? 'widget'}
       sandbox="allow-scripts"
-      srcDoc={WIDGET_SHELL_HTML}
+      srcDoc={srcDoc}
       style={{ width: width ? `${width}px` : '100%', height, border: 'none' }}
       className="rounded-lg border border-border bg-muted"
     />
@@ -651,7 +662,29 @@ generic `write_file` handling, add:
   }
 ```
 
-- [ ] **Step 2: Add the completed branch (before ToolCallGroup)**
+- [ ] **Step 2: Exclude `show_widget` from `groupBlocks` (REQUIRED — the real fix)**
+
+Completed `tool_call` blocks are grouped by `groupBlocks` (`:361`) **before**
+`ContentBlockRenderer` ever sees them (`:430` builds `grouped`, rendered at
+`:467`/`:478`). `groupBlocks` already exempts `subagent`/`save_artifact`/
+`write_todos` by name. Add `show_widget` to that exemption so it passes through
+ungrouped to `ContentBlockRenderer`:
+
+```tsx
+    if (
+      block.type === 'tool_call' &&
+      block.name !== 'subagent' &&
+      block.name !== 'save_artifact' &&
+      block.name !== 'write_todos' &&
+      block.name !== 'show_widget'        // <-- add
+    ) {
+      // ...existing grouping push...
+```
+
+Without this, a completed widget is swallowed into a `ToolCallGroup` and the
+custom branch below never runs.
+
+- [ ] **Step 3: Add the completed branch in `ContentBlockRenderer`**
 
 Alongside the existing `subagent` (~`:230`) and `save_artifact` (~`:256`)
 special cases, before the generic `if (block.type === 'tool_call')` →
@@ -659,35 +692,37 @@ special cases, before the generic `if (block.type === 'tool_call')` →
 
 ```tsx
   if (block.type === 'tool_call' && block.name === 'show_widget') {
+    const a = block.arguments ?? {}
     return (
       <WidgetView
         widgetId={block.id}
-        widgetCode={typeof block.arguments?.widget_code === 'string' ? block.arguments.widget_code : ''}
+        widgetCode={typeof a.widget_code === 'string' ? a.widget_code : ''}
         status="complete"
-        title={typeof block.arguments?.title === 'string' ? block.arguments.title : undefined}
+        title={typeof a.title === 'string' ? a.title : undefined}
+        width={typeof a.width === 'number' ? a.width : undefined}
+        height={typeof a.height === 'number' ? a.height : undefined}
       />
     )
   }
 ```
 
-This early return means a completed `show_widget` never reaches the generic
-`ToolCallGroup`, so it renders as a widget rather than collapsing into the
-tool-call list.
+Combined with Step 2, a completed `show_widget` reaches this branch ungrouped
+and renders as a widget instead of collapsing into the tool-call list.
 
-- [ ] **Step 3: Add imports**
+- [ ] **Step 4: Add imports**
 
 ```tsx
 import { WidgetView } from '@/components/chat/widget/WidgetView'
 import { extractWidgetCode } from '@/lib/partialJson'
 ```
 
-- [ ] **Step 4: Type-check + existing component tests**
+- [ ] **Step 5: Type-check + existing component tests**
 
 Run: `pnpm --filter web type-check`
 Run: `pnpm --filter web test AssistantMessage` (if present)
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -696,26 +731,54 @@ git commit -m "feat(widget): mount WidgetView for streaming + completed show_wid
 
 ---
 
-## Task 7: Frontend — `SubAgentCard` parity (if widgets can appear in subagent output)
+## Task 7: Subagent scope — exclude `show_widget` from subagent tools (v1)
+
+**Context:** `SubAgentMiddleware` shares the same `_builtin_tools` list
+(`run_manager.py:1292-1300`), so registering `show_widget` in builtins makes it
+callable from inside subagents too. Rendering widgets inside `SubAgentCard.tsx`
+(which has its own block-rendering path) is extra surface we don't want in v1.
+
+**v1 decision:** keep widgets a **top-level assistant feature only**. The
+cleanest way is to **not expose `show_widget` to subagents**, so subagent output
+can never contain a widget block to render.
 
 **Files:**
-- Modify: `frontend/packages/web/components/chat/SubAgentCard.tsx`
+- Modify: `backend/cubebox/streams/run_manager.py` (subagent tool assembly, ~`:1292-1303`)
 
-`SubAgentCard.tsx` also renders streamed tool blocks (it imports
-`getWriteFileSummary`). If subagents may emit widgets, mirror Task 6's two
-branches there.
+- [ ] **Step 1: Exclude `show_widget` from the subagent tool set**
 
-- [ ] **Step 1: Decide scope**
+Where `_subagent_tools` / the SubAgentMiddleware tool list is built from the
+shared builtins (~`:1292-1303`), filter it out:
 
-If subagents are not expected to call `show_widget` in v1, **skip this task**
-and note it: widgets render only in top-level assistant messages for v1.
-Otherwise mirror the streaming + completed branches from Task 6.
+```python
+        _subagent_tools = [t for t in _subagent_tools if t.name != "show_widget"]
+```
 
-- [ ] **Step 2 (if applying): add the branches + imports, type-check, commit**
+> Verify the exact variable that feeds `SubAgentMiddleware` and filter that one.
+> The goal: the top-level run includes `show_widget`; subagent runs do not.
+
+- [ ] **Step 2: Add a backend test**
+
+```python
+# backend/tests/tools/test_show_widget.py
+def test_show_widget_excluded_from_subagent_tools():
+    # Build the subagent tool list the way run_manager does and assert
+    # no tool named "show_widget" is present. (Use the helper/path that
+    # run_manager uses to assemble _subagent_tools.)
+    ...
+```
+
+> Fill in using the actual assembly helper. If a direct unit seam isn't
+> available, assert it via the Task 8 E2E instead (a subagent prompt that would
+> trigger a widget produces no iframe).
+
+- [ ] **Step 3: Run + commit**
+
+Run: `uv run pytest tests/tools/test_show_widget.py -v`
 
 ```bash
-git add frontend/packages/web/components/chat/SubAgentCard.tsx
-git commit -m "feat(widget): render show_widget inside subagent cards"
+git add backend/cubebox/streams/run_manager.py backend/tests/tools/test_show_widget.py
+git commit -m "feat(widget): keep show_widget out of subagent tool set (v1 top-level only)"
 ```
 
 ---
@@ -723,17 +786,23 @@ git commit -m "feat(widget): render show_widget inside subagent cards"
 ## Task 8: E2E — streaming, latest-wins, reload, fallback, multi, security
 
 **Files:**
-- Create: `frontend/packages/web/tests/e2e/generative-ui-widgets.spec.ts`
+- Create: `frontend/packages/web/__tests__/e2e/generative-ui-widgets.spec.ts`
+
+> Verified repo layout: frontend E2E specs live in
+> `frontend/packages/web/__tests__/e2e/` (e.g. `admin-settings.spec.ts`), and the
+> Playwright runner is `test:e2e` in **`frontend/package.json`** (`playwright test`),
+> run as `cd frontend && pnpm test:e2e`. There is no `test:e2e` in
+> `packages/web/package.json` (that only has `test` = vitest).
 
 Uses the faux provider (`cubepi/providers/faux.py`) to script a `show_widget`
 tool call streamed across frames. Wire the faux script via the existing E2E
-config switch (match how other E2E specs select faux — see existing specs in
-`tests/e2e/`).
+config switch (match how a sibling spec in `__tests__/e2e/` selects faux and
+sends a prompt — reuse those exact helpers; do not invent harness APIs).
 
 - [ ] **Step 1: Write the E2E spec**
 
 ```typescript
-// frontend/packages/web/tests/e2e/generative-ui-widgets.spec.ts
+// frontend/packages/web/__tests__/e2e/generative-ui-widgets.spec.ts
 import { test, expect } from '@playwright/test'
 
 // Helper: the faux script emits a show_widget tool call whose widget_code is:
@@ -781,22 +850,37 @@ test('widget cannot reach parent or network', async ({ page }) => {
   // fetch() is blocked by connect-src 'none'. Assert via a widget that posts
   // its probe result, or via console/network assertions.
 })
+
+test('parent ignores a forged-source message', async ({ page }) => {
+  // From the page (not the iframe), postMessage a {widgetId, type:'resize',
+  // height: 9999} directly to window. Because WidgetView checks
+  // e.source === iframe.contentWindow, the forged message (source = top window)
+  // must be ignored — assert the iframe height does NOT jump to 9999.
+})
+
+// Subagent scope (Task 7): a subagent prompt that would otherwise trigger a
+// widget produces NO iframe, since show_widget is excluded from subagent tools.
+test('subagents do not render widgets', async ({ page }) => {
+  // drive a faux subagent run that would call show_widget; assert no iframe[title].
+})
 ```
 
 > The exact navigation/prompt-send steps and faux wiring follow the patterns in
-> the existing `tests/e2e/` specs. Fill those in from a sibling spec; do not
+> a sibling spec in `__tests__/e2e/`. Fill those in from that spec; do not
 > invent new harness APIs.
 
 - [ ] **Step 2: Run the E2E on worktree ports**
 
-Run (from `frontend/`): the repo's Playwright command (e.g. `pnpm --filter web test:e2e generative-ui-widgets`). Ensure backend (8075) + frontend (3075) are up via the worktree env.
+Run: `cd frontend && pnpm test:e2e generative-ui-widgets` (the `test:e2e` script
+is in `frontend/package.json`). Ensure backend (8075) + frontend (3075) are up
+via the worktree env (`cat .worktree.env`).
 Expected: all specs PASS.
 
 - [ ] **Step 3: Commit**
 
 ```bash
-git add frontend/packages/web/tests/e2e/generative-ui-widgets.spec.ts
-git commit -m "test(widget): E2E for streaming, latest-wins, reload, fallback, security"
+git add frontend/packages/web/__tests__/e2e/generative-ui-widgets.spec.ts
+git commit -m "test(widget): E2E for streaming, latest-wins, reload, fallback, security, subagent-scope"
 ```
 
 ---
@@ -818,14 +902,25 @@ git commit -m "test(widget): E2E for streaming, latest-wins, reload, fallback, s
 
 ## Self-Review
 
-- **Spec coverage:** tool (T1) + registration/prompt (T2) + extract reuse (T3) +
-  shell (T4) + WidgetView with seq/debounce/ready-timeout/fallback/limits (T5) +
-  mount excluding ToolCallGroup (T6) + subagent parity decision (T7) + E2E incl.
-  latest-wins/reload/fallback/multi/security (T8) + manual + theme check (T9).
+- **Spec coverage:** tool (T1) + registration/prompt-injection-in-`_execute_run`
+  (T2) + extract reuse (T3) + shell with `__WIDGET_ID__` injection (T4) +
+  WidgetView with id-injected srcDoc, seq/debounce/ready-timeout/fallback/limits,
+  height applied (T5) + mount with `groupBlocks` exclusion + completed branch (T6)
+  + subagent exclusion (T7) + E2E incl. latest-wins/reload/fallback/multi/security/
+  forged-source/subagent-scope (T8) + manual + theme check (T9).
   Interrupted-widget non-persistence is inherited behavior (no task needed).
+- **Verified against real code:** cubepi imports (`cubepi.agent.types` /
+  `cubepi.providers.base`), builtin registration order (`run_manager.py:977-996`),
+  prompt site (`_execute_run` `:1760-1807`), `groupBlocks` name-exclusion
+  (`AssistantMessage.tsx:361`), E2E dir (`__tests__/e2e/`) + runner
+  (`frontend/package.json` `test:e2e`).
+- **Handshake:** the deadlock is removed — the shell gets its id via
+  `__WIDGET_ID__` replacement at mount and posts `ready` (with the right id)
+  after morphdom loads; the parent sends only after `ready`.
 - **Placeholders:** the E2E navigation/faux-wiring steps intentionally defer to
   sibling-spec patterns rather than inventing harness APIs; all code units have
   complete implementations.
 - **Type consistency:** message shape `{widgetId, seq, type, html?}` (parent→child)
   and `{widgetId, type, ...}` (child→parent) is identical in `widgetShell.ts` and
-  `WidgetView.tsx`; `extractWidgetCode` signature matches its callers.
+  `WidgetView.tsx`; `extractWidgetCode` signature matches its callers; `WidgetViewProps`
+  `width`/`height`/`title` are all passed from the mount branches.

--- a/docs/dev/plans/2026-05-27-generative-ui-widgets.md
+++ b/docs/dev/plans/2026-05-27-generative-ui-widgets.md
@@ -205,7 +205,10 @@ def test_guidelines_mention_tool_and_constraints():
 - [ ] **Step 2: Run it, verify it passes** (the prompt already exists from Task 1)
 
 Run: `uv run pytest tests/tools/test_show_widget.py::test_guidelines_mention_tool_and_constraints -v`
-Expected: PASS. (This locks the guideline content; the registration wiring below is verified by the Task 8 E2E, which exercises the full run path.)
+Expected: PASS. (This locks the guideline content. The registration/prompt
+wiring itself is verified by the Step 5 import smoke + the manual model→widget
+run in Task 9 — Task 8 is deterministic frontend-only testing and does not
+exercise the backend run path.)
 
 - [ ] **Step 3: Register the tool in run_manager**
 
@@ -417,11 +420,14 @@ body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;backgr
 <body><div id="root"></div>
 <script>
 (function(){
-  // WidgetView replaces the placeholder below with the real id at mount, so the
-  // shell knows its identity from the start (no learn-from-first-message
-  // handshake -> no deadlock). The placeholder appears exactly ONCE in this
-  // whole srcDoc string (here), so a single string replace is unambiguous.
-  var WIDGET_ID = "%%WIDGET_ID%%";
+  // WidgetView replaces the placeholder below with JSON.stringify(widgetId) at
+  // mount (note: NO surrounding quotes here — JSON.stringify supplies them and
+  // escapes any special chars, so an id with quotes/backslashes can't break out
+  // of the literal). The placeholder appears exactly ONCE in this whole srcDoc
+  // string (here), so a single string replace is unambiguous. The shell knows
+  // its identity from the start (no learn-from-first-message handshake → no
+  // deadlock).
+  var WIDGET_ID = %%WIDGET_ID%%;
   var lastSeq = -1;
   var finalized = false;
 
@@ -487,8 +493,9 @@ body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;backgr
 > The CSP `meta` is the first `<head>` child, before the inline `<style>`/`<script>`.
 > `%%WIDGET_ID%%` is a literal placeholder appearing exactly once in the string
 > (in the `var WIDGET_ID` assignment, not in any comment), so `WidgetView`'s
-> single `.replace('%%WIDGET_ID%%', widgetId)` is unambiguous. `ready` fires only
-> after morphdom loads, and the parent sends nothing before `ready`, so no
+> single `.replace('%%WIDGET_ID%%', JSON.stringify(widgetId))` is unambiguous and
+> injection-safe (JSON.stringify provides the quotes + escaping). `ready` fires
+> only after morphdom loads, and the parent sends nothing before `ready`, so no
 > pre-ready buffering is needed.
 
 - [ ] **Step 2: Type-check**
@@ -548,9 +555,13 @@ export function WidgetView({
   const latestRef = useRef('')
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Inject the real id into the shell (stable per widgetId). The placeholder
-  // appears exactly once in WIDGET_SHELL_HTML, so a single replace is safe.
-  const srcDoc = useMemo(() => WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', widgetId), [widgetId])
+  // Inject the real id into the shell (stable per widgetId). JSON.stringify
+  // supplies quotes + escaping, so an id with special chars can't break the JS
+  // literal. The placeholder appears exactly once in WIDGET_SHELL_HTML.
+  const srcDoc = useMemo(
+    () => WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', JSON.stringify(widgetId)),
+    [widgetId],
+  )
 
   const tooBig = new Blob([widgetCode]).size > MAX_CODE_BYTES
   latestRef.current = widgetCode
@@ -672,9 +683,11 @@ generic `write_file` handling, add:
 ```
 
 > `width`/`height` are integers that may not have streamed yet mid-call; they
-> are left `undefined` during streaming and applied when the completed branch
-> re-renders the same widget (same `widgetId` → same iframe, no remount). Only
-> `title` (a leading string field) is cheap to extract live.
+> are left `undefined` during streaming. They are only *initial hints*: the
+> shell posts a `resize` message (scrollHeight) after every morph and after
+> finalize, and that drives the authoritative height via `setHeight` — so the
+> rendered height self-corrects regardless of the `height` prop, with no remount
+> needed. Only `title` (a leading string field) is cheap to extract live.
 
 - [ ] **Step 2: Exclude `show_widget` from `groupBlocks` (REQUIRED — the real fix)**
 
@@ -761,10 +774,20 @@ still includes it from `_builtin_tools`.)
 **Files:**
 - Modify: `backend/cubebox/streams/run_manager.py` (SubAgentMiddleware construction, `:1292-1300`)
 
-- [ ] **Step 1: Exclude `show_widget` from the subagent `shared_tools`**
+- [ ] **Step 1: Extract a tiny pure helper (so it is unit-testable)**
 
-At the `SubAgentMiddleware(...)` construction (`:1299`), filter the
-`shared_tools` argument:
+The filter is currently inline at `SubAgentMiddleware(...)` (`:1299`). Make it a
+named module-level pure function in `run_manager.py` (above `_execute_run`) so it
+has a unit seam:
+
+```python
+# backend/cubebox/streams/run_manager.py (module level)
+def _subagent_shared_tools(tools: list[AgentTool[Any]]) -> list[AgentTool[Any]]:
+    """Tools shared into subagents. show_widget is top-level only (v1)."""
+    return [t for t in tools if t.name != "show_widget"]
+```
+
+- [ ] **Step 2: Use it at the SubAgentMiddleware construction (`:1299`)**
 
 ```python
             subagent_mw = SubAgentMiddleware(
@@ -772,35 +795,39 @@ At the `SubAgentMiddleware(...)` construction (`:1299`), filter the
                 default_provider=provider,
                 default_model_id=model_id,
                 default_provider_name=provider_name,
-                shared_tools=[
-                    t
-                    for t in (_sandbox_tools + _artifact_tools + _builtin_tools)
-                    if t.name != "show_widget"
-                ],
+                shared_tools=_subagent_shared_tools(
+                    _sandbox_tools + _artifact_tools + _builtin_tools
+                ),
                 inherited_middleware=_cost_mw_for_inherit,
             )
 ```
 
-> This is the list actually handed to subagents. (`SubAgentMiddleware` already
-> drops self-referential tools internally, but `show_widget` isn't one of those,
-> so we exclude it here.)
+> This is the list actually handed to subagents. (`SubAgentMiddleware` also drops
+> self-referential tools internally, but `show_widget` isn't one of those.)
 
-- [ ] **Step 2: Add a backend test**
+- [ ] **Step 3: Add a concrete backend test**
 
 ```python
 # backend/tests/tools/test_show_widget.py
-def test_show_widget_excluded_from_subagent_tools():
-    # Build the subagent tool list the way run_manager does and assert
-    # no tool named "show_widget" is present. (Use the helper/path that
-    # run_manager uses to assemble _subagent_tools.)
-    ...
+from types import SimpleNamespace
+
+from cubebox.streams.run_manager import _subagent_shared_tools
+from cubebox.tools.builtin.show_widget import make_show_widget_tool
+
+
+def test_subagent_shared_tools_drops_show_widget():
+    sw = make_show_widget_tool()
+    keep = SimpleNamespace(name="execute")  # helper only reads .name
+    result = _subagent_shared_tools([sw, keep])  # type: ignore[list-item]
+    assert sw not in result          # show_widget removed
+    assert keep in result            # other tools retained
 ```
 
-> Fill in using the actual assembly helper. If a direct unit seam isn't
-> available, assert it via the Task 8 E2E instead (a subagent prompt that would
-> trigger a widget produces no iframe).
+> `_subagent_shared_tools` only reads `t.name`, so a `SimpleNamespace` stand-in
+> is enough to prove a non-widget tool is retained without constructing a second
+> real `AgentTool`.
 
-- [ ] **Step 3: Run + commit**
+- [ ] **Step 4: Run + commit**
 
 Run: `uv run pytest tests/tools/test_show_widget.py -v`
 
@@ -876,6 +903,10 @@ test('morph applies, then finalize runs scripts exactly once', async ({ page }) 
   await expect(frame.locator('#w')).toHaveText('hi')         // script not run yet
   await send(page, { widgetId: WIDGET_ID, seq: 2, type: 'finalize' })
   await expect(frame.locator('#w')).toHaveText('done1')      // ran once
+  // a second (higher-seq) finalize must NOT re-run scripts (idempotent)
+  await send(page, { widgetId: WIDGET_ID, seq: 3, type: 'finalize' })
+  await page.waitForTimeout(200)
+  await expect(frame.locator('#w')).toHaveText('done1')      // still 1, not done2
 })
 
 test('latest-wins: a stale lower-seq morph is ignored', async ({ page }) => {
@@ -1002,11 +1033,13 @@ git commit -m "test(widget): deterministic shell (playwright) + WidgetView (vite
   (`AssistantMessage.tsx:361`), E2E dir (`__tests__/e2e/`) + runner
   (`frontend/package.json` `test:e2e`).
 - **Handshake:** the deadlock is removed — the shell gets its id via
-  `__WIDGET_ID__` replacement at mount and posts `ready` (with the right id)
-  after morphdom loads; the parent sends only after `ready`.
-- **Placeholders:** the E2E navigation/faux-wiring steps intentionally defer to
-  sibling-spec patterns rather than inventing harness APIs; all code units have
-  complete implementations.
+  `%%WIDGET_ID%%` → `JSON.stringify(widgetId)` replacement at mount (injection-safe)
+  and posts `ready` (with the right id) after morphdom loads; the parent sends
+  only after `ready`.
+- **Placeholders:** none blocking. Task 8 is fully concrete (shell driven via
+  `setContent`, WidgetView via vitest); the only deferral is the *manual* Task 9
+  model→widget/reload check, which is manual by necessity (the frontend harness
+  uses a real model). All code units have complete implementations.
 - **Type consistency:** message shape `{widgetId, seq, type, html?}` (parent→child)
   and `{widgetId, type, ...}` (child→parent) is identical in `widgetShell.ts` and
   `WidgetView.tsx`; `extractWidgetCode` signature matches its callers; `WidgetViewProps`

--- a/docs/dev/plans/2026-05-27-generative-ui-widgets.md
+++ b/docs/dev/plans/2026-05-27-generative-ui-widgets.md
@@ -493,8 +493,9 @@ body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;backgr
 > The CSP `meta` is the first `<head>` child, before the inline `<style>`/`<script>`.
 > `%%WIDGET_ID%%` is a literal placeholder appearing exactly once in the string
 > (in the `var WIDGET_ID` assignment, not in any comment), so `WidgetView`'s
-> single `.replace('%%WIDGET_ID%%', JSON.stringify(widgetId))` is unambiguous and
-> injection-safe (JSON.stringify provides the quotes + escaping). `ready` fires
+> single replace is unambiguous and injection-safe: `WidgetView` substitutes
+> `JSON.stringify(widgetId)` with every `<` further escaped to the JS sequence
+> `<` (so a hypothetical `</script>` can't close this block). `ready` fires
 > only after morphdom loads, and the parent sends nothing before `ready`, so no
 > pre-ready buffering is needed.
 
@@ -555,13 +556,16 @@ export function WidgetView({
   const latestRef = useRef('')
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Inject the real id into the shell (stable per widgetId). JSON.stringify
-  // supplies quotes + escaping, so an id with special chars can't break the JS
-  // literal. The placeholder appears exactly once in WIDGET_SHELL_HTML.
-  const srcDoc = useMemo(
-    () => WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', JSON.stringify(widgetId)),
-    [widgetId],
-  )
+  // Inject the real id into the shell (stable per widgetId). widgetId is a
+  // public id (alphanumeric + `_`) or `idx-<n>`, so it cannot contain quotes or
+  // an angle bracket. We still harden defensively: JSON.stringify supplies
+  // quotes + standard escaping, then we replace every "<" with the JS escape
+  // "\\u003c" so a hypothetical "</script>" can't close the shell's script
+  // block. A function replacement avoids String.replace's "$" special-handling.
+  const srcDoc = useMemo(() => {
+    const idLiteral = JSON.stringify(widgetId).replace(/</g, '\\u003c')
+    return WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', () => idLiteral)
+  }, [widgetId])
 
   const tooBig = new Blob([widgetCode]).size > MAX_CODE_BYTES
   latestRef.current = widgetCode
@@ -782,10 +786,15 @@ has a unit seam:
 
 ```python
 # backend/cubebox/streams/run_manager.py (module level)
-def _subagent_shared_tools(tools: list[AgentTool[Any]]) -> list[AgentTool[Any]]:
+# Annotated `list[Any]` to match this file's convention (it does not import
+# AgentTool at module level — tools are built via lazy imports inside functions).
+def _subagent_shared_tools(tools: list[Any]) -> list[Any]:
     """Tools shared into subagents. show_widget is top-level only (v1)."""
     return [t for t in tools if t.name != "show_widget"]
 ```
+
+> `Any` avoids adding a new top-level `AgentTool` import to `run_manager.py`,
+> which uses lazy imports throughout. The helper only reads `t.name`.
 
 - [ ] **Step 2: Use it at the SubAgentMiddleware construction (`:1299`)**
 
@@ -867,9 +876,11 @@ import { test, expect, type Page } from '@playwright/test'
 import { WIDGET_SHELL_HTML } from '../../components/chat/widget/widgetShell'
 
 const WIDGET_ID = 'w-test'
-// Must match WidgetView's production injection: JSON.stringify supplies the
-// quotes (the shell has `var WIDGET_ID = %%WIDGET_ID%%;` with no quotes).
-const SHELL = WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', JSON.stringify(WIDGET_ID))
+// Must match WidgetView's production injection exactly: JSON.stringify supplies
+// the quotes (the shell has `var WIDGET_ID = %%WIDGET_ID%%;` with no quotes),
+// and `<` is escaped to <.
+const ID_LITERAL = JSON.stringify(WIDGET_ID).replace(/</g, '\\u003c')
+const SHELL = WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', () => ID_LITERAL)
 
 async function mountShell(page: Page) {
   await page.setContent('<div id="host"></div>')

--- a/docs/dev/plans/2026-05-27-generative-ui-widgets.md
+++ b/docs/dev/plans/2026-05-27-generative-ui-widgets.md
@@ -867,7 +867,9 @@ import { test, expect, type Page } from '@playwright/test'
 import { WIDGET_SHELL_HTML } from '../../components/chat/widget/widgetShell'
 
 const WIDGET_ID = 'w-test'
-const SHELL = WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', WIDGET_ID)
+// Must match WidgetView's production injection: JSON.stringify supplies the
+// quotes (the shell has `var WIDGET_ID = %%WIDGET_ID%%;` with no quotes).
+const SHELL = WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', JSON.stringify(WIDGET_ID))
 
 async function mountShell(page: Page) {
   await page.setContent('<div id="host"></div>')

--- a/docs/dev/specs/2026-05-27-generative-ui-widgets-design.md
+++ b/docs/dev/specs/2026-05-27-generative-ui-widgets-design.md
@@ -83,12 +83,22 @@ model decides to visualize
 | Frontend shell | new `widgetShell.ts` (srcDoc string) | morphdom runtime + message listener |
 | Frontend mount | `AssistantMessage.tsx:314` | render `<WidgetView>` when `block.name === 'show_widget'` |
 
-### Persistence is free
+### Persistence (completed widgets only)
 
-The `show_widget` tool call (including the full `widget_code`) is already
-persisted in the Postgres message history. On reload / history view, the
-frontend re-renders from the stored `tool_call.arguments.widget_code` with a
-one-shot `morph` + `finalize` — no separate artifact table or storage logic.
+A **completed** `show_widget` tool call (full `widget_code`) is already persisted
+in the Postgres message history. On reload / history view, the frontend
+re-renders from the stored `tool_call.arguments.widget_code` with a one-shot
+`morph` + `finalize` — no separate artifact table or storage logic.
+
+**Interrupted widgets are not persisted in v1.** `buildTurnMessages()`
+(`messageStore.ts:541`) filters out `tool_call_streaming` blocks when it builds
+the assistant message, so a widget cancelled mid-stream shows its frozen partial
+frame during the live session but **disappears on the next turn finalize /
+reload**. This matches the current behavior for every streaming block; v1
+accepts it. Persisting a partial widget would require changing
+`buildTurnMessages` to convert an interrupted `show_widget` streaming block into
+a `tool_call` block carrying the partial `widget_code` — explicitly out of scope
+for v1.
 
 ## Components and interfaces
 
@@ -121,8 +131,12 @@ Each unit is bounded so it can be understood and tested independently.
 - **Does:** pulls the current `widget_code` string value out of the accumulated
   partial JSON.
 - **Interface:** `(raw: string) => string`.
-- **Depends on:** existing `extractJsonStringPrefix(raw, 'widget_code')` — already
-  proven to handle unterminated/escaped input.
+- **Depends on:** `extractJsonStringPrefix(raw, 'widget_code')` — already proven
+  to handle unterminated/escaped input. **It is currently a private function in
+  `writeFilePreview.ts`.** First refactor: promote it to a shared module (e.g.
+  `lib/partialJson.ts`) and export it, since it's generic partial-JSON
+  string-prefix extraction, not write-file-specific. `writeFilePreview.ts` and
+  `extractWidgetCode` both import the shared version — no duplicated parser.
 - **Boundary:** pure function, unit-testable.
 
 **`<WidgetView>`** (new component)
@@ -137,20 +151,35 @@ Each unit is bounded so it can be understood and tested independently.
 **iframe shell runtime** (new `widgetShell.ts`, exports the srcDoc string)
 - **Does:** inside the iframe, listens for parent messages — `morph` → morphdom
   diff `#root` + fade-in new nodes; `finalize` → clone-and-run `<script>` tags.
-- **Interface (postMessage protocol):**
-  - parent → child: `{type:'morph', html}` / `{type:'finalize'}`
-  - child → parent: `{type:'ready'}` / `{type:'error', message}` /
-    `{type:'resize', height}` (height auto-fit)
+- **Interface (postMessage protocol):** every message carries `{ widgetId, seq }`
+  (a monotonically increasing sequence number) so the shell can apply
+  **latest-wins** and stay idempotent.
+  - parent → child: `{widgetId, seq, type:'morph', html}` / `{widgetId, seq, type:'finalize'}`
+  - child → parent: `{widgetId, type:'ready'}` / `{widgetId, type:'error', message}` /
+    `{widgetId, type:'resize', height}` (height auto-fit)
+  - **Latest-wins:** the shell tracks the highest `seq` it has applied. A `morph`
+    or `finalize` with a `seq` ≤ the last applied is **ignored** — this defuses
+    the debounce/finalize race (a delayed `morph` landing after `finalize` cannot
+    regress the DOM). `finalize` runs `<script>` exactly once; later `morph`s
+    below the finalized `seq` are dropped.
 - **Depends on:** morphdom, loaded from the CDN allowlist.
 - **Boundary:** runs inside the sandbox; cannot reach parent DOM/data; only
-  responds to postMessage.
+  responds to postMessage. `error.message` from the child is length-clamped and
+  string-checked by the parent before it is rendered or logged.
 
-**Mount point** (`AssistantMessage.tsx:314`, extending the `tool_call_streaming` branch)
-- **Does:** when `block.name === 'show_widget'`, `extractWidgetCode(block.args_text)`
-  → render `<WidgetView status="streaming">`; when matched by a completed
-  `tool_call` block, `status="complete"`.
-- **Boundary:** sits alongside the existing `write_file` preview branch; they
-  don't interfere.
+**Mount point** (`AssistantMessage.tsx`)
+- **Does (streaming):** in the `tool_call_streaming` branch (~`:314`), when
+  `block.name === 'show_widget'`, `extractWidgetCode(block.args_text)` →
+  render `<WidgetView status="streaming">`.
+- **Does (completed):** `AssistantMessage.tsx` already special-cases completed
+  `tool_call` blocks by name **before** the generic `ToolCallGroup` fallback
+  (`subagent` ~`:230`, `save_artifact` ~`:256`, then `ToolCallGroup` ~`:303`).
+  Add a `block.type === 'tool_call' && block.name === 'show_widget'` branch in
+  that same spot so a completed widget renders `<WidgetView status="complete">`
+  and is **excluded from `ToolCallGroup`** (otherwise it would collapse into the
+  generic tool-call list instead of rendering).
+- **Boundary:** sits alongside the existing `write_file` / `subagent` /
+  `save_artifact` branches; they don't interfere.
 
 **Key interface rule:** parent↔child exchange **structured data only**
 (`{type, html}`). The shell does its own morphdom. We never concatenate HTML
@@ -185,16 +214,24 @@ toolcall_end → SSE tool_call (full arguments)
 place script nodes in the DOM but do not execute them (inert scripts, as in the
 pi version), so Chart.js never initializes on half-complete data.
 
-**'ready' race:** the shell must finish loading morphdom (CDN) before it can
-morph. The shell caches with `_pending`: HTML arriving before `ready` is stored
-and flushed once `ready` fires (same logic as the pi version's `window._pending`).
+**'ready' race:** the shell must finish loading morphdom (CDN) **and install its
+message listener** before it can accept a morph. Two-sided guard:
+- **Parent side (authoritative):** `WidgetView` does not send any `morph` until
+  it has received `{type:'ready'}` from the child. It holds the latest
+  `widgetCode` and sends it the moment `ready` arrives. This is the real fix —
+  messages sent before the listener exists are simply never sent.
+- **Child side (belt-and-suspenders):** the shell also caches with `_pending`
+  (as in the pi version's `window._pending`) in case morphdom finishes loading
+  after the listener is installed but the first morph arrives in between.
 
 ### Debounce ownership
 
 Debounce lives in **WidgetView** (the component), not the store. The store
 accumulates `args_text` faithfully every frame (other consumers, e.g. a debug
 view, may want it real-time); only the "push to iframe" step is batched at
-~120ms for smooth visuals.
+~120ms for smooth visuals. On `finalize`, any pending debounced `morph` timer is
+**cancelled** before sending the final `morph` + `finalize`; combined with the
+`seq` latest-wins guard in the shell, a stale morph cannot land after finalize.
 
 ### Reload / history view
 
@@ -209,17 +246,20 @@ Reopening a conversation:
 
 | Case | Handling |
 |---|---|
-| User stops mid-stream | toolcall never ends → frozen on the last morphed frame; no finalize, scripts don't run. Acceptable (show "stopped"). |
+| User stops mid-stream | toolcall never ends → frozen on the last morphed frame for the live session; no finalize, scripts don't run. On turn finalize/reload the partial block is dropped by `buildTurnMessages` (see "Persistence"), so the widget is not retained. Acceptable for v1. |
 | `widget_code` ends unterminated | `extractWidgetCode` returns the prefix; finalize still fires; partial HTML renders (browser auto-closes tags). |
 | Shell runtime throws | child → parent `{type:'error'}` → WidgetView shows a fallback: a collapsible source block (reuses existing code highlighting). |
 | morphdom CDN fails to load | shell `onerror` → fall back to source block. v1 accepts the CDN dependency (same risk class as the existing artifact preview). |
+| morphdom CDN **stalls** (no error, no load) | `WidgetView` arms a **shell-readiness timeout** (e.g. 5s after iframe mount): if no `{type:'ready'}` arrives, fall back to the source block rather than sitting blank. |
 
 ### Multiple widgets
 
 One message may contain several `show_widget` calls (different `content_index`).
-The store already keys `tool_call_streaming` blocks by `index`
-(`messageStore.ts:445`), so each block → its own `<WidgetView>` → its own
-iframe. Naturally isolated, no extra handling. (This avoids Streamdown issue #51
+The store keys `tool_call_streaming` blocks by `index` (`messageStore.ts:445`) —
+**this depends on cubepi emitting a stable `content_index` per concurrent tool
+call**, which it does today (the index originates from the provider's content
+block index). Each block → its own `<WidgetView>` → its own iframe. Naturally
+isolated, no extra handling. (This avoids Streamdown issue #51
 — multiple mermaid blocks showing only the last — because each widget is an
 independent iframe and store block, not a shared render target.)
 
@@ -248,6 +288,11 @@ sandbox="allow-scripts"
 
 ### 2. CSP (a `<meta http-equiv="Content-Security-Policy">` in the shell)
 
+There is **no HTTP response header** for a `srcDoc` document — the policy must
+ride as a `<meta http-equiv>` tag, and it must be the **first element in
+`<head>`, before any `<script>`, `<style>`, or resource reference**, or the
+directives won't apply to content parsed before the meta tag.
+
 ```
 default-src 'none';
 script-src 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com https://esm.sh;
@@ -255,25 +300,42 @@ style-src 'unsafe-inline';
 img-src data: https:;
 font-src data: https:;
 connect-src 'none';
+base-uri 'none';
+form-action 'none';
+worker-src 'none';
+frame-src 'none';
+object-src 'none';
 ```
 
 - `default-src 'none'`: deny by default, open per directive.
 - `script-src` allowlist = the same four CDNs as the pi version.
   `'unsafe-inline'` is required (the widget's scripts are inline) — the opaque
   origin sandbox is the backstop for that.
-- **`connect-src 'none'`** is the key data-exfiltration defense: the widget
-  cannot fetch/XHR/WebSocket anywhere, so even a prompt-injected widget cannot
-  POST conversation context out. Cost: widgets can't fetch data; data must be
-  written directly into `widget_code` by the model. v1 accepts this.
+- **`connect-src 'none'`** blocks fetch/XHR/WebSocket. Note it is **not** a
+  complete exfiltration seal (see residual risk below): with `img-src`/`font-src`
+  allowing `https:`, widget JS can still encode data into an outbound image/font
+  URL. `connect-src 'none'` blocks the easy/bulk channels (POST a payload), not
+  every covert channel.
+- `base-uri 'none'`, `form-action 'none'`, `worker-src 'none'`, `frame-src 'none'`,
+  `object-src 'none'`: harden against base-tag hijack, form posts, worker-based
+  network access, and nested frame/plugin loads.
 - `img-src`/`font-src` allow `https:` + `data:` so charts/illustrations can use
-  images.
+  images. **Decision:** v1 keeps broad `https:` here because widgets legitimately
+  pull images from arbitrary sources; we accept the residual image/font-URL
+  exfil channel rather than maintain an image-CDN allowlist. If exfil resistance
+  later becomes a hard requirement, tighten `img-src`/`font-src` to `data:` only
+  (+ an allowlist) — called out as a future tightening, not v1.
 
 ### 3. postMessage validation (both directions)
 
 - **parent → child:** WidgetView only `iframe.contentWindow.postMessage(msg, '*')`.
-  Because the iframe is opaque-origin, `'*'` targetOrigin is unavoidable but
-  acceptable — we put **no sensitive data** in the message (only the widget HTML,
-  which is itself a model artifact).
+  Because the iframe is opaque-origin, `'*'` targetOrigin is unavoidable. The
+  message body is the widget HTML — which **may contain conversation/user data**
+  the model embedded (since data must live in `widget_code`, per the
+  `connect-src 'none'` decision). This is acceptable because the **only** frame
+  that can receive it is our own sandboxed widget iframe (a child we created with
+  a known `srcDoc`); `'*'` does not broadcast to unrelated frames. We rely on the
+  sandbox keeping that data inside the opaque-origin frame, not on `'*'` secrecy.
 - **child → parent:** the parent listener **must** verify
   `event.source === iframe.contentWindow` (object identity — `event.origin` is
   `"null"` for opaque origins and unreliable) and that `event.data.type` is in
@@ -292,13 +354,32 @@ connect-src 'none';
 ### Residual risk (stated explicitly)
 
 - `'unsafe-inline'` script can't be avoided (inline scripts are the point);
-  mitigated by opaque origin + `connect-src 'none'`: a widget **can** misbehave
-  inside its iframe but **cannot** escape, read user data, or make network
-  requests.
+  mitigated by opaque origin + tightened CSP: a widget **can** misbehave inside
+  its iframe but cannot escape the sandbox or read parent/user data.
+- **Network exfiltration is reduced, not eliminated.** `connect-src 'none'`
+  blocks fetch/XHR/WebSocket, but `img-src`/`font-src https:` leaves a covert
+  channel (encode data in an image URL). v1 accepts this; full sealing would
+  require `data:`-only image/font sources.
+- **Resource exhaustion is not prevented.** Sandbox + CSP isolate *data access*,
+  not CPU/memory. A finalized widget can run an infinite loop or allocate until
+  the tab hangs. v1 mitigation: the widget runs in its own iframe (so it degrades
+  that frame first, not the whole app) + a `widget_code` size cap (see Limits).
+  Hard CPU/timeout enforcement is out of scope for v1.
 - CDN supply chain: theoretical poisoning of an allowlisted CDN, same risk
   level as the existing artifact preview. v1 accepts.
 - This is the standard artifact security posture — trust boundary = inside the
   iframe.
+
+### Limits (production guards)
+
+- **Max `widget_code` size:** cap the accumulated `args_text` / final
+  `widget_code` (e.g. ~256KB); beyond it, stop morphing and show the source-block
+  fallback. Bounds memory and the resource-exhaustion surface.
+- **Max rendered height:** clamp the `resize` height to an upper bound so a
+  runaway widget can't grow unbounded in the chat.
+- **Shell readiness timeout:** 5s after mount with no `{type:'ready'}` → source
+  fallback (see Interruption table).
+- **`error.message` bound:** length-clamp + type-check before render/log.
 
 ## Testing strategy
 
@@ -326,13 +407,18 @@ Cheapest layer, highest regression value (streaming bugs almost always live here
 - mid-stream, `#root` already has partial nodes (morph works — not waiting for end);
 - after end, the script executes (e.g. a script writing `window.__ran=true` or
   known text into the DOM, assert it appears) — verifies finalize timing;
-- the script runs **once** (`__count++`, assert === 1).
+- the script runs **once** (`__count++`, assert === 1);
+- **latest-wins:** after `finalize`, a late/duplicate `morph` (lower `seq`) does
+  not regress the DOM — assert the finalized content stays put.
 
 **Reload path:** send a widget → refresh → assert the iframe renders the
 finished result (no streaming) and the script has executed.
 
-**Fallback path:** faux emits input that makes the shell error (or mock a CDN
-failure) → assert fallback to a collapsible source block, no blank frame.
+**Fallback paths:**
+- shell error: faux emits input that makes the shell error (or mock a CDN
+  failure) → assert fallback to a collapsible source block, no blank frame;
+- readiness timeout: block the morphdom CDN so `ready` never fires → assert the
+  5s timeout fallback to the source block, not a permanently blank frame.
 
 **Multiple widgets:** one message with two `show_widget` calls → assert two
 independent iframes each render (guards against the Streamdown-#51 cross-talk
@@ -365,3 +451,7 @@ fixture wiring is settled in the implementation plan.
 - Widgets fetching live data (blocked by `connect-src 'none'`) — model writes
   data into `widget_code`.
 - A saved/standalone widget artifact type — persistence rides on message history.
+- Persisting interrupted/partial widgets (would need a `buildTurnMessages` change).
+- Hard CPU/memory/timeout enforcement on widget scripts (only iframe isolation +
+  size cap in v1).
+- Image/font-CDN allowlisting to fully seal exfiltration (broad `https:` in v1).

--- a/docs/dev/specs/2026-05-27-generative-ui-widgets-design.md
+++ b/docs/dev/specs/2026-05-27-generative-ui-widgets-design.md
@@ -64,8 +64,8 @@ model decides to visualize
    │
    ▼
 [new] <WidgetView>  sandboxed iframe (srcDoc = shell runtime)
-   │      parent → child: postMessage({type:'morph', html})  per frame
-   │      parent → child: postMessage({type:'finalize'})      on toolcall end
+   │      parent → child: postMessage({widgetId, seq, type:'morph', html})  per frame
+   │      parent → child: postMessage({widgetId, seq, type:'finalize'})      on toolcall end
    ▼
 [new] iframe shell runtime: morphdom diff + fade-in + run <script> on finalize
 ```
@@ -181,9 +181,10 @@ Each unit is bounded so it can be understood and tested independently.
 - **Boundary:** sits alongside the existing `write_file` / `subagent` /
   `save_artifact` branches; they don't interfere.
 
-**Key interface rule:** parent↔child exchange **structured data only**
-(`{type, html}`). The shell does its own morphdom. We never concatenate HTML
-into a JS string for injection — this is the security improvement over
+**Key interface rule:** parent↔child exchange **structured data only** — the
+canonical message shape is `{ widgetId, seq, type, html? }` (see the postMessage
+protocol above). The shell does its own morphdom. We never concatenate HTML into
+a JS string for injection — this is the security improvement over
 pi-generative-ui's `escapeJS(...)` `win.send(jsString)` approach.
 
 ## Data flow and lifecycle
@@ -200,13 +201,13 @@ toolcall_delta ×N
   → store: args_text += partial_json fragment
   → extractWidgetCode(args_text) → current HTML prefix
   → WidgetView receives new widgetCode prop
-  → debounce ~120ms → postMessage({type:'morph', html})
+  → debounce ~120ms → postMessage({widgetId, seq, type:'morph', html})
   → shell: morphdom diff #root, fade-in new nodes
 
 toolcall_end → SSE tool_call (full arguments)
   → store: tool_call_streaming converges to a tool_call block
   → WidgetView status='complete', widgetCode=final
-  → postMessage({type:'morph', html=final}) then postMessage({type:'finalize'})
+  → postMessage({widgetId, seq, type:'morph', html=final}) then postMessage({widgetId, seq, type:'finalize'})
   → shell: run <script> (Chart.js etc. execute only now)
 ```
 

--- a/docs/dev/specs/2026-05-27-generative-ui-widgets-design.md
+++ b/docs/dev/specs/2026-05-27-generative-ui-widgets-design.md
@@ -1,0 +1,367 @@
+# Generative UI Widgets — Design
+
+**Date:** 2026-05-27
+**Branch:** `feat/generative-ui-widgets`
+**Status:** Design (approved in brainstorming, pending spec review)
+
+## What we're building
+
+Let the agent render live, interactive HTML/JS widgets inline in the chat
+stream — charts, sliders, diagrams, animations — that assemble themselves
+token-by-token as the model generates them. This is the Claude.ai "artifacts /
+generative UI" experience, adapted for cubebox's web frontend.
+
+The model calls a new `show_widget` tool whose `widget_code` parameter is an
+HTML fragment. That fragment streams to the browser and renders inside a
+sandboxed iframe, morphed in place (no flicker) as more tokens arrive.
+
+### Why this is cheap to build
+
+The streaming data channel already exists end to end. `show_widget`'s
+`widget_code` travels the exact same path `write_file`'s `content` does today:
+
+```
+toolcall_delta (cubepi) → SSE tool_call_delta (raw partial_json)
+  → messageStore accumulates args_text
+  → extractJsonStringPrefix(...) pulls the in-progress string value
+```
+
+cubepi's `tool_call_delta` does **not** carry parsed arguments mid-stream — the
+`partial.arguments` dict stays `{}` until `toolcall_end`
+(`cubepi/providers/anthropic.py:586-637`). It emits the raw `partial_json`
+fragment on each delta. The frontend already accumulates those fragments
+(`messageStore.ts:430`) and extracts the live string value with a hand-rolled
+tolerant parser (`lib/writeFilePreview.ts` `extractJsonStringPrefix`). We reuse
+that machinery; we do not touch the streaming pipeline.
+
+## Decisions (locked in brainstorming)
+
+- **v1 scope:** full HTML+JS interactive widgets (not SVG-only).
+- **Render surface:** inline in the chat bubble (not the side artifact panel).
+- **Streaming:** live morphdom rendering — watch it build, not render-on-complete.
+- **Design guidelines prompt:** our own, rewritten in our words, informed by
+  (not copied verbatim from) the extracted Claude guidelines.
+- **Rendering architecture:** Approach A — shell iframe + structured
+  postMessage (chosen over per-frame `srcDoc` reset, which reintroduces the
+  flicker we're trying to avoid).
+
+## Architecture
+
+```
+model decides to visualize
+   │
+   ▼
+[backend] show_widget tool (cubepi AgentTool)
+   │  widget_code streams as a tool-call parameter
+   ▼
+[existing] agents/stream.py:109  toolcall_delta → SSE tool_call_delta (raw partial_json)
+   │                              toolcall_end   → SSE tool_call (full arguments)
+   ▼
+[existing] messageStore.ts:430   accumulate args_text on a tool_call_streaming block
+   │
+   ▼
+[new] extractWidgetCode(args_text)   ← reuses extractJsonStringPrefix
+   │
+   ▼
+[new] <WidgetView>  sandboxed iframe (srcDoc = shell runtime)
+   │      parent → child: postMessage({type:'morph', html})  per frame
+   │      parent → child: postMessage({type:'finalize'})      on toolcall end
+   ▼
+[new] iframe shell runtime: morphdom diff + fade-in + run <script> on finalize
+```
+
+### Change map
+
+| Layer | File | Change |
+|---|---|---|
+| Backend tool | new `middleware/widget.py` (or `tools/`) | define `show_widget` AgentTool; `execute()` returns a light ack |
+| Backend prompt | new `prompts/widget.py` | self-authored design guidelines, injected when the tool is available |
+| Backend stream | `agents/stream.py` | **no change** — widget_code already streams via tool_call_delta |
+| Frontend store | `messageStore.ts` | **essentially no change** — tool_call_streaming block is already generic |
+| Frontend extract | next to `lib/writeFilePreview.ts` | `extractWidgetCode` reusing `extractJsonStringPrefix` |
+| Frontend component | new `components/.../WidgetView.tsx` | sandboxed iframe + postMessage |
+| Frontend shell | new `widgetShell.ts` (srcDoc string) | morphdom runtime + message listener |
+| Frontend mount | `AssistantMessage.tsx:314` | render `<WidgetView>` when `block.name === 'show_widget'` |
+
+### Persistence is free
+
+The `show_widget` tool call (including the full `widget_code`) is already
+persisted in the Postgres message history. On reload / history view, the
+frontend re-renders from the stored `tool_call.arguments.widget_code` with a
+one-shot `morph` + `finalize` — no separate artifact table or storage logic.
+
+## Components and interfaces
+
+Each unit is bounded so it can be understood and tested independently.
+
+### Backend
+
+**`show_widget` tool** (new `middleware/widget.py`)
+- **Does:** declares the tool schema so the model can stream a widget. The
+  `execute()` does no real work — it returns a light ack (`{"status":"rendered"}`)
+  because rendering happens entirely in the frontend.
+- **Interface:** params `{ title: str, widget_code: str, width?: int, height?: int }`.
+  `widget_code` is an HTML fragment (no `<html>`/`<body>`).
+- **Depends on:** `cubepi.AgentTool`. Registered in the same place the agent
+  assembles its tool set (alongside `_make_write_file_tool`).
+- **Boundary:** does not touch the sandbox or the streaming pipeline.
+
+**Design-guidelines prompt** (new `prompts/widget.py`)
+- **Does:** exports a self-authored design-constraint string (CSS variables for
+  color, two font weights, streaming-safe structure `style → content → script`,
+  no gradients/shadows, libraries only from the CDN allowlist) and an
+  injection switch.
+- **Interface:** `WIDGET_GUIDELINES: str` + a "when to inject" hook.
+- **Boundary:** v1 injects the whole block (no lazy per-module `read_me`
+  loading — YAGNI). Plain string asset, no dependencies.
+
+### Frontend
+
+**`extractWidgetCode(argsText)`** (next to `lib/writeFilePreview.ts`)
+- **Does:** pulls the current `widget_code` string value out of the accumulated
+  partial JSON.
+- **Interface:** `(raw: string) => string`.
+- **Depends on:** existing `extractJsonStringPrefix(raw, 'widget_code')` — already
+  proven to handle unterminated/escaped input.
+- **Boundary:** pure function, unit-testable.
+
+**`<WidgetView>`** (new component)
+- **Does:** renders the sandboxed iframe; pushes incremental/complete
+  `widget_code` in via postMessage; manages finalize timing.
+- **Interface:** props `{ widgetCode: string, status: 'streaming' | 'complete',
+  title, width?, height? }`.
+- **Depends on:** the shell HTML string; `window.postMessage`.
+- **Boundary:** only feeds HTML into the isolated container. Does not parse or
+  fetch data (parent passes it in).
+
+**iframe shell runtime** (new `widgetShell.ts`, exports the srcDoc string)
+- **Does:** inside the iframe, listens for parent messages — `morph` → morphdom
+  diff `#root` + fade-in new nodes; `finalize` → clone-and-run `<script>` tags.
+- **Interface (postMessage protocol):**
+  - parent → child: `{type:'morph', html}` / `{type:'finalize'}`
+  - child → parent: `{type:'ready'}` / `{type:'error', message}` /
+    `{type:'resize', height}` (height auto-fit)
+- **Depends on:** morphdom, loaded from the CDN allowlist.
+- **Boundary:** runs inside the sandbox; cannot reach parent DOM/data; only
+  responds to postMessage.
+
+**Mount point** (`AssistantMessage.tsx:314`, extending the `tool_call_streaming` branch)
+- **Does:** when `block.name === 'show_widget'`, `extractWidgetCode(block.args_text)`
+  → render `<WidgetView status="streaming">`; when matched by a completed
+  `tool_call` block, `status="complete"`.
+- **Boundary:** sits alongside the existing `write_file` preview branch; they
+  don't interfere.
+
+**Key interface rule:** parent↔child exchange **structured data only**
+(`{type, html}`). The shell does its own morphdom. We never concatenate HTML
+into a JS string for injection — this is the security improvement over
+pi-generative-ui's `escapeJS(...)` `win.send(jsString)` approach.
+
+## Data flow and lifecycle
+
+### Streaming (main path)
+
+```
+toolcall_start (name=show_widget)
+  → store creates tool_call_streaming block (args_text="")
+  → AssistantMessage renders <WidgetView status="streaming">
+  → WidgetView mounts iframe (srcDoc=shell), waits for child 'ready'
+
+toolcall_delta ×N
+  → store: args_text += partial_json fragment
+  → extractWidgetCode(args_text) → current HTML prefix
+  → WidgetView receives new widgetCode prop
+  → debounce ~120ms → postMessage({type:'morph', html})
+  → shell: morphdom diff #root, fade-in new nodes
+
+toolcall_end → SSE tool_call (full arguments)
+  → store: tool_call_streaming converges to a tool_call block
+  → WidgetView status='complete', widgetCode=final
+  → postMessage({type:'morph', html=final}) then postMessage({type:'finalize'})
+  → shell: run <script> (Chart.js etc. execute only now)
+```
+
+**Script timing:** `<script>` runs **once, on finalize**. Mid-stream morphs
+place script nodes in the DOM but do not execute them (inert scripts, as in the
+pi version), so Chart.js never initializes on half-complete data.
+
+**'ready' race:** the shell must finish loading morphdom (CDN) before it can
+morph. The shell caches with `_pending`: HTML arriving before `ready` is stored
+and flushed once `ready` fires (same logic as the pi version's `window._pending`).
+
+### Debounce ownership
+
+Debounce lives in **WidgetView** (the component), not the store. The store
+accumulates `args_text` faithfully every frame (other consumers, e.g. a debug
+view, may want it real-time); only the "push to iframe" step is batched at
+~120ms for smooth visuals.
+
+### Reload / history view
+
+The message history stores the full `tool_call.arguments.widget_code`.
+Reopening a conversation:
+- the block is a `tool_call` (not streaming), `WidgetView status='complete'`;
+- one-shot `morph(final html)` + `finalize`;
+- no streaming animation — just the finished widget. No special persistence
+  logic.
+
+### Interruption / errors
+
+| Case | Handling |
+|---|---|
+| User stops mid-stream | toolcall never ends → frozen on the last morphed frame; no finalize, scripts don't run. Acceptable (show "stopped"). |
+| `widget_code` ends unterminated | `extractWidgetCode` returns the prefix; finalize still fires; partial HTML renders (browser auto-closes tags). |
+| Shell runtime throws | child → parent `{type:'error'}` → WidgetView shows a fallback: a collapsible source block (reuses existing code highlighting). |
+| morphdom CDN fails to load | shell `onerror` → fall back to source block. v1 accepts the CDN dependency (same risk class as the existing artifact preview). |
+
+### Multiple widgets
+
+One message may contain several `show_widget` calls (different `content_index`).
+The store already keys `tool_call_streaming` blocks by `index`
+(`messageStore.ts:445`), so each block → its own `<WidgetView>` → its own
+iframe. Naturally isolated, no extra handling. (This avoids Streamdown issue #51
+— multiple mermaid blocks showing only the last — because each widget is an
+independent iframe and store block, not a shared render target.)
+
+## Security model
+
+Inline full HTML+JS is the highest-risk part: model-generated arbitrary scripts
+run in the user's browser. Isolation rests on three walls.
+
+### 1. iframe sandbox attribute
+
+```
+sandbox="allow-scripts"
+```
+
+- **Include** `allow-scripts`: widgets need JS.
+- **Never include** `allow-same-origin`. With both `allow-scripts` and
+  `allow-same-origin`, the frame gets its own origin and scripts can remove the
+  frame's own sandbox attribute and escape. Keeping them mutually exclusive
+  makes the widget iframe an **opaque origin** (`origin = "null"`): it cannot
+  read parent cookies/localStorage/DOM.
+- The cost: `localStorage`/`sessionStorage` throw inside the iframe. This
+  matches the Claude artifact constraint (use in-memory variables, not storage)
+  — encode it in the prompt guidelines.
+- No `allow-top-navigation`, no `allow-popups`, no `allow-forms` in v1.
+- Use `srcDoc` (not a remote `src`) to load our own shell string.
+
+### 2. CSP (a `<meta http-equiv="Content-Security-Policy">` in the shell)
+
+```
+default-src 'none';
+script-src 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com https://esm.sh;
+style-src 'unsafe-inline';
+img-src data: https:;
+font-src data: https:;
+connect-src 'none';
+```
+
+- `default-src 'none'`: deny by default, open per directive.
+- `script-src` allowlist = the same four CDNs as the pi version.
+  `'unsafe-inline'` is required (the widget's scripts are inline) — the opaque
+  origin sandbox is the backstop for that.
+- **`connect-src 'none'`** is the key data-exfiltration defense: the widget
+  cannot fetch/XHR/WebSocket anywhere, so even a prompt-injected widget cannot
+  POST conversation context out. Cost: widgets can't fetch data; data must be
+  written directly into `widget_code` by the model. v1 accepts this.
+- `img-src`/`font-src` allow `https:` + `data:` so charts/illustrations can use
+  images.
+
+### 3. postMessage validation (both directions)
+
+- **parent → child:** WidgetView only `iframe.contentWindow.postMessage(msg, '*')`.
+  Because the iframe is opaque-origin, `'*'` targetOrigin is unavoidable but
+  acceptable — we put **no sensitive data** in the message (only the widget HTML,
+  which is itself a model artifact).
+- **child → parent:** the parent listener **must** verify
+  `event.source === iframe.contentWindow` (object identity — `event.origin` is
+  `"null"` for opaque origins and unreliable) and that `event.data.type` is in
+  the `{ready, error, resize}` allowlist. Everything else is dropped.
+- When handling child messages, the parent reads **only the agreed fields**
+  (e.g. `resize.height` via `Number()` + clamped to an upper bound). No eval,
+  no injection.
+
+### Not copied from pi
+
+| pi-generative-ui | us | reason |
+|---|---|---|
+| `win.send(jsString)` eval | structured postMessage | no JS-injection seam beyond the widget itself |
+| native WKWebView full capabilities | sandbox + CSP opaque iframe | web requires isolation; native didn't |
+
+### Residual risk (stated explicitly)
+
+- `'unsafe-inline'` script can't be avoided (inline scripts are the point);
+  mitigated by opaque origin + `connect-src 'none'`: a widget **can** misbehave
+  inside its iframe but **cannot** escape, read user data, or make network
+  requests.
+- CDN supply chain: theoretical poisoning of an allowlisted CDN, same risk
+  level as the existing artifact preview. v1 accepts.
+- This is the standard artifact security posture — trust boundary = inside the
+  iframe.
+
+## Testing strategy
+
+Per repo discipline (E2E over mocks): E2E what can be exercised end to end; unit
+only pure functions.
+
+### Unit (vitest)
+
+**`extractWidgetCode` / `extractJsonStringPrefix`** — core of streaming
+correctness, cover the edges:
+- complete JSON extracts the value;
+- unterminated `{"widget_code":"<div>` → returns the prefix so far;
+- escape sequences `\n` `\"` `\\` `\uXXXX` decode correctly;
+- a `"` inside the HTML (escaped) is not mistaken for the field end;
+- empty / missing key → empty string.
+
+Cheapest layer, highest regression value (streaming bugs almost always live here).
+
+### E2E (Playwright, `tests/e2e/`, marker auto-applied)
+
+**Main path — streaming render:** use the faux provider
+(`cubepi/providers/faux.py`) to script a `show_widget` tool call whose
+`widget_code` is emitted across several frames, then assert:
+- iframe appears with `sandbox="allow-scripts"` and **without** `allow-same-origin`;
+- mid-stream, `#root` already has partial nodes (morph works — not waiting for end);
+- after end, the script executes (e.g. a script writing `window.__ran=true` or
+  known text into the DOM, assert it appears) — verifies finalize timing;
+- the script runs **once** (`__count++`, assert === 1).
+
+**Reload path:** send a widget → refresh → assert the iframe renders the
+finished result (no streaming) and the script has executed.
+
+**Fallback path:** faux emits input that makes the shell error (or mock a CDN
+failure) → assert fallback to a collapsible source block, no blank frame.
+
+**Multiple widgets:** one message with two `show_widget` calls → assert two
+independent iframes each render (guards against the Streamdown-#51 cross-talk
+class).
+
+### Security assertions (folded into the E2E above)
+
+- opaque origin: a widget trying to read `parent.document` → assert it throws /
+  is blocked;
+- `fetch('https://...')` inside a widget → assert blocked by CSP `connect-src 'none'`;
+- the parent listener ignores a forged-`event.source` message (inject a message
+  from a non-iframe source, assert no side effect).
+
+### Not tested
+
+- no test for morphdom itself (third-party, trusted);
+- no pixel screenshot comparison (brittle, and widget content is
+  model-defined — no stable baseline);
+- visual feel (fade-in animation) is confirmed manually in-browser during dev +
+  user review, not automated.
+
+**Toolchain note:** this runs on the worktree ports (8075/3075); the faux
+provider is selected via config switch to avoid real model calls. The exact
+fixture wiring is settled in the implementation plan.
+
+## Out of scope (v1)
+
+- Lazy per-module guideline loading (pi's `read_me` pattern) — inject one block.
+- Side artifact-panel rendering — inline only.
+- Widgets fetching live data (blocked by `connect-src 'none'`) — model writes
+  data into `widget_code`.
+- A saved/standalone widget artifact type — persistence rides on message history.

--- a/docs/dev/specs/2026-05-27-generative-ui-widgets-design.md
+++ b/docs/dev/specs/2026-05-27-generative-ui-widgets-design.md
@@ -151,17 +151,21 @@ Each unit is bounded so it can be understood and tested independently.
 **iframe shell runtime** (new `widgetShell.ts`, exports the srcDoc string)
 - **Does:** inside the iframe, listens for parent messages — `morph` → morphdom
   diff `#root` + fade-in new nodes; `finalize` → clone-and-run `<script>` tags.
-- **Interface (postMessage protocol):** every message carries `{ widgetId, seq }`
-  (a monotonically increasing sequence number) so the shell can apply
-  **latest-wins** and stay idempotent.
+- **Interface (postMessage protocol):** every message carries `widgetId`.
+  **Parent → child** messages additionally carry a monotonically increasing
+  `seq` (the ordering token); **child → parent** messages do not need `seq`
+  (they are status notifications, not an ordered stream). The canonical shapes:
   - parent → child: `{widgetId, seq, type:'morph', html}` / `{widgetId, seq, type:'finalize'}`
   - child → parent: `{widgetId, type:'ready'}` / `{widgetId, type:'error', message}` /
     `{widgetId, type:'resize', height}` (height auto-fit)
-  - **Latest-wins:** the shell tracks the highest `seq` it has applied. A `morph`
-    or `finalize` with a `seq` ≤ the last applied is **ignored** — this defuses
-    the debounce/finalize race (a delayed `morph` landing after `finalize` cannot
-    regress the DOM). `finalize` runs `<script>` exactly once; later `morph`s
-    below the finalized `seq` are dropped.
+  - **Latest-wins (parent → child only):** the shell tracks the highest `seq` it
+    has applied. A `morph` or `finalize` with `seq` ≤ the last applied is
+    **ignored** — this defuses the debounce/finalize race (a delayed `morph`
+    landing after `finalize` cannot regress the DOM). `finalize` runs `<script>`
+    exactly once; later `morph`s below the finalized `seq` are dropped.
+  - **Note on shorthand:** prose and the lifecycle/diagram examples elsewhere in
+    this doc abbreviate messages by `type` (e.g. "a `morph`", "`{type:'ready'}`")
+    for readability; the shapes above are authoritative.
 - **Depends on:** morphdom, loaded from the CDN allowlist.
 - **Boundary:** runs inside the sandbox; cannot reach parent DOM/data; only
   responds to postMessage. `error.message` from the child is length-clamped and
@@ -207,7 +211,7 @@ toolcall_delta ×N
 toolcall_end → SSE tool_call (full arguments)
   → store: tool_call_streaming converges to a tool_call block
   → WidgetView status='complete', widgetCode=final
-  → postMessage({widgetId, seq, type:'morph', html=final}) then postMessage({widgetId, seq, type:'finalize'})
+  → postMessage({widgetId, seq, type:'morph', html}) with the final html, then postMessage({widgetId, seq, type:'finalize'})
   → shell: run <script> (Chart.js etc. execute only now)
 ```
 

--- a/docs/dev/specs/2026-05-27-generative-ui-widgets-design.md
+++ b/docs/dev/specs/2026-05-27-generative-ui-widgets-design.md
@@ -185,10 +185,10 @@ Each unit is bounded so it can be understood and tested independently.
 - **Boundary:** sits alongside the existing `write_file` / `subagent` /
   `save_artifact` branches; they don't interfere.
 
-**Key interface rule:** parent↔child exchange **structured data only** — the
-canonical message shape is `{ widgetId, seq, type, html? }` (see the postMessage
-protocol above). The shell does its own morphdom. We never concatenate HTML into
-a JS string for injection — this is the security improvement over
+**Key interface rule:** parent↔child exchange **structured data only**, in the
+shapes defined by the postMessage protocol above (parent→child carry `seq`,
+child→parent do not). The shell does its own morphdom. We never concatenate HTML
+into a JS string for injection — this is the security improvement over
 pi-generative-ui's `escapeJS(...)` `win.send(jsString)` approach.
 
 ## Data flow and lifecycle

--- a/frontend/packages/web/__tests__/e2e/widget-shell.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/widget-shell.spec.ts
@@ -61,6 +61,18 @@ test('latest-wins: a stale lower-seq morph is ignored', async ({ page }) => {
   await expect(frame.locator('#w')).toHaveText('new') // unchanged
 })
 
+test('a stale morph arriving AFTER finalize does not regress the DOM', async ({ page }) => {
+  await mountShell(page)
+  const frame = page.frameLocator('#wf')
+  await send(page, { widgetId: WIDGET_ID, seq: 10, type: 'morph', html: '<p id="w">final</p>' })
+  await expect(frame.locator('#w')).toHaveText('final')
+  await send(page, { widgetId: WIDGET_ID, seq: 11, type: 'finalize' })
+  // a delayed morph with a LOWER seq lands after finalize — must be ignored
+  await send(page, { widgetId: WIDGET_ID, seq: 9, type: 'morph', html: '<p id="w">stale</p>' })
+  await page.waitForTimeout(200)
+  await expect(frame.locator('#w')).toHaveText('final') // unchanged
+})
+
 test('widget cannot reach parent (opaque origin) nor fetch (connect-src none)', async ({
   page,
 }) => {

--- a/frontend/packages/web/__tests__/e2e/widget-shell.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/widget-shell.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, type Page } from '@playwright/test'
+import { WIDGET_SHELL_HTML } from '../../components/chat/widget/widgetShell'
+
+const WIDGET_ID = 'w-test'
+// Must match WidgetView's production injection exactly: JSON.stringify supplies
+// the quotes (the shell has `var WIDGET_ID = %%WIDGET_ID%%;` with no quotes),
+// and `<` is escaped to <.
+const ID_LITERAL = JSON.stringify(WIDGET_ID).replace(/</g, '\\u003c')
+const SHELL = WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', () => ID_LITERAL)
+
+async function mountShell(page: Page) {
+  await page.setContent('<div id="host"></div>')
+  await page.evaluate((srcdoc) => {
+    ;(window as unknown as { __ready: boolean }).__ready = false
+    window.addEventListener('message', (e) => {
+      if ((e.data || {}).type === 'ready')
+        (window as unknown as { __ready: boolean }).__ready = true
+    })
+    const f = document.createElement('iframe')
+    f.id = 'wf'
+    f.setAttribute('sandbox', 'allow-scripts')
+    f.srcdoc = srcdoc
+    document.getElementById('host')!.appendChild(f)
+  }, SHELL)
+  await page.waitForFunction(() => (window as unknown as { __ready: boolean }).__ready === true, {
+    timeout: 15_000,
+  })
+}
+
+async function send(page: Page, msg: Record<string, unknown>) {
+  await page.evaluate((m) => {
+    ;(document.getElementById('wf') as HTMLIFrameElement).contentWindow!.postMessage(m, '*')
+  }, msg)
+}
+
+test('morph applies, then finalize runs scripts exactly once (idempotent)', async ({ page }) => {
+  await mountShell(page)
+  const frame = page.frameLocator('#wf')
+  await send(page, {
+    widgetId: WIDGET_ID,
+    seq: 1,
+    type: 'morph',
+    html: '<p id="w">hi</p><script>window.__c=(window.__c||0)+1;document.getElementById("w").textContent="done"+window.__c;</script>',
+  })
+  await expect(frame.locator('#w')).toHaveText('hi') // script not run yet
+  await send(page, { widgetId: WIDGET_ID, seq: 2, type: 'finalize' })
+  await expect(frame.locator('#w')).toHaveText('done1') // ran once
+  // a second (higher-seq) finalize must NOT re-run scripts (idempotent)
+  await send(page, { widgetId: WIDGET_ID, seq: 3, type: 'finalize' })
+  await page.waitForTimeout(200)
+  await expect(frame.locator('#w')).toHaveText('done1') // still 1, not done2
+})
+
+test('latest-wins: a stale lower-seq morph is ignored', async ({ page }) => {
+  await mountShell(page)
+  const frame = page.frameLocator('#wf')
+  await send(page, { widgetId: WIDGET_ID, seq: 5, type: 'morph', html: '<p id="w">new</p>' })
+  await expect(frame.locator('#w')).toHaveText('new')
+  await send(page, { widgetId: WIDGET_ID, seq: 2, type: 'morph', html: '<p id="w">stale</p>' })
+  await page.waitForTimeout(200)
+  await expect(frame.locator('#w')).toHaveText('new') // unchanged
+})
+
+test('widget cannot reach parent (opaque origin) nor fetch (connect-src none)', async ({
+  page,
+}) => {
+  await mountShell(page)
+  const frame = page.frameLocator('#wf')
+  await send(page, {
+    widgetId: WIDGET_ID,
+    seq: 1,
+    type: 'morph',
+    html: `<p id="probe"></p><script>
+      var r='';
+      try { void parent.document; r+='PARENT_OK'; } catch(e){ r+='PARENT_BLOCKED'; }
+      fetch('https://example.com').then(function(){document.getElementById('probe').textContent=r+' FETCH_OK';})
+        .catch(function(){document.getElementById('probe').textContent=r+' FETCH_BLOCKED';});
+    </script>`,
+  })
+  await send(page, { widgetId: WIDGET_ID, seq: 2, type: 'finalize' })
+  await expect(frame.locator('#probe')).toHaveText('PARENT_BLOCKED FETCH_BLOCKED')
+})

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -18,6 +18,8 @@ import { TaskProgressCard } from './TaskProgressCard'
 import { ToolCallGroup } from './ToolCallGroup'
 import { ToolCallItem } from './ToolCallItem'
 import { getWriteFileSummary } from '@/lib/writeFilePreview'
+import { extractWidgetCode, extractJsonStringPrefix } from '@/lib/partialJson'
+import { WidgetView } from '@/components/chat/widget/WidgetView'
 import { MarkdownWithCitations } from '@/components/shared/MarkdownWithCitations'
 
 interface ReasoningBlockProps {
@@ -300,6 +302,19 @@ function ContentBlockRenderer({
       />
     )
   }
+  if (block.type === 'tool_call' && block.name === 'show_widget') {
+    const a = block.arguments ?? {}
+    return (
+      <WidgetView
+        widgetId={block.id}
+        widgetCode={typeof a.widget_code === 'string' ? a.widget_code : ''}
+        status="complete"
+        title={typeof a.title === 'string' ? a.title : undefined}
+        width={typeof a.width === 'number' ? a.width : undefined}
+        height={typeof a.height === 'number' ? a.height : undefined}
+      />
+    )
+  }
   if (block.type === 'tool_call') {
     return (
       <ToolCallGroup
@@ -308,6 +323,17 @@ function ContentBlockRenderer({
         isStreaming={isStreaming}
         messageCreatedAt={messageCreatedAt}
         agentId={agentId}
+      />
+    )
+  }
+  if (block.type === 'tool_call_streaming' && block.name === 'show_widget') {
+    const title = extractJsonStringPrefix(block.args_text, 'title') || undefined
+    return (
+      <WidgetView
+        widgetId={block.tool_call_id ?? `idx-${block.index}`}
+        widgetCode={extractWidgetCode(block.args_text)}
+        status="streaming"
+        title={title}
       />
     )
   }
@@ -365,7 +391,8 @@ function groupBlocks(blocks: ContentBlock[]): (ContentBlock | ContentBlock[])[] 
       block.type === 'tool_call' &&
       block.name !== 'subagent' &&
       block.name !== 'save_artifact' &&
-      block.name !== 'write_todos'
+      block.name !== 'write_todos' &&
+      block.name !== 'show_widget'
     ) {
       const last = result[result.length - 1]
       if (

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -306,6 +306,7 @@ function ContentBlockRenderer({
     const a = block.arguments ?? {}
     return (
       <WidgetView
+        key={block.id}
         widgetId={block.id}
         widgetCode={typeof a.widget_code === 'string' ? a.widget_code : ''}
         status="complete"
@@ -327,11 +328,21 @@ function ContentBlockRenderer({
     )
   }
   if (block.type === 'tool_call_streaming' && block.name === 'show_widget') {
+    const widgetId = block.tool_call_id ?? `idx-${block.index}`
+    const code = extractWidgetCode(block.args_text)
     const title = extractJsonStringPrefix(block.args_text, 'title') || undefined
+    if (!code) {
+      return (
+        <div className="rounded-lg border border-border bg-muted p-3 text-sm text-muted-foreground">
+          {`Preparing widget${title ? ` (${title})` : ''}…`}
+        </div>
+      )
+    }
     return (
       <WidgetView
-        widgetId={block.tool_call_id ?? `idx-${block.index}`}
-        widgetCode={extractWidgetCode(block.args_text)}
+        key={widgetId}
+        widgetId={widgetId}
+        widgetCode={code}
         status="streaming"
         title={title}
       />

--- a/frontend/packages/web/components/chat/widget/WidgetView.tsx
+++ b/frontend/packages/web/components/chat/widget/WidgetView.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { WIDGET_SHELL_HTML } from './widgetShell'
+
+const READY_TIMEOUT_MS = 5000
+const MAX_HEIGHT_PX = 4000
+const MAX_CODE_BYTES = 256 * 1024
+
+interface WidgetViewProps {
+  widgetCode: string
+  status: 'streaming' | 'complete'
+  widgetId: string
+  title?: string
+  width?: number
+  height?: number
+}
+
+export function WidgetView({
+  widgetCode,
+  status,
+  widgetId,
+  title,
+  width,
+  height: initialHeight,
+}: WidgetViewProps) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
+  const [ready, setReady] = useState(false)
+  const [failed, setFailed] = useState(false)
+  const [height, setHeight] = useState(initialHeight ?? 120)
+  const seqRef = useRef(0)
+  const latestRef = useRef('')
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Inject the real id into the shell. JSON.stringify supplies quotes + standard
+  // escaping; we further escape "<" to "<" so a hypothetical "</script>"
+  // can't close the shell's script block. A function replacement avoids
+  // String.replace's "$" special-handling. Placeholder appears once in the shell.
+  const srcDoc = useMemo(() => {
+    const idLiteral = JSON.stringify(widgetId).replace(/</g, '\\u003c')
+    return WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', () => idLiteral)
+  }, [widgetId])
+
+  const tooBig = new Blob([widgetCode]).size > MAX_CODE_BYTES
+  latestRef.current = widgetCode
+
+  // child -> parent listener (validate source + type)
+  useEffect(() => {
+    function onMessage(e: MessageEvent) {
+      if (e.source !== iframeRef.current?.contentWindow) return
+      const d = e.data as { widgetId?: string; type?: string; height?: number; message?: string }
+      if (d.widgetId !== widgetId) return
+      if (d.type === 'ready') setReady(true)
+      else if (d.type === 'error') setFailed(true)
+      else if (d.type === 'resize' && typeof d.height === 'number') {
+        setHeight(Math.min(Math.max(d.height, 40), MAX_HEIGHT_PX))
+      }
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [widgetId])
+
+  // readiness timeout -> fallback. If `ready` flips true, this effect re-runs,
+  // early-returns, and the cleanup clears the pending timer.
+  useEffect(() => {
+    if (ready || failed) return
+    const t = setTimeout(() => setFailed(true), READY_TIMEOUT_MS)
+    return () => clearTimeout(t)
+  }, [ready, failed])
+
+  // push morph (debounced) once ready
+  useEffect(() => {
+    if (!ready || failed || tooBig) return
+    const send = (final: boolean) => {
+      const win = iframeRef.current?.contentWindow
+      if (!win) return
+      seqRef.current += 1
+      win.postMessage(
+        { widgetId, seq: seqRef.current, type: 'morph', html: latestRef.current },
+        '*',
+      )
+      if (final) {
+        seqRef.current += 1
+        win.postMessage({ widgetId, seq: seqRef.current, type: 'finalize' }, '*')
+      }
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (status === 'complete') {
+      send(true)
+    } else {
+      debounceRef.current = setTimeout(() => send(false), 120)
+    }
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [widgetCode, status, ready, failed, tooBig, widgetId])
+
+  if (failed || tooBig) {
+    return (
+      <details className="rounded-lg border border-border bg-muted p-2 text-sm">
+        <summary className="cursor-pointer text-muted-foreground">
+          {tooBig
+            ? 'Widget too large — showing source'
+            : 'Widget failed to render — showing source'}
+          {title ? ` (${title})` : ''}
+        </summary>
+        <pre className="overflow-auto text-xs">
+          <code>{widgetCode}</code>
+        </pre>
+      </details>
+    )
+  }
+
+  return (
+    <iframe
+      ref={iframeRef}
+      title={title ?? 'widget'}
+      sandbox="allow-scripts"
+      srcDoc={srcDoc}
+      style={{ width: width ? `${width}px` : '100%', height, border: 'none' }}
+      className="rounded-lg border border-border bg-muted"
+    />
+  )
+}

--- a/frontend/packages/web/components/chat/widget/WidgetView.tsx
+++ b/frontend/packages/web/components/chat/widget/WidgetView.tsx
@@ -48,6 +48,7 @@ export function WidgetView({
   useEffect(() => {
     function onMessage(e: MessageEvent) {
       if (e.source !== iframeRef.current?.contentWindow) return
+      if (!e.data || typeof e.data !== 'object') return
       const d = e.data as { widgetId?: string; type?: string; height?: number; message?: string }
       if (d.widgetId !== widgetId) return
       if (d.type === 'ready') setReady(true)

--- a/frontend/packages/web/components/chat/widget/__tests__/WidgetView.test.tsx
+++ b/frontend/packages/web/components/chat/widget/__tests__/WidgetView.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { WidgetView } from '../WidgetView'
+
+describe('WidgetView', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('falls back to a source block when widget_code exceeds the size cap', () => {
+    const big = 'x'.repeat(256 * 1024 + 1)
+    render(<WidgetView widgetId="a" widgetCode={big} status="complete" />)
+    expect(screen.getByText(/too large/i)).toBeInTheDocument()
+  })
+
+  it('falls back when no ready arrives before the timeout', () => {
+    render(<WidgetView widgetId="a" widgetCode="<p>x</p>" status="complete" />)
+    act(() => {
+      vi.advanceTimersByTime(5001)
+    })
+    expect(screen.getByText(/failed to render/i)).toBeInTheDocument()
+  })
+
+  it('posts a morph only after a ready from the iframe (ignores forged source)', () => {
+    const { container } = render(
+      <WidgetView widgetId="a" widgetCode="<p>x</p>" status="complete" />,
+    )
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement
+    const post = vi.spyOn(iframe.contentWindow as Window, 'postMessage')
+
+    // forged source (window, not the iframe) -> ignored
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', { data: { widgetId: 'a', type: 'ready' }, source: window }),
+      )
+    })
+    expect(post).not.toHaveBeenCalled()
+
+    // real ready (source === iframe.contentWindow) -> morph is sent
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { widgetId: 'a', type: 'ready' },
+          source: iframe.contentWindow,
+        }),
+      )
+    })
+    expect(post).toHaveBeenCalledWith(expect.objectContaining({ type: 'morph' }), '*')
+  })
+})

--- a/frontend/packages/web/components/chat/widget/widgetShell.ts
+++ b/frontend/packages/web/components/chat/widget/widgetShell.ts
@@ -1,0 +1,77 @@
+// srcDoc for the widget iframe. The CSP meta MUST be the first element in
+// <head>. Parent -> child: {widgetId, seq, type:'morph', html} / {...'finalize'}.
+// Child -> parent: {widgetId, type:'ready'|'error'|'resize', ...}.
+//
+// WidgetView replaces the %%WIDGET_ID%% placeholder (which appears exactly once,
+// in the `var WIDGET_ID` assignment below, with NO surrounding quotes) with
+// JSON.stringify(widgetId) — additionally escaping `<` — at mount.
+export const WIDGET_SHELL_HTML = `<!DOCTYPE html><html><head>
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; style-src 'unsafe-inline'; img-src data: https:; font-src data: https:; connect-src 'none'; base-uri 'none'; form-action 'none'; worker-src 'none'; frame-src 'none'; object-src 'none';">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<style>
+*{box-sizing:border-box}
+body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;background:#1a1a1a;color:#e0e0e0;}
+@keyframes _fadeIn{from{opacity:0;transform:translateY(4px);}to{opacity:1;transform:none;}}
+</style></head>
+<body><div id="root"></div>
+<script>
+(function(){
+  var WIDGET_ID = %%WIDGET_ID%%;
+  var lastSeq = -1;
+  var finalized = false;
+
+  function post(msg){ parent.postMessage(Object.assign({widgetId: WIDGET_ID}, msg), '*'); }
+
+  function applyMorph(html){
+    var root = document.getElementById('root');
+    var target = document.createElement('div');
+    target.id = 'root';
+    target.innerHTML = html;
+    window.morphdom(root, target, {
+      onBeforeElUpdated: function(from, to){ return !from.isEqualNode(to); },
+      onNodeAdded: function(node){
+        if (node.nodeType === 1 && node.tagName !== 'STYLE' && node.tagName !== 'SCRIPT') {
+          node.style.animation = '_fadeIn 0.3s ease both';
+        }
+        return node;
+      }
+    });
+    post({type:'resize', height: document.body.scrollHeight});
+  }
+
+  function runScripts(){
+    document.querySelectorAll('#root script').forEach(function(old){
+      var s = document.createElement('script');
+      if (old.src) { s.src = old.src; } else { s.textContent = old.textContent; }
+      old.parentNode.replaceChild(s, old);
+    });
+  }
+
+  window.addEventListener('message', function(e){
+    if (e.source !== parent) return;
+    var d = e.data || {};
+    if (d.widgetId !== WIDGET_ID) return;
+    if (typeof d.seq !== 'number' || d.seq <= lastSeq) return; // latest-wins
+    lastSeq = d.seq;
+    try {
+      if (d.type === 'morph') {
+        if (finalized) return;
+        applyMorph(d.html);
+      } else if (d.type === 'finalize') {
+        if (finalized) return;
+        finalized = true;
+        runScripts();
+        post({type:'resize', height: document.body.scrollHeight});
+      }
+    } catch (err) {
+      post({type:'error', message: String(err && err.message || err).slice(0, 500)});
+    }
+  });
+
+  var s = document.createElement('script');
+  s.src = 'https://cdn.jsdelivr.net/npm/morphdom@2.7.4/dist/morphdom-umd.min.js';
+  s.onload = function(){ post({type:'ready'}); };
+  s.onerror = function(){ post({type:'error', message:'morphdom failed to load'}); };
+  document.head.appendChild(s);
+})();
+</script></body></html>`

--- a/frontend/packages/web/components/chat/widget/widgetShell.ts
+++ b/frontend/packages/web/components/chat/widget/widgetShell.ts
@@ -39,17 +39,36 @@ body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;backgr
     post({type:'resize', height: document.body.scrollHeight});
   }
 
-  function runScripts(){
-    document.querySelectorAll('#root script').forEach(function(old){
+  // Run #root scripts in document order. External (src) scripts are awaited
+  // before the next script runs, so an inline initializer (e.g. new Chart(...))
+  // never executes before its CDN library has loaded. Attributes are preserved.
+  function runScripts(done){
+    var scripts = Array.prototype.slice.call(document.querySelectorAll('#root script'));
+    var i = 0;
+    function next(){
+      if (i >= scripts.length) { if (done) done(); return; }
+      var old = scripts[i++];
       var s = document.createElement('script');
-      if (old.src) { s.src = old.src; } else { s.textContent = old.textContent; }
-      old.parentNode.replaceChild(s, old);
-    });
+      for (var a = 0; a < old.attributes.length; a++) {
+        s.setAttribute(old.attributes[a].name, old.attributes[a].value);
+      }
+      if (old.src) {
+        s.onload = next;
+        s.onerror = next; // proceed even if a CDN script fails
+        old.parentNode.replaceChild(s, old);
+      } else {
+        s.textContent = old.textContent;
+        old.parentNode.replaceChild(s, old); // inline runs synchronously
+        next();
+      }
+    }
+    next();
   }
 
   window.addEventListener('message', function(e){
     if (e.source !== parent) return;
-    var d = e.data || {};
+    var d = e.data;
+    if (!d || typeof d !== 'object') return;
     if (d.widgetId !== WIDGET_ID) return;
     if (typeof d.seq !== 'number' || d.seq <= lastSeq) return; // latest-wins
     lastSeq = d.seq;
@@ -60,8 +79,7 @@ body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;backgr
       } else if (d.type === 'finalize') {
         if (finalized) return;
         finalized = true;
-        runScripts();
-        post({type:'resize', height: document.body.scrollHeight});
+        runScripts(function(){ post({type:'resize', height: document.body.scrollHeight}); });
       }
     } catch (err) {
       post({type:'error', message: String(err && err.message || err).slice(0, 500)});

--- a/frontend/packages/web/lib/__tests__/partialJson.test.ts
+++ b/frontend/packages/web/lib/__tests__/partialJson.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { extractJsonStringPrefix, extractWidgetCode } from '@/lib/partialJson'
+
+describe('extractJsonStringPrefix', () => {
+  it('extracts a complete value', () => {
+    expect(extractJsonStringPrefix('{"content":"hello"}', 'content')).toBe('hello')
+  })
+  it('returns the prefix for an unterminated value', () => {
+    expect(extractJsonStringPrefix('{"content":"# Title\\nbody', 'content')).toBe('# Title\nbody')
+  })
+  it('decodes escapes', () => {
+    expect(extractJsonStringPrefix('{"c":"a\\tb\\"c\\u0041"}', 'c')).toBe('a\tb"cA')
+  })
+  it('does not end early on an escaped quote inside the value', () => {
+    expect(extractJsonStringPrefix('{"c":"say \\"hi\\" ok"}', 'c')).toBe('say "hi" ok')
+  })
+  it('returns empty when the key is absent', () => {
+    expect(extractJsonStringPrefix('{"other":"x"}', 'content')).toBe('')
+  })
+})
+
+describe('extractWidgetCode', () => {
+  it('pulls widget_code mid-stream', () => {
+    expect(extractWidgetCode('{"title":"t","widget_code":"<div>part')).toBe('<div>part')
+  })
+})

--- a/frontend/packages/web/lib/partialJson.ts
+++ b/frontend/packages/web/lib/partialJson.ts
@@ -1,0 +1,58 @@
+function decodeEscapeSequence(char: string): string {
+  switch (char) {
+    case 'n':
+      return '\n'
+    case 'r':
+      return '\r'
+    case 't':
+      return '\t'
+    case 'b':
+      return '\b'
+    case 'f':
+      return '\f'
+    case '"':
+      return '"'
+    case '\\':
+      return '\\'
+    case '/':
+      return '/'
+    default:
+      return char
+  }
+}
+
+/** Tolerantly extract a JSON string field's value from possibly-incomplete JSON. */
+export function extractJsonStringPrefix(raw: string, key: string): string {
+  const keyMatch = new RegExp(`"${key}"\\s*:\\s*"`, 'm').exec(raw)
+  if (!keyMatch) return ''
+
+  let i = keyMatch.index + keyMatch[0].length
+  let value = ''
+
+  while (i < raw.length) {
+    const char = raw[i]
+    if (char === '"') break
+    if (char === '\\') {
+      const next = raw[i + 1]
+      if (!next) break
+      if (next === 'u') {
+        const hex = raw.slice(i + 2, i + 6)
+        if (hex.length < 4 || /[^0-9a-fA-F]/.test(hex)) break
+        value += String.fromCharCode(parseInt(hex, 16))
+        i += 6
+        continue
+      }
+      value += decodeEscapeSequence(next)
+      i += 2
+      continue
+    }
+    value += char
+    i++
+  }
+
+  return value
+}
+
+export function extractWidgetCode(rawArgsText: string): string {
+  return extractJsonStringPrefix(rawArgsText, 'widget_code')
+}

--- a/frontend/packages/web/lib/writeFilePreview.ts
+++ b/frontend/packages/web/lib/writeFilePreview.ts
@@ -1,4 +1,5 @@
 import type { ContentBlock, ToolCallRef } from '@cubebox/core'
+import { extractJsonStringPrefix } from '@/lib/partialJson'
 
 export type WriteFileStatus = 'streaming_args' | 'pending_execution' | 'completed'
 
@@ -10,60 +11,6 @@ export interface ParsedWriteFile {
 
 function readStringArg(args: Record<string, unknown>, key: string): string {
   return typeof args[key] === 'string' ? args[key] : ''
-}
-
-function decodeEscapeSequence(char: string): string {
-  switch (char) {
-    case 'n':
-      return '\n'
-    case 'r':
-      return '\r'
-    case 't':
-      return '\t'
-    case 'b':
-      return '\b'
-    case 'f':
-      return '\f'
-    case '"':
-      return '"'
-    case '\\':
-      return '\\'
-    case '/':
-      return '/'
-    default:
-      return char
-  }
-}
-
-function extractJsonStringPrefix(raw: string, key: string): string {
-  const keyMatch = new RegExp(`"${key}"\\s*:\\s*"`, 'm').exec(raw)
-  if (!keyMatch) return ''
-
-  let i = keyMatch.index + keyMatch[0].length
-  let value = ''
-
-  while (i < raw.length) {
-    const char = raw[i]
-    if (char === '"') break
-    if (char === '\\') {
-      const next = raw[i + 1]
-      if (!next) break
-      if (next === 'u') {
-        const hex = raw.slice(i + 2, i + 6)
-        if (hex.length < 4 || /[^0-9a-fA-F]/.test(hex)) break
-        value += String.fromCharCode(parseInt(hex, 16))
-        i += 6
-        continue
-      }
-      value += decodeEscapeSequence(next)
-      i += 2
-      continue
-    }
-    value += char
-    i++
-  }
-
-  return value
 }
 
 function readFilePath(args: Record<string, unknown>): string {


### PR DESCRIPTION
## Summary

Adds a `show_widget` tool that lets the agent render live, interactive HTML/JS widgets inline in the chat stream — charts, diagrams, sliders, animations — that assemble token-by-token as the model generates them (the Claude-artifacts "generative UI" experience, adapted for cubebox's web frontend).

The widget's `widget_code` rides the **existing** `tool_call_delta → args_text → extractJsonStringPrefix` streaming path — **no change to the streaming pipeline**. The frontend extracts the in-progress HTML and `postMessage`s it into a sandboxed iframe whose shell runs morphdom; scripts run once on finalize.

Spec: `docs/dev/specs/2026-05-27-generative-ui-widgets-design.md`
Plan: `docs/dev/plans/2026-05-27-generative-ui-widgets.md`

### Backend
- `show_widget` builtin tool (`tools/builtin/show_widget.py`) — UI-only, execute() returns a light ack.
- Self-authored design-guidelines prompt (`prompts/widget.py`), injected into the system prompt at a fixed (cache-stable) position.
- Registered in `run_manager` builtin order; **excluded from subagent `shared_tools`** (top-level only in v1) via a `_subagent_shared_tools` helper.

### Frontend
- `lib/partialJson.ts` — promoted the shared tolerant partial-JSON parser (was private in `writeFilePreview.ts`) + `extractWidgetCode`.
- `widgetShell.ts` — sandboxed iframe srcDoc: CSP + morphdom runtime + postMessage protocol (`{widgetId, seq, type}`), latest-wins, finalize-once, ordered script execution (awaits CDN `src` before inline init).
- `WidgetView.tsx` — `sandbox="allow-scripts"` (opaque origin, no `allow-same-origin`), id injected injection-safely, debounce, ready-wait, 5s readiness timeout + source-block fallback, size cap, height self-correcting via `resize`.
- `AssistantMessage.tsx` — mounts widgets (streaming + completed), excludes `show_widget` from `groupBlocks`, placeholder until code is extractable.

### Security
Opaque-origin sandbox + CSP (`connect-src 'none'`, `base-uri/form-action/worker-src/frame-src/object-src 'none'`, CDN-only `script-src`) + `event.source` validation. Residual risks (inline-script CPU, img/font-URL exfil) documented in the spec.

## Test plan
- [x] Backend unit (`tests/unit/test_show_widget.py`) — tool metadata, ack, guidelines, subagent exclusion (4 pass)
- [x] `partialJson` unit (6 pass)
- [x] `WidgetView` vitest — size-cap fallback, ready-timeout fallback, forged-source rejection / posts-after-ready (3 pass)
- [x] Shell Playwright E2E — morph + finalize-once, latest-wins (before & after finalize), opaque-origin + `connect-src 'none'` (4 pass)
- [x] type-check + mypy + lint clean; pre-push CI green
- [ ] Manual: real model → widget streams/morphs/finalizes + reload re-render + light/dark themes (model-driven path is non-deterministic, hence manual)

🤖 Local codex-reviewed at spec, plan, and code stages (each iterated to clean).