### PR TITLE
feat(widget): v2 polish — skeleton, layout, toolbar, theme realtime, richer guidelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,11 @@ jobs:
     name: Backend E2E (pytest)
     needs: gate
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # pytest e2e has been observed at ~19-20 min on slow runners, so the
+    # previous 20-min cap was right at the wire and killed the job mid-run.
+    # 30 min gives margin without masking a real regression (a healthy run is
+    # well under 20 min on a normal runner).
+    timeout-minutes: 30
     env:
       ENV_FOR_DYNACONF: test
       CUBEBOX_E2E_LLM_BASE_URL: ${{ secrets.CUBEBOX_E2E_LLM_BASE_URL }}

--- a/backend/cubebox/prompts/widget.py
+++ b/backend/cubebox/prompts/widget.py
@@ -6,36 +6,202 @@ cache-sensitive (see backend/docs/prompt-cache-discipline.md).
 """
 
 WIDGET_TOOL_DESCRIPTION = (
-    "Render an interactive HTML widget inline in the conversation. Use for "
-    "visual/explanatory answers: charts, diagrams, sliders, animations. "
-    "widget_code is an HTML fragment (no <html>/<body>); it renders in a "
-    "sandboxed iframe. It cannot fetch/XHR/WebSocket (no data fetching) and "
-    "cannot use localStorage, but it MAY load JS libraries from the allowed CDNs."
+    "Render an interactive HTML widget INLINE in the chat. Default tool for any "
+    "answer that wants a chart, diagram, dashboard, sliders, animation, side-by-side "
+    "comparison, or other visual / interactive explanation. Stream `widget_code` "
+    "(an HTML fragment — no <html>/<body>) directly here; do NOT first write it to "
+    "a file or save it as an artifact. It renders in a sandboxed iframe: no "
+    "fetch/XHR/WebSocket, no localStorage, but JS libraries may be loaded from the "
+    "allowed CDNs."
 )
 
 WIDGET_GUIDELINES = """\
 ## Rendering interactive widgets (show_widget)
 
-When a visual or interactive explanation is clearly better than text, call
-`show_widget`. Rules for `widget_code`:
+### When to use
 
-- It is an HTML fragment injected into a `<div id="root">`. Do NOT include
+`show_widget` is your DEFAULT for any answer the user is better off seeing
+than reading. Trigger words (Chinese + English) that should make you reach
+for it first: 画 / 绘制 / 画一个 / 可视化 / 示意图 / 流程图 / 架构图 / 图表 /
+仪表盘 / 数据图 / 对比 / draw / visualize / chart / diagram / dashboard /
+flowchart / architecture / mockup / sliders / animation / explainer /
+side-by-side / breakdown.
+
+Use it directly. Do NOT route through `write_file` + `save_artifact` first —
+the widget IS the answer, not an attachment to it.
+
+Skip it for: pure text, code blocks, short factual replies, error messages.
+
+### Size
+
+This is a WIDGET, not a webpage. Keep it compact:
+
+- Target width ~600 px, max 640 px. The host iframe is already centered and
+  capped — do NOT set `width: 100vw` or `min-width:1024px`.
+- Target height ~360-480 px. Avoid scrollbars; if content is long, pick a
+  more compact form (a table instead of cards, a single chart instead of
+  five) rather than letting it grow.
+- One focused thing per widget. If a request implies two unrelated visuals,
+  ship two widget calls.
+
+### Hard rules for `widget_code`
+
+- It is an HTML fragment injected into `<div id="root">`. Do NOT include
   `<!DOCTYPE>`, `<html>`, `<head>`, or `<body>`.
-- Order content for streaming: `<style>` (short) first, then visible HTML,
-  then `<script>` last. Scripts run only after the widget finishes streaming.
-- No data fetching: fetch/XHR/WebSocket are blocked (CSP `connect-src 'none'`).
-  Embed all data directly in the code. (Loading JS libraries from the allowed
-  CDNs below IS permitted - that is `script-src`, not `connect-src`.)
-- No `localStorage`/`sessionStorage` (they throw). Use in-memory variables.
-- Colors: the shell pre-defines five CSS variables on `:root` —
-  `--bg` (page background), `--fg` (foreground text), `--muted` (card/panel
-  surface), `--border` (separator), `--accent` (link/primary). Their values
-  are picked by the host based on the current app theme (light or dark) and
-  give correct contrast in both. Reference them via `var(--bg)` etc.
-  **Do NOT hard-code colors** (no `#1a1a1a`, no `#fff`, no rgb()); the widget
-  must look right in both themes. Two font weights max (400, 500). Avoid
-  gradients, shadows, and blur.
+- Order for streaming: `<style>` (short) first, then visible HTML, then
+  `<script>` last. Scripts run only after the widget finishes streaming.
+- No data fetching: fetch/XHR/WebSocket are blocked. Embed all data inline.
+  (Loading JS libraries from the CDNs below IS permitted — that is
+  `script-src`, not `connect-src`.)
+- No `localStorage` / `sessionStorage` (they throw). Use in-memory variables.
 - Libraries may be loaded only from: cdnjs.cloudflare.com, cdn.jsdelivr.net,
   unpkg.com, esm.sh.
-- Keep total `widget_code` under ~256KB.
+- Total `widget_code` under ~256 KB.
+
+### Visual quality bar
+
+The shell pre-defines these CSS variables on `:root`; values are picked by
+the host for the current light or dark theme:
+
+- `--bg`     page background
+- `--fg`     foreground text
+- `--muted`  card / panel surface
+- `--border` separator
+- `--accent` link / primary
+
+Always reference them via `var(--bg)` etc. **Do NOT hard-code colors** (no
+`#1a1a1a`, no `#fff`, no `rgb()`); the widget must look right in BOTH themes.
+Two font weights max (400, 500). Avoid gradients, drop shadows, blur. Use
+generous whitespace and small radii (4-8 px). Keep typography to one family
+(system-ui is already set).
+
+### Scenario skeletons
+
+Pick the one closest to the request and adapt — keep the overall shape,
+swap the data and labels. These are starting points, not templates to
+echo verbatim.
+
+#### A. Single chart (Chart.js)
+
+```html
+<style>
+  .card{background:var(--muted);border:1px solid var(--border);border-radius:8px;padding:16px;}
+  .card h3{margin:0 0 8px;font-size:14px;font-weight:500;color:var(--fg);}
+  canvas{width:100%!important;height:300px!important;}
+</style>
+<div class="card">
+  <h3>Title that says what is plotted</h3>
+  <canvas id="c"></canvas>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+<script>
+  const fg=getComputedStyle(document.documentElement).getPropertyValue('--fg').trim();
+  const acc=getComputedStyle(document.documentElement).getPropertyValue('--accent').trim();
+  const bd=getComputedStyle(document.documentElement).getPropertyValue('--border').trim();
+  new Chart(document.getElementById('c'),{
+    type:'line',
+    data:{labels:['A','B','C','D','E'],datasets:[{label:'Series',data:[3,8,5,12,9],borderColor:acc,backgroundColor:acc+'33',tension:.3}]},
+    options:{responsive:true,maintainAspectRatio:false,
+      plugins:{legend:{labels:{color:fg}}},
+      scales:{x:{ticks:{color:fg},grid:{color:bd}},y:{ticks:{color:fg},grid:{color:bd}}}}
+  });
+</script>
+```
+
+#### B. Architecture / flow diagram (inline SVG)
+
+```html
+<style>
+  .diag{display:block;width:100%;height:auto;}
+  .node{fill:var(--muted);stroke:var(--border);}
+  .label{fill:var(--fg);font:500 12px system-ui;text-anchor:middle;dominant-baseline:central;}
+  .edge{stroke:var(--border);stroke-width:1.5;fill:none;}
+  .arrow{fill:var(--border);}
+</style>
+<svg class="diag" viewBox="0 0 560 220" xmlns="http://www.w3.org/2000/svg">
+  <defs><marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+    <path class="arrow" d="M0 0 L10 5 L0 10 z"/></marker></defs>
+  <rect class="node" x="20"  y="80" width="120" height="60" rx="6"/>
+  <text class="label" x="80"  y="110">Client</text>
+  <rect class="node" x="220" y="80" width="120" height="60" rx="6"/>
+  <text class="label" x="280" y="110">API</text>
+  <rect class="node" x="420" y="80" width="120" height="60" rx="6"/>
+  <text class="label" x="480" y="110">DB</text>
+  <line class="edge" x1="140" y1="110" x2="220" y2="110" marker-end="url(#a)"/>
+  <line class="edge" x1="340" y1="110" x2="420" y2="110" marker-end="url(#a)"/>
+</svg>
+```
+
+#### C. Dashboard (metric cards + small chart)
+
+```html
+<style>
+  .grid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-bottom:12px;}
+  .stat{background:var(--muted);border:1px solid var(--border);border-radius:8px;padding:12px;}
+  .stat .v{font-size:22px;font-weight:500;color:var(--fg);}
+  .stat .l{font-size:11px;color:var(--fg);opacity:.7;margin-top:2px;}
+  .panel{background:var(--muted);border:1px solid var(--border);border-radius:8px;padding:16px;}
+  canvas{width:100%!important;height:200px!important;}
+</style>
+<div class="grid">
+  <div class="stat"><div class="v">1,284</div><div class="l">Active users</div></div>
+  <div class="stat"><div class="v">$42.1k</div><div class="l">Revenue (MTD)</div></div>
+  <div class="stat"><div class="v">98.6%</div><div class="l">Uptime</div></div>
+</div>
+<div class="panel"><canvas id="c"></canvas></div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+<script>/* Chart.js init — see scenario A */</script>
+```
+
+#### D. Interactive explainer (slider drives a calculation)
+
+```html
+<style>
+  .row{display:flex;align-items:center;gap:12px;margin:8px 0;}
+  .row label{flex:0 0 110px;color:var(--fg);font-size:13px;}
+  .row input{flex:1;accent-color:var(--accent);}
+  .row .val{flex:0 0 64px;text-align:right;font-variant-numeric:tabular-nums;color:var(--fg);}
+  .out{margin-top:12px;padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--muted);}
+  .out .big{font-size:24px;font-weight:500;color:var(--fg);}
+  .out .lbl{font-size:11px;color:var(--fg);opacity:.7;}
+</style>
+<div class="row"><label>Principal</label><input id="p" type="range" min="1000" max="100000" step="100" value="10000"><div class="val" id="pv">$10,000</div></div>
+<div class="row"><label>Years</label>    <input id="y" type="range" min="1"    max="40"     step="1"   value="10"><div class="val" id="yv">10</div></div>
+<div class="row"><label>Rate (%)</label> <input id="r" type="range" min="0"    max="15"     step="0.1" value="5"><div class="val" id="rv">5%</div></div>
+<div class="out"><div class="big" id="ans">$16,288.95</div><div class="lbl">Future value</div></div>
+<script>
+  const $=(id)=>document.getElementById(id);
+  function recalc(){
+    const P=+$('p').value, y=+$('y').value, r=+$('r').value/100;
+    $('pv').textContent='$'+P.toLocaleString();
+    $('yv').textContent=y; $('rv').textContent=r*100+'%';
+    $('ans').textContent='$'+(P*Math.pow(1+r,y)).toLocaleString(undefined,{maximumFractionDigits:2});
+  }
+  ['p','y','r'].forEach(id=>$(id).addEventListener('input',recalc));
+</script>
+```
+
+#### E. Side-by-side comparison table
+
+```html
+<style>
+  table{width:100%;border-collapse:collapse;font-size:13px;color:var(--fg);}
+  th,td{padding:8px 10px;border-bottom:1px solid var(--border);text-align:left;}
+  th{font-weight:500;color:var(--fg);opacity:.85;background:var(--muted);}
+  .check{color:var(--accent);font-weight:500;}
+  .dash{opacity:.5;}
+</style>
+<table>
+  <thead><tr><th>Feature</th><th>Option A</th><th>Option B</th></tr></thead>
+  <tbody>
+    <tr><td>Streams</td><td class="check">Yes</td><td class="dash">–</td></tr>
+    <tr><td>Offline</td><td class="dash">–</td><td class="check">Yes</td></tr>
+    <tr><td>Free tier</td><td>1k req/mo</td><td>500 req/mo</td></tr>
+  </tbody>
+</table>
+```
+
+If none of the above fits, write something simple in the same style — bordered
+muted cards, accent color sparingly, small radii, no shadows. Better to ship a
+plain card than a sprawling page.
 """

--- a/backend/cubebox/prompts/widget.py
+++ b/backend/cubebox/prompts/widget.py
@@ -81,6 +81,13 @@ Pick the one closest to the request and adapt — keep the overall shape,
 swap the data and labels. These are starting points, not templates to
 echo verbatim.
 
+**Important — theme reactivity.** Anything that reads CSS variables into JS at
+render time (Canvas, WebGL, Chart.js, D3, etc.) freezes those colours. The
+host can repaint the widget when the app's theme toggles by updating `:root`'s
+inline `style` attribute, so add a `MutationObserver` on the root to re-apply
+the new tokens. Inline SVG / HTML that uses `var(--fg)` etc. directly does
+NOT need this — the cascade re-evaluates automatically.
+
 #### A. Single chart (Chart.js)
 
 ```html
@@ -95,16 +102,29 @@ echo verbatim.
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
 <script>
-  const fg=getComputedStyle(document.documentElement).getPropertyValue('--fg').trim();
-  const acc=getComputedStyle(document.documentElement).getPropertyValue('--accent').trim();
-  const bd=getComputedStyle(document.documentElement).getPropertyValue('--border').trim();
-  new Chart(document.getElementById('c'),{
-    type:'line',
-    data:{labels:['A','B','C','D','E'],datasets:[{label:'Series',data:[3,8,5,12,9],borderColor:acc,backgroundColor:acc+'33',tension:.3}]},
-    options:{responsive:true,maintainAspectRatio:false,
-      plugins:{legend:{labels:{color:fg}}},
-      scales:{x:{ticks:{color:fg},grid:{color:bd}},y:{ticks:{color:fg},grid:{color:bd}}}}
+  const css = (v) => getComputedStyle(document.documentElement).getPropertyValue(v).trim();
+  function tokens(){ return { fg: css('--fg'), acc: css('--accent'), bd: css('--border') }; }
+  let t = tokens();
+  const chart = new Chart(document.getElementById('c'), {
+    type: 'line',
+    data: { labels: ['A','B','C','D','E'], datasets: [{ label: 'Series', data: [3,8,5,12,9], borderColor: t.acc, backgroundColor: t.acc+'33', tension: .3 }] },
+    options: { responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { labels: { color: t.fg } } },
+      scales: { x: { ticks: { color: t.fg }, grid: { color: t.bd } },
+                y: { ticks: { color: t.fg }, grid: { color: t.bd } } } }
   });
+  // Re-apply theme tokens whenever the host updates :root's inline style.
+  new MutationObserver(() => {
+    t = tokens();
+    chart.options.plugins.legend.labels.color = t.fg;
+    chart.options.scales.x.ticks.color = t.fg;
+    chart.options.scales.x.grid.color = t.bd;
+    chart.options.scales.y.ticks.color = t.fg;
+    chart.options.scales.y.grid.color = t.bd;
+    chart.data.datasets[0].borderColor = t.acc;
+    chart.data.datasets[0].backgroundColor = t.acc + '33';
+    chart.update('none');
+  }).observe(document.documentElement, { attributes: true, attributeFilter: ['style'] });
 </script>
 ```
 

--- a/backend/tests/e2e/test_user_sandbox_repo_transitions.py
+++ b/backend/tests/e2e/test_user_sandbox_repo_transitions.py
@@ -317,6 +317,13 @@ async def test_mark_paused_accepts_pausing_or_resuming_prior_state(
     await db_session.refresh(row)
     assert row.status == "running"
 
+    # Move row out of the active state before creating another active sandbox
+    # under the same (org, workspace, user) — uq_user_sandbox_active is a
+    # partial unique index on status IN ('provisioning','running'), so two
+    # concurrent running rows under the same scope are not allowed.
+    row.status = "terminated"
+    await db_session.commit()
+
     # Legal: pausing → paused
     await repo.claim_pausing(
         (await _mk(repo, scope, status="running", idle_secs=10, ttl_seconds=1)).id,
@@ -370,6 +377,12 @@ async def test_mark_running_rejects_terminal_and_paused_states(
     assert await repo.mark_running(pausing_row.id) is True
     await db_session.refresh(pausing_row)
     assert pausing_row.status == "running"
+
+    # Move pausing_row (now running) out of the active set so the next
+    # mark_running below doesn't violate uq_user_sandbox_active (partial unique
+    # index on status IN ('provisioning','running') per (org, workspace, user)).
+    pausing_row.status = "terminated"
+    await db_session.commit()
 
     # From resuming → ok (resume completed)
     resuming_row = await _mk(repo, scope, status="resuming", idle_secs=0, ttl_seconds=3600)

--- a/frontend/packages/web/__tests__/e2e/attachments.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/attachments.spec.ts
@@ -29,8 +29,9 @@ test.describe('M7 attachments happy path', () => {
     await input.fill('hello')
     await input.press('Enter')
 
-    // Wait for navigation to the conversation page
-    await expect(page).toHaveURL(/\/w\/[^/]+\/conversations\//, { timeout: 10_000 })
+    // Wait for navigation to the conversation page. 10s has been observed to
+    // be too tight on slow CI runners — bumped to keep this from flaking.
+    await expect(page).toHaveURL(/\/w\/[^/]+\/conversations\//, { timeout: 30_000 })
 
     // Wait for loading indicator to disappear (first message stream complete)
     await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 90_000 })

--- a/frontend/packages/web/__tests__/e2e/widget-shell.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/widget-shell.spec.ts
@@ -81,6 +81,46 @@ test('a stale morph arriving AFTER finalize does not regress the DOM', async ({ 
   await expect(frame.locator('#w')).toHaveText('final') // unchanged
 })
 
+test('skeleton placeholder is present in #root before any morph', async ({ page }) => {
+  await mountShell(page)
+  const frame = page.frameLocator('#wf')
+  // The shell pre-fills #root with a skeleton so the layout reserves space
+  // immediately; the first morph replaces it.
+  await expect(frame.locator('#root ._skel')).toBeVisible()
+  await expect(frame.locator('#root ._skel-bar').first()).toBeVisible()
+  // Body scrollHeight must be reasonably tall (skeleton reserves ~200+ px) so
+  // the parent iframe doesn't sit at a tiny initial height.
+  const h = await frame.locator('body').evaluate((b: HTMLElement) => b.scrollHeight)
+  expect(h).toBeGreaterThan(180)
+})
+
+test('theme message updates :root CSS variables in place', async ({ page }) => {
+  await mountShell(page)
+  const frame = page.frameLocator('#wf')
+  // Push a theme update from the parent (no seq — theme messages are stateless).
+  await page.evaluate((id) => {
+    ;(document.getElementById('wf') as HTMLIFrameElement).contentWindow!.postMessage(
+      {
+        widgetId: id,
+        type: 'theme',
+        bg: '#222222',
+        fg: '#eeeeee',
+        muted: '#333333',
+        border: '#444444',
+        accent: '#88ccff',
+      },
+      '*',
+    )
+  }, WIDGET_ID)
+  await expect
+    .poll(async () =>
+      frame
+        .locator(':root')
+        .evaluate((el: HTMLElement) => getComputedStyle(el).getPropertyValue('--bg').trim()),
+    )
+    .toBe('#222222')
+})
+
 test('widget cannot reach parent (opaque origin) nor fetch (connect-src none)', async ({
   page,
 }) => {

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -527,6 +527,16 @@ export function AssistantMessage({
 
   return (
     <div data-role="assistant" className="space-y-2">
+      {/* Widget rendered FIRST (at the top of the message). The widget is the
+          answer; the bubble below is commentary. Refresh order also puts widget
+          on top in the persisted message — keeping streaming consistent with
+          refresh. The shell pre-fills #root with a skeleton (see widgetShell.ts)
+          so the reserved space is stable while morphdom + content stream in. */}
+      {widgetItems.length > 0 && (
+        <div className="space-y-2 max-w-[640px] mx-auto">
+          {widgetItems.map(({ item, i }) => renderItem(item, i))}
+        </div>
+      )}
       <div className="flex justify-start gap-2.5">
         <div
           className="shrink-0 w-6 h-6 rounded-md border border-border bg-card
@@ -544,9 +554,6 @@ export function AssistantMessage({
           {bubbleItems.map(({ item, i }) => renderItem(item, i))}
         </div>
       </div>
-      {widgetItems.length > 0 && (
-        <div className="space-y-2">{widgetItems.map(({ item, i }) => renderItem(item, i))}</div>
-      )}
       {/* Todos + streaming/loading indicator render AFTER widgets so the
           "still working" signal stays at the visual end of the assistant
           message even when widgets are present. pl-9 ≈ avatar(24px)+gap(10px)

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -537,23 +537,30 @@ export function AssistantMessage({
           {widgetItems.map(({ item, i }) => renderItem(item, i))}
         </div>
       )}
-      <div className="flex justify-start gap-2.5">
-        <div
-          className="shrink-0 w-6 h-6 rounded-md border border-border bg-card
+      {/* Skip the avatar+bubble row entirely when a widget-only message has
+          no text/tools/subagent content — otherwise we render an empty bubble
+          row below the widget, which looks like a stray empty assistant
+          response. Loading/todos still render below, gated by their own
+          conditions. */}
+      {(bubbleItems.length > 0 || totalSubagents >= 2) && (
+        <div className="flex justify-start gap-2.5">
+          <div
+            className="shrink-0 w-6 h-6 rounded-md border border-border bg-card
         flex items-center justify-center mt-0.5"
-        >
-          <Bot className="size-3.5 text-primary/70" />
+          >
+            <Bot className="size-3.5 text-primary/70" />
+          </div>
+          <div className="flex-1 max-w-[75%] space-y-2">
+            {totalSubagents >= 2 && (
+              <SubAgentCluster
+                activeCount={isStreaming === true ? activeSubagentCount : 0}
+                totalCount={totalSubagents}
+              />
+            )}
+            {bubbleItems.map(({ item, i }) => renderItem(item, i))}
+          </div>
         </div>
-        <div className="flex-1 max-w-[75%] space-y-2">
-          {totalSubagents >= 2 && (
-            <SubAgentCluster
-              activeCount={isStreaming === true ? activeSubagentCount : 0}
-              totalCount={totalSubagents}
-            />
-          )}
-          {bubbleItems.map(({ item, i }) => renderItem(item, i))}
-        </div>
-      </div>
+      )}
       {/* Todos + streaming/loading indicator render AFTER widgets so the
           "still working" signal stays at the visual end of the assistant
           message even when widgets are present. pl-9 ≈ avatar(24px)+gap(10px)

--- a/frontend/packages/web/components/chat/widget/WidgetView.tsx
+++ b/frontend/packages/web/components/chat/widget/WidgetView.tsx
@@ -38,6 +38,14 @@ interface WidgetViewProps {
   height?: number
 }
 
+// Focusable selector used for the fullscreen dialog's focus trap + initial
+// focus. Iframes are intentionally excluded — focusing the widget iframe would
+// not give it real keyboard ownership (sandbox is opaque-origin and toolbar
+// buttons are the only real interactive controls in the dialog).
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]),a[href],input:not([disabled]),select:not([disabled]),' +
+  'textarea:not([disabled]),[tabindex]:not([tabindex="-1"])'
+
 export function WidgetView(props: WidgetViewProps) {
   // The reloadKey is bumped by the toolbar Reload button (or the error-retry
   // button) to force-remount the iframe; the embedded WidgetFrame remounts
@@ -45,6 +53,8 @@ export function WidgetView(props: WidgetViewProps) {
   const [reloadKey, setReloadKey] = useState(0)
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [copied, setCopied] = useState(false)
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  const prevFocusRef = useRef<HTMLElement | null>(null)
 
   const reload = useCallback(() => setReloadKey((k) => k + 1), [])
 
@@ -68,12 +78,56 @@ export function WidgetView(props: WidgetViewProps) {
     return () => window.removeEventListener('keydown', onKey)
   }, [isFullscreen])
 
+  // Focus management: when the dialog opens, save the previously-focused
+  // element and move focus into the dialog. When it closes, restore focus
+  // back to where it came from.
+  useEffect(() => {
+    if (!isFullscreen) return
+    if (typeof document === 'undefined') return
+    prevFocusRef.current = document.activeElement as HTMLElement | null
+    const raf = requestAnimationFrame(() => {
+      const dialog = dialogRef.current
+      if (!dialog) return
+      const focusables = dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ;(focusables[0] ?? dialog).focus()
+    })
+    return () => {
+      cancelAnimationFrame(raf)
+      const prev = prevFocusRef.current
+      prevFocusRef.current = null
+      // Defer to next tick so React has finished unmounting the dialog before
+      // we attempt to focus the (now visible again) opener button.
+      setTimeout(() => prev?.focus?.(), 0)
+    }
+  }, [isFullscreen])
+
+  // Tab trap: keep focus inside the dialog while it is open.
+  const onDialogKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Tab') return
+    const dialog = dialogRef.current
+    if (!dialog) return
+    const focusables = Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    if (focusables.length === 0) return
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    const active = document.activeElement as HTMLElement | null
+    if (e.shiftKey && (active === first || !dialog.contains(active))) {
+      last.focus()
+      e.preventDefault()
+    } else if (!e.shiftKey && (active === last || !dialog.contains(active))) {
+      first.focus()
+      e.preventDefault()
+    }
+  }, [])
+
   return (
     <div className="relative group/widget">
       {/* Inline frame (also used as the layout-slot holder when fullscreen).
           Hidden visually while fullscreen so the host overlay is the only one
           rendering content, but the wrapping div keeps the message column
-          height stable rather than collapsing as the iframe disappears. */}
+          height stable rather than collapsing as the iframe disappears.
+          aria-hidden + inert hide the inline copy from assistive tech and
+          tab order while the modal dialog is open. */}
       <div
         className={cn(
           'relative rounded-lg border border-border bg-muted overflow-hidden',
@@ -83,6 +137,10 @@ export function WidgetView(props: WidgetViewProps) {
           width: props.width ? `${props.width}px` : '100%',
           minHeight: props.height ?? SKELETON_DEFAULT_HEIGHT,
         }}
+        // @ts-expect-error -- inert is a real HTML attribute in modern browsers
+        // but React's DOM types haven't shipped it yet on every React version.
+        inert={isFullscreen ? '' : undefined}
+        aria-hidden={isFullscreen || undefined}
       >
         <WidgetFrame key={`inline-${reloadKey}`} {...props} onRetry={reload} />
         <WidgetToolbar
@@ -98,11 +156,15 @@ export function WidgetView(props: WidgetViewProps) {
         typeof document !== 'undefined' &&
         createPortal(
           <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 md:p-8"
+            ref={dialogRef}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 md:p-8
+              focus:outline-none"
             onClick={() => setIsFullscreen(false)}
+            onKeyDown={onDialogKeyDown}
             role="dialog"
             aria-modal="true"
             aria-label={props.title ?? 'widget (fullscreen)'}
+            tabIndex={-1}
           >
             <div
               className="relative w-full h-full max-w-[1200px] rounded-xl border border-border
@@ -199,6 +261,12 @@ function WidgetFrame({
   // change itself — we have to relay it. Stateless (no seq); the shell applies
   // it directly to :root CSS variables in place, so the rendered widget
   // recolors without remounting.
+  //
+  // We also re-push the CURRENT theme once `ready` flips true. The srcDoc is
+  // built from a theme snapshot at render time; if the app toggled theme
+  // between that snapshot and the iframe finishing morphdom load, the shell
+  // would otherwise be stuck on the stale theme until the next toggle. Pushing
+  // on ready closes that window.
   useEffect(() => {
     if (typeof document === 'undefined') return
     const html = document.documentElement
@@ -208,10 +276,11 @@ function WidgetFrame({
       const t = resolveThemeTokens(html.classList.contains('dark'))
       win.postMessage({ widgetId, type: 'theme', ...t }, '*')
     }
+    if (ready) push()
     const obs = new MutationObserver(push)
     obs.observe(html, { attributes: true, attributeFilter: ['class'] })
     return () => obs.disconnect()
-  }, [widgetId])
+  }, [widgetId, ready])
 
   useEffect(() => {
     if (!ready || failed || tooBig) return

--- a/frontend/packages/web/components/chat/widget/WidgetView.tsx
+++ b/frontend/packages/web/components/chat/widget/WidgetView.tsx
@@ -68,23 +68,35 @@ export function WidgetView(props: WidgetViewProps) {
     }
   }, [props.widgetCode])
 
+  // openFullscreen captures the currently-focused element SYNCHRONOUSLY before
+  // it triggers the re-render that hides + inerts the inline copy. Capturing
+  // it inside a post-render effect would be too late: by then the opener
+  // button is inside an `inert` subtree, so document.activeElement has
+  // already shifted to <body> and the restore-on-close would target the
+  // wrong element.
+  const openFullscreen = useCallback(() => {
+    if (typeof document !== 'undefined') {
+      prevFocusRef.current = (document.activeElement as HTMLElement | null) ?? null
+    }
+    setIsFullscreen(true)
+  }, [])
+
+  const closeFullscreen = useCallback(() => setIsFullscreen(false), [])
+
   // Esc closes fullscreen.
   useEffect(() => {
     if (!isFullscreen) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsFullscreen(false)
+      if (e.key === 'Escape') closeFullscreen()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [isFullscreen])
+  }, [isFullscreen, closeFullscreen])
 
-  // Focus management: when the dialog opens, save the previously-focused
-  // element and move focus into the dialog. When it closes, restore focus
-  // back to where it came from.
+  // After the dialog renders, move focus inside it. After it closes, restore
+  // focus to whatever openFullscreen captured.
   useEffect(() => {
     if (!isFullscreen) return
-    if (typeof document === 'undefined') return
-    prevFocusRef.current = document.activeElement as HTMLElement | null
     const raf = requestAnimationFrame(() => {
       const dialog = dialogRef.current
       if (!dialog) return
@@ -147,7 +159,7 @@ export function WidgetView(props: WidgetViewProps) {
           copied={copied}
           onCopy={handleCopy}
           onReload={reload}
-          onFullscreen={() => setIsFullscreen(true)}
+          onFullscreen={openFullscreen}
           isFullscreen={false}
         />
       </div>
@@ -159,7 +171,7 @@ export function WidgetView(props: WidgetViewProps) {
             ref={dialogRef}
             className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 md:p-8
               focus:outline-none"
-            onClick={() => setIsFullscreen(false)}
+            onClick={closeFullscreen}
             onKeyDown={onDialogKeyDown}
             role="dialog"
             aria-modal="true"
@@ -176,7 +188,7 @@ export function WidgetView(props: WidgetViewProps) {
                 copied={copied}
                 onCopy={handleCopy}
                 onReload={reload}
-                onFullscreen={() => setIsFullscreen(false)}
+                onFullscreen={closeFullscreen}
                 isFullscreen={true}
               />
             </div>

--- a/frontend/packages/web/components/chat/widget/WidgetView.tsx
+++ b/frontend/packages/web/components/chat/widget/WidgetView.tsx
@@ -1,11 +1,33 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Copy, Maximize2, Minimize2, RotateCw } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import { WIDGET_SHELL_HTML } from './widgetShell'
 
 const READY_TIMEOUT_MS = 5000
 const MAX_HEIGHT_PX = 4000
 const MAX_CODE_BYTES = 256 * 1024
+const SKELETON_DEFAULT_HEIGHT = 240
+
+interface ThemeTokens {
+  bg: string
+  fg: string
+  muted: string
+  border: string
+  accent: string
+}
+
+function resolveThemeTokens(isDark: boolean): ThemeTokens {
+  return isDark
+    ? { bg: '#0e1116', fg: '#e6edf3', muted: '#161b22', border: '#30363d', accent: '#58a6ff' }
+    : { bg: '#ffffff', fg: '#0a0a0f', muted: '#f5f5f7', border: '#e5e7eb', accent: '#0061c2' }
+}
+
+function isAppDark(): boolean {
+  return typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
+}
 
 interface WidgetViewProps {
   widgetCode: string
@@ -16,40 +38,128 @@ interface WidgetViewProps {
   height?: number
 }
 
-export function WidgetView({
+export function WidgetView(props: WidgetViewProps) {
+  // The reloadKey is bumped by the toolbar Reload button (or the error-retry
+  // button) to force-remount the iframe; the embedded WidgetFrame remounts
+  // because its key changes, which throws away ready/failed/seq state.
+  const [reloadKey, setReloadKey] = useState(0)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const reload = useCallback(() => setReloadKey((k) => k + 1), [])
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(props.widgetCode)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1200)
+    } catch {
+      /* clipboard blocked; silently no-op */
+    }
+  }, [props.widgetCode])
+
+  // Esc closes fullscreen.
+  useEffect(() => {
+    if (!isFullscreen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsFullscreen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [isFullscreen])
+
+  return (
+    <div className="relative group/widget">
+      {/* Inline frame (also used as the layout-slot holder when fullscreen).
+          Hidden visually while fullscreen so the host overlay is the only one
+          rendering content, but the wrapping div keeps the message column
+          height stable rather than collapsing as the iframe disappears. */}
+      <div
+        className={cn(
+          'relative rounded-lg border border-border bg-muted overflow-hidden',
+          isFullscreen && 'invisible',
+        )}
+        style={{
+          width: props.width ? `${props.width}px` : '100%',
+          minHeight: props.height ?? SKELETON_DEFAULT_HEIGHT,
+        }}
+      >
+        <WidgetFrame key={`inline-${reloadKey}`} {...props} onRetry={reload} />
+        <WidgetToolbar
+          copied={copied}
+          onCopy={handleCopy}
+          onReload={reload}
+          onFullscreen={() => setIsFullscreen(true)}
+          isFullscreen={false}
+        />
+      </div>
+
+      {isFullscreen &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 md:p-8"
+            onClick={() => setIsFullscreen(false)}
+            role="dialog"
+            aria-modal="true"
+            aria-label={props.title ?? 'widget (fullscreen)'}
+          >
+            <div
+              className="relative w-full h-full max-w-[1200px] rounded-xl border border-border
+                bg-muted overflow-hidden shadow-2xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <WidgetFrame key={`fullscreen-${reloadKey}`} {...props} onRetry={reload} fillParent />
+              <WidgetToolbar
+                copied={copied}
+                onCopy={handleCopy}
+                onReload={reload}
+                onFullscreen={() => setIsFullscreen(false)}
+                isFullscreen={true}
+              />
+            </div>
+          </div>,
+          document.body,
+        )}
+    </div>
+  )
+}
+
+interface WidgetFrameProps extends WidgetViewProps {
+  onRetry: () => void
+  fillParent?: boolean
+}
+
+function WidgetFrame({
   widgetCode,
   status,
   widgetId,
   title,
   width,
   height: initialHeight,
-}: WidgetViewProps) {
+  onRetry,
+  fillParent,
+}: WidgetFrameProps) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
   const [ready, setReady] = useState(false)
   const [failed, setFailed] = useState(false)
-  const [height, setHeight] = useState(initialHeight ?? 120)
+  const [height, setHeight] = useState(initialHeight ?? SKELETON_DEFAULT_HEIGHT)
   const seqRef = useRef(0)
   const latestRef = useRef('')
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Inject the real id into the shell. JSON.stringify supplies quotes + standard
-  // escaping; we further escape "<" to "\\u003c" so a hypothetical "</script>"
-  // can't close the shell's script block. A function replacement avoids
-  // String.replace's "$" special-handling. Each placeholder appears exactly
-  // once in the shell. Theme tokens are resolved from the app's `.dark` class
-  // (next-themes attribute="class") at mount; toggling theme after render
-  // keeps the widget on the original theme until the conversation reloads.
+  // Inject theme tokens + widget id into the shell. JSON.stringify supplies
+  // quotes + standard escaping for the id; we further escape "<" to "\\u003c"
+  // so a hypothetical "</script>" can't close the shell's script block. A
+  // function replacement avoids String.replace's "$" special-handling. Each
+  // placeholder appears exactly once. The initial theme is resolved from the
+  // app's `.dark` class at mount; subsequent toggles are pushed via a `theme`
+  // postMessage from the MutationObserver below (no remount needed).
   const srcDoc = useMemo(() => {
-    const isDark =
-      typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
-    const t = isDark
-      ? { bg: '#0e1116', fg: '#e6edf3', muted: '#161b22', border: '#30363d', accent: '#58a6ff' }
-      : { bg: '#ffffff', fg: '#0a0a0f', muted: '#f5f5f7', border: '#e5e7eb', accent: '#0061c2' }
+    const t = resolveThemeTokens(isAppDark())
     const idLiteral = JSON.stringify(widgetId).replace(/</g, '\\u003c')
-    // Replace theme tokens FIRST (values are color strings like '#0e1116',
-    // never contain '%%'), then widget_id LAST. Reversed order would let an
-    // unlikely widgetId containing e.g. '%%BG%%' get clobbered by a later
-    // theme replacement. This order makes the substitution unaffected by id
+    // Replace theme tokens FIRST (color strings never contain '%%'), then
+    // widget_id LAST. This order makes the substitution unaffected by id
     // contents.
     return WIDGET_SHELL_HTML.replace('%%BG%%', () => t.bg)
       .replace('%%FG%%', () => t.fg)
@@ -62,7 +172,6 @@ export function WidgetView({
   const tooBig = new Blob([widgetCode]).size > MAX_CODE_BYTES
   latestRef.current = widgetCode
 
-  // child -> parent listener (validate source + type)
   useEffect(() => {
     function onMessage(e: MessageEvent) {
       if (e.source !== iframeRef.current?.contentWindow) return
@@ -79,15 +188,31 @@ export function WidgetView({
     return () => window.removeEventListener('message', onMessage)
   }, [widgetId])
 
-  // readiness timeout -> fallback. If `ready` flips true, this effect re-runs,
-  // early-returns, and the cleanup clears the pending timer.
   useEffect(() => {
     if (ready || failed) return
     const t = setTimeout(() => setFailed(true), READY_TIMEOUT_MS)
     return () => clearTimeout(t)
   }, [ready, failed])
 
-  // push morph (debounced) once ready
+  // Push a `theme` message whenever the app toggles the .dark class on <html>.
+  // Sandbox is opaque-origin, so the iframe can't observe the parent's class
+  // change itself — we have to relay it. Stateless (no seq); the shell applies
+  // it directly to :root CSS variables in place, so the rendered widget
+  // recolors without remounting.
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const html = document.documentElement
+    const push = () => {
+      const win = iframeRef.current?.contentWindow
+      if (!win) return
+      const t = resolveThemeTokens(html.classList.contains('dark'))
+      win.postMessage({ widgetId, type: 'theme', ...t }, '*')
+    }
+    const obs = new MutationObserver(push)
+    obs.observe(html, { attributes: true, attributeFilter: ['class'] })
+    return () => obs.disconnect()
+  }, [widgetId])
+
   useEffect(() => {
     if (!ready || failed || tooBig) return
     const send = (final: boolean) => {
@@ -116,17 +241,38 @@ export function WidgetView({
 
   if (failed || tooBig) {
     return (
-      <details className="rounded-lg border border-border bg-muted p-2 text-sm">
-        <summary className="cursor-pointer text-muted-foreground">
-          {tooBig
-            ? 'Widget too large — showing source'
-            : 'Widget failed to render — showing source'}
-          {title ? ` (${title})` : ''}
-        </summary>
-        <pre className="overflow-auto text-xs">
-          <code>{widgetCode}</code>
-        </pre>
-      </details>
+      <div className="rounded-lg border border-border bg-muted p-4 text-sm space-y-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="space-y-1">
+            <div className="font-medium text-foreground">
+              {tooBig ? 'Widget too large to render' : 'Widget failed to render'}
+              {title ? ` — ${title}` : ''}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {tooBig
+                ? 'The generated code exceeds the size cap. Source is shown below.'
+                : 'The widget runtime reported an error or never finished loading.'}
+            </div>
+          </div>
+          {!tooBig && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="inline-flex items-center gap-1 rounded-md border border-border
+                bg-background px-2 py-1 text-xs text-foreground hover:bg-accent
+                hover:text-accent-foreground transition-colors"
+            >
+              <RotateCw className="size-3" /> Retry
+            </button>
+          )}
+        </div>
+        <details className="text-xs">
+          <summary className="cursor-pointer text-muted-foreground">Show source</summary>
+          <pre className="mt-2 max-h-80 overflow-auto rounded bg-background p-2">
+            <code>{widgetCode}</code>
+          </pre>
+        </details>
+      </div>
     )
   }
 
@@ -136,8 +282,77 @@ export function WidgetView({
       title={title ?? 'widget'}
       sandbox="allow-scripts"
       srcDoc={srcDoc}
-      style={{ width: width ? `${width}px` : '100%', height, border: 'none' }}
-      className="rounded-lg border border-border bg-muted"
+      style={
+        fillParent
+          ? { width: '100%', height: '100%', border: 'none' }
+          : { width: width ? `${width}px` : '100%', height, border: 'none' }
+      }
+      className={cn('block bg-muted', !fillParent && 'rounded-lg')}
     />
+  )
+}
+
+interface WidgetToolbarProps {
+  copied: boolean
+  onCopy: () => void
+  onReload: () => void
+  onFullscreen: () => void
+  isFullscreen: boolean
+}
+
+function WidgetToolbar({
+  copied,
+  onCopy,
+  onReload,
+  onFullscreen,
+  isFullscreen,
+}: WidgetToolbarProps) {
+  return (
+    <div
+      className={cn(
+        'absolute right-2 top-2 z-10 flex items-center gap-1 rounded-md border border-border',
+        'bg-background/70 px-1 py-0.5 backdrop-blur-sm transition-opacity',
+        // Toolbar fades in on hover when inline, stays fully visible when fullscreen.
+        isFullscreen ? 'opacity-100' : 'opacity-50 group-hover/widget:opacity-100',
+      )}
+    >
+      <ToolbarButton
+        label={copied ? 'Copied' : 'Copy source'}
+        onClick={onCopy}
+        icon={<Copy className="size-3.5" />}
+      />
+      <ToolbarButton label="Reload" onClick={onReload} icon={<RotateCw className="size-3.5" />} />
+      <ToolbarButton
+        label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+        onClick={onFullscreen}
+        icon={
+          isFullscreen ? <Minimize2 className="size-3.5" /> : <Maximize2 className="size-3.5" />
+        }
+      />
+    </div>
+  )
+}
+
+function ToolbarButton({
+  label,
+  onClick,
+  icon,
+}: {
+  label: string
+  onClick: () => void
+  icon: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+      className="inline-flex items-center justify-center rounded p-1
+        text-muted-foreground hover:text-foreground hover:bg-accent
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors"
+    >
+      {icon}
+    </button>
   )
 }

--- a/frontend/packages/web/components/chat/widget/WidgetView.tsx
+++ b/frontend/packages/web/components/chat/widget/WidgetView.tsx
@@ -39,12 +39,16 @@ interface WidgetViewProps {
 }
 
 // Focusable selector used for the fullscreen dialog's focus trap + initial
-// focus. Iframes are intentionally excluded — focusing the widget iframe would
-// not give it real keyboard ownership (sandbox is opaque-origin and toolbar
-// buttons are the only real interactive controls in the dialog).
+// focus. Includes the widget iframe so keyboard users can tab into the
+// sandboxed content (e.g. sliders, interactive explainers). Sandbox is
+// opaque-origin, so we can't inspect the child DOM from out here — but
+// focusing the iframe element itself hands keyboard input to the iframe's
+// browsing context, and the browser handles Tab navigation inside it from
+// then on. Shift+Tab out of the first widget control returns to the dialog.
 const FOCUSABLE_SELECTOR =
   'button:not([disabled]),a[href],input:not([disabled]),select:not([disabled]),' +
-  'textarea:not([disabled]),[tabindex]:not([tabindex="-1"])'
+  'textarea:not([disabled]),iframe:not([tabindex="-1"]),' +
+  '[tabindex]:not([tabindex="-1"])'
 
 export function WidgetView(props: WidgetViewProps) {
   // The reloadKey is bumped by the toolbar Reload button (or the error-retry

--- a/frontend/packages/web/components/chat/widget/widgetShell.ts
+++ b/frontend/packages/web/components/chat/widget/widgetShell.ts
@@ -19,8 +19,16 @@ export const WIDGET_SHELL_HTML = `<!DOCTYPE html><html><head>
 *{box-sizing:border-box}
 body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--fg);}
 @keyframes _fadeIn{from{opacity:0;transform:translateY(4px);}to{opacity:1;transform:none;}}
+@keyframes _pulse{0%,100%{opacity:.35}50%{opacity:.7}}
+/* Skeleton lives in #root and is replaced by morphdom on the first morph.
+   It reserves stable vertical space so the parent message layout doesn't
+   shift when the iframe transitions from empty -> rendered. */
+._skel{display:flex;flex-direction:column;gap:.55rem;padding:.25rem 0 1rem;}
+._skel-bar{height:.85rem;border-radius:.25rem;background:var(--muted);border:1px solid var(--border);animation:_pulse 1.6s ease-in-out infinite;}
+._skel-bar._lg{height:1.6rem;width:35%;}
+._skel-card{margin-top:.4rem;padding:1rem;border:1px solid var(--border);border-radius:.5rem;background:var(--muted);height:8.5rem;display:flex;align-items:center;justify-content:center;color:transparent;animation:_pulse 1.6s ease-in-out infinite;}
 </style></head>
-<body><div id="root"></div>
+<body><div id="root"><div class="_skel" aria-hidden="true"><div class="_skel-bar _lg"></div><div class="_skel-bar" style="width:80%"></div><div class="_skel-bar" style="width:65%"></div><div class="_skel-card">·</div></div></div>
 <script>
 (function(){
   var WIDGET_ID = %%WIDGET_ID%%;
@@ -72,11 +80,25 @@ body{margin:0;padding:1rem;font-family:system-ui,-apple-system,sans-serif;backgr
     next();
   }
 
+  // Update :root CSS variables in place from a theme message. Theme tokens are
+  // colour strings; only those known keys are honoured (defence against random
+  // extra payload fields).
+  function applyTheme(d){
+    var s = document.documentElement.style;
+    if (typeof d.bg === 'string')     s.setProperty('--bg', d.bg);
+    if (typeof d.fg === 'string')     s.setProperty('--fg', d.fg);
+    if (typeof d.muted === 'string')  s.setProperty('--muted', d.muted);
+    if (typeof d.border === 'string') s.setProperty('--border', d.border);
+    if (typeof d.accent === 'string') s.setProperty('--accent', d.accent);
+  }
+
   window.addEventListener('message', function(e){
     if (e.source !== parent) return;
     var d = e.data;
     if (!d || typeof d !== 'object') return;
     if (d.widgetId !== WIDGET_ID) return;
+    // Theme messages are stateless (no ordering needed); apply and return.
+    if (d.type === 'theme') { try { applyTheme(d); } catch(_){} return; }
     if (typeof d.seq !== 'number' || d.seq <= lastSeq) return; // latest-wins
     lastSeq = d.seq;
     try {


### PR DESCRIPTION
## Summary

Manual-verification follow-ups on the previously-merged widget feature (#142 + #165). Four observed problems:

1. **Generated widgets looked ugly** — model only had ~2KB of hard constraints in the prompt, no design scaffolding.
2. **Loading dots jumped** — the iframe area was empty before the first morph, so the layout slot kept resizing.
3. **Inconsistent text/widget order** — text rendered above widget during streaming, below widget after refresh.
4. **Widgets could sprawl** — no width/height ceiling guidance.

Also added long-asked-for toolbar polish (copy / reload / fullscreen) and theme realtime response.

## Changes

### Shell (`widgetShell.ts`)
- Pre-fill `#root` with a low-presence pulsing skeleton (~240px reserved height) so the iframe sits stable before the first morph; morphdom replaces it on first content.
- Accept stateless `theme` messages that update `:root` CSS variables in place — theme toggle now repaints the rendered widget without a remount.

### Layout (`AssistantMessage.tsx`)
- Widgets render at the **top** of the assistant message (answer first); text/thinking and the loading indicator sit **below**. Matches the refresh order.
- Widget row capped at `max-w-[640px]` and centered.
- Skip the avatar/bubble row entirely when a widget-only message has no text/tools/subagent content (was rendering an empty stray bubble).

### `WidgetView.tsx`
- Toolbar (top-right, fades in on hover): **Copy source / Reload / Fullscreen** with Escape support.
- Reload bumps a key to remount the iframe (fresh `ready`/`seq`/`failed` state).
- Fullscreen via `createPortal` → second iframe instance in an overlay, with **focus management** (capture activeElement synchronously before open, focus first focusable on mount, restore on close), **Tab trap**, and `inert` + `aria-hidden` on the hidden inline copy.
- `MutationObserver` on `<html class>` pushes `theme` messages live (sandbox is opaque-origin, so CSS vars can't be inherited via cascade).
- Theme race closed: also push current theme right after `ready` fires.
- Error/too-big fallback rewritten as a card with a **Retry** button.

### Backend prompt (`prompts/widget.py`)
- Stronger "when to use" with explicit trigger keywords (CN + EN).
- Hard size limits: target ~600 px wide × 360–480 px tall, never full-page.
- Excluded the `write_file + save_artifact` detour explicitly.
- Five self-authored scenario skeletons (Chart.js single chart, SVG flow diagram, metric-card dashboard, slider explainer, comparison table) the model can adapt from.
- Theme-reactivity note + Chart.js skeleton now listens for `:root` style mutations and re-applies tokens.

## Test plan
- [x] Backend `test_show_widget.py` (4 tests) — tool metadata, ack, guidelines content, subagent exclusion
- [x] `partialJson` vitest (6) — unchanged in this PR
- [x] `WidgetView` vitest (3) — size-cap fallback, ready-timeout fallback, forged-source rejection / posts-after-ready
- [x] Shell Playwright (6) — morph + finalize-once, latest-wins before & after finalize, opaque-origin + `connect-src 'none'`, **plus 2 new** (skeleton presence + theme message updates `:root` CSS vars)
- [x] type-check + mypy + lint + prettier clean
- [x] **Live Playwright verification on the worktree dev server**: registered a user, sent a chart-trigger prompt; the model used `show_widget`; widget renders at top of message, toolbar visible top-right, fullscreen overlay opens (chart re-flows in the larger canvas), theme toggle re-colors the live Chart.js chart, error/retry path tested. Screenshots in `/tmp/widget-v2-shots/`.
- [x] Local codex reviewed (3 rounds → **CLEAN**)