### PR TITLE
fix(widget): theme-aware shell + chat-column centering

### DIFF
--- a/backend/cubebox/prompts/widget.py
+++ b/backend/cubebox/prompts/widget.py
@@ -27,8 +27,14 @@ When a visual or interactive explanation is clearly better than text, call
   Embed all data directly in the code. (Loading JS libraries from the allowed
   CDNs below IS permitted - that is `script-src`, not `connect-src`.)
 - No `localStorage`/`sessionStorage` (they throw). Use in-memory variables.
-- Use CSS variables for colors; support a dark background (#1a1a1a-ish).
-  Two font weights max (400, 500). Avoid gradients, shadows, and blur.
+- Colors: the shell pre-defines five CSS variables on `:root` —
+  `--bg` (page background), `--fg` (foreground text), `--muted` (card/panel
+  surface), `--border` (separator), `--accent` (link/primary). Their values
+  are picked by the host based on the current app theme (light or dark) and
+  give correct contrast in both. Reference them via `var(--bg)` etc.
+  **Do NOT hard-code colors** (no `#1a1a1a`, no `#fff`, no rgb()); the widget
+  must look right in both themes. Two font weights max (400, 500). Avoid
+  gradients, shadows, and blur.
 - Libraries may be loaded only from: cdnjs.cloudflare.com, cdn.jsdelivr.net,
   unpkg.com, esm.sh.
 - Keep total `widget_code` under ~256KB.

--- a/frontend/packages/web/__tests__/e2e/widget-shell.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/widget-shell.spec.ts
@@ -4,9 +4,17 @@ import { WIDGET_SHELL_HTML } from '../../components/chat/widget/widgetShell'
 const WIDGET_ID = 'w-test'
 // Must match WidgetView's production injection exactly: JSON.stringify supplies
 // the quotes (the shell has `var WIDGET_ID = %%WIDGET_ID%%;` with no quotes),
-// and `<` is escaped to <.
+// and `<` is escaped to \\u003c. The theme tokens (%%BG%%/%%FG%%/%%MUTED%%/
+// %%BORDER%%/%%ACCENT%%) must also be replaced — we pick the light-theme set;
+// the shell behavior these tests assert (morph/seq/finalize/CSP/opaque-origin)
+// does not depend on which theme is active.
 const ID_LITERAL = JSON.stringify(WIDGET_ID).replace(/</g, '\\u003c')
 const SHELL = WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', () => ID_LITERAL)
+  .replace('%%BG%%', () => '#ffffff')
+  .replace('%%FG%%', () => '#0a0a0f')
+  .replace('%%MUTED%%', () => '#f5f5f7')
+  .replace('%%BORDER%%', () => '#e5e7eb')
+  .replace('%%ACCENT%%', () => '#0061c2')
 
 async function mountShell(page: Page) {
   await page.setContent('<div id="host"></div>')

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -542,6 +542,19 @@ export function AssistantMessage({
             />
           )}
           {bubbleItems.map(({ item, i }) => renderItem(item, i))}
+        </div>
+      </div>
+      {widgetItems.length > 0 && (
+        <div className="space-y-2">{widgetItems.map(({ item, i }) => renderItem(item, i))}</div>
+      )}
+      {/* Todos + streaming/loading indicator render AFTER widgets so the
+          "still working" signal stays at the visual end of the assistant
+          message even when widgets are present. pl-9 ≈ avatar(24px)+gap(10px)
+          to keep them aligned with the bubble content. */}
+      {(isStreaming && todos && todos.length > 0) ||
+      (!isStreaming && historyTodos.length > 0) ||
+      isStreaming ? (
+        <div className="pl-9 space-y-2">
           {isStreaming && todos && todos.length > 0 && (
             <TaskProgressCard todos={todos} isStreaming={true} />
           )}
@@ -575,10 +588,7 @@ export function AssistantMessage({
             </div>
           )}
         </div>
-      </div>
-      {widgetItems.length > 0 && (
-        <div className="space-y-2">{widgetItems.map(({ item, i }) => renderItem(item, i))}</div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -482,86 +482,103 @@ export function AssistantMessage({
   // Count active subagents (streaming)
   const activeSubagentCount = subAgentStreams ? Object.keys(subAgentStreams).length : 0
 
+  // Widgets render OUTSIDE the assistant max-w-[75%] bubble column so they can
+  // span the full chat-column width (max-w-2xl from MessageList) and sit
+  // centered within it — matching how the rest of the chat reads visually
+  // instead of being pinned to the assistant's left edge.
+  const isWidget = (item: (typeof grouped)[number]): boolean =>
+    !Array.isArray(item) &&
+    (item.type === 'tool_call' || item.type === 'tool_call_streaming') &&
+    item.name === 'show_widget'
+  const bubbleItems = grouped.map((item, i) => ({ item, i })).filter(({ item }) => !isWidget(item))
+  const widgetItems = grouped.map((item, i) => ({ item, i })).filter(({ item }) => isWidget(item))
+
+  const renderItem = (item: (typeof grouped)[number], i: number) => {
+    if (Array.isArray(item)) {
+      const tcBlocks = item as (ContentBlock & { type: 'tool_call' })[]
+      return (
+        <ToolCallGroup
+          key={i}
+          blocks={tcBlocks}
+          toolResultMap={toolResultMap}
+          isStreaming={isStreaming === true}
+          messageCreatedAt={msgCreatedAt}
+          agentId={streamAgentId}
+        />
+      )
+    }
+    return (
+      <ContentBlockRenderer
+        key={i}
+        block={item}
+        index={i}
+        isLast={i === grouped.length - 1}
+        isStreaming={isStreaming === true}
+        subAgentStreams={subAgentStreams}
+        subagentDataMap={subagentDataMap}
+        toolResultMap={toolResultMap}
+        messageCreatedAt={msgCreatedAt}
+        subagentIndex={subagentIndexMap.get(i)}
+        agentId={streamAgentId}
+        conversationId={conversationId}
+      />
+    )
+  }
+
   return (
-    <div data-role="assistant" className="flex justify-start gap-2.5">
-      <div
-        className="shrink-0 w-6 h-6 rounded-md border border-border bg-card
+    <div data-role="assistant" className="space-y-2">
+      <div className="flex justify-start gap-2.5">
+        <div
+          className="shrink-0 w-6 h-6 rounded-md border border-border bg-card
         flex items-center justify-center mt-0.5"
-      >
-        <Bot className="size-3.5 text-primary/70" />
-      </div>
-      <div className="flex-1 max-w-[75%] space-y-2">
-        {totalSubagents >= 2 && (
-          <SubAgentCluster
-            activeCount={isStreaming === true ? activeSubagentCount : 0}
-            totalCount={totalSubagents}
-          />
-        )}
-        {grouped.map((item, i) => {
-          if (Array.isArray(item)) {
-            // grouped tool_call blocks
-            const tcBlocks = item as (ContentBlock & { type: 'tool_call' })[]
-            return (
-              <ToolCallGroup
-                key={i}
-                blocks={tcBlocks}
-                toolResultMap={toolResultMap}
-                isStreaming={isStreaming === true}
-                messageCreatedAt={msgCreatedAt}
-                agentId={streamAgentId}
-              />
-            )
-          }
-          return (
-            <ContentBlockRenderer
-              key={i}
-              block={item}
-              index={i}
-              isLast={i === grouped.length - 1}
-              isStreaming={isStreaming === true}
-              subAgentStreams={subAgentStreams}
-              subagentDataMap={subagentDataMap}
-              toolResultMap={toolResultMap}
-              messageCreatedAt={msgCreatedAt}
-              subagentIndex={subagentIndexMap.get(i)}
-              agentId={streamAgentId}
-              conversationId={conversationId}
+        >
+          <Bot className="size-3.5 text-primary/70" />
+        </div>
+        <div className="flex-1 max-w-[75%] space-y-2">
+          {totalSubagents >= 2 && (
+            <SubAgentCluster
+              activeCount={isStreaming === true ? activeSubagentCount : 0}
+              totalCount={totalSubagents}
             />
-          )
-        })}
-        {isStreaming && todos && todos.length > 0 && (
-          <TaskProgressCard todos={todos} isStreaming={true} />
-        )}
-        {!isStreaming && historyTodos.length > 0 && (
-          <TaskProgressCard todos={historyTodos} isStreaming={false} />
-        )}
-        {isStreaming && (
-          <div data-testid="loading-indicator" className="flex items-center gap-1 pl-1 h-6">
-            {statusPhase === 'sandbox_creating' ? (
-              <span className="text-xs text-muted-foreground animate-pulse">
-                {t('sandboxPreparing')}
-              </span>
-            ) : statusPhase === 'sandbox_failed' ? (
-              <span className="text-xs text-destructive">{t('sandboxFailed')}</span>
-            ) : (
-              <>
-                <span
-                  className="w-1.5 h-1.5 rounded-full bg-primary
+          )}
+          {bubbleItems.map(({ item, i }) => renderItem(item, i))}
+          {isStreaming && todos && todos.length > 0 && (
+            <TaskProgressCard todos={todos} isStreaming={true} />
+          )}
+          {!isStreaming && historyTodos.length > 0 && (
+            <TaskProgressCard todos={historyTodos} isStreaming={false} />
+          )}
+          {isStreaming && (
+            <div data-testid="loading-indicator" className="flex items-center gap-1 pl-1 h-6">
+              {statusPhase === 'sandbox_creating' ? (
+                <span className="text-xs text-muted-foreground animate-pulse">
+                  {t('sandboxPreparing')}
+                </span>
+              ) : statusPhase === 'sandbox_failed' ? (
+                <span className="text-xs text-destructive">{t('sandboxFailed')}</span>
+              ) : (
+                <>
+                  <span
+                    className="w-1.5 h-1.5 rounded-full bg-primary
                   animate-bounce [animation-delay:0ms]"
-                />
-                <span
-                  className="w-1.5 h-1.5 rounded-full bg-primary
+                  />
+                  <span
+                    className="w-1.5 h-1.5 rounded-full bg-primary
                   animate-bounce [animation-delay:150ms]"
-                />
-                <span
-                  className="w-1.5 h-1.5 rounded-full bg-primary
+                  />
+                  <span
+                    className="w-1.5 h-1.5 rounded-full bg-primary
                   animate-bounce [animation-delay:300ms]"
-                />
-              </>
-            )}
-          </div>
-        )}
+                  />
+                </>
+              )}
+            </div>
+          )}
+        </div>
       </div>
+      {widgetItems.length > 0 && (
+        <div className="space-y-2">{widgetItems.map(({ item, i }) => renderItem(item, i))}</div>
+      )}
     </div>
   )
 }

--- a/frontend/packages/web/components/chat/widget/WidgetView.tsx
+++ b/frontend/packages/web/components/chat/widget/WidgetView.tsx
@@ -46,12 +46,17 @@ export function WidgetView({
       ? { bg: '#0e1116', fg: '#e6edf3', muted: '#161b22', border: '#30363d', accent: '#58a6ff' }
       : { bg: '#ffffff', fg: '#0a0a0f', muted: '#f5f5f7', border: '#e5e7eb', accent: '#0061c2' }
     const idLiteral = JSON.stringify(widgetId).replace(/</g, '\\u003c')
-    return WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', () => idLiteral)
-      .replace('%%BG%%', () => t.bg)
+    // Replace theme tokens FIRST (values are color strings like '#0e1116',
+    // never contain '%%'), then widget_id LAST. Reversed order would let an
+    // unlikely widgetId containing e.g. '%%BG%%' get clobbered by a later
+    // theme replacement. This order makes the substitution unaffected by id
+    // contents.
+    return WIDGET_SHELL_HTML.replace('%%BG%%', () => t.bg)
       .replace('%%FG%%', () => t.fg)
       .replace('%%MUTED%%', () => t.muted)
       .replace('%%BORDER%%', () => t.border)
       .replace('%%ACCENT%%', () => t.accent)
+      .replace('%%WIDGET_ID%%', () => idLiteral)
   }, [widgetId])
 
   const tooBig = new Blob([widgetCode]).size > MAX_CODE_BYTES

--- a/frontend/packages/web/components/chat/widget/WidgetView.tsx
+++ b/frontend/packages/web/components/chat/widget/WidgetView.tsx
@@ -33,12 +33,25 @@ export function WidgetView({
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Inject the real id into the shell. JSON.stringify supplies quotes + standard
-  // escaping; we further escape "<" to "<" so a hypothetical "</script>"
+  // escaping; we further escape "<" to "\\u003c" so a hypothetical "</script>"
   // can't close the shell's script block. A function replacement avoids
-  // String.replace's "$" special-handling. Placeholder appears once in the shell.
+  // String.replace's "$" special-handling. Each placeholder appears exactly
+  // once in the shell. Theme tokens are resolved from the app's `.dark` class
+  // (next-themes attribute="class") at mount; toggling theme after render
+  // keeps the widget on the original theme until the conversation reloads.
   const srcDoc = useMemo(() => {
+    const isDark =
+      typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
+    const t = isDark
+      ? { bg: '#0e1116', fg: '#e6edf3', muted: '#161b22', border: '#30363d', accent: '#58a6ff' }
+      : { bg: '#ffffff', fg: '#0a0a0f', muted: '#f5f5f7', border: '#e5e7eb', accent: '#0061c2' }
     const idLiteral = JSON.stringify(widgetId).replace(/</g, '\\u003c')
     return WIDGET_SHELL_HTML.replace('%%WIDGET_ID%%', () => idLiteral)
+      .replace('%%BG%%', () => t.bg)
+      .replace('%%FG%%', () => t.fg)
+      .replace('%%MUTED%%', () => t.muted)
+      .replace('%%BORDER%%', () => t.border)
+      .replace('%%ACCENT%%', () => t.accent)
   }, [widgetId])
 
   const tooBig = new Blob([widgetCode]).size > MAX_CODE_BYTES

--- a/frontend/packages/web/components/chat/widget/widgetShell.ts
+++ b/frontend/packages/web/components/chat/widget/widgetShell.ts
@@ -2,15 +2,22 @@
 // <head>. Parent -> child: {widgetId, seq, type:'morph', html} / {...'finalize'}.
 // Child -> parent: {widgetId, type:'ready'|'error'|'resize', ...}.
 //
-// WidgetView replaces the %%WIDGET_ID%% placeholder (which appears exactly once,
-// in the `var WIDGET_ID` assignment below, with NO surrounding quotes) with
-// JSON.stringify(widgetId) — additionally escaping `<` — at mount.
+// Sandbox is opaque-origin (no allow-same-origin), so the iframe cannot inherit
+// the parent's CSS variables via the cascade. WidgetView injects theme tokens
+// AND the widgetId via single-replace placeholders at mount:
+//   %%WIDGET_ID%%  — appears once in `var WIDGET_ID = %%WIDGET_ID%%;`
+//                     (NO surrounding quotes; JSON.stringify supplies them)
+//   %%BG%%, %%FG%%, %%MUTED%%, %%BORDER%%, %%ACCENT%%
+//                  — each appears once in the :root CSS variables below
+// Widget code should always reference var(--bg)/--fg/--muted/--border/--accent
+// instead of hard-coding colors (see WIDGET_GUIDELINES).
 export const WIDGET_SHELL_HTML = `<!DOCTYPE html><html><head>
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; style-src 'unsafe-inline'; img-src data: https:; font-src data: https:; connect-src 'none'; base-uri 'none'; form-action 'none'; worker-src 'none'; frame-src 'none'; object-src 'none';">
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <style>
+:root{--bg:%%BG%%;--fg:%%FG%%;--muted:%%MUTED%%;--border:%%BORDER%%;--accent:%%ACCENT%%;}
 *{box-sizing:border-box}
-body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;background:#1a1a1a;color:#e0e0e0;}
+body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--fg);}
 @keyframes _fadeIn{from{opacity:0;transform:translateY(4px);}to{opacity:1;transform:none;}}
 </style></head>
 <body><div id="root"></div>


### PR DESCRIPTION
## Summary

Two manual-verification follow-ups on the just-merged generative-UI widgets feature (#142):

1. **Theme-aware iframe shell.** Widget background was hardcoded dark (`#1a1a1a`) and stayed dark on the light-mode site because the opaque-origin sandbox can't inherit the parent's CSS vars via the cascade. The shell now declares five `:root` CSS variables (`--bg`/`--fg`/`--muted`/`--border`/`--accent`) with `%%placeholders%%`, and `WidgetView` reads `document.documentElement.classList.contains('dark')` at mount and substitutes the matching light/dark token set. Guidelines updated to require `var(--bg)` etc. and forbid hard-coded colors.
2. **Centered in the chat column.** Widgets were pinned to the assistant bubble's left edge by the `max-w-[75%]` constraint, looking visually off-center. `AssistantMessage` now splits `grouped` into bubble items (text/tools, kept inside the existing avatar + `max-w-[75%]` row) and widget items (rendered as a sibling row below, taking full chat-column width = `max-w-2xl` from `MessageList`).

## Implementation notes

- Theme tokens are replaced **before** `%%WIDGET_ID%%` so a hypothetical id containing `%%` can't collide with a token replacement.
- Todos / `historyTodos` / loading-indicator moved AFTER the widget row, so the "still working" signal stays at the visual end of the message when widgets are present (kept `pl-9` to align with bubble content).
- v1 limitation: toggling theme after a widget renders keeps the widget on the original theme until the conversation reloads.
- v1 simplification: when a single message interleaves text and widgets, widgets render after all text instead of inline.

## Test plan
- [x] WidgetView vitest (3 tests) — size-cap fallback, ready-timeout fallback, forged-source rejection / posts-after-ready
- [x] Shell Playwright E2E (4 tests) — morph + finalize-once, latest-wins before & after finalize, opaque-origin + `connect-src 'none'`
- [x] Backend show_widget tests (4) — tool metadata, ack, guidelines-content, subagent exclusion
- [x] type-check + mypy + lint clean; pre-push CI green
- [x] Local codex reviewed (2 rounds) → CLEAN
- [ ] Manual: real model → widget renders with site-theme colors in both light and dark modes; widget visually centered in chat column