### PR TITLE
feat(sandbox-env): edit support + live EgressRef lookup

### DIFF
--- a/backend/cubebox/api/routes/internal_egress.py
+++ b/backend/cubebox/api/routes/internal_egress.py
@@ -11,6 +11,7 @@ from cubebox.credentials.encryption import EncryptionBackend
 from cubebox.db import get_session
 from cubebox.repositories.credential import CredentialRepository
 from cubebox.repositories.egress_ref import EgressRefRepository
+from cubebox.repositories.sandbox_env import SandboxEnvRepository
 from cubebox.sandbox_env.exchange_auth import SidecarAuthenticator
 from cubebox.sandbox_env.placeholder import PLACEHOLDER_RE
 from cubebox.services.credential import CredentialService
@@ -62,6 +63,7 @@ async def exchange(
             org_id=org_id,
             actor_user_id=None,
         ),
+        env_var_repo_factory=lambda org_id: SandboxEnvRepository(session, org_id=org_id),
     )
     try:
         secret, header_names = await svc.exchange(

--- a/backend/cubebox/api/routes/v1/admin_sandbox_env.py
+++ b/backend/cubebox/api/routes/v1/admin_sandbox_env.py
@@ -9,7 +9,7 @@ from cubebox.api.schemas.sandbox_env import (
     CreateOrgEnvIn,
     EnvEntryListOut,
     EnvEntryOut,
-    UpdateSecretValueIn,
+    UpdateEntryIn,
 )
 from cubebox.auth.context import RequestContext
 from cubebox.credentials.dependencies import get_encryption_backend
@@ -102,9 +102,9 @@ async def list_org_env(
 
 
 @router.patch("/{entry_id}", response_model=EnvEntryOut)
-async def rotate_org_env(
+async def update_org_env(
     entry_id: str,
-    body: UpdateSecretValueIn,
+    body: UpdateEntryIn,
     session: Annotated[AsyncSession, Depends(get_session)],
     backend: Annotated[EncryptionBackend, Depends(get_encryption_backend)],
     ctx: Annotated[RequestContext, Depends(get_admin_request_context)],
@@ -113,10 +113,13 @@ async def rotate_org_env(
     if row is None or row.scope != "org":
         raise HTTPException(status.HTTP_404_NOT_FOUND, "not found")
     try:
-        await _service(session, backend, ctx).update_value(
-            entry_id=entry_id, secret_value=body.secret_value
+        await _service(session, backend, ctx).update_entry(
+            entry_id=entry_id,
+            hosts=body.hosts,
+            header_names=body.header_names,
+            secret_value=body.secret_value,
         )
-    except SandboxEnvShapeError as exc:
+    except (SandboxEnvShapeError, HostPatternError) as exc:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
     updated = await SandboxEnvRepository(session, org_id=ctx.org_id).get(entry_id)
     assert updated is not None

--- a/backend/cubebox/api/routes/v1/admin_sandbox_env.py
+++ b/backend/cubebox/api/routes/v1/admin_sandbox_env.py
@@ -117,6 +117,7 @@ async def update_org_env(
             entry_id=entry_id,
             hosts=body.hosts,
             header_names=body.header_names,
+            update_header_names="header_names" in body.model_fields_set,
             secret_value=body.secret_value,
         )
     except (SandboxEnvShapeError, HostPatternError) as exc:

--- a/backend/cubebox/api/routes/v1/ws_sandbox_env.py
+++ b/backend/cubebox/api/routes/v1/ws_sandbox_env.py
@@ -207,6 +207,7 @@ async def update_workspace_env(
             entry_id=entry_id,
             hosts=body.hosts,
             header_names=body.header_names,
+            update_header_names="header_names" in body.model_fields_set,
             secret_value=body.secret_value,
         )
     except (SandboxEnvShapeError, HostPatternError) as exc:
@@ -238,6 +239,7 @@ async def update_user_env(
             entry_id=entry_id,
             hosts=body.hosts,
             header_names=body.header_names,
+            update_header_names="header_names" in body.model_fields_set,
             secret_value=body.secret_value,
         )
     except (SandboxEnvShapeError, HostPatternError) as exc:

--- a/backend/cubebox/api/routes/v1/ws_sandbox_env.py
+++ b/backend/cubebox/api/routes/v1/ws_sandbox_env.py
@@ -10,7 +10,7 @@ from cubebox.api.schemas.sandbox_env import (
     CreateWorkspaceEnvIn,
     EnvEntryListOut,
     EnvEntryOut,
-    UpdateSecretValueIn,
+    UpdateEntryIn,
 )
 from cubebox.auth.context import RequestContext
 from cubebox.auth.dependencies import require_admin, require_member
@@ -186,10 +186,10 @@ async def delete_user_env(
 
 
 @router.patch("/workspace/{entry_id}", response_model=EnvEntryOut)
-async def rotate_workspace_env(
+async def update_workspace_env(
     workspace_id: str,
     entry_id: str,
-    body: UpdateSecretValueIn,
+    body: UpdateEntryIn,
     session: Annotated[AsyncSession, Depends(get_session)],
     backend: Annotated[EncryptionBackend, Depends(get_encryption_backend)],
     ctx: Annotated[RequestContext, Depends(require_admin)],
@@ -203,10 +203,13 @@ async def rotate_workspace_env(
     ):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "not found")
     try:
-        await _service(session, backend, ctx).update_value(
-            entry_id=entry_id, secret_value=body.secret_value
+        await _service(session, backend, ctx).update_entry(
+            entry_id=entry_id,
+            hosts=body.hosts,
+            header_names=body.header_names,
+            secret_value=body.secret_value,
         )
-    except SandboxEnvShapeError as exc:
+    except (SandboxEnvShapeError, HostPatternError) as exc:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
     updated = await SandboxEnvRepository(session, org_id=ctx.org_id).get(entry_id)
     assert updated is not None
@@ -214,10 +217,10 @@ async def rotate_workspace_env(
 
 
 @router.patch("/me/{entry_id}", response_model=EnvEntryOut)
-async def rotate_user_env(
+async def update_user_env(
     workspace_id: str,
     entry_id: str,
-    body: UpdateSecretValueIn,
+    body: UpdateEntryIn,
     session: Annotated[AsyncSession, Depends(get_session)],
     backend: Annotated[EncryptionBackend, Depends(get_encryption_backend)],
     ctx: Annotated[RequestContext, Depends(require_member)],
@@ -231,10 +234,13 @@ async def rotate_user_env(
     ):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "not found")
     try:
-        await _service(session, backend, ctx).update_value(
-            entry_id=entry_id, secret_value=body.secret_value
+        await _service(session, backend, ctx).update_entry(
+            entry_id=entry_id,
+            hosts=body.hosts,
+            header_names=body.header_names,
+            secret_value=body.secret_value,
         )
-    except SandboxEnvShapeError as exc:
+    except (SandboxEnvShapeError, HostPatternError) as exc:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
     updated = await SandboxEnvRepository(session, org_id=ctx.org_id).get(entry_id)
     assert updated is not None

--- a/backend/cubebox/api/schemas/sandbox_env.py
+++ b/backend/cubebox/api/schemas/sandbox_env.py
@@ -24,6 +24,20 @@ class UpdateSecretValueIn(BaseModel):
     secret_value: str
 
 
+class UpdateEntryIn(BaseModel):
+    """Partial update for an existing env entry.
+
+    At least one field must be provided.  ``secret_value`` rotates the stored
+    credential.  ``hosts`` / ``header_names`` update the substitution rules
+    (secret entries only; ignored / rejected for plain env-value entries by the
+    service layer).  All three may be provided in a single request.
+    """
+
+    secret_value: str | None = None
+    hosts: list[str] | None = None
+    header_names: list[str] | None = None
+
+
 class EnvEntryOut(BaseModel):
     id: str
     env_name: str

--- a/backend/cubebox/sandbox_env/injector.py
+++ b/backend/cubebox/sandbox_env/injector.py
@@ -41,6 +41,10 @@ class SandboxEnvInjector:
                     {
                         "ref_hash": hash_placeholder(placeholder),
                         "env_name": r.env_name,
+                        "env_var_id": r.id,
+                        # hosts/header_names/credential_id are kept as a snapshot
+                        # for backward-compat with old EgressRefs; the exchange
+                        # service prefers the live DB lookup via env_var_id.
                         "hosts": r.hosts,
                         "header_names": r.header_names,
                         "credential_id": r.credential_id,

--- a/backend/cubebox/services/egress_exchange.py
+++ b/backend/cubebox/services/egress_exchange.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 from cubebox.credentials.exceptions import CredentialKindMismatch, CredentialNotFound
 from cubebox.repositories.egress_ref import EgressRefRepository
+from cubebox.repositories.sandbox_env import SandboxEnvRepository
 from cubebox.sandbox_env.exchange_auth import SidecarIdentity
 from cubebox.sandbox_env.host_rules import host_matches
 from cubebox.sandbox_env.placeholder import hash_placeholder
@@ -23,17 +24,22 @@ class EgressExchangeService:
         *,
         ref_repo: EgressRefRepository,
         credentials_factory: Callable[[str], CredentialService],
+        env_var_repo_factory: Callable[[str], SandboxEnvRepository] | None = None,
     ) -> None:
         self._refs = ref_repo
         self._credentials_factory = credentials_factory
+        self._env_var_repo_factory = env_var_repo_factory
 
     async def exchange(
         self, *, identity: SidecarIdentity, placeholder: str, host: str
     ) -> tuple[str, list[str] | None]:
         """Return (secret, header_names) for the matched binding.
 
-        header_names is the binding's allow-list of HTTP header names the secret
-        may be substituted into, or None if the binding allows any header.
+        When the binding carries an ``env_var_id`` the service does a live DB
+        lookup so that user edits to hosts/header_names take effect immediately
+        without requiring a sandbox restart or a new ``_apply_egress`` call.
+        Bindings created before this change (no ``env_var_id``) fall back to
+        the snapshot embedded in the EgressRef.
         """
         ref = await self._refs.get_valid_by_hash(hash_placeholder(placeholder))
         if ref is None:
@@ -41,17 +47,44 @@ class EgressExchangeService:
         if ref.sandbox_id != identity.sandbox_id:
             raise EgressExchangeError("sandbox_id mismatch")
         host_norm = host.lower().split(":", 1)[0]
-        binding = next((b for b in ref.bindings if host_matches(host_norm, b["hosts"])), None)
-        if binding is None:
+
+        matched_binding = None
+        matched_credential_id: str | None = None
+        matched_header_names: list[str] | None = None
+
+        for b in ref.bindings:
+            env_var_id: str | None = b.get("env_var_id")
+            if env_var_id and self._env_var_repo_factory is not None:
+                # Live lookup: use current hosts/header_names/credential_id from DB.
+                repo = self._env_var_repo_factory(ref.org_id)
+                env_var = await repo.get(env_var_id)
+                if env_var is None:
+                    # Entry deleted while sandbox was running — fail closed for this binding.
+                    continue
+                if not host_matches(host_norm, env_var.hosts or []):
+                    continue
+                matched_binding = b
+                matched_credential_id = env_var.credential_id
+                matched_header_names = env_var.header_names
+            else:
+                # Backward compat: snapshot-based lookup for old EgressRefs.
+                if not host_matches(host_norm, b.get("hosts") or []):
+                    continue
+                matched_binding = b
+                matched_credential_id = b.get("credential_id")
+                matched_header_names = b.get("header_names")
+            break
+
+        if matched_binding is None:
             raise EgressExchangeError(f"host {host_norm!r} not allowed for this placeholder")
+        if matched_credential_id is None:
+            raise EgressExchangeError("bound credential is gone")
+
         creds = self._credentials_factory(ref.org_id)
         try:
             secret = await creds.get_decrypted(
-                credential_id=binding["credential_id"], requesting_kind=SANDBOX_ENV_KIND
+                credential_id=matched_credential_id, requesting_kind=SANDBOX_ENV_KIND
             )
         except (CredentialNotFound, CredentialKindMismatch) as exc:
-            # The vault entry/credential was deleted while a ref was still valid
-            # (e.g. the env entry was removed mid-run). Fail closed (403), not 500.
             raise EgressExchangeError("bound credential is gone") from exc
-        header_names: list[str] | None = binding.get("header_names")
-        return secret, header_names
+        return secret, matched_header_names

--- a/backend/cubebox/services/sandbox_env.py
+++ b/backend/cubebox/services/sandbox_env.py
@@ -154,21 +154,24 @@ class SandboxEnvService:
         entry_id: str,
         hosts: list[str] | None = None,
         header_names: list[str] | None = None,
+        update_header_names: bool = False,
         secret_value: str | None = None,
     ) -> None:
         """Update hosts/header_names and/or rotate the credential value.
 
-        ``hosts`` and ``header_names`` are only applicable to secret entries;
-        passing them for a plain entry raises SandboxEnvShapeError.
-        At least one argument must be non-None.
+        ``hosts`` and ``header_names`` are only applicable to secret entries.
+        ``update_header_names`` must be True to write ``header_names``; this
+        separates "explicitly set to None (clear restriction)" from "omitted
+        (leave unchanged)".  Callers should pass
+        ``update_header_names='header_names' in body.model_fields_set``.
         """
-        if hosts is None and header_names is None and secret_value is None:
+        if hosts is None and not update_header_names and secret_value is None:
             raise SandboxEnvShapeError("update_entry: at least one field must be provided")
         row = await self._repo.get(entry_id)
         if row is None:
             raise SandboxEnvShapeError(f"entry {entry_id!r} not found")
 
-        if hosts is not None or header_names is not None:
+        if hosts is not None or update_header_names:
             if not row.is_secret:
                 raise SandboxEnvShapeError(
                     "hosts/header_names are only applicable to secret entries"
@@ -176,7 +179,8 @@ class SandboxEnvService:
             if hosts is not None:
                 validate_hosts(hosts)
                 row.hosts = hosts
-            if header_names is not None:
+            if update_header_names:
+                # None means "allow any header"; an empty list is normalised to None.
                 row.header_names = header_names or None
             await self._repo.update(row)
 

--- a/backend/cubebox/services/sandbox_env.py
+++ b/backend/cubebox/services/sandbox_env.py
@@ -58,6 +58,7 @@ def _validate_value_shape(
 
 @dataclass
 class ResolvedEnv:
+    id: str
     env_name: str
     is_secret: bool
     hosts: list[str] | None
@@ -147,6 +148,43 @@ class SandboxEnvService:
             raise SandboxEnvShapeError(f"no entry with credential {entry_id}")
         await self._credentials.update(credential_id=row.credential_id, plaintext=secret_value)
 
+    async def update_entry(
+        self,
+        *,
+        entry_id: str,
+        hosts: list[str] | None = None,
+        header_names: list[str] | None = None,
+        secret_value: str | None = None,
+    ) -> None:
+        """Update hosts/header_names and/or rotate the credential value.
+
+        ``hosts`` and ``header_names`` are only applicable to secret entries;
+        passing them for a plain entry raises SandboxEnvShapeError.
+        At least one argument must be non-None.
+        """
+        if hosts is None and header_names is None and secret_value is None:
+            raise SandboxEnvShapeError("update_entry: at least one field must be provided")
+        row = await self._repo.get(entry_id)
+        if row is None:
+            raise SandboxEnvShapeError(f"entry {entry_id!r} not found")
+
+        if hosts is not None or header_names is not None:
+            if not row.is_secret:
+                raise SandboxEnvShapeError(
+                    "hosts/header_names are only applicable to secret entries"
+                )
+            if hosts is not None:
+                validate_hosts(hosts)
+                row.hosts = hosts
+            if header_names is not None:
+                row.header_names = header_names or None
+            await self._repo.update(row)
+
+        if secret_value is not None:
+            if row.credential_id is None:
+                raise SandboxEnvShapeError(f"entry {entry_id!r} has no credential")
+            await self._credentials.update(credential_id=row.credential_id, plaintext=secret_value)
+
     async def delete_entry(self, *, entry_id: str) -> None:
         row = await self._repo.get(entry_id)
         if row is None:
@@ -171,6 +209,7 @@ class SandboxEnvResolver:
                 best[row.env_name] = row
         return [
             ResolvedEnv(
+                id=r.id,
                 env_name=r.env_name,
                 is_secret=r.is_secret,
                 hosts=r.hosts,

--- a/backend/tests/unit/test_egress_injector.py
+++ b/backend/tests/unit/test_egress_injector.py
@@ -8,8 +8,8 @@ from cubebox.services.sandbox_env import ResolvedEnv
 def test_secret_becomes_placeholder_env_value_passes_through():
     inj = SandboxEnvInjector(exchange_host="egress-exchange.internal")
     resolved = [
-        ResolvedEnv("GITHUB_TOKEN", True, ["api.github.com"], None, "cred-1"),
-        ResolvedEnv("LOG_LEVEL", False, None, None, None, value="info"),
+        ResolvedEnv("senv-1", "GITHUB_TOKEN", True, ["api.github.com"], None, "cred-1"),
+        ResolvedEnv("senv-2", "LOG_LEVEL", False, None, None, None, value="info"),
     ]
     result = inj.build(resolved)
     assert PLACEHOLDER_RE.fullmatch(result.env["GITHUB_TOKEN"])
@@ -21,14 +21,14 @@ def test_secret_becomes_placeholder_env_value_passes_through():
 def test_env_value_missing_value_raises():
     inj = SandboxEnvInjector(exchange_host="x.internal")
     with pytest.raises(ValueError, match="no decrypted value"):
-        inj.build([ResolvedEnv("MISSING", False, None, None, None)])
+        inj.build([ResolvedEnv("senv-x", "MISSING", False, None, None, None)])
 
 
 def test_vault_hosts_do_not_leak_into_a_network_policy():
     # Network reachability is independent of credential substitution: the
     # injector must not expose any network policy / allow-list.
     inj = SandboxEnvInjector(exchange_host="x.internal")
-    result = inj.build([ResolvedEnv("T", True, ["*.example.com"], None, "c")])
+    result = inj.build([ResolvedEnv("senv-t", "T", True, ["*.example.com"], None, "c")])
     assert not hasattr(result, "network_policy")
     assert isinstance(result, InjectionResult)
     assert result.bindings[0]["hosts"] == ["*.example.com"]

--- a/backend/tests/unit/test_manager_egress_injection.py
+++ b/backend/tests/unit/test_manager_egress_injection.py
@@ -57,6 +57,7 @@ async def _fake_reconnect(sandbox_id: str, **kwargs: Any) -> Any:
 
 _RESOLVED_ENVS = [
     ResolvedEnv(
+        id="senv-1",
         env_name="GITHUB_TOKEN",
         is_secret=True,
         hosts=["api.github.com"],
@@ -64,6 +65,7 @@ _RESOLVED_ENVS = [
         credential_id="cred-1",
     ),
     ResolvedEnv(
+        id="senv-2",
         env_name="LOG_LEVEL",
         is_secret=False,
         hosts=None,

--- a/frontend/packages/core/src/api/sandboxEnv.ts
+++ b/frontend/packages/core/src/api/sandboxEnv.ts
@@ -25,8 +25,10 @@ export interface CreateEnvIn {
   plain_value?: string | null
 }
 
-export interface RotateSecretIn {
-  secret_value: string
+export interface UpdateEntryIn {
+  secret_value?: string | null
+  hosts?: string[] | null
+  header_names?: string[] | null
 }
 
 // ── Workspace: workspace scope (/workspace) ──────────────────────────────────
@@ -50,11 +52,11 @@ export async function createWsEnvWorkspace(
   return (await res.json()) as EnvEntryOut
 }
 
-export async function rotateWsEnvWorkspace(
+export async function updateWsEnvWorkspace(
   client: ApiClient,
   wsId: string,
   id: string,
-  body: RotateSecretIn,
+  body: UpdateEntryIn,
 ): Promise<EnvEntryOut> {
   const res = await client.patch(`/api/v1/ws/${wsId}/sandbox-env/workspace/${id}`, body)
   if (!res.ok) throw await toApiError(res)
@@ -88,11 +90,11 @@ export async function createWsEnvMe(
   return (await res.json()) as EnvEntryOut
 }
 
-export async function rotateWsEnvMe(
+export async function updateWsEnvMe(
   client: ApiClient,
   wsId: string,
   id: string,
-  body: RotateSecretIn,
+  body: UpdateEntryIn,
 ): Promise<EnvEntryOut> {
   const res = await client.patch(`/api/v1/ws/${wsId}/sandbox-env/me/${id}`, body)
   if (!res.ok) throw await toApiError(res)
@@ -118,10 +120,10 @@ export async function createAdminEnv(client: ApiClient, body: CreateEnvIn): Prom
   return (await res.json()) as EnvEntryOut
 }
 
-export async function rotateAdminEnv(
+export async function updateAdminEnv(
   client: ApiClient,
   id: string,
-  body: RotateSecretIn,
+  body: UpdateEntryIn,
 ): Promise<EnvEntryOut> {
   const res = await client.patch(`/api/v1/admin/sandbox-env/${id}`, body)
   if (!res.ok) throw await toApiError(res)

--- a/frontend/packages/web/app/(app)/w/[wsId]/sandbox-env/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/sandbox-env/page.tsx
@@ -10,11 +10,12 @@ import {
   deleteWsEnvWorkspace,
   listWsEnvMe,
   listWsEnvWorkspace,
-  rotateWsEnvMe,
-  rotateWsEnvWorkspace,
+  updateWsEnvMe,
+  updateWsEnvWorkspace,
   useWorkspaceStore,
   type CreateEnvIn,
   type EnvEntryOut,
+  type UpdateEntryIn,
 } from '@cubebox/core'
 import { EnvTable } from '@/components/sandbox-env/EnvTable'
 import { EnvModal, type ModalMode } from '@/components/sandbox-env/EnvModal'
@@ -77,20 +78,18 @@ export default function WorkspaceSandboxEnvPage({ params }: PageProps): React.Re
   }, [client, wsId, isAdmin])
 
   async function handleSubmit(
-    body: CreateEnvIn | { secret_value: string },
+    body: CreateEnvIn | UpdateEntryIn,
     entryId?: string,
     scope?: 'workspace' | 'user',
   ) {
     if (entryId) {
-      // Rotate: find the entry to determine which path to call
       const entry = entries.find((e) => e.id === entryId)
       if (entry?.scope === 'workspace') {
-        await rotateWsEnvWorkspace(client, wsId, entryId, body as { secret_value: string })
+        await updateWsEnvWorkspace(client, wsId, entryId, body as UpdateEntryIn)
       } else {
-        await rotateWsEnvMe(client, wsId, entryId, body as { secret_value: string })
+        await updateWsEnvMe(client, wsId, entryId, body as UpdateEntryIn)
       }
     } else {
-      // Add: use the scope the user selected inside the modal
       const createBody = body as CreateEnvIn
       if (scope === 'workspace') {
         await createWsEnvWorkspace(client, wsId, createBody)
@@ -153,7 +152,7 @@ export default function WorkspaceSandboxEnvPage({ params }: PageProps): React.Re
             entries={entries}
             loading={loading}
             error={loadError}
-            onRotate={(entry) => setModal({ kind: 'rotate', entry })}
+            onEdit={(entry) => setModal({ kind: 'edit', entry })}
             onDelete={handleDelete}
           />
         </div>

--- a/frontend/packages/web/app/admin/sandbox-env/page.tsx
+++ b/frontend/packages/web/app/admin/sandbox-env/page.tsx
@@ -7,9 +7,10 @@ import {
   createAdminEnv,
   deleteAdminEnv,
   listAdminEnv,
-  rotateAdminEnv,
+  updateAdminEnv,
   type CreateEnvIn,
   type EnvEntryOut,
+  type UpdateEntryIn,
 } from '@cubebox/core'
 import { EnvTable } from '@/components/sandbox-env/EnvTable'
 import { EnvModal, type ModalMode } from '@/components/sandbox-env/EnvModal'
@@ -52,12 +53,12 @@ export default function AdminSandboxEnvPage() {
   }, [client])
 
   async function handleSubmit(
-    body: CreateEnvIn | { secret_value: string },
+    body: CreateEnvIn | UpdateEntryIn,
     entryId?: string,
     _scope?: 'workspace' | 'user',
   ) {
     if (entryId) {
-      await rotateAdminEnv(client, entryId, body as { secret_value: string })
+      await updateAdminEnv(client, entryId, body as UpdateEntryIn)
     } else {
       await createAdminEnv(client, body as CreateEnvIn)
     }
@@ -100,7 +101,7 @@ export default function AdminSandboxEnvPage() {
             entries={entries}
             loading={loading}
             error={loadError}
-            onRotate={(entry) => setModal({ kind: 'rotate', entry })}
+            onEdit={(entry) => setModal({ kind: 'edit', entry })}
             onDelete={handleDelete}
           />
         </div>

--- a/frontend/packages/web/components/sandbox-env/EnvModal.tsx
+++ b/frontend/packages/web/components/sandbox-env/EnvModal.tsx
@@ -3,7 +3,7 @@
 
 import { useState } from 'react'
 import { X } from 'lucide-react'
-import { type CreateEnvIn, type EnvEntryOut } from '@cubebox/core'
+import { type CreateEnvIn, type EnvEntryOut, type UpdateEntryIn } from '@cubebox/core'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -11,19 +11,17 @@ import { Label } from '@/components/ui/label'
 export type ModalMode =
   | { kind: 'add-org' }
   | { kind: 'add-workspace'; defaultScope: 'workspace' | 'user' }
-  | { kind: 'rotate'; entry: EnvEntryOut }
+  | { kind: 'edit'; entry: EnvEntryOut }
 
 interface Props {
   mode: ModalMode
   onSubmit: (
-    body: CreateEnvIn | { secret_value: string },
+    body: CreateEnvIn | UpdateEntryIn,
     entryId?: string,
     scope?: 'workspace' | 'user',
   ) => Promise<void>
   onClose: () => void
 }
-
-const NAME_RE = /^[A-Z_][A-Z0-9_]*$/
 
 function parseHosts(raw: string): string[] {
   return raw
@@ -32,20 +30,30 @@ function parseHosts(raw: string): string[] {
     .filter(Boolean)
 }
 
-export function EnvModal({ mode, onSubmit, onClose }: Props) {
-  const isRotate = mode.kind === 'rotate'
+function hostsToRaw(hosts: string[] | null | undefined): string {
+  return hosts ? hosts.join(' ') : ''
+}
 
-  const [name, setName] = useState(isRotate ? mode.entry.env_name : '')
+export function EnvModal({ mode, onSubmit, onClose }: Props) {
+  const isEdit = mode.kind === 'edit'
+  const entry = isEdit ? mode.entry : null
+
+  const [name, setName] = useState(entry?.env_name ?? '')
   const [scope, setScope] = useState<'workspace' | 'user'>(
     mode.kind === 'add-workspace' ? mode.defaultScope : 'workspace',
   )
-  const [isSecret, setIsSecret] = useState(true)
+  const [isSecret, setIsSecret] = useState(entry ? entry.is_secret : true)
   const [value, setValue] = useState('')
-  const [hostsRaw, setHostsRaw] = useState('')
+  const [hostsRaw, setHostsRaw] = useState(hostsToRaw(entry?.hosts))
+  const [headerNamesRaw, setHeaderNamesRaw] = useState(
+    entry?.header_names ? entry.header_names.join(' ') : '',
+  )
   const [nameError, setNameError] = useState<string | null>(null)
   const [hostsError, setHostsError] = useState<string | null>(null)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+
+  const NAME_RE = /^[A-Z_][A-Z0-9_]*$/
 
   function validateName(v: string): string | null {
     if (!v) return 'Name is required'
@@ -70,7 +78,43 @@ export function EnvModal({ mode, onSubmit, onClose }: Props) {
     e.preventDefault()
     setSubmitError(null)
 
-    const nErr = isRotate ? null : validateName(name)
+    if (isEdit) {
+      // Edit mode: hosts required for secrets, value optional
+      const hErr = isSecret ? validateHosts(hostsRaw) : null
+      setHostsError(hErr)
+      if (hErr) return
+
+      const body: UpdateEntryIn = {}
+      if (isSecret) {
+        body.hosts = parseHosts(hostsRaw)
+        body.header_names = headerNamesRaw.trim()
+          ? headerNamesRaw
+              .split(/[\s,]+/)
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : null
+      }
+      if (value) body.secret_value = value
+
+      if (!body.hosts && !body.secret_value) {
+        setSubmitError('No changes to save')
+        return
+      }
+
+      setSaving(true)
+      try {
+        await onSubmit(body, entry!.id)
+        onClose()
+      } catch (err: unknown) {
+        setSubmitError(err instanceof Error ? err.message : 'An error occurred')
+      } finally {
+        setSaving(false)
+      }
+      return
+    }
+
+    // Add mode
+    const nErr = validateName(name)
     const hErr = isSecret ? validateHosts(hostsRaw) : null
     setNameError(nErr)
     setHostsError(hErr)
@@ -82,20 +126,15 @@ export function EnvModal({ mode, onSubmit, onClose }: Props) {
 
     setSaving(true)
     try {
-      if (isRotate) {
-        await onSubmit({ secret_value: value }, mode.entry.id)
-      } else {
-        const body: CreateEnvIn = {
-          env_name: name,
-          is_secret: isSecret,
-          ...(isSecret
-            ? { secret_value: value, hosts: parseHosts(hostsRaw) }
-            : { secret_value: value }),
-        }
-        // Pass the final scope selection (only relevant for workspace-mode adds)
-        const finalScope = mode.kind === 'add-workspace' ? scope : undefined
-        await onSubmit(body, undefined, finalScope)
+      const body: CreateEnvIn = {
+        env_name: name,
+        is_secret: isSecret,
+        ...(isSecret
+          ? { secret_value: value, hosts: parseHosts(hostsRaw) }
+          : { secret_value: value }),
       }
+      const finalScope = mode.kind === 'add-workspace' ? scope : undefined
+      await onSubmit(body, undefined, finalScope)
       onClose()
     } catch (err: unknown) {
       setSubmitError(err instanceof Error ? err.message : 'An error occurred')
@@ -115,28 +154,34 @@ export function EnvModal({ mode, onSubmit, onClose }: Props) {
         </button>
 
         <h2 className="mb-5 text-base font-semibold">
-          {isRotate ? 'Rotate value' : 'Add environment variable'}
+          {isEdit ? 'Edit environment variable' : 'Add environment variable'}
         </h2>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          {/* NAME */}
-          {!isRotate && (
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="env-name" className="text-xs font-medium">
-                Name
-              </Label>
-              <Input
-                id="env-name"
-                value={name}
-                onChange={(e) => setName(e.target.value.toUpperCase())}
-                onBlur={() => setNameError(validateName(name))}
-                className="font-mono text-sm"
-                placeholder="VARIABLE_NAME"
-                maxLength={128}
-              />
-              {nameError && <p className="text-xs text-destructive">{nameError}</p>}
-            </div>
-          )}
+          {/* NAME — read-only in edit, editable in add */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="env-name" className="text-xs font-medium">
+              Name
+            </Label>
+            {isEdit ? (
+              <div className="rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-sm text-muted-foreground">
+                {entry!.env_name}
+              </div>
+            ) : (
+              <>
+                <Input
+                  id="env-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value.toUpperCase())}
+                  onBlur={() => setNameError(validateName(name))}
+                  className="font-mono text-sm"
+                  placeholder="VARIABLE_NAME"
+                  maxLength={128}
+                />
+                {nameError && <p className="text-xs text-destructive">{nameError}</p>}
+              </>
+            )}
+          </div>
 
           {/* SCOPE — only for workspace-admin add */}
           {mode.kind === 'add-workspace' && (
@@ -159,8 +204,15 @@ export function EnvModal({ mode, onSubmit, onClose }: Props) {
             </div>
           )}
 
-          {/* TYPE — only for add */}
-          {!isRotate && (
+          {/* TYPE — read-only in edit, selectable in add */}
+          {isEdit ? (
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs font-medium">Type</Label>
+              <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                {entry!.is_secret ? 'Secret token' : 'Env value'}
+              </div>
+            </div>
+          ) : (
             <div className="flex flex-col gap-1.5">
               <Label className="text-xs font-medium">Type</Label>
               <div className="flex flex-col gap-2.5">
@@ -206,25 +258,8 @@ export function EnvModal({ mode, onSubmit, onClose }: Props) {
             </div>
           )}
 
-          {/* VALUE */}
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="env-value" className="text-xs font-medium">
-              {isRotate ? 'New secret value' : 'Value'}
-            </Label>
-            <Input
-              id="env-value"
-              type="password"
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              className="font-mono text-sm"
-              placeholder="••••••••"
-              autoComplete="off"
-              maxLength={isSecret ? undefined : 4096}
-            />
-          </div>
-
-          {/* HOSTS — only for secrets */}
-          {isSecret && !isRotate && (
+          {/* HOSTS — for secrets */}
+          {isSecret && (
             <div className="flex flex-col gap-1.5">
               <Label htmlFor="env-hosts" className="text-xs font-medium">
                 Allowed hosts{' '}
@@ -244,6 +279,42 @@ export function EnvModal({ mode, onSubmit, onClose }: Props) {
             </div>
           )}
 
+          {/* HEADER NAMES — optional, for secrets in edit mode */}
+          {isSecret && isEdit && (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="env-header-names" className="text-xs font-medium">
+                Allowed header names{' '}
+                <span className="font-normal text-muted-foreground">
+                  (optional; leave blank for any header)
+                </span>
+              </Label>
+              <Input
+                id="env-header-names"
+                value={headerNamesRaw}
+                onChange={(e) => setHeaderNamesRaw(e.target.value)}
+                placeholder="authorization x-api-key"
+                className="text-sm"
+              />
+            </div>
+          )}
+
+          {/* VALUE */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="env-value" className="text-xs font-medium">
+              {isEdit ? 'New value (leave blank to keep current)' : 'Value'}
+            </Label>
+            <Input
+              id="env-value"
+              type="password"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              className="font-mono text-sm"
+              placeholder="••••••••"
+              autoComplete="off"
+              maxLength={isSecret ? undefined : 4096}
+            />
+          </div>
+
           {/* Submit error */}
           {submitError && (
             <p className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
@@ -257,7 +328,7 @@ export function EnvModal({ mode, onSubmit, onClose }: Props) {
               Cancel
             </Button>
             <Button type="submit" size="sm" disabled={saving}>
-              {saving ? 'Saving…' : isRotate ? 'Rotate' : 'Add'}
+              {saving ? 'Saving…' : isEdit ? 'Save' : 'Add'}
             </Button>
           </div>
         </form>

--- a/frontend/packages/web/components/sandbox-env/EnvModal.tsx
+++ b/frontend/packages/web/components/sandbox-env/EnvModal.tsx
@@ -63,13 +63,17 @@ export function EnvModal({ mode, onSubmit, onClose }: Props) {
     return null
   }
 
+  function isValidHostPattern(h: string): boolean {
+    // Backend also accepts anchored regex patterns like /^api\.example\.com$/
+    if (/^\/\^.*\$\/$/.test(h)) return true
+    return /^(\*\.)?[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/.test(h)
+  }
+
   function validateHosts(raw: string): string | null {
     if (!isSecret) return null
     const hosts = parseHosts(raw)
     if (hosts.length === 0) return 'At least one host is required for secrets'
-    const invalid = hosts.filter(
-      (h) => !/^(\*\.)?[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/.test(h),
-    )
+    const invalid = hosts.filter((h) => !isValidHostPattern(h))
     if (invalid.length > 0) return `Invalid host pattern: ${invalid[0]}`
     return null
   }

--- a/frontend/packages/web/components/sandbox-env/EnvTable.tsx
+++ b/frontend/packages/web/components/sandbox-env/EnvTable.tsx
@@ -13,7 +13,7 @@ interface Props {
   entries: EnvEntryOut[]
   loading: boolean
   error: string | null
-  onRotate: (entry: EnvEntryOut) => void
+  onEdit: (entry: EnvEntryOut) => void
   onDelete: (entry: EnvEntryOut) => void
 }
 
@@ -32,7 +32,7 @@ function ScopeBadge({ scope }: { scope: 'workspace' | 'user' }) {
   )
 }
 
-export function EnvTable({ mode, entries, loading, error, onRotate, onDelete }: Props) {
+export function EnvTable({ mode, entries, loading, error, onEdit, onDelete }: Props) {
   const showScope = mode !== 'org'
 
   if (loading) {
@@ -113,14 +113,12 @@ export function EnvTable({ mode, entries, loading, error, onRotate, onDelete }: 
                 </td>
                 <td className="px-4 py-2.5 text-right">
                   <div className="flex items-center justify-end gap-3">
-                    {entry.is_secret && (
-                      <button
-                        onClick={() => onRotate(entry)}
-                        className="text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        rotate
-                      </button>
-                    )}
+                    <button
+                      onClick={() => onEdit(entry)}
+                      className="text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      edit
+                    </button>
                     <button
                       onClick={() => onDelete(entry)}
                       className="text-muted-foreground hover:text-destructive transition-colors"


### PR DESCRIPTION
## Summary

- **Edit UI**: sandbox env entries now have an **Edit** button (replaces the separate Rotate button). Edit modal pre-fills current hosts/header_names; value field is optional (leave blank to keep current value). Type and name are read-only in edit mode.
- **Immediate effect on edits**: `EgressExchangeService` now does a live DB lookup via `env_var_id` (added to bindings by the injector) so changes to hosts or header_names take effect for the currently running sandbox without requiring a restart or new `_apply_egress` call. Old EgressRefs (without `env_var_id`) fall back to the snapshot-based path for backward compat.
- **New `update_entry()` service method**: handles hosts/header_names/value updates in one call with proper validation (hosts required for secrets, forbidden for plain entries).
- **API**: PATCH endpoints now accept `UpdateEntryIn` (`{hosts?, header_names?, secret_value?}`) instead of `{secret_value}` only.

## Test plan

- [ ] Open sandbox env page, click Edit on a secret entry → modal shows current hosts pre-filled
- [ ] Change hosts (e.g. fix `*.cuecue.cn` → `cuecue.cn`), save → API PATCH succeeds, table updates
- [ ] Edit without changing value → value unchanged (no rotation)
- [ ] Edit with a new value → credential rotated
- [ ] Edit a plain (non-secret) entry → hosts field hidden, only value editable
- [ ] Run cue research after editing hosts → 200 OK (verifies live EgressRef lookup works)