### PR TITLE
fix(hitl): wire ask_user_tool + fix hydration mismatch (post #171)

### DIFF
--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1478,6 +1478,11 @@ class RunManager:
                 # Middleware tools (execute, write_file, edit_file, file_read) collected for
                 # ordered merge below
                 _sandbox_tools.extend(sandbox_mw.tools)
+                # ask_user built-in tool shares the same HITL channel so the agent
+                # can ask structured questions that pause execution just like a confirm rule.
+                from cubepi.hitl import ask_user_tool
+
+                _builtin_tools.append(ask_user_tool(sandbox_hitl_channel))
             except Exception as _exc:
                 logger.warning("SandboxMiddleware unavailable: {}", _exc)
 

--- a/frontend/packages/web/components/chat/AskUserCard.tsx
+++ b/frontend/packages/web/components/chat/AskUserCard.tsx
@@ -99,17 +99,20 @@ export function AskUserCard({ pending, onSubmit }: AskUserCardProps) {
     return init
   })
   const [submitting, setSubmitting] = useState(false)
-  const [secondsLeft, setSecondsLeft] = useState<number | null>(() => {
-    if (pending.timeout_seconds === null) return null
-    const elapsed = Math.floor((Date.now() - pending.requestedAt) / 1000)
-    return Math.max(0, pending.timeout_seconds - elapsed)
-  })
+  // Initialise to null to avoid SSR/CSR hydration mismatch (Date.now() differs).
+  // The first useEffect sets the real value after mount.
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(null)
 
   useEffect(() => {
-    if (secondsLeft === null || secondsLeft <= 0) return
-    const id = setInterval(() => setSecondsLeft((s) => (s !== null && s > 0 ? s - 1 : 0)), 1000)
+    if (pending.timeout_seconds === null) return
+    const computeLeft = () => {
+      const elapsed = Math.floor((Date.now() - pending.requestedAt) / 1000)
+      return Math.max(0, pending.timeout_seconds! - elapsed)
+    }
+    setSecondsLeft(computeLeft())
+    const id = setInterval(() => setSecondsLeft(computeLeft()), 1000)
     return () => clearInterval(id)
-  }, [secondsLeft])
+  }, [pending.timeout_seconds, pending.requestedAt])
 
   const setAnswer = (key: string, value: string | string[]) => {
     setAnswers((prev) => ({ ...prev, [key]: value }))


### PR DESCRIPTION
Two fixes missed before #171 merged:

1. **`wire ask_user_tool into agent`** — Critical: `ask_user_tool` was never added to the agent's tool list. Without this, the agent doesn't know about the `ask_user` tool and can never call it. Fixed by appending `ask_user_tool(sandbox_hitl_channel)` to `_builtin_tools` when the sandbox HITL channel is created.

2. **`initialize secondsLeft in useEffect`** — Hydration mismatch: `secondsLeft` was initialized via `useState(() => Date.now() - ...)` which runs at different times on server vs client, causing a recoverable React hydration error. Fixed by initializing to `null` and computing the value in `useEffect` after mount.