### PR TITLE
feat(sandbox-ui): sandbox confirm HITL frontend — store + card + wiring

### DIFF
--- a/frontend/packages/core/__tests__/stores/messageStore.sandboxConfirm.test.ts
+++ b/frontend/packages/core/__tests__/stores/messageStore.sandboxConfirm.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useMessageStore } from '../../src/stores/messageStore'
+import type { AgentEvent } from '../../src/types'
+
+function makeRequestEvent(overrides?: {
+  question_id?: string
+  tool_call_id?: string
+  command?: string
+  matched_pattern?: string | null
+  timeout_seconds?: number | null
+}): AgentEvent {
+  return {
+    type: 'sandbox_confirm_request',
+    event_id: '1000-1',
+    timestamp: new Date().toISOString(),
+    agent_id: null,
+    agent_name: null,
+    data: {
+      question_id: overrides?.question_id ?? 'qid-1',
+      tool_call_id: overrides?.tool_call_id ?? 'tc-1',
+      command: overrides?.command ?? 'rm -rf /tmp/x',
+      matched_pattern: overrides?.matched_pattern ?? 'rm *',
+      timeout_seconds: overrides?.timeout_seconds ?? 180,
+    },
+  } as unknown as AgentEvent
+}
+
+function makeResolvedEvent(questionId = 'qid-1'): AgentEvent {
+  return {
+    type: 'sandbox_confirm_resolved',
+    event_id: '1000-2',
+    timestamp: new Date().toISOString(),
+    agent_id: null,
+    agent_name: null,
+    data: {
+      question_id: questionId,
+      decision: 'approve',
+      cancelled: false,
+      timed_out: false,
+      reason: null,
+    },
+  } as unknown as AgentEvent
+}
+
+beforeEach(() => {
+  useMessageStore.setState({ pendingConfirmMap: {}, lastAppliedEventId: null })
+})
+
+describe('sandbox_confirm_request', () => {
+  it('adds entry to pendingConfirmMap keyed by tool_call_id', () => {
+    useMessageStore.getState().__applyEvent(makeRequestEvent())
+    const map = useMessageStore.getState().pendingConfirmMap
+    expect(map['tc-1']).toEqual({
+      question_id: 'qid-1',
+      command: 'rm -rf /tmp/x',
+      matched_pattern: 'rm *',
+      timeout_seconds: 180,
+      requestedAt: expect.any(Number),
+    })
+  })
+
+  it('is idempotent — duplicate event_id is ignored', () => {
+    const evt = makeRequestEvent()
+    useMessageStore.getState().__applyEvent(evt)
+    useMessageStore.getState().__applyEvent(evt)
+    expect(Object.keys(useMessageStore.getState().pendingConfirmMap)).toHaveLength(1)
+  })
+})
+
+describe('sandbox_confirm_resolved', () => {
+  it('removes entry from pendingConfirmMap by question_id', () => {
+    useMessageStore.getState().__applyEvent(makeRequestEvent())
+    useMessageStore.getState().__applyEvent(makeResolvedEvent('qid-1'))
+    expect(useMessageStore.getState().pendingConfirmMap['tc-1']).toBeUndefined()
+  })
+
+  it('is a no-op when question_id is not pending', () => {
+    useMessageStore.getState().__applyEvent(makeResolvedEvent('qid-unknown'))
+    expect(useMessageStore.getState().pendingConfirmMap).toEqual({})
+  })
+})

--- a/frontend/packages/core/src/api/stream.ts
+++ b/frontend/packages/core/src/api/stream.ts
@@ -59,6 +59,28 @@ export async function cancelSteer(
   return (await res.json()) as CancelSteerResponse
 }
 
+export interface SandboxConfirmResponse {
+  status: 'delivered' | 'published' | 'no_active_run'
+  run_id: string | null
+}
+
+export async function submitSandboxConfirm(
+  client: ApiClient,
+  conversationId: string,
+  questionId: string,
+  decision: 'approve' | 'deny',
+  reason?: string,
+): Promise<SandboxConfirmResponse> {
+  const res = await client.post(
+    `/api/v1/conversations/${conversationId}/sandbox-confirm/${questionId}`,
+    { decision, reason: reason ?? null },
+  )
+  if (!res.ok) {
+    throw new Error(`Failed to submit sandbox confirm: HTTP ${res.status}`)
+  }
+  return (await res.json()) as SandboxConfirmResponse
+}
+
 async function* readLines(reader: ReadableStreamDefaultReader<Uint8Array>): AsyncGenerator<string> {
   let buffer = ''
   const decoder = new TextDecoder()

--- a/frontend/packages/core/src/stores/index.ts
+++ b/frontend/packages/core/src/stores/index.ts
@@ -1,7 +1,12 @@
 export { useCitationStore, type CitationStore } from './citationStore'
 export { useArtifactStore, type ArtifactStore } from './artifactStore'
 export { useConversationStore, type ConversationStore } from './conversationStore'
-export { useMessageStore, type MessageStore, type AgentStream } from './messageStore'
+export {
+  useMessageStore,
+  type MessageStore,
+  type AgentStream,
+  type PendingConfirm,
+} from './messageStore'
 export {
   usePanelStore,
   type PanelStore,

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -548,7 +548,7 @@ function applyStreamEvent(state: MessageStore, event: AgentEvent): Partial<Messa
           command: d.command,
           matched_pattern: d.matched_pattern ?? null,
           timeout_seconds: d.timeout_seconds ?? null,
-          requestedAt: Date.now(),
+          requestedAt: event.timestamp ? new Date(event.timestamp).getTime() : Date.now(),
         },
       },
     }

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -51,6 +51,14 @@ export interface AgentStream {
   name: string | null
 }
 
+export interface PendingConfirm {
+  question_id: string
+  command: string
+  matched_pattern: string | null
+  timeout_seconds: number | null
+  requestedAt: number
+}
+
 export interface MessageStore {
   messages: Record<string, Message[]>
   pendingSteers: Record<string, { steerId: string; text: string }[]>
@@ -71,6 +79,7 @@ export interface MessageStore {
   turnUsage: Record<string, import('../types').TurnUsage | null>
   sessionUsage: Record<string, import('../types').SessionUsage | null>
   contextWindow: Record<string, number | null>
+  pendingConfirmMap: Record<string, PendingConfirm>
 
   loadMessages(client: ApiClient, conversationId: string): Promise<void>
   send(
@@ -86,6 +95,8 @@ export interface MessageStore {
   __commitTurnAndInject(conversationId: string, data: { content: string; steer_id: string }): void
   clearStream(): void
   clearLastRunStatus(): void
+  /** Test hook: apply a single AgentEvent synchronously */
+  __applyEvent(event: AgentEvent): void
 }
 
 let activeStreamController: AbortController | null = null
@@ -519,6 +530,41 @@ function applyStreamEvent(state: MessageStore, event: AgentEvent): Partial<Messa
     return base
   }
 
+  if (event.type === 'sandbox_confirm_request') {
+    const d = event.data as {
+      question_id: string
+      tool_call_id: string
+      command: string
+      matched_pattern: string | null
+      timeout_seconds: number | null
+    }
+    if (!d.tool_call_id) return base
+    return {
+      ...base,
+      pendingConfirmMap: {
+        ...state.pendingConfirmMap,
+        [d.tool_call_id]: {
+          question_id: d.question_id,
+          command: d.command,
+          matched_pattern: d.matched_pattern ?? null,
+          timeout_seconds: d.timeout_seconds ?? null,
+          requestedAt: Date.now(),
+        },
+      },
+    }
+  }
+
+  if (event.type === 'sandbox_confirm_resolved') {
+    const d = event.data as { question_id: string }
+    const tcId = Object.entries(state.pendingConfirmMap).find(
+      ([, v]) => v.question_id === d.question_id,
+    )?.[0]
+    if (!tcId) return base
+    const next = { ...state.pendingConfirmMap }
+    delete next[tcId]
+    return { ...base, pendingConfirmMap: next }
+  }
+
   return base
 }
 
@@ -650,6 +696,7 @@ async function finalizeCompletedStream(
   if (!assistantMessage) {
     set((state) => ({
       isStreaming: false,
+      pendingConfirmMap: {},
       streamingConversationId: null,
       currentRunId: null,
       statusPhase: null,
@@ -668,6 +715,7 @@ async function finalizeCompletedStream(
       ],
     },
     isStreaming: false,
+    pendingConfirmMap: {},
     streamingConversationId: null,
     currentRunId: null,
     statusPhase: null,
@@ -716,6 +764,7 @@ async function consumeRunStream(
         set((s) => ({
           error: errData.details || errData.message,
           isStreaming: false,
+          pendingConfirmMap: {},
           streamingConversationId: null,
           currentRunId: null,
           statusPhase: null,
@@ -788,6 +837,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
   todos: [],
   toolStartedMap: {},
   toolResultMap: {},
+  pendingConfirmMap: {},
   turnUsage: {},
   sessionUsage: {},
   contextWindow: {},
@@ -839,6 +889,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
         pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
         toolStartedMap: {},
         toolResultMap: {},
+        pendingConfirmMap: {},
         isStreaming: !!bootstrap.active_run,
         streamingConversationId: bootstrap.active_run ? conversationId : null,
         currentRunId: bootstrap.active_run?.run_id ?? null,
@@ -911,6 +962,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       todos: [],
       toolStartedMap: {},
       toolResultMap: {},
+      pendingConfirmMap: {},
       turnUsage: { ...state.turnUsage, [conversationId]: null },
     }))
 
@@ -965,6 +1017,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
             set((s) => ({
               error: errData.details || errData.message,
               isStreaming: false,
+              pendingConfirmMap: {},
               streamingConversationId: null,
               currentRunId: null,
               statusPhase: null,
@@ -1019,6 +1072,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       set((s) => ({
         error: (err as Error).message,
         isStreaming: false,
+        pendingConfirmMap: {},
         streamingConversationId: null,
         currentRunId: null,
         pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
@@ -1174,6 +1228,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
     } else {
       set((s) => ({
         isStreaming: false,
+        pendingConfirmMap: {},
         streamingConversationId: null,
         currentRunId: null,
         statusPhase: null,
@@ -1193,6 +1248,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       streamAgents: {},
       pendingSteers: {},
       isStreaming: false,
+      pendingConfirmMap: {},
       streamingConversationId: null,
       currentRunId: null,
       lastAppliedEventId: null,
@@ -1205,5 +1261,8 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
 
   clearLastRunStatus() {
     set({ lastRunStatus: null })
+  },
+  __applyEvent(event: AgentEvent) {
+    set((s) => applyStreamEvent(s, event) as MessageStore)
   },
 }))

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import type {
   AssistantMessage as AssistantMessageType,
   ContentBlock,
+  PendingConfirm,
   SubagentSummary,
   TodoItem,
 } from '@cubebox/core'
@@ -152,6 +153,8 @@ interface HistoryProps {
   statusPhase?: never
   subAgentStreams?: never
   todos?: never
+  pendingConfirmMap?: Record<string, PendingConfirm>
+  onSandboxConfirm?: (toolCallId: string, decision: 'approve' | 'deny') => Promise<void>
 }
 
 interface StreamingProps {
@@ -164,6 +167,8 @@ interface StreamingProps {
   statusPhase?: string | null
   subAgentStreams?: Record<string, AgentStream>
   todos?: TodoItem[]
+  pendingConfirmMap?: Record<string, PendingConfirm>
+  onSandboxConfirm?: (toolCallId: string, decision: 'approve' | 'deny') => Promise<void>
 }
 
 type AssistantMessageProps = HistoryProps | StreamingProps
@@ -204,6 +209,8 @@ function ContentBlockRenderer({
   subagentIndex,
   agentId,
   conversationId,
+  pendingConfirmMap,
+  onSandboxConfirm,
 }: {
   block: ContentBlock
   index: number
@@ -216,6 +223,8 @@ function ContentBlockRenderer({
   subagentIndex?: number
   agentId?: string | null
   conversationId?: string
+  pendingConfirmMap?: Record<string, PendingConfirm>
+  onSandboxConfirm?: (toolCallId: string, decision: 'approve' | 'deny') => Promise<void>
 }) {
   if (block.type === 'thinking') {
     return (
@@ -299,6 +308,8 @@ function ContentBlockRenderer({
         isStreaming={isStreaming}
         messageCreatedAt={messageCreatedAt}
         agentId={agentId}
+        pendingConfirmMap={pendingConfirmMap}
+        onSandboxConfirm={onSandboxConfirm}
       />
     )
   }
@@ -324,6 +335,8 @@ function ContentBlockRenderer({
         isStreaming={isStreaming}
         messageCreatedAt={messageCreatedAt}
         agentId={agentId}
+        pendingConfirmMap={pendingConfirmMap}
+        onSandboxConfirm={onSandboxConfirm}
       />
     )
   }
@@ -453,6 +466,8 @@ export function AssistantMessage({
   toolResultMap,
   todos,
   conversationId,
+  pendingConfirmMap,
+  onSandboxConfirm,
 }: AssistantMessageProps) {
   const t = useTranslations('chat')
   const streamAgentId = stream ? 'main' : undefined
@@ -504,6 +519,8 @@ export function AssistantMessage({
           isStreaming={isStreaming === true}
           messageCreatedAt={msgCreatedAt}
           agentId={streamAgentId}
+          pendingConfirmMap={pendingConfirmMap}
+          onSandboxConfirm={onSandboxConfirm}
         />
       )
     }
@@ -521,6 +538,8 @@ export function AssistantMessage({
         subagentIndex={subagentIndexMap.get(i)}
         agentId={streamAgentId}
         conversationId={conversationId}
+        pendingConfirmMap={pendingConfirmMap}
+        onSandboxConfirm={onSandboxConfirm}
       />
     )
   }

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -8,6 +8,7 @@ import {
   getTextContent,
   getToolResultPreviewContent,
   getSubagentSummary,
+  submitSandboxConfirm,
 } from '@cubebox/core'
 import type { Message, SubagentSummary } from '@cubebox/core'
 import { AlertCircle } from 'lucide-react'
@@ -122,6 +123,8 @@ export function MessageList({ conversationId }: MessageListProps) {
   } = useMessages(conversationId)
   const loadMessages = useMessageStore((s) => s.loadMessages)
   const lastRunStatus = useMessageStore((s) => s.lastRunStatus)
+  const pendingConfirmMap = useMessageStore((s) => s.pendingConfirmMap)
+  const streamingConversationId = useMessageStore((s) => s.streamingConversationId)
   const { workspaceId } = useWorkspaceContext()
 
   useEffect(() => {
@@ -129,6 +132,24 @@ export function MessageList({ conversationId }: MessageListProps) {
     if (workspaceId) client.setWorkspaceId(workspaceId)
     loadMessages(client, conversationId)
   }, [conversationId, loadMessages, workspaceId])
+
+  const handleSandboxConfirm = useCallback(
+    async (toolCallId: string, decision: 'approve' | 'deny') => {
+      const convId = streamingConversationId ?? conversationId
+      const pending = pendingConfirmMap[toolCallId]
+      if (!pending) return
+      const client = createApiClient('')
+      if (workspaceId) client.setWorkspaceId(workspaceId)
+      await submitSandboxConfirm(client, convId, pending.question_id, decision)
+      // Optimistic removal — sandbox_confirm_resolved SSE will also clean up
+      useMessageStore.setState((s) => {
+        const next = { ...s.pendingConfirmMap }
+        delete next[toolCallId]
+        return { pendingConfirmMap: next }
+      })
+    },
+    [conversationId, streamingConversationId, pendingConfirmMap, workspaceId],
+  )
 
   const subagentDataMap = useMemo(() => buildSubagentDataMap(messages ?? []), [messages])
 
@@ -219,6 +240,8 @@ export function MessageList({ conversationId }: MessageListProps) {
                 subagentDataMap={subagentDataMap}
                 toolResultMap={mergedToolResultMap}
                 conversationId={conversationId}
+                pendingConfirmMap={pendingConfirmMap}
+                onSandboxConfirm={handleSandboxConfirm}
               />
             )}
           </div>
@@ -233,6 +256,8 @@ export function MessageList({ conversationId }: MessageListProps) {
             toolResultMap={mergedToolResultMap}
             todos={todos}
             conversationId={conversationId}
+            pendingConfirmMap={pendingConfirmMap}
+            onSandboxConfirm={handleSandboxConfirm}
           />
         )}
 

--- a/frontend/packages/web/components/chat/SandboxConfirmCard.tsx
+++ b/frontend/packages/web/components/chat/SandboxConfirmCard.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Check, X, Clock } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { PendingConfirm } from '@cubebox/core'
+
+interface SandboxConfirmCardProps {
+  pending: PendingConfirm
+  onApprove: () => Promise<void>
+  onDeny: () => Promise<void>
+}
+
+export function SandboxConfirmCard({ pending, onApprove, onDeny }: SandboxConfirmCardProps) {
+  const [submitting, setSubmitting] = useState<'approve' | 'deny' | null>(null)
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(() => {
+    if (pending.timeout_seconds === null) return null
+    const elapsed = Math.floor((Date.now() - pending.requestedAt) / 1000)
+    return Math.max(0, pending.timeout_seconds - elapsed)
+  })
+
+  useEffect(() => {
+    if (secondsLeft === null || secondsLeft <= 0) return
+    const id = setInterval(() => setSecondsLeft((s) => (s !== null && s > 0 ? s - 1 : 0)), 1000)
+    return () => clearInterval(id)
+  }, [secondsLeft])
+
+  const handle = async (decision: 'approve' | 'deny') => {
+    if (submitting) return
+    setSubmitting(decision)
+    try {
+      if (decision === 'approve') await onApprove()
+      else await onDeny()
+    } catch {
+      setSubmitting(null)
+    }
+  }
+
+  return (
+    <div className="my-2 rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/30">
+      <div className="mb-2 flex items-center gap-2 text-sm font-medium text-amber-800 dark:text-amber-200">
+        <Clock className="h-4 w-4 shrink-0" />
+        <span>Command requires approval</span>
+        {secondsLeft !== null && secondsLeft > 0 && (
+          <span className="ml-auto tabular-nums text-amber-600 dark:text-amber-400">
+            {secondsLeft}s
+          </span>
+        )}
+      </div>
+      <code className="mb-3 block rounded bg-amber-100 px-2 py-1 text-xs text-amber-900 dark:bg-amber-900/40 dark:text-amber-100">
+        {pending.command}
+      </code>
+      {pending.matched_pattern && (
+        <p className="mb-3 text-xs text-amber-700 dark:text-amber-300">
+          Matched rule: <code className="font-mono">{pending.matched_pattern}</code>
+        </p>
+      )}
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          className="gap-1 bg-green-600 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-600"
+          disabled={!!submitting}
+          onClick={() => handle('approve')}
+        >
+          <Check className="h-3.5 w-3.5" />
+          {submitting === 'approve' ? 'Approving…' : 'Approve'}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          className="gap-1 border-red-300 text-red-600 hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950/30"
+          disabled={!!submitting}
+          onClick={() => handle('deny')}
+        >
+          <X className="h-3.5 w-3.5" />
+          {submitting === 'deny' ? 'Denying…' : 'Deny'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/packages/web/components/chat/ToolCallGroup.tsx
+++ b/frontend/packages/web/components/chat/ToolCallGroup.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ContentBlock, ToolCallRef } from '@cubebox/core'
+import type { ContentBlock, PendingConfirm, ToolCallRef } from '@cubebox/core'
 import { ToolCallItem } from './ToolCallItem'
 
 interface ToolCallGroupProps {
@@ -10,6 +10,8 @@ interface ToolCallGroupProps {
   /** ISO timestamp of the parent assistant message (used to compute tool call duration) */
   messageCreatedAt?: string
   agentId?: string | null
+  pendingConfirmMap?: Record<string, PendingConfirm>
+  onSandboxConfirm?: (toolCallId: string, decision: 'approve' | 'deny') => Promise<void>
 }
 
 export function ToolCallGroup({
@@ -18,6 +20,8 @@ export function ToolCallGroup({
   isStreaming,
   messageCreatedAt,
   agentId,
+  pendingConfirmMap,
+  onSandboxConfirm,
 }: ToolCallGroupProps) {
   return (
     <div
@@ -49,6 +53,8 @@ export function ToolCallGroup({
             isPending={isPending}
             allowOpenWhenPending={block.name === 'write_file'}
             showDivider={i > 0}
+            pendingConfirm={pendingConfirmMap?.[block.id] ?? null}
+            onSandboxConfirm={onSandboxConfirm ? (d) => onSandboxConfirm(block.id, d) : undefined}
           />
         )
       })}

--- a/frontend/packages/web/components/chat/ToolCallItem.tsx
+++ b/frontend/packages/web/components/chat/ToolCallItem.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useState, useEffect, useRef, memo } from 'react'
-import type { MCPToolIcon, ToolCallRef } from '@cubebox/core'
+import type { MCPToolIcon, PendingConfirm, ToolCallRef } from '@cubebox/core'
 import { CheckCircle2, Circle, PanelRight, Plug } from 'lucide-react'
 import { getToolIcon, getParamSummary } from '@/lib/toolIcons'
 import { useMcpToolRegistryStore, useToolDetailStore } from '@cubebox/core'
+import { SandboxConfirmCard } from './SandboxConfirmCard'
 
 /** Pick the best icon variant: prefer per-tool over server icon; fall back
  * to the first entry when nothing else matches. Theme matching is best-effort
@@ -35,6 +36,8 @@ interface ToolCallItemProps {
   allowOpenWhenPending?: boolean
   /** Show border-top separator (not first in group) */
   showDivider?: boolean
+  pendingConfirm?: PendingConfirm | null
+  onSandboxConfirm?: (decision: 'approve' | 'deny') => Promise<void>
 }
 
 function formatDuration(ms: number): string {
@@ -58,6 +61,8 @@ export const ToolCallItem = memo(function ToolCallItem({
   isPending,
   allowOpenWhenPending,
   showDivider,
+  pendingConfirm,
+  onSandboxConfirm,
 }: ToolCallItemProps) {
   const [elapsed, setElapsed] = useState(0)
   const startedAt = useRef(timestamp ? new Date(timestamp).getTime() : Date.now())
@@ -144,7 +149,7 @@ export const ToolCallItem = memo(function ToolCallItem({
           className="ml-auto flex items-center gap-1.5
             shrink-0"
         >
-          {isPending ? (
+          {pendingConfirm ? null : isPending ? (
             <>
               <Circle
                 className="size-2.5 text-blue-500
@@ -173,6 +178,13 @@ export const ToolCallItem = memo(function ToolCallItem({
           ) : null}
         </span>
       </button>
+      {pendingConfirm && onSandboxConfirm && (
+        <SandboxConfirmCard
+          pending={pendingConfirm}
+          onApprove={() => onSandboxConfirm('approve')}
+          onDeny={() => onSandboxConfirm('deny')}
+        />
+      )}
     </div>
   )
 })


### PR DESCRIPTION
## What

Frontend half of the sandbox HITL confirm feature (spec §8 PR split). The backend (#169) is already merged and frozen the SSE/API contract.

## Changes

- **`submitSandboxConfirm`** — API method posting to `/sandbox-confirm/{question_id}`
- **`pendingConfirmMap`** in `messageStore` — populated by `sandbox_confirm_request` SSE, cleared by `sandbox_confirm_resolved` or optimistic removal on submit; reset on all run-terminal paths
- **`SandboxConfirmCard`** — inline approve/deny card with server-time countdown
- **`ToolCallItem`** — renders card and suppresses pending spinner when confirmation is pending
- **`ToolCallGroup` / `AssistantMessage` / `MessageList`** — prop threading; submit callback injected at `MessageList`

## Test plan

- [ ] 4 vitest unit tests covering `pendingConfirmMap` state transitions (request → add, resolved → remove, idempotency)
- [ ] `pnpm --filter @cubebox/core exec vitest run` — 73 passed
- [ ] `pnpm --filter web run test` — 128 passed, 1 skipped
- [ ] `pnpm --filter web run build` — Next.js build clean
- [ ] Manual: requires live backend with a `confirm` command rule configured (frontend-only E2E not feasible)

## Known limitation

`SubAgentCard` is not wired — backend does not emit HITL confirmations for subagent tool calls (tracked separately).

## Deferred (LOW)

Submit failure currently re-enables buttons but shows no error feedback. Needs toast/inline error — deferred pending UX design decision.