### PR TITLE
docs(spec): Curate China-vendor MCP sources (#147)

### DIFF
--- a/docs/dev/plans/2026-05-27-mcp-china-sources.md
+++ b/docs/dev/plans/2026-05-27-mcp-china-sources.md
@@ -8,31 +8,58 @@
 
 ## Goal
 
-Add the China-vendor MCP connector(s) that fit the **current**
-`MCPConnectorTemplateSeedEntry` schema unchanged to the seeded catalog
-(`backend/cubebox/mcp/template_seed.py`), so a workspace/org admin sees them in
-the one-click install list. Honor the spec's v1 scope decision:
+Land the catalog groundwork for China-vendor MCP sources **without** adding any
+seed entry yet, because a local codex review of this plan found that the one
+candidate we believed was a clean fit (Feishu / Lark) is in fact blocked by a
+runtime auth gap. Concretely:
 
-- **v1 (this plan):** **Feishu / Lark** only — official, supports a documented
-  remote mode, and authenticates with an `Authorization: Bearer <token>`
-  header, which maps cleanly onto the existing `static` auth path with the
-  shared `_TOKEN_FIELD` + `_BEARER_TEMPLATE`. No schema change, no migration.
-- **Deferred (NOT in this plan):** every other curated source. They are blocked
-  on a schema/runtime gap the spec calls out (§6.2, §8):
-  - **Amap, Baidu Maps, Tencent Location** — API key lives in a URL query
-    param (`?key=` / `?ak=`), which `static_auth_header_template` cannot
-    express. Needs a new `static_auth_query_param` field + install-time URL
-    injection. Blocked.
-  - **Alipay** — stdio-only launch + asymmetric (App ID + RSA key-pair) auth.
-    Needs a managed launcher and a key-pair credential kind. Blocked.
-  - **DingTalk, WeCom, MiniMax (official), Tushare** — stdio-only packages;
-    cubebox installs remote URLs only. Blocked until a managed launcher or a
-    vendor-published remote endpoint exists.
-  - **Bailian, ModelScope** — hosting marketplaces, not single connectors;
-    each hosted service would be its own future row.
+- The runtime resolves **static** auth by hardcoding
+  `headers["Authorization"] = f"Bearer {plaintext}"`
+  (`backend/cubebox/mcp/cubepi_runtime.py:244-250`). It **never reads**
+  `static_auth_header_template`, so neither a custom header *name* nor a custom
+  template is honored at install/runtime today.
+- Feishu remote mode authenticates with **`X-Lark-MCP-UAT`** (user access
+  token) and **`X-Lark-MCP-TAT`** (tenant access token) headers against
+  `https://mcp.feishu.cn/mcp`, **not** `Authorization: Bearer`. So Feishu is
+  **not** a schema-unchanged fit: it needs (a) a configurable static auth header
+  *name* and (b) the runtime to actually apply that template.
 
-This plan is therefore deliberately small: it lands the one clean fit, asserts
-it loads/validates and surfaces in the catalog, and refreshes the one stale doc.
+**v1 (this plan): ship NO new connector source.** Adding the Feishu row now
+would surface it in the catalog while every install silently sends the wrong
+header (`Authorization: Bearer`) and fails against Feishu — false confidence.
+Instead this plan:
+
+1. Records the runtime gap and the corrected Feishu facts (URL + header names)
+   so the next editor has accurate ground truth.
+2. Refreshes the stale catalog runbook and the stale `template_seed.py` module
+   docstring so the docs match the live system.
+3. Defers Feishu and every other curated source until the auth plumbing exists
+   (see the table below + §"Deferred").
+
+The optional Task 2 sketches the *minimal* auth-plumbing change (configurable
+static header name/template + runtime application) for whoever picks up Feishu
+next; it is scoped but **not** required to be implemented in this PR.
+
+**Deferred (NOT landed in this plan):**
+
+- **Feishu / Lark** — needs a configurable static auth-header name/template
+  (`X-Lark-MCP-UAT` / `X-Lark-MCP-TAT`) **and** runtime application of that
+  template (the runtime currently ignores it). Correct endpoint:
+  `https://mcp.feishu.cn/mcp`.
+- **Amap, Baidu Maps, Tencent Location** — API key lives in a URL query
+  param (`?key=` / `?ak=`), which `static_auth_header_template` cannot
+  express. Needs a new `static_auth_query_param` field + install-time URL
+  injection. Blocked.
+- **Alipay** — stdio-only launch + asymmetric (App ID + RSA key-pair) auth.
+  Needs a managed launcher and a key-pair credential kind. Blocked.
+- **DingTalk, WeCom, MiniMax (official), Tushare** — stdio-only packages;
+  cubebox installs remote URLs only. Blocked until a managed launcher or a
+  vendor-published remote endpoint exists.
+- **Bailian, ModelScope** — hosting marketplaces, not single connectors;
+  each hosted service would be its own future row.
+
+This plan is therefore deliberately small: it fixes doc drift, records the
+runtime auth gap blocking Feishu, and leaves the catalog list unchanged.
 
 ## Architecture
 
@@ -44,13 +71,26 @@ The connector catalog is a frozen Python list (`CATALOG`) of
 a system-level `Credential`, and deprecating DB rows whose slug left the list.
 The seeder runs idempotently (lock-guarded) on FastAPI startup
 (`backend/cubebox/api/app.py`) and via `python -m cubebox.cli seed-mcp-templates`.
+(The `template_seed.py` module docstring still claims it is *not* wired into
+startup — that is stale and Task 1 fixes it.)
 
 The admin route `GET /api/v1/admin/mcp/templates` reads the catalog through
 `MCPConnectorTemplateService.list_active()`
 (`backend/cubebox/services/mcp_templates.py`) and returns the active rows.
 
-Adding a connector = appending one `MCPConnectorTemplateSeedEntry` to `CATALOG`.
-No new tables, columns, routes, services, or migrations for v1.
+**The runtime auth gap.** At connect time, `_resolve_headers_from_spec()`
+(`backend/cubebox/mcp/cubepi_runtime.py:244-250`) resolves a `static` credential
+by hardcoding `headers["Authorization"] = f"Bearer {plaintext}"`. It does
+**not** read the template's `static_auth_header_template`. So the seed entries
+that carry a non-Bearer template today (e.g. the `Basic {b64(...)}` entry) are
+*not* actually honored at runtime either — the field is stored but unused. Any
+connector needing a custom header *name* (Feishu's `X-Lark-MCP-UAT` /
+`X-Lark-MCP-TAT`) cannot work until this is fixed.
+
+Adding a connector that fits the current behavior = appending one
+`MCPConnectorTemplateSeedEntry` to `CATALOG` whose static auth is a plain
+`Authorization: Bearer <token>` header. Anything else (custom header name,
+URL-query-param key) needs runtime work first. This plan adds **no** new entry.
 
 ## Tech Stack
 
@@ -61,305 +101,111 @@ No new tables, columns, routes, services, or migrations for v1.
 
 ---
 
-## Task 1 — Add the Feishu seed entry to `CATALOG`
+## Task 1 — Fix the stale `template_seed.py` module docstring
 
-The single v1 connector. Feishu's remote mode is reached over an SSE endpoint
-and authenticates with a Bearer App Access Token — a clean `static` fit.
-
-**Files**
-
-- Modify: `backend/cubebox/mcp/template_seed.py`
-- Test (new): `backend/tests/unit/test_catalog_seed_china.py`
-
-**Steps**
-
-1. **Write the failing test.** Create
-   `backend/tests/unit/test_catalog_seed_china.py`. Reuse the in-memory
-   `session` / `backend` fixture pattern from
-   `backend/tests/unit/test_catalog_seed.py` (copy the two fixtures and the
-   `_make_get_env` helper verbatim — they are small and self-contained). Add a
-   pure-data test that asserts the Feishu entry exists and is shaped as a
-   header-Bearer `static` connector:
-
-   ```python
-   """Tests for the China-vendor additions to the MCP connector catalog."""
-
-   from collections.abc import AsyncIterator, Callable
-
-   import pytest
-   from cryptography.fernet import Fernet
-   from sqlalchemy.ext.asyncio import (
-       AsyncSession,
-       async_sessionmaker,
-       create_async_engine,
-   )
-   from sqlmodel import SQLModel
-
-   from cubebox.credentials.encryption import FernetBackend
-   from cubebox.mcp.template_seed import CATALOG, seed_templates
-   from cubebox.repositories.mcp import MCPConnectorTemplateRepository
-
-
-   @pytest.fixture
-   async def session() -> AsyncIterator[AsyncSession]:
-       engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-       async with engine.begin() as conn:
-           await conn.run_sync(SQLModel.metadata.create_all)
-       maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-       async with maker() as s:
-           yield s
-       await engine.dispose()
-
-
-   @pytest.fixture
-   def backend() -> FernetBackend:
-       return FernetBackend([Fernet.generate_key()])
-
-
-   def _make_get_env(values: dict[str, str]) -> Callable[[str], str | None]:
-       def _getter(key: str) -> str | None:
-           return values.get(key)
-
-       return _getter
-
-
-   def test_feishu_entry_is_header_bearer_static() -> None:
-       by_slug = {e.slug: e for e in CATALOG}
-       assert "feishu" in by_slug
-       entry = by_slug["feishu"]
-
-       assert entry.provider == "Feishu"
-       assert entry.transport == "sse"
-       assert entry.supported_auth_methods == ["static"]
-       assert entry.default_credential_policy == "workspace"
-       # Bearer-in-header static auth — the schema-fitting shape.
-       assert entry.static_auth_header_template == "Bearer {token}"
-       assert entry.static_form_schema is not None
-       assert entry.static_form_schema[0]["name"] == "token"
-       # Not an OAuth-app / URL-query-param / stdio connector.
-       assert entry.oauth_static_client_id_env is None
-       assert entry.oauth_static_client_secret_env is None
-       assert entry.oauth_dcr_supported is None
-       assert entry.server_url.startswith("https://")
-       assert "{token}" not in entry.server_url  # secret never baked into URL
-       assert entry.template_metadata["docs_url"].startswith("https://")
-   ```
-
-2. **Run it, expect fail** (KeyError / assertion — `feishu` not yet in
-   `CATALOG`):
-
-   ```bash
-   uv run pytest tests/unit/test_catalog_seed_china.py::test_feishu_entry_is_header_bearer_static -q
-   ```
-
-3. **Implement.** In `backend/cubebox/mcp/template_seed.py`, append this entry
-   to the `CATALOG` list (after the existing `webtools` entry, before the
-   closing `]`). It reuses `_TOKEN_FIELD` and `_BEARER_TEMPLATE` already defined
-   in the module:
-
-   ```python
-       MCPConnectorTemplateSeedEntry(
-           slug="feishu",
-           name="Feishu / Lark",
-           provider="Feishu",
-           description=(
-               "Feishu/Lark OpenAPI MCP (remote mode): docs, messages, "
-               "calendar, bitable."
-           ),
-           server_url="https://lark-mcp.feishu.cn/mcp",
-           transport="sse",
-           supported_auth_methods=["static"],
-           default_credential_policy="workspace",
-           oauth_dcr_supported=None,
-           oauth_default_scope=None,
-           oauth_static_client_id_env=None,
-           oauth_static_client_secret_env=None,
-           static_form_schema=_TOKEN_FIELD,
-           static_auth_header_template=_BEARER_TEMPLATE,
-           template_metadata={
-               "docs_url": (
-                   "https://open.larksuite.com/document/mcp_open_tools/"
-                   "call-feishu-mcp-server-in-remote-mode"
-               ),
-               "region": "cn",
-           },
-       ),
-   ```
-
-4. **Run it, expect pass:**
-
-   ```bash
-   uv run pytest tests/unit/test_catalog_seed_china.py::test_feishu_entry_is_header_bearer_static -q
-   ```
-
-5. **Commit:**
-
-   ```bash
-   git add backend/cubebox/mcp/template_seed.py \
-       backend/tests/unit/test_catalog_seed_china.py
-   git commit -m "$(cat <<'EOF'
-   feat(mcp): add Feishu/Lark connector to the v1 catalog (#147)
-
-   Feishu remote mode authenticates with a Bearer App Access Token, which
-   maps onto the existing static header path with no schema change. It is the
-   only curated China-vendor source that fits MCPConnectorTemplateSeedEntry
-   unchanged; maps (URL-query-param key) and stdio/key-pair sources are
-   deferred per the design doc.
-   EOF
-   )"
-   ```
-
----
-
-## Task 2 — Assert Feishu seeds and validates through `seed_templates()`
-
-Prove the new entry isn't just well-shaped data but actually upserts a row and
-passes the seeder's existing invariants (no env vars required, no skip, no
-deprecation), the same way the existing catalog is exercised.
+The module docstring (`backend/cubebox/mcp/template_seed.py:18`) still claims
+the seeder is "Not wired into FastAPI startup; this is intentionally an explicit
+deploy step." That is no longer true — the seeder runs lock-guarded on FastAPI
+startup (`backend/cubebox/api/app.py`) **and** via the CLI. Doc-only change in
+the module; no behavior change, no catalog change, no test.
 
 **Files**
 
-- Test (modify): `backend/tests/unit/test_catalog_seed_china.py`
+- Modify: `backend/cubebox/mcp/template_seed.py` (docstring only)
 
 **Steps**
 
-1. **Write the failing test.** Append to `test_catalog_seed_china.py`:
-
-   ```python
-   async def test_feishu_seeds_as_active_template_without_env(
-       session: AsyncSession, backend: FernetBackend
-   ) -> None:
-       # Feishu needs no OAuth-app env vars → seeds even with an empty env.
-       result = await seed_templates(
-           session, backend, get_env=_make_get_env({})
-       )
-
-       # The empty env only skips connectors that require an OAuth client
-       # secret; Feishu must not be among the skipped.
-       repo = MCPConnectorTemplateRepository(session)
-       active = {row.slug for row in await repo.list_active()}
-       assert "feishu" in active
-       assert result.deprecated == 0
-
-       row = await repo.get_by_slug("feishu")
-       assert row is not None
-       assert row.status == "active"
-       assert row.supported_auth_methods == ["static"]
-       assert row.transport == "sse"
-       assert row.static_auth_header_template == "Bearer {token}"
-   ```
-
-2. **Run it, expect pass already** (Task 1 added the entry, so this should pass
-   immediately — that is acceptable; it locks the behavior in). Confirm:
+1. **Confirm the live wiring** so the rewritten docstring is accurate:
 
    ```bash
-   uv run pytest tests/unit/test_catalog_seed_china.py -q
+   grep -n "seed_templates" backend/cubebox/api/app.py
    ```
 
-   If it fails, debug the seeder mapping for the Feishu entry before
-   proceeding.
+   Expect a startup call (lock-guarded). Note the function / lock used.
 
-3. **Regression sweep on the seeder suite** — the count-based assertions in
-   `test_catalog_seed.py` (`upserted == len(CATALOG)`) must still hold after the
-   catalog grew by one:
+2. **Rewrite the last paragraph of the module docstring** with `Edit` to say
+   the seeder runs idempotently on FastAPI startup (lock-guarded) **and** via
+   `python -m cubebox.cli seed-mcp-templates`. Keep it ≤ 100-char lines, plain
+   English. Do not touch any code outside the docstring.
+
+3. **Verify nothing else changed** and the module still imports:
 
    ```bash
-   uv run pytest tests/unit/test_catalog_seed.py tests/unit/test_catalog_seed_china.py -q
+   uv run python -c "import cubebox.mcp.template_seed"
    ```
-
-   If any count assertion in `test_catalog_seed.py` references a hard-coded
-   number, update it to track `len(CATALOG)` (it already uses `len(CATALOG)`,
-   so no change is expected — verify).
 
 4. **Commit:**
 
    ```bash
-   git add backend/tests/unit/test_catalog_seed_china.py
+   git add backend/cubebox/mcp/template_seed.py
    git commit -m "$(cat <<'EOF'
-   test(mcp): assert Feishu seeds as an active template (#147)
+   docs(mcp): correct template_seed docstring re: startup wiring (#147)
 
-   Locks in that the Feishu entry upserts a static/SSE row with no OAuth env
-   vars and survives the existing seeder invariants.
+   The seeder now runs lock-guarded on FastAPI startup and via the CLI; the
+   module docstring still claimed it was only an explicit deploy step.
    EOF
    )"
    ```
 
 ---
 
-## Task 3 — E2E: Feishu appears in the admin catalog endpoint
+## Task 2 (OPTIONAL — only if landing Feishu in this PR) — auth-header plumbing
 
-E2E-first per project discipline: assert the connector is reachable through the
-real `GET /api/v1/admin/mcp/templates` route after seeding, not just in the
-Python list. Mirror the existing admin-MCP E2E setup.
+This task is **not required** for the docs-only v1. Implement it only if the
+decision is to ship Feishu in this same PR rather than deferring. It closes the
+runtime gap so a connector can carry a custom static auth header name/template.
+
+Whoever picks this up: do **not** rely solely on catalog-visibility tests —
+those only prove the row appears in `GET /api/v1/admin/mcp/templates`. They give
+false confidence because the runtime ignores `static_auth_header_template`. You
+must add a test that exercises **header resolution** so the wrong header can't
+ship silently.
 
 **Files**
 
-- Test (new): `backend/tests/e2e/test_mcp_china_catalog.py`
+- Modify: `backend/cubebox/mcp/cubepi_runtime.py` (the `static` branch of
+  `_resolve_headers_from_spec`, around lines 244-250)
+- Modify: `backend/cubebox/mcp/template_seed.py` (add the Feishu entry once the
+  runtime honors a custom header)
+- Test (new): `backend/tests/unit/test_mcp_static_header_resolution.py`
+- Test (new): `backend/tests/e2e/test_mcp_china_catalog.py` (catalog visibility,
+  in addition to the unit header test — not as a substitute for it)
 
 **Steps**
 
-1. **Locate the pattern.** Read an existing admin-MCP E2E test that seeds
-   templates and calls the admin templates/installs routes (e.g.
-   `backend/tests/e2e/test_mcp_four_layer_routes.py`,
-   `backend/tests/e2e/test_mcp_oauth_handoff.py`) plus
-   `backend/tests/e2e/conftest.py` for the seeded-catalog / authed-admin-client
-   fixtures. Reuse those fixtures; do not invent a new harness.
+1. **Decide the schema-fitting shape for a custom header.** The template already
+   stores `static_auth_header_template` (e.g. `"Bearer {token}"`); the runtime
+   just doesn't apply it. The minimal change is: in the `static` branch, if the
+   spec carries a header template, render it with the decrypted secret and the
+   configured header *name* instead of hardcoding `Authorization: Bearer`. For
+   Feishu the header name is `X-Lark-MCP-UAT` (user access token) and/or
+   `X-Lark-MCP-TAT` (tenant access token); the endpoint is
+   `https://mcp.feishu.cn/mcp`. Confirm whether the existing schema can carry a
+   header *name* (it currently only has a value template) — if not, this needs
+   a small field addition, which pushes Feishu out of a docs-only PR. Record the
+   decision in the spec's §8 before coding.
 
-2. **Write the failing test.** Create
-   `backend/tests/e2e/test_mcp_china_catalog.py` that:
-   - uses the existing fixture that seeds the catalog and yields an authed
-     admin HTTP client (copy the fixture wiring from the chosen reference
-     test verbatim — adapt only the assertions);
-   - `GET`s `/api/v1/admin/mcp/templates`;
-   - asserts the response is 200 and that an item with `slug == "feishu"` is
-     present, with `transport == "sse"`, `supported_auth_methods == ["static"]`,
-     and a non-secret token field in its `static_form_schema`.
+2. **Write the failing unit test** in
+   `backend/tests/unit/test_mcp_static_header_resolution.py`: build a runtime
+   spec for a static connector whose template uses a non-`Authorization` header
+   and assert `_resolve_headers_from_spec` emits exactly that header (name +
+   rendered value), and that it does **not** emit a bogus
+   `Authorization: Bearer` for such connectors. Run it, expect fail (the runtime
+   currently always sets `Authorization`).
 
-   Shape of the assertion body (adapt request mechanics to the reference
-   fixture's client/URL helpers):
+3. **Implement** the `static` branch so it honors the template/header name, then
+   re-run the unit test to green.
 
-   ```python
-   async def test_feishu_appears_in_admin_catalog(...) -> None:
-       resp = await admin_client.get("/api/v1/admin/mcp/templates")
-       assert resp.status_code == 200
-       items = resp.json()["items"]
-       by_slug = {it["slug"]: it for it in items}
-       assert "feishu" in by_slug
-       feishu = by_slug["feishu"]
-       assert feishu["transport"] == "sse"
-       assert feishu["supported_auth_methods"] == ["static"]
-   ```
+4. **Add the Feishu seed entry** with the corrected `server_url`
+   (`https://mcp.feishu.cn/mcp`) and the correct header name, plus the catalog
+   visibility E2E. Run both the unit header test and the E2E.
 
-3. **Run it, expect pass** (the seeder runs in the E2E harness, so Feishu should
-   surface once Task 1 landed). If the reference fixture seeds via
-   `seed_templates(...)` or app startup, confirm Feishu is included:
-
-   ```bash
-   uv run pytest tests/e2e/test_mcp_china_catalog.py -q
-   ```
-
-   If the route field names differ from the assumed JSON keys, read
-   `backend/cubebox/api/schemas/mcp.py` (`MCPConnectorTemplateListOut` and the
-   item schema) and `_template_to_out` in
-   `backend/cubebox/api/routes/v1/admin_mcp.py`, then fix the assertion keys —
-   this is a test-only correction, not an implementation change.
-
-4. **Commit:**
-
-   ```bash
-   git add backend/tests/e2e/test_mcp_china_catalog.py
-   git commit -m "$(cat <<'EOF'
-   test(mcp): e2e assert Feishu surfaces in the admin catalog (#147)
-
-   Proves the seeded Feishu template is reachable through the real admin
-   templates route, not just the Python CATALOG list.
-   EOF
-   )"
-   ```
+5. **Commit** in logically separate commits (runtime+test, then seed entry).
+   Scope every message `(#147)`.
 
 ---
 
-## Task 4 — Fix the doc drift in `mcp_catalog_oauth.md`
+## Task 3 — Fix the doc drift in `mcp_catalog_oauth.md`
 
 The spec (§8) flags that `backend/docs/mcp_catalog_oauth.md` still uses the old
 M2 naming — `mcp_catalog_connectors` table and `cubebox.mcp.catalog_seed.CATALOG`
@@ -389,12 +235,15 @@ editor. Doc-only change; no code, no tests.
      `python -m cubebox.cli seed-mcp-templates`; the seeder also runs
      idempotently on FastAPI startup (lock-guarded). Correct any sentence that
      claims it is *only* an out-of-band step if the doc says so.
-   - Add one short line under the catalog section noting Feishu is the first
-     China-vendor entry and that URL-query-param-key sources (maps) and
-     stdio/key-pair sources (Alipay, DingTalk, WeCom, MiniMax, Tushare) are
-     deferred pending a `static_auth_query_param` field / managed launcher
-     (cross-reference the design doc
-     `docs/dev/specs/2026-05-27-mcp-china-sources-design.md`).
+   - Add one short line under the catalog section noting that **no**
+     China-vendor entry ships in v1: Feishu is deferred because its remote mode
+     uses custom `X-Lark-MCP-UAT` / `X-Lark-MCP-TAT` headers at
+     `https://mcp.feishu.cn/mcp` and the runtime currently ignores
+     `static_auth_header_template` (always sends `Authorization: Bearer`).
+     URL-query-param-key sources (maps) and stdio/key-pair sources (Alipay,
+     DingTalk, WeCom, MiniMax, Tushare) remain deferred pending a
+     `static_auth_query_param` field / managed launcher. Cross-reference the
+     design doc `docs/dev/specs/2026-05-27-mcp-china-sources-design.md`.
 
 3. **Verify no stale names remain:**
 
@@ -412,15 +261,15 @@ editor. Doc-only change; no code, no tests.
    docs(mcp): refresh catalog runbook to template_seed naming (#147)
 
    Replace stale M2 mcp_catalog_connectors / catalog_seed references with the
-   live mcp_connector_templates / template_seed names, and note the v1 Feishu
-   addition plus the deferred China-vendor sources.
+   live mcp_connector_templates / template_seed names, and note that no
+   China-vendor source ships in v1 (Feishu + all others deferred).
    EOF
    )"
    ```
 
 ---
 
-## Task 5 — Pre-PR sweep + self-review
+## Task 4 — Pre-PR sweep + self-review
 
 **Files**
 
@@ -428,33 +277,32 @@ editor. Doc-only change; no code, no tests.
 
 **Steps**
 
-1. **Run the full MCP-affected suite:**
+1. **Run the seeder suite** to confirm nothing regressed (the catalog list is
+   unchanged in the docs-only v1, so the existing count assertions still hold):
 
    ```bash
-   uv run pytest tests/unit/test_catalog_seed.py \
-       tests/unit/test_catalog_seed_china.py \
-       tests/unit/test_cli_seed.py \
-       tests/e2e/test_mcp_china_catalog.py -q
+   uv run pytest tests/unit/test_catalog_seed.py tests/unit/test_cli_seed.py -q
    ```
 
-   All must pass.
+   All must pass. (If Task 2 was implemented, also run
+   `tests/unit/test_mcp_static_header_resolution.py` and
+   `tests/e2e/test_mcp_china_catalog.py`.)
 
-2. **Type check** the changed module + tests:
+2. **Type check** the touched module:
 
    ```bash
    uv run mypy cubebox/mcp/template_seed.py
    ```
 
 3. **Self-review checklist:**
-   - [ ] Only Feishu added to `CATALOG`; no deferred source (maps / Alipay /
-         DingTalk / WeCom / MiniMax / Tushare / marketplaces) slipped in.
-   - [ ] No new column, migration, route, or service — schema unchanged.
-   - [ ] Feishu `server_url` carries no secret; auth is header-Bearer only.
-   - [ ] `static_form_schema` reuses `_TOKEN_FIELD`; header uses
-         `_BEARER_TEMPLATE` — no duplicated literals.
-   - [ ] Line length ≤ 100; full type annotations; no placeholder strings.
+   - [ ] `CATALOG` is unchanged — no Feishu, no deferred source slipped in
+         (docs-only v1). If Task 2 was done, Feishu's runtime header is honored
+         by a passing header-resolution test, not just catalog visibility.
+   - [ ] No new column, migration, route, or service in the docs-only v1.
+   - [ ] `template_seed.py` docstring no longer claims "not wired into startup".
+   - [ ] Line length ≤ 100; plain English; no placeholder strings.
    - [ ] Doc drift fixed: zero `mcp_catalog_connectors` / `catalog_seed`
-         references remain.
+         references remain in `mcp_catalog_oauth.md`.
    - [ ] Every commit message scopes `(#147)`; no amend, no push, no codex.
 
 4. **Confirm clean tree** (all work committed):
@@ -468,11 +316,12 @@ editor. Doc-only change; no code, no tests.
 
 ## Deferred (explicitly out of this plan)
 
-Per design doc §6.2 / §7 / §8, these are recorded as future work, each blocked
-on a named gap:
+Per design doc §6.2 / §7 / §8 plus the runtime gap found in local review, these
+are recorded as future work, each blocked on a named gap:
 
 | Source | Blocker | Unblocks when |
 |---|---|---|
+| Feishu / Lark | runtime ignores `static_auth_header_template`; needs custom header name `X-Lark-MCP-UAT` / `X-Lark-MCP-TAT` (not `Authorization: Bearer`) | runtime applies a configurable static header name/template (Task 2) |
 | Amap, Baidu Maps, Tencent Location | API key in URL query param | `static_auth_query_param` field + install-time URL injection (secret stays in vault) |
 | Alipay | stdio launch + RSA key-pair auth | managed launcher + key-pair credential kind |
 | DingTalk, WeCom, MiniMax (official), Tushare | stdio-only packages | managed launcher or vendor remote endpoint |

--- a/docs/dev/plans/2026-05-27-mcp-china-sources.md
+++ b/docs/dev/plans/2026-05-27-mcp-china-sources.md
@@ -1,0 +1,479 @@
+# China-Vendor MCP Sources Implementation Plan
+
+> Agentic-workers: execute tasks top-to-bottom. Each task is self-contained —
+> write the failing test first, run it and confirm the expected failure, write
+> the real implementation, run it and confirm pass, then commit. Stay on
+> branch `feat/mcp-china-sources`. Do not amend, do not push, do not invoke
+> codex. Run all `uv` / `pytest` commands from `backend/`.
+
+## Goal
+
+Add the China-vendor MCP connector(s) that fit the **current**
+`MCPConnectorTemplateSeedEntry` schema unchanged to the seeded catalog
+(`backend/cubebox/mcp/template_seed.py`), so a workspace/org admin sees them in
+the one-click install list. Honor the spec's v1 scope decision:
+
+- **v1 (this plan):** **Feishu / Lark** only — official, supports a documented
+  remote mode, and authenticates with an `Authorization: Bearer <token>`
+  header, which maps cleanly onto the existing `static` auth path with the
+  shared `_TOKEN_FIELD` + `_BEARER_TEMPLATE`. No schema change, no migration.
+- **Deferred (NOT in this plan):** every other curated source. They are blocked
+  on a schema/runtime gap the spec calls out (§6.2, §8):
+  - **Amap, Baidu Maps, Tencent Location** — API key lives in a URL query
+    param (`?key=` / `?ak=`), which `static_auth_header_template` cannot
+    express. Needs a new `static_auth_query_param` field + install-time URL
+    injection. Blocked.
+  - **Alipay** — stdio-only launch + asymmetric (App ID + RSA key-pair) auth.
+    Needs a managed launcher and a key-pair credential kind. Blocked.
+  - **DingTalk, WeCom, MiniMax (official), Tushare** — stdio-only packages;
+    cubebox installs remote URLs only. Blocked until a managed launcher or a
+    vendor-published remote endpoint exists.
+  - **Bailian, ModelScope** — hosting marketplaces, not single connectors;
+    each hosted service would be its own future row.
+
+This plan is therefore deliberately small: it lands the one clean fit, asserts
+it loads/validates and surfaces in the catalog, and refreshes the one stale doc.
+
+## Architecture
+
+The connector catalog is a frozen Python list (`CATALOG`) of
+`MCPConnectorTemplateSeedEntry` dataclasses in
+`backend/cubebox/mcp/template_seed.py`. `seed_templates()` upserts each entry by
+`slug` into the `mcp_connector_templates` table (`MCPConnectorTemplate`,
+`backend/cubebox/models/mcp.py`), encrypting any static-OAuth client secret into
+a system-level `Credential`, and deprecating DB rows whose slug left the list.
+The seeder runs idempotently (lock-guarded) on FastAPI startup
+(`backend/cubebox/api/app.py`) and via `python -m cubebox.cli seed-mcp-templates`.
+
+The admin route `GET /api/v1/admin/mcp/templates` reads the catalog through
+`MCPConnectorTemplateService.list_active()`
+(`backend/cubebox/services/mcp_templates.py`) and returns the active rows.
+
+Adding a connector = appending one `MCPConnectorTemplateSeedEntry` to `CATALOG`.
+No new tables, columns, routes, services, or migrations for v1.
+
+## Tech Stack
+
+- Python 3.x, FastAPI, SQLModel / SQLAlchemy async, Postgres (sqlite in-memory
+  for the seed unit tests, per `test_catalog_seed.py`).
+- `pytest` (async); `uv run pytest` from `backend/`.
+- mypy strict; 100-char lines; type annotations everywhere.
+
+---
+
+## Task 1 — Add the Feishu seed entry to `CATALOG`
+
+The single v1 connector. Feishu's remote mode is reached over an SSE endpoint
+and authenticates with a Bearer App Access Token — a clean `static` fit.
+
+**Files**
+
+- Modify: `backend/cubebox/mcp/template_seed.py`
+- Test (new): `backend/tests/unit/test_catalog_seed_china.py`
+
+**Steps**
+
+1. **Write the failing test.** Create
+   `backend/tests/unit/test_catalog_seed_china.py`. Reuse the in-memory
+   `session` / `backend` fixture pattern from
+   `backend/tests/unit/test_catalog_seed.py` (copy the two fixtures and the
+   `_make_get_env` helper verbatim — they are small and self-contained). Add a
+   pure-data test that asserts the Feishu entry exists and is shaped as a
+   header-Bearer `static` connector:
+
+   ```python
+   """Tests for the China-vendor additions to the MCP connector catalog."""
+
+   from collections.abc import AsyncIterator, Callable
+
+   import pytest
+   from cryptography.fernet import Fernet
+   from sqlalchemy.ext.asyncio import (
+       AsyncSession,
+       async_sessionmaker,
+       create_async_engine,
+   )
+   from sqlmodel import SQLModel
+
+   from cubebox.credentials.encryption import FernetBackend
+   from cubebox.mcp.template_seed import CATALOG, seed_templates
+   from cubebox.repositories.mcp import MCPConnectorTemplateRepository
+
+
+   @pytest.fixture
+   async def session() -> AsyncIterator[AsyncSession]:
+       engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+       async with engine.begin() as conn:
+           await conn.run_sync(SQLModel.metadata.create_all)
+       maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+       async with maker() as s:
+           yield s
+       await engine.dispose()
+
+
+   @pytest.fixture
+   def backend() -> FernetBackend:
+       return FernetBackend([Fernet.generate_key()])
+
+
+   def _make_get_env(values: dict[str, str]) -> Callable[[str], str | None]:
+       def _getter(key: str) -> str | None:
+           return values.get(key)
+
+       return _getter
+
+
+   def test_feishu_entry_is_header_bearer_static() -> None:
+       by_slug = {e.slug: e for e in CATALOG}
+       assert "feishu" in by_slug
+       entry = by_slug["feishu"]
+
+       assert entry.provider == "Feishu"
+       assert entry.transport == "sse"
+       assert entry.supported_auth_methods == ["static"]
+       assert entry.default_credential_policy == "workspace"
+       # Bearer-in-header static auth — the schema-fitting shape.
+       assert entry.static_auth_header_template == "Bearer {token}"
+       assert entry.static_form_schema is not None
+       assert entry.static_form_schema[0]["name"] == "token"
+       # Not an OAuth-app / URL-query-param / stdio connector.
+       assert entry.oauth_static_client_id_env is None
+       assert entry.oauth_static_client_secret_env is None
+       assert entry.oauth_dcr_supported is None
+       assert entry.server_url.startswith("https://")
+       assert "{token}" not in entry.server_url  # secret never baked into URL
+       assert entry.template_metadata["docs_url"].startswith("https://")
+   ```
+
+2. **Run it, expect fail** (KeyError / assertion — `feishu` not yet in
+   `CATALOG`):
+
+   ```bash
+   uv run pytest tests/unit/test_catalog_seed_china.py::test_feishu_entry_is_header_bearer_static -q
+   ```
+
+3. **Implement.** In `backend/cubebox/mcp/template_seed.py`, append this entry
+   to the `CATALOG` list (after the existing `webtools` entry, before the
+   closing `]`). It reuses `_TOKEN_FIELD` and `_BEARER_TEMPLATE` already defined
+   in the module:
+
+   ```python
+       MCPConnectorTemplateSeedEntry(
+           slug="feishu",
+           name="Feishu / Lark",
+           provider="Feishu",
+           description=(
+               "Feishu/Lark OpenAPI MCP (remote mode): docs, messages, "
+               "calendar, bitable."
+           ),
+           server_url="https://lark-mcp.feishu.cn/mcp",
+           transport="sse",
+           supported_auth_methods=["static"],
+           default_credential_policy="workspace",
+           oauth_dcr_supported=None,
+           oauth_default_scope=None,
+           oauth_static_client_id_env=None,
+           oauth_static_client_secret_env=None,
+           static_form_schema=_TOKEN_FIELD,
+           static_auth_header_template=_BEARER_TEMPLATE,
+           template_metadata={
+               "docs_url": (
+                   "https://open.larksuite.com/document/mcp_open_tools/"
+                   "call-feishu-mcp-server-in-remote-mode"
+               ),
+               "region": "cn",
+           },
+       ),
+   ```
+
+4. **Run it, expect pass:**
+
+   ```bash
+   uv run pytest tests/unit/test_catalog_seed_china.py::test_feishu_entry_is_header_bearer_static -q
+   ```
+
+5. **Commit:**
+
+   ```bash
+   git add backend/cubebox/mcp/template_seed.py \
+       backend/tests/unit/test_catalog_seed_china.py
+   git commit -m "$(cat <<'EOF'
+   feat(mcp): add Feishu/Lark connector to the v1 catalog (#147)
+
+   Feishu remote mode authenticates with a Bearer App Access Token, which
+   maps onto the existing static header path with no schema change. It is the
+   only curated China-vendor source that fits MCPConnectorTemplateSeedEntry
+   unchanged; maps (URL-query-param key) and stdio/key-pair sources are
+   deferred per the design doc.
+   EOF
+   )"
+   ```
+
+---
+
+## Task 2 — Assert Feishu seeds and validates through `seed_templates()`
+
+Prove the new entry isn't just well-shaped data but actually upserts a row and
+passes the seeder's existing invariants (no env vars required, no skip, no
+deprecation), the same way the existing catalog is exercised.
+
+**Files**
+
+- Test (modify): `backend/tests/unit/test_catalog_seed_china.py`
+
+**Steps**
+
+1. **Write the failing test.** Append to `test_catalog_seed_china.py`:
+
+   ```python
+   async def test_feishu_seeds_as_active_template_without_env(
+       session: AsyncSession, backend: FernetBackend
+   ) -> None:
+       # Feishu needs no OAuth-app env vars → seeds even with an empty env.
+       result = await seed_templates(
+           session, backend, get_env=_make_get_env({})
+       )
+
+       # The empty env only skips connectors that require an OAuth client
+       # secret; Feishu must not be among the skipped.
+       repo = MCPConnectorTemplateRepository(session)
+       active = {row.slug for row in await repo.list_active()}
+       assert "feishu" in active
+       assert result.deprecated == 0
+
+       row = await repo.get_by_slug("feishu")
+       assert row is not None
+       assert row.status == "active"
+       assert row.supported_auth_methods == ["static"]
+       assert row.transport == "sse"
+       assert row.static_auth_header_template == "Bearer {token}"
+   ```
+
+2. **Run it, expect pass already** (Task 1 added the entry, so this should pass
+   immediately — that is acceptable; it locks the behavior in). Confirm:
+
+   ```bash
+   uv run pytest tests/unit/test_catalog_seed_china.py -q
+   ```
+
+   If it fails, debug the seeder mapping for the Feishu entry before
+   proceeding.
+
+3. **Regression sweep on the seeder suite** — the count-based assertions in
+   `test_catalog_seed.py` (`upserted == len(CATALOG)`) must still hold after the
+   catalog grew by one:
+
+   ```bash
+   uv run pytest tests/unit/test_catalog_seed.py tests/unit/test_catalog_seed_china.py -q
+   ```
+
+   If any count assertion in `test_catalog_seed.py` references a hard-coded
+   number, update it to track `len(CATALOG)` (it already uses `len(CATALOG)`,
+   so no change is expected — verify).
+
+4. **Commit:**
+
+   ```bash
+   git add backend/tests/unit/test_catalog_seed_china.py
+   git commit -m "$(cat <<'EOF'
+   test(mcp): assert Feishu seeds as an active template (#147)
+
+   Locks in that the Feishu entry upserts a static/SSE row with no OAuth env
+   vars and survives the existing seeder invariants.
+   EOF
+   )"
+   ```
+
+---
+
+## Task 3 — E2E: Feishu appears in the admin catalog endpoint
+
+E2E-first per project discipline: assert the connector is reachable through the
+real `GET /api/v1/admin/mcp/templates` route after seeding, not just in the
+Python list. Mirror the existing admin-MCP E2E setup.
+
+**Files**
+
+- Test (new): `backend/tests/e2e/test_mcp_china_catalog.py`
+
+**Steps**
+
+1. **Locate the pattern.** Read an existing admin-MCP E2E test that seeds
+   templates and calls the admin templates/installs routes (e.g.
+   `backend/tests/e2e/test_mcp_four_layer_routes.py`,
+   `backend/tests/e2e/test_mcp_oauth_handoff.py`) plus
+   `backend/tests/e2e/conftest.py` for the seeded-catalog / authed-admin-client
+   fixtures. Reuse those fixtures; do not invent a new harness.
+
+2. **Write the failing test.** Create
+   `backend/tests/e2e/test_mcp_china_catalog.py` that:
+   - uses the existing fixture that seeds the catalog and yields an authed
+     admin HTTP client (copy the fixture wiring from the chosen reference
+     test verbatim — adapt only the assertions);
+   - `GET`s `/api/v1/admin/mcp/templates`;
+   - asserts the response is 200 and that an item with `slug == "feishu"` is
+     present, with `transport == "sse"`, `supported_auth_methods == ["static"]`,
+     and a non-secret token field in its `static_form_schema`.
+
+   Shape of the assertion body (adapt request mechanics to the reference
+   fixture's client/URL helpers):
+
+   ```python
+   async def test_feishu_appears_in_admin_catalog(...) -> None:
+       resp = await admin_client.get("/api/v1/admin/mcp/templates")
+       assert resp.status_code == 200
+       items = resp.json()["items"]
+       by_slug = {it["slug"]: it for it in items}
+       assert "feishu" in by_slug
+       feishu = by_slug["feishu"]
+       assert feishu["transport"] == "sse"
+       assert feishu["supported_auth_methods"] == ["static"]
+   ```
+
+3. **Run it, expect pass** (the seeder runs in the E2E harness, so Feishu should
+   surface once Task 1 landed). If the reference fixture seeds via
+   `seed_templates(...)` or app startup, confirm Feishu is included:
+
+   ```bash
+   uv run pytest tests/e2e/test_mcp_china_catalog.py -q
+   ```
+
+   If the route field names differ from the assumed JSON keys, read
+   `backend/cubebox/api/schemas/mcp.py` (`MCPConnectorTemplateListOut` and the
+   item schema) and `_template_to_out` in
+   `backend/cubebox/api/routes/v1/admin_mcp.py`, then fix the assertion keys —
+   this is a test-only correction, not an implementation change.
+
+4. **Commit:**
+
+   ```bash
+   git add backend/tests/e2e/test_mcp_china_catalog.py
+   git commit -m "$(cat <<'EOF'
+   test(mcp): e2e assert Feishu surfaces in the admin catalog (#147)
+
+   Proves the seeded Feishu template is reachable through the real admin
+   templates route, not just the Python CATALOG list.
+   EOF
+   )"
+   ```
+
+---
+
+## Task 4 — Fix the doc drift in `mcp_catalog_oauth.md`
+
+The spec (§8) flags that `backend/docs/mcp_catalog_oauth.md` still uses the old
+M2 naming — `mcp_catalog_connectors` table and `cubebox.mcp.catalog_seed.CATALOG`
+— whereas the live schema is the `mcp_connector_templates` table seeded from
+`cubebox.mcp.template_seed.CATALOG`. This is **in scope** because we are adding
+a row to that exact catalog and the runbook should be correct for the next
+editor. Doc-only change; no code, no tests.
+
+**Files**
+
+- Modify: `backend/docs/mcp_catalog_oauth.md`
+
+**Steps**
+
+1. **Find every stale reference:**
+
+   ```bash
+   grep -n "mcp_catalog_connectors\|catalog_seed" backend/docs/mcp_catalog_oauth.md
+   ```
+
+2. **Rewrite each occurrence** to the live names, using `Edit` (not sed):
+   - `mcp_catalog_connectors` → `mcp_connector_templates`
+   - `cubebox.mcp.catalog_seed.CATALOG` / `catalog_seed.py` →
+     `cubebox.mcp.template_seed.CATALOG` / `template_seed.py`
+   - Keep prose accurate: the source-of-truth dataclass is
+     `MCPConnectorTemplateSeedEntry`; the CLI command is
+     `python -m cubebox.cli seed-mcp-templates`; the seeder also runs
+     idempotently on FastAPI startup (lock-guarded). Correct any sentence that
+     claims it is *only* an out-of-band step if the doc says so.
+   - Add one short line under the catalog section noting Feishu is the first
+     China-vendor entry and that URL-query-param-key sources (maps) and
+     stdio/key-pair sources (Alipay, DingTalk, WeCom, MiniMax, Tushare) are
+     deferred pending a `static_auth_query_param` field / managed launcher
+     (cross-reference the design doc
+     `docs/dev/specs/2026-05-27-mcp-china-sources-design.md`).
+
+3. **Verify no stale names remain:**
+
+   ```bash
+   grep -n "mcp_catalog_connectors\|catalog_seed" backend/docs/mcp_catalog_oauth.md
+   ```
+
+   Expect zero matches.
+
+4. **Commit:**
+
+   ```bash
+   git add backend/docs/mcp_catalog_oauth.md
+   git commit -m "$(cat <<'EOF'
+   docs(mcp): refresh catalog runbook to template_seed naming (#147)
+
+   Replace stale M2 mcp_catalog_connectors / catalog_seed references with the
+   live mcp_connector_templates / template_seed names, and note the v1 Feishu
+   addition plus the deferred China-vendor sources.
+   EOF
+   )"
+   ```
+
+---
+
+## Task 5 — Pre-PR sweep + self-review
+
+**Files**
+
+- (verification only)
+
+**Steps**
+
+1. **Run the full MCP-affected suite:**
+
+   ```bash
+   uv run pytest tests/unit/test_catalog_seed.py \
+       tests/unit/test_catalog_seed_china.py \
+       tests/unit/test_cli_seed.py \
+       tests/e2e/test_mcp_china_catalog.py -q
+   ```
+
+   All must pass.
+
+2. **Type check** the changed module + tests:
+
+   ```bash
+   uv run mypy cubebox/mcp/template_seed.py
+   ```
+
+3. **Self-review checklist:**
+   - [ ] Only Feishu added to `CATALOG`; no deferred source (maps / Alipay /
+         DingTalk / WeCom / MiniMax / Tushare / marketplaces) slipped in.
+   - [ ] No new column, migration, route, or service — schema unchanged.
+   - [ ] Feishu `server_url` carries no secret; auth is header-Bearer only.
+   - [ ] `static_form_schema` reuses `_TOKEN_FIELD`; header uses
+         `_BEARER_TEMPLATE` — no duplicated literals.
+   - [ ] Line length ≤ 100; full type annotations; no placeholder strings.
+   - [ ] Doc drift fixed: zero `mcp_catalog_connectors` / `catalog_seed`
+         references remain.
+   - [ ] Every commit message scopes `(#147)`; no amend, no push, no codex.
+
+4. **Confirm clean tree** (all work committed):
+
+   ```bash
+   git status
+   git log --oneline -5
+   ```
+
+---
+
+## Deferred (explicitly out of this plan)
+
+Per design doc §6.2 / §7 / §8, these are recorded as future work, each blocked
+on a named gap:
+
+| Source | Blocker | Unblocks when |
+|---|---|---|
+| Amap, Baidu Maps, Tencent Location | API key in URL query param | `static_auth_query_param` field + install-time URL injection (secret stays in vault) |
+| Alipay | stdio launch + RSA key-pair auth | managed launcher + key-pair credential kind |
+| DingTalk, WeCom, MiniMax (official), Tushare | stdio-only packages | managed launcher or vendor remote endpoint |
+| Bailian, ModelScope | marketplaces, not single connectors | curate individual hosted services as their own rows |

--- a/docs/dev/specs/2026-05-27-mcp-china-sources-design.md
+++ b/docs/dev/specs/2026-05-27-mcp-china-sources-design.md
@@ -1,0 +1,385 @@
+# China-Vendor MCP Sources — Curation + Catalog Integration
+
+**Date:** 2026-05-27
+**Branch:** `feat/mcp-china-sources` (off `main`)
+**Issue:** #147
+**Status:** ready for review
+
+**Related:**
+- `backend/cubebox/mcp/template_seed.py` — the connector template seed (the
+  schema every catalog entry must fill).
+- `backend/cubebox/models/mcp.py` — `MCPConnectorTemplate` table columns.
+- `backend/docs/mcp_catalog_oauth.md` — install / OAuth / static-auth runbook.
+- `docs/dev/specs/2026-05-22-preset-catalog-redesign-design.md` — the *LLM
+  provider* preset catalog (a separate catalog; named here only to avoid
+  confusing the two).
+
+---
+
+## 1. Problem & Motivation
+
+cubebox ships a curated MCP connector catalog — the one-click "install" list a
+workspace admin sees. Today that catalog
+(`CATALOG` in `backend/cubebox/mcp/template_seed.py`) is entirely
+Western-vendor: GitHub, Notion, Linear, Atlassian, Asana, Slack, Cloudflare,
+Sentry, Intercom, Google Workspace, Microsoft Learn.
+
+For users operating in China this catalog is close to empty in practice:
+
+- The maps, payments, and office-collaboration tools they actually use every
+  day (高德/Amap, 百度地图/Baidu Maps, 支付宝/Alipay, 飞书/Feishu, 钉钉/DingTalk,
+  企业微信/WeCom) are simply not offered.
+- Several Western entries are network-unreachable or low-value from inside
+  China.
+
+This spec is a **research deliverable first, integration plan second.** The
+core output is a curated, cited list of mainstream, actively-maintained
+China-vendor MCP servers grouped by domain, each recorded with the exact
+fields our catalog schema needs (transport, auth method, server URL,
+maintenance signal). The integration section then maps those records onto the
+existing template schema and flags where the schema does **not yet** cover a
+vendor's auth model.
+
+---
+
+## 2. Goals / Non-Goals
+
+**Goals**
+
+- Produce a curated, cited list of China-vendor MCP servers by domain, each
+  with: name, vendor, domain, repo/official URL, transport, auth method,
+  maintenance signal (official vs community, freshness).
+- State, per source, how its record maps onto the existing
+  `MCPConnectorTemplateSeedEntry` fields.
+- Identify the auth shapes our catalog schema does **not** support yet
+  (notably API-key-as-URL-query-param remote servers) and record them as open
+  questions rather than papering over them.
+- Recommend a v1 subset to land first, biased toward official + remote-hosted +
+  standard-auth servers.
+
+**Non-Goals**
+
+- Implementing the seed entries or any schema migration. This is a design /
+  research doc; the actual `CATALOG` edits and any new columns are follow-up
+  work gated on the open questions in §8.
+- Building a localhost / stdio launcher. cubebox installs **remote** connectors
+  (`server_url` + transport); stdio-only servers (npm/uvx packages a user runs
+  locally) are out of scope until we have a managed-launcher story.
+- Curating Western vendors' China regions of LLM *model* providers — that's the
+  separate LLM provider catalog (§Related).
+- E-commerce transactional connectors (淘宝/京东/拼多多): no official MCP servers
+  exist as of this writing (§4.7).
+
+---
+
+## 3. How the Preset Catalog Works Today
+
+The connector catalog is a pure-Python list seeded into Postgres by an explicit
+deploy step. There are two relevant files.
+
+### 3.1 The seed entry schema
+
+`backend/cubebox/mcp/template_seed.py` defines `MCPConnectorTemplateSeedEntry`.
+Every catalog addition must fill these fields:
+
+| Field | Meaning / constraint |
+|---|---|
+| `slug` | Stable catalog id, also the env-var prefix for static OAuth apps. |
+| `name` / `provider` / `description` | Display strings. |
+| `server_url` | The **remote** MCP endpoint. cubebox connects to this; it does not spawn local processes. |
+| `transport` | `"streamable_http"` or `"sse"` (the only two `Literal` values). |
+| `supported_auth_methods` | Subset of `["oauth", "static", "none"]`. |
+| `default_credential_policy` | `"org" \| "workspace" \| "user" \| "none"`. |
+| `oauth_dcr_supported` | `True` if the AS supports Dynamic Client Registration; `False` needs a pre-registered app via env vars; `None` for non-OAuth. |
+| `oauth_default_scope` | OAuth scope string, or `None`. |
+| `oauth_static_client_id_env` / `oauth_static_client_secret_env` | Env-var names for a pre-registered OAuth app (DCR=False); `None` otherwise. |
+| `static_form_schema` | List of field dicts the install UI renders (e.g. the shared `_TOKEN_FIELD`). |
+| `static_auth_header_template` | How the static credential becomes a header, e.g. `"Bearer {token}"`. |
+| `template_metadata` | Free dict; today holds `{"docs_url": ...}`. |
+| `tool_citation_defaults` | Per-tool citation mapping (see WebTools entry). |
+
+The matching DB columns are on `MCPConnectorTemplate`
+(`backend/cubebox/models/mcp.py`, lines 18–62). Notably the table stores
+`server_url`, `transport`, `supported_auth_methods` (JSON), the OAuth fields,
+and `static_form_schema` / `static_auth_header_template`. **There is no field
+for "API key carried as a URL query parameter"** — see §6.2 and §8.
+
+### 3.2 The seeder
+
+`seed_templates()` (same file) is idempotent: it upserts each entry by `slug`,
+encrypts any static OAuth client secret into a system-level `Credential`
+(`org_id IS NULL`), and marks DB rows whose slug left the list as
+`status='deprecated'`. Invoked out-of-band:
+`python -m cubebox.cli seed-mcp-templates`. Not run at FastAPI startup.
+
+Auth at runtime (`backend/docs/mcp_catalog_oauth.md`): OAuth flows go through
+the shared `/api/v1/oauth/mcp/callback`; static credentials are encrypted into
+the vault and applied via `static_auth_header_template`. **Both paths assume the
+credential travels in an HTTP header.**
+
+---
+
+## 4. Curated Source List
+
+Maintenance signal legend: **Official** = published by the vendor's own org;
+**Community** = third-party. Freshness reflects observation at time of writing
+(May 2026). Transport values map to our `transport` literal where applicable;
+"stdio" entries are local-launch packages and are **not directly installable**
+under the current remote-only model (§2 Non-Goals).
+
+### 4.1 Maps / Mobility
+
+| Name | Vendor | Repo / Official URL | Transport | Auth | Maintenance | Citation |
+|---|---|---|---|---|---|---|
+| Amap / 高德地图 | AutoNavi (Alibaba) | `https://mcp.amap.com/sse?key=<KEY>` (remote); `@amap/amap-maps-mcp-server` (stdio) | SSE (remote), stdio | **API key in URL query param** (`?key=`) | Official | [1][2] |
+| Baidu Maps / 百度地图 | Baidu | `https://github.com/baidu-maps/mcp`; remote SSE/Streamable on lbs.baidu.com (enable "MCP (SSE)") | Streamable HTTP (recommended), SSE, stdio | **API key (AK) in URL** | Official, first CN maps vendor on MCP | [3][4][5] |
+| Tencent Location / 腾讯位置服务 | Tencent | `https://lbs.qq.com/service/MCPServer/MCPServerGuide/overview` | SSE + Streamable HTTP | **API key in URL**, built on WebServiceAPI | Official | [6][7] |
+
+All three official maps servers expose geocoding, reverse-geocoding, POI
+search, route planning, weather, IP location. The catalog-relevant catch: they
+authenticate by a **`key`/`ak` query parameter on the URL**, not an `Authorization`
+header (§6.2).
+
+### 4.2 Payments
+
+| Name | Vendor | Repo / Official URL | Transport | Auth | Maintenance | Citation |
+|---|---|---|---|---|---|---|
+| Alipay / 支付宝 | Ant Group | `@alipay/mcp-server-alipay` (npm); `https://open.alipay.com/` | stdio (local) | App ID + RSA private/public key pair (env) | Official, China's first payment MCP | [8][9][10] |
+| Alipay+ Global | Ant Group | `https://github.com/alipay/global-alipayplus-mcp` | stdio | App credentials | Official | [11] |
+
+Alipay's official server is **stdio / local-launch** (an npm package the user
+runs), and its auth is an asymmetric key pair entered as env vars — neither the
+remote-URL model nor the header-template static model fits cleanly (§6.2, §8).
+
+### 4.3 Office Collaboration
+
+| Name | Vendor | Repo / Official URL | Transport | Auth | Maintenance | Citation |
+|---|---|---|---|---|---|---|
+| Feishu / Lark | ByteDance | `https://github.com/larksuite/lark-openapi-mcp`; `@larksuiteoapi/lark-mcp` (npm); remote mode documented | stdio + SSE; **remote mode** available | App Access Token + User Access Token; **OAuth** for user token | Official | [12][13][14] |
+| DingTalk / 钉钉 | Alibaba | `https://github.com/open-dingtalk/dingtalk-mcp`; server-API MCP on open.dingtalk.com | stdio (per repo); server-side API MCP | Client ID + Client Secret (env) | Official (published Jan 2026) | [15][16] |
+| WeCom / 企业微信 | Tencent | OpenClaw plugin + Tencent Cloud bot MCP (`cloud.tencent.com/developer/mcp/server/10854`); community `loonghao/wecom-bot-mcp-server` | stdio / SSE | Bot webhook key or app secret | Official (bot MCP) + community | [17][18][19] |
+
+Feishu is the strongest office-collaboration candidate: official, supports a
+documented **remote mode**, and has an OAuth user-token flow that could map to
+our `oauth` path.
+
+### 4.4 Cloud / DevOps
+
+| Name | Vendor | Repo / Official URL | Transport | Auth | Maintenance | Citation |
+|---|---|---|---|---|---|---|
+| Alibaba Cloud (Bailian-hosted) | Alibaba | `https://bailian.console.aliyun.com/?tab=mcp` — hosts/registers MCP services | Hosted remote (varies per service) | Per-service (often API key) | Official platform | [20][21] |
+| Tencent CloudBase | Tencent | `https://github.com/TencentCloudBase/CloudBase-MCP` | stdio / remote | Tencent Cloud credentials (env) | Official | [22] |
+| Tencent EdgeOne Pages | Tencent | `cloud.tencent.com/developer/mcp/server/10011` | Remote | API token | Official | [23] |
+| Tencent Cloud (community aggregator) | Tencent community | `https://github.com/TencentCloudCommunity/mcp-server` | Remote + local | Tencent Cloud SecretId/SecretKey | Community (Tencent-affiliated) | [24] |
+
+Alibaba's "Bailian" console is itself an **MCP hosting marketplace** — it
+registers and hosts third-party MCP services rather than being a single
+connector. That makes it a *source of* remote MCP URLs, not a single catalog
+row; we'd curate specific hosted services, not "Bailian" as one entry.
+
+### 4.5 Content / Media / AI Platforms
+
+| Name | Vendor | Repo / Official URL | Transport | Auth | Maintenance | Citation |
+|---|---|---|---|---|---|---|
+| MiniMax MCP | MiniMax | `https://github.com/MiniMax-AI/MiniMax-MCP` (py); `MiniMax-MCP-JS` | stdio + SSE | `MINIMAX_API_KEY` + `MINIMAX_API_HOST` (region: api.minimax.io / api.minimaxi.com) | Official | [25][26][27] |
+| MiniMax Search | MiniMax | `https://github.com/MiniMax-AI/minimax_search` | stdio | API key | Official | [28] |
+| ModelScope MCP Square | Alibaba (ModelScope) | `https://www.modelscope.cn/mcp` — ~1500 hosted MCP services | Hosted remote | Per-service | Official marketplace | [29][30] |
+
+MiniMax bundles TTS, voice cloning, image and video generation as MCP tools —
+high product value for a content/media workspace. Like Bailian, ModelScope's
+"MCP 广场" is a hosting marketplace (a source of URLs), not a single connector.
+
+### 4.6 Financial / Market Data
+
+| Name | Vendor | Repo / Official URL | Transport | Auth | Maintenance | Citation |
+|---|---|---|---|---|---|---|
+| Tushare (CN financial data) | Tushare + community | `https://tushare.pro/`; servers: `sunyalou/tushare-mcp-server`, `hanxuanliang/...`, `guangxiangdebizi/FinanceMCP-DCTHS` | stdio / HTTP (FastMCP) | Tushare Pro API token (env) | Data source official; **MCP servers community** | [31][32][33] |
+
+Tushare exposes A-share / fund / futures data; the data API is first-party but
+**every MCP wrapper is community-maintained**. Treat as community trust tier
+(§5).
+
+### 4.7 E-commerce — no official sources (recorded for completeness)
+
+As of May 2026, 淘宝/Taobao, 京东/JD, and 拼多多/Pinduoduo have **not** published
+official MCP servers; commentary notes the big platforms are deliberately
+holding back. Only community scrapers / affiliate-link tools exist
+(`JeremyDong22/taobao_mcp`, `liuliang520530/taoke-mcp`). **Recommendation: do
+not include in v1** — community scrapers risk ToS/anti-bot breakage and carry
+no maintenance guarantee. [34][35]
+
+---
+
+## 5. Selection Criteria
+
+How each candidate was judged for inclusion / trust tier:
+
+1. **Official over community.** First-party vendor org is tier 1. A first-party
+   *data* API wrapped by a community MCP server (Tushare) is tier 2. Pure
+   community (e-commerce scrapers) is tier 3 and excluded from v1.
+2. **Remote-installable now.** A server we can reach over `server_url` +
+   `streamable_http`/`sse` fits the current model. stdio-only packages are
+   recorded but parked until we have a managed launcher (§2).
+3. **Standard auth.** Header-bearer (`static`) or OAuth maps onto the existing
+   schema. URL-query-param keys and asymmetric key pairs do **not** (§6.2) and
+   are flagged.
+4. **Maintenance freshness.** Recent commits / active vendor platform. DingTalk
+   (Jan 2026), Feishu (active), MiniMax (active) clear this.
+5. **Product value in a CN workspace.** Maps, payments, office collaboration,
+   media generation are daily-driver categories; obscure single-purpose servers
+   are deprioritized.
+6. **Licensing clarity.** Vendor servers under a clear OSS license or vendor
+   ToS preferred; ambiguous-license community repos excluded (§8).
+
+---
+
+## 6. Catalog Integration
+
+### 6.1 Mapping a source onto `MCPConnectorTemplateSeedEntry`
+
+For a source that *does* fit the current model (remote + header/OAuth auth),
+the mapping is mechanical. Worked example — **Feishu** (remote mode, static App
+token):
+
+```text
+slug                          = "feishu"
+name / provider               = "Feishu / Lark" / "Feishu"
+description                   = "Feishu/Lark OpenAPI: docs, messages, calendar, bitable."
+server_url                    = <documented Feishu remote-mode endpoint>
+transport                     = "sse"            # or streamable_http if offered
+supported_auth_methods        = ["static"]       # ["oauth"] if we wire the user-token OAuth flow
+default_credential_policy     = "workspace"
+oauth_* fields                = None             # unless OAuth path adopted
+static_form_schema            = _TOKEN_FIELD     # App Access Token
+static_auth_header_template   = "Bearer {token}"
+template_metadata             = {"docs_url": "https://open.larksuite.com/document/..."}
+```
+
+MiniMax maps the same way (`static`, `Bearer {token}`, `MINIMAX_API_KEY`),
+**if** a remote endpoint is used; the public repos are stdio, so MiniMax is a
+v1.5 candidate (§7).
+
+### 6.2 Auth shapes the current schema does NOT cover
+
+Two recurring CN-vendor auth models have **no home** in the schema today:
+
+- **API key as a URL query parameter** (Amap, Baidu Maps, Tencent Location):
+  the key lives in `?key=`/`?ak=` on `server_url`, not in a header.
+  `static_auth_header_template` cannot express this, and baking a secret into
+  `server_url` is wrong (the URL is stored plaintext; the vault is for secrets).
+  This needs either a new `auth_query_param` field on the template + an install
+  flow that injects the vault secret into the URL, or a small server-side proxy.
+  **Blocking for the maps domain** (§8).
+- **Asymmetric key pair** (Alipay: App ID + RSA private key): not a bearer
+  token; the server signs requests. Our `static` model is single-secret-bearer.
+  Alipay is also stdio-only. **Out of scope until both gaps close** (§8).
+
+### 6.3 Possible new fields (deferred to follow-up, not decided here)
+
+If we adopt the URL-query-param auth model, the minimal addition is one
+nullable column on `MCPConnectorTemplate` (e.g. `static_auth_query_param: str |
+None`) plus install-flow handling that reads the vault secret and appends it to
+the connect URL — keeping the secret in the vault, never in `server_url`. This
+is called out as an open question (§8), not specified here, per "don't prescribe
+implementation minutiae."
+
+---
+
+## 7. Rollout / v1 Subset
+
+Land in waves, biased to what fits the schema unchanged.
+
+**v1 — fits the current schema, official, remote, header/OAuth auth:**
+
+- **Feishu / Lark** — official, remote mode, `static` Bearer (OAuth as a
+  fast-follow). The single highest-value entry that needs no schema change.
+
+That is genuinely the only candidate that drops in cleanly today. Everything
+else needs one of the gaps in §6.2 closed first. Being honest about that is the
+point of this spec.
+
+**v1.5 — needs a small, well-scoped change:**
+
+- **Amap, Baidu Maps, Tencent Location** — unblocked by the
+  URL-query-param auth field (§6.3). High value; recommended as the first
+  schema follow-up.
+- **MiniMax** — needs a remote endpoint (or a managed stdio launcher) since the
+  official servers are stdio; auth itself (`Bearer`) already fits.
+
+**v2 — needs a launcher and/or richer auth:**
+
+- **Alipay** (stdio + asymmetric keys), **DingTalk / WeCom** (largely stdio),
+  **Tencent CloudBase / EdgeOne**, **Tushare** (community tier).
+
+**Marketplaces (Bailian, ModelScope) are not single entries** — they are
+sources of individual hosted MCP URLs; if adopted, we curate specific hosted
+services from them as their own rows.
+
+---
+
+## 8. Open Questions
+
+- **URL-query-param auth (maps).** Amap / Baidu / Tencent maps put the key in
+  `?key=`/`?ak=`. Add a `static_auth_query_param` template field + install-time
+  URL injection (secret stays in the vault), or stand up a proxy? This blocks
+  the entire maps domain (§6.2).
+- **stdio / local-launch servers.** Alipay, DingTalk, WeCom, MiniMax (official),
+  Tushare are npm/uvx packages run locally. cubebox installs remote URLs only.
+  Do we add a managed launcher, or wait for vendors to publish remote
+  endpoints? Blocks payments + most office-collaboration.
+- **Alipay asymmetric-key auth.** App ID + RSA private key is not a bearer
+  token. Does the vault + install flow get a "key pair" credential kind, or is
+  Alipay deferred indefinitely?
+- **Marketplace sources (Bailian / ModelScope).** Curate individual hosted
+  services as catalog rows, or skip aggregators entirely? Each hosted service
+  has its own URL, auth, and (unclear) uptime/SLA.
+- **Community-MCP licensing & trust (Tushare, e-commerce).** Several community
+  servers have unclear licenses and no maintenance guarantee. What's the bar for
+  admitting a community-maintained wrapper to an official-looking catalog?
+- **Regional host selection (MiniMax).** `api.minimax.io` vs `api.minimaxi.com`
+  must match the key's region. Does the install UI need a region selector, or do
+  we ship two slugs?
+- **`mcp_catalog_oauth.md` drift.** That doc still describes the older M2
+  `mcp_catalog_connectors` / `catalog_seed.py` naming; the live schema is
+  `mcp_connector_templates` / `template_seed.py`. Refresh it when these entries
+  land.
+
+---
+
+## 9. References
+
+1. Amap remote MCP endpoint — https://github.com/sugarforever/amap-mcp-server
+2. `@amap/amap-maps-mcp-server` (npm) — https://www.npmjs.com/package/@amap/amap-maps-mcp-server
+3. Baidu Maps MCP (official) — https://github.com/baidu-maps/mcp
+4. Baidu Maps MCP quickstart — https://lbs.baidu.com/faq/api?title=mcpserver/quickstart
+5. Official Baidu Maps MCP (PulseMCP) — https://www.pulsemcp.com/servers/baidu-maps
+6. Tencent Location MCP guide — https://lbs.qq.com/service/MCPServer/MCPServerGuide/overview
+7. Tencent Location MCP access — https://tcb.cloud.tencent.com/mcp-server/mcp-tencent-map
+8. Alipay MCP (npm) — https://www.npmjs.com/package/@alipay/mcp-server-alipay
+9. Alipay Open Platform — https://open.alipay.com/
+10. Alipay MCP (ModelScope) — https://modelscope.cn/mcp/servers/Alipay/mcp-server-alipay
+11. Alipay+ Global MCP — https://github.com/alipay/global-alipayplus-mcp
+12. Feishu/Lark OpenAPI MCP (official) — https://github.com/larksuite/lark-openapi-mcp
+13. `@larksuiteoapi/lark-mcp` (npm) — https://www.npmjs.com/package/@larksuiteoapi/lark-mcp
+14. Lark remote-mode docs — https://open.larksuite.com/document/mcp_open_tools/call-feishu-mcp-server-in-remote-mode
+15. DingTalk MCP (official) — https://github.com/open-dingtalk/dingtalk-mcp
+16. DingTalk server-API MCP overview — https://open.dingtalk.com/document/ai-dev/dingtalk-server-api-mcp-overview
+17. WeCom bot MCP (Tencent Cloud) — https://cloud.tencent.com/developer/mcp/server/10854
+18. WeCom OpenClaw integration — https://work.weixin.qq.com/nl/index/openclaw
+19. WeCom bot MCP (community) — https://github.com/loonghao/wecom-bot-mcp-server
+20. Alibaba Cloud Bailian MCP tab — https://bailian.console.aliyun.com/?tab=mcp
+21. Bailian product page — https://www.aliyun.com/product/bailian
+22. Tencent CloudBase MCP (official) — https://github.com/TencentCloudBase/CloudBase-MCP
+23. Tencent EdgeOne Pages MCP — https://cloud.tencent.com/developer/mcp/server/10011
+24. Tencent Cloud MCP server (community) — https://github.com/TencentCloudCommunity/mcp-server
+25. MiniMax MCP (official, py) — https://github.com/MiniMax-AI/MiniMax-MCP
+26. MiniMax MCP JS — https://github.com/MiniMax-AI/MiniMax-MCP-JS
+27. MiniMax MCP guide — https://platform.minimax.io/docs/guides/mcp-guide
+28. MiniMax Search MCP — https://github.com/MiniMax-AI/minimax_search
+29. ModelScope MCP Square — https://www.modelscope.cn/mcp
+30. ModelScope MCP community launch — https://modelscope.cn/headlines/article/1142
+31. Tushare data platform — https://tushare.pro/
+32. Tushare MCP server (community) — https://github.com/sunyalou/tushare-mcp-server
+33. FinanceMCP-DCTHS (Tushare + 东财 + 同花顺) — https://github.com/guangxiangdebizi/FinanceMCP-DCTHS
+34. Taobao MCP (community) — https://github.com/JeremyDong22/taobao_mcp
+35. Taoke MCP (淘宝客/京东客/多多客, community) — https://github.com/liuliang520530/taoke-mcp


### PR DESCRIPTION
Design spec for #147.

Adds `docs/dev/specs/2026-05-27-mcp-china-sources-design.md`. Design-only (no code).
The implementation plan will follow as a separate commit after codex review.
Unresolved design decisions are captured in the spec's **Open Questions** section.

Refs #147