### PR TITLE
ci+test(sandbox): bump backend-e2e timeout + fix uq_user_sandbox_active violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,11 @@ jobs:
     name: Backend E2E (pytest)
     needs: gate
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # pytest e2e has been observed at ~19-20 min on slow runners, so the
+    # previous 20-min cap was right at the wire and killed the job mid-run.
+    # 30 min gives margin without masking a real regression (a healthy run is
+    # well under 20 min on a normal runner).
+    timeout-minutes: 30
     env:
       ENV_FOR_DYNACONF: test
       CUBEBOX_E2E_LLM_BASE_URL: ${{ secrets.CUBEBOX_E2E_LLM_BASE_URL }}

--- a/backend/tests/e2e/test_user_sandbox_repo_transitions.py
+++ b/backend/tests/e2e/test_user_sandbox_repo_transitions.py
@@ -317,6 +317,13 @@ async def test_mark_paused_accepts_pausing_or_resuming_prior_state(
     await db_session.refresh(row)
     assert row.status == "running"
 
+    # Move row out of the active state before creating another active sandbox
+    # under the same (org, workspace, user) — uq_user_sandbox_active is a
+    # partial unique index on status IN ('provisioning','running'), so two
+    # concurrent running rows under the same scope are not allowed.
+    row.status = "terminated"
+    await db_session.commit()
+
     # Legal: pausing → paused
     await repo.claim_pausing(
         (await _mk(repo, scope, status="running", idle_secs=10, ttl_seconds=1)).id,
@@ -370,6 +377,12 @@ async def test_mark_running_rejects_terminal_and_paused_states(
     assert await repo.mark_running(pausing_row.id) is True
     await db_session.refresh(pausing_row)
     assert pausing_row.status == "running"
+
+    # Move pausing_row (now running) out of the active set so the next
+    # mark_running below doesn't violate uq_user_sandbox_active (partial unique
+    # index on status IN ('provisioning','running') per (org, workspace, user)).
+    pausing_row.status = "terminated"
+    await db_session.commit()
 
     # From resuming → ok (resume completed)
     resuming_row = await _mk(repo, scope, status="resuming", idle_secs=0, ttl_seconds=3600)


### PR DESCRIPTION
Tiny standalone PR pulled out of #167 so its /ci can pass. Two pre-existing infra issues need to land first because issue_comment workflows always use main's ci.yml — fixes to that workflow file in a feature branch are ignored until merged.

## (1) ci.yml: backend-e2e timeout-minutes 20 → 30
Pytest e2e has been observed at ~19-20 min on slow CI runners; the 20-min cap lands right at the wire and kills pytest mid-run. 30 min gives margin without masking a real regression (a healthy run is well under 20 min).

## (2) test(sandbox): clear active rows before adding new ones
Two backend e2e tests for user_sandbox state transitions were creating multiple rows in 'running' state under the same (org, workspace, user) scope, which violates the partial unique index uq_user_sandbox_active (WHERE status IN ('provisioning','running')). Likely uncovered after a recent migration re-parent reliably enforced the constraint.

- test_mark_paused_accepts_pausing_or_resuming_prior_state: mark the first running row 'terminated' before claiming another running row.
- test_mark_running_rejects_terminal_and_paused_states: mark the pausing→running row 'terminated' before the resuming→running transition.

Both pre-existing failures, surfaced during #167's CI loop.