### PR TITLE
feat(ws/skills): add Files, Versions, Compare tabs to workspace skill detail

### DIFF
--- a/backend/cubebox/api/routes/v1/ws_skills.py
+++ b/backend/cubebox/api/routes/v1/ws_skills.py
@@ -19,6 +19,7 @@ from cubebox.api.schemas.skill import (
     SkillContentResponse,
     SkillFiles,
     SkillSummary,
+    SkillVersionDetail,
 )
 from cubebox.api.schemas.skill_discovery import (
     CandidatePreviewResponse,
@@ -57,6 +58,7 @@ from cubebox.skills.service import (
 )
 from cubebox.skills.sources.base import CandidateIdError, decode_candidate_id
 from cubebox.skills.sources.registry import SkillsAdapterManager
+from cubebox.utils.time import utc_isoformat
 
 router = APIRouter(prefix="/ws/{workspace_id}/skills", tags=["ws-skills"])
 
@@ -402,6 +404,33 @@ async def refresh_skill(
         installed_version=result.installed_version,
         changed=result.installed_version != prev_version,
     )
+
+
+@router.get("/{skill_id}/versions", response_model=list[SkillVersionDetail])
+async def list_skill_versions(
+    workspace_id: str,
+    skill_id: str,
+    *,
+    ctx: Annotated[RequestContext, Depends(require_member)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> list[SkillVersionDetail]:
+    skill = await SkillRepository(session).get(skill_id)
+    if skill is None or not _visible(skill, ctx.org_id):
+        raise HTTPException(status_code=404, detail="SKILL_NOT_FOUND")
+    versions = await SkillVersionRepository(session).list_for_skill(skill_id)
+    return [
+        SkillVersionDetail(
+            id=v.id,
+            version=v.version,
+            description=v.description or "",
+            keywords=v.keywords or [],
+            storage_prefix=v.storage_prefix,
+            entry_file=v.entry_file,
+            uploaded_by_user_id=v.uploaded_by_user_id,
+            created_at=utc_isoformat(v.created_at),
+        )
+        for v in versions
+    ]
 
 
 @router.get("/{skill_id}", response_model=SkillContentResponse)

--- a/backend/cubebox/api/routes/v1/ws_skills.py
+++ b/backend/cubebox/api/routes/v1/ws_skills.py
@@ -485,6 +485,8 @@ async def get_skill_file(
     session: Annotated[AsyncSession, Depends(get_session)],
     version: str | None = Query(None),
 ) -> bytes:
+    from fastapi.responses import Response
+
     skill = await SkillRepository(session).get(skill_id)
     if skill is None or not _visible(skill, ctx.org_id):
         raise HTTPException(status_code=404, detail="SKILL_NOT_FOUND")
@@ -502,7 +504,12 @@ async def get_skill_file(
         raise HTTPException(status_code=400, detail="INVALID_PATH")
     if not target.is_file():
         raise HTTPException(status_code=404, detail="FILE_NOT_FOUND")
-    return target.read_bytes()
+    data = target.read_bytes()
+    try:
+        text = data.decode("utf-8")
+        return Response(content=text, media_type="text/plain; charset=utf-8")  # type: ignore[return-value]
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=422, detail="BINARY_FILE") from None
 
 
 @router.post("/publish", status_code=201)

--- a/frontend/packages/web/components/admin/skills/SkillDetailPanel.tsx
+++ b/frontend/packages/web/components/admin/skills/SkillDetailPanel.tsx
@@ -42,6 +42,11 @@ function stripFrontmatter(content: string): string {
   return content.replace(/^---\s*\n[\s\S]*?\n---\s*(\n|$)/, '')
 }
 
+/** Encode each path segment while preserving "/" separators. */
+function encodeFilePath(filePath: string): string {
+  return filePath.split('/').map(encodeURIComponent).join('/')
+}
+
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
@@ -63,7 +68,7 @@ function FilesTab({
   const [selected, setSelected] = useState<string | null>(null)
 
   const fileUrl = selected
-    ? `/api/v1/admin/skills/${skillId}/versions/${version}/files/${selected}`
+    ? `/api/v1/admin/skills/${skillId}/versions/${version}/files/${encodeFilePath(selected)}`
     : null
   const { data: fileContent, isLoading: fileLoading } = useSWR<string>(fileUrl, textFetcher, {
     revalidateOnFocus: false,
@@ -276,11 +281,11 @@ function CompareTab({ skillId, versions }: { skillId: string; versions: SkillVer
   // Fetch selected file content from both sides
   const fileLeftUrl =
     selectedFile && vLeft
-      ? `/api/v1/admin/skills/${skillId}/versions/${vLeft}/files/${selectedFile}`
+      ? `/api/v1/admin/skills/${skillId}/versions/${vLeft}/files/${encodeFilePath(selectedFile)}`
       : null
   const fileRightUrl =
     selectedFile && vRight
-      ? `/api/v1/admin/skills/${skillId}/versions/${vRight}/files/${selectedFile}`
+      ? `/api/v1/admin/skills/${skillId}/versions/${vRight}/files/${encodeFilePath(selectedFile)}`
       : null
   const { data: fileLeft } = useSWR<string>(fileLeftUrl, textFetcher, { revalidateOnFocus: false })
   const { data: fileRight } = useSWR<string>(fileRightUrl, textFetcher, {

--- a/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillDetail.tsx
+++ b/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillDetail.tsx
@@ -73,6 +73,11 @@ async function textFetcher(url: string): Promise<string> {
   return res.text()
 }
 
+/** Encode each path segment while preserving "/" separators. */
+function encodeFilePath(filePath: string): string {
+  return filePath.split('/').map(encodeURIComponent).join('/')
+}
+
 // ─── Files Tab ───────────────────────────────────────────────────────────────
 
 function FilesTab({
@@ -90,7 +95,7 @@ function FilesTab({
   const [selected, setSelected] = useState<string | null>(null)
 
   const fileUrl = selected
-    ? `/api/v1/ws/${wsId}/skills/${skillId}/files/${selected}?version=${encodeURIComponent(version)}`
+    ? `/api/v1/ws/${wsId}/skills/${skillId}/files/${encodeFilePath(selected)}?version=${encodeURIComponent(version)}`
     : null
   const { data: fileContent, isLoading: fileLoading } = useSWR<string>(fileUrl, textFetcher, {
     revalidateOnFocus: false,
@@ -257,11 +262,11 @@ function CompareTab({
 
   const fileLeftUrl =
     selectedFile && vLeft
-      ? `/api/v1/ws/${wsId}/skills/${skillId}/files/${selectedFile}?version=${encodeURIComponent(vLeft)}`
+      ? `/api/v1/ws/${wsId}/skills/${skillId}/files/${encodeFilePath(selectedFile)}?version=${encodeURIComponent(vLeft)}`
       : null
   const fileRightUrl =
     selectedFile && vRight
-      ? `/api/v1/ws/${wsId}/skills/${skillId}/files/${selectedFile}?version=${encodeURIComponent(vRight)}`
+      ? `/api/v1/ws/${wsId}/skills/${skillId}/files/${encodeFilePath(selectedFile)}?version=${encodeURIComponent(vRight)}`
       : null
   const { data: fileLeft } = useSWR<string>(fileLeftUrl, textFetcher, { revalidateOnFocus: false })
   const { data: fileRight } = useSWR<string>(fileRightUrl, textFetcher, {

--- a/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillDetail.tsx
+++ b/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillDetail.tsx
@@ -1,16 +1,18 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import dynamic from 'next/dynamic'
 import useSWR from 'swr'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { FileText } from 'lucide-react'
+import { FileText, Files, GitCompare, History } from 'lucide-react'
 import {
   createApiClient,
   deleteWorkspaceSkill,
   installWorkspaceSkill,
   toggleWorkspaceSkill,
   type SkillContent,
+  type SkillVersionDetail,
 } from '@cubebox/core'
 import { useTranslations } from 'next-intl'
 
@@ -20,6 +22,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { cn, proseClasses } from '@/lib/utils'
 import type { WorkspaceSkillEntry, WorkspaceSkillState } from '@/hooks/useWorkspaceSkillsCatalog'
 
+const ReactDiffViewer = dynamic(() => import('react-diff-viewer-continued'), { ssr: false })
+
 interface WorkspaceSkillDetailProps {
   wsId: string
   skill: WorkspaceSkillEntry
@@ -28,6 +32,12 @@ interface WorkspaceSkillDetailProps {
 
 function stripFrontmatter(content: string): string {
   return content.replace(/^---\s*\n[\s\S]*?\n---\s*(\n|$)/, '')
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
 const STATE_KEY = {
@@ -49,6 +59,338 @@ async function contentFetcher(url: string): Promise<SkillContent> {
   if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
   return res.json() as Promise<SkillContent>
 }
+
+async function versionsFetcher(url: string): Promise<SkillVersionDetail[]> {
+  const res = await fetch(url, { credentials: 'include' })
+  if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
+  return res.json() as Promise<SkillVersionDetail[]>
+}
+
+async function textFetcher(url: string): Promise<string> {
+  const res = await fetch(url, { credentials: 'include' })
+  if (res.status === 422) return '__BINARY__'
+  if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
+  return res.text()
+}
+
+// ─── Files Tab ───────────────────────────────────────────────────────────────
+
+function FilesTab({
+  wsId,
+  skillId,
+  version,
+  files,
+}: {
+  wsId: string
+  skillId: string
+  version: string
+  files: SkillContent['files']
+}) {
+  const t = useTranslations('wsSettings.skillDetail')
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const fileUrl = selected
+    ? `/api/v1/ws/${wsId}/skills/${skillId}/files/${selected}?version=${encodeURIComponent(version)}`
+    : null
+  const { data: fileContent, isLoading: fileLoading } = useSWR<string>(fileUrl, textFetcher, {
+    revalidateOnFocus: false,
+    shouldRetryOnError: false,
+  })
+
+  if (files.length === 0)
+    return <p className="text-xs text-muted-foreground">{t('noAdditionalFiles')}</p>
+
+  return (
+    <div className="grid min-h-[200px] grid-cols-[200px_1fr] gap-3 overflow-hidden rounded-lg border border-border/70">
+      <ul className="flex flex-col divide-y divide-border/60 border-r border-border/60 overflow-y-auto">
+        {files.map((f) => (
+          <li key={f.rel_path}>
+            <button
+              type="button"
+              onClick={() => setSelected(f.rel_path)}
+              className={`w-full cursor-pointer px-3 py-2 text-left text-xs transition-colors hover:bg-accent/50 ${
+                selected === f.rel_path ? 'bg-accent/70 font-medium' : ''
+              }`}
+            >
+              <div className="truncate font-mono">{f.rel_path}</div>
+              <div className="text-[10px] text-muted-foreground">{formatBytes(f.size)}</div>
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="overflow-auto p-3">
+        {!selected && <p className="text-xs text-muted-foreground">{t('clickToPreview')}</p>}
+        {selected && fileLoading && (
+          <p className="text-xs text-muted-foreground">{t('previewLoading')}</p>
+        )}
+        {selected && fileContent === '__BINARY__' && (
+          <p className="text-xs text-muted-foreground">{t('binaryFile')}</p>
+        )}
+        {selected && fileContent && fileContent !== '__BINARY__' && (
+          <pre className="whitespace-pre-wrap break-all font-mono text-xs leading-relaxed text-foreground/80">
+            {fileContent}
+          </pre>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── Versions Tab ────────────────────────────────────────────────────────────
+
+function VersionsTab({
+  installedVersion,
+  currentVersion,
+  versions,
+}: {
+  installedVersion: string | null
+  currentVersion: string
+  versions: SkillVersionDetail[]
+}) {
+  const t = useTranslations('wsSettings.skillDetail')
+  const sorted = versions.slice().sort((a, b) => b.version.localeCompare(a.version))
+
+  if (sorted.length === 0) return <p className="text-xs text-muted-foreground">{t('noVersions')}</p>
+
+  return (
+    <ul className="flex flex-col gap-1.5">
+      {sorted.map((v) => {
+        const isInstalled = v.version === installedVersion
+        const isCurrent = v.version === currentVersion
+        return (
+          <li
+            key={v.id}
+            className="flex items-center justify-between rounded-md border border-border/70 px-3 py-2.5 text-xs"
+          >
+            <div className="flex items-center gap-2">
+              <span className="font-mono font-semibold">v{v.version}</span>
+              {isInstalled && (
+                <Badge
+                  variant="outline"
+                  className="border-emerald-500/40 text-[10px] text-emerald-600"
+                >
+                  {t('versionInstalled')}
+                </Badge>
+              )}
+              {isCurrent && !isInstalled && (
+                <Badge variant="outline" className="text-[10px]">
+                  {t('versionLatest')}
+                </Badge>
+              )}
+            </div>
+            <span className="text-muted-foreground">{new Date(v.created_at).toLocaleString()}</span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+// ─── Compare Tab ─────────────────────────────────────────────────────────────
+
+type FileStatus = 'added' | 'removed' | 'changed' | 'same'
+
+interface FileDiffEntry {
+  path: string
+  status: FileStatus
+}
+
+const STATUS_STYLES: Record<FileStatus, { label: string; cls: string }> = {
+  added: { label: 'added', cls: 'text-emerald-600 bg-emerald-500/10' },
+  removed: { label: 'removed', cls: 'text-red-600 bg-red-500/10' },
+  changed: { label: 'changed', cls: 'text-amber-600 bg-amber-500/10' },
+  same: { label: 'same', cls: 'text-muted-foreground bg-muted/40' },
+}
+
+function CompareTab({
+  wsId,
+  skillId,
+  versions,
+}: {
+  wsId: string
+  skillId: string
+  versions: SkillVersionDetail[]
+}) {
+  const t = useTranslations('wsSettings.skillDetail')
+  const sorted = versions.slice().sort((a, b) => b.version.localeCompare(a.version))
+
+  const [vLeft, setVLeft] = useState<string>(sorted[1]?.version ?? '')
+  const [vRight, setVRight] = useState<string>(sorted[0]?.version ?? '')
+  const [selectedFile, setSelectedFile] = useState<string | null>(null)
+  const [splitView, setSplitView] = useState(false)
+
+  const leftKey = vLeft
+    ? `/api/v1/ws/${wsId}/skills/${skillId}?version=${encodeURIComponent(vLeft)}`
+    : null
+  const rightKey = vRight
+    ? `/api/v1/ws/${wsId}/skills/${skillId}?version=${encodeURIComponent(vRight)}`
+    : null
+
+  const { data: leftContent } = useSWR<SkillContent>(leftKey, contentFetcher, {
+    revalidateOnFocus: false,
+  })
+  const { data: rightContent } = useSWR<SkillContent>(rightKey, contentFetcher, {
+    revalidateOnFocus: false,
+  })
+
+  const fileDiffs = useMemo((): FileDiffEntry[] => {
+    if (!leftContent || !rightContent) return []
+    const leftMap = new Map(leftContent.files.map((f) => [f.rel_path, f]))
+    const rightMap = new Map(rightContent.files.map((f) => [f.rel_path, f]))
+    const allPaths = new Set([...leftMap.keys(), ...rightMap.keys()])
+    const entries: FileDiffEntry[] = []
+    for (const path of allPaths) {
+      const a = leftMap.get(path)
+      const b = rightMap.get(path)
+      let status: FileStatus
+      if (a === undefined) status = 'added'
+      else if (b === undefined) status = 'removed'
+      else if (a.content_hash !== b.content_hash) status = 'changed'
+      else status = 'same'
+      entries.push({ path, status })
+    }
+    return entries.sort((a, b) => {
+      const order: FileStatus[] = ['changed', 'added', 'removed', 'same']
+      return order.indexOf(a.status) - order.indexOf(b.status) || a.path.localeCompare(b.path)
+    })
+  }, [leftContent, rightContent])
+
+  const fileLeftUrl =
+    selectedFile && vLeft
+      ? `/api/v1/ws/${wsId}/skills/${skillId}/files/${selectedFile}?version=${encodeURIComponent(vLeft)}`
+      : null
+  const fileRightUrl =
+    selectedFile && vRight
+      ? `/api/v1/ws/${wsId}/skills/${skillId}/files/${selectedFile}?version=${encodeURIComponent(vRight)}`
+      : null
+  const { data: fileLeft } = useSWR<string>(fileLeftUrl, textFetcher, { revalidateOnFocus: false })
+  const { data: fileRight } = useSWR<string>(fileRightUrl, textFetcher, {
+    revalidateOnFocus: false,
+  })
+
+  const ready = vLeft && vRight && vLeft !== vRight
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-end gap-3">
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/70">
+            {t('versionA')}
+          </label>
+          <select
+            value={vLeft}
+            onChange={(e) => {
+              setVLeft(e.target.value)
+              setSelectedFile(null)
+            }}
+            className="rounded-md border border-border/70 bg-background px-2 py-1.5 text-xs"
+          >
+            {sorted.map((v) => (
+              <option key={v.id} value={v.version}>
+                v{v.version}
+              </option>
+            ))}
+          </select>
+        </div>
+        <span className="mb-2 text-muted-foreground">→</span>
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/70">
+            {t('versionB')}
+          </label>
+          <select
+            value={vRight}
+            onChange={(e) => {
+              setVRight(e.target.value)
+              setSelectedFile(null)
+            }}
+            className="rounded-md border border-border/70 bg-background px-2 py-1.5 text-xs"
+          >
+            {sorted.map((v) => (
+              <option key={v.id} value={v.version}>
+                v{v.version}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="mb-1.5 ml-auto flex items-center gap-1 rounded-md border border-border/70 p-0.5">
+          <button
+            type="button"
+            onClick={() => setSplitView(true)}
+            className={`cursor-pointer rounded px-2 py-1 text-[11px] transition-colors ${splitView ? 'bg-accent font-medium' : 'text-muted-foreground hover:text-foreground'}`}
+          >
+            {t('compareSideBySide')}
+          </button>
+          <button
+            type="button"
+            onClick={() => setSplitView(false)}
+            className={`cursor-pointer rounded px-2 py-1 text-[11px] transition-colors ${!splitView ? 'bg-accent font-medium' : 'text-muted-foreground hover:text-foreground'}`}
+          >
+            {t('compareInline')}
+          </button>
+        </div>
+      </div>
+
+      {!ready && <p className="text-xs text-muted-foreground">{t('selectTwoVersions')}</p>}
+
+      {ready && (
+        <div className="grid grid-cols-[180px_1fr] gap-3 overflow-hidden">
+          <ul className="flex flex-col gap-1 overflow-y-auto">
+            {fileDiffs.length === 0 && (
+              <li className="text-xs text-muted-foreground">{t('loading')}</li>
+            )}
+            {fileDiffs.map(({ path, status }) => {
+              const { label, cls } = STATUS_STYLES[status]
+              return (
+                <li key={path}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedFile(path)}
+                    className={`w-full cursor-pointer rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent/50 ${
+                      selectedFile === path ? 'bg-accent/70' : ''
+                    }`}
+                  >
+                    <div className="flex items-center gap-1.5">
+                      <span
+                        className={`shrink-0 rounded px-1 py-0.5 text-[9px] font-semibold uppercase ${cls}`}
+                      >
+                        {label}
+                      </span>
+                    </div>
+                    <div className="mt-0.5 truncate font-mono text-[10px]">{path}</div>
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+          <div className="min-w-0 overflow-auto rounded-lg border border-border/70">
+            {!selectedFile && (
+              <div className="flex h-full items-center justify-center p-6 text-xs text-muted-foreground">
+                {t('clickViewDiff')}
+              </div>
+            )}
+            {selectedFile && (fileLeft === '__BINARY__' || fileRight === '__BINARY__') && (
+              <div className="flex h-full items-center justify-center p-6 text-xs text-muted-foreground">
+                {t('binaryDiff')}
+              </div>
+            )}
+            {selectedFile && fileLeft !== '__BINARY__' && fileRight !== '__BINARY__' && (
+              <ReactDiffViewer
+                oldValue={fileLeft ?? ''}
+                newValue={fileRight ?? ''}
+                splitView={splitView}
+                leftTitle={`v${vLeft} — ${selectedFile}`}
+                rightTitle={`v${vRight} — ${selectedFile}`}
+                useDarkTheme={false}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Workspace Actions ────────────────────────────────────────────────────────
 
 function WorkspaceActions({
   wsId,
@@ -129,14 +471,25 @@ function WorkspaceActions({
   )
 }
 
+// ─── Main Component ───────────────────────────────────────────────────────────
+
 export function WorkspaceSkillDetail({ wsId, skill, onActionDone }: WorkspaceSkillDetailProps) {
   const t = useTranslations('wsSettings.skillDetail')
   const targetVersion = skill.installed_version ?? skill.current_version
   const contentKey = `/api/v1/ws/${wsId}/skills/${skill.id}?version=${encodeURIComponent(targetVersion)}`
+  const versionsKey = `/api/v1/ws/${wsId}/skills/${skill.id}/versions`
+
   const { data: content, isLoading } = useSWR<SkillContent>(contentKey, contentFetcher, {
     revalidateOnFocus: false,
     shouldRetryOnError: false,
   })
+  const { data: versions } = useSWR<SkillVersionDetail[]>(versionsKey, versionsFetcher, {
+    revalidateOnFocus: false,
+    shouldRetryOnError: false,
+  })
+
+  const sortedVersions = (versions ?? []).slice().sort((a, b) => b.version.localeCompare(a.version))
+  const hasMultipleVersions = sortedVersions.length > 1
 
   return (
     <div className="flex w-full flex-col gap-4 p-6">
@@ -185,6 +538,22 @@ export function WorkspaceSkillDetail({ wsId, skill, onActionDone }: WorkspaceSki
             <FileText className="size-3.5" />
             {t('overview')}
           </TabsTrigger>
+          <TabsTrigger value="files">
+            <Files className="size-3.5" />
+            {content ? t('filesCount', { count: content.files.length }) : t('files')}
+          </TabsTrigger>
+          <TabsTrigger value="versions">
+            <History className="size-3.5" />
+            {sortedVersions.length > 0
+              ? t('versionsCount', { count: sortedVersions.length })
+              : t('versions')}
+          </TabsTrigger>
+          {hasMultipleVersions && (
+            <TabsTrigger value="compare">
+              <GitCompare className="size-3.5" />
+              {t('compare')}
+            </TabsTrigger>
+          )}
         </TabsList>
 
         <TabsContent value="overview" className="mt-4">
@@ -199,6 +568,32 @@ export function WorkspaceSkillDetail({ wsId, skill, onActionDone }: WorkspaceSki
             </div>
           )}
         </TabsContent>
+
+        <TabsContent value="files" className="mt-4">
+          {isLoading && <p className="text-xs text-muted-foreground">{t('previewLoading')}</p>}
+          {content && (
+            <FilesTab
+              wsId={wsId}
+              skillId={skill.id}
+              version={targetVersion}
+              files={content.files}
+            />
+          )}
+        </TabsContent>
+
+        <TabsContent value="versions" className="mt-4">
+          <VersionsTab
+            installedVersion={skill.installed_version ?? null}
+            currentVersion={skill.current_version}
+            versions={sortedVersions}
+          />
+        </TabsContent>
+
+        {hasMultipleVersions && (
+          <TabsContent value="compare" className="mt-4">
+            <CompareTab wsId={wsId} skillId={skill.id} versions={sortedVersions} />
+          </TabsContent>
+        )}
       </Tabs>
     </div>
   )

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -384,10 +384,22 @@
       "discardYes": "Delete",
       "discardNo": "Keep",
       "step": {
-        "preset": { "label": "Preset", "hint": "Choose a provider" },
-        "configure": { "label": "Configure", "hint": "Credentials & capability" },
-        "models": { "label": "Models", "hint": "Pick models to import" },
-        "test": { "label": "Test", "hint": "Verify connection" }
+        "preset": {
+          "label": "Preset",
+          "hint": "Choose a provider"
+        },
+        "configure": {
+          "label": "Configure",
+          "hint": "Credentials & capability"
+        },
+        "models": {
+          "label": "Models",
+          "hint": "Pick models to import"
+        },
+        "test": {
+          "label": "Test",
+          "hint": "Verify connection"
+        }
       },
       "preset": {
         "searchPlaceholder": "Search providers",
@@ -706,7 +718,27 @@
       "actionRemove": "Remove from workspace",
       "actionRemoving": "Removing…",
       "actionInstall": "Install in workspace",
-      "actionInstalling": "Installing…"
+      "actionInstalling": "Installing…",
+      "files": "Files",
+      "filesCount": "Files ({count})",
+      "noAdditionalFiles": "No additional files in this version.",
+      "clickToPreview": "Click a file to preview its content.",
+      "previewLoading": "Loading…",
+      "binaryFile": "Cannot preview: binary file.",
+      "versions": "Versions",
+      "versionsCount": "Versions ({count})",
+      "noVersions": "No version history.",
+      "versionInstalled": "Installed",
+      "versionLatest": "Latest",
+      "compare": "Compare",
+      "versionA": "Version A (old)",
+      "versionB": "Version B (new)",
+      "compareSideBySide": "Side by side",
+      "compareInline": "Inline",
+      "selectTwoVersions": "Select two different versions to compare.",
+      "clickViewDiff": "Click a file to view its diff",
+      "binaryDiff": "Binary file — diff not available.",
+      "loading": "Loading…"
     },
     "skillsToolbar": {
       "searchPlaceholder": "Search by name or description",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -384,10 +384,22 @@
       "discardYes": "删除",
       "discardNo": "返回",
       "step": {
-        "preset": { "label": "选择预设", "hint": "挑选 provider" },
-        "configure": { "label": "配置", "hint": "凭证与能力" },
-        "models": { "label": "模型", "hint": "选择要导入的模型" },
-        "test": { "label": "测试", "hint": "验证连接" }
+        "preset": {
+          "label": "选择预设",
+          "hint": "挑选 provider"
+        },
+        "configure": {
+          "label": "配置",
+          "hint": "凭证与能力"
+        },
+        "models": {
+          "label": "模型",
+          "hint": "选择要导入的模型"
+        },
+        "test": {
+          "label": "测试",
+          "hint": "验证连接"
+        }
       },
       "preset": {
         "searchPlaceholder": "搜索 provider",
@@ -706,7 +718,27 @@
       "actionRemove": "从工作区移除",
       "actionRemoving": "移除中…",
       "actionInstall": "安装到工作区",
-      "actionInstalling": "安装中…"
+      "actionInstalling": "安装中…",
+      "files": "文件",
+      "filesCount": "文件 ({count})",
+      "noAdditionalFiles": "该版本无附加文件。",
+      "clickToPreview": "点击左侧文件名预览内容。",
+      "previewLoading": "加载中…",
+      "binaryFile": "无法预览：该文件为二进制文件。",
+      "versions": "版本",
+      "versionsCount": "版本 ({count})",
+      "noVersions": "暂无版本记录。",
+      "versionInstalled": "已安装",
+      "versionLatest": "最新",
+      "compare": "对比",
+      "versionA": "版本 A（旧）",
+      "versionB": "版本 B（新）",
+      "compareSideBySide": "左右对比",
+      "compareInline": "内联",
+      "selectTwoVersions": "请选择两个不同的版本进行对比。",
+      "clickViewDiff": "点击左侧文件查看 diff",
+      "binaryDiff": "该文件为二进制文件，无法显示 diff。",
+      "loading": "加载中…"
     },
     "skillsToolbar": {
       "searchPlaceholder": "按名称或描述搜索",


### PR DESCRIPTION
## Summary

- **Backend**: adds `GET /api/v1/ws/{wsId}/skills/{skillId}/versions` endpoint so workspace users can fetch version history
- **Frontend**: adds three new tabs to `WorkspaceSkillDetail` — Files (browse + preview), Versions (read-only history), Compare (side-by-side / inline diff between any two versions)
- **i18n**: 20 new keys added under `wsSettings.skillDetail` in both `zh.json` and `en.json`

Mirrors the admin `SkillDetailPanel` feature set. The only intentional difference: the Versions tab has no "install version" button — workspace users cannot switch versions (admin-only action).

## Test plan

- [ ] Open workspace Settings → Skills, click any skill
- [ ] Files tab: sidebar lists all files, click one to preview content; binary files show placeholder
- [ ] Versions tab: shows version history with Installed / Latest badges; no action buttons
- [ ] Compare tab: only visible when skill has 2+ versions; select two versions, pick a file to see diff; side-by-side / inline toggle works
- [ ] Skills with a single version: Compare tab is hidden