### PR TITLE
feat(skills): skill search UX — preview_skill, install_skill tools + skill cards

### DIFF
--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1133,10 +1133,18 @@ class RunManager:
         # for None (the catalog DB may be unavailable at run start).
         if skill_catalog is not None and catalog_session is not None:
             try:
+                from sqlalchemy.ext.asyncio import AsyncSession as _AsyncSession
+
                 from cubebox.repositories.organization import OrganizationRepository
-                from cubebox.skills.discovery import SkillDiscoveryService
+                from cubebox.skills.discovery import (
+                    SkillDiscoveryService,
+                    SkillInstallService,
+                )
+                from cubebox.skills.service import SkillCatalogService, SkillPublishService
                 from cubebox.skills.sources.registry import SkillsAdapterManager
                 from cubebox.tools.builtin.find_skills import create_find_skills_tool
+                from cubebox.tools.builtin.install_skill import create_install_skill_tool
+                from cubebox.tools.builtin.preview_skill import create_preview_skill_tool
 
                 _org = await OrganizationRepository(catalog_session).get(ctx.org_id)
                 if _org is not None:
@@ -1149,6 +1157,37 @@ class RunManager:
                     )
                     _builtin_tools.append(
                         create_find_skills_tool(discovery=SkillDiscoveryService(_registry))
+                    )
+                    _builtin_tools.append(
+                        create_preview_skill_tool(
+                            session=catalog_session,
+                            registry=_registry,
+                            catalog=skill_catalog,
+                            org_id=ctx.org_id,
+                        )
+                    )
+
+                    def _make_install_factory(
+                        _session: _AsyncSession = catalog_session,
+                        _registry: SkillsAdapterManager = _registry,
+                        _catalog: SkillCatalogService = skill_catalog,
+                        _org_id: str = ctx.org_id,
+                        _org_slug: str = _org.slug,
+                        _workspace_id: str | None = ctx.workspace_id,
+                        _actor: str = ctx.user_id,
+                    ) -> SkillInstallService:
+                        return SkillInstallService(
+                            session=_session,
+                            registry=_registry,
+                            publisher=SkillPublishService(session=_session, cache=_catalog.cache),
+                            org_id=_org_id,
+                            org_slug=_org_slug,
+                            workspace_id=_workspace_id,
+                            actor_user_id=_actor,
+                        )
+
+                    _builtin_tools.append(
+                        create_install_skill_tool(install_service_factory=_make_install_factory)
                     )
             except Exception as _exc:  # noqa: BLE001
                 logger.warning("find_skills unavailable for cubepi run: {}", _exc)

--- a/backend/cubebox/tools/builtin/find_skills.py
+++ b/backend/cubebox/tools/builtin/find_skills.py
@@ -50,9 +50,10 @@ def create_find_skills_tool(*, discovery: SkillDiscoveryService) -> AgentTool[Fi
             ],
             "hint": (
                 "To use an 'enabled' candidate now, call load_skill(canonical_name). "
-                "To install an 'in_catalog' or 'available' candidate, ask the user "
-                "to confirm — installation is a user action via the install "
-                "button/route, never silent."
+                "To install an 'in_catalog' or 'available' candidate: present it to the "
+                "user with preview_skill(candidate_id) so they can see what it does, then "
+                "call install_skill(candidate_id) only when the user explicitly asks to install. "
+                "Never install silently."
             ),
         }
         return AgentToolResult(content=[TextContent(text=json.dumps(payload))])

--- a/backend/cubebox/tools/builtin/find_skills.py
+++ b/backend/cubebox/tools/builtin/find_skills.py
@@ -44,6 +44,7 @@ def create_find_skills_tool(*, discovery: SkillDiscoveryService) -> AgentTool[Fi
                     "repo": c.repo,
                     "trust": c.trust.value,
                     "install_state": c.install_state,
+                    "install_count": c.install_count,
                     "unvetted": c.source_kind == "remote" and c.trust.value != "official",
                 }
                 for c in cands

--- a/backend/cubebox/tools/builtin/install_skill.py
+++ b/backend/cubebox/tools/builtin/install_skill.py
@@ -1,0 +1,73 @@
+"""install_skill tool — install a skill candidate for the current workspace.
+
+Only call this when the user has explicitly requested installation in
+the current conversation. On success, call load_skill(canonical_name)
+immediately to begin using the installed skill.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import TextContent
+from pydantic import BaseModel, Field
+
+from cubebox.skills.discovery import SkillInstallError, SkillInstallService
+from cubebox.skills.sources.base import CandidateIdError, decode_candidate_id
+
+
+class InstallSkillInput(BaseModel):
+    candidate_id: str = Field(
+        description=(
+            "The candidate_id from a find_skills result. "
+            "Only call this after the user has explicitly confirmed they want to install."
+        )
+    )
+
+
+def create_install_skill_tool(
+    *,
+    install_service_factory: Callable[[], SkillInstallService],
+) -> AgentTool[InstallSkillInput]:
+    async def _execute(
+        tool_call_id: str,
+        args: InstallSkillInput,
+        *,
+        signal: object = None,
+        on_update: object = None,
+    ) -> AgentToolResult:
+        del tool_call_id, signal, on_update
+
+        try:
+            decode_candidate_id(args.candidate_id)
+        except CandidateIdError as exc:
+            return AgentToolResult(
+                content=[TextContent(text=f"BAD_CANDIDATE_ID: {exc}")], is_error=True
+            )
+
+        svc = install_service_factory()
+        try:
+            result = await svc.install(args.candidate_id)
+        except SkillInstallError as exc:
+            return AgentToolResult(content=[TextContent(text=str(exc))], is_error=True)
+
+        payload = {
+            "installed": True,
+            "canonical_name": result.canonical_name,
+            "version": result.installed_version,
+        }
+        return AgentToolResult(content=[TextContent(text=json.dumps(payload))])
+
+    return AgentTool(
+        name="install_skill",
+        description=(
+            "Install a skill candidate into the current workspace. "
+            "Only call this when the user has explicitly asked to install. "
+            "Pass the candidate_id from a find_skills result. "
+            "On success, call load_skill(canonical_name) to use the skill immediately."
+        ),
+        parameters=InstallSkillInput,
+        execute=_execute,
+    )

--- a/backend/cubebox/tools/builtin/preview_skill.py
+++ b/backend/cubebox/tools/builtin/preview_skill.py
@@ -1,0 +1,120 @@
+"""preview_skill tool — fetch SKILL.md content for any candidate (installed or not).
+
+Used by the agent to read a skill before recommending installation. Mirrors
+the logic in GET /ws/{ws}/skills/discover/preview without requiring an HTTP
+round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import TextContent
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.skills.frontmatter import extract_env_vars, parse_skill_md
+from cubebox.skills.service import SkillCatalogService
+from cubebox.skills.sources.base import CandidateIdError, decode_candidate_id
+from cubebox.skills.sources.registry import SkillsAdapterManager
+
+
+class PreviewSkillInput(BaseModel):
+    candidate_id: str = Field(
+        description=(
+            "The candidate_id from a find_skills result. "
+            "Returns the SKILL.md content so you can describe the skill before suggesting installation."
+        )
+    )
+
+
+def _env_vars(content: str) -> list[str]:
+    try:
+        fm = parse_skill_md(content)
+        return extract_env_vars(fm.raw_metadata)
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def create_preview_skill_tool(
+    *,
+    session: AsyncSession,
+    registry: SkillsAdapterManager,
+    catalog: SkillCatalogService,
+    org_id: str,
+) -> AgentTool[PreviewSkillInput]:
+    async def _execute(
+        tool_call_id: str,
+        args: PreviewSkillInput,
+        *,
+        signal: object = None,
+        on_update: object = None,
+    ) -> AgentToolResult:
+        del tool_call_id, signal, on_update
+
+        try:
+            kind, source_id, source_ref = decode_candidate_id(args.candidate_id)
+        except CandidateIdError:
+            return AgentToolResult(content=[TextContent(text="BAD_CANDIDATE_ID")], is_error=True)
+
+        if kind == "local":
+            from cubebox.repositories.skill import SkillRepository, SkillVersionRepository
+
+            skill = await SkillRepository(session).get(source_ref)
+            if skill is None or not (
+                skill.source == "preinstalled" or skill.owner_org_id == org_id
+            ):
+                return AgentToolResult(content=[TextContent(text="SKILL_NOT_FOUND")], is_error=True)
+            sv = await SkillVersionRepository(session).find(skill.id, skill.current_version)
+            if sv is None:
+                return AgentToolResult(
+                    content=[TextContent(text="SKILL_VERSION_NOT_FOUND")], is_error=True
+                )
+            content = await catalog.fetch_skill_md(sv.id)
+            payload = {
+                "candidate_id": args.candidate_id,
+                "name": skill.name,
+                "content": content,
+                "env_vars": _env_vars(content),
+            }
+            return AgentToolResult(content=[TextContent(text=json.dumps(payload))])
+
+        # Remote path
+        adapter = registry.adapter_by_id(source_id)
+        if adapter is None:
+            return AgentToolResult(content=[TextContent(text="SOURCE_NOT_FOUND")], is_error=True)
+        try:
+            files = await adapter.fetch(source_ref)
+        except (httpx.HTTPError, ValueError) as exc:
+            return AgentToolResult(
+                content=[TextContent(text=f"REMOTE_FETCH_FAILED: {exc}")], is_error=True
+            )
+        if "SKILL.md" not in files:
+            return AgentToolResult(content=[TextContent(text="SKILL_MD_MISSING")], is_error=True)
+        try:
+            content = files["SKILL.md"].decode("utf-8")
+        except UnicodeDecodeError as exc:
+            return AgentToolResult(
+                content=[TextContent(text=f"INVALID_UTF8: {exc}")], is_error=True
+            )
+        slug = source_ref.rsplit("/", 1)[-1]
+        payload = {
+            "candidate_id": args.candidate_id,
+            "name": slug,
+            "content": content,
+            "env_vars": _env_vars(content),
+        }
+        return AgentToolResult(content=[TextContent(text=json.dumps(payload))])
+
+    return AgentTool(
+        name="preview_skill",
+        description=(
+            "Fetch the full SKILL.md of any skill candidate — installed or not. "
+            "Use this after find_skills to read what a skill does before recommending installation. "
+            "Pass the candidate_id from the find_skills result."
+        ),
+        parameters=PreviewSkillInput,
+        execute=_execute,
+    )

--- a/backend/cubebox/tools/builtin/preview_skill.py
+++ b/backend/cubebox/tools/builtin/preview_skill.py
@@ -60,13 +60,23 @@ def create_preview_skill_tool(
             return AgentToolResult(content=[TextContent(text="BAD_CANDIDATE_ID")], is_error=True)
 
         if kind == "local":
-            from cubebox.repositories.skill import SkillRepository, SkillVersionRepository
+            from cubebox.repositories.skill import (
+                OrgPreinstalledTombstoneRepository,
+                SkillRepository,
+                SkillVersionRepository,
+            )
 
             skill = await SkillRepository(session).get(source_ref)
             if skill is None or not (
                 skill.source == "preinstalled" or skill.owner_org_id == org_id
             ):
                 return AgentToolResult(content=[TextContent(text="SKILL_NOT_FOUND")], is_error=True)
+            if skill.source == "preinstalled":
+                tombstone = await OrgPreinstalledTombstoneRepository(session).get(org_id, skill.id)
+                if tombstone is not None:
+                    return AgentToolResult(
+                        content=[TextContent(text="SKILL_NOT_FOUND")], is_error=True
+                    )
             sv = await SkillVersionRepository(session).find(skill.id, skill.current_version)
             if sv is None:
                 return AgentToolResult(
@@ -100,9 +110,14 @@ def create_preview_skill_tool(
                 content=[TextContent(text=f"INVALID_UTF8: {exc}")], is_error=True
             )
         slug = source_ref.rsplit("/", 1)[-1]
+        try:
+            fm = parse_skill_md(content)
+            display_name = fm.name or slug
+        except Exception:  # noqa: BLE001
+            display_name = slug
         payload = {
             "candidate_id": args.candidate_id,
-            "name": slug,
+            "name": display_name,
             "content": content,
             "env_vars": _env_vars(content),
         }

--- a/backend/tests/unit/test_install_skill.py
+++ b/backend/tests/unit/test_install_skill.py
@@ -1,0 +1,66 @@
+"""Unit tests for the install_skill agent tool."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cubebox.skills.discovery import InstallResult, SkillInstallError
+from cubebox.tools.builtin.install_skill import InstallSkillInput, create_install_skill_tool
+
+
+class _FakeInstallService:
+    def __init__(self, result: InstallResult | Exception) -> None:
+        self._result = result
+
+    async def install(self, candidate_id: str) -> InstallResult:
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_install_skill_success() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    candidate_id = encode_candidate_id("remote", "owner/repo/main/skill", source_id="src-1")
+    svc = _FakeInstallService(
+        InstallResult(
+            canonical_name="myorg:my-skill",
+            skill_id="skl-abc",
+            installed_version="1.0.0",
+        )
+    )
+
+    tool = create_install_skill_tool(install_service_factory=lambda: svc)
+    result = await tool.execute("tc-1", InstallSkillInput(candidate_id=candidate_id))
+
+    assert not result.is_error
+    out = json.loads(result.content[0].text)
+    assert out["installed"] is True
+    assert out["canonical_name"] == "myorg:my-skill"
+    assert out["version"] == "1.0.0"
+
+
+@pytest.mark.asyncio
+async def test_install_skill_error_propagates() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    candidate_id = encode_candidate_id("remote", "owner/repo/main/skill", source_id="src-1")
+    svc = _FakeInstallService(SkillInstallError("trust tier too low"))
+
+    tool = create_install_skill_tool(install_service_factory=lambda: svc)
+    result = await tool.execute("tc-2", InstallSkillInput(candidate_id=candidate_id))
+
+    assert result.is_error
+    assert "trust tier too low" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_install_bad_candidate_id_returns_error() -> None:
+    svc = _FakeInstallService(InstallResult("x", "y", "1.0"))
+    tool = create_install_skill_tool(install_service_factory=lambda: svc)
+    result = await tool.execute("tc-3", InstallSkillInput(candidate_id="!!!bad!!!"))
+
+    assert result.is_error

--- a/backend/tests/unit/test_install_skill.py
+++ b/backend/tests/unit/test_install_skill.py
@@ -64,3 +64,4 @@ async def test_install_bad_candidate_id_returns_error() -> None:
     result = await tool.execute("tc-3", InstallSkillInput(candidate_id="!!!bad!!!"))
 
     assert result.is_error
+    assert "BAD_CANDIDATE_ID" in result.content[0].text

--- a/backend/tests/unit/test_preview_skill.py
+++ b/backend/tests/unit/test_preview_skill.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 import pytest
 
@@ -15,11 +16,18 @@ class _FakeSkillVersion:
 
 
 class _FakeSkill:
-    def __init__(self, skill_id: str, current_version: str, source: str = "preinstalled") -> None:
+    def __init__(
+        self,
+        skill_id: str,
+        current_version: str,
+        source: str = "preinstalled",
+        name: str = "fake-skill",
+    ) -> None:
         self.id = skill_id
         self.current_version = current_version
         self.source = source
         self.owner_org_id: str | None = None
+        self.name = name
 
 
 class _FakeCatalog:
@@ -62,6 +70,14 @@ class _FakeSkillVersionRepo:
 
     async def find(self, skill_id: str, version: str) -> _FakeSkillVersion | None:
         return self._sv
+
+
+class _FakeTombstoneRepo:
+    def __init__(self, tombstone: object | None) -> None:
+        self._tombstone = tombstone
+
+    async def get(self, org_id: str, skill_id: str) -> object | None:
+        return self._tombstone
 
 
 class _FakeSession:
@@ -149,3 +165,127 @@ async def test_preview_bad_candidate_id_returns_error() -> None:
 
     assert result.is_error
     assert "BAD_CANDIDATE_ID" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_preview_local_success() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    skill = _FakeSkill("skl-1", "1.0.0", name="my-skill")
+    sv = _FakeSkillVersion("sv-1")
+    catalog = _FakeCatalog("# Local Skill\nContent here.")
+
+    candidate_id = encode_candidate_id("local", "skl-1")
+    with (
+        patch("cubebox.repositories.skill.SkillRepository", return_value=_FakeSkillRepo(skill)),
+        patch(
+            "cubebox.repositories.skill.SkillVersionRepository",
+            return_value=_FakeSkillVersionRepo(sv),
+        ),
+        patch(
+            "cubebox.repositories.skill.OrgPreinstalledTombstoneRepository",
+            return_value=_FakeTombstoneRepo(None),
+        ),
+    ):
+        tool = create_preview_skill_tool(
+            session=_FakeSession(),
+            registry=_FakeRegistry(adapter=None),
+            catalog=catalog,
+            org_id="org-1",
+        )
+        result = await tool.execute("tc-5", PreviewSkillInput(candidate_id=candidate_id))
+
+    assert not result.is_error
+    out = json.loads(result.content[0].text)
+    assert out["content"] == "# Local Skill\nContent here."
+    assert out["name"] == "my-skill"
+    assert out["candidate_id"] == candidate_id
+
+
+@pytest.mark.asyncio
+async def test_preview_local_skill_not_found() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    candidate_id = encode_candidate_id("local", "skl-missing")
+    with (
+        patch("cubebox.repositories.skill.SkillRepository", return_value=_FakeSkillRepo(None)),
+        patch(
+            "cubebox.repositories.skill.SkillVersionRepository",
+            return_value=_FakeSkillVersionRepo(None),
+        ),
+        patch(
+            "cubebox.repositories.skill.OrgPreinstalledTombstoneRepository",
+            return_value=_FakeTombstoneRepo(None),
+        ),
+    ):
+        tool = create_preview_skill_tool(
+            session=_FakeSession(),
+            registry=_FakeRegistry(adapter=None),
+            catalog=_FakeCatalog("irrelevant"),
+            org_id="org-1",
+        )
+        result = await tool.execute("tc-6", PreviewSkillInput(candidate_id=candidate_id))
+
+    assert result.is_error
+    assert "SKILL_NOT_FOUND" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_preview_local_skill_version_not_found() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    skill = _FakeSkill("skl-1", "1.0.0", name="my-skill")
+    candidate_id = encode_candidate_id("local", "skl-1")
+    with (
+        patch("cubebox.repositories.skill.SkillRepository", return_value=_FakeSkillRepo(skill)),
+        patch(
+            "cubebox.repositories.skill.SkillVersionRepository",
+            return_value=_FakeSkillVersionRepo(None),
+        ),
+        patch(
+            "cubebox.repositories.skill.OrgPreinstalledTombstoneRepository",
+            return_value=_FakeTombstoneRepo(None),
+        ),
+    ):
+        tool = create_preview_skill_tool(
+            session=_FakeSession(),
+            registry=_FakeRegistry(adapter=None),
+            catalog=_FakeCatalog("irrelevant"),
+            org_id="org-1",
+        )
+        result = await tool.execute("tc-7", PreviewSkillInput(candidate_id=candidate_id))
+
+    assert result.is_error
+    assert "SKILL_VERSION_NOT_FOUND" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_preview_local_tombstoned_preinstalled_returns_not_found() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    skill = _FakeSkill("skl-1", "1.0.0", source="preinstalled", name="my-skill")
+    sv = _FakeSkillVersion("sv-1")
+    tombstone = object()  # non-None signals the skill has been tombstoned
+
+    candidate_id = encode_candidate_id("local", "skl-1")
+    with (
+        patch("cubebox.repositories.skill.SkillRepository", return_value=_FakeSkillRepo(skill)),
+        patch(
+            "cubebox.repositories.skill.SkillVersionRepository",
+            return_value=_FakeSkillVersionRepo(sv),
+        ),
+        patch(
+            "cubebox.repositories.skill.OrgPreinstalledTombstoneRepository",
+            return_value=_FakeTombstoneRepo(tombstone),
+        ),
+    ):
+        tool = create_preview_skill_tool(
+            session=_FakeSession(),
+            registry=_FakeRegistry(adapter=None),
+            catalog=_FakeCatalog("# My Skill\nContent."),
+            org_id="org-1",
+        )
+        result = await tool.execute("tc-8", PreviewSkillInput(candidate_id=candidate_id))
+
+    assert result.is_error
+    assert "SKILL_NOT_FOUND" in result.content[0].text

--- a/backend/tests/unit/test_preview_skill.py
+++ b/backend/tests/unit/test_preview_skill.py
@@ -1,0 +1,151 @@
+"""Unit tests for the preview_skill agent tool."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cubebox.tools.builtin.preview_skill import PreviewSkillInput, create_preview_skill_tool
+
+
+class _FakeSkillVersion:
+    def __init__(self, sv_id: str) -> None:
+        self.id = sv_id
+
+
+class _FakeSkill:
+    def __init__(self, skill_id: str, current_version: str, source: str = "preinstalled") -> None:
+        self.id = skill_id
+        self.current_version = current_version
+        self.source = source
+        self.owner_org_id: str | None = None
+
+
+class _FakeCatalog:
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    async def fetch_skill_md(self, skill_version_id: str) -> str:
+        return self._content
+
+
+class _FakeAdapter:
+    def __init__(self, files: dict[str, bytes] | Exception) -> None:
+        self._files = files
+
+    async def fetch(self, source_ref: str) -> dict[str, bytes]:
+        if isinstance(self._files, Exception):
+            raise self._files
+        return self._files
+
+
+class _FakeRegistry:
+    def __init__(self, adapter: _FakeAdapter | None) -> None:
+        self._adapter = adapter
+
+    def adapter_by_id(self, source_id: str) -> _FakeAdapter | None:
+        return self._adapter
+
+
+class _FakeSkillRepo:
+    def __init__(self, skill: _FakeSkill | None) -> None:
+        self._skill = skill
+
+    async def get(self, skill_id: str) -> _FakeSkill | None:
+        return self._skill
+
+
+class _FakeSkillVersionRepo:
+    def __init__(self, sv: _FakeSkillVersion | None) -> None:
+        self._sv = sv
+
+    async def find(self, skill_id: str, version: str) -> _FakeSkillVersion | None:
+        return self._sv
+
+
+class _FakeSession:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_preview_remote_returns_skill_md() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    candidate_id = encode_candidate_id(
+        "remote", "owner/repo/main/skills/my-skill", source_id="src-1"
+    )
+    adapter = _FakeAdapter({"SKILL.md": b"# My Skill\nDoes stuff.", "extra.txt": b"ignore"})
+    registry = _FakeRegistry(adapter)
+    catalog = _FakeCatalog("irrelevant")
+
+    tool = create_preview_skill_tool(
+        session=_FakeSession(),
+        registry=registry,
+        catalog=catalog,
+        org_id="org-1",
+    )
+    result = await tool.execute("tc-1", PreviewSkillInput(candidate_id=candidate_id))
+
+    assert not result.is_error
+    out = json.loads(result.content[0].text)
+    assert out["content"] == "# My Skill\nDoes stuff."
+    assert out["candidate_id"] == candidate_id
+
+
+@pytest.mark.asyncio
+async def test_preview_remote_no_adapter_returns_error() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    candidate_id = encode_candidate_id("remote", "owner/repo/main/skill", source_id="src-x")
+    registry = _FakeRegistry(adapter=None)
+    catalog = _FakeCatalog("irrelevant")
+
+    tool = create_preview_skill_tool(
+        session=_FakeSession(),
+        registry=registry,
+        catalog=catalog,
+        org_id="org-1",
+    )
+    result = await tool.execute("tc-2", PreviewSkillInput(candidate_id=candidate_id))
+
+    assert result.is_error
+    assert "SOURCE_NOT_FOUND" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_preview_remote_missing_skill_md_returns_error() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    candidate_id = encode_candidate_id("remote", "owner/repo/main/skill", source_id="src-1")
+    adapter = _FakeAdapter({"README.md": b"no SKILL.md here"})
+    registry = _FakeRegistry(adapter)
+    catalog = _FakeCatalog("irrelevant")
+
+    tool = create_preview_skill_tool(
+        session=_FakeSession(),
+        registry=registry,
+        catalog=catalog,
+        org_id="org-1",
+    )
+    result = await tool.execute("tc-3", PreviewSkillInput(candidate_id=candidate_id))
+
+    assert result.is_error
+    assert "SKILL_MD_MISSING" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_preview_bad_candidate_id_returns_error() -> None:
+    registry = _FakeRegistry(adapter=None)
+    catalog = _FakeCatalog("irrelevant")
+
+    tool = create_preview_skill_tool(
+        session=_FakeSession(),
+        registry=registry,
+        catalog=catalog,
+        org_id="org-1",
+    )
+    result = await tool.execute("tc-4", PreviewSkillInput(candidate_id="not-base64-valid!!!"))
+
+    assert result.is_error
+    assert "BAD_CANDIDATE_ID" in result.content[0].text

--- a/docs/dev/plans/2026-06-01-skill-search-ux.md
+++ b/docs/dev/plans/2026-06-01-skill-search-ux.md
@@ -1,0 +1,1353 @@
+# Skill Search UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `preview_skill` and `install_skill` agent tools, and auto-render `find_skills` results as interactive skill cards with a right-panel preview.
+
+**Architecture:** Backend adds two new `AgentTool`s registered in `run_manager.py` (sharing the existing `catalog_session` / registry infrastructure of `find_skills`). Frontend auto-renders `find_skills` tool_call blocks as `SkillSearchResults` cards in `AssistantMessage.tsx`, with a new `skill-candidate` panel view type in `panelStore` and a `SkillCandidatePanel` component.
+
+**Tech Stack:** Python / cubepi `AgentTool`, FastAPI, SQLAlchemy async; React 19 / Next.js, Zustand, SWR, ReactMarkdown, Tailwind, shadcn/ui.
+
+---
+
+## File map
+
+**Backend — new files:**
+- `backend/cubebox/tools/builtin/preview_skill.py` — `create_preview_skill_tool` factory
+- `backend/cubebox/tools/builtin/install_skill.py` — `create_install_skill_tool` factory
+- `backend/tests/unit/test_preview_skill.py` — unit tests for preview_skill
+- `backend/tests/unit/test_install_skill.py` — unit tests for install_skill
+
+**Backend — modified files:**
+- `backend/cubebox/streams/run_manager.py` — register both tools in the `find_skills` block (~line 1134)
+- `backend/cubebox/tools/builtin/find_skills.py` — update `hint` to mention `install_skill`
+
+**Frontend — new files:**
+- `frontend/packages/web/app/api/v1/ws/[wsId]/skills/discover/preview/route.ts` — Next.js proxy for `GET /discover/preview?candidate_id=`
+- `frontend/packages/web/components/chat/tool-results/SkillSearchResults.tsx` — card list container
+- `frontend/packages/web/components/chat/tool-results/SkillCandidateCard.tsx` — individual skill card
+- `frontend/packages/web/components/panel/SkillCandidatePanel.tsx` — right-panel SKILL.md preview
+
+**Frontend — modified files:**
+- `frontend/packages/core/src/stores/panelStore.ts` — add `skill-candidate` view type + `openSkillCandidate` action
+- `frontend/packages/web/components/layout/AppShell.tsx` — add `skill-candidate` panel branch
+- `frontend/packages/web/components/chat/AssistantMessage.tsx` — add `find_skills` render branch + groupBlocks exclusion
+- `frontend/packages/web/messages/en.json` — add i18n keys for new UI text
+
+---
+
+## Task 1: `preview_skill` backend tool
+
+**Files:**
+- Create: `backend/cubebox/tools/builtin/preview_skill.py`
+- Create: `backend/tests/unit/test_preview_skill.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# backend/tests/unit/test_preview_skill.py
+"""Unit tests for the preview_skill agent tool."""
+
+from __future__ import annotations
+
+import json
+import pytest
+from cubebox.tools.builtin.preview_skill import create_preview_skill_tool, PreviewSkillInput
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeSkillVersion:
+    def __init__(self, sv_id: str) -> None:
+        self.id = sv_id
+
+
+class _FakeSkill:
+    def __init__(self, skill_id: str, current_version: str, source: str = "preinstalled") -> None:
+        self.id = skill_id
+        self.current_version = current_version
+        self.source = source
+        self.owner_org_id: str | None = None
+
+
+class _FakeCatalog:
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    async def fetch_skill_md(self, skill_version_id: str) -> str:
+        return self._content
+
+
+class _FakeAdapter:
+    def __init__(self, files: dict[str, bytes] | Exception) -> None:
+        self._files = files
+
+    async def fetch(self, source_ref: str) -> dict[str, bytes]:
+        if isinstance(self._files, Exception):
+            raise self._files
+        return self._files
+
+
+class _FakeRegistry:
+    def __init__(self, adapter: _FakeAdapter | None) -> None:
+        self._adapter = adapter
+
+    def adapter_by_id(self, source_id: str) -> _FakeAdapter | None:
+        return self._adapter
+
+
+class _FakeSkillRepo:
+    def __init__(self, skill: _FakeSkill | None) -> None:
+        self._skill = skill
+
+    async def get(self, skill_id: str) -> _FakeSkill | None:
+        return self._skill
+
+
+class _FakeSkillVersionRepo:
+    def __init__(self, sv: _FakeSkillVersion | None) -> None:
+        self._sv = sv
+
+    async def find(self, skill_id: str, version: str) -> _FakeSkillVersion | None:
+        return self._sv
+
+
+class _FakeSession:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Tests — remote path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_remote_returns_skill_md() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    candidate_id = encode_candidate_id(
+        "remote", "owner/repo/main/skills/my-skill", source_id="src-1"
+    )
+    adapter = _FakeAdapter({"SKILL.md": b"# My Skill\nDoes stuff.", "extra.txt": b"ignore"})
+    registry = _FakeRegistry(adapter)
+    catalog = _FakeCatalog("irrelevant")
+
+    tool = create_preview_skill_tool(
+        session=_FakeSession(),
+        registry=registry,
+        catalog=catalog,
+        org_id="org-1",
+    )
+    result = await tool.execute("tc-1", PreviewSkillInput(candidate_id=candidate_id))
+
+    assert not result.is_error
+    out = json.loads(result.content[0].text)
+    assert out["content"] == "# My Skill\nDoes stuff."
+    assert out["candidate_id"] == candidate_id
+
+
+@pytest.mark.asyncio
+async def test_preview_remote_no_adapter_returns_error() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    candidate_id = encode_candidate_id("remote", "owner/repo/main/skill", source_id="src-x")
+    registry = _FakeRegistry(adapter=None)  # no adapter for src-x
+    catalog = _FakeCatalog("irrelevant")
+
+    tool = create_preview_skill_tool(
+        session=_FakeSession(),
+        registry=registry,
+        catalog=catalog,
+        org_id="org-1",
+    )
+    result = await tool.execute("tc-2", PreviewSkillInput(candidate_id=candidate_id))
+
+    assert result.is_error
+    assert "SOURCE_NOT_FOUND" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_preview_remote_missing_skill_md_returns_error() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    candidate_id = encode_candidate_id("remote", "owner/repo/main/skill", source_id="src-1")
+    adapter = _FakeAdapter({"README.md": b"no SKILL.md here"})
+    registry = _FakeRegistry(adapter)
+    catalog = _FakeCatalog("irrelevant")
+
+    tool = create_preview_skill_tool(
+        session=_FakeSession(),
+        registry=registry,
+        catalog=catalog,
+        org_id="org-1",
+    )
+    result = await tool.execute("tc-3", PreviewSkillInput(candidate_id=candidate_id))
+
+    assert result.is_error
+    assert "SKILL_MD_MISSING" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_preview_bad_candidate_id_returns_error() -> None:
+    registry = _FakeRegistry(adapter=None)
+    catalog = _FakeCatalog("irrelevant")
+
+    tool = create_preview_skill_tool(
+        session=_FakeSession(),
+        registry=registry,
+        catalog=catalog,
+        org_id="org-1",
+    )
+    result = await tool.execute("tc-4", PreviewSkillInput(candidate_id="not-base64-valid!!!"))
+
+    assert result.is_error
+    assert "BAD_CANDIDATE_ID" in result.content[0].text
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_preview_skill.py -v 2>&1 | head -20
+```
+Expected: `ModuleNotFoundError` or `ImportError` — `preview_skill` does not exist yet.
+
+- [ ] **Step 3: Implement `preview_skill` tool**
+
+```python
+# backend/cubebox/tools/builtin/preview_skill.py
+"""preview_skill tool — fetch SKILL.md content for any candidate (installed or not).
+
+Used by the agent to read a skill before recommending installation. Mirrors
+the logic in GET /ws/{ws}/skills/discover/preview without requiring an HTTP
+round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import TextContent
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.skills.frontmatter import extract_env_vars, parse_skill_md
+from cubebox.skills.service import SkillCatalogService
+from cubebox.skills.sources.base import CandidateIdError, decode_candidate_id
+from cubebox.skills.sources.registry import SkillsAdapterManager
+
+
+class PreviewSkillInput(BaseModel):
+    candidate_id: str = Field(
+        description=(
+            "The candidate_id from a find_skills result. "
+            "Returns the SKILL.md content so you can describe the skill before suggesting installation."
+        )
+    )
+
+
+def _env_vars(content: str) -> list[str]:
+    try:
+        fm = parse_skill_md(content)
+        return extract_env_vars(fm.raw_metadata)
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def create_preview_skill_tool(
+    *,
+    session: AsyncSession,
+    registry: SkillsAdapterManager,
+    catalog: SkillCatalogService,
+    org_id: str,
+) -> AgentTool[PreviewSkillInput]:
+    async def _execute(
+        tool_call_id: str,
+        args: PreviewSkillInput,
+        *,
+        signal: object = None,
+        on_update: object = None,
+    ) -> AgentToolResult:
+        del tool_call_id, signal, on_update
+
+        try:
+            kind, source_id, source_ref = decode_candidate_id(args.candidate_id)
+        except CandidateIdError:
+            return AgentToolResult(
+                content=[TextContent(text="BAD_CANDIDATE_ID")], is_error=True
+            )
+
+        if kind == "local":
+            from cubebox.repositories.skill import SkillRepository, SkillVersionRepository
+
+            skill = await SkillRepository(session).get(source_ref)
+            if skill is None or not (
+                skill.source == "preinstalled" or skill.owner_org_id == org_id
+            ):
+                return AgentToolResult(
+                    content=[TextContent(text="SKILL_NOT_FOUND")], is_error=True
+                )
+            sv = await SkillVersionRepository(session).find(skill.id, skill.current_version)
+            if sv is None:
+                return AgentToolResult(
+                    content=[TextContent(text="SKILL_VERSION_NOT_FOUND")], is_error=True
+                )
+            content = await catalog.fetch_skill_md(sv.id)
+            payload = {
+                "candidate_id": args.candidate_id,
+                "name": skill.name,
+                "content": content,
+                "env_vars": _env_vars(content),
+            }
+            return AgentToolResult(content=[TextContent(text=json.dumps(payload))])
+
+        # Remote path
+        adapter = registry.adapter_by_id(source_id)
+        if adapter is None:
+            return AgentToolResult(
+                content=[TextContent(text="SOURCE_NOT_FOUND")], is_error=True
+            )
+        try:
+            files = await adapter.fetch(source_ref)
+        except (httpx.HTTPError, ValueError) as exc:
+            return AgentToolResult(
+                content=[TextContent(text=f"REMOTE_FETCH_FAILED: {exc}")], is_error=True
+            )
+        if "SKILL.md" not in files:
+            return AgentToolResult(
+                content=[TextContent(text="SKILL_MD_MISSING")], is_error=True
+            )
+        try:
+            content = files["SKILL.md"].decode("utf-8")
+        except UnicodeDecodeError as exc:
+            return AgentToolResult(
+                content=[TextContent(text=f"INVALID_UTF8: {exc}")], is_error=True
+            )
+        slug = source_ref.rsplit("/", 1)[-1]
+        payload = {
+            "candidate_id": args.candidate_id,
+            "name": slug,
+            "content": content,
+            "env_vars": _env_vars(content),
+        }
+        return AgentToolResult(content=[TextContent(text=json.dumps(payload))])
+
+    return AgentTool(
+        name="preview_skill",
+        description=(
+            "Fetch the full SKILL.md of any skill candidate — installed or not. "
+            "Use this after find_skills to read what a skill does before recommending installation. "
+            "Pass the candidate_id from the find_skills result."
+        ),
+        parameters=PreviewSkillInput,
+        execute=_execute,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_preview_skill.py -v
+```
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/tools/builtin/preview_skill.py backend/tests/unit/test_preview_skill.py
+git commit -m "feat(skills): add preview_skill agent tool"
+```
+
+---
+
+## Task 2: `install_skill` backend tool + update `find_skills` hint
+
+**Files:**
+- Create: `backend/cubebox/tools/builtin/install_skill.py`
+- Create: `backend/tests/unit/test_install_skill.py`
+- Modify: `backend/cubebox/tools/builtin/find_skills.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# backend/tests/unit/test_install_skill.py
+"""Unit tests for the install_skill agent tool."""
+
+from __future__ import annotations
+
+import json
+import pytest
+from cubebox.tools.builtin.install_skill import InstallSkillInput, create_install_skill_tool
+from cubebox.skills.discovery import InstallResult, SkillInstallError
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeInstallService:
+    def __init__(self, result: InstallResult | Exception) -> None:
+        self._result = result
+
+    async def install(self, candidate_id: str) -> InstallResult:
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_skill_success() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    candidate_id = encode_candidate_id("remote", "owner/repo/main/skill", source_id="src-1")
+    svc = _FakeInstallService(
+        InstallResult(
+            canonical_name="myorg:my-skill",
+            skill_id="skl-abc",
+            installed_version="1.0.0",
+        )
+    )
+
+    tool = create_install_skill_tool(install_service_factory=lambda: svc)
+    result = await tool.execute("tc-1", InstallSkillInput(candidate_id=candidate_id))
+
+    assert not result.is_error
+    out = json.loads(result.content[0].text)
+    assert out["installed"] is True
+    assert out["canonical_name"] == "myorg:my-skill"
+    assert out["version"] == "1.0.0"
+
+
+@pytest.mark.asyncio
+async def test_install_skill_error_propagates() -> None:
+    from cubebox.skills.sources.base import encode_candidate_id
+
+    candidate_id = encode_candidate_id("remote", "owner/repo/main/skill", source_id="src-1")
+    svc = _FakeInstallService(SkillInstallError("trust tier too low"))
+
+    tool = create_install_skill_tool(install_service_factory=lambda: svc)
+    result = await tool.execute("tc-2", InstallSkillInput(candidate_id=candidate_id))
+
+    assert result.is_error
+    assert "trust tier too low" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_install_bad_candidate_id_returns_error() -> None:
+    svc = _FakeInstallService(InstallResult("x", "y", "1.0"))
+    tool = create_install_skill_tool(install_service_factory=lambda: svc)
+    result = await tool.execute("tc-3", InstallSkillInput(candidate_id="!!!bad!!!"))
+
+    assert result.is_error
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_install_skill.py -v 2>&1 | head -10
+```
+Expected: `ImportError` — `install_skill` does not exist yet.
+
+- [ ] **Step 3: Implement `install_skill` tool**
+
+Note: the factory accepts an `install_service_factory` callable (for testability) rather than a pre-built service. In `run_manager.py` (Task 3), the factory will close over `catalog_session`, `registry`, `catalog`, `org_id`, `org_slug`, `workspace_id`, and `actor_user_id`.
+
+```python
+# backend/cubebox/tools/builtin/install_skill.py
+"""install_skill tool — install a skill candidate for the current workspace.
+
+Only call this when the user has explicitly requested installation in
+the current conversation. On success, call load_skill(canonical_name)
+immediately to begin using the installed skill.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import TextContent
+from pydantic import BaseModel, Field
+
+from cubebox.skills.discovery import SkillInstallError, SkillInstallService
+from cubebox.skills.sources.base import CandidateIdError
+
+
+class InstallSkillInput(BaseModel):
+    candidate_id: str = Field(
+        description=(
+            "The candidate_id from a find_skills result. "
+            "Only call this after the user has explicitly confirmed they want to install."
+        )
+    )
+
+
+def create_install_skill_tool(
+    *,
+    install_service_factory: Callable[[], SkillInstallService],
+) -> AgentTool[InstallSkillInput]:
+    async def _execute(
+        tool_call_id: str,
+        args: InstallSkillInput,
+        *,
+        signal: object = None,
+        on_update: object = None,
+    ) -> AgentToolResult:
+        del tool_call_id, signal, on_update
+
+        svc = install_service_factory()
+        try:
+            result = await svc.install(args.candidate_id)
+        except CandidateIdError as exc:
+            return AgentToolResult(
+                content=[TextContent(text=f"BAD_CANDIDATE_ID: {exc}")], is_error=True
+            )
+        except SkillInstallError as exc:
+            return AgentToolResult(
+                content=[TextContent(text=str(exc))], is_error=True
+            )
+
+        payload = {
+            "installed": True,
+            "canonical_name": result.canonical_name,
+            "version": result.installed_version,
+        }
+        return AgentToolResult(content=[TextContent(text=json.dumps(payload))])
+
+    return AgentTool(
+        name="install_skill",
+        description=(
+            "Install a skill candidate into the current workspace. "
+            "Only call this when the user has explicitly asked to install. "
+            "Pass the candidate_id from a find_skills result. "
+            "On success, call load_skill(canonical_name) to use the skill immediately."
+        ),
+        parameters=InstallSkillInput,
+        execute=_execute,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_install_skill.py -v
+```
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Update `find_skills` hint**
+
+In `backend/cubebox/tools/builtin/find_skills.py`, replace the `hint` string:
+
+```python
+            "hint": (
+                "To use an 'enabled' candidate now, call load_skill(canonical_name). "
+                "To install an 'in_catalog' or 'available' candidate: present it to the "
+                "user with preview_skill(candidate_id) so they can see what it does, then "
+                "call install_skill(candidate_id) only when the user explicitly asks to install. "
+                "Never install silently."
+            ),
+```
+
+- [ ] **Step 6: Run existing find_skills tests to confirm no regression**
+
+```bash
+cd backend && uv run pytest tests/unit/ tests/e2e/test_find_skills_tool.py -v -k "skill" 2>&1 | tail -15
+```
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/cubebox/tools/builtin/install_skill.py backend/cubebox/tools/builtin/find_skills.py backend/tests/unit/test_install_skill.py
+git commit -m "feat(skills): add install_skill agent tool; update find_skills hint"
+```
+
+---
+
+## Task 3: Register `preview_skill` and `install_skill` in `run_manager.py`
+
+**Files:**
+- Modify: `backend/cubebox/streams/run_manager.py`
+
+- [ ] **Step 1: Locate the `find_skills` registration block**
+
+Open `backend/cubebox/streams/run_manager.py`. The block to extend is around line 1134:
+
+```python
+        if skill_catalog is not None and catalog_session is not None:
+            try:
+                from cubebox.repositories.organization import OrganizationRepository
+                from cubebox.skills.discovery import SkillDiscoveryService
+                from cubebox.skills.sources.registry import SkillsAdapterManager
+                from cubebox.tools.builtin.find_skills import create_find_skills_tool
+
+                _org = await OrganizationRepository(catalog_session).get(ctx.org_id)
+                if _org is not None:
+                    _registry = await SkillsAdapterManager.build(
+                        session=catalog_session,
+                        catalog=skill_catalog,
+                        org_id=ctx.org_id,
+                        org_slug=_org.slug,
+                        workspace_id=ctx.workspace_id,
+                    )
+                    _builtin_tools.append(
+                        create_find_skills_tool(discovery=SkillDiscoveryService(_registry))
+                    )
+            except Exception as _exc:  # noqa: BLE001
+                logger.warning("find_skills unavailable for cubepi run: {}", _exc)
+```
+
+- [ ] **Step 2: Extend the block to also register `preview_skill` and `install_skill`**
+
+Replace the entire `if skill_catalog is not None and catalog_session is not None:` block with:
+
+```python
+        if skill_catalog is not None and catalog_session is not None:
+            try:
+                from cubebox.repositories.organization import OrganizationRepository
+                from cubebox.skills.discovery import (
+                    SkillDiscoveryService,
+                    SkillInstallService,
+                )
+                from cubebox.skills.service import SkillPublishService
+                from cubebox.skills.sources.registry import SkillsAdapterManager
+                from cubebox.tools.builtin.find_skills import create_find_skills_tool
+                from cubebox.tools.builtin.install_skill import create_install_skill_tool
+                from cubebox.tools.builtin.preview_skill import create_preview_skill_tool
+
+                _org = await OrganizationRepository(catalog_session).get(ctx.org_id)
+                if _org is not None:
+                    _registry = await SkillsAdapterManager.build(
+                        session=catalog_session,
+                        catalog=skill_catalog,
+                        org_id=ctx.org_id,
+                        org_slug=_org.slug,
+                        workspace_id=ctx.workspace_id,
+                    )
+                    _builtin_tools.append(
+                        create_find_skills_tool(discovery=SkillDiscoveryService(_registry))
+                    )
+                    _builtin_tools.append(
+                        create_preview_skill_tool(
+                            session=catalog_session,
+                            registry=_registry,
+                            catalog=skill_catalog,
+                            org_id=ctx.org_id,
+                        )
+                    )
+
+                    def _make_install_factory(
+                        _session: object = catalog_session,
+                        _registry: object = _registry,
+                        _catalog: object = skill_catalog,
+                        _org_id: str = ctx.org_id,
+                        _org_slug: str = _org.slug,
+                        _workspace_id: str | None = ctx.workspace_id,
+                        _actor: str = ctx.user_id,
+                    ) -> SkillInstallService:
+                        return SkillInstallService(
+                            session=_session,
+                            registry=_registry,
+                            publisher=SkillPublishService(
+                                session=_session, cache=_catalog.cache
+                            ),
+                            org_id=_org_id,
+                            org_slug=_org_slug,
+                            workspace_id=_workspace_id,
+                            actor_user_id=_actor,
+                        )
+
+                    _builtin_tools.append(
+                        create_install_skill_tool(
+                            install_service_factory=_make_install_factory
+                        )
+                    )
+            except Exception as _exc:  # noqa: BLE001
+                logger.warning("find_skills unavailable for cubepi run: {}", _exc)
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd backend && uv run mypy cubebox/streams/run_manager.py cubebox/tools/builtin/preview_skill.py cubebox/tools/builtin/install_skill.py
+```
+Expected: no errors (or only pre-existing `Any` notes).
+
+- [ ] **Step 4: Run full unit test suite**
+
+```bash
+cd backend && uv run pytest tests/unit/ -x -q 2>&1 | tail -10
+```
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/streams/run_manager.py
+git commit -m "feat(skills): register preview_skill and install_skill in run_manager"
+```
+
+---
+
+## Task 4: Frontend — `/discover/preview` proxy route
+
+The `SkillCandidatePanel` (Task 6) calls `GET /api/v1/ws/{wsId}/skills/discover/preview?candidate_id=xxx`. This Next.js proxy route does not yet exist.
+
+**Files:**
+- Create: `frontend/packages/web/app/api/v1/ws/[wsId]/skills/discover/preview/route.ts`
+
+- [ ] **Step 1: Create the proxy route**
+
+```typescript
+// frontend/packages/web/app/api/v1/ws/[wsId]/skills/discover/preview/route.ts
+/**
+ * Skill candidate preview proxy — GET /discover/preview?candidate_id=
+ * Forwards to the backend and returns { candidate_id, name, canonical_name, content, env_vars }.
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.CUBEBOX_API_URL ?? 'http://localhost:8000'
+
+function buildProxyHeaders(request: NextRequest): HeadersInit {
+  const headers: Record<string, string> = { Accept: 'application/json' }
+  const cookie = request.headers.get('cookie')
+  const userId = request.headers.get('x-user-id')
+  const csrf = request.headers.get('x-csrf-token')
+  if (cookie) headers.cookie = cookie
+  if (userId) headers['x-user-id'] = userId
+  if (csrf) headers['X-CSRF-Token'] = csrf
+  return headers
+}
+
+function appendSetCookie(target: Headers, source: Headers): void {
+  const getSetCookie = (source as Headers & { getSetCookie?: () => string[] }).getSetCookie
+  if (typeof getSetCookie === 'function') {
+    for (const value of getSetCookie.call(source)) {
+      target.append('set-cookie', value)
+    }
+    return
+  }
+  const setCookie = source.get('set-cookie')
+  if (setCookie) target.append('set-cookie', setCookie)
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ wsId: string }> },
+) {
+  const { wsId } = await params
+  const url = new URL(request.url)
+  const candidateId = url.searchParams.get('candidate_id') ?? ''
+
+  const backendRes = await fetch(
+    `${BACKEND_URL}/api/v1/ws/${wsId}/skills/discover/preview?candidate_id=${encodeURIComponent(candidateId)}`,
+    { headers: buildProxyHeaders(request) },
+  )
+
+  const data = await backendRes.json()
+  const response = NextResponse.json(data, { status: backendRes.status })
+  appendSetCookie(response.headers, backendRes.headers)
+  return response
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd frontend && pnpm --filter web tsc --noEmit 2>&1 | grep -E "error|Error" | head -10
+```
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "frontend/packages/web/app/api/v1/ws/[wsId]/skills/discover/preview/route.ts"
+git commit -m "feat(skills): add /discover/preview Next.js proxy route"
+```
+
+---
+
+## Task 5: panelStore — `skill-candidate` view type
+
+**Files:**
+- Modify: `frontend/packages/core/src/stores/panelStore.ts`
+
+- [ ] **Step 1: Add `skill-candidate` to `PanelView` union and `PanelStore` interface**
+
+In `frontend/packages/core/src/stores/panelStore.ts`, add to the `PanelView` union:
+
+```typescript
+export type PanelView =
+  | { type: 'closed' }
+  | {
+      type: 'tool'
+      toolName: string
+      toolArgs: Record<string, unknown>
+      toolResult: string | null
+      contentType: PanelContentType
+      toolRef: ToolCallRef | null
+      highlightText: string | null
+      highlightKey: number
+    }
+  | {
+      type: 'artifact'
+      conversationId: string
+      artifactId: string
+    }
+  | {
+      type: 'attachment'
+      info: AttachmentPanelInfo
+    }
+  | { type: 'browser' }
+  | { type: 'skill-candidate'; candidateId: string }  // ← add this
+```
+
+Add to the `PanelStore` interface:
+
+```typescript
+  openSkillCandidate: (candidateId: string) => void
+```
+
+Add to the `create<PanelStore>` implementation (after `openBrowser`):
+
+```typescript
+  openSkillCandidate: (candidateId) => set({ view: { type: 'skill-candidate', candidateId } }),
+```
+
+- [ ] **Step 2: Build `@cubebox/core` to check for type errors**
+
+```bash
+cd frontend && pnpm --filter @cubebox/core build 2>&1 | tail -10
+```
+Expected: build succeeds, no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/packages/core/src/stores/panelStore.ts
+git commit -m "feat(skills): add skill-candidate panel view type to panelStore"
+```
+
+---
+
+## Task 6: `SkillCandidatePanel` + i18n keys + AppShell integration
+
+**Files:**
+- Create: `frontend/packages/web/components/panel/SkillCandidatePanel.tsx`
+- Modify: `frontend/packages/web/messages/en.json`
+- Modify: `frontend/packages/web/components/layout/AppShell.tsx`
+
+- [ ] **Step 1: Add i18n keys to `en.json`**
+
+In `frontend/packages/web/messages/en.json`, add a `skillCandidatePanel` key inside `panel`:
+
+```json
+"panel": {
+  ...existing keys...,
+  "skillCandidatePanel": {
+    "loading": "Loading skill preview…",
+    "fetchError": "Could not load skill preview. The remote source may be unavailable.",
+    "retry": "Retry",
+    "noDescription": "No description available.",
+    "installButton": "Install",
+    "installing": "Installing…",
+    "installed": "Installed",
+    "installError": "Installation failed. Please try again."
+  }
+}
+```
+
+- [ ] **Step 2: Create `SkillCandidatePanel`**
+
+```typescript
+// frontend/packages/web/components/panel/SkillCandidatePanel.tsx
+'use client'
+
+import useSWR from 'swr'
+import { useState } from 'react'
+import { useTranslations } from 'next-intl'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Download } from 'lucide-react'
+import { usePanelStore } from '@cubebox/core'
+import { Button } from '@/components/ui/button'
+import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
+import { csrfHeaders } from '@/lib/csrf'
+import { proseClasses, cn } from '@/lib/utils'
+
+interface CandidatePreview {
+  candidate_id: string
+  name: string
+  canonical_name: string
+  content: string
+  env_vars: string[]
+}
+
+async function fetchPreview(url: string): Promise<CandidatePreview> {
+  const res = await fetch(url, { credentials: 'include' })
+  if (!res.ok) throw new Error(`preview fetch failed: ${res.status}`)
+  return res.json() as Promise<CandidatePreview>
+}
+
+export function SkillCandidatePanel({ candidateId }: { candidateId: string }) {
+  const t = useTranslations('panel.skillCandidatePanel')
+  const { workspaceId } = useWorkspaceContext()
+  const close = usePanelStore((s) => s.close)
+
+  const url = workspaceId
+    ? `/api/v1/ws/${workspaceId}/skills/discover/preview?candidate_id=${encodeURIComponent(candidateId)}`
+    : null
+
+  const { data, error, isLoading, mutate } = useSWR<CandidatePreview>(url, fetchPreview, {
+    revalidateOnFocus: false,
+    shouldRetryOnError: false,
+  })
+
+  const [installing, setInstalling] = useState(false)
+  const [installState, setInstallState] = useState<'idle' | 'done' | 'error'>('idle')
+  const [installError, setInstallError] = useState<string | null>(null)
+
+  async function handleInstall(): Promise<void> {
+    if (!workspaceId) return
+    setInstalling(true)
+    setInstallError(null)
+    try {
+      const res = await fetch(`/api/v1/ws/${workspaceId}/skills/install`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { ...csrfHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ candidate_id: candidateId }),
+      })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as Record<string, unknown>
+        setInstallError(typeof body.detail === 'string' ? body.detail : t('installError'))
+        setInstallState('error')
+        return
+      }
+      setInstallState('done')
+    } finally {
+      setInstalling(false)
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-4">
+        {isLoading && (
+          <p className="text-sm text-muted-foreground">{t('loading')}</p>
+        )}
+
+        {error && !isLoading && (
+          <div className="flex flex-col gap-2">
+            <p className="text-sm text-destructive">{t('fetchError')}</p>
+            <Button variant="outline" size="sm" onClick={() => void mutate()}>
+              {t('retry')}
+            </Button>
+          </div>
+        )}
+
+        {data && (
+          <>
+            <header className="flex flex-wrap items-baseline gap-2">
+              <span className="font-mono font-semibold">{data.name}</span>
+              {data.env_vars.length > 0 && (
+                <span className="text-xs text-muted-foreground">
+                  requires: {data.env_vars.join(', ')}
+                </span>
+              )}
+            </header>
+
+            {installError && (
+              <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {installError}
+              </p>
+            )}
+
+            <div className={proseClasses}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{data.content}</ReactMarkdown>
+            </div>
+          </>
+        )}
+      </div>
+
+      {data && (
+        <div className="shrink-0 border-t p-4">
+          <Button
+            size="sm"
+            disabled={installing || installState === 'done'}
+            onClick={() => void handleInstall()}
+            className="flex items-center gap-1.5"
+          >
+            <Download className="size-3.5" />
+            {installState === 'done'
+              ? t('installed')
+              : installing
+                ? t('installing')
+                : t('installButton')}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Add `skill-candidate` branch to `AppShell`**
+
+In `frontend/packages/web/components/layout/AppShell.tsx`, add the import:
+
+```typescript
+import { SkillCandidatePanel } from '@/components/panel/SkillCandidatePanel'
+```
+
+Replace the panel content conditional (the `{view.type === 'artifact' ? ... : <ToolDetailPanel />}` block) with:
+
+```typescript
+            {view.type === 'artifact' ? (
+              <ArtifactPanel />
+            ) : view.type === 'attachment' ? (
+              <AttachmentPreviewView info={view.info} />
+            ) : view.type === 'browser' ? (
+              <BrowserView workspaceId={workspaceId} />
+            ) : view.type === 'skill-candidate' ? (
+              <SkillCandidatePanel candidateId={view.candidateId} />
+            ) : (
+              <ToolDetailPanel />
+            )}
+```
+
+- [ ] **Step 4: Check TypeScript**
+
+```bash
+cd frontend && pnpm --filter web tsc --noEmit 2>&1 | grep -E "error TS" | head -10
+```
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/packages/web/components/panel/SkillCandidatePanel.tsx \
+        frontend/packages/web/messages/en.json \
+        frontend/packages/web/components/layout/AppShell.tsx
+git commit -m "feat(skills): add SkillCandidatePanel and skill-candidate AppShell branch"
+```
+
+---
+
+## Task 7: `SkillCandidateCard` + `SkillSearchResults`
+
+**Files:**
+- Create: `frontend/packages/web/components/chat/tool-results/SkillCandidateCard.tsx`
+- Create: `frontend/packages/web/components/chat/tool-results/SkillSearchResults.tsx`
+
+First, add i18n keys for the card in `en.json` under a new `skillCard` key inside `chat` (or a top-level `skillSearch` namespace — check existing chat keys and follow the convention):
+
+```json
+"skillSearch": {
+  "noDescription": "No description available",
+  "preview": "Preview",
+  "install": "Install",
+  "installing": "Installing…",
+  "installed": "Installed",
+  "installError": "Install failed",
+  "trustOfficial": "official",
+  "trustCommunity": "community",
+  "trustUnvetted": "unvetted",
+  "stateEnabled": "installed",
+  "stateAvailable": "available",
+  "downloads": "{count} installs"
+}
+```
+
+- [ ] **Step 1: Add `skillSearch` i18n keys to `en.json`**
+
+Add the `skillSearch` block from above as a top-level key in `frontend/packages/web/messages/en.json`.
+
+- [ ] **Step 2: Create `SkillCandidateCard`**
+
+```typescript
+// frontend/packages/web/components/chat/tool-results/SkillCandidateCard.tsx
+'use client'
+
+import { useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { Download } from 'lucide-react'
+import { usePanelStore } from '@cubebox/core'
+import { Button } from '@/components/ui/button'
+import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
+import { csrfHeaders } from '@/lib/csrf'
+import { cn } from '@/lib/utils'
+
+export interface SkillCandidate {
+  candidate_id: string
+  name: string
+  canonical_name: string
+  description: string
+  source: string
+  source_name: string
+  repo: string | null
+  trust: 'official' | 'community' | 'untrusted'
+  install_state: 'enabled' | 'in_catalog' | 'available'
+  install_count: number | null
+  unvetted: boolean
+}
+
+const TRUST_BADGE: Record<string, string> = {
+  official: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+  community: 'bg-amber-500/10 text-amber-700 dark:text-amber-400',
+  untrusted: 'bg-muted text-muted-foreground',
+}
+
+const STATE_BADGE: Record<string, string> = {
+  enabled: 'bg-green-500/10 text-green-700 dark:text-green-400',
+  in_catalog: 'bg-muted text-muted-foreground',
+  available: 'bg-muted text-muted-foreground',
+}
+
+export function SkillCandidateCard({ candidate }: { candidate: SkillCandidate }) {
+  const t = useTranslations('skillSearch')
+  const { workspaceId } = useWorkspaceContext()
+  const openSkillCandidate = usePanelStore((s) => s.openSkillCandidate)
+
+  const [installing, setInstalling] = useState(false)
+  const [installState, setInstallState] = useState<SkillCandidate['install_state']>(
+    candidate.install_state,
+  )
+  const [installError, setInstallError] = useState<string | null>(null)
+
+  async function handleInstall(): Promise<void> {
+    if (!workspaceId || installState === 'enabled') return
+    setInstalling(true)
+    setInstallError(null)
+    try {
+      const res = await fetch(`/api/v1/ws/${workspaceId}/skills/install`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { ...csrfHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ candidate_id: candidate.candidate_id }),
+      })
+      if (!res.ok) {
+        setInstallError(t('installError'))
+        return
+      }
+      setInstallState('enabled')
+    } finally {
+      setInstalling(false)
+    }
+  }
+
+  const trustLabel = t(`trust${candidate.trust.charAt(0).toUpperCase()}${candidate.trust.slice(1)}` as 'trustOfficial' | 'trustCommunity' | 'trustUnvetted')
+  const stateLabel = installState === 'enabled' ? t('stateEnabled') : t('stateAvailable')
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-3 flex flex-col gap-2 shadow-sm">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-1 min-w-0">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="font-mono text-sm font-semibold truncate">{candidate.name}</span>
+            <span
+              className={cn(
+                'rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+                TRUST_BADGE[candidate.trust] ?? TRUST_BADGE.untrusted,
+              )}
+            >
+              {trustLabel}
+            </span>
+            <span
+              className={cn(
+                'rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+                STATE_BADGE[installState] ?? STATE_BADGE.available,
+              )}
+            >
+              {stateLabel}
+            </span>
+          </div>
+          <span className="text-xs text-muted-foreground">{candidate.source_name}</span>
+        </div>
+        {candidate.install_count != null && (
+          <div className="flex items-center gap-0.5 shrink-0 text-xs text-muted-foreground">
+            <Download className="size-3" />
+            <span>{candidate.install_count.toLocaleString()}</span>
+          </div>
+        )}
+      </div>
+
+      <p className="text-xs text-foreground/80 leading-relaxed">
+        {candidate.description || t('noDescription')}
+      </p>
+
+      {installError && (
+        <p className="text-xs text-destructive">{installError}</p>
+      )}
+
+      <div className="flex gap-1.5">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          onClick={() => openSkillCandidate(candidate.candidate_id)}
+        >
+          {t('preview')}
+        </Button>
+        <Button
+          size="sm"
+          className="h-7 text-xs"
+          disabled={installing || installState === 'enabled'}
+          onClick={() => void handleInstall()}
+        >
+          {installState === 'enabled'
+            ? t('installed')
+            : installing
+              ? t('installing')
+              : t('install')}
+        </Button>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Create `SkillSearchResults`**
+
+```typescript
+// frontend/packages/web/components/chat/tool-results/SkillSearchResults.tsx
+'use client'
+
+import { SkillCandidateCard, type SkillCandidate } from './SkillCandidateCard'
+
+interface SkillSearchResultsProps {
+  resultJson: string
+}
+
+interface FindSkillsPayload {
+  candidates: SkillCandidate[]
+  hint?: string
+}
+
+function parsePayload(json: string): SkillCandidate[] {
+  try {
+    const parsed = JSON.parse(json) as FindSkillsPayload
+    return Array.isArray(parsed.candidates) ? parsed.candidates : []
+  } catch {
+    return []
+  }
+}
+
+export function SkillSearchResults({ resultJson }: SkillSearchResultsProps) {
+  const candidates = parsePayload(resultJson)
+  if (candidates.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-2 py-1">
+      {candidates.map((c) => (
+        <SkillCandidateCard key={c.candidate_id} candidate={c} />
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd frontend && pnpm --filter web tsc --noEmit 2>&1 | grep -E "error TS" | head -10
+```
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/packages/web/components/chat/tool-results/ frontend/packages/web/messages/en.json
+git commit -m "feat(skills): add SkillCandidateCard and SkillSearchResults components"
+```
+
+---
+
+## Task 8: Wire `find_skills` rendering in `AssistantMessage.tsx`
+
+**Files:**
+- Modify: `frontend/packages/web/components/chat/AssistantMessage.tsx`
+
+- [ ] **Step 1: Add `SkillSearchResults` import**
+
+At the top of `AssistantMessage.tsx` with the other component imports, add:
+
+```typescript
+import { SkillSearchResults } from './tool-results/SkillSearchResults'
+```
+
+- [ ] **Step 2: Add `find_skills` branch in `ContentBlockRenderer`**
+
+In `ContentBlockRenderer`, immediately before the `if (block.type === 'tool_call' && block.name === 'show_widget')` check (around line 316), add:
+
+```typescript
+  if (block.type === 'tool_call' && block.name === 'find_skills') {
+    const toolResult = toolResultMap[block.id]
+    if (!toolResult) return null
+    return (
+      <SkillSearchResults
+        key={block.id}
+        resultJson={toolResult.content}
+      />
+    )
+  }
+```
+
+- [ ] **Step 3: Exclude `find_skills` from `groupBlocks`**
+
+In the `groupBlocks` function, add `'find_skills'` to the exclusion list:
+
+```typescript
+    if (
+      block.type === 'tool_call' &&
+      block.name !== 'subagent' &&
+      block.name !== 'save_artifact' &&
+      block.name !== 'write_todos' &&
+      block.name !== 'show_widget' &&
+      block.name !== 'find_skills'   // ← add this
+    ) {
+```
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd frontend && pnpm --filter web tsc --noEmit 2>&1 | grep -E "error TS" | head -10
+```
+Expected: no errors.
+
+- [ ] **Step 5: Verify `pnpm build` passes**
+
+```bash
+cd frontend && pnpm --filter web build 2>&1 | tail -15
+```
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/packages/web/components/chat/AssistantMessage.tsx
+git commit -m "feat(skills): auto-render find_skills results as skill cards in chat"
+```
+
+---
+
+## Self-review notes
+
+- All three spec goals covered: `preview_skill` tool (Tasks 1, 3), `install_skill` tool (Tasks 2, 3), card rendering + panel preview (Tasks 4–8).
+- `find_skills` hint updated in Task 2 to mention both `preview_skill` and `install_skill`.
+- Frontend proxy route for `/discover/preview` added in Task 4 (was missing — caught by codex review).
+- Session lifetime for `install_skill` is the same `catalog_session` as `find_skills`; write commits are handled by SQLAlchemy's unit-of-work when `session.commit()` is called inside `SkillInstallService` operations.
+- `install_count` shown when non-null; hidden (not shown as zero) when null, per spec.
+- `find_skills` excluded from `groupBlocks` so it renders standalone, not merged with adjacent tool calls.
+- i18n parity: `en.json` gets both `skillSearch` and `panel.skillCandidatePanel` keys. Other locale files (if any) will need the same keys — run `pnpm --filter web build` to catch missing i18n key errors at build time.

--- a/docs/dev/specs/2026-06-01-skill-search-ux-design.md
+++ b/docs/dev/specs/2026-06-01-skill-search-ux-design.md
@@ -1,0 +1,185 @@
+# Skill Search UX — Design Spec
+
+**Date:** 2026-06-01  
+**Branch:** feat/skill-search-ux
+
+---
+
+## Problem
+
+When a user asks the agent to find a skill (e.g., "find a Twitter management skill"), the
+current flow has three failure modes:
+
+1. **Empty descriptions.** Most remote skills from skills.sh return `description: ""`. The agent
+   cannot evaluate relevance, so it guesses.
+2. **Wrong tool for uninstalled skills.** The agent tries `load_skill(canonical_name)` on skills
+   that aren't enabled, getting three consecutive errors. `load_skill` only works for already-
+   installed skills; the hint in `find_skills` says to use `candidate_id` for install, but the
+   agent ignores it.
+3. **No preview path.** There is no mechanism — for the agent or the user — to read a skill's
+   `SKILL.md` before installing it. Discovery stops at a name and an empty description.
+
+---
+
+## Goals
+
+- Agent can read a skill's content before suggesting installation (`preview_skill` tool).
+- Agent can install a skill when the user explicitly asks (`install_skill` tool).
+- `find_skills` results render as visual skill cards in the chat UI instead of raw JSON.
+- Each card has a Preview button (opens right panel) and an Install button (inline install).
+- Cards show install/download count.
+
+---
+
+## Non-goals
+
+- Enriching descriptions at search time (too slow; preview-on-demand is sufficient).
+- Changing the `find_skills` ranking or scoring logic.
+- Auto-installing without user request.
+
+---
+
+## Architecture
+
+Three independent deliverables that can be built and shipped separately:
+
+| # | What | Where |
+|---|------|--------|
+| 1 | `preview_skill` agent tool | Backend |
+| 2 | `install_skill` agent tool | Backend |
+| 3 | `find_skills` card rendering + right-panel preview | Frontend |
+
+No new HTTP endpoints are needed. The frontend Preview button calls the existing
+`GET /ws/{ws}/skills/discover/preview?candidate_id=xxx`, which already handles both local
+and remote candidates.
+
+---
+
+## Backend
+
+### `preview_skill` tool
+
+**File:** `backend/cubebox/tools/builtin/preview_skill.py`
+
+```
+Input:  candidate_id: str
+Output: { candidate_id, name, content: str (SKILL.md), env_vars: list[str] }
+        or error string on failure
+```
+
+Internally calls `SkillsAdapterManager` + `source.fetch(source_ref)` for remote candidates,
+or `SkillCatalogService.fetch_skill_md` for local ones — the same logic already in
+`GET /discover/preview`. Returns SKILL.md content as plain text so the agent can read it
+and describe the skill to the user before recommending installation.
+
+Registration: same pattern as `find_skills` in `run_manager.py`.
+
+### `install_skill` tool
+
+**File:** `backend/cubebox/tools/builtin/install_skill.py`
+
+```
+Input:  candidate_id: str
+Output: { installed: true, canonical_name: str, version: str }
+        or error string on failure
+```
+
+Calls `SkillInstallService.install(candidate_id)`. The agent should only call this when the
+user has explicitly requested installation in the conversation (not proactively). On success,
+the agent can immediately call `load_skill(canonical_name)` to use the skill.
+
+Registration: same pattern as `find_skills`.
+
+---
+
+## Frontend
+
+### Auto-rendering `find_skills` results
+
+The message renderer detects a `tool_result` where `tool_name == "find_skills"` and renders
+`<SkillSearchResults>` instead of the default JSON text block. The candidates array is parsed
+directly from the tool result JSON.
+
+**Files to create/modify:**
+- `components/chat/tool-results/SkillSearchResults.tsx` — container + card list
+- `components/chat/tool-results/SkillCandidateCard.tsx` — individual card
+- Modify the tool-result renderer to route `find_skills` → `SkillSearchResults`
+
+### `SkillCandidateCard`
+
+Displays per candidate:
+
+| Field | Display |
+|-------|---------|
+| `name` | Bold title |
+| `description` | Body text; "No description available" when empty |
+| `trust` | Badge: official (blue) / community (amber) / unvetted (grey) |
+| `install_state` | Badge: enabled (green) / available |
+| `install_count` | Download count with icon (hidden when null) |
+| `source_name` | Muted label (skills.sh / Clawhub / catalog) |
+
+Two action buttons:
+- **Preview** — calls `openSkillCandidate(candidateId)` → opens right panel
+- **Install** — calls `POST /ws/{ws}/skills/install`, then updates card to "enabled" on success;
+  button disabled while in-flight and after install
+
+### Right-panel `skill-candidate` view
+
+**New panel view type** in `panelStore`:
+```ts
+| { type: 'skill-candidate'; candidateId: string }
+```
+
+New action: `openSkillCandidate(candidateId: string)`.
+
+**New component:** `components/panel/SkillCandidatePanel.tsx`
+- Fetches `GET /ws/{ws}/skills/discover/preview?candidate_id=xxx` via SWR
+- Shows loading state while fetching (GitHub fetch can take 1-3 s)
+- Renders SKILL.md as markdown using existing `ReactMarkdown + remarkGfm` pattern
+- Shows name, trust badge, install count at top
+- Install button at bottom (same behavior as card button)
+
+AppShell adds a branch for `view.type === 'skill-candidate'` rendering `<SkillCandidatePanel>`.
+
+---
+
+## Data Flow
+
+```
+User: "find a Twitter skill"
+  → agent: find_skills(query="Twitter automation")
+    → returns 10 candidates (JSON)
+    → frontend auto-renders as SkillSearchResults cards
+
+User clicks Preview on card
+  → frontend: openSkillCandidate(candidateId)
+  → right panel opens SkillCandidatePanel
+  → fetches GET /discover/preview?candidate_id=xxx
+  → renders SKILL.md markdown
+
+User clicks Install on card (or says "install the second one")
+  → frontend: POST /skills/install  (UI path)
+  OR
+  → agent: install_skill(candidateId)  (conversation path)
+  → on success: card badge → "enabled"; agent can load_skill immediately
+```
+
+---
+
+## Error Handling
+
+- `preview_skill` tool: remote fetch failures (GitHub down, 404) return an error string; agent
+  surfaces it as "couldn't fetch preview, here's what I know from the description".
+- `install_skill` tool: returns error string on `SkillInstallError`; agent tells user what went
+  wrong (trust tier, not found, etc.).
+- `SkillCandidatePanel`: shows an error state if the fetch fails; user can retry.
+- Card Install button: shows toast on failure, button re-enabled for retry.
+
+---
+
+## Testing
+
+- **Unit:** `preview_skill` tool with mocked `SkillsAdapterManager` (local + remote paths).
+- **Unit:** `install_skill` tool with mocked `SkillInstallService`.
+- **E2E:** `find_skills` → card renders with correct fields (description, trust badge, install
+  count) → Preview opens panel with markdown → Install updates card state.

--- a/docs/dev/specs/2026-06-01-skill-search-ux-design.md
+++ b/docs/dev/specs/2026-06-01-skill-search-ux-design.md
@@ -72,7 +72,12 @@ or `SkillCatalogService.fetch_skill_md` for local ones — the same logic alread
 `GET /discover/preview`. Returns SKILL.md content as plain text so the agent can read it
 and describe the skill to the user before recommending installation.
 
-Registration: same pattern as `find_skills` in `run_manager.py`.
+**Registration (run_manager.py):** `AgentTool.execute` receives only
+`(tool_call_id, args, signal, on_update)` — no `AsyncSession`. The tool must be
+constructed in `run_manager.py` with a prebuilt `SkillsAdapterManager` and a
+`SkillCatalogService` closed over the existing `catalog_session` (same pattern used by
+`find_skills` at line ~1131). The `create_preview_skill_tool(*, registry, catalog)` factory
+captures both at run-start; the inner `_execute` closure never opens its own session.
 
 ### `install_skill` tool
 
@@ -88,7 +93,11 @@ Calls `SkillInstallService.install(candidate_id)`. The agent should only call th
 user has explicitly requested installation in the conversation (not proactively). On success,
 the agent can immediately call `load_skill(canonical_name)` to use the skill.
 
-Registration: same pattern as `find_skills`.
+**Registration (run_manager.py):** Constructed at run-start with `org_id`, `workspace_id`,
+and `actor_user_id` from `ctx`, plus a `catalog_session` (same session as `find_skills`).
+`SkillInstallService` is instantiated inside the `_execute` closure using these closed-over
+values — no cross-workspace risk because `workspace_id` is bound at construction time from
+the authenticated run context, not from the `candidate_id` payload.
 
 ---
 
@@ -96,14 +105,17 @@ Registration: same pattern as `find_skills`.
 
 ### Auto-rendering `find_skills` results
 
-The message renderer detects a `tool_result` where `tool_name == "find_skills"` and renders
-`<SkillSearchResults>` instead of the default JSON text block. The candidates array is parsed
-directly from the tool result JSON.
+The integration point is `AssistantMessage.tsx`, which already has a `show_widget`
+special-case at the `tool_call` block level (line ~316). `find_skills` rendering follows
+the same pattern but at the **`tool_call_response` block level** — when a message block
+has `type == 'tool_call'` and `name == 'find_skills'`, render `<SkillSearchResults>`
+inline using the `toolResultMap[block.id]` payload instead of passing the block to
+`ToolCallGroup`. The candidates array is parsed directly from the JSON result string.
 
 **Files to create/modify:**
-- `components/chat/tool-results/SkillSearchResults.tsx` — container + card list
-- `components/chat/tool-results/SkillCandidateCard.tsx` — individual card
-- Modify the tool-result renderer to route `find_skills` → `SkillSearchResults`
+- `frontend/packages/web/components/chat/tool-results/SkillSearchResults.tsx` — container + card list
+- `frontend/packages/web/components/chat/tool-results/SkillCandidateCard.tsx` — individual card
+- `frontend/packages/web/components/chat/AssistantMessage.tsx` — add `find_skills` branch before the generic `ToolCallGroup` fallthrough (same location as `show_widget` check)
 
 ### `SkillCandidateCard`
 

--- a/frontend/packages/core/src/stores/panelStore.ts
+++ b/frontend/packages/core/src/stores/panelStore.ts
@@ -57,6 +57,7 @@ export type PanelView =
       info: AttachmentPanelInfo
     }
   | { type: 'browser' }
+  | { type: 'skill-candidate'; candidateId: string }
 
 export interface PanelStore {
   view: PanelView
@@ -75,6 +76,8 @@ export interface PanelStore {
   openAttachment: (info: AttachmentPanelInfo) => void
 
   openBrowser: () => void
+
+  openSkillCandidate: (candidateId: string) => void
 
   close: () => void
 }
@@ -109,6 +112,8 @@ export const usePanelStore = create<PanelStore>((set) => ({
     }),
 
   openBrowser: () => set({ view: { type: 'browser' } }),
+
+  openSkillCandidate: (candidateId) => set({ view: { type: 'skill-candidate', candidateId } }),
 
   close: () => set({ view: { type: 'closed' } }),
 }))

--- a/frontend/packages/web/app/api/v1/ws/[wsId]/skills/discover/preview/route.ts
+++ b/frontend/packages/web/app/api/v1/ws/[wsId]/skills/discover/preview/route.ts
@@ -1,0 +1,46 @@
+/**
+ * Skill candidate preview proxy — GET /discover/preview?candidate_id=
+ * Forwards to the backend and returns { candidate_id, name, canonical_name, content, env_vars }.
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.CUBEBOX_API_URL ?? 'http://localhost:8000'
+
+function buildProxyHeaders(request: NextRequest): HeadersInit {
+  const headers: Record<string, string> = { Accept: 'application/json' }
+  const cookie = request.headers.get('cookie')
+  const userId = request.headers.get('x-user-id')
+  const csrf = request.headers.get('x-csrf-token')
+  if (cookie) headers.cookie = cookie
+  if (userId) headers['x-user-id'] = userId
+  if (csrf) headers['X-CSRF-Token'] = csrf
+  return headers
+}
+
+function appendSetCookie(target: Headers, source: Headers): void {
+  const getSetCookie = (source as Headers & { getSetCookie?: () => string[] }).getSetCookie
+  if (typeof getSetCookie === 'function') {
+    for (const value of getSetCookie.call(source)) {
+      target.append('set-cookie', value)
+    }
+    return
+  }
+  const setCookie = source.get('set-cookie')
+  if (setCookie) target.append('set-cookie', setCookie)
+}
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ wsId: string }> }) {
+  const { wsId } = await params
+  const url = new URL(request.url)
+  const candidateId = url.searchParams.get('candidate_id') ?? ''
+
+  const backendRes = await fetch(
+    `${BACKEND_URL}/api/v1/ws/${wsId}/skills/discover/preview?candidate_id=${encodeURIComponent(candidateId)}`,
+    { headers: buildProxyHeaders(request) },
+  )
+
+  const data = await backendRes.json()
+  const response = NextResponse.json(data, { status: backendRes.status })
+  appendSetCookie(response.headers, backendRes.headers)
+  return response
+}

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -22,6 +22,7 @@ import { getWriteFileSummary } from '@/lib/writeFilePreview'
 import { extractWidgetCode, extractJsonStringPrefix } from '@/lib/partialJson'
 import { WidgetView } from '@/components/chat/widget/WidgetView'
 import { MarkdownWithCitations } from '@/components/shared/MarkdownWithCitations'
+import { SkillSearchResults } from './tool-results/SkillSearchResults'
 
 interface ReasoningBlockProps {
   thinking: string
@@ -313,6 +314,11 @@ function ContentBlockRenderer({
       />
     )
   }
+  if (block.type === 'tool_call' && block.name === 'find_skills') {
+    const toolResult = toolResultMap[block.id]
+    if (!toolResult) return null
+    return <SkillSearchResults key={block.id} resultJson={toolResult.content} />
+  }
   if (block.type === 'tool_call' && block.name === 'show_widget') {
     const a = block.arguments ?? {}
     return (
@@ -416,7 +422,8 @@ function groupBlocks(blocks: ContentBlock[]): (ContentBlock | ContentBlock[])[] 
       block.name !== 'subagent' &&
       block.name !== 'save_artifact' &&
       block.name !== 'write_todos' &&
-      block.name !== 'show_widget'
+      block.name !== 'show_widget' &&
+      block.name !== 'find_skills'
     ) {
       const last = result[result.length - 1]
       if (

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -317,7 +317,16 @@ function ContentBlockRenderer({
   if (block.type === 'tool_call' && block.name === 'find_skills') {
     const toolResult = toolResultMap[block.id]
     if (!toolResult) return null
-    return <SkillSearchResults key={block.id} resultJson={toolResult.content} />
+    let hasCandidates = false
+    try {
+      const parsed = JSON.parse(toolResult.content) as { candidates?: unknown }
+      hasCandidates = Array.isArray(parsed.candidates)
+    } catch {
+      // invalid JSON — fall through to generic tool rendering below
+    }
+    if (hasCandidates) {
+      return <SkillSearchResults key={block.id} resultJson={toolResult.content} />
+    }
   }
   if (block.type === 'tool_call' && block.name === 'show_widget') {
     const a = block.arguments ?? {}

--- a/frontend/packages/web/components/chat/tool-results/SkillCandidateCard.tsx
+++ b/frontend/packages/web/components/chat/tool-results/SkillCandidateCard.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { Download } from 'lucide-react'
+import { usePanelStore } from '@cubebox/core'
+import { Button } from '@/components/ui/button'
+import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
+import { csrfHeaders } from '@/lib/csrf'
+import { cn } from '@/lib/utils'
+
+export interface SkillCandidate {
+  candidate_id: string
+  name: string
+  canonical_name: string
+  description: string
+  source: string
+  source_name: string
+  repo: string | null
+  trust: 'official' | 'community' | 'untrusted'
+  install_state: 'enabled' | 'in_catalog' | 'available'
+  install_count: number | null
+  unvetted: boolean
+}
+
+const TRUST_BADGE: Record<string, string> = {
+  official: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+  community: 'bg-amber-500/10 text-amber-700 dark:text-amber-400',
+  untrusted: 'bg-muted text-muted-foreground',
+}
+
+const STATE_BADGE: Record<string, string> = {
+  enabled: 'bg-green-500/10 text-green-700 dark:text-green-400',
+  in_catalog: 'bg-muted text-muted-foreground',
+  available: 'bg-muted text-muted-foreground',
+}
+
+export function SkillCandidateCard({ candidate }: { candidate: SkillCandidate }) {
+  const t = useTranslations('skillSearch')
+  const { workspaceId } = useWorkspaceContext()
+  const openSkillCandidate = usePanelStore((s) => s.openSkillCandidate)
+
+  const [installing, setInstalling] = useState(false)
+  const [installState, setInstallState] = useState<SkillCandidate['install_state']>(
+    candidate.install_state,
+  )
+  const [installError, setInstallError] = useState<string | null>(null)
+
+  async function handleInstall(): Promise<void> {
+    if (!workspaceId || installState === 'enabled') return
+    setInstalling(true)
+    setInstallError(null)
+    try {
+      const res = await fetch(`/api/v1/ws/${workspaceId}/skills/install`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { ...csrfHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ candidate_id: candidate.candidate_id }),
+      })
+      if (!res.ok) {
+        setInstallError(t('installError'))
+        return
+      }
+      setInstallState('enabled')
+    } finally {
+      setInstalling(false)
+    }
+  }
+
+  const trustKey = `trust${candidate.trust.charAt(0).toUpperCase()}${candidate.trust.slice(1)}` as
+    | 'trustOfficial'
+    | 'trustCommunity'
+    | 'trustUnvetted'
+  const trustLabel = t(trustKey)
+  const stateLabel = installState === 'enabled' ? t('stateEnabled') : t('stateAvailable')
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-3 flex flex-col gap-2 shadow-sm">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-1 min-w-0">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="font-mono text-sm font-semibold truncate">{candidate.name}</span>
+            <span
+              className={cn(
+                'rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+                TRUST_BADGE[candidate.trust] ?? TRUST_BADGE.untrusted,
+              )}
+            >
+              {trustLabel}
+            </span>
+            <span
+              className={cn(
+                'rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+                STATE_BADGE[installState] ?? STATE_BADGE.available,
+              )}
+            >
+              {stateLabel}
+            </span>
+          </div>
+          <span className="text-xs text-muted-foreground">{candidate.source_name}</span>
+        </div>
+        {candidate.install_count != null && (
+          <div className="flex items-center gap-0.5 shrink-0 text-xs text-muted-foreground">
+            <Download className="size-3" />
+            <span>{candidate.install_count.toLocaleString()}</span>
+          </div>
+        )}
+      </div>
+
+      <p className="text-xs text-foreground/80 leading-relaxed">
+        {candidate.description || t('noDescription')}
+      </p>
+
+      {installError && <p className="text-xs text-destructive">{installError}</p>}
+
+      <div className="flex gap-1.5">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          onClick={() => openSkillCandidate(candidate.candidate_id)}
+        >
+          {t('preview')}
+        </Button>
+        <Button
+          size="sm"
+          className="h-7 text-xs"
+          disabled={installing || installState === 'enabled'}
+          onClick={() => void handleInstall()}
+        >
+          {installState === 'enabled'
+            ? t('installed')
+            : installing
+              ? t('installing')
+              : t('install')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/packages/web/components/chat/tool-results/SkillCandidateCard.tsx
+++ b/frontend/packages/web/components/chat/tool-results/SkillCandidateCard.tsx
@@ -67,11 +67,15 @@ export function SkillCandidateCard({ candidate }: { candidate: SkillCandidate })
     }
   }
 
-  const trustKey = `trust${candidate.trust.charAt(0).toUpperCase()}${candidate.trust.slice(1)}` as
-    | 'trustOfficial'
-    | 'trustCommunity'
-    | 'trustUnvetted'
-  const trustLabel = t(trustKey)
+  const TRUST_KEY = {
+    official: 'trustOfficial',
+    community: 'trustCommunity',
+    untrusted: 'trustUnvetted',
+  } as const satisfies Record<
+    SkillCandidate['trust'],
+    'trustOfficial' | 'trustCommunity' | 'trustUnvetted'
+  >
+  const trustLabel = t(TRUST_KEY[candidate.trust] ?? 'trustUnvetted')
   const stateLabel = installState === 'enabled' ? t('stateEnabled') : t('stateAvailable')
 
   return (

--- a/frontend/packages/web/components/chat/tool-results/SkillSearchResults.tsx
+++ b/frontend/packages/web/components/chat/tool-results/SkillSearchResults.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { SkillCandidateCard, type SkillCandidate } from './SkillCandidateCard'
+
+interface FindSkillsPayload {
+  candidates: SkillCandidate[]
+  hint?: string
+}
+
+function parsePayload(json: string): SkillCandidate[] {
+  try {
+    const parsed = JSON.parse(json) as FindSkillsPayload
+    return Array.isArray(parsed.candidates) ? parsed.candidates : []
+  } catch {
+    return []
+  }
+}
+
+export function SkillSearchResults({ resultJson }: { resultJson: string }) {
+  const candidates = parsePayload(resultJson)
+  if (candidates.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-2 py-1">
+      {candidates.map((c) => (
+        <SkillCandidateCard key={c.candidate_id} candidate={c} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/packages/web/components/layout/AppShell.tsx
+++ b/frontend/packages/web/components/layout/AppShell.tsx
@@ -8,6 +8,7 @@ import { ToolDetailPanel } from '@/components/panel/ToolDetailPanel'
 import { ArtifactPanel } from '@/components/panel/artifact/ArtifactPanel'
 import { AttachmentPreviewView } from '@/components/panel/AttachmentPreviewView'
 import { BrowserView } from '@/components/panel/BrowserView'
+import { SkillCandidatePanel } from '@/components/panel/SkillCandidatePanel'
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
 import { usePanelStore } from '@cubebox/core'
 import { useDeploymentMode } from '@cubebox/core/hooks/useDeploymentMode'
@@ -61,6 +62,8 @@ export function AppShell({ children, headerTitle }: AppShellProps) {
               <AttachmentPreviewView info={view.info} />
             ) : view.type === 'browser' ? (
               <BrowserView workspaceId={workspaceId} />
+            ) : view.type === 'skill-candidate' ? (
+              <SkillCandidatePanel candidateId={view.candidateId} />
             ) : (
               <ToolDetailPanel />
             )}

--- a/frontend/packages/web/components/panel/SkillCandidatePanel.tsx
+++ b/frontend/packages/web/components/panel/SkillCandidatePanel.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useState } from 'react'
+import { useTranslations } from 'next-intl'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Download } from 'lucide-react'
+import useSWR from 'swr'
+import { Button } from '@/components/ui/button'
+import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
+import { csrfHeaders } from '@/lib/csrf'
+import { proseClasses } from '@/lib/utils'
+
+interface CandidatePreview {
+  candidate_id: string
+  name: string
+  canonical_name: string
+  content: string
+  env_vars: string[]
+}
+
+async function fetchPreview(url: string): Promise<CandidatePreview> {
+  const res = await fetch(url, { credentials: 'include' })
+  if (!res.ok) throw new Error(`preview fetch failed: ${res.status}`)
+  return res.json() as Promise<CandidatePreview>
+}
+
+export function SkillCandidatePanel({ candidateId }: { candidateId: string }) {
+  const t = useTranslations('panel.skillCandidatePanel')
+  const { workspaceId } = useWorkspaceContext()
+
+  const url = workspaceId
+    ? `/api/v1/ws/${workspaceId}/skills/discover/preview?candidate_id=${encodeURIComponent(candidateId)}`
+    : null
+
+  const { data, error, isLoading, mutate } = useSWR<CandidatePreview>(url, fetchPreview, {
+    revalidateOnFocus: false,
+    shouldRetryOnError: false,
+  })
+
+  const [installing, setInstalling] = useState(false)
+  const [installState, setInstallState] = useState<'idle' | 'done' | 'error'>('idle')
+  const [installError, setInstallError] = useState<string | null>(null)
+
+  async function handleInstall(): Promise<void> {
+    if (!workspaceId) return
+    setInstalling(true)
+    setInstallError(null)
+    try {
+      const res = await fetch(`/api/v1/ws/${workspaceId}/skills/install`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { ...csrfHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ candidate_id: candidateId }),
+      })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as Record<string, unknown>
+        setInstallError(typeof body.detail === 'string' ? body.detail : t('installError'))
+        setInstallState('error')
+        return
+      }
+      setInstallState('done')
+    } finally {
+      setInstalling(false)
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-4">
+        {isLoading && <p className="text-sm text-muted-foreground">{t('loading')}</p>}
+
+        {error && !isLoading && (
+          <div className="flex flex-col gap-2">
+            <p className="text-sm text-destructive">{t('fetchError')}</p>
+            <Button variant="outline" size="sm" onClick={() => void mutate()}>
+              {t('retry')}
+            </Button>
+          </div>
+        )}
+
+        {data && (
+          <>
+            <header className="flex flex-wrap items-baseline gap-2">
+              <span className="font-mono font-semibold">{data.name}</span>
+              {data.env_vars.length > 0 && (
+                <span className="text-xs text-muted-foreground">
+                  requires: {data.env_vars.join(', ')}
+                </span>
+              )}
+            </header>
+
+            {installError && (
+              <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {installError}
+              </p>
+            )}
+
+            <div className={proseClasses}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{data.content}</ReactMarkdown>
+            </div>
+          </>
+        )}
+      </div>
+
+      {data && (
+        <div className="shrink-0 border-t p-4">
+          <Button
+            size="sm"
+            disabled={installing || installState === 'done'}
+            onClick={() => void handleInstall()}
+            className="flex items-center gap-1.5"
+          >
+            <Download className="size-3.5" />
+            {installState === 'done'
+              ? t('installed')
+              : installing
+                ? t('installing')
+                : t('installButton')}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -1117,6 +1117,20 @@
     "addCustomConnector": "+ Add custom connector",
     "promoteToOrg": "Promote to org-wide"
   },
+  "skillSearch": {
+    "noDescription": "No description available",
+    "preview": "Preview",
+    "install": "Install",
+    "installing": "Installing…",
+    "installed": "Installed",
+    "installError": "Install failed",
+    "trustOfficial": "official",
+    "trustCommunity": "community",
+    "trustUnvetted": "unvetted",
+    "stateEnabled": "installed",
+    "stateAvailable": "available",
+    "downloads": "{count} installs"
+  },
   "adminSkillRegistries": {
     "pageTitle": "Skill Registries",
     "title": "Skill Registries",

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -838,6 +838,15 @@
     "pdf": {
       "tableOfContents": "Table of contents",
       "loadFailed": "Failed to load PDF"
+    },
+    "skillCandidatePanel": {
+      "loading": "Loading skill preview…",
+      "fetchError": "Could not load skill preview. The remote source may be unavailable.",
+      "retry": "Retry",
+      "installButton": "Install",
+      "installing": "Installing…",
+      "installed": "Installed",
+      "installError": "Installation failed. Please try again."
     }
   },
   "common": {

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -1117,6 +1117,20 @@
     "addCustomConnector": "+ 添加自定义连接器",
     "promoteToOrg": "提升为组织级"
   },
+  "skillSearch": {
+    "noDescription": "暂无描述",
+    "preview": "预览",
+    "install": "安装",
+    "installing": "安装中…",
+    "installed": "已安装",
+    "installError": "安装失败",
+    "trustOfficial": "官方",
+    "trustCommunity": "社区",
+    "trustUnvetted": "未审核",
+    "stateEnabled": "已安装",
+    "stateAvailable": "可用",
+    "downloads": "{count} 次安装"
+  },
   "adminSkillRegistries": {
     "pageTitle": "技能仓库",
     "title": "技能仓库",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -838,6 +838,15 @@
     "pdf": {
       "tableOfContents": "目录",
       "loadFailed": "加载 PDF 失败"
+    },
+    "skillCandidatePanel": {
+      "loading": "正在加载 skill 预览…",
+      "fetchError": "无法加载 skill 预览，远程来源可能不可用。",
+      "retry": "重试",
+      "installButton": "安装",
+      "installing": "安装中…",
+      "installed": "已安装",
+      "installError": "安装失败，请重试。"
     }
   },
   "common": {


### PR DESCRIPTION
## Summary

- preview_skill agent tool: fetches SKILL.md before suggesting install (local + remote, tombstone check)
- install_skill agent tool: registered in run_manager.py alongside find_skills, sharing catalog_session
- find_skills card UI: results render as skill cards with trust badge, install count, Preview + Install buttons; error responses fall back to generic display
- Right-panel SkillCandidatePanel: fetches /discover/preview, renders markdown with Install button
- find_skills hint updated to guide agent through preview_skill then install_skill

## Test plan
- [ ] Ask agent "find a Twitter skill" — skill cards render instead of raw JSON
- [ ] Click Preview — right panel opens with SKILL.md markdown
- [ ] Click Install — badge updates to installed, button disables
- [ ] Agent conversation install — install_skill fires, agent calls load_skill after
- [ ] `uv run pytest tests/unit/ -k skill -q` — all 70 pass