### PR TITLE
feat(hitl): wire ask_user tool end-to-end — form card for agent questions

### DIFF
--- a/backend/cubebox/agents/schemas.py
+++ b/backend/cubebox/agents/schemas.py
@@ -194,3 +194,28 @@ class SandboxConfirmResolvedEvent(AgentEvent):
     data: dict[str, Any] = Field(
         description="Resolution: question_id, decision, cancelled, timed_out, reason"
     )
+
+
+class AskUserRequestEvent(AgentEvent):
+    """The agent called the ask_user built-in tool and is paused waiting for
+    the user to fill in the form. The frontend renders an AskUserCard.
+    """
+
+    type: Literal["ask_user_request"] = "ask_user_request"
+    data: dict[str, Any] = Field(
+        description=(
+            "question_id, questions (list of {key,prompt,options,multi_select,required}), "
+            "timeout_seconds"
+        )
+    )
+
+
+class AskUserResolvedEvent(AgentEvent):
+    """The pending ask_user was answered, cancelled, or timed out.
+    The frontend removes the AskUserCard.
+    """
+
+    type: Literal["ask_user_resolved"] = "ask_user_resolved"
+    data: dict[str, Any] = Field(
+        description="question_id, answers ({key: value|[values]}|null), cancelled, timed_out"
+    )

--- a/backend/cubebox/agents/stream.py
+++ b/backend/cubebox/agents/stream.py
@@ -224,9 +224,31 @@ def convert_agent_event_to_sse(evt: AgentEvent) -> list[dict[str, Any]]:
                     "timeout_seconds": req.timeout_seconds,
                 }
             ]
+        if payload.kind == "ask":
+            return [
+                {
+                    "type": "ask_user_request",
+                    "question_id": req.question_id,
+                    "questions": [q.model_dump() for q in payload.questions],
+                    "timeout_seconds": req.timeout_seconds,
+                }
+            ]
         return []
 
     if isinstance(evt, HitlAnswerEvent):
+        # Distinguish ask (dict answer) from approve (ApproveAnswer object).
+        # Cancelled answers (answer=None) default to sandbox_confirm_resolved —
+        # in v1 there is no cancel endpoint so this branch is unreachable.
+        if isinstance(evt.answer, dict):
+            return [
+                {
+                    "type": "ask_user_resolved",
+                    "question_id": evt.question_id,
+                    "answers": evt.answer,
+                    "cancelled": evt.cancelled,
+                    "timed_out": evt.timed_out,
+                }
+            ]
         resolved: dict[str, Any] = {
             "type": "sandbox_confirm_resolved",
             "question_id": evt.question_id,

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -370,6 +370,12 @@ class SandboxConfirmAnswer(BaseModel):
     reason: str | None = None
 
 
+class AskUserAnswer(BaseModel):
+    """Request body for submitting ask_user form answers."""
+
+    answers: dict[str, Any]
+
+
 class SendMessageRequest(BaseModel):
     """Request body for sending a message."""
 
@@ -1162,5 +1168,45 @@ async def submit_sandbox_confirm(
     run_manager = raw_request.app.state.run_manager
     dispatch_status = await run_manager.dispatch_hitl_answer(
         active_run.run_id, question_id, body.decision, body.reason
+    )
+    return {"status": dispatch_status, "run_id": active_run.run_id}
+
+
+@router.post(
+    "/{conversation_id}/ask-user/{question_id}",
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def submit_ask_user_answer(
+    conversation_id: str,
+    question_id: str,
+    body: AskUserAnswer,
+    raw_request: Request,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    ctx: Annotated[RequestContext, Depends(require_member)],
+    rds: Annotated[RedisHandle, Depends(redis_dep)],
+) -> dict[str, object]:
+    """Submit the user's answers for a pending ask_user form."""
+    conv_repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
+    conversation = await conv_repo.get_by_id(conversation_id)
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Conversation {conversation_id} not found",
+        )
+
+    active_run = await get_active_run(
+        rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
+    )
+    if active_run is None or active_run.status != "running":
+        return {"status": "no_active_run", "run_id": None}
+
+    run_manager = raw_request.app.state.run_manager
+    dispatch_status = await run_manager.dispatch_ask_user_answer(
+        active_run.run_id, question_id, body.answers
     )
     return {"status": dispatch_status, "run_id": active_run.run_id}

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -259,6 +259,8 @@ def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent 
     """
     from cubebox.agents.schemas import (
         ArtifactEvent,
+        AskUserRequestEvent,
+        AskUserResolvedEvent,
         ErrorEvent,
         InjectedMessageEvent,
         ReasoningEvent,
@@ -353,6 +355,25 @@ def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent 
                 "cancelled": d.get("cancelled", False),
                 "timed_out": d.get("timed_out", False),
                 "reason": d.get("reason"),
+            },
+        )
+    if t == "ask_user_request":
+        return AskUserRequestEvent(
+            timestamp=timestamp,
+            data={
+                "question_id": d.get("question_id", ""),
+                "questions": d.get("questions", []),
+                "timeout_seconds": d.get("timeout_seconds"),
+            },
+        )
+    if t == "ask_user_resolved":
+        return AskUserResolvedEvent(
+            timestamp=timestamp,
+            data={
+                "question_id": d.get("question_id", ""),
+                "answers": d.get("answers"),
+                "cancelled": d.get("cancelled", False),
+                "timed_out": d.get("timed_out", False),
             },
         )
     if t == "usage":
@@ -689,6 +710,39 @@ class RunManager:
             logger.warning("hitl_answer delivery failed for run {}", run_id, exc_info=True)
         return True
 
+    async def dispatch_ask_user_answer(
+        self, run_id: str, question_id: str, answers: dict[str, Any]
+    ) -> str:
+        """Deliver a user's ask_user form answers to the pending ask.
+
+        Fast path when this worker holds the run's channel; otherwise publish
+        on the control channel so the worker that does can deliver it.
+        """
+        if await self._deliver_ask_user_answer(run_id, question_id, answers):
+            return "delivered"
+        await self._publish_control(
+            run_id,
+            "ask_user_answer",
+            extra={"question_id": question_id, "answers": answers},
+        )
+        return "published"
+
+    async def _deliver_ask_user_answer(
+        self, run_id: str, question_id: str, answers: dict[str, Any]
+    ) -> bool:
+        """Answer the in-process channel with ask_user form answers.
+
+        Returns True if delivered; False if this worker doesn't own the run.
+        """
+        channel = self._hitl_channels.get(run_id)
+        if channel is None:
+            return False
+        try:
+            await channel.answer(question_id, answers)
+        except Exception:
+            logger.warning("ask_user_answer delivery failed for run {}", run_id, exc_info=True)
+        return True
+
     async def dispatch_cancel_steer(self, run_id: str, steer_id: str) -> str:
         agent = self._agents.get(run_id)
         if agent is not None:
@@ -747,6 +801,12 @@ class RunManager:
                 data.get("question_id") or "",
                 data.get("decision") or "",
                 data.get("reason"),
+            )
+        elif type_ == "ask_user_answer":
+            await self._deliver_ask_user_answer(
+                run_id,
+                data.get("question_id") or "",
+                data.get("answers") or {},
             )
 
     async def _handle_ack(self, data: dict[str, Any]) -> None:

--- a/backend/tests/unit/test_run_manager_ask_user_answer.py
+++ b/backend/tests/unit/test_run_manager_ask_user_answer.py
@@ -1,0 +1,123 @@
+"""RunManager delivers an ask_user HITL answer to the in-process channel."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from cubebox.streams.run_manager import RunManager, cubepi_dict_to_agent_event
+
+
+class _RecordingChannel:
+    def __init__(self) -> None:
+        self.answers: list[tuple[str, object]] = []
+
+    async def answer(self, question_id: str, answer: object) -> None:
+        self.answers.append((question_id, answer))
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, str]] = []
+
+    async def publish(self, channel: str, data: str) -> int:
+        self.published.append((channel, data))
+        return 0
+
+
+def _make_rm() -> RunManager:
+    return RunManager(
+        app=MagicMock(),
+        redis=_FakeRedis(),  # type: ignore[arg-type]
+        key_prefix="t",
+        run_event_ttl_seconds=60,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_ask_user_answer_delivers_in_process() -> None:
+    rm = _make_rm()
+    ch = _RecordingChannel()
+    rm._hitl_channels["run_1"] = ch
+    answers = {"color": "red", "size": "medium"}
+    result = await rm.dispatch_ask_user_answer("run_1", "qid-ask", answers)
+    assert result == "delivered"
+    assert ch.answers == [("qid-ask", answers)]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_ask_user_answer_publishes_when_not_local() -> None:
+    rm = _make_rm()
+    answers = {"topic": "python"}
+    result = await rm.dispatch_ask_user_answer("ghost", "qid-ask", answers)
+    assert result == "published"
+    assert rm._redis.published  # type: ignore[attr-defined]
+    _, payload = rm._redis.published[0]  # type: ignore[attr-defined]
+    data = json.loads(payload)
+    assert data["type"] == "ask_user_answer"
+    assert data["question_id"] == "qid-ask"
+    assert data["answers"] == answers
+
+
+@pytest.mark.asyncio
+async def test_handle_control_routes_ask_user_answer() -> None:
+    rm = _make_rm()
+    ch = _RecordingChannel()
+    rm._hitl_channels["run_1"] = ch
+    await rm._handle_control(
+        {
+            "type": "ask_user_answer",
+            "run_id": "run_1",
+            "question_id": "qid-ask",
+            "answers": {"color": "blue"},
+        }
+    )
+    assert ch.answers == [("qid-ask", {"color": "blue"})]
+
+
+def test_cubepi_dict_to_agent_event_ask_user_request() -> None:
+    from cubebox.agents.schemas import AskUserRequestEvent
+
+    evt = cubepi_dict_to_agent_event(
+        {
+            "type": "ask_user_request",
+            "question_id": "qid-1",
+            "questions": [
+                {
+                    "key": "color",
+                    "prompt": "Pick a color?",
+                    "options": None,
+                    "multi_select": False,
+                    "required": True,
+                }
+            ],
+            "timeout_seconds": 120.0,
+        },
+        "2026-05-30T00:00:00+00:00",
+    )
+    assert isinstance(evt, AskUserRequestEvent)
+    assert evt.data["question_id"] == "qid-1"
+    assert len(evt.data["questions"]) == 1
+    assert evt.data["questions"][0]["key"] == "color"
+    assert evt.data["timeout_seconds"] == 120.0
+
+
+def test_cubepi_dict_to_agent_event_ask_user_resolved() -> None:
+    from cubebox.agents.schemas import AskUserResolvedEvent
+
+    evt = cubepi_dict_to_agent_event(
+        {
+            "type": "ask_user_resolved",
+            "question_id": "qid-1",
+            "answers": {"color": "red"},
+            "cancelled": False,
+            "timed_out": False,
+        },
+        "2026-05-30T00:00:00+00:00",
+    )
+    assert isinstance(evt, AskUserResolvedEvent)
+    assert evt.data["question_id"] == "qid-1"
+    assert evt.data["answers"] == {"color": "red"}
+    assert evt.data["cancelled"] is False

--- a/backend/tests/unit/test_stream_ask_user.py
+++ b/backend/tests/unit/test_stream_ask_user.py
@@ -1,0 +1,98 @@
+"""Unit tests for ask_user HITL event translation in convert_agent_event_to_sse."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from cubebox.agents.stream import convert_agent_event_to_sse
+
+
+def _make_hitl_request(kind: str, question_id: str = "qid-1") -> MagicMock:
+    req = MagicMock()
+    req.question_id = question_id
+    req.timeout_seconds = 120.0
+    if kind == "ask":
+        payload = MagicMock()
+        payload.kind = "ask"
+        q = MagicMock()
+        q.model_dump.return_value = {
+            "key": "color",
+            "prompt": "Pick a color?",
+            "options": None,
+            "multi_select": False,
+            "required": True,
+        }
+        payload.questions = [q]
+        req.payload = payload
+    else:
+        payload = MagicMock()
+        payload.kind = "approve"
+        payload.tool_call_id = "tc-1"
+        payload.tool_name = "execute"
+        payload.args = {"command": "rm /tmp/x"}
+        payload.details = {"matched_pattern": "rm *"}
+        req.payload = payload
+    return req
+
+
+def _make_hitl_event(req: MagicMock) -> MagicMock:
+    from cubepi.agent.types import HitlRequestEvent  # type: ignore[import-untyped]
+
+    evt = MagicMock(spec=HitlRequestEvent)
+    evt.__class__ = HitlRequestEvent
+    evt.request = req
+    return evt
+
+
+def _make_answer_event(answer: object, *, cancelled: bool = False) -> MagicMock:
+    from cubepi.agent.types import HitlAnswerEvent  # type: ignore[import-untyped]
+
+    evt = MagicMock(spec=HitlAnswerEvent)
+    evt.__class__ = HitlAnswerEvent
+    evt.question_id = "qid-1"
+    evt.answer = answer
+    evt.cancelled = cancelled
+    evt.timed_out = False
+    return evt
+
+
+def test_ask_kind_emits_ask_user_request() -> None:
+    req = _make_hitl_request("ask", "qid-1")
+    evt = _make_hitl_event(req)
+    out = convert_agent_event_to_sse(evt)
+    assert len(out) == 1
+    d = out[0]
+    assert d["type"] == "ask_user_request"
+    assert d["question_id"] == "qid-1"
+    assert d["timeout_seconds"] == 120.0
+    assert len(d["questions"]) == 1
+    assert d["questions"][0]["key"] == "color"
+
+
+def test_approve_kind_still_emits_sandbox_confirm_request() -> None:
+    req = _make_hitl_request("approve", "qid-2")
+    evt = _make_hitl_event(req)
+    out = convert_agent_event_to_sse(evt)
+    assert len(out) == 1
+    assert out[0]["type"] == "sandbox_confirm_request"
+
+
+def test_answer_dict_emits_ask_user_resolved() -> None:
+    evt = _make_answer_event({"color": "red"})
+    out = convert_agent_event_to_sse(evt)
+    assert len(out) == 1
+    d = out[0]
+    assert d["type"] == "ask_user_resolved"
+    assert d["question_id"] == "qid-1"
+    assert d["answers"] == {"color": "red"}
+    assert d["cancelled"] is False
+
+
+def test_approve_answer_emits_sandbox_confirm_resolved() -> None:
+    from cubepi.hitl import ApproveAnswer
+
+    evt = _make_answer_event(ApproveAnswer(decision="approve", reason=None))
+    out = convert_agent_event_to_sse(evt)
+    assert len(out) == 1
+    assert out[0]["type"] == "sandbox_confirm_resolved"
+    assert out[0]["decision"] == "approve"

--- a/frontend/packages/core/__tests__/stores/messageStore.askUser.test.ts
+++ b/frontend/packages/core/__tests__/stores/messageStore.askUser.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useMessageStore } from '../../src/stores/messageStore'
+import type { AgentEvent } from '../../src/types'
+
+const TS = new Date().toISOString()
+
+function makeRequestEvent(overrides?: {
+  question_id?: string
+  timeout_seconds?: number | null
+}): AgentEvent {
+  return {
+    type: 'ask_user_request',
+    event_id: 'ev-1',
+    timestamp: TS,
+    agent_id: null,
+    agent_name: null,
+    data: {
+      question_id: overrides?.question_id ?? 'qid-ask-1',
+      questions: [
+        {
+          key: 'color',
+          prompt: 'Pick a color?',
+          options: null,
+          multi_select: false,
+          required: true,
+        },
+      ],
+      timeout_seconds: overrides?.timeout_seconds ?? 120,
+    },
+  } as unknown as AgentEvent
+}
+
+function makeResolvedEvent(questionId = 'qid-ask-1'): AgentEvent {
+  return {
+    type: 'ask_user_resolved',
+    event_id: 'ev-2',
+    timestamp: TS,
+    agent_id: null,
+    agent_name: null,
+    data: {
+      question_id: questionId,
+      answers: { color: 'red' },
+      cancelled: false,
+      timed_out: false,
+    },
+  } as unknown as AgentEvent
+}
+
+beforeEach(() => {
+  useMessageStore.setState({ pendingAsk: null, lastAppliedEventId: null })
+})
+
+describe('ask_user_request', () => {
+  it('sets pendingAsk with question data and requestedAt', () => {
+    useMessageStore.getState().__applyEvent(makeRequestEvent())
+    const ask = useMessageStore.getState().pendingAsk
+    expect(ask).not.toBeNull()
+    expect(ask?.question_id).toBe('qid-ask-1')
+    expect(ask?.questions).toHaveLength(1)
+    expect(ask?.questions[0].key).toBe('color')
+    expect(ask?.timeout_seconds).toBe(120)
+    expect(ask?.requestedAt).toBeGreaterThan(0)
+  })
+
+  it('uses event.timestamp for requestedAt', () => {
+    const past = '2026-01-01T00:00:00.000Z'
+    const evt = makeRequestEvent()
+    evt.timestamp = past
+    useMessageStore.getState().__applyEvent(evt)
+    const ask = useMessageStore.getState().pendingAsk
+    expect(ask?.requestedAt).toBe(new Date(past).getTime())
+  })
+
+  it('is idempotent on duplicate event_id', () => {
+    const evt = makeRequestEvent()
+    useMessageStore.getState().__applyEvent(evt)
+    useMessageStore.getState().__applyEvent(evt) // same event_id
+    expect(useMessageStore.getState().pendingAsk?.question_id).toBe('qid-ask-1')
+  })
+})
+
+describe('ask_user_resolved', () => {
+  it('clears pendingAsk when question_id matches', () => {
+    useMessageStore.getState().__applyEvent(makeRequestEvent())
+    expect(useMessageStore.getState().pendingAsk).not.toBeNull()
+    useMessageStore.getState().__applyEvent(makeResolvedEvent())
+    expect(useMessageStore.getState().pendingAsk).toBeNull()
+  })
+
+  it('is a no-op when no pending ask', () => {
+    useMessageStore.getState().__applyEvent(makeResolvedEvent('unknown-qid'))
+    expect(useMessageStore.getState().pendingAsk).toBeNull()
+  })
+})
+
+describe('tool_result clears pendingAsk for ask_user tool', () => {
+  it('clears pendingAsk when tool_result name is ask_user', () => {
+    useMessageStore.getState().__applyEvent(makeRequestEvent())
+    expect(useMessageStore.getState().pendingAsk).not.toBeNull()
+    const toolResultEvt = {
+      type: 'tool_result',
+      event_id: 'ev-3',
+      timestamp: TS,
+      agent_id: null,
+      agent_name: null,
+      data: {
+        tool_call_id: 'tc-ask-1',
+        name: 'ask_user',
+        content: 'User answers: {"color": "red"}',
+        is_error: false,
+        details: null,
+      },
+    } as unknown as AgentEvent
+    useMessageStore.getState().__applyEvent(toolResultEvt)
+    expect(useMessageStore.getState().pendingAsk).toBeNull()
+  })
+
+  it('does not clear pendingAsk for other tool results', () => {
+    useMessageStore.getState().__applyEvent(makeRequestEvent())
+    const toolResultEvt = {
+      type: 'tool_result',
+      event_id: 'ev-4',
+      timestamp: TS,
+      agent_id: null,
+      agent_name: null,
+      data: {
+        tool_call_id: 'tc-other-1',
+        name: 'execute',
+        content: 'done',
+        is_error: false,
+        details: null,
+      },
+    } as unknown as AgentEvent
+    useMessageStore.getState().__applyEvent(toolResultEvt)
+    expect(useMessageStore.getState().pendingAsk).not.toBeNull()
+  })
+})

--- a/frontend/packages/core/src/api/stream.ts
+++ b/frontend/packages/core/src/api/stream.ts
@@ -81,6 +81,26 @@ export async function submitSandboxConfirm(
   return (await res.json()) as SandboxConfirmResponse
 }
 
+export interface AskUserResponse {
+  status: 'delivered' | 'published' | 'no_active_run'
+  run_id: string | null
+}
+
+export async function submitAskUserAnswer(
+  client: ApiClient,
+  conversationId: string,
+  questionId: string,
+  answers: Record<string, string | string[]>,
+): Promise<AskUserResponse> {
+  const res = await client.post(`/api/v1/conversations/${conversationId}/ask-user/${questionId}`, {
+    answers,
+  })
+  if (!res.ok) {
+    throw new Error(`Failed to submit ask_user answer: HTTP ${res.status}`)
+  }
+  return (await res.json()) as AskUserResponse
+}
+
 async function* readLines(reader: ReadableStreamDefaultReader<Uint8Array>): AsyncGenerator<string> {
   let buffer = ''
   const decoder = new TextDecoder()

--- a/frontend/packages/core/src/stores/index.ts
+++ b/frontend/packages/core/src/stores/index.ts
@@ -6,6 +6,7 @@ export {
   type MessageStore,
   type AgentStream,
   type PendingConfirm,
+  type PendingAsk,
 } from './messageStore'
 export {
   usePanelStore,

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -59,6 +59,13 @@ export interface PendingConfirm {
   requestedAt: number
 }
 
+export interface PendingAsk {
+  question_id: string
+  questions: import('../types/events').AskQuestion[]
+  timeout_seconds: number | null
+  requestedAt: number
+}
+
 export interface MessageStore {
   messages: Record<string, Message[]>
   pendingSteers: Record<string, { steerId: string; text: string }[]>
@@ -80,6 +87,7 @@ export interface MessageStore {
   sessionUsage: Record<string, import('../types').SessionUsage | null>
   contextWindow: Record<string, number | null>
   pendingConfirmMap: Record<string, PendingConfirm>
+  pendingAsk: PendingAsk | null
 
   loadMessages(client: ApiClient, conversationId: string): Promise<void>
   send(
@@ -506,8 +514,13 @@ function applyStreamEvent(state: MessageStore, event: AgentEvent): Partial<Messa
       }
     }
 
+    // ask_user tool result (including timeout/error) means the ask is resolved.
+    // The SSE dict key is "name" (runtime); TypeScript type says "tool_name" — cast to access it.
+    const clearAsk =
+      (e.data as unknown as { name?: string }).name === 'ask_user' ? { pendingAsk: null } : {}
     return {
       ...base,
+      ...clearAsk,
       toolResultMap: newMap,
       streamAgents: {
         ...state.streamAgents,
@@ -563,6 +576,30 @@ function applyStreamEvent(state: MessageStore, event: AgentEvent): Partial<Messa
     const next = { ...state.pendingConfirmMap }
     delete next[tcId]
     return { ...base, pendingConfirmMap: next }
+  }
+
+  if (event.type === 'ask_user_request') {
+    const d = event.data as {
+      question_id: string
+      questions: import('../types/events').AskQuestion[]
+      timeout_seconds: number | null
+    }
+    if (state.pendingAsk?.question_id === d.question_id) return base // idempotent
+    return {
+      ...base,
+      pendingAsk: {
+        question_id: d.question_id,
+        questions: d.questions,
+        timeout_seconds: d.timeout_seconds ?? null,
+        requestedAt: event.timestamp ? new Date(event.timestamp).getTime() : Date.now(),
+      },
+    }
+  }
+
+  if (event.type === 'ask_user_resolved') {
+    const d = event.data as { question_id: string }
+    if (state.pendingAsk?.question_id !== d.question_id) return base
+    return { ...base, pendingAsk: null }
   }
 
   return base
@@ -697,6 +734,7 @@ async function finalizeCompletedStream(
     set((state) => ({
       isStreaming: false,
       pendingConfirmMap: {},
+      pendingAsk: null,
       streamingConversationId: null,
       currentRunId: null,
       statusPhase: null,
@@ -716,6 +754,7 @@ async function finalizeCompletedStream(
     },
     isStreaming: false,
     pendingConfirmMap: {},
+    pendingAsk: null,
     streamingConversationId: null,
     currentRunId: null,
     statusPhase: null,
@@ -765,6 +804,7 @@ async function consumeRunStream(
           error: errData.details || errData.message,
           isStreaming: false,
           pendingConfirmMap: {},
+          pendingAsk: null,
           streamingConversationId: null,
           currentRunId: null,
           statusPhase: null,
@@ -838,6 +878,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
   toolStartedMap: {},
   toolResultMap: {},
   pendingConfirmMap: {},
+  pendingAsk: null,
   turnUsage: {},
   sessionUsage: {},
   contextWindow: {},
@@ -890,6 +931,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
         toolStartedMap: {},
         toolResultMap: {},
         pendingConfirmMap: {},
+        pendingAsk: null,
         isStreaming: !!bootstrap.active_run,
         streamingConversationId: bootstrap.active_run ? conversationId : null,
         currentRunId: bootstrap.active_run?.run_id ?? null,
@@ -963,6 +1005,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       toolStartedMap: {},
       toolResultMap: {},
       pendingConfirmMap: {},
+      pendingAsk: null,
       turnUsage: { ...state.turnUsage, [conversationId]: null },
     }))
 
@@ -1018,6 +1061,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
               error: errData.details || errData.message,
               isStreaming: false,
               pendingConfirmMap: {},
+              pendingAsk: null,
               streamingConversationId: null,
               currentRunId: null,
               statusPhase: null,
@@ -1073,6 +1117,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
         error: (err as Error).message,
         isStreaming: false,
         pendingConfirmMap: {},
+        pendingAsk: null,
         streamingConversationId: null,
         currentRunId: null,
         pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
@@ -1229,6 +1274,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       set((s) => ({
         isStreaming: false,
         pendingConfirmMap: {},
+        pendingAsk: null,
         streamingConversationId: null,
         currentRunId: null,
         statusPhase: null,
@@ -1249,6 +1295,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       pendingSteers: {},
       isStreaming: false,
       pendingConfirmMap: {},
+      pendingAsk: null,
       streamingConversationId: null,
       currentRunId: null,
       lastAppliedEventId: null,

--- a/frontend/packages/core/src/types/events.ts
+++ b/frontend/packages/core/src/types/events.ts
@@ -63,6 +63,8 @@ export type AgentEventType =
   | 'injected_message'
   | 'sandbox_confirm_request'
   | 'sandbox_confirm_resolved'
+  | 'ask_user_request'
+  | 'ask_user_resolved'
 
 export interface AgentEvent {
   type: AgentEventType
@@ -185,6 +187,40 @@ export interface SandboxConfirmResolvedEvent extends AgentEvent {
     cancelled: boolean
     timed_out: boolean
     reason: string | null
+  }
+}
+
+export interface AskOption {
+  label: string
+  value: string
+  description: string | null
+  allow_input: boolean
+}
+
+export interface AskQuestion {
+  key: string
+  prompt: string
+  options: AskOption[] | null
+  multi_select: boolean
+  required: boolean
+}
+
+export interface AskUserRequestEvent extends AgentEvent {
+  type: 'ask_user_request'
+  data: {
+    question_id: string
+    questions: AskQuestion[]
+    timeout_seconds: number | null
+  }
+}
+
+export interface AskUserResolvedEvent extends AgentEvent {
+  type: 'ask_user_resolved'
+  data: {
+    question_id: string
+    answers: Record<string, string | string[]> | null
+    cancelled: boolean
+    timed_out: boolean
   }
 }
 

--- a/frontend/packages/web/components/chat/AskUserCard.tsx
+++ b/frontend/packages/web/components/chat/AskUserCard.tsx
@@ -115,8 +115,14 @@ export function AskUserCard({ pending, onSubmit }: AskUserCardProps) {
     setAnswers((prev) => ({ ...prev, [key]: value }))
   }
 
+  const hasUnfilledRequired = pending.questions.some((q) => {
+    if (!q.required) return false
+    const v = answers[q.key]
+    return Array.isArray(v) ? v.length === 0 : v === ''
+  })
+
   const handleSubmit = async () => {
-    if (submitting) return
+    if (submitting || hasUnfilledRequired) return
     setSubmitting(true)
     try {
       await onSubmit(answers)
@@ -147,7 +153,12 @@ export function AskUserCard({ pending, onSubmit }: AskUserCardProps) {
         ))}
       </div>
       <div className="mt-3">
-        <Button size="sm" className="gap-1" disabled={submitting} onClick={handleSubmit}>
+        <Button
+          size="sm"
+          className="gap-1"
+          disabled={submitting || hasUnfilledRequired}
+          onClick={handleSubmit}
+        >
           <Send className="h-3.5 w-3.5" />
           {submitting ? 'Sending…' : 'Submit'}
         </Button>

--- a/frontend/packages/web/components/chat/AskUserCard.tsx
+++ b/frontend/packages/web/components/chat/AskUserCard.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Clock, Send } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import type { PendingAsk, AskQuestion } from '@cubebox/core'
+
+interface AskUserCardProps {
+  pending: PendingAsk
+  onSubmit: (answers: Record<string, string | string[]>) => Promise<void>
+}
+
+function QuestionField({
+  question,
+  value,
+  onChange,
+}: {
+  question: AskQuestion
+  value: string | string[]
+  onChange: (v: string | string[]) => void
+}) {
+  if (!question.options) {
+    return (
+      <div className="flex flex-col gap-1">
+        <Label className="text-sm font-medium text-foreground">{question.prompt}</Label>
+        <Input
+          value={typeof value === 'string' ? value : ''}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-8 text-sm"
+        />
+      </div>
+    )
+  }
+
+  if (question.multi_select) {
+    const selected = Array.isArray(value) ? value : []
+    return (
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-sm font-medium text-foreground">{question.prompt}</Label>
+        {question.options.map((opt) => (
+          <div key={opt.value} className="flex items-center gap-2">
+            <Checkbox
+              id={`${question.key}-${opt.value}`}
+              checked={selected.includes(opt.value)}
+              onCheckedChange={(checked) => {
+                const next = checked
+                  ? [...selected, opt.value]
+                  : selected.filter((v) => v !== opt.value)
+                onChange(next)
+              }}
+            />
+            <Label
+              htmlFor={`${question.key}-${opt.value}`}
+              className="cursor-pointer text-sm text-foreground"
+            >
+              {opt.label}
+            </Label>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  // Single select — radio group
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label className="text-sm font-medium text-foreground">{question.prompt}</Label>
+      <RadioGroup
+        value={typeof value === 'string' ? value : ''}
+        onValueChange={(v) => onChange(v)}
+        className="flex flex-col gap-1"
+      >
+        {question.options.map((opt) => (
+          <div key={opt.value} className="flex items-center gap-2">
+            <RadioGroupItem value={opt.value} id={`${question.key}-${opt.value}`} />
+            <Label
+              htmlFor={`${question.key}-${opt.value}`}
+              className="cursor-pointer text-sm text-foreground"
+            >
+              {opt.label}
+            </Label>
+          </div>
+        ))}
+      </RadioGroup>
+    </div>
+  )
+}
+
+export function AskUserCard({ pending, onSubmit }: AskUserCardProps) {
+  const [answers, setAnswers] = useState<Record<string, string | string[]>>(() => {
+    const init: Record<string, string | string[]> = {}
+    for (const q of pending.questions) {
+      init[q.key] = q.multi_select ? [] : ''
+    }
+    return init
+  })
+  const [submitting, setSubmitting] = useState(false)
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(() => {
+    if (pending.timeout_seconds === null) return null
+    const elapsed = Math.floor((Date.now() - pending.requestedAt) / 1000)
+    return Math.max(0, pending.timeout_seconds - elapsed)
+  })
+
+  useEffect(() => {
+    if (secondsLeft === null || secondsLeft <= 0) return
+    const id = setInterval(() => setSecondsLeft((s) => (s !== null && s > 0 ? s - 1 : 0)), 1000)
+    return () => clearInterval(id)
+  }, [secondsLeft])
+
+  const setAnswer = (key: string, value: string | string[]) => {
+    setAnswers((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const handleSubmit = async () => {
+    if (submitting) return
+    setSubmitting(true)
+    try {
+      await onSubmit(answers)
+    } catch {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="my-2 rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/30">
+      <div className="mb-3 flex items-center gap-2 text-sm font-medium text-blue-800 dark:text-blue-200">
+        <Clock className="h-4 w-4 shrink-0" />
+        <span>Agent is asking for your input</span>
+        {secondsLeft !== null && secondsLeft > 0 && (
+          <span className="ml-auto tabular-nums text-blue-600 dark:text-blue-400">
+            {secondsLeft}s
+          </span>
+        )}
+      </div>
+      <div className="flex flex-col gap-3">
+        {pending.questions.map((q) => (
+          <QuestionField
+            key={q.key}
+            question={q}
+            value={answers[q.key] ?? (q.multi_select ? [] : '')}
+            onChange={(v) => setAnswer(q.key, v)}
+          />
+        ))}
+      </div>
+      <div className="mt-3">
+        <Button size="sm" className="gap-1" disabled={submitting} onClick={handleSubmit}>
+          <Send className="h-3.5 w-3.5" />
+          {submitting ? 'Sending…' : 'Submit'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -281,7 +281,11 @@ export function MessageList({ conversationId }: MessageListProps) {
           <div className="flex gap-2.5">
             <div className="shrink-0 w-6 h-6" />
             <div className="flex-1 max-w-[75%]">
-              <AskUserCard pending={pendingAsk} onSubmit={handleAskUserSubmit} />
+              <AskUserCard
+                key={pendingAsk.question_id}
+                pending={pendingAsk}
+                onSubmit={handleAskUserSubmit}
+              />
             </div>
           </div>
         )}

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -9,11 +9,13 @@ import {
   getToolResultPreviewContent,
   getSubagentSummary,
   submitSandboxConfirm,
+  submitAskUserAnswer,
 } from '@cubebox/core'
 import type { Message, SubagentSummary } from '@cubebox/core'
 import { AlertCircle } from 'lucide-react'
 import { UserMessage } from './UserMessage'
 import { AssistantMessage } from './AssistantMessage'
+import { AskUserCard } from './AskUserCard'
 import { MessageAttachments } from './MessageAttachments'
 import { TokenUsageBar } from './TokenUsageBar'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -124,6 +126,7 @@ export function MessageList({ conversationId }: MessageListProps) {
   const loadMessages = useMessageStore((s) => s.loadMessages)
   const lastRunStatus = useMessageStore((s) => s.lastRunStatus)
   const pendingConfirmMap = useMessageStore((s) => s.pendingConfirmMap)
+  const pendingAsk = useMessageStore((s) => s.pendingAsk)
   const streamingConversationId = useMessageStore((s) => s.streamingConversationId)
   const { workspaceId } = useWorkspaceContext()
 
@@ -149,6 +152,19 @@ export function MessageList({ conversationId }: MessageListProps) {
       })
     },
     [conversationId, streamingConversationId, pendingConfirmMap, workspaceId],
+  )
+
+  const handleAskUserSubmit = useCallback(
+    async (answers: Record<string, string | string[]>) => {
+      if (!pendingAsk) return
+      const convId = streamingConversationId ?? conversationId
+      const client = createApiClient('')
+      if (workspaceId) client.setWorkspaceId(workspaceId)
+      await submitAskUserAnswer(client, convId, pendingAsk.question_id, answers)
+      // Optimistic clear — ask_user_resolved SSE will also clean up
+      useMessageStore.setState({ pendingAsk: null })
+    },
+    [conversationId, streamingConversationId, pendingAsk, workspaceId],
   )
 
   const subagentDataMap = useMemo(() => buildSubagentDataMap(messages ?? []), [messages])
@@ -259,6 +275,15 @@ export function MessageList({ conversationId }: MessageListProps) {
             pendingConfirmMap={pendingConfirmMap}
             onSandboxConfirm={handleSandboxConfirm}
           />
+        )}
+
+        {pendingAsk && streamingConversationId === conversationId && (
+          <div className="flex gap-2.5">
+            <div className="shrink-0 w-6 h-6" />
+            <div className="flex-1 max-w-[75%]">
+              <AskUserCard pending={pendingAsk} onSubmit={handleAskUserSubmit} />
+            </div>
+          </div>
         )}
 
         {!isStreaming &&


### PR DESCRIPTION
## Summary

- **Backend**: `stream.py` translates `HitlRequestEvent(kind=ask)` → `ask_user_request` SSE dict, and distinguishes ask/approve answers in `HitlAnswerEvent` by type. `run_manager.py` adds `dispatch_ask_user_answer` / `_deliver_ask_user_answer` + Redis control channel routing. New `POST /{conv}/ask-user/{question_id}` endpoint delivers form answers to the in-process channel.
- **Frontend**: `pendingAsk` state in Zustand; `AskUserCard` renders text input / radio / checkbox questions with countdown, required-field validation, and state reset on `question_id` change; `MessageList` shows the card only when `streamingConversationId === conversationId` to prevent cross-conversation leakage.

## Architecture

```
agent calls ask_user tool
  → HitlRequestEvent(kind=ask)
  → convert_agent_event_to_sse → ask_user_request SSE dict
  → cubepi_dict_to_agent_event → AskUserRequestEvent
  → SSE → applyStreamEvent → pendingAsk state → AskUserCard renders

user submits form
  → POST /{conv}/ask-user/{question_id} {answers:{...}}
  → dispatch_ask_user_answer → channel.answer(qid, dict)
  → HitlAnswerEvent(answer=dict) → ask_user_resolved SSE
  → applyStreamEvent → pendingAsk = null (card removed)
```

## Deferred

- `allow_input: true` options (custom text on a select option) — needs UX design
- Toast/inline error on submit failure — same as sandbox confirm deferral

## Test plan

- [ ] Backend unit tests: `test_stream_ask_user.py` (4 tests), `test_run_manager_ask_user_answer.py` (5 tests) — all passing
- [ ] Frontend unit tests: `messageStore.askUser.test.ts` (8 tests) — all passing
- [ ] mypy strict: all 4 modified backend files clean
- [ ] tsc --noEmit: both `@cubebox/core` and `web` clean
- [ ] E2E: agent uses `ask_user` tool → form card appears → submit → agent receives answers → continues