### PR TITLE
feat(skills): show repo link in skill card and preview panel

### DIFF
--- a/frontend/packages/core/src/stores/panelStore.ts
+++ b/frontend/packages/core/src/stores/panelStore.ts
@@ -57,7 +57,7 @@ export type PanelView =
       info: AttachmentPanelInfo
     }
   | { type: 'browser' }
-  | { type: 'skill-candidate'; candidateId: string }
+  | { type: 'skill-candidate'; candidateId: string; repo: string | null; sourceName: string }
 
 export interface PanelStore {
   view: PanelView
@@ -77,7 +77,7 @@ export interface PanelStore {
 
   openBrowser: () => void
 
-  openSkillCandidate: (candidateId: string) => void
+  openSkillCandidate: (candidateId: string, repo: string | null, sourceName: string) => void
 
   close: () => void
 }
@@ -113,7 +113,8 @@ export const usePanelStore = create<PanelStore>((set) => ({
 
   openBrowser: () => set({ view: { type: 'browser' } }),
 
-  openSkillCandidate: (candidateId) => set({ view: { type: 'skill-candidate', candidateId } }),
+  openSkillCandidate: (candidateId, repo, sourceName) =>
+    set({ view: { type: 'skill-candidate', candidateId, repo, sourceName } }),
 
   close: () => set({ view: { type: 'closed' } }),
 }))

--- a/frontend/packages/web/components/chat/tool-results/SkillCandidateCard.tsx
+++ b/frontend/packages/web/components/chat/tool-results/SkillCandidateCard.tsx
@@ -35,6 +35,15 @@ const STATE_BADGE: Record<string, string> = {
   available: 'bg-muted text-muted-foreground',
 }
 
+function safeRepoUrl(url: string | null): string | null {
+  if (!url) return null
+  try {
+    return new URL(url).protocol === 'https:' ? url : null
+  } catch {
+    return null
+  }
+}
+
 export function SkillCandidateCard({ candidate }: { candidate: SkillCandidate }) {
   const t = useTranslations('skillSearch')
   const { workspaceId } = useWorkspaceContext()
@@ -103,16 +112,16 @@ export function SkillCandidateCard({ candidate }: { candidate: SkillCandidate })
           </div>
           <div className="flex items-center gap-1.5">
             <span className="text-xs text-muted-foreground">{candidate.source_name}</span>
-            {candidate.repo && (
+            {safeRepoUrl(candidate.repo) && (
               <a
-                href={candidate.repo}
+                href={safeRepoUrl(candidate.repo)!}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground"
                 onClick={(e) => e.stopPropagation()}
               >
                 <ExternalLink className="size-3" />
-                <span>{candidate.repo.replace('https://github.com/', '')}</span>
+                <span>{candidate.repo!.replace('https://github.com/', '')}</span>
               </a>
             )}
           </div>
@@ -137,7 +146,11 @@ export function SkillCandidateCard({ candidate }: { candidate: SkillCandidate })
           size="sm"
           className="h-7 text-xs"
           onClick={() =>
-            openSkillCandidate(candidate.candidate_id, candidate.repo, candidate.source_name)
+            openSkillCandidate(
+              candidate.candidate_id,
+              safeRepoUrl(candidate.repo),
+              candidate.source_name,
+            )
           }
         >
           {t('preview')}

--- a/frontend/packages/web/components/chat/tool-results/SkillCandidateCard.tsx
+++ b/frontend/packages/web/components/chat/tool-results/SkillCandidateCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useTranslations } from 'next-intl'
-import { Download } from 'lucide-react'
+import { Download, ExternalLink } from 'lucide-react'
 import { usePanelStore } from '@cubebox/core'
 import { Button } from '@/components/ui/button'
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
@@ -101,7 +101,21 @@ export function SkillCandidateCard({ candidate }: { candidate: SkillCandidate })
               {stateLabel}
             </span>
           </div>
-          <span className="text-xs text-muted-foreground">{candidate.source_name}</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-muted-foreground">{candidate.source_name}</span>
+            {candidate.repo && (
+              <a
+                href={candidate.repo}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <ExternalLink className="size-3" />
+                <span>{candidate.repo.replace('https://github.com/', '')}</span>
+              </a>
+            )}
+          </div>
         </div>
         {candidate.install_count != null && (
           <div className="flex items-center gap-0.5 shrink-0 text-xs text-muted-foreground">
@@ -122,7 +136,9 @@ export function SkillCandidateCard({ candidate }: { candidate: SkillCandidate })
           variant="outline"
           size="sm"
           className="h-7 text-xs"
-          onClick={() => openSkillCandidate(candidate.candidate_id)}
+          onClick={() =>
+            openSkillCandidate(candidate.candidate_id, candidate.repo, candidate.source_name)
+          }
         >
           {t('preview')}
         </Button>

--- a/frontend/packages/web/components/layout/AppShell.tsx
+++ b/frontend/packages/web/components/layout/AppShell.tsx
@@ -63,7 +63,11 @@ export function AppShell({ children, headerTitle }: AppShellProps) {
             ) : view.type === 'browser' ? (
               <BrowserView workspaceId={workspaceId} />
             ) : view.type === 'skill-candidate' ? (
-              <SkillCandidatePanel candidateId={view.candidateId} />
+              <SkillCandidatePanel
+                candidateId={view.candidateId}
+                repo={view.repo}
+                sourceName={view.sourceName}
+              />
             ) : (
               <ToolDetailPanel />
             )}

--- a/frontend/packages/web/components/panel/SkillCandidatePanel.tsx
+++ b/frontend/packages/web/components/panel/SkillCandidatePanel.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { Download } from 'lucide-react'
+import { Download, ExternalLink } from 'lucide-react'
 import useSWR from 'swr'
 import { Button } from '@/components/ui/button'
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
@@ -25,7 +25,15 @@ async function fetchPreview(url: string): Promise<CandidatePreview> {
   return res.json() as Promise<CandidatePreview>
 }
 
-export function SkillCandidatePanel({ candidateId }: { candidateId: string }) {
+export function SkillCandidatePanel({
+  candidateId,
+  repo,
+  sourceName,
+}: {
+  candidateId: string
+  repo?: string | null
+  sourceName?: string
+}) {
   const t = useTranslations('panel.skillCandidatePanel')
   const { workspaceId } = useWorkspaceContext()
 
@@ -81,13 +89,27 @@ export function SkillCandidatePanel({ candidateId }: { candidateId: string }) {
 
         {data && (
           <>
-            <header className="flex flex-wrap items-baseline gap-2">
+            <header className="flex flex-col gap-1">
               <span className="font-mono font-semibold">{data.name}</span>
-              {data.env_vars.length > 0 && (
-                <span className="text-xs text-muted-foreground">
-                  requires: {data.env_vars.join(', ')}
-                </span>
-              )}
+              <div className="flex flex-wrap items-center gap-2">
+                {sourceName && <span className="text-xs text-muted-foreground">{sourceName}</span>}
+                {repo && (
+                  <a
+                    href={repo}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    <ExternalLink className="size-3" />
+                    <span>{repo.replace('https://github.com/', '')}</span>
+                  </a>
+                )}
+                {data.env_vars.length > 0 && (
+                  <span className="text-xs text-muted-foreground">
+                    requires: {data.env_vars.join(', ')}
+                  </span>
+                )}
+              </div>
             </header>
 
             {installError && (

--- a/frontend/packages/web/components/panel/SkillCandidatePanel.tsx
+++ b/frontend/packages/web/components/panel/SkillCandidatePanel.tsx
@@ -25,6 +25,15 @@ async function fetchPreview(url: string): Promise<CandidatePreview> {
   return res.json() as Promise<CandidatePreview>
 }
 
+function safeRepoUrl(url: string | null | undefined): string | null {
+  if (!url) return null
+  try {
+    return new URL(url).protocol === 'https:' ? url : null
+  } catch {
+    return null
+  }
+}
+
 export function SkillCandidatePanel({
   candidateId,
   repo,
@@ -93,15 +102,15 @@ export function SkillCandidatePanel({
               <span className="font-mono font-semibold">{data.name}</span>
               <div className="flex flex-wrap items-center gap-2">
                 {sourceName && <span className="text-xs text-muted-foreground">{sourceName}</span>}
-                {repo && (
+                {safeRepoUrl(repo) && (
                   <a
-                    href={repo}
+                    href={safeRepoUrl(repo)!}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground"
                   >
                     <ExternalLink className="size-3" />
-                    <span>{repo.replace('https://github.com/', '')}</span>
+                    <span>{repo!.replace('https://github.com/', '')}</span>
                   </a>
                 )}
                 {data.env_vars.length > 0 && (


### PR DESCRIPTION
## Summary

In the skill search results, each card now shows the source registry (e.g. "skills.sh") alongside a clickable link to the upstream GitHub repo (e.g. `skills-shell/skills`). The same link appears in the right-panel preview header.

## What changed

- `SkillCandidateCard`: added repo link with `ExternalLink` icon below the source_name badge; GitHub URLs are shortened to `owner/repo` format
- `SkillCandidatePanel`: shows source_name + repo link in the header; repo/sourceName passed via panelStore view state
- `panelStore`: `skill-candidate` view type now carries `repo: string | null` and `sourceName: string`; `openSkillCandidate` signature updated accordingly

## Test plan

- [ ] Ask agent to find a skill from skills.sh — card shows "skills.sh" + `owner/repo` link
- [ ] Click Preview — panel header shows source + repo link
- [ ] Local-catalog skills (no repo) — link is hidden, only source_name shown
- [ ] Link opens correct GitHub URL in new tab