### PR TITLE
feat: unified agent platform actions + scheduled-tasks capability

### DIFF
--- a/backend/cubebox/agents/actions/__init__.py
+++ b/backend/cubebox/agents/actions/__init__.py
@@ -1,0 +1,1 @@
+"""Agent platform actions — unified mechanism for agent-operable capabilities."""

--- a/backend/cubebox/agents/actions/builder.py
+++ b/backend/cubebox/agents/actions/builder.py
@@ -1,0 +1,152 @@
+"""Build a single cubepi AgentTool from an AgentCapability definition."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from typing import Annotated, Any, Literal, Union
+
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import TextContent
+from pydantic import BaseModel, Field, create_model
+
+from cubebox.agents.actions.context import ScopeContext
+from cubebox.agents.actions.types import (
+    ActionInvalidInput,
+    ActionNotFound,
+    ActionPermissionDenied,
+    AgentCapability,
+    AgentOperation,
+)
+
+logger = logging.getLogger(__name__)
+
+ContextFactory = Callable[[], AbstractAsyncContextManager[tuple[ScopeContext, Any]]]
+
+
+def _make_literal_type(value: str) -> Any:
+    """Create ``Literal["value"]`` at runtime (opaque to static analysis)."""
+    # Literal subscript with a runtime string is valid at runtime but
+    # cannot be tracked statically — the Any return communicates that.
+    return Literal[value]  # noqa: F821 – runtime subscript
+
+
+def _build_operation_model(op: AgentOperation) -> type[BaseModel]:
+    """Create a wrapper model with a fixed ``operation`` discriminator field.
+
+    The wrapper inherits all fields from the operation's ``input_model`` and
+    prepends an ``operation: Literal["<name>"]`` discriminator.
+    """
+    op_literal = _make_literal_type(op.name)
+    field_definitions: dict[str, Any] = {
+        "operation": (op_literal, Field(default=op.name)),
+    }
+    for field_name, field_info in op.input_model.model_fields.items():
+        field_definitions[field_name] = (
+            field_info.annotation,
+            field_info,
+        )
+    model: Any = create_model(
+        f"Op_{op.name}",
+        **field_definitions,
+    )
+    return model  # type: ignore[no-any-return]
+
+
+def _build_union_model(
+    cap_name: str,
+    operations: list[AgentOperation],
+) -> type[BaseModel]:
+    """Build a discriminated-union input model over multiple operations."""
+    sub_models = [_build_operation_model(op) for op in operations]
+
+    # Build Union type dynamically — opaque to mypy.
+    union_type: Any = Union[tuple(sub_models)]  # noqa: UP007
+    annotated_union = Annotated[union_type, Field(discriminator="operation")]
+    model: Any = create_model(
+        f"{cap_name}_Input",
+        params=(annotated_union, ...),
+    )
+    return model  # type: ignore[no-any-return]
+
+
+def build_capability_tool(
+    cap: AgentCapability,
+    context_factory: ContextFactory,
+    *,
+    allow_mutations: bool,
+) -> AgentTool[Any] | None:
+    """Convert an :class:`AgentCapability` into a cubepi :class:`AgentTool`.
+
+    Returns ``None`` when no operations survive the mutation gate (e.g. all
+    operations mutate and ``allow_mutations=False``).
+    """
+    surviving: list[AgentOperation] = [
+        op for op in cap.operations if allow_mutations or not op.mutates
+    ]
+    if not surviving:
+        return None
+
+    # Build the handler lookup.
+    ops_by_name: dict[str, AgentOperation] = {op.name: op for op in surviving}
+
+    # Single-operation optimisation: expose the operation's own model
+    # directly (no discriminated wrapper).
+    single = len(surviving) == 1
+
+    if single:
+        the_op = surviving[0]
+        params_model: type[BaseModel] = the_op.input_model
+    else:
+        params_model = _build_union_model(cap.name, surviving)
+
+    async def _execute(
+        tool_call_id: str,
+        args: BaseModel,
+        *,
+        signal: Any = None,
+        on_update: Any = None,
+    ) -> AgentToolResult:
+        # Determine which operation was called.
+        if single:
+            op = surviving[0]
+            parsed = args
+        else:
+            # ``args`` is the union wrapper; the discriminated payload
+            # lives in ``.params``.
+            inner = args.params  # type: ignore[attr-defined]
+            op_name: str = inner.operation
+            op = ops_by_name[op_name]
+            parsed = inner
+
+        try:
+            async with context_factory() as (ctx, session):
+                result = await op.handler(ctx, session, parsed)
+        except (
+            ActionNotFound,
+            ActionPermissionDenied,
+            ActionInvalidInput,
+        ) as exc:
+            return AgentToolResult(
+                content=[TextContent(text=f"{type(exc).__name__}: {exc}")],
+                is_error=True,
+            )
+
+        # Serialize the handler result to JSON text.
+        if isinstance(result, BaseModel):
+            text = result.model_dump_json()
+        else:
+            text = json.dumps(result, default=str)
+
+        return AgentToolResult(
+            content=[TextContent(text=text)],
+        )
+
+    return AgentTool(
+        name=cap.name,
+        description=cap.description,
+        parameters=params_model,
+        execute=_execute,
+    )

--- a/backend/cubebox/agents/actions/builder.py
+++ b/backend/cubebox/agents/actions/builder.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any, Literal, Union
 
 from cubepi.agent.types import AgentTool, AgentToolResult
 from cubepi.providers.base import TextContent
-from pydantic import BaseModel, Field, create_model
+from pydantic import BaseModel, Field, RootModel, create_model
 
 from cubebox.agents.actions.context import ScopeContext
 from cubebox.agents.actions.types import (
@@ -59,15 +59,21 @@ def _build_union_model(
     cap_name: str,
     operations: list[AgentOperation],
 ) -> type[BaseModel]:
-    """Build a discriminated-union input model over multiple operations."""
+    """Build a discriminated-union input model over multiple operations.
+
+    Uses ``RootModel`` so the discriminated union IS the top-level schema
+    (no wrapping ``params`` field). The LLM sees ``{operation: "create", ...}``
+    directly.
+    """
     sub_models = [_build_operation_model(op) for op in operations]
 
-    # Build Union type dynamically — opaque to mypy.
     union_type: Any = Union[tuple(sub_models)]  # noqa: UP007
     annotated_union = Annotated[union_type, Field(discriminator="operation")]
-    model: Any = create_model(
+
+    model: Any = type(
         f"{cap_name}_Input",
-        params=(annotated_union, ...),
+        (RootModel[annotated_union],),
+        {},
     )
     return model  # type: ignore[no-any-return]
 
@@ -114,9 +120,8 @@ def build_capability_tool(
             op = surviving[0]
             parsed = args
         else:
-            # ``args`` is the union wrapper; the discriminated payload
-            # lives in ``.params``.
-            inner = args.params  # type: ignore[attr-defined]
+            # RootModel: the discriminated payload is ``.root``.
+            inner = args.root  # type: ignore[attr-defined]
             op_name: str = inner.operation
             op = ops_by_name[op_name]
             parsed = inner

--- a/backend/cubebox/agents/actions/builder.py
+++ b/backend/cubebox/agents/actions/builder.py
@@ -41,7 +41,7 @@ def _build_operation_model(op: AgentOperation) -> type[BaseModel]:
     """
     op_literal = _make_literal_type(op.name)
     field_definitions: dict[str, Any] = {
-        "operation": (op_literal, Field(default=op.name)),
+        "operation": (op_literal, ...),
     }
     for field_name, field_info in op.input_model.model_fields.items():
         field_definitions[field_name] = (

--- a/backend/cubebox/agents/actions/capabilities/__init__.py
+++ b/backend/cubebox/agents/actions/capabilities/__init__.py
@@ -1,0 +1,1 @@
+"""Capability declarations for agent platform actions."""

--- a/backend/cubebox/agents/actions/capabilities/scheduled_tasks.py
+++ b/backend/cubebox/agents/actions/capabilities/scheduled_tasks.py
@@ -1,0 +1,283 @@
+"""Scheduled-tasks agent capability — 8 operations for CRUD and lifecycle."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.agents.actions.context import ScopeContext
+from cubebox.agents.actions.types import ActionInvalidInput, AgentCapability, AgentOperation
+from cubebox.services.scheduled_task import ScheduledTaskService
+from cubebox.utils.time import utc_isoformat
+
+_svc = ScheduledTaskService()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso(dt: datetime | None) -> str | None:
+    return utc_isoformat(dt) if dt is not None else None
+
+
+def _task_summary(task: Any) -> dict[str, Any]:
+    return {
+        "id": task.id,
+        "name": task.name,
+        "status": task.status,
+        "schedule_kind": task.schedule_kind,
+        "cron_expr": task.cron_expr,
+        "interval_seconds": task.interval_seconds,
+        "timezone": task.timezone,
+        "prompt": task.prompt,
+        "target_mode": task.target_mode,
+        "next_fire_at": _iso(task.next_fire_at),
+        "last_fired_at": _iso(task.last_fired_at),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Input models
+# ---------------------------------------------------------------------------
+
+
+class ListInput(BaseModel):
+    """No parameters — returns all non-deleted tasks in the workspace."""
+
+
+class GetInput(BaseModel):
+    task_id: str
+
+
+class ListRunsInput(BaseModel):
+    task_id: str
+
+
+class CreateInput(BaseModel):
+    name: str
+    prompt: str
+    schedule_kind: Literal["cron", "interval", "once"]
+    cron_expr: str | None = None
+    interval_seconds: int | None = Field(default=None, ge=60)
+    run_at: datetime | None = Field(
+        default=None,
+        description="Required when schedule_kind='once'. ISO 8601 datetime for the single fire.",
+    )
+    timezone: str = Field(
+        default="UTC",
+        description="IANA timezone name, e.g. 'America/New_York'. Defaults to UTC.",
+    )
+    target: Literal["new_each_run", "current_conversation"] = Field(
+        default="new_each_run",
+        description=(
+            "Where the task runs: 'new_each_run' opens a fresh conversation each time; "
+            "'current_conversation' appends to the conversation where this tool was called."
+        ),
+    )
+    end_at: datetime | None = Field(
+        default=None,
+        description="Optional ISO 8601 datetime after which the task stops firing.",
+    )
+
+
+class UpdateInput(BaseModel):
+    task_id: str
+    name: str | None = None
+    prompt: str | None = None
+    schedule_kind: Literal["cron", "interval", "once"] | None = None
+    cron_expr: str | None = None
+    interval_seconds: int | None = Field(default=None, ge=60)
+    run_at: datetime | None = None
+    timezone: str | None = None
+    target_mode: Literal["new_each_run", "fixed"] | None = None
+    target_conversation_id: str | None = None
+    end_at: datetime | None = None
+
+
+class PauseInput(BaseModel):
+    task_id: str
+
+
+class ResumeInput(BaseModel):
+    task_id: str
+
+
+class DeleteInput(BaseModel):
+    task_id: str
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def _handle_list(ctx: ScopeContext, session: AsyncSession, inp: ListInput) -> Any:
+    tasks = await _svc.list_tasks(ctx, session)
+    return [_task_summary(t) for t in tasks]
+
+
+async def _handle_get(ctx: ScopeContext, session: AsyncSession, inp: GetInput) -> Any:
+    task = await _svc.get_task(ctx, session, inp.task_id)
+    return _task_summary(task)
+
+
+async def _handle_list_runs(ctx: ScopeContext, session: AsyncSession, inp: ListRunsInput) -> Any:
+    runs = await _svc.list_runs(ctx, session, inp.task_id)
+    return [
+        {
+            "id": r.id,
+            "scheduled_for": _iso(r.scheduled_for),
+            "claimed_at": _iso(r.claimed_at),
+            "started_at": _iso(r.started_at),
+            "state": r.state,
+            "conversation_id": r.conversation_id,
+            "detail": r.detail,
+        }
+        for r in runs
+    ]
+
+
+async def _handle_create(ctx: ScopeContext, session: AsyncSession, inp: CreateInput) -> Any:
+    if inp.target == "current_conversation":
+        if ctx.conversation_id is None:
+            raise ActionInvalidInput(
+                "target='current_conversation' requires a conversation context; "
+                "either start from within a conversation or use target='new_each_run'."
+            )
+        target_mode = "fixed"
+        target_conversation_id: str | None = ctx.conversation_id
+    else:
+        target_mode = "new_each_run"
+        target_conversation_id = None
+
+    data: dict[str, Any] = {
+        "name": inp.name,
+        "prompt": inp.prompt,
+        "schedule_kind": inp.schedule_kind,
+        "cron_expr": inp.cron_expr,
+        "interval_seconds": inp.interval_seconds,
+        "run_at": inp.run_at,
+        "timezone": inp.timezone,
+        "target_mode": target_mode,
+        "target_conversation_id": target_conversation_id,
+        "end_at": inp.end_at,
+    }
+    task = await _svc.create(ctx, session, data)
+    return _task_summary(task)
+
+
+async def _handle_update(ctx: ScopeContext, session: AsyncSession, inp: UpdateInput) -> Any:
+    # Only pass fields the caller explicitly set (mirrors the PATCH route).
+    data = inp.model_dump(exclude={"task_id"}, exclude_unset=True)
+
+    # end_at must be handled separately because the generic loop in the
+    # service skips None values; preserve the key if it was explicitly set.
+    # model_dump(exclude_unset=True) already does the right thing here —
+    # end_at will appear in `data` only if the caller included it (even as null).
+
+    task = await _svc.update(ctx, session, inp.task_id, data)
+    return _task_summary(task)
+
+
+async def _handle_pause(ctx: ScopeContext, session: AsyncSession, inp: PauseInput) -> Any:
+    task = await _svc.pause(ctx, session, inp.task_id)
+    return _task_summary(task)
+
+
+async def _handle_resume(ctx: ScopeContext, session: AsyncSession, inp: ResumeInput) -> Any:
+    task = await _svc.resume(ctx, session, inp.task_id)
+    return _task_summary(task)
+
+
+async def _handle_delete(ctx: ScopeContext, session: AsyncSession, inp: DeleteInput) -> Any:
+    await _svc.delete(ctx, session, inp.task_id)
+    return {"deleted": True, "task_id": inp.task_id}
+
+
+# ---------------------------------------------------------------------------
+# Capability declaration
+# ---------------------------------------------------------------------------
+
+SCHEDULED_TASKS_CAPABILITY = AgentCapability(
+    name="scheduled_tasks",
+    description=(
+        "Manage scheduled tasks in the current workspace. "
+        "Each task runs a prompt on a cron, interval, or one-shot schedule. "
+        "Only create, update, pause, resume, or delete tasks when the user "
+        "has explicitly asked you to."
+    ),
+    operations=[
+        AgentOperation(
+            name="list",
+            description="List all scheduled tasks in the workspace.",
+            input_model=ListInput,
+            handler=_handle_list,
+            mutates=False,
+        ),
+        AgentOperation(
+            name="get",
+            description="Get details for a single scheduled task by ID.",
+            input_model=GetInput,
+            handler=_handle_get,
+            mutates=False,
+        ),
+        AgentOperation(
+            name="list_runs",
+            description="List recent execution history for a scheduled task.",
+            input_model=ListRunsInput,
+            handler=_handle_list_runs,
+            mutates=False,
+        ),
+        AgentOperation(
+            name="create",
+            description=("Create a new scheduled task. Only call when the user explicitly asks."),
+            input_model=CreateInput,
+            handler=_handle_create,
+            mutates=True,
+        ),
+        AgentOperation(
+            name="update",
+            description=(
+                "Update fields on an existing scheduled task. "
+                "Only call when the user explicitly asks."
+            ),
+            input_model=UpdateInput,
+            handler=_handle_update,
+            mutates=True,
+        ),
+        AgentOperation(
+            name="pause",
+            description=(
+                "Pause a scheduled task so it stops firing. "
+                "Only call when the user explicitly asks."
+            ),
+            input_model=PauseInput,
+            handler=_handle_pause,
+            mutates=True,
+        ),
+        AgentOperation(
+            name="resume",
+            description=(
+                "Resume a paused scheduled task. Only call when the user explicitly asks."
+            ),
+            input_model=ResumeInput,
+            handler=_handle_resume,
+            mutates=True,
+        ),
+        AgentOperation(
+            name="delete",
+            description=(
+                "Soft-delete a scheduled task (it will no longer fire). "
+                "Only call when the user explicitly asks."
+            ),
+            input_model=DeleteInput,
+            handler=_handle_delete,
+            mutates=True,
+        ),
+    ],
+)

--- a/backend/cubebox/agents/actions/context.py
+++ b/backend/cubebox/agents/actions/context.py
@@ -1,0 +1,18 @@
+"""Scoped context for agent platform actions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cubebox.models.membership import Role
+
+
+@dataclass(frozen=True)
+class ScopeContext:
+    """Everything an operation needs to be scoped and authorized."""
+
+    org_id: str
+    workspace_id: str
+    user_id: str
+    role: Role
+    conversation_id: str | None = None

--- a/backend/cubebox/agents/actions/registry.py
+++ b/backend/cubebox/agents/actions/registry.py
@@ -1,0 +1,29 @@
+"""Agent capability registry — the single entry point for run_manager."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cubepi.agent.types import AgentTool
+
+from cubebox.agents.actions.builder import ContextFactory, build_capability_tool
+from cubebox.agents.actions.capabilities.scheduled_tasks import SCHEDULED_TASKS_CAPABILITY
+from cubebox.agents.actions.types import AgentCapability
+
+AGENT_CAPABILITIES: list[AgentCapability] = [
+    SCHEDULED_TASKS_CAPABILITY,
+]
+
+
+def tools_for_run(
+    context_factory: ContextFactory,
+    *,
+    allow_mutations: bool,
+) -> list[AgentTool[Any]]:
+    """Build agent tools for all registered capabilities."""
+    tools: list[AgentTool[Any]] = []
+    for cap in AGENT_CAPABILITIES:
+        tool = build_capability_tool(cap, context_factory, allow_mutations=allow_mutations)
+        if tool is not None:
+            tools.append(tool)
+    return tools

--- a/backend/cubebox/agents/actions/types.py
+++ b/backend/cubebox/agents/actions/types.py
@@ -1,0 +1,46 @@
+"""Core types for the agent platform actions mechanism."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import BaseModel
+
+# --- Domain exceptions (raised by services, mapped by front doors) ---
+
+
+class ActionNotFound(Exception):
+    """Target entity does not exist or is soft-deleted."""
+
+
+class ActionPermissionDenied(Exception):
+    """Caller lacks the required role (e.g. not owner or admin)."""
+
+
+class ActionInvalidInput(Exception):
+    """Validation failure (bad cron, missing field, etc.)."""
+
+
+# --- Registry types ---
+
+
+@dataclass(frozen=True)
+class AgentOperation:
+    """One operation within a capability (e.g. 'create', 'list')."""
+
+    name: str
+    description: str
+    input_model: type[BaseModel]
+    handler: Callable[..., Awaitable[Any]]
+    mutates: bool = False
+
+
+@dataclass(frozen=True)
+class AgentCapability:
+    """A named group of operations exposed as a single agent tool."""
+
+    name: str
+    description: str
+    operations: list[AgentOperation] = field(default_factory=list)

--- a/backend/cubebox/api/routes/v1/ws_scheduled_tasks.py
+++ b/backend/cubebox/api/routes/v1/ws_scheduled_tasks.py
@@ -3,17 +3,24 @@
 Reads require membership; mutations (edit/pause/resume/delete) require being the
 task owner OR a workspace admin — a scheduled run executes as the owner, so a
 non-owner editing the prompt would run code under the owner's identity.
+
+Route handlers are thin adapters: construct ScopeContext, call the service,
+map domain exceptions to HTTP responses.
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 
+from cubebox.agents.actions.context import ScopeContext
+from cubebox.agents.actions.types import (
+    ActionInvalidInput,
+    ActionNotFound,
+    ActionPermissionDenied,
+)
 from cubebox.api.schemas.ws_scheduled_tasks import (
     ScheduledTaskCreate,
     ScheduledTaskListOut,
@@ -24,42 +31,29 @@ from cubebox.api.schemas.ws_scheduled_tasks import (
 from cubebox.auth.context import RequestContext
 from cubebox.auth.dependencies import require_member
 from cubebox.db.engine import async_session_maker
-from cubebox.models import Role
-from cubebox.models.scheduled_task import ScheduledTask, ScheduledTaskRun
-from cubebox.repositories.conversation import ConversationRepository
-from cubebox.repositories.scheduled_task import (
-    ScheduledTaskRepository,
-    ScheduledTaskRunRepository,
-)
-from cubebox.schedules.compute import as_utc, latest_due_before, next_fire_after
+from cubebox.models.scheduled_task import ScheduledTask
+from cubebox.services.scheduled_task import ScheduledTaskService
 from cubebox.utils.time import utc_isoformat
 
-router = APIRouter(prefix="/ws/{workspace_id}/scheduled-tasks", tags=["scheduled-tasks"])
+router = APIRouter(
+    prefix="/ws/{workspace_id}/scheduled-tasks",
+    tags=["scheduled-tasks"],
+)
+
+_svc = ScheduledTaskService()
+
+
+def _scope(ctx: RequestContext) -> ScopeContext:
+    return ScopeContext(
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+        role=ctx.role,
+    )
 
 
 def _iso(dt: datetime | None) -> str | None:
     return utc_isoformat(dt) if dt is not None else None
-
-
-def _to_utc_naive(dt: datetime) -> datetime:
-    """Convert an aware datetime to UTC then strip tzinfo for storage.
-
-    Scheduled-task DB columns are ``timestamp without time zone``; storing an
-    aware datetime drops the offset and persists the wall-clock value, so a
-    client-supplied ``2030-01-01T09:00:00-05:00`` would otherwise come back
-    as 09:00Z instead of 14:00Z (firing five hours early). Normalizing to
-    UTC naive before persist keeps every column in the same frame as the
-    rest of the module's arithmetic (which treats naive DB values as UTC).
-    """
-    return dt.astimezone(UTC).replace(tzinfo=None) if dt.tzinfo is not None else dt
-
-
-# Fields whose change requires recomputing next_fire_at. Editing only
-# name/prompt/target_* must NOT slide the schedule (codex P2): on an hourly
-# task due at 13:00, a 12:30 prompt edit shouldn't push the next fire to 13:30.
-_SCHEDULE_FIELDS: frozenset[str] = frozenset(
-    {"schedule_kind", "cron_expr", "interval_seconds", "run_at", "timezone"}
-)
 
 
 def _to_out(t: ScheduledTask) -> ScheduledTaskOut:
@@ -84,136 +78,17 @@ def _to_out(t: ScheduledTask) -> ScheduledTaskOut:
     )
 
 
-def _initial_next_fire(t: ScheduledTask) -> datetime | None:
-    now = datetime.now(UTC)
-    if t.schedule_kind == "once":
-        return t.run_at
-    return next_fire_after(
-        kind=t.schedule_kind,
-        after=now,
-        cron_expr=t.cron_expr,
-        interval_seconds=t.interval_seconds,
-        tz=t.timezone,
-    )
-
-
-async def _resume_next_fire(session: AsyncSession, t: ScheduledTask) -> datetime | None:
-    """Resume policy: account for occurrences that fell due while paused.
-
-    Mirrors the outage missed-run policy: at most ONE summary history row.
-    """
-    now = datetime.now(UTC)
-    anchor = as_utc(t.next_fire_at) if t.next_fire_at is not None else None
-    if t.schedule_kind == "once":
-        run_at = as_utc(t.run_at) if t.run_at is not None else None
-        if run_at is not None and run_at <= now:
-            # Atomic, race-safe insert. The unique (scheduled_task_id,
-            # scheduled_for) constraint guards against duplicates from
-            # ALL three sources: a prior fire of the same one-shot, a
-            # prior resume that already recorded the row, or a concurrent
-            # resume request (e.g. double-click). A SAVEPOINT isolates
-            # the insert; if the constraint fires we swallow it as a
-            # no-op so the outer commit (status=active, next_fire_at=None)
-            # still lands.
-            scheduled_for_naive = _to_utc_naive(run_at)
-            try:
-                async with session.begin_nested():
-                    session.add(
-                        ScheduledTaskRun(
-                            scheduled_task_id=t.id,
-                            org_id=t.org_id,
-                            workspace_id=t.workspace_id,
-                            scheduled_for=scheduled_for_naive,
-                            claimed_at=now,
-                            state="skipped_missed",
-                            detail="paused past its one-shot fire time",
-                        )
-                    )
-                    await session.flush()
-            except IntegrityError:
-                pass
-            return None
-        return run_at
-    if anchor is None or anchor > now:
-        return anchor if anchor is not None else _initial_next_fire(t)
-    latest_due = latest_due_before(
-        kind=t.schedule_kind,
-        candidate=anchor,
-        now=now,
-        cron_expr=t.cron_expr,
-        interval_seconds=t.interval_seconds,
-        tz=t.timezone,
-    )
-    session.add(
-        ScheduledTaskRun(
-            scheduled_task_id=t.id,
-            org_id=t.org_id,
-            workspace_id=t.workspace_id,
-            scheduled_for=anchor,
-            claimed_at=now,
-            state="skipped_missed",
-            detail=f"paused: skipped {anchor.isoformat()}..{latest_due.isoformat()}",
-        )
-    )
-    return next_fire_after(
-        kind=t.schedule_kind,
-        after=latest_due,
-        cron_expr=t.cron_expr,
-        interval_seconds=t.interval_seconds,
-        tz=t.timezone,
-    )
-
-
-async def _load_for_mutation(ctx: RequestContext, task_id: str) -> ScheduledTask:
-    """Load task (404 if missing) and enforce owner-or-admin (403 otherwise)."""
-    async with async_session_maker() as session:
-        repo = ScheduledTaskRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
-        task = await repo.get_active(task_id)
-    if task is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "Scheduled task not found")
-    if task.owner_user_id != ctx.user.id and ctx.role != Role.ADMIN:
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "Owner or admin required")
-    return task
-
-
 @router.post("", status_code=status.HTTP_201_CREATED, response_model=ScheduledTaskOut)
 async def create_task(
     body: ScheduledTaskCreate,
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> ScheduledTaskOut:
     async with async_session_maker() as session:
-        if body.target_mode == "fixed":
-            conv_repo = ConversationRepository(
-                session,
-                org_id=ctx.org_id,
-                workspace_id=ctx.workspace_id,
-                user_id=ctx.user.id,
-            )
-            if await conv_repo.get_by_id(body.target_conversation_id or "") is None:
-                raise HTTPException(
-                    status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    "target_conversation_id must be your own conversation",
-                )
-        repo = ScheduledTaskRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
-        task = ScheduledTask(
-            org_id=ctx.org_id,
-            workspace_id=ctx.workspace_id,
-            owner_user_id=ctx.user.id,
-            name=body.name,
-            prompt=body.prompt,
-            schedule_kind=body.schedule_kind,
-            cron_expr=body.cron_expr,
-            interval_seconds=body.interval_seconds,
-            run_at=_to_utc_naive(body.run_at) if body.run_at is not None else None,
-            end_at=_to_utc_naive(body.end_at) if body.end_at is not None else None,
-            timezone=body.timezone,
-            target_mode=body.target_mode,
-            target_conversation_id=body.target_conversation_id,
-            status="active",
-        )
-        task.next_fire_at = _initial_next_fire(task)
-        task = await repo.create(task)
-        return _to_out(task)
+        try:
+            task = await _svc.create(_scope(ctx), session, body.model_dump())
+        except ActionInvalidInput as exc:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
+    return _to_out(task)
 
 
 @router.get("", response_model=ScheduledTaskListOut)
@@ -221,8 +96,7 @@ async def list_tasks(
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> ScheduledTaskListOut:
     async with async_session_maker() as session:
-        repo = ScheduledTaskRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
-        tasks = await repo.list_all()
+        tasks = await _svc.list_tasks(_scope(ctx), session)
     return ScheduledTaskListOut(tasks=[_to_out(t) for t in tasks])
 
 
@@ -232,10 +106,10 @@ async def get_task(
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> ScheduledTaskOut:
     async with async_session_maker() as session:
-        repo = ScheduledTaskRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
-        task = await repo.get_active(task_id)
-    if task is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "Scheduled task not found")
+        try:
+            task = await _svc.get_task(_scope(ctx), session, task_id)
+        except ActionNotFound as exc:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
     return _to_out(task)
 
 
@@ -245,65 +119,17 @@ async def patch_task(
     body: ScheduledTaskPatch,
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> ScheduledTaskOut:
-    await _load_for_mutation(ctx, task_id)
     async with async_session_maker() as session:
-        repo = ScheduledTaskRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
-        task = await repo.get_active(task_id)
-        assert task is not None
-        if body.target_mode == "fixed" or (
-            body.target_conversation_id is not None and task.target_mode == "fixed"
-        ):
-            conv_repo = ConversationRepository(
-                session,
-                org_id=ctx.org_id,
-                workspace_id=ctx.workspace_id,
-                user_id=task.owner_user_id,
-            )
-            target = body.target_conversation_id or task.target_conversation_id
-            if target is None or await conv_repo.get_by_id(target) is None:
-                raise HTTPException(
-                    status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    "target_conversation_id must be the owner's conversation",
-                )
-        touched_schedule = False
-        for field in (
-            "name",
-            "prompt",
-            "schedule_kind",
-            "cron_expr",
-            "interval_seconds",
-            "run_at",
-            "timezone",
-            "target_mode",
-            "target_conversation_id",
-        ):
-            val = getattr(body, field)
-            if val is None:
-                continue
-            if field == "run_at":
-                val = _to_utc_naive(val)
-            # Only flip touched_schedule when a schedule field's value
-            # *actually changes*. The UI's edit dialog re-sends the whole
-            # form (including unchanged schedule_kind / interval_seconds /
-            # run_at / timezone), so presence in the patch alone would
-            # slide next_fire_at on every name/prompt edit. Compare against
-            # the current task value (already normalized in storage form).
-            if field in _SCHEDULE_FIELDS and val != getattr(task, field):
-                touched_schedule = True
-            setattr(task, field, val)
-        # end_at must be handled separately: the generic loop skips None values,
-        # so explicit null (clear-the-deadline) would be silently ignored.
-        if "end_at" in body.model_fields_set:
-            task.end_at = _to_utc_naive(body.end_at) if body.end_at is not None else None
-        # Only recompute next_fire_at when the schedule actually changed.
-        # Metadata-only edits (name/prompt/target_*) must NOT slide the next
-        # fire forward; that would silently delay or skip the pending run.
-        if touched_schedule:
-            task.next_fire_at = _initial_next_fire(task) if task.status == "active" else None
-        task.updated_at = datetime.now(UTC)
-        await session.commit()
-        await session.refresh(task)
-        return _to_out(task)
+        try:
+            data = body.model_dump(exclude_unset=True)
+            task = await _svc.update(_scope(ctx), session, task_id, data)
+        except ActionNotFound as exc:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+        except ActionPermissionDenied as exc:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+        except ActionInvalidInput as exc:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
+    return _to_out(task)
 
 
 @router.post("/{task_id}/pause", response_model=ScheduledTaskOut)
@@ -311,16 +137,14 @@ async def pause_task(
     task_id: str,
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> ScheduledTaskOut:
-    await _load_for_mutation(ctx, task_id)
     async with async_session_maker() as session:
-        repo = ScheduledTaskRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
-        task = await repo.get_active(task_id)
-        assert task is not None
-        task.status = "paused"
-        task.updated_at = datetime.now(UTC)
-        await session.commit()
-        await session.refresh(task)
-        return _to_out(task)
+        try:
+            task = await _svc.pause(_scope(ctx), session, task_id)
+        except ActionNotFound as exc:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+        except ActionPermissionDenied as exc:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+    return _to_out(task)
 
 
 @router.post("/{task_id}/resume", response_model=ScheduledTaskOut)
@@ -328,17 +152,14 @@ async def resume_task(
     task_id: str,
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> ScheduledTaskOut:
-    await _load_for_mutation(ctx, task_id)
     async with async_session_maker() as session:
-        repo = ScheduledTaskRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
-        task = await repo.get_active(task_id)
-        assert task is not None
-        task.status = "active"
-        task.next_fire_at = await _resume_next_fire(session, task)
-        task.updated_at = datetime.now(UTC)
-        await session.commit()
-        await session.refresh(task)
-        return _to_out(task)
+        try:
+            task = await _svc.resume(_scope(ctx), session, task_id)
+        except ActionNotFound as exc:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+        except ActionPermissionDenied as exc:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+    return _to_out(task)
 
 
 @router.delete("/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -346,10 +167,13 @@ async def delete_task(
     task_id: str,
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> None:
-    await _load_for_mutation(ctx, task_id)
     async with async_session_maker() as session:
-        repo = ScheduledTaskRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
-        await repo.soft_delete(task_id)
+        try:
+            await _svc.delete(_scope(ctx), session, task_id)
+        except ActionNotFound as exc:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+        except ActionPermissionDenied as exc:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
 
 
 @router.get("/{task_id}/runs", response_model=list[ScheduledTaskRunOut])
@@ -358,15 +182,10 @@ async def list_task_runs(
     ctx: Annotated[RequestContext, Depends(require_member)],
 ) -> list[ScheduledTaskRunOut]:
     async with async_session_maker() as session:
-        task_repo = ScheduledTaskRepository(
-            session, org_id=ctx.org_id, workspace_id=ctx.workspace_id
-        )
-        if await task_repo.get_active(task_id) is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, "Scheduled task not found")
-        run_repo = ScheduledTaskRunRepository(
-            session, org_id=ctx.org_id, workspace_id=ctx.workspace_id
-        )
-        rows = await run_repo.list_for_task(task_id)
+        try:
+            rows = await _svc.list_runs(_scope(ctx), session, task_id)
+        except ActionNotFound as exc:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
     return [
         ScheduledTaskRunOut(
             id=r.id,

--- a/backend/cubebox/schedules/dispatch.py
+++ b/backend/cubebox/schedules/dispatch.py
@@ -92,6 +92,7 @@ async def dispatch_scheduled_run(
         user_id=task.owner_user_id,
         org_id=task.org_id,
         workspace_id=task.workspace_id,
+        trigger="automated",
     )
     try:
         actual_run_id = await run_manager.start_run(

--- a/backend/cubebox/services/scheduled_task.py
+++ b/backend/cubebox/services/scheduled_task.py
@@ -399,6 +399,13 @@ class ScheduledTaskService:
             if data.get("run_at") is None:
                 raise ActionInvalidInput("run_at required for once schedule")
 
+        run_at = data.get("run_at")
+        if isinstance(run_at, datetime) and run_at.tzinfo is None:
+            raise ActionInvalidInput("run_at must include a timezone offset")
+        end_at = data.get("end_at")
+        if isinstance(end_at, datetime) and end_at.tzinfo is None:
+            raise ActionInvalidInput("end_at must include a timezone offset")
+
         if not data.get("name"):
             raise ActionInvalidInput("name is required")
         if not data.get("prompt"):
@@ -433,3 +440,10 @@ class ScheduledTaskService:
             )
         if kind == "once" and data.get("run_at") is None:
             raise ActionInvalidInput("run_at required when changing schedule_kind to once")
+
+        run_at = data.get("run_at")
+        if isinstance(run_at, datetime) and run_at.tzinfo is None:
+            raise ActionInvalidInput("run_at must include a timezone offset")
+        end_at = data.get("end_at")
+        if isinstance(end_at, datetime) and end_at.tzinfo is None:
+            raise ActionInvalidInput("end_at must include a timezone offset")

--- a/backend/cubebox/services/scheduled_task.py
+++ b/backend/cubebox/services/scheduled_task.py
@@ -1,0 +1,435 @@
+"""Stateless service for scheduled-task CRUD and lifecycle operations.
+
+Extracted from route handlers so that both HTTP routes and agent tool
+front-doors can share the same validated business logic. Every mutating
+method owns its transaction (calls ``session.commit()`` exactly once).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.agents.actions.context import ScopeContext
+from cubebox.agents.actions.types import (
+    ActionInvalidInput,
+    ActionNotFound,
+    ActionPermissionDenied,
+)
+from cubebox.api.schemas.ws_scheduled_tasks import (
+    _validate_cron,
+    _validate_timezone,
+)
+from cubebox.models import Role
+from cubebox.models.scheduled_task import ScheduledTask, ScheduledTaskRun
+from cubebox.repositories.conversation import ConversationRepository
+from cubebox.schedules.compute import (
+    as_utc,
+    latest_due_before,
+    next_fire_after,
+)
+
+# Fields whose change requires recomputing next_fire_at.  Editing only
+# name/prompt/target_* must NOT slide the schedule.
+_SCHEDULE_FIELDS: frozenset[str] = frozenset(
+    {"schedule_kind", "cron_expr", "interval_seconds", "run_at", "timezone"}
+)
+
+
+def _to_utc_naive(dt: datetime) -> datetime:
+    """Convert an aware datetime to UTC naive for storage."""
+    if dt.tzinfo is not None:
+        return dt.astimezone(UTC).replace(tzinfo=None)
+    return dt
+
+
+def _initial_next_fire(t: ScheduledTask) -> datetime | None:
+    now = datetime.now(UTC)
+    if t.schedule_kind == "once":
+        return t.run_at
+    return next_fire_after(
+        kind=t.schedule_kind,
+        after=now,
+        cron_expr=t.cron_expr,
+        interval_seconds=t.interval_seconds,
+        tz=t.timezone,
+    )
+
+
+class ScheduledTaskService:
+    """Stateless service — no constructor args.
+
+    Every public method takes ``(ctx, session, ...)`` so the caller
+    controls both identity and connection lifetime.
+    """
+
+    # ------------------------------------------------------------------
+    # Read operations
+    # ------------------------------------------------------------------
+
+    async def list_tasks(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+    ) -> list[ScheduledTask]:
+        stmt = (
+            select(ScheduledTask)
+            .where(
+                ScheduledTask.org_id == ctx.org_id,  # type: ignore[arg-type]
+                ScheduledTask.workspace_id == ctx.workspace_id,  # type: ignore[arg-type]
+                cast(Any, ScheduledTask.deleted_at).is_(None),
+            )
+            .order_by(
+                ScheduledTask.created_at.desc(),  # type: ignore[attr-defined]
+            )
+            .limit(100)
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_task(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> ScheduledTask:
+        return await self._load(ctx, session, task_id)
+
+    async def list_runs(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> list[ScheduledTaskRun]:
+        # Validate task exists first
+        await self._load(ctx, session, task_id)
+        stmt = (
+            select(ScheduledTaskRun)
+            .where(
+                ScheduledTaskRun.org_id == ctx.org_id,  # type: ignore[arg-type]
+                ScheduledTaskRun.workspace_id == ctx.workspace_id,  # type: ignore[arg-type]
+                ScheduledTaskRun.scheduled_task_id == task_id,  # type: ignore[arg-type]
+            )
+            .order_by(
+                ScheduledTaskRun.scheduled_for.desc(),  # type: ignore[attr-defined]
+            )
+            .limit(50)
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+
+    async def create(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        data: dict[str, Any],
+    ) -> ScheduledTask:
+        self._validate_create(data)
+
+        # Conversation ownership check for fixed target
+        if data.get("target_mode") == "fixed":
+            await self._check_conversation_ownership(
+                session, ctx, data.get("target_conversation_id", "")
+            )
+
+        run_at = data.get("run_at")
+        end_at = data.get("end_at")
+        task = ScheduledTask(
+            org_id=ctx.org_id,
+            workspace_id=ctx.workspace_id,
+            owner_user_id=ctx.user_id,
+            name=data["name"],
+            prompt=data["prompt"],
+            schedule_kind=data["schedule_kind"],
+            cron_expr=data.get("cron_expr"),
+            interval_seconds=data.get("interval_seconds"),
+            run_at=_to_utc_naive(run_at) if run_at is not None else None,
+            end_at=_to_utc_naive(end_at) if end_at is not None else None,
+            timezone=data.get("timezone", "UTC"),
+            target_mode=data["target_mode"],
+            target_conversation_id=data.get("target_conversation_id"),
+            status="active",
+        )
+        task.next_fire_at = _initial_next_fire(task)
+        session.add(task)
+        await session.commit()
+        await session.refresh(task)
+        return task
+
+    async def update(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+        data: dict[str, Any],
+    ) -> ScheduledTask:
+        task = await self._load_for_mutation(ctx, session, task_id)
+        self._validate_patch(data)
+
+        # Conversation ownership check when switching to / staying in fixed
+        if data.get("target_mode") == "fixed" or (
+            data.get("target_conversation_id") is not None and task.target_mode == "fixed"
+        ):
+            conv_repo = ConversationRepository(
+                session,
+                org_id=ctx.org_id,
+                workspace_id=ctx.workspace_id,
+                user_id=task.owner_user_id,
+            )
+            target = data.get("target_conversation_id") or task.target_conversation_id
+            if target is None or await conv_repo.get_by_id(target) is None:
+                raise ActionInvalidInput("target_conversation_id must be the owner's conversation")
+
+        touched_schedule = False
+        for field in (
+            "name",
+            "prompt",
+            "schedule_kind",
+            "cron_expr",
+            "interval_seconds",
+            "run_at",
+            "timezone",
+            "target_mode",
+            "target_conversation_id",
+        ):
+            val = data.get(field)
+            if val is None:
+                continue
+            if field == "run_at":
+                val = _to_utc_naive(val)
+            if field in _SCHEDULE_FIELDS and val != getattr(task, field):
+                touched_schedule = True
+            setattr(task, field, val)
+
+        # end_at explicit null handling: must be handled separately because
+        # the generic loop skips None values.
+        if "end_at" in data:
+            raw_end = data["end_at"]
+            task.end_at = _to_utc_naive(raw_end) if raw_end is not None else None
+
+        # Only recompute next_fire_at when schedule actually changed
+        if touched_schedule:
+            task.next_fire_at = _initial_next_fire(task) if task.status == "active" else None
+
+        task.updated_at = datetime.now(UTC)
+        await session.commit()
+        await session.refresh(task)
+        return task
+
+    async def pause(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> ScheduledTask:
+        task = await self._load_for_mutation(ctx, session, task_id)
+        task.status = "paused"
+        task.updated_at = datetime.now(UTC)
+        await session.commit()
+        await session.refresh(task)
+        return task
+
+    async def resume(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> ScheduledTask:
+        task = await self._load_for_mutation(ctx, session, task_id)
+        task.status = "active"
+        task.next_fire_at = await self._resume_next_fire(session, task)
+        task.updated_at = datetime.now(UTC)
+        await session.commit()
+        await session.refresh(task)
+        return task
+
+    async def delete(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> None:
+        task = await self._load_for_mutation(ctx, session, task_id)
+        task.deleted_at = datetime.now(UTC)
+        task.next_fire_at = None
+        await session.commit()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _load(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> ScheduledTask:
+        stmt = select(ScheduledTask).where(
+            ScheduledTask.org_id == ctx.org_id,  # type: ignore[arg-type]
+            ScheduledTask.workspace_id == ctx.workspace_id,  # type: ignore[arg-type]
+            ScheduledTask.id == task_id,  # type: ignore[arg-type]
+            cast(Any, ScheduledTask.deleted_at).is_(None),
+        )
+        result = await session.execute(stmt)
+        task = result.scalar_one_or_none()
+        if task is None:
+            raise ActionNotFound("Scheduled task not found")
+        return task
+
+    async def _load_for_mutation(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> ScheduledTask:
+        task = await self._load(ctx, session, task_id)
+        if task.owner_user_id != ctx.user_id and ctx.role != Role.ADMIN:
+            raise ActionPermissionDenied("Owner or admin required")
+        return task
+
+    async def _check_conversation_ownership(
+        self,
+        session: AsyncSession,
+        ctx: ScopeContext,
+        conversation_id: str,
+    ) -> None:
+        conv_repo = ConversationRepository(
+            session,
+            org_id=ctx.org_id,
+            workspace_id=ctx.workspace_id,
+            user_id=ctx.user_id,
+        )
+        if await conv_repo.get_by_id(conversation_id) is None:
+            raise ActionInvalidInput("target_conversation_id must be your own conversation")
+
+    async def _resume_next_fire(
+        self,
+        session: AsyncSession,
+        t: ScheduledTask,
+    ) -> datetime | None:
+        """Resume policy: account for occurrences due while paused.
+
+        Mirrors the outage missed-run policy: at most ONE summary
+        history row.
+        """
+        now = datetime.now(UTC)
+        anchor = as_utc(t.next_fire_at) if t.next_fire_at is not None else None
+
+        if t.schedule_kind == "once":
+            run_at = as_utc(t.run_at) if t.run_at is not None else None
+            if run_at is not None and run_at <= now:
+                scheduled_for_naive = _to_utc_naive(run_at)
+                try:
+                    async with session.begin_nested():
+                        session.add(
+                            ScheduledTaskRun(
+                                scheduled_task_id=t.id,
+                                org_id=t.org_id,
+                                workspace_id=t.workspace_id,
+                                scheduled_for=scheduled_for_naive,
+                                claimed_at=now,
+                                state="skipped_missed",
+                                detail=("paused past its one-shot fire time"),
+                            )
+                        )
+                        await session.flush()
+                except IntegrityError:
+                    pass
+                return None
+            return run_at
+
+        if anchor is None or anchor > now:
+            return anchor if anchor is not None else _initial_next_fire(t)
+
+        latest_due = latest_due_before(
+            kind=t.schedule_kind,
+            candidate=anchor,
+            now=now,
+            cron_expr=t.cron_expr,
+            interval_seconds=t.interval_seconds,
+            tz=t.timezone,
+        )
+        session.add(
+            ScheduledTaskRun(
+                scheduled_task_id=t.id,
+                org_id=t.org_id,
+                workspace_id=t.workspace_id,
+                scheduled_for=anchor,
+                claimed_at=now,
+                state="skipped_missed",
+                detail=(f"paused: skipped {anchor.isoformat()}..{latest_due.isoformat()}"),
+            )
+        )
+        return next_fire_after(
+            kind=t.schedule_kind,
+            after=latest_due,
+            cron_expr=t.cron_expr,
+            interval_seconds=t.interval_seconds,
+            tz=t.timezone,
+        )
+
+    @staticmethod
+    def _validate_create(data: dict[str, Any]) -> None:
+        tz = data.get("timezone", "UTC")
+        try:
+            _validate_timezone(tz)
+        except ValueError as exc:
+            raise ActionInvalidInput(str(exc)) from exc
+
+        kind = data.get("schedule_kind")
+        if kind == "cron":
+            expr = data.get("cron_expr")
+            if not expr:
+                raise ActionInvalidInput("cron_expr required for cron schedule")
+            try:
+                _validate_cron(expr)
+            except ValueError as exc:
+                raise ActionInvalidInput(str(exc)) from exc
+        if kind == "interval" and not data.get("interval_seconds"):
+            raise ActionInvalidInput("interval_seconds required for interval schedule")
+        if kind == "once":
+            if data.get("run_at") is None:
+                raise ActionInvalidInput("run_at required for once schedule")
+
+        if not data.get("name"):
+            raise ActionInvalidInput("name is required")
+        if not data.get("prompt"):
+            raise ActionInvalidInput("prompt is required")
+        if not data.get("target_mode"):
+            raise ActionInvalidInput("target_mode is required")
+        if data.get("target_mode") == "fixed" and not data.get("target_conversation_id"):
+            raise ActionInvalidInput("target_conversation_id required when target_mode=fixed")
+
+    @staticmethod
+    def _validate_patch(data: dict[str, Any]) -> None:
+        tz = data.get("timezone")
+        if tz is not None:
+            try:
+                _validate_timezone(tz)
+            except ValueError as exc:
+                raise ActionInvalidInput(str(exc)) from exc
+
+        expr = data.get("cron_expr")
+        if expr is not None:
+            try:
+                _validate_cron(expr)
+            except ValueError as exc:
+                raise ActionInvalidInput(str(exc)) from exc
+
+        kind = data.get("schedule_kind")
+        if kind == "cron" and not data.get("cron_expr"):
+            raise ActionInvalidInput("cron_expr required when changing schedule_kind to cron")
+        if kind == "interval" and not data.get("interval_seconds"):
+            raise ActionInvalidInput(
+                "interval_seconds required when changing schedule_kind to interval"
+            )
+        if kind == "once" and data.get("run_at") is None:
+            raise ActionInvalidInput("run_at required when changing schedule_kind to once")

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -33,6 +33,7 @@ class RunContext:
     user_id: str
     org_id: str
     workspace_id: str
+    trigger: str = "interactive"
 
 
 def _ns_to_agent_id(ns: tuple[Any, ...]) -> str | None:
@@ -981,6 +982,7 @@ class RunManager:
         sandbox: Any | None = None,
         skill_catalog: Any | None = None,
         catalog_session: Any | None = None,
+        trigger: str = "interactive",
     ) -> None:
         """Execute a single user turn through the cubepi runtime.
 
@@ -1336,6 +1338,58 @@ class RunManager:
                 mcp_citation_configs.update(_new_citations)
         except Exception as _exc:
             logger.warning("MCP tools unavailable for cubepi run: {}", _exc)
+
+        # Platform action tools (scheduled_tasks, etc.) — via the capability
+        # registry. Automated runs get read-only tools (mutation gate).
+        try:
+            from cubebox.agents.actions.registry import (
+                tools_for_run as _action_tools_for_run,
+            )
+            from cubebox.repositories.membership import MembershipRepository
+
+            async with async_session_maker() as _action_session:
+                _role = await MembershipRepository(_action_session).get_role(
+                    user_id=ctx.user_id,
+                    workspace_id=ctx.workspace_id,
+                )
+
+            if _role is not None:
+                from collections.abc import (
+                    AsyncIterator as _ActionsAsyncIterator,
+                )
+                from contextlib import (
+                    asynccontextmanager as _actions_acm,
+                )
+
+                from cubebox.agents.actions.context import (
+                    ScopeContext as _ScopeContext,
+                )
+
+                @_actions_acm
+                async def _action_ctx_factory() -> _ActionsAsyncIterator[tuple[_ScopeContext, Any]]:
+                    async with async_session_maker() as _sess:
+                        yield (
+                            _ScopeContext(
+                                org_id=ctx.org_id,
+                                workspace_id=ctx.workspace_id,
+                                user_id=ctx.user_id,
+                                role=_role,
+                                conversation_id=conversation_id,
+                            ),
+                            _sess,
+                        )
+
+                _builtin_tools.extend(
+                    _action_tools_for_run(
+                        _action_ctx_factory,
+                        allow_mutations=(trigger == "interactive"),
+                    )
+                )
+        except Exception as _exc:
+            logger.warning(
+                "platform action tools unavailable for cubepi run: {}",
+                _exc,
+            )
 
         # Bridge the synchronous cubepi listener to the async world via a queue.
         # agent.prompt() is async and invokes synchronous listeners on each
@@ -2112,6 +2166,7 @@ class RunManager:
                 sandbox=sandbox,
                 skill_catalog=skill_catalog,
                 catalog_session=catalog_session,
+                trigger=ctx.trigger,
             )
             await _update_conversation_timestamp(
                 conversation_id,

--- a/backend/cubebox/triggers/pipeline.py
+++ b/backend/cubebox/triggers/pipeline.py
@@ -105,6 +105,7 @@ class TriggerPipeline:
                 user_id=trigger.run_as_user_id,
                 org_id=trigger.org_id,
                 workspace_id=trigger.workspace_id,
+                trigger="automated",
             )
 
             # 5. start_run with retry/backoff.

--- a/backend/tests/unit/test_agent_action_builder.py
+++ b/backend/tests/unit/test_agent_action_builder.py
@@ -1,0 +1,306 @@
+"""Tests for the generic capability tool builder."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock
+
+from pydantic import BaseModel
+
+from cubebox.agents.actions.builder import build_capability_tool
+from cubebox.agents.actions.context import ScopeContext
+from cubebox.agents.actions.types import (
+    ActionInvalidInput,
+    ActionNotFound,
+    ActionPermissionDenied,
+    AgentCapability,
+    AgentOperation,
+)
+from cubebox.models.membership import Role
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+FAKE_CTX = ScopeContext(
+    org_id="org_1",
+    workspace_id="ws_1",
+    user_id="user_1",
+    role=Role.MEMBER,
+    conversation_id="conv_1",
+)
+
+
+@asynccontextmanager
+async def fake_context_factory() -> AsyncGenerator[tuple[ScopeContext, Any]]:
+    yield (FAKE_CTX, "fake-session")
+
+
+class ListInput(BaseModel):
+    page: int = 1
+
+
+class CreateInput(BaseModel):
+    title: str
+
+
+class DeleteInput(BaseModel):
+    item_id: str
+
+
+# ---------------------------------------------------------------------------
+# Mutation gate
+# ---------------------------------------------------------------------------
+
+
+class TestMutationGate:
+    def test_allow_mutations_includes_all(self) -> None:
+        list_op = AgentOperation(
+            name="list",
+            description="List items",
+            input_model=ListInput,
+            handler=AsyncMock(),
+            mutates=False,
+        )
+        create_op = AgentOperation(
+            name="create",
+            description="Create item",
+            input_model=CreateInput,
+            handler=AsyncMock(),
+            mutates=True,
+        )
+        cap = AgentCapability(
+            name="items",
+            description="Item management",
+            operations=[list_op, create_op],
+        )
+        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
+        assert tool is not None
+        # The union model should contain both operations.
+        schema = tool.parameters.model_json_schema()
+        # Both sub-models should appear under $defs.
+        assert "Op_list" in str(schema)
+        assert "Op_create" in str(schema)
+
+    def test_deny_mutations_drops_mutating(self) -> None:
+        list_op = AgentOperation(
+            name="list",
+            description="List items",
+            input_model=ListInput,
+            handler=AsyncMock(),
+            mutates=False,
+        )
+        create_op = AgentOperation(
+            name="create",
+            description="Create item",
+            input_model=CreateInput,
+            handler=AsyncMock(),
+            mutates=True,
+        )
+        cap = AgentCapability(
+            name="items",
+            description="Item management",
+            operations=[list_op, create_op],
+        )
+        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=False)
+        assert tool is not None
+        # Single surviving op → no union wrapper, model is ListInput.
+        assert tool.parameters is ListInput
+
+    def test_deny_mutations_all_mutating_returns_none(self) -> None:
+        create_op = AgentOperation(
+            name="create",
+            description="Create item",
+            input_model=CreateInput,
+            handler=AsyncMock(),
+            mutates=True,
+        )
+        delete_op = AgentOperation(
+            name="delete",
+            description="Delete item",
+            input_model=DeleteInput,
+            handler=AsyncMock(),
+            mutates=True,
+        )
+        cap = AgentCapability(
+            name="items",
+            description="Item management",
+            operations=[create_op, delete_op],
+        )
+        result = build_capability_tool(cap, fake_context_factory, allow_mutations=False)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    async def test_single_op_dispatches_correctly(self) -> None:
+        handler = AsyncMock(return_value={"status": "ok"})
+        list_op = AgentOperation(
+            name="list",
+            description="List items",
+            input_model=ListInput,
+            handler=handler,
+            mutates=False,
+        )
+        cap = AgentCapability(
+            name="items",
+            description="Item management",
+            operations=[list_op],
+        )
+        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
+        assert tool is not None
+
+        # Build input matching the single-op model (ListInput directly).
+        args = ListInput(page=3)
+        result = await tool.execute("call_1", args)
+
+        assert result.is_error is None
+        handler.assert_awaited_once_with(FAKE_CTX, "fake-session", args)
+
+    async def test_multi_op_dispatches_to_correct_handler(self) -> None:
+        list_handler = AsyncMock(return_value={"items": []})
+        create_handler = AsyncMock(return_value={"id": "new_1"})
+        list_op = AgentOperation(
+            name="list",
+            description="List items",
+            input_model=ListInput,
+            handler=list_handler,
+            mutates=False,
+        )
+        create_op = AgentOperation(
+            name="create",
+            description="Create item",
+            input_model=CreateInput,
+            handler=create_handler,
+            mutates=True,
+        )
+        cap = AgentCapability(
+            name="items",
+            description="Item management",
+            operations=[list_op, create_op],
+        )
+        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
+        assert tool is not None
+
+        # Call the "create" operation via the union model.
+        args = tool.parameters.model_validate(
+            {"params": {"operation": "create", "title": "My Item"}}
+        )
+        result = await tool.execute("call_2", args)
+
+        assert result.is_error is None
+        create_handler.assert_awaited_once()
+        # Verify the handler received (ctx, session, parsed_input).
+        call_args = create_handler.call_args
+        assert call_args[0][0] is FAKE_CTX
+        assert call_args[0][1] == "fake-session"
+        inner = call_args[0][2]
+        assert inner.title == "My Item"
+
+    async def test_handler_receives_correct_arguments(self) -> None:
+        """Verify the handler receives (ctx, session, parsed_input)."""
+        handler = AsyncMock(return_value={"ok": True})
+        op = AgentOperation(
+            name="create",
+            description="Create",
+            input_model=CreateInput,
+            handler=handler,
+            mutates=True,
+        )
+        cap = AgentCapability(
+            name="things",
+            description="Things",
+            operations=[op],
+        )
+        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
+        assert tool is not None
+
+        args = CreateInput(title="Test")
+        await tool.execute("call_3", args)
+
+        ctx_arg, session_arg, input_arg = handler.call_args[0]
+        assert ctx_arg is FAKE_CTX
+        assert session_arg == "fake-session"
+        assert isinstance(input_arg, CreateInput)
+        assert input_arg.title == "Test"
+
+
+# ---------------------------------------------------------------------------
+# Error mapping
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMapping:
+    async def test_action_not_found(self) -> None:
+        handler = AsyncMock(side_effect=ActionNotFound("item xyz not found"))
+        op = AgentOperation(
+            name="get",
+            description="Get item",
+            input_model=ListInput,
+            handler=handler,
+        )
+        cap = AgentCapability(
+            name="items",
+            description="Items",
+            operations=[op],
+        )
+        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
+        assert tool is not None
+
+        result = await tool.execute("call_err1", ListInput())
+        assert result.is_error is True
+        text = result.content[0].text  # type: ignore[union-attr]
+        assert "ActionNotFound" in text
+        assert "item xyz not found" in text
+
+    async def test_action_permission_denied(self) -> None:
+        handler = AsyncMock(side_effect=ActionPermissionDenied("admin required"))
+        op = AgentOperation(
+            name="delete",
+            description="Delete item",
+            input_model=DeleteInput,
+            handler=handler,
+            mutates=True,
+        )
+        cap = AgentCapability(
+            name="items",
+            description="Items",
+            operations=[op],
+        )
+        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
+        assert tool is not None
+
+        result = await tool.execute("call_err2", DeleteInput(item_id="x"))
+        assert result.is_error is True
+        text = result.content[0].text  # type: ignore[union-attr]
+        assert "ActionPermissionDenied" in text
+        assert "admin required" in text
+
+    async def test_action_invalid_input(self) -> None:
+        handler = AsyncMock(side_effect=ActionInvalidInput("bad cron expression"))
+        op = AgentOperation(
+            name="create",
+            description="Create",
+            input_model=CreateInput,
+            handler=handler,
+            mutates=True,
+        )
+        cap = AgentCapability(
+            name="items",
+            description="Items",
+            operations=[op],
+        )
+        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
+        assert tool is not None
+
+        result = await tool.execute("call_err3", CreateInput(title="bad"))
+        assert result.is_error is True
+        text = result.content[0].text  # type: ignore[union-attr]
+        assert "ActionInvalidInput" in text
+        assert "bad cron expression" in text

--- a/backend/tests/unit/test_agent_action_builder.py
+++ b/backend/tests/unit/test_agent_action_builder.py
@@ -189,9 +189,7 @@ class TestDispatch:
         assert tool is not None
 
         # Call the "create" operation via the union model.
-        args = tool.parameters.model_validate(
-            {"params": {"operation": "create", "title": "My Item"}}
-        )
+        args = tool.parameters.model_validate({"operation": "create", "title": "My Item"})
         result = await tool.execute("call_2", args)
 
         assert result.is_error is None

--- a/backend/tests/unit/test_scheduled_task_service.py
+++ b/backend/tests/unit/test_scheduled_task_service.py
@@ -1,0 +1,257 @@
+"""Tests for ScheduledTaskService (needs real DB).
+
+Uses the standard SQLAlchemy "join session into external transaction"
+pattern: the fixture opens a real connection + transaction, binds the
+session to it, and monkeypatches ``session.commit`` → ``session.flush``
+so the service's commit calls are harmless. After the test the outer
+transaction rolls back, leaving a clean DB.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    create_async_engine,
+)
+from sqlalchemy.pool import NullPool
+
+from cubebox.agents.actions.context import ScopeContext
+from cubebox.agents.actions.types import (
+    ActionInvalidInput,
+    ActionNotFound,
+    ActionPermissionDenied,
+)
+from cubebox.db.engine import _build_database_url
+from cubebox.models.membership import Role
+from cubebox.models.organization import Organization
+from cubebox.models.user import User
+from cubebox.models.workspace import Workspace
+from cubebox.services.scheduled_task import ScheduledTaskService
+
+pytestmark = pytest.mark.e2e
+
+_ORG_ID = "org-test0000000000"
+_WS_ID = "ws-test00000000000"
+_OWNER_ID = "usr-owner00000000"
+_ADMIN_ID = "usr-admin00000000"
+_OTHER_ID = "usr-other00000000"
+
+
+@pytest.fixture()
+async def db_session() -> AsyncIterator[AsyncSession]:
+    """Transactional session: everything rolls back after each test."""
+    engine = create_async_engine(_build_database_url(), poolclass=NullPool)
+    conn = await engine.connect()
+    txn = await conn.begin()
+    session = AsyncSession(bind=conn, expire_on_commit=False)
+
+    # Redirect session.commit → flush so the service's commits are
+    # harmless but the data is visible within the transaction.
+    _real_commit = session.commit
+    session.commit = session.flush  # type: ignore[assignment]
+
+    # For _resume_next_fire's begin_nested (SAVEPOINT), we need the
+    # real connection-level begin_nested. Patch session.begin_nested
+    # to use the connection's begin_nested which works inside the
+    # outer transaction.
+    # (This works because session is already bound to conn.)
+
+    try:
+        # Seed FK parent rows
+        session.add(Organization(id=_ORG_ID, name="test", slug="svc-test"))
+        await session.flush()
+        session.add(Workspace(id=_WS_ID, org_id=_ORG_ID, name="test ws"))
+        await session.flush()
+        for uid, email in [
+            (_OWNER_ID, "owner@test.local"),
+            (_ADMIN_ID, "admin@test.local"),
+            (_OTHER_ID, "other@test.local"),
+        ]:
+            session.add(User(id=uid, email=email, hashed_password="x"))
+        await session.flush()
+
+        yield session
+    finally:
+        await session.close()
+        await txn.rollback()
+        await conn.close()
+        await engine.dispose()
+
+
+def _owner_ctx() -> ScopeContext:
+    return ScopeContext(
+        org_id=_ORG_ID,
+        workspace_id=_WS_ID,
+        user_id=_OWNER_ID,
+        role=Role.MEMBER,
+    )
+
+
+def _admin_ctx() -> ScopeContext:
+    return ScopeContext(
+        org_id=_ORG_ID,
+        workspace_id=_WS_ID,
+        user_id=_ADMIN_ID,
+        role=Role.ADMIN,
+    )
+
+
+def _other_ctx() -> ScopeContext:
+    return ScopeContext(
+        org_id=_ORG_ID,
+        workspace_id=_WS_ID,
+        user_id=_OTHER_ID,
+        role=Role.MEMBER,
+    )
+
+
+def _interval_data(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "name": "test task",
+        "prompt": "do something",
+        "schedule_kind": "interval",
+        "interval_seconds": 3600,
+        "timezone": "UTC",
+        "target_mode": "new_each_run",
+    }
+    base.update(overrides)
+    return base
+
+
+# ------------------------------------------------------------------
+# TestCreate
+# ------------------------------------------------------------------
+
+
+class TestCreate:
+    async def test_create_interval_task(self, db_session):  # type: ignore[no-untyped-def]
+        svc = ScheduledTaskService()
+        ctx = _owner_ctx()
+        task = await svc.create(ctx, db_session, _interval_data())
+        assert task.status == "active"
+        assert task.next_fire_at is not None
+        assert task.owner_user_id == ctx.user_id
+
+    async def test_cron_requires_expr(self, db_session):  # type: ignore[no-untyped-def]
+        svc = ScheduledTaskService()
+        with pytest.raises(ActionInvalidInput, match="cron_expr"):
+            await svc.create(
+                _owner_ctx(),
+                db_session,
+                {
+                    "name": "bad",
+                    "prompt": "x",
+                    "schedule_kind": "cron",
+                    "target_mode": "new_each_run",
+                },
+            )
+
+    async def test_once_requires_run_at(self, db_session):  # type: ignore[no-untyped-def]
+        svc = ScheduledTaskService()
+        with pytest.raises(ActionInvalidInput, match="run_at"):
+            await svc.create(
+                _owner_ctx(),
+                db_session,
+                {
+                    "name": "bad",
+                    "prompt": "x",
+                    "schedule_kind": "once",
+                    "target_mode": "new_each_run",
+                },
+            )
+
+
+# ------------------------------------------------------------------
+# TestAuthorization
+# ------------------------------------------------------------------
+
+
+class TestAuthorization:
+    async def test_owner_can_pause(self, db_session):  # type: ignore[no-untyped-def]
+        svc = ScheduledTaskService()
+        task = await svc.create(_owner_ctx(), db_session, _interval_data())
+        paused = await svc.pause(_owner_ctx(), db_session, task.id)
+        assert paused.status == "paused"
+
+    async def test_admin_can_pause(self, db_session):  # type: ignore[no-untyped-def]
+        svc = ScheduledTaskService()
+        task = await svc.create(_owner_ctx(), db_session, _interval_data())
+        paused = await svc.pause(_admin_ctx(), db_session, task.id)
+        assert paused.status == "paused"
+
+    async def test_other_member_cannot_pause(self, db_session):  # type: ignore[no-untyped-def]
+        svc = ScheduledTaskService()
+        task = await svc.create(_owner_ctx(), db_session, _interval_data())
+        with pytest.raises(ActionPermissionDenied):
+            await svc.pause(_other_ctx(), db_session, task.id)
+
+
+# ------------------------------------------------------------------
+# TestPauseResume
+# ------------------------------------------------------------------
+
+
+class TestPauseResume:
+    async def test_pause_resume_cycle(self, db_session):  # type: ignore[no-untyped-def]
+        svc = ScheduledTaskService()
+        ctx = _owner_ctx()
+        task = await svc.create(ctx, db_session, _interval_data())
+        assert task.status == "active"
+
+        paused = await svc.pause(ctx, db_session, task.id)
+        assert paused.status == "paused"
+
+        resumed = await svc.resume(ctx, db_session, task.id)
+        assert resumed.status == "active"
+        assert resumed.next_fire_at is not None
+
+
+# ------------------------------------------------------------------
+# TestDelete
+# ------------------------------------------------------------------
+
+
+class TestDelete:
+    async def test_delete_then_get_raises(self, db_session):  # type: ignore[no-untyped-def]
+        svc = ScheduledTaskService()
+        ctx = _owner_ctx()
+        task = await svc.create(ctx, db_session, _interval_data())
+        await svc.delete(ctx, db_session, task.id)
+        with pytest.raises(ActionNotFound):
+            await svc.get_task(ctx, db_session, task.id)
+
+
+# ------------------------------------------------------------------
+# TestUpdate
+# ------------------------------------------------------------------
+
+
+class TestUpdate:
+    async def test_prompt_update_keeps_next_fire(
+        self,
+        db_session,  # type: ignore[no-untyped-def]
+    ):
+        svc = ScheduledTaskService()
+        ctx = _owner_ctx()
+        task = await svc.create(ctx, db_session, _interval_data())
+        original_next = task.next_fire_at
+
+        updated = await svc.update(ctx, db_session, task.id, {"prompt": "new prompt"})
+        assert updated.prompt == "new prompt"
+        assert updated.next_fire_at == original_next
+
+    async def test_interval_update_recomputes_next_fire(
+        self,
+        db_session,  # type: ignore[no-untyped-def]
+    ):
+        svc = ScheduledTaskService()
+        ctx = _owner_ctx()
+        task = await svc.create(ctx, db_session, _interval_data())
+        original_next = task.next_fire_at
+
+        updated = await svc.update(ctx, db_session, task.id, {"interval_seconds": 7200})
+        # Schedule field changed -> next_fire_at recomputed
+        assert updated.next_fire_at != original_next

--- a/docs/dev/plans/2026-06-01-agent-platform-actions.md
+++ b/docs/dev/plans/2026-06-01-agent-platform-actions.md
@@ -1,0 +1,1709 @@
+# Agent Platform Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish a unified mechanism for agent-operable platform capabilities and land scheduled-task management as the first capability.
+
+**Architecture:** Three layers — (1) `ScheduledTaskService` owns all business logic + transaction + authorization; (2) an action registry (`AgentOperation`/`AgentCapability`) + generic builder produces one cubepi `AgentTool` per capability via a Pydantic discriminated union; (3) two thin front doors (REST route and agent tool) both delegate to the service. A structural mutation gate excludes write operations from automated (non-interactive) runs.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy async, cubepi `AgentTool`, Pydantic v2 discriminated unions, pytest.
+
+**Spec:** `docs/dev/specs/2026-06-01-agent-platform-actions-design.md`
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `backend/cubebox/agents/actions/__init__.py` | Package init |
+| Create | `backend/cubebox/agents/actions/context.py` | `ScopeContext` dataclass + builders |
+| Create | `backend/cubebox/agents/actions/types.py` | `AgentOperation`, `AgentCapability`, domain exceptions |
+| Create | `backend/cubebox/agents/actions/builder.py` | `build_capability_tool()` — generic factory |
+| Create | `backend/cubebox/agents/actions/registry.py` | `AGENT_CAPABILITIES` list + `tools_for_run()` |
+| Create | `backend/cubebox/agents/actions/capabilities/__init__.py` | Package init |
+| Create | `backend/cubebox/agents/actions/capabilities/scheduled_tasks.py` | Declares the `scheduled_tasks` capability |
+| Create | `backend/cubebox/services/scheduled_task.py` | `ScheduledTaskService` — source of truth |
+| Modify | `backend/cubebox/api/routes/v1/ws_scheduled_tasks.py` | Refactor to thin adapter over service |
+| Modify | `backend/cubebox/streams/run_manager.py:30` | Add `trigger` field to `RunContext` |
+| Modify | `backend/cubebox/streams/run_manager.py:540` | Thread `trigger` through `start_run` |
+| Modify | `backend/cubebox/streams/run_manager.py:1860` | Thread `trigger` through `_execute_run` |
+| Modify | `backend/cubebox/streams/run_manager.py:969` | Thread `trigger` through `_run_cubepi_path`, wire `tools_for_run` |
+| Modify | `backend/cubebox/schedules/dispatch.py:91-102` | Pass `trigger="automated"` to `RunContext` |
+| Create | `backend/tests/unit/test_scheduled_task_service.py` | Service unit tests |
+| Create | `backend/tests/unit/test_agent_action_builder.py` | Builder + mutation gate tests |
+| Modify | `backend/tests/e2e/test_scheduled_tasks_api.py` | Existing route tests stay green (guard) |
+
+---
+
+### Task 1: Domain Exceptions + ScopeContext + AgentOperation/AgentCapability types
+
+**Files:**
+- Create: `backend/cubebox/agents/actions/__init__.py`
+- Create: `backend/cubebox/agents/actions/context.py`
+- Create: `backend/cubebox/agents/actions/types.py`
+- Create: `backend/cubebox/agents/actions/capabilities/__init__.py`
+
+These are pure data types with no dependencies on DB or services — they can be built and tested in isolation.
+
+- [ ] **Step 1: Create the package and `context.py`**
+
+```python
+# backend/cubebox/agents/actions/__init__.py
+"""Agent platform actions — unified mechanism for agent-operable capabilities."""
+
+# backend/cubebox/agents/actions/capabilities/__init__.py
+"""Capability declarations for agent platform actions."""
+```
+
+```python
+# backend/cubebox/agents/actions/context.py
+"""Scoped context for agent platform actions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cubebox.models.membership import Role
+
+
+@dataclass(frozen=True)
+class ScopeContext:
+    """Everything an operation needs to be scoped and authorized."""
+
+    org_id: str
+    workspace_id: str
+    user_id: str
+    role: Role
+    conversation_id: str | None = None
+```
+
+- [ ] **Step 2: Create `types.py` — domain exceptions + operation/capability dataclasses**
+
+```python
+# backend/cubebox/agents/actions/types.py
+"""Core types for the agent platform actions mechanism."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import BaseModel
+
+from cubebox.agents.actions.context import ScopeContext
+
+
+# --- Domain exceptions (raised by services, mapped by front doors) ---
+
+class ActionNotFound(Exception):
+    """Target entity does not exist or is soft-deleted."""
+
+
+class ActionPermissionDenied(Exception):
+    """Caller lacks the required role (e.g. not owner or admin)."""
+
+
+class ActionInvalidInput(Exception):
+    """Validation failure (bad cron, missing field, etc.)."""
+
+
+# --- Registry types ---
+
+@dataclass(frozen=True)
+class AgentOperation:
+    """One operation within a capability (e.g. 'create', 'list')."""
+
+    name: str
+    description: str
+    input_model: type[BaseModel]
+    handler: Callable[..., Awaitable[Any]]
+    mutates: bool = False
+
+
+@dataclass(frozen=True)
+class AgentCapability:
+    """A named group of operations exposed as a single agent tool."""
+
+    name: str
+    description: str
+    operations: list[AgentOperation] = field(default_factory=list)
+```
+
+- [ ] **Step 3: Verify types are importable**
+
+Run: `cd backend && uv run python -c "from cubebox.agents.actions.types import AgentCapability, AgentOperation, ActionNotFound; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 4: Run mypy on the new files**
+
+Run: `cd backend && uv run mypy cubebox/agents/actions/`
+Expected: `Success: no issues found`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cubebox/agents/actions/
+git commit -m "feat(actions): add ScopeContext, domain exceptions, AgentOperation/AgentCapability types"
+```
+
+---
+
+### Task 2: Generic capability tool builder
+
+**Files:**
+- Create: `backend/cubebox/agents/actions/builder.py`
+- Create: `backend/tests/unit/test_agent_action_builder.py`
+
+The builder takes an `AgentCapability` + a context factory and produces one cubepi `AgentTool` with a Pydantic discriminated-union input model. It also implements the mutation gate: when `allow_mutations=False`, mutating operations are excluded.
+
+- [ ] **Step 1: Write builder tests (mutation gate + dispatch + error mapping)**
+
+```python
+# backend/tests/unit/test_agent_action_builder.py
+"""Tests for the generic capability tool builder."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import BaseModel
+
+from cubebox.agents.actions.builder import build_capability_tool
+from cubebox.agents.actions.context import ScopeContext
+from cubebox.agents.actions.types import (
+    ActionInvalidInput,
+    ActionNotFound,
+    ActionPermissionDenied,
+    AgentCapability,
+    AgentOperation,
+)
+from cubebox.models.membership import Role
+
+
+class EchoInput(BaseModel):
+    message: str
+
+
+class EmptyInput(BaseModel):
+    pass
+
+
+def _make_scope() -> ScopeContext:
+    return ScopeContext(
+        org_id="org-test",
+        workspace_id="ws-test",
+        user_id="usr-test",
+        role=Role.MEMBER,
+        conversation_id="conv-test",
+    )
+
+
+@asynccontextmanager
+async def _fake_context_factory() -> AsyncIterator[tuple[ScopeContext, Any]]:
+    """Yields (ScopeContext, fake-session)."""
+    yield (_make_scope(), "fake-session")
+
+
+def _cap_with_ops(*, read_handler: Any = None, write_handler: Any = None) -> AgentCapability:
+    ops: list[AgentOperation] = []
+    if read_handler is not None:
+        ops.append(
+            AgentOperation(
+                name="list",
+                description="List items",
+                input_model=EmptyInput,
+                handler=read_handler,
+                mutates=False,
+            )
+        )
+    if write_handler is not None:
+        ops.append(
+            AgentOperation(
+                name="create",
+                description="Create an item",
+                input_model=EchoInput,
+                handler=write_handler,
+                mutates=True,
+            )
+        )
+    return AgentCapability(name="test_cap", description="Test capability", operations=ops)
+
+
+class TestMutationGate:
+    def test_allow_mutations_true_includes_all_ops(self) -> None:
+        cap = _cap_with_ops(read_handler=AsyncMock(), write_handler=AsyncMock())
+        tool = build_capability_tool(cap, _fake_context_factory, allow_mutations=True)
+        assert tool is not None
+        schema = tool.parameters.model_json_schema()
+        op_enum = schema["$defs"]["CreateInput"]["properties"]["operation"]["const"]
+        assert op_enum == "create"
+
+    def test_allow_mutations_false_drops_mutating_ops(self) -> None:
+        cap = _cap_with_ops(read_handler=AsyncMock(), write_handler=AsyncMock())
+        tool = build_capability_tool(cap, _fake_context_factory, allow_mutations=False)
+        assert tool is not None
+        schema = tool.parameters.model_json_schema()
+        # Only "list" operation should remain
+        assert "CreateInput" not in schema.get("$defs", {})
+
+    def test_allow_mutations_false_all_mutating_returns_none(self) -> None:
+        cap = _cap_with_ops(write_handler=AsyncMock())
+        tool = build_capability_tool(cap, _fake_context_factory, allow_mutations=False)
+        assert tool is None
+
+
+class TestDispatch:
+    @pytest.mark.anyio
+    async def test_dispatches_to_correct_handler(self) -> None:
+        handler = AsyncMock(return_value={"id": "stask-123", "name": "daily"})
+        cap = _cap_with_ops(write_handler=handler)
+        tool = build_capability_tool(cap, _fake_context_factory, allow_mutations=True)
+        assert tool is not None
+
+        result = await tool.execute("tc-1", tool.parameters(operation="create", message="hello"))
+        handler.assert_called_once()
+        assert not result.is_error
+        payload = json.loads(result.content[0].text)
+        assert payload["id"] == "stask-123"
+
+
+class TestErrorMapping:
+    @pytest.mark.anyio
+    async def test_not_found_maps_to_error(self) -> None:
+        handler = AsyncMock(side_effect=ActionNotFound("gone"))
+        cap = _cap_with_ops(read_handler=handler)
+        tool = build_capability_tool(cap, _fake_context_factory, allow_mutations=True)
+        assert tool is not None
+        result = await tool.execute("tc-1", tool.parameters(operation="list"))
+        assert result.is_error
+        assert "gone" in result.content[0].text
+
+    @pytest.mark.anyio
+    async def test_permission_denied_maps_to_error(self) -> None:
+        handler = AsyncMock(side_effect=ActionPermissionDenied("not owner"))
+        cap = _cap_with_ops(read_handler=handler)
+        tool = build_capability_tool(cap, _fake_context_factory, allow_mutations=True)
+        assert tool is not None
+        result = await tool.execute("tc-1", tool.parameters(operation="list"))
+        assert result.is_error
+        assert "not owner" in result.content[0].text
+
+    @pytest.mark.anyio
+    async def test_invalid_input_maps_to_error(self) -> None:
+        handler = AsyncMock(side_effect=ActionInvalidInput("bad cron"))
+        cap = _cap_with_ops(read_handler=handler)
+        tool = build_capability_tool(cap, _fake_context_factory, allow_mutations=True)
+        assert tool is not None
+        result = await tool.execute("tc-1", tool.parameters(operation="list"))
+        assert result.is_error
+        assert "bad cron" in result.content[0].text
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/unit/test_agent_action_builder.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'cubebox.agents.actions.builder'`
+
+- [ ] **Step 3: Implement `builder.py`**
+
+```python
+# backend/cubebox/agents/actions/builder.py
+"""Generic factory: AgentCapability → one cubepi AgentTool.
+
+Builds a Pydantic discriminated-union input model from the capability's
+operations, dispatches to the matching handler, and maps domain exceptions
+to AgentToolResult(is_error=True).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from typing import Annotated, Any, Literal, Union, get_args
+
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import TextContent
+from pydantic import BaseModel, Field
+
+from cubebox.agents.actions.context import ScopeContext
+from cubebox.agents.actions.types import (
+    ActionInvalidInput,
+    ActionNotFound,
+    ActionPermissionDenied,
+    AgentCapability,
+    AgentOperation,
+)
+
+type ContextFactory = Callable[[], AbstractAsyncContextManager[tuple[ScopeContext, Any]]]
+
+
+def _make_op_model(op: AgentOperation) -> type[BaseModel]:
+    """Create a per-operation input model with a fixed `operation` literal."""
+    fields: dict[str, Any] = {
+        "operation": (Literal[op.name], Field(default=op.name)),  # type: ignore[valid-type]
+    }
+    for name, field_info in op.input_model.model_fields.items():
+        fields[name] = (field_info.annotation, field_info)
+
+    model = type(
+        f"{op.name.capitalize()}Input",
+        (BaseModel,),
+        {"__annotations__": {k: v[0] for k, v in fields.items()}, **{k: v[1] for k, v in fields.items()}},
+    )
+    return model
+
+
+def build_capability_tool(
+    cap: AgentCapability,
+    context_factory: ContextFactory,
+    *,
+    allow_mutations: bool,
+) -> AgentTool[Any] | None:
+    """Build one cubepi AgentTool for a capability, or None if no ops survive the gate."""
+    ops = [op for op in cap.operations if allow_mutations or not op.mutates]
+    if not ops:
+        return None
+
+    op_models = {op.name: (_make_op_model(op), op) for op in ops}
+
+    if len(op_models) == 1:
+        only_name = next(iter(op_models))
+        union_model = op_models[only_name][0]
+    else:
+        union_type = Union[tuple(m for m, _ in op_models.values())]  # type: ignore[valid-type]
+        discriminated = Annotated[union_type, Field(discriminator="operation")]
+
+        class _CapInput(BaseModel):
+            root: discriminated  # type: ignore[valid-type]
+
+            def __init__(self, **data: Any) -> None:
+                if "root" not in data and "operation" in data:
+                    super().__init__(root=data)
+                else:
+                    super().__init__(**data)
+
+            @property
+            def operation(self) -> str:
+                return self.root.operation  # type: ignore[attr-defined, no-any-return]
+
+        _CapInput.__name__ = f"{cap.name.capitalize()}Input"
+        _CapInput.__qualname__ = _CapInput.__name__
+        union_model = _CapInput
+
+    handler_map: dict[str, AgentOperation] = {op.name: op for op in ops}
+
+    async def _execute(
+        tool_call_id: str,
+        args: Any,
+        *,
+        signal: object = None,
+        on_update: object = None,
+    ) -> AgentToolResult:
+        del tool_call_id, signal, on_update
+
+        inner = args.root if hasattr(args, "root") else args
+        op_name: str = inner.operation
+        op = handler_map.get(op_name)
+        if op is None:
+            return AgentToolResult(
+                content=[TextContent(text=f"Unknown operation: {op_name}")],
+                is_error=True,
+            )
+
+        input_data = {
+            k: v for k, v in inner.model_dump().items() if k != "operation"
+        }
+        parsed_input = op.input_model(**input_data) if input_data else op.input_model()
+
+        try:
+            async with context_factory() as (ctx, session):
+                result = await op.handler(ctx, session, parsed_input)
+        except ActionNotFound as exc:
+            return AgentToolResult(
+                content=[TextContent(text=f"NOT_FOUND: {exc}")], is_error=True
+            )
+        except ActionPermissionDenied as exc:
+            return AgentToolResult(
+                content=[TextContent(text=f"PERMISSION_DENIED: {exc}")], is_error=True
+            )
+        except ActionInvalidInput as exc:
+            return AgentToolResult(
+                content=[TextContent(text=f"INVALID_INPUT: {exc}")], is_error=True
+            )
+
+        text = json.dumps(result, default=str) if not isinstance(result, str) else result
+        return AgentToolResult(content=[TextContent(text=text)])
+
+    return AgentTool(
+        name=cap.name,
+        description=cap.description,
+        parameters=union_model,
+        execute=_execute,
+    )
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd backend && uv run pytest tests/unit/test_agent_action_builder.py -v`
+Expected: all pass
+
+- [ ] **Step 5: Run mypy**
+
+Run: `cd backend && uv run mypy cubebox/agents/actions/builder.py`
+Expected: `Success: no issues found`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/agents/actions/builder.py backend/tests/unit/test_agent_action_builder.py
+git commit -m "feat(actions): generic capability tool builder with mutation gate"
+```
+
+---
+
+### Task 3: ScheduledTaskService — extract business logic from routes
+
+**Files:**
+- Create: `backend/cubebox/services/scheduled_task.py`
+- Create: `backend/tests/unit/test_scheduled_task_service.py`
+
+This is the largest task. The service absorbs all logic from `ws_scheduled_tasks.py`: validation, `next_fire_at` computation, timezone normalization, owner-or-admin authorization, and the resume missed-run policy. The service owns the transaction (single commit per mutating call).
+
+- [ ] **Step 1: Write service tests — create + authorization**
+
+```python
+# backend/tests/unit/test_scheduled_task_service.py
+"""Unit tests for ScheduledTaskService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.agents.actions.context import ScopeContext
+from cubebox.agents.actions.types import ActionInvalidInput, ActionNotFound, ActionPermissionDenied
+from cubebox.models.membership import Role
+from cubebox.models.scheduled_task import ScheduledTask
+from cubebox.services.scheduled_task import ScheduledTaskService
+
+pytestmark = pytest.mark.e2e  # needs real DB
+
+
+def _owner_ctx(
+    org_id: str = "org-00000000000000",
+    workspace_id: str = "ws-00000000000000",
+    user_id: str = "usr-owner",
+) -> ScopeContext:
+    return ScopeContext(
+        org_id=org_id,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        role=Role.MEMBER,
+    )
+
+
+def _admin_ctx(
+    org_id: str = "org-00000000000000",
+    workspace_id: str = "ws-00000000000000",
+    user_id: str = "usr-admin",
+) -> ScopeContext:
+    return ScopeContext(
+        org_id=org_id,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        role=Role.ADMIN,
+    )
+
+
+def _other_ctx(
+    org_id: str = "org-00000000000000",
+    workspace_id: str = "ws-00000000000000",
+    user_id: str = "usr-other",
+) -> ScopeContext:
+    return ScopeContext(
+        org_id=org_id,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        role=Role.MEMBER,
+    )
+
+
+async def _create_task(
+    session: AsyncSession,
+    ctx: ScopeContext | None = None,
+    **overrides: object,
+) -> ScheduledTask:
+    svc = ScheduledTaskService()
+    if ctx is None:
+        ctx = _owner_ctx()
+    defaults: dict[str, object] = {
+        "name": "test-task",
+        "prompt": "do something",
+        "schedule_kind": "interval",
+        "interval_seconds": 3600,
+        "target_mode": "new_each_run",
+    }
+    defaults.update(overrides)
+    return await svc.create(ctx, session, defaults)
+
+
+class TestCreate:
+    @pytest.mark.anyio
+    async def test_create_interval(self, async_session: AsyncSession) -> None:
+        task = await _create_task(async_session)
+        assert task.status == "active"
+        assert task.next_fire_at is not None
+        assert task.owner_user_id == "usr-owner"
+
+    @pytest.mark.anyio
+    async def test_create_cron_requires_expr(self, async_session: AsyncSession) -> None:
+        with pytest.raises(ActionInvalidInput, match="cron_expr"):
+            await _create_task(async_session, schedule_kind="cron", interval_seconds=None)
+
+    @pytest.mark.anyio
+    async def test_create_once_requires_run_at(self, async_session: AsyncSession) -> None:
+        with pytest.raises(ActionInvalidInput, match="run_at"):
+            await _create_task(
+                async_session,
+                schedule_kind="once",
+                interval_seconds=None,
+            )
+
+
+class TestAuthorization:
+    @pytest.mark.anyio
+    async def test_owner_can_pause(self, async_session: AsyncSession) -> None:
+        task = await _create_task(async_session, ctx=_owner_ctx())
+        svc = ScheduledTaskService()
+        result = await svc.pause(_owner_ctx(), async_session, task.id)
+        assert result.status == "paused"
+
+    @pytest.mark.anyio
+    async def test_admin_can_pause(self, async_session: AsyncSession) -> None:
+        task = await _create_task(async_session, ctx=_owner_ctx())
+        svc = ScheduledTaskService()
+        result = await svc.pause(_admin_ctx(), async_session, task.id)
+        assert result.status == "paused"
+
+    @pytest.mark.anyio
+    async def test_other_member_cannot_pause(self, async_session: AsyncSession) -> None:
+        task = await _create_task(async_session, ctx=_owner_ctx())
+        svc = ScheduledTaskService()
+        with pytest.raises(ActionPermissionDenied):
+            await svc.pause(_other_ctx(), async_session, task.id)
+
+
+class TestPauseResume:
+    @pytest.mark.anyio
+    async def test_pause_resume_cycle(self, async_session: AsyncSession) -> None:
+        task = await _create_task(async_session)
+        svc = ScheduledTaskService()
+        paused = await svc.pause(_owner_ctx(), async_session, task.id)
+        assert paused.status == "paused"
+        resumed = await svc.resume(_owner_ctx(), async_session, task.id)
+        assert resumed.status == "active"
+        assert resumed.next_fire_at is not None
+
+
+class TestDelete:
+    @pytest.mark.anyio
+    async def test_delete_then_not_found(self, async_session: AsyncSession) -> None:
+        task = await _create_task(async_session)
+        svc = ScheduledTaskService()
+        await svc.delete(_owner_ctx(), async_session, task.id)
+        with pytest.raises(ActionNotFound):
+            await svc.get_task(_owner_ctx(), async_session, task.id)
+
+
+class TestUpdate:
+    @pytest.mark.anyio
+    async def test_update_prompt_no_schedule_slide(self, async_session: AsyncSession) -> None:
+        task = await _create_task(async_session)
+        svc = ScheduledTaskService()
+        original_fire = task.next_fire_at
+        updated = await svc.update(_owner_ctx(), async_session, task.id, {"prompt": "new"})
+        assert updated.prompt == "new"
+        assert updated.next_fire_at == original_fire
+
+    @pytest.mark.anyio
+    async def test_update_interval_recomputes_fire(self, async_session: AsyncSession) -> None:
+        task = await _create_task(async_session)
+        svc = ScheduledTaskService()
+        original_fire = task.next_fire_at
+        updated = await svc.update(
+            _owner_ctx(), async_session, task.id, {"interval_seconds": 7200}
+        )
+        assert updated.next_fire_at != original_fire
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/unit/test_scheduled_task_service.py -v --no-header 2>&1 | head -20`
+Expected: FAIL — `ModuleNotFoundError: No module named 'cubebox.services.scheduled_task'`
+
+- [ ] **Step 3: Implement `ScheduledTaskService`**
+
+This service extracts all logic from `ws_scheduled_tasks.py`. The key rules:
+- Service owns the transaction (single `session.commit()` at the end of each mutation).
+- Does NOT use `ScopedRepository.add()` or `.delete()` (they auto-commit). Instead uses `session.add()` + explicit `session.commit()`.
+- Uses `begin_nested()` for the race-safe history insert in `resume` (mirrors `_resume_next_fire`).
+- Authorization: checks `task.owner_user_id == ctx.user_id or ctx.role == Role.ADMIN` before mutations.
+- Validation: reuses `_validate_timezone`, `_validate_cron` from `cubebox.api.schemas.ws_scheduled_tasks`.
+
+```python
+# backend/cubebox/services/scheduled_task.py
+"""ScheduledTaskService — source of truth for scheduled-task operations.
+
+Both the REST route (thin adapter) and the agent tool (via the action
+registry) delegate here. The service owns:
+  - input validation (cron, timezone, schedule-kind consistency)
+  - authorization (owner-or-admin for mutations)
+  - schedule computation (next_fire_at via schedules.compute)
+  - transaction ownership (single commit per mutating call)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.agents.actions.context import ScopeContext
+from cubebox.agents.actions.types import ActionInvalidInput, ActionNotFound, ActionPermissionDenied
+from cubebox.api.schemas.ws_scheduled_tasks import _validate_cron, _validate_timezone
+from cubebox.models.membership import Role
+from cubebox.models.scheduled_task import ScheduledTask, ScheduledTaskRun
+from cubebox.schedules.compute import as_utc, latest_due_before, next_fire_after
+
+
+_SCHEDULE_FIELDS: frozenset[str] = frozenset(
+    {"schedule_kind", "cron_expr", "interval_seconds", "run_at", "timezone"}
+)
+
+
+def _to_utc_naive(dt: datetime) -> datetime:
+    return dt.astimezone(UTC).replace(tzinfo=None) if dt.tzinfo is not None else dt
+
+
+def _initial_next_fire(task: ScheduledTask) -> datetime | None:
+    now = datetime.now(UTC)
+    if task.schedule_kind == "once":
+        return task.run_at
+    return next_fire_after(
+        kind=task.schedule_kind,
+        after=now,
+        cron_expr=task.cron_expr,
+        interval_seconds=task.interval_seconds,
+        tz=task.timezone,
+    )
+
+
+def _validate_create(data: dict[str, Any]) -> None:
+    """Validate create input — mirrors ScheduledTaskCreate model_validator."""
+    kind = data.get("schedule_kind")
+    tz = data.get("timezone", "UTC")
+    try:
+        _validate_timezone(tz)
+    except ValueError as exc:
+        raise ActionInvalidInput(str(exc)) from exc
+
+    if kind == "cron":
+        expr = data.get("cron_expr")
+        if not expr:
+            raise ActionInvalidInput("cron_expr required for cron schedule")
+        try:
+            _validate_cron(expr)
+        except ValueError as exc:
+            raise ActionInvalidInput(str(exc)) from exc
+    elif kind == "interval":
+        interval = data.get("interval_seconds")
+        if not interval or interval < 60:
+            raise ActionInvalidInput("interval_seconds >= 60 required for interval schedule")
+    elif kind == "once":
+        run_at = data.get("run_at")
+        if run_at is None:
+            raise ActionInvalidInput("run_at required for once schedule")
+        if isinstance(run_at, datetime) and run_at.tzinfo is None:
+            raise ActionInvalidInput("run_at must include a timezone offset")
+    else:
+        raise ActionInvalidInput(f"unknown schedule_kind: {kind!r}")
+
+    end_at = data.get("end_at")
+    if end_at is not None and isinstance(end_at, datetime) and end_at.tzinfo is None:
+        raise ActionInvalidInput("end_at must include a timezone offset")
+
+    target_mode = data.get("target_mode")
+    if target_mode == "fixed" and not data.get("target_conversation_id"):
+        raise ActionInvalidInput("target_conversation_id required when target_mode=fixed")
+
+
+def _validate_patch(data: dict[str, Any]) -> None:
+    """Validate patch input — mirrors ScheduledTaskPatch model_validator."""
+    tz = data.get("timezone")
+    if tz is not None:
+        try:
+            _validate_timezone(tz)
+        except ValueError as exc:
+            raise ActionInvalidInput(str(exc)) from exc
+
+    expr = data.get("cron_expr")
+    if expr is not None:
+        try:
+            _validate_cron(expr)
+        except ValueError as exc:
+            raise ActionInvalidInput(str(exc)) from exc
+
+    run_at = data.get("run_at")
+    if run_at is not None and isinstance(run_at, datetime) and run_at.tzinfo is None:
+        raise ActionInvalidInput("run_at must include a timezone offset")
+    end_at = data.get("end_at")
+    if end_at is not None and isinstance(end_at, datetime) and end_at.tzinfo is None:
+        raise ActionInvalidInput("end_at must include a timezone offset")
+
+    kind = data.get("schedule_kind")
+    if kind == "cron" and not data.get("cron_expr"):
+        raise ActionInvalidInput("cron_expr required when changing schedule_kind to cron")
+    if kind == "interval" and not data.get("interval_seconds"):
+        raise ActionInvalidInput("interval_seconds required when changing schedule_kind to interval")
+    if kind == "once" and data.get("run_at") is None:
+        raise ActionInvalidInput("run_at required when changing schedule_kind to once")
+
+
+class ScheduledTaskService:
+    """Source of truth for scheduled-task CRUD + lifecycle.
+
+    Stateless — no constructor args. All state comes from (ctx, session, input).
+    """
+
+    # --- reads ---
+
+    async def list_tasks(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        _input: Any = None,
+    ) -> list[ScheduledTask]:
+        stmt = (
+            select(ScheduledTask)
+            .where(
+                ScheduledTask.org_id == ctx.org_id,  # type: ignore[arg-type]
+                ScheduledTask.workspace_id == ctx.workspace_id,  # type: ignore[arg-type]
+                cast(Any, ScheduledTask.deleted_at).is_(None),
+            )
+            .order_by(ScheduledTask.created_at.desc())  # type: ignore[attr-defined]
+            .limit(100)
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_task(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> ScheduledTask:
+        task = await self._load(ctx, session, task_id)
+        return task
+
+    async def list_runs(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> list[ScheduledTaskRun]:
+        await self._load(ctx, session, task_id)
+        stmt = (
+            select(ScheduledTaskRun)
+            .where(
+                ScheduledTaskRun.org_id == ctx.org_id,  # type: ignore[arg-type]
+                ScheduledTaskRun.workspace_id == ctx.workspace_id,  # type: ignore[arg-type]
+                ScheduledTaskRun.scheduled_task_id == task_id,
+            )
+            .order_by(ScheduledTaskRun.scheduled_for.desc())  # type: ignore[attr-defined]
+            .limit(50)
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    # --- mutations (service owns the transaction) ---
+
+    async def create(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        data: dict[str, Any],
+    ) -> ScheduledTask:
+        _validate_create(data)
+
+        if data.get("target_mode") == "fixed":
+            await self._check_conversation_ownership(
+                session, ctx, data.get("target_conversation_id", "")
+            )
+
+        run_at = data.get("run_at")
+        end_at = data.get("end_at")
+        task = ScheduledTask(
+            org_id=ctx.org_id,
+            workspace_id=ctx.workspace_id,
+            owner_user_id=ctx.user_id,
+            name=data["name"],
+            prompt=data["prompt"],
+            schedule_kind=data["schedule_kind"],
+            cron_expr=data.get("cron_expr"),
+            interval_seconds=data.get("interval_seconds"),
+            run_at=_to_utc_naive(run_at) if isinstance(run_at, datetime) else None,
+            end_at=_to_utc_naive(end_at) if isinstance(end_at, datetime) else None,
+            timezone=data.get("timezone", "UTC"),
+            target_mode=data["target_mode"],
+            target_conversation_id=data.get("target_conversation_id"),
+            status="active",
+        )
+        task.next_fire_at = _initial_next_fire(task)
+        session.add(task)
+        await session.commit()
+        await session.refresh(task)
+        return task
+
+    async def update(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+        data: dict[str, Any],
+    ) -> ScheduledTask:
+        _validate_patch(data)
+        task = await self._load_for_mutation(ctx, session, task_id)
+
+        if data.get("target_mode") == "fixed" or (
+            data.get("target_conversation_id") is not None and task.target_mode == "fixed"
+        ):
+            target = data.get("target_conversation_id") or task.target_conversation_id
+            await self._check_conversation_ownership(
+                session,
+                ScopeContext(
+                    org_id=ctx.org_id,
+                    workspace_id=ctx.workspace_id,
+                    user_id=task.owner_user_id,
+                    role=ctx.role,
+                ),
+                target or "",
+            )
+
+        touched_schedule = False
+        for field in (
+            "name", "prompt", "schedule_kind", "cron_expr", "interval_seconds",
+            "run_at", "timezone", "target_mode", "target_conversation_id",
+        ):
+            val = data.get(field)
+            if val is None and field not in data:
+                continue
+            if field == "run_at" and isinstance(val, datetime):
+                val = _to_utc_naive(val)
+            if field in _SCHEDULE_FIELDS and val != getattr(task, field):
+                touched_schedule = True
+            setattr(task, field, val)
+
+        if "end_at" in data:
+            end_val = data["end_at"]
+            task.end_at = _to_utc_naive(end_val) if isinstance(end_val, datetime) else None
+
+        if touched_schedule:
+            task.next_fire_at = _initial_next_fire(task) if task.status == "active" else None
+
+        task.updated_at = datetime.now(UTC)
+        await session.commit()
+        await session.refresh(task)
+        return task
+
+    async def pause(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> ScheduledTask:
+        task = await self._load_for_mutation(ctx, session, task_id)
+        task.status = "paused"
+        task.updated_at = datetime.now(UTC)
+        await session.commit()
+        await session.refresh(task)
+        return task
+
+    async def resume(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> ScheduledTask:
+        task = await self._load_for_mutation(ctx, session, task_id)
+        task.status = "active"
+        task.next_fire_at = await self._resume_next_fire(session, task)
+        task.updated_at = datetime.now(UTC)
+        await session.commit()
+        await session.refresh(task)
+        return task
+
+    async def delete(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> None:
+        task = await self._load_for_mutation(ctx, session, task_id)
+        task.deleted_at = datetime.now(UTC)
+        task.next_fire_at = None
+        await session.commit()
+
+    # --- internals ---
+
+    async def _load(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> ScheduledTask:
+        stmt = select(ScheduledTask).where(
+            ScheduledTask.id == task_id,
+            ScheduledTask.org_id == ctx.org_id,  # type: ignore[arg-type]
+            ScheduledTask.workspace_id == ctx.workspace_id,  # type: ignore[arg-type]
+            cast(Any, ScheduledTask.deleted_at).is_(None),
+        )
+        task = (await session.execute(stmt)).scalar_one_or_none()
+        if task is None:
+            raise ActionNotFound("Scheduled task not found")
+        return task
+
+    async def _load_for_mutation(
+        self,
+        ctx: ScopeContext,
+        session: AsyncSession,
+        task_id: str,
+    ) -> ScheduledTask:
+        task = await self._load(ctx, session, task_id)
+        if task.owner_user_id != ctx.user_id and ctx.role != Role.ADMIN:
+            raise ActionPermissionDenied("Owner or admin required")
+        return task
+
+    async def _check_conversation_ownership(
+        self,
+        session: AsyncSession,
+        ctx: ScopeContext,
+        conversation_id: str,
+    ) -> None:
+        from cubebox.repositories.conversation import ConversationRepository
+
+        conv_repo = ConversationRepository(
+            session,
+            org_id=ctx.org_id,
+            workspace_id=ctx.workspace_id,
+            user_id=ctx.user_id,
+        )
+        if await conv_repo.get_by_id(conversation_id) is None:
+            raise ActionInvalidInput("target_conversation_id must be your own conversation")
+
+    async def _resume_next_fire(
+        self,
+        session: AsyncSession,
+        task: ScheduledTask,
+    ) -> datetime | None:
+        now = datetime.now(UTC)
+        anchor = as_utc(task.next_fire_at) if task.next_fire_at is not None else None
+
+        if task.schedule_kind == "once":
+            run_at = as_utc(task.run_at) if task.run_at is not None else None
+            if run_at is not None and run_at <= now:
+                scheduled_for_naive = _to_utc_naive(run_at)
+                try:
+                    async with session.begin_nested():
+                        session.add(
+                            ScheduledTaskRun(
+                                scheduled_task_id=task.id,
+                                org_id=task.org_id,
+                                workspace_id=task.workspace_id,
+                                scheduled_for=scheduled_for_naive,
+                                claimed_at=now,
+                                state="skipped_missed",
+                                detail="paused past its one-shot fire time",
+                            )
+                        )
+                        await session.flush()
+                except IntegrityError:
+                    pass
+                return None
+            return run_at
+
+        if anchor is None or anchor > now:
+            return anchor if anchor is not None else _initial_next_fire(task)
+
+        latest_due = latest_due_before(
+            kind=task.schedule_kind,
+            candidate=anchor,
+            now=now,
+            cron_expr=task.cron_expr,
+            interval_seconds=task.interval_seconds,
+            tz=task.timezone,
+        )
+        session.add(
+            ScheduledTaskRun(
+                scheduled_task_id=task.id,
+                org_id=task.org_id,
+                workspace_id=task.workspace_id,
+                scheduled_for=anchor,
+                claimed_at=now,
+                state="skipped_missed",
+                detail=f"paused: skipped {anchor.isoformat()}..{latest_due.isoformat()}",
+            )
+        )
+        return next_fire_after(
+            kind=task.schedule_kind,
+            after=latest_due,
+            cron_expr=task.cron_expr,
+            interval_seconds=task.interval_seconds,
+            tz=task.timezone,
+        )
+```
+
+- [ ] **Step 4: Make `_validate_cron` and `_validate_timezone` importable from schemas**
+
+The functions are module-level in `ws_scheduled_tasks.py` (schemas). They are already importable — confirm by checking:
+
+Run: `cd backend && uv run python -c "from cubebox.api.schemas.ws_scheduled_tasks import _validate_cron, _validate_timezone; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 5: Run the service tests**
+
+Run: `cd backend && uv run pytest tests/unit/test_scheduled_task_service.py -v --no-header 2>&1 | tail -20`
+Expected: all pass
+
+- [ ] **Step 6: Run mypy on the service**
+
+Run: `cd backend && uv run mypy cubebox/services/scheduled_task.py`
+Expected: `Success: no issues found`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/cubebox/services/scheduled_task.py backend/tests/unit/test_scheduled_task_service.py
+git commit -m "feat(services): extract ScheduledTaskService from route handlers"
+```
+
+---
+
+### Task 4: Refactor routes to thin adapters
+
+**Files:**
+- Modify: `backend/cubebox/api/routes/v1/ws_scheduled_tasks.py`
+
+Replace all inline business logic with calls to `ScheduledTaskService`. The route keeps `_to_out` serialization and the `_iso` helper (these are route-layer concerns — translating domain objects into HTTP response shapes). All existing E2E tests must stay green.
+
+- [ ] **Step 1: Run existing route tests (baseline)**
+
+Run: `cd backend && uv run pytest tests/e2e/test_scheduled_tasks_api.py -v --no-header 2>&1 | tail -25`
+Expected: all pass (establish green baseline)
+
+- [ ] **Step 2: Refactor the route module**
+
+Replace `ws_scheduled_tasks.py` with a thin adapter. Keep:
+- `router`, `_iso`, `_to_out`, `ScheduledTaskOut` import, all FastAPI decorators
+- `ScopeContext.from_request(ctx)` construction per handler
+
+Remove from the route module:
+- `_initial_next_fire`, `_resume_next_fire`, `_to_utc_naive`, `_SCHEDULE_FIELDS`
+- All inline validation, schedule computation, owner-or-admin checks
+- Direct `ScheduledTask(...)` construction
+
+Each handler becomes:
+
+```python
+# Pattern for all handlers:
+from cubebox.agents.actions.context import ScopeContext
+from cubebox.agents.actions.types import ActionInvalidInput, ActionNotFound, ActionPermissionDenied
+from cubebox.services.scheduled_task import ScheduledTaskService
+
+_svc = ScheduledTaskService()
+
+
+def _scope(ctx: RequestContext) -> ScopeContext:
+    return ScopeContext(
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+        role=ctx.role,
+    )
+
+
+async def _handle_domain_errors(coro):
+    """Call a service coroutine and translate domain exceptions to HTTP."""
+    try:
+        return await coro
+    except ActionNotFound as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+    except ActionPermissionDenied as exc:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from exc
+    except ActionInvalidInput as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
+```
+
+Then each route is 3-5 lines:
+
+```python
+@router.post("", status_code=status.HTTP_201_CREATED, response_model=ScheduledTaskOut)
+async def create_task(
+    body: ScheduledTaskCreate,
+    ctx: Annotated[RequestContext, Depends(require_member)],
+) -> ScheduledTaskOut:
+    async with async_session_maker() as session:
+        task = await _handle_domain_errors(
+            _svc.create(_scope(ctx), session, body.model_dump())
+        )
+    return _to_out(task)
+```
+
+Apply this pattern to all 8 handlers: `create_task`, `list_tasks`, `get_task`, `patch_task`, `pause_task`, `resume_task`, `delete_task`, `list_task_runs`.
+
+- [ ] **Step 3: Remove unused imports from the route module**
+
+After refactoring, remove: `IntegrityError`, `ConversationRepository`, `next_fire_after`, `latest_due_before`, `as_utc`, and any other now-unused imports.
+
+- [ ] **Step 4: Run the existing E2E tests**
+
+Run: `cd backend && uv run pytest tests/e2e/test_scheduled_tasks_api.py -v --no-header 2>&1 | tail -25`
+Expected: all pass (behavior-preserving refactor)
+
+- [ ] **Step 5: Run mypy**
+
+Run: `cd backend && uv run mypy cubebox/api/routes/v1/ws_scheduled_tasks.py`
+Expected: `Success: no issues found`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cubebox/api/routes/v1/ws_scheduled_tasks.py
+git commit -m "refactor(routes): scheduled-tasks routes → thin adapters over ScheduledTaskService"
+```
+
+---
+
+### Task 5: Scheduled-tasks capability declaration
+
+**Files:**
+- Create: `backend/cubebox/agents/actions/capabilities/scheduled_tasks.py`
+
+Declares the 8 operations pointing at `ScheduledTaskService` methods, with LLM-facing descriptions.
+
+- [ ] **Step 1: Create the capability declaration**
+
+```python
+# backend/cubebox/agents/actions/capabilities/scheduled_tasks.py
+"""scheduled_tasks capability — declares operations for the agent tool."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from cubebox.agents.actions.context import ScopeContext
+from cubebox.agents.actions.types import AgentCapability, AgentOperation
+from cubebox.services.scheduled_task import ScheduledTaskService
+from cubebox.utils.time import utc_isoformat
+
+_svc = ScheduledTaskService()
+
+
+def _iso(dt: datetime | None) -> str | None:
+    return utc_isoformat(dt) if dt is not None else None
+
+
+def _task_summary(task: Any) -> dict[str, Any]:
+    return {
+        "id": task.id,
+        "name": task.name,
+        "status": task.status,
+        "schedule_kind": task.schedule_kind,
+        "cron_expr": task.cron_expr,
+        "interval_seconds": task.interval_seconds,
+        "timezone": task.timezone,
+        "prompt": task.prompt,
+        "target_mode": task.target_mode,
+        "next_fire_at": _iso(task.next_fire_at),
+        "last_fired_at": _iso(task.last_fired_at),
+    }
+
+
+# --- Input models per operation ---
+
+class ListInput(BaseModel):
+    pass
+
+
+class GetInput(BaseModel):
+    task_id: str = Field(description="The scheduled task ID (e.g. stask-...)")
+
+
+class ListRunsInput(BaseModel):
+    task_id: str = Field(description="The scheduled task ID")
+
+
+class CreateInput(BaseModel):
+    name: str = Field(description="Human-readable name for the task")
+    prompt: str = Field(description="The prompt the agent will execute on each run")
+    schedule_kind: Literal["cron", "interval", "once"] = Field(
+        description="'cron' for cron expression, 'interval' for fixed seconds, 'once' for one-shot"
+    )
+    cron_expr: str | None = Field(
+        default=None,
+        description="5-field cron expression (required when schedule_kind='cron')",
+    )
+    interval_seconds: int | None = Field(
+        default=None,
+        ge=60,
+        description="Seconds between runs (required when schedule_kind='interval', min 60)",
+    )
+    run_at: datetime | None = Field(
+        default=None,
+        description="ISO 8601 datetime with tz offset (required when schedule_kind='once')",
+    )
+    timezone: str = Field(
+        default="UTC",
+        description="IANA timezone for cron evaluation (e.g. 'Asia/Shanghai')",
+    )
+    target: Literal["new_each_run", "current_conversation"] = Field(
+        default="new_each_run",
+        description=(
+            "'new_each_run' creates a fresh conversation each time (default). "
+            "'current_conversation' pins results to the conversation you're in now."
+        ),
+    )
+    end_at: datetime | None = Field(
+        default=None,
+        description="Optional: stop scheduling after this datetime (ISO 8601 with tz offset)",
+    )
+
+
+class UpdateInput(BaseModel):
+    task_id: str = Field(description="The scheduled task ID")
+    name: str | None = None
+    prompt: str | None = None
+    schedule_kind: Literal["cron", "interval", "once"] | None = None
+    cron_expr: str | None = None
+    interval_seconds: int | None = Field(default=None, ge=60)
+    run_at: datetime | None = None
+    timezone: str | None = None
+    target_mode: Literal["fixed", "new_each_run"] | None = None
+    target_conversation_id: str | None = None
+    end_at: datetime | None = None
+
+
+class PauseInput(BaseModel):
+    task_id: str = Field(description="The scheduled task ID")
+
+
+class ResumeInput(BaseModel):
+    task_id: str = Field(description="The scheduled task ID")
+
+
+class DeleteInput(BaseModel):
+    task_id: str = Field(description="The scheduled task ID")
+
+
+# --- Handlers (adapt service methods to the registry's calling convention) ---
+
+async def _handle_list(ctx: ScopeContext, session: Any, _input: ListInput) -> Any:
+    tasks = await _svc.list_tasks(ctx, session)
+    return {"tasks": [_task_summary(t) for t in tasks]}
+
+
+async def _handle_get(ctx: ScopeContext, session: Any, inp: GetInput) -> Any:
+    task = await _svc.get_task(ctx, session, inp.task_id)
+    return _task_summary(task)
+
+
+async def _handle_list_runs(ctx: ScopeContext, session: Any, inp: ListRunsInput) -> Any:
+    runs = await _svc.list_runs(ctx, session, inp.task_id)
+    return {
+        "runs": [
+            {
+                "id": r.id,
+                "scheduled_for": _iso(r.scheduled_for),
+                "state": r.state,
+                "run_id": r.run_id,
+                "conversation_id": r.conversation_id,
+                "detail": r.detail,
+            }
+            for r in runs
+        ]
+    }
+
+
+async def _handle_create(ctx: ScopeContext, session: Any, inp: CreateInput) -> Any:
+    data: dict[str, Any] = {
+        "name": inp.name,
+        "prompt": inp.prompt,
+        "schedule_kind": inp.schedule_kind,
+        "cron_expr": inp.cron_expr,
+        "interval_seconds": inp.interval_seconds,
+        "run_at": inp.run_at,
+        "timezone": inp.timezone,
+        "end_at": inp.end_at,
+        "target_mode": "new_each_run",
+        "target_conversation_id": None,
+    }
+    if inp.target == "current_conversation":
+        if ctx.conversation_id is None:
+            from cubebox.agents.actions.types import ActionInvalidInput
+
+            raise ActionInvalidInput("Cannot pin to current conversation: no conversation context")
+        data["target_mode"] = "fixed"
+        data["target_conversation_id"] = ctx.conversation_id
+
+    task = await _svc.create(ctx, session, data)
+    return _task_summary(task)
+
+
+async def _handle_update(ctx: ScopeContext, session: Any, inp: UpdateInput) -> Any:
+    data = {k: v for k, v in inp.model_dump(exclude={"task_id"}).items() if v is not None}
+    if "end_at" in inp.model_fields_set:
+        data["end_at"] = inp.end_at
+    task = await _svc.update(ctx, session, inp.task_id, data)
+    return _task_summary(task)
+
+
+async def _handle_pause(ctx: ScopeContext, session: Any, inp: PauseInput) -> Any:
+    task = await _svc.pause(ctx, session, inp.task_id)
+    return _task_summary(task)
+
+
+async def _handle_resume(ctx: ScopeContext, session: Any, inp: ResumeInput) -> Any:
+    task = await _svc.resume(ctx, session, inp.task_id)
+    return _task_summary(task)
+
+
+async def _handle_delete(ctx: ScopeContext, session: Any, inp: DeleteInput) -> Any:
+    await _svc.delete(ctx, session, inp.task_id)
+    return {"deleted": True, "task_id": inp.task_id}
+
+
+# --- Capability declaration ---
+
+SCHEDULED_TASKS_CAPABILITY = AgentCapability(
+    name="scheduled_tasks",
+    description=(
+        "Manage scheduled tasks in the current workspace. "
+        "Each task runs a prompt on a cron, interval, or one-shot schedule. "
+        "Only create, update, pause, resume, or delete tasks when the user "
+        "has explicitly asked you to."
+    ),
+    operations=[
+        AgentOperation(
+            name="list",
+            description="List all scheduled tasks in the workspace",
+            input_model=ListInput,
+            handler=_handle_list,
+            mutates=False,
+        ),
+        AgentOperation(
+            name="get",
+            description="Get details of a specific scheduled task by ID",
+            input_model=GetInput,
+            handler=_handle_get,
+            mutates=False,
+        ),
+        AgentOperation(
+            name="list_runs",
+            description="List run history for a scheduled task",
+            input_model=ListRunsInput,
+            handler=_handle_list_runs,
+            mutates=False,
+        ),
+        AgentOperation(
+            name="create",
+            description=(
+                "Create a new scheduled task. Only call when the user explicitly asks. "
+                "Default target is 'new_each_run' (each trigger creates a new conversation). "
+                "Use 'current_conversation' to pin results to this conversation."
+            ),
+            input_model=CreateInput,
+            handler=_handle_create,
+            mutates=True,
+        ),
+        AgentOperation(
+            name="update",
+            description="Update a scheduled task's settings. Only call when the user explicitly asks.",
+            input_model=UpdateInput,
+            handler=_handle_update,
+            mutates=True,
+        ),
+        AgentOperation(
+            name="pause",
+            description="Pause a scheduled task. Only call when the user explicitly asks.",
+            input_model=PauseInput,
+            handler=_handle_pause,
+            mutates=True,
+        ),
+        AgentOperation(
+            name="resume",
+            description="Resume a paused scheduled task. Only call when the user explicitly asks.",
+            input_model=ResumeInput,
+            handler=_handle_resume,
+            mutates=True,
+        ),
+        AgentOperation(
+            name="delete",
+            description="Delete a scheduled task. Only call when the user explicitly asks.",
+            input_model=DeleteInput,
+            handler=_handle_delete,
+            mutates=True,
+        ),
+    ],
+)
+```
+
+- [ ] **Step 2: Verify the capability is importable**
+
+Run: `cd backend && uv run python -c "from cubebox.agents.actions.capabilities.scheduled_tasks import SCHEDULED_TASKS_CAPABILITY; print(len(SCHEDULED_TASKS_CAPABILITY.operations), 'operations')"`
+Expected: `8 operations`
+
+- [ ] **Step 3: Run mypy**
+
+Run: `cd backend && uv run mypy cubebox/agents/actions/capabilities/scheduled_tasks.py`
+Expected: `Success: no issues found`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/cubebox/agents/actions/capabilities/
+git commit -m "feat(actions): declare scheduled_tasks capability with 8 operations"
+```
+
+---
+
+### Task 6: Registry + `tools_for_run`
+
+**Files:**
+- Create: `backend/cubebox/agents/actions/registry.py`
+
+Simple module: lists all capabilities, exposes `tools_for_run()` that the run manager calls.
+
+- [ ] **Step 1: Create the registry**
+
+```python
+# backend/cubebox/agents/actions/registry.py
+"""Agent capability registry — the single entry point for run_manager."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cubepi.agent.types import AgentTool
+
+from cubebox.agents.actions.builder import ContextFactory, build_capability_tool
+from cubebox.agents.actions.capabilities.scheduled_tasks import SCHEDULED_TASKS_CAPABILITY
+from cubebox.agents.actions.types import AgentCapability
+
+AGENT_CAPABILITIES: list[AgentCapability] = [
+    SCHEDULED_TASKS_CAPABILITY,
+]
+
+
+def tools_for_run(
+    context_factory: ContextFactory,
+    *,
+    allow_mutations: bool,
+) -> list[AgentTool[Any]]:
+    """Build agent tools for all registered capabilities.
+
+    Called once per run from run_manager. Returns one tool per capability
+    (or zero if a capability has no surviving operations after the mutation gate).
+    """
+    tools: list[AgentTool[Any]] = []
+    for cap in AGENT_CAPABILITIES:
+        tool = build_capability_tool(cap, context_factory, allow_mutations=allow_mutations)
+        if tool is not None:
+            tools.append(tool)
+    return tools
+```
+
+- [ ] **Step 2: Verify importable**
+
+Run: `cd backend && uv run python -c "from cubebox.agents.actions.registry import tools_for_run; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Run mypy**
+
+Run: `cd backend && uv run mypy cubebox/agents/actions/registry.py`
+Expected: `Success: no issues found`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/cubebox/agents/actions/registry.py
+git commit -m "feat(actions): capability registry with tools_for_run entry point"
+```
+
+---
+
+### Task 7: Thread trigger signal + wire `tools_for_run` into run_manager
+
+**Files:**
+- Modify: `backend/cubebox/streams/run_manager.py:30` — add `trigger` to `RunContext`
+- Modify: `backend/cubebox/streams/run_manager.py:540` — thread `trigger` through `start_run` → `_execute_run` → `_run_cubepi_path`
+- Modify: `backend/cubebox/streams/run_manager.py:969` — accept `trigger`, wire `tools_for_run`
+- Modify: `backend/cubebox/schedules/dispatch.py:91` — pass `trigger="automated"` in `RunContext`
+
+This task threads the interactivity signal and wires the action registry's tools into the agent.
+
+- [ ] **Step 1: Add `trigger` field to `RunContext`**
+
+In `run_manager.py`, change the `RunContext` dataclass (~line 30):
+
+```python
+@dataclass
+class RunContext:
+    """Scoped context required to execute a run."""
+
+    user_id: str
+    org_id: str
+    workspace_id: str
+    trigger: str = "interactive"  # "interactive" | "automated"
+```
+
+- [ ] **Step 2: Thread `trigger` from `_execute_run` to `_run_cubepi_path`**
+
+Add `trigger` to `_run_cubepi_path`'s signature (~line 969) and pass it from `_execute_run` (~line 2102):
+
+In `_run_cubepi_path` signature, add after `catalog_session`:
+```python
+    trigger: str = "interactive",
+```
+
+In the `_execute_run` call to `_run_cubepi_path` (~line 2102), add:
+```python
+    trigger=ctx.trigger,
+```
+
+- [ ] **Step 3: Wire `tools_for_run` into `_run_cubepi_path`**
+
+After the existing `show_widget` tool block (after ~line 1220), add:
+
+```python
+        # Platform action tools (scheduled_tasks, etc.) — via the capability
+        # registry. Automated runs get read-only tools (mutation gate).
+        try:
+            from cubebox.agents.actions.registry import tools_for_run as _action_tools_for_run
+
+            async with async_session_maker() as _action_session:
+                _role = await MembershipRepository(_action_session).get_role(
+                    user_id=ctx.user_id, workspace_id=ctx.workspace_id,
+                )
+
+            if _role is not None:
+                from collections.abc import AsyncIterator as _ActionsAsyncIterator
+                from contextlib import asynccontextmanager as _actions_acm
+
+                from cubebox.agents.actions.context import ScopeContext as _ScopeContext
+
+                @_actions_acm
+                async def _action_context_factory() -> _ActionsAsyncIterator[tuple[_ScopeContext, Any]]:
+                    async with async_session_maker() as _sess:
+                        yield (
+                            _ScopeContext(
+                                org_id=ctx.org_id,
+                                workspace_id=ctx.workspace_id,
+                                user_id=ctx.user_id,
+                                role=_role,
+                                conversation_id=conversation_id,
+                            ),
+                            _sess,
+                        )
+
+                _builtin_tools.extend(
+                    _action_tools_for_run(
+                        _action_context_factory,
+                        allow_mutations=(trigger == "interactive"),
+                    )
+                )
+        except Exception as _exc:
+            logger.warning("platform action tools unavailable for cubepi run: {}", _exc)
+```
+
+- [ ] **Step 4: Update `dispatch_scheduled_run` to pass `trigger="automated"`**
+
+In `dispatch.py` (~line 91), change:
+
+```python
+    ctx = RunContext(
+        user_id=task.owner_user_id,
+        org_id=task.org_id,
+        workspace_id=task.workspace_id,
+        trigger="automated",
+    )
+```
+
+- [ ] **Step 5: Run mypy on changed files**
+
+Run: `cd backend && uv run mypy cubebox/streams/run_manager.py cubebox/schedules/dispatch.py`
+Expected: `Success: no issues found`
+
+- [ ] **Step 6: Run the existing scheduled-task E2E tests (regression check)**
+
+Run: `cd backend && uv run pytest tests/e2e/test_scheduled_tasks_api.py tests/e2e/test_scheduled_tasks_firing.py -v --no-header 2>&1 | tail -30`
+Expected: all pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/cubebox/streams/run_manager.py backend/cubebox/schedules/dispatch.py
+git commit -m "feat(actions): thread trigger signal + wire tools_for_run into run_manager"
+```
+
+---
+
+### Task 8: Full mypy + existing test suite guard
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run full mypy**
+
+Run: `cd backend && uv run mypy cubebox/`
+Expected: `Success: no issues found`
+
+- [ ] **Step 2: Run all existing scheduled-task tests**
+
+Run: `cd backend && uv run pytest tests/e2e/test_scheduled_tasks_api.py tests/e2e/test_scheduled_tasks_firing.py tests/unit/test_schedule_compute.py tests/unit/test_scheduled_task_schemas.py -v --no-header 2>&1 | tail -30`
+Expected: all pass
+
+- [ ] **Step 3: Run the new tests**
+
+Run: `cd backend && uv run pytest tests/unit/test_agent_action_builder.py tests/unit/test_scheduled_task_service.py -v --no-header 2>&1 | tail -30`
+Expected: all pass
+
+- [ ] **Step 4: Commit (only if any fixup was needed)**
+
+```bash
+git add -A
+git commit -m "fix: address mypy/test issues from integration"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:** All 8 operations (list, get, list_runs, create, update, pause, resume, delete) are declared in the capability (Task 5). The mutation gate (codex review HIGH #1) is implemented in the builder (Task 2) and wired via the trigger signal (Task 7). Transaction ownership (codex review HIGH #2) is in the service (Task 3). Route refactor to thin adapter (Task 4). Registry + tools_for_run (Task 6). Full-suite guard (Task 8).
+
+**Placeholder scan:** No TBD, TODO, "fill in later", or "similar to Task N" found.
+
+**Type consistency:** `ScopeContext` used consistently across context.py, builder.py, service, capability, and run_manager wiring. `AgentOperation`/`AgentCapability` used consistently across types.py, builder.py, and registry.py. `ScheduledTaskService` method signatures match between service (Task 3), route adapter (Task 4), and capability handlers (Task 5). `ContextFactory` type alias defined in builder.py, used in registry.py and run_manager wiring.

--- a/docs/dev/specs/2026-06-01-agent-platform-actions-design.md
+++ b/docs/dev/specs/2026-06-01-agent-platform-actions-design.md
@@ -1,0 +1,215 @@
+# Agent Platform Actions — Design
+
+**Date:** 2026-06-01
+**Status:** Approved (brainstorming)
+**Branch:** `feat/agent-schedule-tools`
+
+## Problem
+
+cubebox exposes platform capabilities (skills, scheduled tasks, conversations,
+MCP connectors, memory, …) as workspace-scoped REST routes. We want the
+in-conversation agent to perform those same operations on the user's behalf.
+
+Today this is done **per-capability, ad-hoc**: each capability hand-writes a set
+of `create_X_tool(...)` factories in `run_manager.py` and manually threads
+`org_id` / `workspace_id` / `user_id` through them (this is how the skill tools —
+`find_skills`, `preview_skill`, `install_skill`, `load_skill` — are wired). More
+agent-operable capabilities are coming continuously, so the ad-hoc approach
+accumulates four problems:
+
+1. **Logic duplicated.** Business logic (validation, schedule computation,
+   authorization) lives in the route handler; a tool that needs the same
+   behavior must either re-extract it or reimplement it.
+2. **DI boilerplate.** Every tool re-threads scope (org/ws/user) + a DB session
+   by hand; `run_manager.py` grows per capability.
+3. **Permission drift.** REST routes enforce authorization via FastAPI deps
+   (`require_member`, owner-or-admin). A tool that skips those checks lets the
+   agent perform operations the user is not authorized for.
+4. **Behavior drift.** A tool and its route should validate and fail
+   identically; two code paths drift.
+
+This branch establishes a **unified mechanism** for agent-operable platform
+capabilities and lands **scheduled tasks** as the first capability built on it.
+
+## Goals
+
+- One reusable pattern: adding a new agent-operable capability = write its
+  service (needed anyway) + declare its operations. No new wiring in
+  `run_manager.py`.
+- Single source of truth per capability (the service); REST route and agent
+  tool are thin adapters over it.
+- Authorization enforced in the service, so both front doors get it.
+- Agent tool-list growth bounded: **one tool per capability**, not one per
+  operation.
+
+## Non-Goals
+
+- Migrating the existing skill tools onto this mechanism. Skills stay as-is
+  (already shipped); migration is a follow-up.
+- A sandbox CLI surface. The agent shell only exists inside the sandbox and
+  `sandbox.enabled` defaults to `false`, so a CLI surface would be unavailable
+  by default. The registry is designed so a CLI (or a single global meta-tool)
+  surface can be added later over the same services/actions without rework.
+- New scheduled-task domain features. The capability exposes the existing
+  scheduled-task behavior; it does not add scheduling semantics.
+
+## Decisions (from brainstorming)
+
+- **Operations exposed (8):** `list`, `get`, `list_runs`, `create`, `update`,
+  `pause`, `resume`, `delete`.
+- **Confirmation model:** soft — the tool description instructs the agent to act
+  only on explicit user request (mirrors `install_skill`). No hard
+  confirm-parameter gate.
+- **Run target on create:** support both `new_each_run` (default) and `fixed`;
+  the tool accepts pinning to the current conversation (the builder injects the
+  current `conversation_id`).
+- **Tool granularity:** one tool per capability with an `operation`
+  discriminator (Pydantic discriminated union → `oneOf` in the JSON schema, so
+  the model still sees per-operation fields).
+- **Surface (v1):** native cubepi `AgentTool` (does not depend on sandbox;
+  supports widgets; reliable schema).
+- **Routes:** refactored into thin adapters that delegate to the service.
+
+## Architecture
+
+Three layers plus a registry. The **service + action registry is the invariant
+foundation**; the surface (native tool now, CLI/meta-tool later) is a swappable
+facade over it.
+
+```
+                 ┌─────────────────────────────┐
+   REST route ──▶│   Scope-aware Service        │ ← single source of truth
+  (thin adapter) │   (ScopeContext, session,    │   validation + business
+                 │    input) -> result          │   authorization + operation
+   Agent tool ──▶│                             │
+ (registry-built)└─────────────────────────────┘
+```
+
+### New module layout
+
+```
+backend/cubebox/
+├── agents/actions/
+│   ├── context.py        ScopeContext + builder from RequestContext / RunContext
+│   ├── capability.py     AgentOperation, AgentCapability, domain exceptions
+│   ├── builder.py        build_capability_tool(cap, context_factory) -> AgentTool
+│   ├── registry.py       AGENT_CAPABILITIES, tools_for_run(context_factory)
+│   └── capabilities/
+│       └── scheduled_tasks.py   declares the scheduled_tasks capability
+├── services/
+│   └── scheduled_task.py        ScheduledTaskService (source of truth)
+├── api/routes/v1/
+│   └── ws_scheduled_tasks.py    refactored to thin adapter (delegates to service)
+└── streams/
+    └── run_manager.py           appends tools_for_run(context_factory)
+```
+
+### Components
+
+**`ScopeContext`** (`agents/actions/context.py`)
+Carries everything an operation needs to be scoped and authorized:
+`org_id`, `workspace_id`, `user_id`, `role`, `conversation_id | None`.
+Two builders:
+- `from_request(ctx: RequestContext)` — for routes (role already present).
+- async build for runs — `RunContext` lacks `role`, so the run-side factory
+  looks up the user's workspace membership role once and injects it; it also
+  carries the current `conversation_id` so `create` can pin a fixed target.
+
+**`ScheduledTaskService`** (`services/scheduled_task.py`)
+The source of truth. Methods take `(ctx: ScopeContext, session, input)` and
+return domain objects / dicts:
+- `list_tasks`, `get_task`, `list_runs` — reads (membership is enough).
+- `create`, `update`, `pause`, `resume`, `delete` — mutations; enforce
+  owner-or-admin internally.
+
+All logic currently in the route module moves here: cron/timezone validation
+(reuse the Pydantic validators / `croniter`), `_initial_next_fire`,
+`_resume_next_fire`, `_to_utc_naive`, target-conversation ownership check, and
+`owner_user_id` assignment (`= ctx.user_id`). Failures raise domain exceptions:
+`NotFound`, `PermissionDenied`, `InvalidInput`.
+
+**Action registry + generic builder** (`agents/actions/capability.py`,
+`builder.py`, `registry.py`)
+- `AgentOperation`: `name` (e.g. `"create"`), `description` (for the LLM),
+  `input_model` (operation-specific args), `handler`
+  (`(ScopeContext, session, input) -> Awaitable[result]`, typically a bound
+  service method).
+- `AgentCapability`: `name` (tool name, e.g. `"scheduled_tasks"`),
+  `description`, `operations: list[AgentOperation]`.
+- `build_capability_tool(cap, context_factory)` produces one cubepi
+  `AgentTool`. The tool input is a discriminated union over operations keyed by
+  an `operation: Literal[...]` field. `_execute`: parse → dispatch to the
+  matching operation → build `ScopeContext` + open a session via
+  `context_factory` → call the handler → serialize the result as
+  `AgentToolResult`; domain exceptions map to `is_error=True` text.
+- `registry.py`: `AGENT_CAPABILITIES = [SCHEDULED_TASKS_CAPABILITY]` and
+  `tools_for_run(context_factory) -> list[AgentTool]`.
+
+**`scheduled_tasks` capability** (`agents/actions/capabilities/scheduled_tasks.py`)
+Declares the 8 operations, each pointing at a `ScheduledTaskService` method,
+with LLM-facing descriptions (including the soft "only on explicit user
+request" instruction for mutations and the `new_each_run` default for
+`create`).
+
+**Front doors**
+- Route (`ws_scheduled_tasks.py`): FastAPI auth dep → `ScopeContext.from_request`
+  → service call → map domain exceptions to HTTP (`NotFound`→404,
+  `PermissionDenied`→403, `InvalidInput`→422) → serialize via existing
+  `_to_out` / `ScheduledTaskOut`.
+- Agent tool: `run_manager` builds a `context_factory` from `RunContext` (+ role
+  lookup + current `conversation_id` + session maker) and appends
+  `tools_for_run(context_factory)` to the builtin tool list.
+
+## Data Flow — `create` example
+
+1. Agent calls `scheduled_tasks(operation="create", name=…, schedule_kind=…, …,
+   target="new_each_run")`.
+2. Builder parses the discriminated union, opens a session, builds
+   `ScopeContext` (org/ws/user/role from the run; `conversation_id` if
+   `target="current_conversation"`).
+3. `ScheduledTaskService.create(ctx, input)` validates, sets
+   `owner_user_id = ctx.user_id`, computes `next_fire_at`, persists.
+4. Result serialized to `AgentToolResult` text (task id, name, next_fire_at).
+   The same `create` called from the route returns `ScheduledTaskOut`.
+
+## Error Handling
+
+The service raises domain exceptions; each front door maps them:
+
+| Domain exception   | Route   | Tool                          |
+|--------------------|---------|-------------------------------|
+| `NotFound`         | 404     | `is_error=True`, message      |
+| `PermissionDenied` | 403     | `is_error=True`, message      |
+| `InvalidInput`     | 422     | `is_error=True`, message      |
+
+One validation path, two consistent surfaces.
+
+## Testing
+
+- **Service unit tests** — `create` / `update` / `pause` / `resume` / `delete`
+  + `next_fire_at` computation + authorization (owner allowed, admin allowed,
+  other denied). This is where the bulk of behavior is verified.
+- **Route tests** — existing scheduled-task route tests must stay green after
+  the thin-adapter refactor (behavior-preserving guard).
+- **Builder unit tests** — discriminated-union dispatch and
+  domain-exception → `AgentToolResult` mapping, using a fake capability.
+- **E2E** — an agent run that calls the `scheduled_tasks` tool to create a task
+  and asserts it lands in the DB (following the existing builtin-tool test
+  pattern). Full LLM-driven end-to-end is optional given nondeterminism.
+
+## Risks / Open Items
+
+- **Route refactor regression.** Mitigated by keeping it behavior-preserving and
+  relying on existing route tests as the guard.
+- **Role lookup cost on every run.** One membership query per run when building
+  the context factory; acceptable, and only paid when the capability tools are
+  constructed.
+- **Discriminated-union schema size.** Bounded by per-capability tools; if a
+  capability has many operations the schema grows, but the tool count stays at
+  one per capability.
+
+## Follow-ups (out of scope here)
+
+- Migrate the skill tools onto this mechanism.
+- Add a CLI / global meta-tool surface once sandbox networking stabilizes.
+- Register further capabilities (conversations, MCP connectors, …) as needed.

--- a/docs/dev/specs/2026-06-01-agent-platform-actions-design.md
+++ b/docs/dev/specs/2026-06-01-agent-platform-actions-design.md
@@ -57,9 +57,17 @@ capabilities and lands **scheduled tasks** as the first capability built on it.
 
 - **Operations exposed (8):** `list`, `get`, `list_runs`, `create`, `update`,
   `pause`, `resume`, `delete`.
-- **Confirmation model:** soft — the tool description instructs the agent to act
-  only on explicit user request (mirrors `install_skill`). No hard
-  confirm-parameter gate.
+- **Confirmation model (interactive runs):** soft — the tool description
+  instructs the agent to act only on explicit user request (mirrors
+  `install_skill`). No hard confirm-parameter gate inside an interactive run.
+- **Mutation gating (non-interactive runs):** structural, not prompt-based. A
+  scheduled-task-triggered run re-enters the agent with the same builtin tool
+  set, so prompt text alone cannot stop a schedule from recursively
+  creating/deleting tasks (fanout). Each `AgentOperation` declares
+  `mutates: bool`; the run carries a trigger signal
+  (`interactive` vs `automated`); the builder **excludes mutating operations
+  from automated runs**. Automated runs see read-only operations only. This is
+  a code-enforced boundary that generalizes to every future capability.
 - **Run target on create:** support both `new_each_run` (default) and `fixed`;
   the tool accepts pinning to the current conversation (the builder injects the
   current `conversation_id`).
@@ -128,22 +136,37 @@ All logic currently in the route module moves here: cron/timezone validation
 `owner_user_id` assignment (`= ctx.user_id`). Failures raise domain exceptions:
 `NotFound`, `PermissionDenied`, `InvalidInput`.
 
+**Transaction ownership.** The service owns the transaction for each call and
+commits exactly once at the end of a mutating method. Multi-write operations
+(notably `resume`, which inserts a skipped-occurrence history row *and* updates
+`status`/`next_fire_at`; and `update`/`delete`) must be atomic. Because
+`ScopedRepository.add()` / `delete()` commit immediately, the service does NOT
+compose those auto-committing helpers for multi-row writes — it uses
+`session.add(...)` + a single trailing `session.commit()` (with `begin_nested()`
+for the race-safe history insert, mirroring today's `_resume_next_fire`). The
+caller (route or tool builder) only provides the session and never commits;
+this is the unit-of-work contract both front doors share, so a mid-operation
+failure rolls back the whole operation rather than leaving a partial write.
+
 **Action registry + generic builder** (`agents/actions/capability.py`,
 `builder.py`, `registry.py`)
 - `AgentOperation`: `name` (e.g. `"create"`), `description` (for the LLM),
-  `input_model` (operation-specific args), `handler`
-  (`(ScopeContext, session, input) -> Awaitable[result]`, typically a bound
-  service method).
+  `input_model` (operation-specific args), `mutates: bool` (write vs read),
+  `handler` (`(ScopeContext, session, input) -> Awaitable[result]`, typically a
+  bound service method).
 - `AgentCapability`: `name` (tool name, e.g. `"scheduled_tasks"`),
   `description`, `operations: list[AgentOperation]`.
-- `build_capability_tool(cap, context_factory)` produces one cubepi
-  `AgentTool`. The tool input is a discriminated union over operations keyed by
-  an `operation: Literal[...]` field. `_execute`: parse → dispatch to the
-  matching operation → build `ScopeContext` + open a session via
-  `context_factory` → call the handler → serialize the result as
+- `build_capability_tool(cap, context_factory, *, allow_mutations: bool)`
+  produces one cubepi `AgentTool`. When `allow_mutations` is false (automated
+  runs) the builder drops every `mutates=True` operation from the discriminated
+  union before constructing the tool (and skips the capability entirely if no
+  read operations remain). The tool input is a discriminated union over the
+  surviving operations keyed by an `operation: Literal[...]` field. `_execute`:
+  parse → dispatch to the matching operation → build `ScopeContext` + open a
+  session via `context_factory` → call the handler → serialize the result as
   `AgentToolResult`; domain exceptions map to `is_error=True` text.
 - `registry.py`: `AGENT_CAPABILITIES = [SCHEDULED_TASKS_CAPABILITY]` and
-  `tools_for_run(context_factory) -> list[AgentTool]`.
+  `tools_for_run(context_factory, *, allow_mutations) -> list[AgentTool]`.
 
 **`scheduled_tasks` capability** (`agents/actions/capabilities/scheduled_tasks.py`)
 Declares the 8 operations, each pointing at a `ScheduledTaskService` method,
@@ -158,7 +181,10 @@ request" instruction for mutations and the `new_each_run` default for
   `_to_out` / `ScheduledTaskOut`.
 - Agent tool: `run_manager` builds a `context_factory` from `RunContext` (+ role
   lookup + current `conversation_id` + session maker) and appends
-  `tools_for_run(context_factory)` to the builtin tool list.
+  `tools_for_run(context_factory, allow_mutations=<run is interactive>)` to the
+  builtin tool list. The interactivity signal is threaded as a new `start_run`
+  parameter (default `interactive`); `dispatch_scheduled_run` passes
+  `automated`, so scheduled runs receive read-only capability tools.
 
 ## Data Flow — `create` example
 
@@ -191,8 +217,13 @@ One validation path, two consistent surfaces.
   other denied). This is where the bulk of behavior is verified.
 - **Route tests** — existing scheduled-task route tests must stay green after
   the thin-adapter refactor (behavior-preserving guard).
-- **Builder unit tests** — discriminated-union dispatch and
-  domain-exception → `AgentToolResult` mapping, using a fake capability.
+- **Builder unit tests** — discriminated-union dispatch,
+  domain-exception → `AgentToolResult` mapping, and the mutation gate:
+  `allow_mutations=False` drops `mutates=True` operations (and omits a
+  capability left with no read operations), using a fake capability.
+- **Transaction atomicity test** — force a failure between `resume`'s two
+  writes and assert neither the history row nor the task-state change persists
+  (no partial commit).
 - **E2E** — an agent run that calls the `scheduled_tasks` tool to create a task
   and asserts it lands in the DB (following the existing builtin-tool test
   pattern). Full LLM-driven end-to-end is optional given nondeterminism.
@@ -207,6 +238,18 @@ One validation path, two consistent surfaces.
 - **Discriminated-union schema size.** Bounded by per-capability tools; if a
   capability has many operations the schema grows, but the tool count stays at
   one per capability.
+- **Threading the interactivity signal.** `start_run` gains a trigger parameter
+  that must reach the tool-composition site in `_run_cubepi_path`. Touches the
+  run entrypoint; covered by the mutation-gate tests and an automated-run E2E
+  asserting mutating operations are absent.
+
+### Resolved by design (from review)
+
+- **Autonomous-run fanout** (agent mutating state during a scheduled run): closed
+  by the structural mutation gate — automated runs get read-only capability
+  tools, independent of prompt text.
+- **Partial commits across the two front doors:** closed by the
+  service-owns-the-transaction / single-commit unit-of-work contract above.
 
 ## Follow-ups (out of scope here)
 


### PR DESCRIPTION
## Summary

- Establishes a **unified mechanism** for agent-operable platform capabilities: `AgentOperation`/`AgentCapability` registry + a generic `build_capability_tool()` that produces one cubepi `AgentTool` per capability via Pydantic discriminated unions.
- Extracts `ScheduledTaskService` from route handlers (single source of truth for validation, authorization, schedule computation, transaction ownership) and refactors routes into thin adapters.
- Lands **scheduled tasks** as the first capability: 1 tool (`scheduled_tasks`) with 8 operations (list, get, list_runs, create, update, pause, resume, delete).
- Implements a **structural mutation gate**: `RunContext.trigger` distinguishes interactive vs automated runs; automated runs (scheduled-task-triggered) receive read-only tools only, preventing recursive task creation/deletion.

## Key files

| File | Role |
|------|------|
| `agents/actions/context.py` | `ScopeContext` (org/ws/user/role/conversation) |
| `agents/actions/types.py` | `AgentOperation`, `AgentCapability`, domain exceptions |
| `agents/actions/builder.py` | Generic factory: capability → cubepi AgentTool |
| `agents/actions/registry.py` | `tools_for_run()` entry point |
| `agents/actions/capabilities/scheduled_tasks.py` | 8-operation capability declaration |
| `services/scheduled_task.py` | `ScheduledTaskService` (source of truth) |
| `api/routes/v1/ws_scheduled_tasks.py` | Refactored to thin adapter |
| `streams/run_manager.py` | `trigger` signal + `tools_for_run` wiring |
| `schedules/dispatch.py` | Passes `trigger="automated"` |

## Test plan

- [ ] 32 existing E2E scheduled-task tests pass (behavior-preserving route refactor guard)
- [ ] 10 new service unit tests (create/update/pause/resume/delete + authorization)
- [ ] 9 new builder unit tests (mutation gate, dispatch, error mapping)
- [ ] Full mypy (315 files) clean