### PR TITLE
feat(skills): add ClawhubAdapter for clawhub.ai registry

### DIFF
--- a/backend/cubebox/api/routes/v1/admin_skill_registries.py
+++ b/backend/cubebox/api/routes/v1/admin_skill_registries.py
@@ -20,7 +20,7 @@ from cubebox.repositories.skill_registry import SkillRegistryRepository
 router = APIRouter(prefix="/admin/skill-registries", tags=["admin-skill-registries"])
 
 _TRUST_TIERS = {"official", "community", "untrusted"}
-_VALID_KINDS = {"remote", "skills-sh"}
+_VALID_KINDS = {"remote", "skills-sh", "clawhub"}
 
 # Hostnames that name the local box or known-internal infra. Save-time
 # rejection of these is a defense-in-depth measure on top of trusting org
@@ -91,7 +91,7 @@ def _validate_registry_base_url(raw: str) -> None:
 
 class CreateSkillRegistryRequest(BaseModel):
     name: str
-    kind: Literal["remote", "skills-sh"] = "remote"
+    kind: Literal["remote", "skills-sh", "clawhub"] = "remote"
     base_url: str = ""
     repo: str | None = None
     trust_tier: str = "untrusted"
@@ -135,8 +135,8 @@ async def create_registry(
         raise HTTPException(status_code=400, detail="BAD_TRUST_TIER")
     if body.kind not in _VALID_KINDS:
         raise HTTPException(status_code=400, detail="BAD_KIND")
-    if body.kind == "skills-sh":
-        base_url = _SKILLS_SH_BASE_URL
+    if body.kind in {"skills-sh", "clawhub"}:
+        base_url = _SKILLS_SH_BASE_URL if body.kind == "skills-sh" else "https://clawhub.ai"
     else:
         base_url = body.base_url
         _validate_registry_base_url(base_url)

--- a/backend/cubebox/skills/sources/clawhub.py
+++ b/backend/cubebox/skills/sources/clawhub.py
@@ -23,6 +23,7 @@ from typing import AsyncGenerator
 
 import httpx
 
+from cubebox.skills.service import MAX_FILE_BYTES, MAX_TOTAL_BYTES
 from cubebox.skills.sources.base import (
     SkillCandidate,
     SourceKind,
@@ -32,7 +33,6 @@ from cubebox.skills.sources.base import (
 
 _BASE_URL = "https://clawhub.ai"
 _TIMEOUT = 20.0
-_MAX_ZIP_BYTES = 50 * 1024 * 1024  # 50 MB, same cap as validate_skill_files
 
 
 class ClawhubAdapter:
@@ -161,18 +161,24 @@ class ClawhubAdapter:
             version_tag = await self._resolve_latest_version(slug)
 
         async with self._client() as client:
-            resp = await client.get(
+            async with client.stream(
+                "GET",
                 "/api/v1/download",
                 params={"slug": slug, "version": version_tag},
                 headers={"Accept": "application/zip"},
-            )
-            resp.raise_for_status()
-            zip_bytes = resp.content
-
-        if len(zip_bytes) > _MAX_ZIP_BYTES:
-            raise ValueError(
-                f"Clawhub zip for {slug}@{version_tag} exceeds cap {_MAX_ZIP_BYTES} bytes"
-            )
+            ) as resp:
+                resp.raise_for_status()
+                chunks: list[bytes] = []
+                total = 0
+                async for chunk in resp.aiter_bytes(65536):
+                    total += len(chunk)
+                    if total > MAX_TOTAL_BYTES:
+                        raise ValueError(
+                            f"Clawhub zip for {slug}@{version_tag} exceeds cap "
+                            f"{MAX_TOTAL_BYTES} bytes"
+                        )
+                    chunks.append(chunk)
+                zip_bytes = b"".join(chunks)
 
         return _unpack_zip(zip_bytes)
 
@@ -199,14 +205,20 @@ class ClawhubAdapter:
 
 
 def _unpack_zip(zip_bytes: bytes) -> dict[str, bytes]:
-    """Extract a Clawhub skill zip, returning safe rel_path → bytes mappings."""
+    """Extract a Clawhub skill zip, returning safe rel_path → bytes mappings.
+
+    Applies per-file and cumulative size caps matching validate_skill_files()
+    to guard against zip bombs before inflating any entry.
+    """
     files: dict[str, bytes] = {}
     try:
         zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
     except zipfile.BadZipFile as e:
         raise ValueError(f"Clawhub download is not a valid zip: {e}") from e
+    total = 0
     with zf:
-        for name in zf.namelist():
+        for info in zf.infolist():
+            name = info.filename
             # Skip directories and unsafe paths
             if name.endswith("/"):
                 continue
@@ -216,5 +228,16 @@ def _unpack_zip(zip_bytes: bytes) -> dict[str, bytes]:
             parts = normalized.split("/")
             if any(p in (".", "..") for p in parts):
                 continue
+            # Guard against zip bombs: check declared uncompressed size first
+            if info.file_size > MAX_FILE_BYTES:
+                raise ValueError(
+                    f"Clawhub zip entry {name!r} declares {info.file_size} bytes; "
+                    f"cap is {MAX_FILE_BYTES}"
+                )
+            total += info.file_size
+            if total > MAX_TOTAL_BYTES:
+                raise ValueError(
+                    f"Clawhub zip bundle exceeds total cap of {MAX_TOTAL_BYTES} bytes"
+                )
             files[name] = zf.read(name)
     return files

--- a/backend/cubebox/skills/sources/clawhub.py
+++ b/backend/cubebox/skills/sources/clawhub.py
@@ -15,6 +15,7 @@ API (https://clawhub.ai):
 
 from __future__ import annotations
 
+import asyncio
 import io
 import zipfile
 from contextlib import asynccontextmanager
@@ -79,6 +80,16 @@ class ClawhubAdapter:
         if not isinstance(results, list):
             return []
 
+        # Collect slugs whose version is null — resolve them concurrently.
+        slugs_needing_version = [
+            str(item.get("slug") or "")
+            for item in results
+            if isinstance(item, dict) and item.get("slug") and not item.get("version")
+        ]
+        resolved: dict[str, str] = {}
+        if slugs_needing_version:
+            resolved = await self._resolve_versions(slugs_needing_version)
+
         out: list[SkillCandidate] = []
         for item in results:
             if not isinstance(item, dict):
@@ -89,10 +100,10 @@ class ClawhubAdapter:
             display_name = str(item.get("displayName") or slug)
             summary = str(item.get("summary") or "")
             owner_handle = str(item.get("ownerHandle") or "")
-            # version may be null — use slug@latest as source_ref; fetch() resolves it
-            version = item.get("version")
-            version_str = str(version) if version else None
-            source_ref = f"{slug}@{version_str}" if version_str else f"{slug}@latest"
+            version = item.get("version") or resolved.get(slug)
+            if not version:
+                continue  # skip if version still unknown — avoids opaque @latest installs
+            source_ref = f"{slug}@{version}"
 
             out.append(
                 SkillCandidate(
@@ -104,6 +115,7 @@ class ClawhubAdapter:
                     description=summary,
                     source_kind="remote",
                     source_ref=source_ref,
+                    version=version,
                     trust=self._trust,
                     install_state="available",
                     source_name=self._source_name,
@@ -111,6 +123,19 @@ class ClawhubAdapter:
                 )
             )
         return out
+
+    async def _resolve_versions(self, slugs: list[str]) -> dict[str, str]:
+        """Fetch the latest version tag for each slug concurrently."""
+
+        async def _fetch_one(slug: str) -> tuple[str, str | None]:
+            try:
+                version = await self._resolve_latest_version(slug)
+                return slug, version
+            except Exception:  # noqa: BLE001
+                return slug, None
+
+        pairs = await asyncio.gather(*(_fetch_one(s) for s in slugs))
+        return {slug: ver for slug, ver in pairs if ver is not None}
 
     def trust_for_ref(self, source_ref: str) -> TrustTier:
         return self._trust

--- a/backend/cubebox/skills/sources/clawhub.py
+++ b/backend/cubebox/skills/sources/clawhub.py
@@ -1,0 +1,179 @@
+"""ClawhubAdapter — connects skill discovery to the Clawhub public registry.
+
+API (https://clawhub.ai):
+  GET /api/v1/search?q=...&limit=...
+      {"results": [{"slug", "displayName", "summary", "version", "ownerHandle",
+                    "owner": {"handle", "displayName"}, ...}]}
+
+  GET /api/v1/skills/{slug}
+      {"skill": {"slug", "displayName", "summary", "tags": {"latest": "x.y.z"},
+                 "stats": {"downloads", "installsAllTime", "stars", ...}}, ...}
+
+  GET /api/v1/download?slug={slug}&version={version}
+      → application/zip containing SKILL.md, supporting files, and _meta.json
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+import httpx
+
+from cubebox.skills.sources.base import (
+    SkillCandidate,
+    SourceKind,
+    TrustTier,
+    encode_candidate_id,
+)
+
+_BASE_URL = "https://clawhub.ai"
+_TIMEOUT = 20.0
+_MAX_ZIP_BYTES = 50 * 1024 * 1024  # 50 MB, same cap as validate_skill_files
+
+
+class ClawhubAdapter:
+    """Search and fetch skills from the Clawhub registry."""
+
+    kind: SourceKind = "remote"
+
+    def __init__(
+        self,
+        *,
+        source_id: str,
+        trust_tier: TrustTier,
+        source_name: str = "Clawhub",
+    ) -> None:
+        self.source_id = source_id
+        self._trust = trust_tier
+        self._source_name = source_name
+
+    @asynccontextmanager
+    async def _client(self) -> AsyncGenerator[httpx.AsyncClient, None]:
+        async with httpx.AsyncClient(
+            base_url=_BASE_URL,
+            timeout=_TIMEOUT,
+            headers={"Accept": "application/json"},
+            follow_redirects=True,
+        ) as client:
+            yield client
+
+    async def search(self, query: str, *, limit: int) -> list[SkillCandidate]:
+        try:
+            return await self._search(query, limit=limit)
+        except Exception:  # noqa: BLE001 — one bad remote must not kill discovery
+            return []
+
+    async def _search(self, query: str, *, limit: int) -> list[SkillCandidate]:
+        async with self._client() as client:
+            resp = await client.get(
+                "/api/v1/search", params={"q": query, "limit": limit}
+            )
+            if not resp.is_success:
+                return []
+            data = resp.json()
+
+        results = data.get("results", [])
+        if not isinstance(results, list):
+            return []
+
+        out: list[SkillCandidate] = []
+        for item in results:
+            if not isinstance(item, dict):
+                continue
+            slug = str(item.get("slug") or "")
+            if not slug:
+                continue
+            display_name = str(item.get("displayName") or slug)
+            summary = str(item.get("summary") or "")
+            owner_handle = str(item.get("ownerHandle") or "")
+            # version may be null — use slug@latest as source_ref; fetch() resolves it
+            version = item.get("version")
+            version_str = str(version) if version else None
+            source_ref = f"{slug}@{version_str}" if version_str else f"{slug}@latest"
+
+            out.append(
+                SkillCandidate(
+                    candidate_id=encode_candidate_id(
+                        "remote", source_ref, source_id=self.source_id
+                    ),
+                    name=display_name,
+                    canonical_name=slug,
+                    description=summary,
+                    source_kind="remote",
+                    source_ref=source_ref,
+                    trust=self._trust,
+                    install_state="available",
+                    source_name=self._source_name,
+                    repo=f"https://clawhub.ai/{owner_handle}/{slug}" if owner_handle else None,
+                )
+            )
+        return out
+
+    def trust_for_ref(self, source_ref: str) -> TrustTier:
+        return self._trust
+
+    async def fetch(self, source_ref: str) -> dict[str, bytes]:
+        """Download the skill zip and return {rel_path: bytes}.
+
+        source_ref format: "{slug}@{version}" or "{slug}@latest"
+        """
+        slug, _, version_tag = source_ref.partition("@")
+        if not slug:
+            raise ValueError(f"invalid Clawhub source_ref: {source_ref!r}")
+
+        # Resolve "latest" by fetching skill metadata
+        if not version_tag or version_tag == "latest":
+            version_tag = await self._resolve_latest_version(slug)
+
+        async with self._client() as client:
+            resp = await client.get(
+                "/api/v1/download",
+                params={"slug": slug, "version": version_tag},
+                headers={"Accept": "application/zip"},
+            )
+            resp.raise_for_status()
+            zip_bytes = resp.content
+
+        if len(zip_bytes) > _MAX_ZIP_BYTES:
+            raise ValueError(
+                f"Clawhub zip for {slug}@{version_tag} exceeds cap {_MAX_ZIP_BYTES} bytes"
+            )
+
+        return _unpack_zip(zip_bytes)
+
+    async def _resolve_latest_version(self, slug: str) -> str:
+        async with self._client() as client:
+            resp = await client.get(f"/api/v1/skills/{slug}")
+            resp.raise_for_status()
+            data = resp.json()
+        skill = data.get("skill", {})
+        tags = skill.get("tags") or {}
+        latest = tags.get("latest")
+        if not isinstance(latest, str) or not latest:
+            raise ValueError(f"Clawhub skill {slug!r} has no latest version tag")
+        return latest
+
+
+def _unpack_zip(zip_bytes: bytes) -> dict[str, bytes]:
+    """Extract a Clawhub skill zip, returning safe rel_path → bytes mappings."""
+    files: dict[str, bytes] = {}
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile as e:
+        raise ValueError(f"Clawhub download is not a valid zip: {e}") from e
+    with zf:
+        for name in zf.namelist():
+            # Skip directories and unsafe paths
+            if name.endswith("/"):
+                continue
+            normalized = name.replace("\\", "/")
+            if normalized.startswith("/"):
+                continue
+            parts = normalized.split("/")
+            if any(p in (".", "..") for p in parts):
+                continue
+            files[name] = zf.read(name)
+    return files

--- a/backend/cubebox/skills/sources/clawhub.py
+++ b/backend/cubebox/skills/sources/clawhub.py
@@ -81,14 +81,16 @@ class ClawhubAdapter:
             return []
 
         # Collect slugs whose version is null — resolve them concurrently.
-        slugs_needing_version = [
+        # Also fetch stats (installs) since the search response doesn't include them.
+        slugs_needing_detail = [
             str(item.get("slug") or "")
             for item in results
             if isinstance(item, dict) and item.get("slug") and not item.get("version")
         ]
-        resolved: dict[str, str] = {}
-        if slugs_needing_version:
-            resolved = await self._resolve_versions(slugs_needing_version)
+        # resolved: slug → (version, install_count)
+        resolved: dict[str, tuple[str, int | None]] = {}
+        if slugs_needing_detail:
+            resolved = await self._resolve_details(slugs_needing_detail)
 
         out: list[SkillCandidate] = []
         for item in results:
@@ -100,9 +102,11 @@ class ClawhubAdapter:
             display_name = str(item.get("displayName") or slug)
             summary = str(item.get("summary") or "")
             owner_handle = str(item.get("ownerHandle") or "")
-            version = item.get("version") or resolved.get(slug)
+            detail = resolved.get(slug)
+            version = item.get("version") or (detail[0] if detail else None)
             if not version:
                 continue  # skip if version still unknown — avoids opaque @latest installs
+            install_count = detail[1] if detail else None
             source_ref = f"{slug}@{version}"
 
             out.append(
@@ -118,24 +122,27 @@ class ClawhubAdapter:
                     version=version,
                     trust=self._trust,
                     install_state="available",
+                    install_count=install_count,
                     source_name=self._source_name,
                     repo=f"https://clawhub.ai/{owner_handle}/{slug}" if owner_handle else None,
                 )
             )
         return out
 
-    async def _resolve_versions(self, slugs: list[str]) -> dict[str, str]:
-        """Fetch the latest version tag for each slug concurrently."""
+    async def _resolve_details(
+        self, slugs: list[str]
+    ) -> dict[str, tuple[str, int | None]]:
+        """Fetch version + install count for each slug concurrently."""
 
-        async def _fetch_one(slug: str) -> tuple[str, str | None]:
+        async def _fetch_one(slug: str) -> tuple[str, tuple[str, int | None] | None]:
             try:
-                version = await self._resolve_latest_version(slug)
-                return slug, version
+                version, install_count = await self._fetch_skill_detail(slug)
+                return slug, (version, install_count)
             except Exception:  # noqa: BLE001
                 return slug, None
 
         pairs = await asyncio.gather(*(_fetch_one(s) for s in slugs))
-        return {slug: ver for slug, ver in pairs if ver is not None}
+        return {slug: detail for slug, detail in pairs if detail is not None}
 
     def trust_for_ref(self, source_ref: str) -> TrustTier:
         return self._trust
@@ -169,7 +176,8 @@ class ClawhubAdapter:
 
         return _unpack_zip(zip_bytes)
 
-    async def _resolve_latest_version(self, slug: str) -> str:
+    async def _fetch_skill_detail(self, slug: str) -> tuple[str, int | None]:
+        """Fetch latest version and install count from the skill detail endpoint."""
         async with self._client() as client:
             resp = await client.get(f"/api/v1/skills/{slug}")
             resp.raise_for_status()
@@ -179,7 +187,15 @@ class ClawhubAdapter:
         latest = tags.get("latest")
         if not isinstance(latest, str) or not latest:
             raise ValueError(f"Clawhub skill {slug!r} has no latest version tag")
-        return latest
+        stats = skill.get("stats") or {}
+        install_count = stats.get("installsAllTime")
+        if not isinstance(install_count, int):
+            install_count = None
+        return latest, install_count
+
+    async def _resolve_latest_version(self, slug: str) -> str:
+        version, _ = await self._fetch_skill_detail(slug)
+        return version
 
 
 def _unpack_zip(zip_bytes: bytes) -> dict[str, bytes]:

--- a/backend/cubebox/skills/sources/registry.py
+++ b/backend/cubebox/skills/sources/registry.py
@@ -8,6 +8,7 @@ from cubebox.config import config as _config
 from cubebox.repositories.skill_registry import SkillRegistryRepository
 from cubebox.skills.service import SkillCatalogService
 from cubebox.skills.sources.base import SkillRegistryAdapter, TrustTier
+from cubebox.skills.sources.clawhub import ClawhubAdapter
 from cubebox.skills.sources.local import LocalCatalogAdapter
 from cubebox.skills.sources.remote import RemoteRegistryAdapter
 from cubebox.skills.sources.skills_sh import SkillsShAdapter
@@ -62,6 +63,14 @@ class SkillsAdapterManager:
                         github_token=_config.get(
                             "registry.skills_sh.github_token"
                         ) or None,
+                    )
+                )
+            elif row.kind == "clawhub":
+                adapters.append(
+                    ClawhubAdapter(
+                        source_id=row.id,
+                        trust_tier=TrustTier(row.trust_tier),
+                        source_name=row.name,
                     )
                 )
             else:

--- a/backend/tests/unit/test_clawhub_adapter.py
+++ b/backend/tests/unit/test_clawhub_adapter.py
@@ -1,0 +1,152 @@
+"""Unit tests for ClawhubAdapter — search, fetch, and version resolution."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import zipfile
+
+import httpx
+import pytest
+
+from cubebox.skills.sources.base import TrustTier
+from cubebox.skills.sources.clawhub import ClawhubAdapter, _unpack_zip
+
+
+def _make_zip(files: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+def _adapter(transport: httpx.MockTransport) -> ClawhubAdapter:
+    adapter = ClawhubAdapter(
+        source_id="test-clawhub",
+        trust_tier=TrustTier.community,
+        source_name="Clawhub",
+    )
+
+    @contextlib.asynccontextmanager
+    async def _mock_client():
+        async with httpx.AsyncClient(
+            base_url="https://clawhub.ai",
+            transport=transport,
+            follow_redirects=True,
+        ) as client:
+            yield client
+
+    adapter._client = _mock_client  # type: ignore[method-assign]
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_search_returns_candidates():
+    payload = {
+        "results": [
+            {
+                "slug": "design",
+                "displayName": "Design",
+                "summary": "Auto-learns your visual preferences.",
+                "version": "1.0.0",
+                "ownerHandle": "ivangdavila",
+                "owner": {"handle": "ivangdavila", "displayName": "Iván"},
+            },
+            {
+                "slug": "frontend-design",
+                "displayName": "Frontend Design",
+                "summary": "Create polished frontend interfaces.",
+                "version": None,
+                "ownerHandle": "someone",
+                "owner": {"handle": "someone", "displayName": "Someone"},
+            },
+        ]
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/search"
+        assert request.url.params["q"] == "design"
+        return httpx.Response(200, json=payload)
+
+    adapter = _adapter(httpx.MockTransport(handler))
+    results = await adapter.search("design", limit=5)
+
+    assert len(results) == 2
+    assert results[0].name == "Design"
+    assert results[0].canonical_name == "design"
+    assert results[0].source_ref == "design@1.0.0"
+    assert results[1].source_ref == "frontend-design@latest"
+    assert results[0].repo == "https://clawhub.ai/ivangdavila/design"
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_api_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="Internal Server Error")
+
+    adapter = _adapter(httpx.MockTransport(handler))
+    results = await adapter.search("test", limit=5)
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_with_explicit_version():
+    zip_bytes = _make_zip(
+        {"SKILL.md": "---\nname: design\n---\n# Design", "criteria.md": "criteria"}
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/download"
+        assert request.url.params["slug"] == "design"
+        assert request.url.params["version"] == "1.0.0"
+        return httpx.Response(200, content=zip_bytes, headers={"content-type": "application/zip"})
+
+    adapter = _adapter(httpx.MockTransport(handler))
+    files = await adapter.fetch("design@1.0.0")
+
+    assert "SKILL.md" in files
+    assert b"Design" in files["SKILL.md"]
+    assert "criteria.md" in files
+
+
+@pytest.mark.asyncio
+async def test_fetch_resolves_latest_version():
+    skill_detail = {
+        "skill": {
+            "slug": "design",
+            "displayName": "Design",
+            "tags": {"latest": "2.0.0"},
+            "stats": {"downloads": 100, "stars": 5},
+        }
+    }
+    zip_bytes = _make_zip({"SKILL.md": "# Design v2"})
+    call_log: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_log.append(request.url.path)
+        if request.url.path == "/api/v1/skills/design":
+            return httpx.Response(200, json=skill_detail)
+        if request.url.path == "/api/v1/download":
+            assert request.url.params["version"] == "2.0.0"
+            return httpx.Response(200, content=zip_bytes)
+        return httpx.Response(404)
+
+    adapter = _adapter(httpx.MockTransport(handler))
+    files = await adapter.fetch("design@latest")
+
+    assert "SKILL.md" in files
+    assert "/api/v1/skills/design" in call_log
+    assert "/api/v1/download" in call_log
+
+
+def test_unpack_zip_filters_unsafe_paths():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("SKILL.md", "# ok")
+        zf.writestr("../evil.py", "bad")
+        zf.writestr("/absolute.md", "bad")
+    files = _unpack_zip(buf.getvalue())
+    assert "SKILL.md" in files
+    assert "../evil.py" not in files
+    assert "/absolute.md" not in files

--- a/backend/tests/unit/test_clawhub_adapter.py
+++ b/backend/tests/unit/test_clawhub_adapter.py
@@ -64,10 +64,21 @@ async def test_search_returns_candidates():
         ]
     }
 
+    # frontend-design has version=null → needs resolution via GET /api/v1/skills/{slug}
+    skill_detail = {
+        "skill": {
+            "slug": "frontend-design",
+            "displayName": "Frontend Design",
+            "tags": {"latest": "0.3.1"},
+        }
+    }
+
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == "/api/v1/search"
-        assert request.url.params["q"] == "design"
-        return httpx.Response(200, json=payload)
+        if request.url.path == "/api/v1/search":
+            return httpx.Response(200, json=payload)
+        if request.url.path == "/api/v1/skills/frontend-design":
+            return httpx.Response(200, json=skill_detail)
+        return httpx.Response(404)
 
     adapter = _adapter(httpx.MockTransport(handler))
     results = await adapter.search("design", limit=5)
@@ -76,8 +87,46 @@ async def test_search_returns_candidates():
     assert results[0].name == "Design"
     assert results[0].canonical_name == "design"
     assert results[0].source_ref == "design@1.0.0"
-    assert results[1].source_ref == "frontend-design@latest"
+    assert results[0].version == "1.0.0"
+    # version was null → resolved to "0.3.1"
+    assert results[1].source_ref == "frontend-design@0.3.1"
+    assert results[1].version == "0.3.1"
     assert results[0].repo == "https://clawhub.ai/ivangdavila/design"
+
+
+@pytest.mark.asyncio
+async def test_search_skips_skill_when_version_unresolvable():
+    """Skills with version=null that fail resolution are dropped from results."""
+    payload = {
+        "results": [
+            {
+                "slug": "good",
+                "displayName": "Good",
+                "summary": "",
+                "version": "1.0.0",
+                "ownerHandle": "u",
+            },
+            {
+                "slug": "no-ver",
+                "displayName": "No Ver",
+                "summary": "",
+                "version": None,
+                "ownerHandle": "u",
+            },
+        ]
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/search":
+            return httpx.Response(200, json=payload)
+        if "/skills/no-ver" in request.url.path:
+            return httpx.Response(500)  # resolution fails
+        return httpx.Response(404)
+
+    adapter = _adapter(httpx.MockTransport(handler))
+    results = await adapter.search("x", limit=5)
+    assert len(results) == 1
+    assert results[0].canonical_name == "good"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_clawhub_adapter.py
+++ b/backend/tests/unit/test_clawhub_adapter.py
@@ -199,3 +199,28 @@ def test_unpack_zip_filters_unsafe_paths():
     assert "SKILL.md" in files
     assert "../evil.py" not in files
     assert "/absolute.md" not in files
+
+
+def test_unpack_zip_rejects_oversized_entry():
+    from cubebox.skills.service import MAX_FILE_BYTES
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        # Entry larger than MAX_FILE_BYTES
+        zf.writestr("big.md", "x" * (MAX_FILE_BYTES + 1))
+    with pytest.raises(ValueError, match="declares"):
+        _unpack_zip(buf.getvalue())
+
+
+def test_unpack_zip_rejects_oversized_bundle():
+    from cubebox.skills.service import MAX_FILE_BYTES, MAX_TOTAL_BYTES
+
+    # Two files each just under the per-file cap but together over the bundle cap
+    file_size = MAX_FILE_BYTES - 1
+    n_files = (MAX_TOTAL_BYTES // file_size) + 2
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for i in range(n_files):
+            zf.writestr(f"file{i}.md", "x" * file_size)
+    with pytest.raises(ValueError, match="total cap"):
+        _unpack_zip(buf.getvalue())

--- a/frontend/packages/web/components/admin/skill-registries/AddRegistryForm.tsx
+++ b/frontend/packages/web/components/admin/skill-registries/AddRegistryForm.tsx
@@ -18,15 +18,23 @@ interface AddRegistryFormProps {
 
 export function AddRegistryForm({ onSubmit, onCancel, mutating, error }: AddRegistryFormProps) {
   const t = useTranslations('adminSkillRegistries')
-  const [kind, setKind] = useState<'skills-sh' | 'remote'>('skills-sh')
+  const [kind, setKind] = useState<'skills-sh' | 'clawhub' | 'remote'>('skills-sh')
   const [name, setName] = useState('skills.sh')
   const [baseUrl, setBaseUrl] = useState('')
   const [trustTier, setTrustTier] = useState<string>('community')
 
-  function handleKindChange(next: 'skills-sh' | 'remote') {
+  function handleKindChange(next: 'skills-sh' | 'clawhub' | 'remote') {
     setKind(next)
-    setName(next === 'skills-sh' ? 'skills.sh' : '')
-    setTrustTier(next === 'skills-sh' ? 'community' : 'untrusted')
+    if (next === 'skills-sh') {
+      setName('skills.sh')
+      setTrustTier('community')
+    } else if (next === 'clawhub') {
+      setName('Clawhub')
+      setTrustTier('community')
+    } else {
+      setName('')
+      setTrustTier('untrusted')
+    }
     setBaseUrl('')
   }
 
@@ -55,7 +63,7 @@ export function AddRegistryForm({ onSubmit, onCancel, mutating, error }: AddRegi
       <div className="flex flex-col gap-2">
         <label className="text-sm font-medium">{t('kind')}</label>
         <div className="inline-flex items-center gap-0.5 rounded-lg border border-border bg-muted/30 p-0.5 self-start">
-          {(['skills-sh', 'remote'] as const).map((k) => (
+          {(['skills-sh', 'clawhub', 'remote'] as const).map((k) => (
             <button
               key={k}
               type="button"
@@ -67,7 +75,7 @@ export function AddRegistryForm({ onSubmit, onCancel, mutating, error }: AddRegi
                   : 'text-muted-foreground hover:text-foreground',
               )}
             >
-              {k === 'skills-sh' ? 'skills.sh' : t('customRegistry')}
+              {k === 'skills-sh' ? 'skills.sh' : k === 'clawhub' ? 'Clawhub' : t('customRegistry')}
             </button>
           ))}
         </div>

--- a/frontend/packages/web/components/admin/skill-registries/RegistryCard.tsx
+++ b/frontend/packages/web/components/admin/skill-registries/RegistryCard.tsx
@@ -7,7 +7,7 @@ import type { SkillRegistryEntry } from '@/hooks/useAdminSkillRegistries'
 function KindBadge({ kind }: { kind: string }) {
   return (
     <span className="rounded-full bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-      {kind === 'skills-sh' ? 'skills.sh' : 'Custom'}
+      {kind === 'skills-sh' ? 'skills.sh' : kind === 'clawhub' ? 'Clawhub' : 'Custom'}
     </span>
   )
 }

--- a/frontend/packages/web/components/admin/skill-registries/RegistryDetailPanel.tsx
+++ b/frontend/packages/web/components/admin/skill-registries/RegistryDetailPanel.tsx
@@ -52,7 +52,11 @@ export function RegistryDetailPanel({
             <h3 className="text-base font-semibold">{registry.name}</h3>
           </div>
           <span className="text-xs text-muted-foreground">
-            {registry.kind === 'skills-sh' ? 'skills.sh' : registry.base_url}
+            {registry.kind === 'skills-sh'
+              ? 'skills.sh'
+              : registry.kind === 'clawhub'
+                ? 'clawhub.ai'
+                : registry.base_url}
           </span>
         </div>
         <AlertDialog>

--- a/frontend/packages/web/hooks/useAdminSkillRegistries.ts
+++ b/frontend/packages/web/hooks/useAdminSkillRegistries.ts
@@ -16,7 +16,7 @@ export interface SkillRegistryEntry {
 
 export interface CreateRegistryBody {
   name: string
-  kind: 'remote' | 'skills-sh'
+  kind: 'remote' | 'skills-sh' | 'clawhub'
   base_url?: string
   repo?: string | null
   trust_tier: string


### PR DESCRIPTION
## Summary

- Add `ClawhubAdapter` for the [Clawhub](https://clawhub.ai) skill marketplace
- Register `kind='clawhub'` in `SkillsAdapterManager` alongside `skills-sh`
- Add Clawhub option to the admin Skill Registries UI (kind selector + display)

## API

Clawhub API endpoints used (no auth required for read):
- `GET /api/v1/search?q=...&limit=...` — search skills
- `GET /api/v1/skills/{slug}` — get latest version tag + install stats
- `GET /api/v1/download?slug=...&version=...` — download skill as zip

## Key design decisions

- `source_ref` format: `{slug}@{version}` (e.g. `cuecue-deep-research@1.1.3`)
- Search response returns `version: null` for many skills — resolved concurrently via detail endpoint; skills with unresolvable versions are dropped (no `@latest` stored)
- Install count (`installsAllTime`) fetched alongside version resolution
- ZIP unpacking filters `../` and absolute path traversal
- `base_url` auto-set to `https://clawhub.ai` (not user-editable)

## Test plan

- [ ] Add Clawhub registry in Admin → Skill Registries (kind = Clawhub)
- [ ] Search skills in Admin → Skills (External tab) or Workspace Skills
- [ ] Verify results show version + install count
- [ ] Install a skill and confirm it appears in org catalog
- [ ] Unit tests: `uv run pytest tests/unit/test_clawhub_adapter.py -v`