### PR TITLE
feat(skills): show downloads count and display required env vars from Clawhub skills

### DIFF
--- a/backend/cubebox/api/routes/v1/admin_skills.py
+++ b/backend/cubebox/api/routes/v1/admin_skills.py
@@ -42,7 +42,12 @@ from cubebox.repositories.skill import (
 )
 from cubebox.skills.cache import SkillCache
 from cubebox.skills.discovery import SkillDiscoveryService, SkillInstallError, SkillInstallService
-from cubebox.skills.frontmatter import InvalidFrontmatterError, peek_skill_name
+from cubebox.skills.frontmatter import (
+    InvalidFrontmatterError,
+    extract_env_vars,
+    parse_skill_md,
+    peek_skill_name,
+)
 from cubebox.skills.service import (
     FileTooLargeError,
     InvalidSkillNameError,
@@ -61,6 +66,14 @@ router = APIRouter(prefix="/admin/skills", tags=["admin-skills"])
 def _cache() -> SkillCache:
     cache_root = Path(_config.get("skills.cache_root", "skills_cache"))
     return SkillCache(cache_root=cache_root)
+
+
+def _env_vars_from_skill_md(content: str) -> list[str]:
+    try:
+        fm = parse_skill_md(content, default_version="0.0.0")
+    except Exception:
+        return []
+    return extract_env_vars(fm.raw_metadata)
 
 
 @router.get("", response_model=list[SkillSummary])
@@ -199,6 +212,7 @@ async def admin_preview_candidate(
         name=name,
         canonical_name=name,
         content=skill_md,
+        env_vars=_env_vars_from_skill_md(skill_md),
     )
 
 

--- a/backend/cubebox/api/routes/v1/ws_skills.py
+++ b/backend/cubebox/api/routes/v1/ws_skills.py
@@ -44,7 +44,7 @@ from cubebox.skills.discovery import (
     SkillInstallError,
     SkillInstallService,
 )
-from cubebox.skills.frontmatter import InvalidFrontmatterError
+from cubebox.skills.frontmatter import InvalidFrontmatterError, extract_env_vars, parse_skill_md
 from cubebox.skills.service import (
     FileTooLargeError,
     InvalidSkillNameError,
@@ -62,6 +62,14 @@ router = APIRouter(prefix="/ws/{workspace_id}/skills", tags=["ws-skills"])
 
 def _cache() -> SkillCache:
     return SkillCache(cache_root=Path(_config.get("skills.cache_root", "skills_cache")))
+
+
+def _env_vars_from_skill_md(content: str) -> list[str]:
+    try:
+        fm = parse_skill_md(content, default_version="0.0.0")
+    except Exception:
+        return []
+    return extract_env_vars(fm.raw_metadata)
 
 
 @router.get("", response_model=list[SkillSummary])
@@ -236,6 +244,7 @@ async def preview_candidate(
             name=skill.name,
             canonical_name=skill.name,
             content=content,
+            env_vars=_env_vars_from_skill_md(content),
         )
     registry = await SkillsAdapterManager.build(
         session=session,
@@ -262,6 +271,7 @@ async def preview_candidate(
         name=slug,
         canonical_name=f"{org.slug}:{slug}",
         content=content,
+        env_vars=_env_vars_from_skill_md(content),
     )
 
 

--- a/backend/cubebox/api/schemas/skill_discovery.py
+++ b/backend/cubebox/api/schemas/skill_discovery.py
@@ -27,6 +27,7 @@ class CandidatePreviewResponse(BaseModel):
     name: str
     canonical_name: str
     content: str
+    env_vars: list[str] = []
 
 
 class InstallCandidateRequest(BaseModel):

--- a/backend/cubebox/skills/frontmatter.py
+++ b/backend/cubebox/skills/frontmatter.py
@@ -95,11 +95,23 @@ def parse_skill_md(text: str, *, default_version: str | None = None) -> SkillFro
     keywords = _normalise_keywords(data.get("keywords"))
 
     raw_metadata: dict[str, Any] = dict(data)
+
+    # Expand metadata.{alias} first (lower priority than top-level aliases).
+    # Clawhub publishes skills with metadata.openclaw nesting; this normalises it.
+    metadata_block = raw_metadata.get("metadata")
+    if isinstance(metadata_block, dict):
+        for alias in _OPENCLAW_ALIASES:
+            nested = metadata_block.get(alias)
+            if isinstance(nested, dict):
+                for k, v in nested.items():
+                    raw_metadata[k] = v  # overrides bare top-level keys
+
+    # Top-level aliases override everything (including metadata.alias results above).
     for alias in _OPENCLAW_ALIASES:
         nested = raw_metadata.pop(alias, None)
         if isinstance(nested, dict):
             for k, v in nested.items():
-                raw_metadata[k] = v  # alias overrides any top-level same-name field
+                raw_metadata[k] = v
 
     return SkillFrontmatter(
         name=name.strip(),
@@ -108,6 +120,21 @@ def parse_skill_md(text: str, *, default_version: str | None = None) -> SkillFro
         keywords=keywords,
         raw_metadata=raw_metadata,
     )
+
+
+def extract_env_vars(raw_metadata: dict[str, Any]) -> list[str]:
+    """Return required env var names from a parsed skill's raw_metadata.
+
+    Reads raw_metadata["requires"]["env"] after alias expansion by parse_skill_md.
+    Returns [] when absent or malformed.
+    """
+    requires = raw_metadata.get("requires")
+    if not isinstance(requires, dict):
+        return []
+    env_list = requires.get("env")
+    if not isinstance(env_list, list):
+        return []
+    return [str(e) for e in env_list if isinstance(e, str) and e]
 
 
 def _normalise_keywords(value: Any) -> list[str]:

--- a/backend/cubebox/skills/sources/clawhub.py
+++ b/backend/cubebox/skills/sources/clawhub.py
@@ -81,7 +81,7 @@ class ClawhubAdapter:
             return []
 
         # Collect slugs whose version is null — resolve them concurrently.
-        # Also fetch stats (installs) since the search response doesn't include them.
+        # Also fetch stats (downloads) since the search response doesn't include them.
         slugs_needing_detail = [
             str(item.get("slug") or "")
             for item in results
@@ -183,7 +183,7 @@ class ClawhubAdapter:
         return _unpack_zip(zip_bytes)
 
     async def _fetch_skill_detail(self, slug: str) -> tuple[str, int | None]:
-        """Fetch latest version and install count from the skill detail endpoint."""
+        """Fetch latest version and download count from the skill detail endpoint."""
         async with self._client() as client:
             resp = await client.get(f"/api/v1/skills/{slug}")
             resp.raise_for_status()
@@ -194,7 +194,7 @@ class ClawhubAdapter:
         if not isinstance(latest, str) or not latest:
             raise ValueError(f"Clawhub skill {slug!r} has no latest version tag")
         stats = skill.get("stats") or {}
-        install_count = stats.get("installsAllTime")
+        install_count = stats.get("downloads")
         if not isinstance(install_count, int):
             install_count = None
         return latest, install_count

--- a/backend/tests/unit/test_skill_frontmatter.py
+++ b/backend/tests/unit/test_skill_frontmatter.py
@@ -4,6 +4,7 @@ import pytest
 
 from cubebox.skills.frontmatter import (
     InvalidFrontmatterError,
+    extract_env_vars,
     parse_skill_md,
 )
 
@@ -111,6 +112,110 @@ def test_no_frontmatter_block() -> None:
     text = "# Just markdown, no YAML block\n"
     with pytest.raises(InvalidFrontmatterError):
         parse_skill_md(text)
+
+
+def test_metadata_openclaw_promoted_to_raw_metadata() -> None:
+    """metadata.openclaw keys are promoted, same as top-level openclaw."""
+    text = """---
+name: x
+description: y
+version: 0.1
+metadata:
+  openclaw:
+    requires:
+      bins: [node]
+      env: [MY_API_KEY]
+    primaryEnv: MY_API_KEY
+---
+"""
+    fm = parse_skill_md(text)
+    assert fm.raw_metadata["requires"] == {"bins": ["node"], "env": ["MY_API_KEY"]}
+    assert fm.raw_metadata["primaryEnv"] == "MY_API_KEY"
+
+
+def test_metadata_alias_does_not_override_top_level_alias() -> None:
+    """Top-level openclaw wins over metadata.openclaw."""
+    text = """---
+name: x
+description: y
+version: 0.1
+metadata:
+  openclaw:
+    requires:
+      env: [FROM_METADATA]
+openclaw:
+  requires:
+    env: [FROM_TOPLEVEL]
+---
+"""
+    fm = parse_skill_md(text)
+    assert fm.raw_metadata["requires"] == {"env": ["FROM_TOPLEVEL"]}
+
+
+def test_metadata_alias_overrides_bare_top_level() -> None:
+    """metadata.openclaw wins over bare (non-alias) top-level keys."""
+    text = """---
+name: x
+description: y
+version: 0.1
+requires:
+  env: [BARE]
+metadata:
+  openclaw:
+    requires:
+      env: [FROM_METADATA]
+---
+"""
+    fm = parse_skill_md(text)
+    assert fm.raw_metadata["requires"] == {"env": ["FROM_METADATA"]}
+
+
+def test_extract_env_vars_from_metadata_openclaw() -> None:
+    text = """---
+name: cuecue-deep-research
+description: desc
+version: 1.0.0
+metadata:
+  openclaw:
+    requires:
+      env: [CUECUE_API_KEY]
+---
+"""
+    fm = parse_skill_md(text)
+    assert extract_env_vars(fm.raw_metadata) == ["CUECUE_API_KEY"]
+
+
+def test_extract_env_vars_from_toplevel_openclaw() -> None:
+    text = """---
+name: x
+description: y
+version: 1.0.0
+openclaw:
+  requires:
+    env: [MY_KEY, OTHER_KEY]
+---
+"""
+    fm = parse_skill_md(text)
+    assert extract_env_vars(fm.raw_metadata) == ["MY_KEY", "OTHER_KEY"]
+
+
+def test_extract_env_vars_empty_when_no_requires() -> None:
+    fm = parse_skill_md("---\nname: x\ndescription: y\nversion: 1.0.0\n---\n")
+    assert extract_env_vars(fm.raw_metadata) == []
+
+
+def test_extract_env_vars_empty_when_requires_has_no_env() -> None:
+    text = """---
+name: x
+description: y
+version: 1.0.0
+openclaw:
+  requires:
+    bins: [node]
+---
+"""
+    fm = parse_skill_md(text)
+    assert extract_env_vars(fm.raw_metadata) == []
 
 
 def test_version_with_whitespace_rejected() -> None:

--- a/docs/dev/plans/2026-05-31-skill-env-vars-display.md
+++ b/docs/dev/plans/2026-05-31-skill-env-vars-display.md
@@ -1,0 +1,542 @@
+# Skill Env Vars Display Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Parse `requires.env` from Clawhub SKILL.md frontmatter and display required env var names in the skill detail panels (both workspace and admin views).
+
+**Architecture:** Fix the frontmatter parser to also expand `metadata.openclaw` nesting (Clawhub's convention). Add `extract_env_vars(raw_metadata)` as a public pure function in `frontmatter.py` — both route files import it (reuse goes one layer down, not at route layer). Expose `env_vars: list[str]` in `CandidatePreviewResponse`. Frontend exports `SkillPreviewResponse` from `@cubebox/core` and shares it across both detail panels.
+
+**Tech Stack:** Python (FastAPI + Pydantic), TypeScript (Next.js + React 19), SWR for data fetching.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `backend/cubebox/skills/frontmatter.py` | Extend alias expansion; add public `extract_env_vars()` |
+| `backend/tests/unit/test_skill_frontmatter.py` | Tests for `metadata.openclaw` nesting + `extract_env_vars` |
+| `backend/cubebox/api/schemas/skill_discovery.py` | Add `env_vars: list[str]` to `CandidatePreviewResponse` |
+| `backend/cubebox/api/routes/v1/ws_skills.py` | Import `extract_env_vars`; populate field in both preview paths |
+| `backend/cubebox/api/routes/v1/admin_skills.py` | Same |
+| `frontend/packages/core/src/api/skills.ts` | Add + export `SkillPreviewResponse` interface |
+| `frontend/packages/core/src/index.ts` | Re-export `SkillPreviewResponse` if not auto-exported |
+| `frontend/packages/web/components/skills/CandidateDetailPanel.tsx` | Import shared type; render env_vars row |
+| `frontend/packages/web/components/admin/skills/AdminCandidateDetailPanel.tsx` | Same |
+
+---
+
+## Task 1: Fix frontmatter parser — handle `metadata.openclaw` nesting + extract_env_vars
+
+**Files:**
+- Modify: `backend/cubebox/skills/frontmatter.py`
+- Test: `backend/tests/unit/test_skill_frontmatter.py`
+
+### Background
+
+Clawhub skills use:
+```yaml
+metadata:
+  openclaw:
+    requires:
+      env: [MY_API_KEY]
+```
+
+The current parser only expands top-level `openclaw`/`clawdbot`/`clawdis`. Fix: also expand `metadata.{alias}`, with precedence: top-level alias > `metadata.alias` > bare top-level keys. Also add `extract_env_vars(raw_metadata)` as a public helper so route files don't duplicate the extraction logic.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `backend/tests/unit/test_skill_frontmatter.py`:
+
+```python
+from cubebox.skills.frontmatter import (
+    InvalidFrontmatterError,
+    extract_env_vars,
+    parse_skill_md,
+)
+
+
+def test_metadata_openclaw_promoted_to_raw_metadata() -> None:
+    """metadata.openclaw keys are promoted, same as top-level openclaw."""
+    text = """---
+name: x
+description: y
+version: 0.1
+metadata:
+  openclaw:
+    requires:
+      bins: [node]
+      env: [MY_API_KEY]
+    primaryEnv: MY_API_KEY
+---
+"""
+    fm = parse_skill_md(text)
+    assert fm.raw_metadata["requires"] == {"bins": ["node"], "env": ["MY_API_KEY"]}
+    assert fm.raw_metadata["primaryEnv"] == "MY_API_KEY"
+
+
+def test_metadata_alias_does_not_override_top_level_alias() -> None:
+    """Top-level openclaw wins over metadata.openclaw."""
+    text = """---
+name: x
+description: y
+version: 0.1
+metadata:
+  openclaw:
+    requires:
+      env: [FROM_METADATA]
+openclaw:
+  requires:
+    env: [FROM_TOPLEVEL]
+---
+"""
+    fm = parse_skill_md(text)
+    assert fm.raw_metadata["requires"] == {"env": ["FROM_TOPLEVEL"]}
+
+
+def test_metadata_alias_overrides_bare_top_level() -> None:
+    """metadata.openclaw wins over bare (non-alias) top-level keys."""
+    text = """---
+name: x
+description: y
+version: 0.1
+requires:
+  env: [BARE]
+metadata:
+  openclaw:
+    requires:
+      env: [FROM_METADATA]
+---
+"""
+    fm = parse_skill_md(text)
+    assert fm.raw_metadata["requires"] == {"env": ["FROM_METADATA"]}
+
+
+def test_extract_env_vars_from_metadata_openclaw() -> None:
+    text = """---
+name: cuecue-deep-research
+description: desc
+version: 1.0.0
+metadata:
+  openclaw:
+    requires:
+      env: [CUECUE_API_KEY]
+---
+"""
+    fm = parse_skill_md(text)
+    assert extract_env_vars(fm.raw_metadata) == ["CUECUE_API_KEY"]
+
+
+def test_extract_env_vars_from_toplevel_openclaw() -> None:
+    text = """---
+name: x
+description: y
+version: 1.0.0
+openclaw:
+  requires:
+    env: [MY_KEY, OTHER_KEY]
+---
+"""
+    fm = parse_skill_md(text)
+    assert extract_env_vars(fm.raw_metadata) == ["MY_KEY", "OTHER_KEY"]
+
+
+def test_extract_env_vars_empty_when_no_requires() -> None:
+    fm = parse_skill_md("---\nname: x\ndescription: y\nversion: 1.0.0\n---\n")
+    assert extract_env_vars(fm.raw_metadata) == []
+
+
+def test_extract_env_vars_empty_when_requires_has_no_env() -> None:
+    text = """---
+name: x
+description: y
+version: 1.0.0
+openclaw:
+  requires:
+    bins: [node]
+---
+"""
+    fm = parse_skill_md(text)
+    assert extract_env_vars(fm.raw_metadata) == []
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_skill_frontmatter.py -k "metadata or extract_env" -v
+```
+
+Expected: failures on the 7 new tests.
+
+- [ ] **Step 3: Fix the parser + add extract_env_vars**
+
+In `backend/cubebox/skills/frontmatter.py`:
+
+**a) Update the alias expansion block** (replace lines 97–102):
+
+```python
+    raw_metadata: dict[str, Any] = dict(data)
+
+    # Expand metadata.{alias} first (lower priority than top-level aliases).
+    # Clawhub publishes skills with metadata.openclaw nesting; this normalises it.
+    metadata_block = raw_metadata.get("metadata")
+    if isinstance(metadata_block, dict):
+        for alias in _OPENCLAW_ALIASES:
+            nested = metadata_block.get(alias)
+            if isinstance(nested, dict):
+                for k, v in nested.items():
+                    raw_metadata[k] = v  # overrides bare top-level keys
+
+    # Top-level aliases override everything (including metadata.alias results above).
+    for alias in _OPENCLAW_ALIASES:
+        nested = raw_metadata.pop(alias, None)
+        if isinstance(nested, dict):
+            for k, v in nested.items():
+                raw_metadata[k] = v
+```
+
+**b) Add public helper after the `_normalise_keywords` function** (at end of file):
+
+```python
+def extract_env_vars(raw_metadata: dict[str, Any]) -> list[str]:
+    """Return the list of required env var names from a parsed skill's raw_metadata.
+
+    Reads raw_metadata["requires"]["env"] after alias expansion by parse_skill_md.
+    Returns [] when absent or malformed.
+    """
+    requires = raw_metadata.get("requires")
+    if not isinstance(requires, dict):
+        return []
+    env_list = requires.get("env")
+    if not isinstance(env_list, list):
+        return []
+    return [str(e) for e in env_list if isinstance(e, str) and e]
+```
+
+- [ ] **Step 4: Run full frontmatter test suite**
+
+```bash
+cd backend && uv run pytest tests/unit/test_skill_frontmatter.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Run mypy**
+
+```bash
+cd backend && uv run mypy cubebox/skills/frontmatter.py
+```
+
+Expected: `Success: no issues found`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/skills/frontmatter.py backend/tests/unit/test_skill_frontmatter.py
+git commit -m "fix(skills): expand metadata.openclaw alias; add extract_env_vars helper"
+```
+
+---
+
+## Task 2: Add env_vars to preview API response
+
+**Files:**
+- Modify: `backend/cubebox/api/schemas/skill_discovery.py`
+- Modify: `backend/cubebox/api/routes/v1/ws_skills.py`
+- Modify: `backend/cubebox/api/routes/v1/admin_skills.py`
+
+### Background
+
+Both preview endpoints fetch and return SKILL.md content. We now also call `parse_skill_md` + `extract_env_vars` on that content and include the result in the response. For local skills (kind=local), the content is fetched via `catalog.fetch_skill_md`. `env_vars` defaults to `[]`.
+
+- [ ] **Step 1: Add `env_vars` to schema**
+
+In `backend/cubebox/api/schemas/skill_discovery.py`:
+
+```python
+class CandidatePreviewResponse(BaseModel):
+    candidate_id: str
+    name: str
+    canonical_name: str
+    content: str
+    env_vars: list[str] = []
+```
+
+- [ ] **Step 2: Update ws_skills route**
+
+In `backend/cubebox/api/routes/v1/ws_skills.py`, add import (check existing imports first — if `peek_skill_name` is already imported from frontmatter, add `extract_env_vars` to that same import line):
+
+```python
+from cubebox.skills.frontmatter import extract_env_vars, parse_skill_md, peek_skill_name
+```
+
+Add a module-level helper that wraps the extraction with error handling (SKILL.md from remote might be malformed):
+
+```python
+def _env_vars_from_skill_md(content: str) -> list[str]:
+    try:
+        fm = parse_skill_md(content, default_version="0.0.0")
+    except Exception:
+        return []
+    return extract_env_vars(fm.raw_metadata)
+```
+
+Update local skill preview return (around line 234):
+
+```python
+        content = await catalog.fetch_skill_md(sv.id)
+        return CandidatePreviewResponse(
+            candidate_id=candidate_id,
+            name=skill.name,
+            canonical_name=skill.name,
+            content=content,
+            env_vars=_env_vars_from_skill_md(content),
+        )
+```
+
+Update remote skill preview return (around line 260):
+
+```python
+    return CandidatePreviewResponse(
+        candidate_id=candidate_id,
+        name=slug,
+        canonical_name=f"{org.slug}:{slug}",
+        content=content,
+        env_vars=_env_vars_from_skill_md(content),
+    )
+```
+
+- [ ] **Step 3: Update admin_skills route**
+
+In `backend/cubebox/api/routes/v1/admin_skills.py`, add import:
+
+```python
+from cubebox.skills.frontmatter import extract_env_vars, parse_skill_md, peek_skill_name
+```
+
+Add the same thin wrapper (each route file owns its own private wrappers, the shared logic is in frontmatter.py):
+
+```python
+def _env_vars_from_skill_md(content: str) -> list[str]:
+    try:
+        fm = parse_skill_md(content, default_version="0.0.0")
+    except Exception:
+        return []
+    return extract_env_vars(fm.raw_metadata)
+```
+
+Update `admin_preview_candidate` return:
+
+```python
+    return CandidatePreviewResponse(
+        candidate_id=candidate_id,
+        name=name,
+        canonical_name=name,
+        content=skill_md,
+        env_vars=_env_vars_from_skill_md(skill_md),
+    )
+```
+
+- [ ] **Step 4: Run mypy**
+
+```bash
+cd backend && uv run mypy cubebox/skills/frontmatter.py cubebox/api/schemas/skill_discovery.py cubebox/api/routes/v1/ws_skills.py cubebox/api/routes/v1/admin_skills.py
+```
+
+Expected: `Success: no issues found`.
+
+- [ ] **Step 5: Run affected unit tests**
+
+```bash
+cd backend && uv run pytest tests/unit/test_skill_frontmatter.py tests/unit/ -k "skill" -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  backend/cubebox/api/schemas/skill_discovery.py \
+  backend/cubebox/api/routes/v1/ws_skills.py \
+  backend/cubebox/api/routes/v1/admin_skills.py
+git commit -m "feat(skills): expose env_vars in skill preview API response"
+```
+
+---
+
+## Task 3: Frontend — shared type + display env vars
+
+**Files:**
+- Modify: `frontend/packages/core/src/api/skills.ts`
+- Modify: `frontend/packages/core/src/api/adminSkills.ts`
+- Modify: `frontend/packages/web/components/skills/CandidateDetailPanel.tsx`
+- Modify: `frontend/packages/web/components/admin/skills/AdminCandidateDetailPanel.tsx`
+
+### Background
+
+Define `SkillPreviewResponse` once in `@cubebox/core/src/api/skills.ts`, export it, and use it in `adminPreviewCandidate` and both detail panels' SWR fetchers. Both panels render a "Requires env" row when `env_vars` is non-empty.
+
+- [ ] **Step 1: Add shared type to core**
+
+In `frontend/packages/core/src/api/skills.ts`, add after the existing interfaces:
+
+```typescript
+export interface SkillPreviewResponse {
+  content: string
+  env_vars: string[]
+}
+```
+
+Check `frontend/packages/core/src/index.ts` (or equivalent barrel) to confirm `skills.ts` exports are re-exported. If the barrel has `export * from './api/skills'`, no further change is needed.
+
+- [ ] **Step 2: Update `adminPreviewCandidate`**
+
+In `frontend/packages/core/src/api/adminSkills.ts`:
+
+```typescript
+import { toApiError } from './client'
+import type { SkillCandidateOut, SkillPreviewResponse } from './skills'
+
+export async function adminPreviewCandidate(candidateId: string): Promise<SkillPreviewResponse> {
+  const params = new URLSearchParams({ candidate_id: candidateId })
+  const res = await fetch(`/api/v1/admin/skills/discover/preview?${params}`, {
+    credentials: 'include',
+  })
+  if (!res.ok) throw await toApiError(res)
+  return (await res.json()) as SkillPreviewResponse
+}
+```
+
+(Remove the old `{ content: string }` inline return type.)
+
+- [ ] **Step 3: Update `CandidateDetailPanel.tsx`**
+
+In `frontend/packages/web/components/skills/CandidateDetailPanel.tsx`:
+
+**a) Import shared type** (add to existing `@cubebox/core` import):
+
+```typescript
+import { createApiClient, useSkillsStore, type SkillCandidateOut, type SkillPreviewResponse } from '@cubebox/core'
+```
+
+**b) Replace the local `previewFetcher` type** (lines 44–48) — remove `interface SkillPreview` if you added one; use `SkillPreviewResponse` directly:
+
+```typescript
+async function previewFetcher(url: string): Promise<SkillPreviewResponse> {
+  const res = await fetch(url, { credentials: 'include' })
+  if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
+  return res.json() as Promise<SkillPreviewResponse>
+}
+```
+
+**c) Update SWR type** (line 71):
+
+```typescript
+  const { data: preview, isLoading } = useSWR<SkillPreviewResponse>(
+    `/api/v1/ws/${wsId}/skills/discover/preview?candidate_id=${candidate.candidate_id}`,
+    previewFetcher,
+    { revalidateOnFocus: false, shouldRetryOnError: false },
+  )
+```
+
+**d) Add env_vars row** — insert after the closing `)}` of the "Repo" `<div>` and before `</dl>` (around line 131):
+
+```tsx
+        {preview?.env_vars && preview.env_vars.length > 0 && (
+          <div className="flex items-start gap-3">
+            <dt className="min-w-20 pt-0.5 text-xs font-medium text-muted-foreground">
+              Requires env
+            </dt>
+            <dd className="flex flex-wrap gap-1">
+              {preview.env_vars.map((v) => (
+                <code
+                  key={v}
+                  className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
+                >
+                  {v}
+                </code>
+              ))}
+            </dd>
+          </div>
+        )}
+```
+
+- [ ] **Step 4: Update `AdminCandidateDetailPanel.tsx`**
+
+In `frontend/packages/web/components/admin/skills/AdminCandidateDetailPanel.tsx`:
+
+**a) Import shared type**:
+
+```typescript
+import { useAdminSkillsStore, type SkillCandidateOut, type SkillPreviewResponse } from '@cubebox/core'
+```
+
+**b) Replace `previewFetcher`** (lines 40–44):
+
+```typescript
+async function previewFetcher(url: string): Promise<SkillPreviewResponse> {
+  const res = await fetch(url, { credentials: 'include' })
+  if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
+  return res.json() as Promise<SkillPreviewResponse>
+}
+```
+
+**c) Update SWR type** (line 65):
+
+```typescript
+  const { data: preview, isLoading } = useSWR<SkillPreviewResponse>(
+    `/api/v1/admin/skills/discover/preview?candidate_id=${candidate.candidate_id}`,
+    previewFetcher,
+    { revalidateOnFocus: false, shouldRetryOnError: false },
+  )
+```
+
+**d) Add env_vars row** — after the "Repo" row, before `</dl>` (around line 134):
+
+```tsx
+        {preview?.env_vars && preview.env_vars.length > 0 && (
+          <div className="flex items-start gap-3">
+            <dt className="min-w-24 pt-0.5 text-xs font-medium text-muted-foreground">
+              Requires env
+            </dt>
+            <dd className="flex flex-wrap gap-1">
+              {preview.env_vars.map((v) => (
+                <code
+                  key={v}
+                  className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
+                >
+                  {v}
+                </code>
+              ))}
+            </dd>
+          </div>
+        )}
+```
+
+- [ ] **Step 5: Build core package (required before web sees type changes)**
+
+```bash
+cd frontend && pnpm --filter @cubebox/core build
+```
+
+Expected: exits 0.
+
+- [ ] **Step 6: TypeScript check**
+
+```bash
+cd frontend && pnpm --filter @cubebox/core tsc --noEmit && pnpm --filter web tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  frontend/packages/core/src/api/skills.ts \
+  frontend/packages/core/src/api/adminSkills.ts \
+  frontend/packages/web/components/skills/CandidateDetailPanel.tsx \
+  frontend/packages/web/components/admin/skills/AdminCandidateDetailPanel.tsx
+git commit -m "feat(skills): display required env vars in skill detail panels"
+```

--- a/frontend/packages/core/src/api/adminSkills.ts
+++ b/frontend/packages/core/src/api/adminSkills.ts
@@ -1,5 +1,5 @@
 import { toApiError } from './client'
-import type { SkillCandidateOut } from './skills'
+import type { SkillCandidateOut, SkillPreviewResponse } from './skills'
 
 export async function adminDiscoverSkills(q: string, limit = 5): Promise<SkillCandidateOut[]> {
   const params = new URLSearchParams({ q, limit: String(limit) })
@@ -8,13 +8,13 @@ export async function adminDiscoverSkills(q: string, limit = 5): Promise<SkillCa
   return (await res.json()) as SkillCandidateOut[]
 }
 
-export async function adminPreviewCandidate(candidateId: string): Promise<{ content: string }> {
+export async function adminPreviewCandidate(candidateId: string): Promise<SkillPreviewResponse> {
   const params = new URLSearchParams({ candidate_id: candidateId })
   const res = await fetch(`/api/v1/admin/skills/discover/preview?${params}`, {
     credentials: 'include',
   })
   if (!res.ok) throw await toApiError(res)
-  return (await res.json()) as { content: string }
+  return (await res.json()) as SkillPreviewResponse
 }
 
 export async function adminInstallCandidate(

--- a/frontend/packages/core/src/api/skills.ts
+++ b/frontend/packages/core/src/api/skills.ts
@@ -19,6 +19,11 @@ export interface SkillCandidateOut {
 
 export type SkillCandidateListResponse = SkillCandidateOut[]
 
+export interface SkillPreviewResponse {
+  content: string
+  env_vars: string[]
+}
+
 export interface SkillInstallResponse {
   canonical_name: string
   skill_id: string

--- a/frontend/packages/web/components/admin/skills/AdminCandidateDetailPanel.tsx
+++ b/frontend/packages/web/components/admin/skills/AdminCandidateDetailPanel.tsx
@@ -5,7 +5,11 @@ import useSWR from 'swr'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { FileText, ShieldAlert, ShieldCheck, ShieldOff } from 'lucide-react'
-import { useAdminSkillsStore, type SkillCandidateOut } from '@cubebox/core'
+import {
+  useAdminSkillsStore,
+  type SkillCandidateOut,
+  type SkillPreviewResponse,
+} from '@cubebox/core'
 import { Badge } from '@/components/ui/badge'
 import { jsonHeaders } from '@/lib/csrf'
 import { Button } from '@/components/ui/button'
@@ -37,10 +41,10 @@ function TrustInfo({ trust }: { trust: SkillCandidateOut['trust'] }) {
   )
 }
 
-async function previewFetcher(url: string): Promise<{ content: string }> {
+async function previewFetcher(url: string): Promise<SkillPreviewResponse> {
   const res = await fetch(url, { credentials: 'include' })
   if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
-  return res.json() as Promise<{ content: string }>
+  return res.json() as Promise<SkillPreviewResponse>
 }
 
 function stripFrontmatter(content: string): string {
@@ -62,7 +66,7 @@ export function AdminCandidateDetailPanel({
 
   const isInCatalog = candidate.install_state === 'in_catalog'
 
-  const { data: preview, isLoading } = useSWR<{ content: string }>(
+  const { data: preview, isLoading } = useSWR<SkillPreviewResponse>(
     `/api/v1/admin/skills/discover/preview?candidate_id=${candidate.candidate_id}`,
     previewFetcher,
     { revalidateOnFocus: false, shouldRetryOnError: false },
@@ -130,6 +134,23 @@ export function AdminCandidateDetailPanel({
           <div className="flex items-center gap-3">
             <dt className="min-w-24 text-xs font-medium text-muted-foreground">Repo</dt>
             <dd className="truncate text-xs text-muted-foreground">{candidate.repo}</dd>
+          </div>
+        )}
+        {preview?.env_vars && preview.env_vars.length > 0 && (
+          <div className="flex items-start gap-3">
+            <dt className="min-w-24 pt-0.5 text-xs font-medium text-muted-foreground">
+              Requires env
+            </dt>
+            <dd className="flex flex-wrap gap-1">
+              {preview.env_vars.map((v) => (
+                <code
+                  key={v}
+                  className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
+                >
+                  {v}
+                </code>
+              ))}
+            </dd>
           </div>
         )}
       </dl>

--- a/frontend/packages/web/components/admin/skills/AdminCandidateDetailPanel.tsx
+++ b/frontend/packages/web/components/admin/skills/AdminCandidateDetailPanel.tsx
@@ -122,7 +122,7 @@ export function AdminCandidateDetailPanel({
       <dl className="flex flex-col gap-3 border-b border-border pb-4">
         {candidate.install_count !== null && (
           <div className="flex items-center gap-3">
-            <dt className="min-w-24 text-xs font-medium text-muted-foreground">Installs</dt>
+            <dt className="min-w-24 text-xs font-medium text-muted-foreground">Downloads</dt>
             <dd className="text-sm">{candidate.install_count.toLocaleString()}</dd>
           </div>
         )}

--- a/frontend/packages/web/components/skills/CandidateDetailPanel.tsx
+++ b/frontend/packages/web/components/skills/CandidateDetailPanel.tsx
@@ -118,7 +118,7 @@ export function CandidateDetailPanel({ wsId, candidate }: CandidateDetailPanelPr
       <dl className="flex flex-col gap-3 border-b border-border pb-4">
         {candidate.install_count !== null && (
           <div className="flex items-center gap-3">
-            <dt className="min-w-20 text-xs font-medium text-muted-foreground">Installs</dt>
+            <dt className="min-w-20 text-xs font-medium text-muted-foreground">Downloads</dt>
             <dd className="text-sm">{candidate.install_count.toLocaleString()}</dd>
           </div>
         )}

--- a/frontend/packages/web/components/skills/CandidateDetailPanel.tsx
+++ b/frontend/packages/web/components/skills/CandidateDetailPanel.tsx
@@ -5,7 +5,12 @@ import useSWR from 'swr'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { ShieldCheck, ShieldAlert, ShieldOff, FileText } from 'lucide-react'
-import { createApiClient, useSkillsStore, type SkillCandidateOut } from '@cubebox/core'
+import {
+  createApiClient,
+  useSkillsStore,
+  type SkillCandidateOut,
+  type SkillPreviewResponse,
+} from '@cubebox/core'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -41,10 +46,10 @@ interface CandidateDetailPanelProps {
   candidate: SkillCandidateOut
 }
 
-async function previewFetcher(url: string): Promise<{ content: string }> {
+async function previewFetcher(url: string): Promise<SkillPreviewResponse> {
   const res = await fetch(url, { credentials: 'include' })
   if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
-  return res.json() as Promise<{ content: string }>
+  return res.json() as Promise<SkillPreviewResponse>
 }
 
 function stripFrontmatter(content: string): string {
@@ -68,7 +73,7 @@ export function CandidateDetailPanel({ wsId, candidate }: CandidateDetailPanelPr
     }
   }
 
-  const { data: preview, isLoading } = useSWR<{ content: string }>(
+  const { data: preview, isLoading } = useSWR<SkillPreviewResponse>(
     `/api/v1/ws/${wsId}/skills/discover/preview?candidate_id=${candidate.candidate_id}`,
     previewFetcher,
     { revalidateOnFocus: false, shouldRetryOnError: false },
@@ -126,6 +131,23 @@ export function CandidateDetailPanel({ wsId, candidate }: CandidateDetailPanelPr
           <div className="flex items-center gap-3">
             <dt className="min-w-20 text-xs font-medium text-muted-foreground">Repo</dt>
             <dd className="truncate text-xs text-muted-foreground">{candidate.repo}</dd>
+          </div>
+        )}
+        {preview?.env_vars && preview.env_vars.length > 0 && (
+          <div className="flex items-start gap-3">
+            <dt className="min-w-20 pt-0.5 text-xs font-medium text-muted-foreground">
+              Requires env
+            </dt>
+            <dd className="flex flex-wrap gap-1">
+              {preview.env_vars.map((v) => (
+                <code
+                  key={v}
+                  className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground"
+                >
+                  {v}
+                </code>
+              ))}
+            </dd>
           </div>
         )}
       </dl>


### PR DESCRIPTION
## Summary

- **Downloads count**: Switch Clawhub skill source from `installsAllTime` to `downloads` (more accurate), and update the label from "Installs" to "Downloads" in both workspace and admin skill detail panels.
- **Env vars display**: Parse `requires.env` from SKILL.md frontmatter and show required env var names (e.g. `CUECUE_API_KEY`) in skill detail panels when browsing the catalog.
- **Parser fix**: Extend frontmatter alias expansion to handle `metadata.openclaw` nesting (Clawhub's convention), in addition to top-level `openclaw`/`clawdbot`/`clawdis`.

## Architecture

- `extract_env_vars(raw_metadata)` added to `frontmatter.py` as a shared pure function.
- Both preview endpoints (`ws_skills` and `admin_skills`) parse SKILL.md content on-the-fly and populate `env_vars: list[str]` in `CandidatePreviewResponse`.
- `SkillPreviewResponse` defined once in `@cubebox/core/src/api/skills.ts` and imported by both detail panels.
- Env vars appear in the metadata row below Downloads/Repo, as monospace code badges.

## Test plan

- [ ] Search for `cuecue-deep-research` in the workspace skill catalog → detail panel shows "Downloads: N" and "Requires env: `CUECUE_API_KEY`"
- [ ] Same in admin skill catalog → same display
- [ ] Skill without env vars shows no "Requires env" row
- [ ] 18 unit tests in `test_skill_frontmatter.py` pass (covers parser fix + `extract_env_vars`)
- [ ] mypy, ruff, eslint, prettier all pass (enforced by pre-commit + CI)