### PR TITLE
perf(frontend): fix streaming-render N×M re-render cascade

### DIFF
--- a/docs/dev/notes/2026-06-02-frontend-stream-perf-verification.md
+++ b/docs/dev/notes/2026-06-02-frontend-stream-perf-verification.md
@@ -1,0 +1,53 @@
+# Frontend streaming-perf — verification trace
+
+Manual perf verification for [PR #188](https://github.com/xfgong/cubebox/pull/188) (branch `feat/frontend-stream-perf`).
+
+## Method
+
+Drove an identical send-and-stream cycle on two builds via a Playwright script
+(`frontend/scripts/perf-compare.mjs`, not committed) and measured main-thread
+work over the streaming window from inside the page via `PerformanceObserver`
+(`longtask`) plus a `window.fetch` hook that tees the SSE response body to
+count `text_delta` / `reasoning` / `tool_call_delta` events.
+
+Both targets point at logical clones of the same data:
+
+| Target | Frontend port | Backend port | DB |
+|---|---|---|---|
+| `before` (main, unfixed) | :3000 | :8000 | `cubebox` |
+| `after` (`feat/frontend-stream-perf`) | :3087 | :8087 | `cubebox_feat_frontend_stream_perf` — `pg_dump | psql` clone of `cubebox` |
+
+Conversation under test: `conv-1fwZQ8u3ZDukx3` in workspace `ws-1cmDVQzDJpWuVG`
+(104 prior messages). Prompt: 50-char Chinese summary request.
+
+The wait loop terminated when the SSE event count was stable for 4 s (or a
+90 s hard cap). The LLM responses on the two runs were of similar length
+(within 1.5×), so per-event metrics are the apples-to-apples comparison.
+
+## Results
+
+| Metric | Before (:3000) | After (:3087) | Delta |
+|---|---:|---:|---:|
+| elapsed wall-clock (ms) | 309 608 | 52 576 | **−257 032** |
+| SSE events (`text_delta` + `reasoning` + `tool_call_delta`) | 896 | 1 363 | +467 |
+| Long-task count (`PerformanceObserver` `longtask`) | 9 | 155 | +146 |
+| Total long-task ms | 301 238 | 23 673 | **−277 565** |
+| Max single long-task ms | **64 552** | **469** | **−64 083** |
+| Long-task ms per SSE event | 336 | 17 | **−95 %** |
+
+The "before" run produced **9** long tasks that averaged ~33 s and peaked at
+**~65 seconds** of synchronously blocked main thread — this is exactly the
+"page unresponsive" Chrome dialog the user originally reported.
+
+The "after" run produced **155** smaller long tasks, max 469 ms. Higher count
+is the expected signature: instead of one monolithic 65 s task, the streaming
+work is now split into many cheap per-frame tasks because the memo barriers
+prevent N×M historical-message re-renders. Average per-event cost dropped from
+336 ms to 17 ms — a **20× reduction** in scripting time per SSE event.
+
+## Caveat
+
+Both builds run Next.js / React in dev mode. Production builds will be
+faster across the board but the relative ratio should hold, since the dropped
+work (remark + rehype + highlight + katex per historical text block per
+delta) is independent of dev vs. prod React optimizations.

--- a/docs/dev/plans/2026-06-02-frontend-stream-perf.md
+++ b/docs/dev/plans/2026-06-02-frontend-stream-perf.md
@@ -1,0 +1,454 @@
+# Frontend Streaming Performance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the O(history × text_blocks × markdown_pipeline) work per stream delta that freezes the page after several conversation turns.
+
+**Architecture:** Two memoization barriers, plus prop scoping:
+1. Wrap `MarkdownWithCitations` in `React.memo` so unchanged markdown text doesn't re-run remark/rehype/highlight/katex on every parent re-render.
+2. Split historical assistant rendering into a memoized `HistoryAssistantMessage`. Stabilize its props by passing the *historical* tool-result map (not the merged one that mutates on every tool_result event) and by omitting streaming-only props (`pendingConfirmMap`, `onSandboxConfirm`) that historical messages never use.
+3. Throttle `ResizeObserver` auto-scroll with `requestAnimationFrame` to coalesce layout writes across rapid deltas.
+
+After these changes, the streaming-render work per delta drops to roughly: 1 × markdown pipeline (for the current text block), instead of N × all-historical-blocks.
+
+**Tech Stack:** React 19, Next.js 15 (app router), Zustand, react-markdown + remark/rehype plugins, Vitest + React Testing Library.
+
+**Worktree:** `/home/chris/cubebox/.worktrees/feat/frontend-stream-perf` (slot 87, frontend on `:3087`, backend on `:8087`). All paths below are relative to that worktree.
+
+**Pre-flight:** From the worktree root, run `cat .worktree.env` to confirm ports, then `cd frontend && pnpm install --frozen-lockfile` (already done by `new-worktree`, just verify). All `pnpm` commands run from `frontend/packages/web/` unless noted.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `frontend/packages/web/components/shared/MarkdownWithCitations.tsx` | Modify | Wrap export in `React.memo` |
+| `frontend/packages/web/components/shared/__tests__/MarkdownWithCitations.memo.test.tsx` | Create | Render-count test proving memo skips re-renders on equal props |
+| `frontend/packages/web/components/chat/AssistantMessage.tsx` | Modify | Add memoized `HistoryAssistantMessage` re-export |
+| `frontend/packages/web/components/chat/MessageList.tsx` | Modify | Use `HistoryAssistantMessage` for history; pass `historicalToolResults` (not `mergedToolResultMap`); rAF-throttle ResizeObserver |
+| `frontend/packages/web/__tests__/components/MessageListMemo.test.tsx` | Create | Assert `HistoryAssistantMessage` is a `React.memo` wrapper over `AssistantMessage` and still renders correctly |
+| `frontend/packages/web/lib/scrollToBottom.ts` | Create | rAF-throttled scroll-to-bottom helper |
+| `frontend/packages/web/lib/__tests__/scrollToBottom.test.ts` | Create | Coalescing behavior test for the helper |
+
+---
+
+## Task 1: Memoize MarkdownWithCitations
+
+**Files:**
+- Modify: `frontend/packages/web/components/shared/MarkdownWithCitations.tsx`
+- Create: `frontend/packages/web/components/shared/__tests__/MarkdownWithCitations.memo.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/packages/web/components/shared/__tests__/MarkdownWithCitations.memo.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MarkdownWithCitations } from '../MarkdownWithCitations'
+
+describe('MarkdownWithCitations memoization', () => {
+  it('is exported as a React.memo component', () => {
+    // React.memo returns an object with $$typeof === Symbol.for('react.memo').
+    // Checking the wrapper marker is the most reliable way to assert the
+    // memoization barrier is in place — DOM-identity checks would pass even
+    // without memo because React reconciliation reuses same-type nodes.
+    const marker = (MarkdownWithCitations as unknown as { $$typeof?: symbol })
+      .$$typeof
+    expect(marker).toBe(Symbol.for('react.memo'))
+  })
+
+  it('still renders markdown correctly', () => {
+    render(
+      <MarkdownWithCitations conversationId="conv-test">
+        hello **world**
+      </MarkdownWithCitations>,
+    )
+    expect(screen.getByText('world')).toBeInTheDocument()
+    expect(screen.getByText('world').tagName).toBe('STRONG')
+  })
+
+  it('updates output when children text changes', () => {
+    const { rerender } = render(
+      <MarkdownWithCitations conversationId="conv-test">alpha</MarkdownWithCitations>,
+    )
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+    rerender(
+      <MarkdownWithCitations conversationId="conv-test">beta</MarkdownWithCitations>,
+    )
+    expect(screen.getByText('beta')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `frontend/packages/web/`:
+```bash
+pnpm vitest run components/shared/__tests__/MarkdownWithCitations.memo.test.tsx
+```
+Expected: the first test FAILS — `firstStrong` and `secondStrong` are different DOM nodes because the component re-rendered.
+
+- [ ] **Step 3: Wrap export in React.memo**
+
+Modify `frontend/packages/web/components/shared/MarkdownWithCitations.tsx`:
+
+- Add `memo` to the `react` import:
+  ```tsx
+  import { memo } from 'react'
+  import type { ComponentProps } from 'react'
+  ```
+- Rename the existing `export function MarkdownWithCitations(...)` to a local `function MarkdownWithCitationsImpl(...)` (keep the body unchanged).
+- At the bottom of the file, replace it with the memo'd export:
+  ```tsx
+  export const MarkdownWithCitations = memo(MarkdownWithCitationsImpl)
+  ```
+
+Rationale: `children` (string), `className` (string), `conversationId` (string|undefined) are all primitives → default shallow `Object.is` comparison is correct. The internal `useConversationStore` call still subscribes to `activeId`; if it changes the memoized component re-renders, which is correct behavior.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pnpm vitest run components/shared/__tests__/MarkdownWithCitations.memo.test.tsx
+```
+Expected: both tests PASS.
+
+- [ ] **Step 5: Run the existing shared-component tests to confirm no regression**
+
+Run:
+```bash
+pnpm vitest run components/shared
+```
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/packages/web/components/shared/MarkdownWithCitations.tsx \
+        frontend/packages/web/components/shared/__tests__/MarkdownWithCitations.memo.test.tsx
+git commit -m "perf(frontend): memoize MarkdownWithCitations to skip remark/rehype on equal props"
+```
+
+---
+
+## Task 2: Memoize historical AssistantMessage and scope its props
+
+**Files:**
+- Modify: `frontend/packages/web/components/chat/AssistantMessage.tsx`
+- Modify: `frontend/packages/web/components/chat/MessageList.tsx`
+- Create: `frontend/packages/web/__tests__/components/MessageListMemo.test.tsx`
+
+- [ ] **Step 1: Add `HistoryAssistantMessage` memoized re-export**
+
+Open `frontend/packages/web/components/chat/AssistantMessage.tsx`. At the very bottom of the file, append:
+
+```tsx
+import { memo } from 'react'
+
+/**
+ * Memoized wrapper for historical (non-streaming) assistant messages. Props
+ * must be reference-stable across stream deltas — MessageList achieves this by
+ * passing the message-stable `historicalToolResults` map instead of the live
+ * `mergedToolResultMap`, and by omitting streaming-only props.
+ */
+export const HistoryAssistantMessage = memo(AssistantMessage)
+```
+
+Also add `memo` to the existing top-of-file React import block (replace `import { useState, useEffect, useRef } from 'react'` with `import { useState, useEffect, useRef, memo } from 'react'`) and **remove** the duplicate `import { memo } from 'react'` you just added at the bottom. Final ordering: single React import at the top, `HistoryAssistantMessage` defined at the bottom.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `frontend/packages/web/__tests__/components/MessageListMemo.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import {
+  AssistantMessage,
+  HistoryAssistantMessage,
+} from '@/components/chat/AssistantMessage'
+import type { AssistantMessage as AssistantMessageType } from '@cubebox/core'
+
+const baseMessage = {
+  id: 'msg-1',
+  role: 'assistant',
+  content: [{ type: 'text', text: 'hello world' }],
+  timestamp: 1_700_000_000,
+} as unknown as AssistantMessageType
+
+describe('HistoryAssistantMessage', () => {
+  it('is a memoized re-export of AssistantMessage', () => {
+    const marker = (HistoryAssistantMessage as unknown as {
+      $$typeof?: symbol
+      type?: unknown
+    })
+    expect(marker.$$typeof).toBe(Symbol.for('react.memo'))
+    expect(marker.type).toBe(AssistantMessage)
+  })
+
+  it('still renders the message text', () => {
+    render(
+      <HistoryAssistantMessage
+        message={baseMessage}
+        subagentDataMap={{}}
+        toolResultMap={{}}
+        conversationId="conv-1"
+      />,
+    )
+    expect(screen.getByText('hello world')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify both pass**
+
+Run from `frontend/packages/web/`:
+```bash
+pnpm vitest run __tests__/components/MessageListMemo.test.tsx
+```
+Expected: both tests PASS (memo already added in Step 1).
+
+- [ ] **Step 4: Switch MessageList to use HistoryAssistantMessage with stable props**
+
+Edit `frontend/packages/web/components/chat/MessageList.tsx`:
+
+1. Update the import on line 17:
+   ```tsx
+   import { AssistantMessage, HistoryAssistantMessage } from './AssistantMessage'
+   ```
+
+2. Replace the historical-message render block (currently lines 253–262) with:
+   ```tsx
+   {msg.role === 'assistant' && msg.id !== lastAssistantId && (
+     <HistoryAssistantMessage
+       message={msg}
+       subagentDataMap={subagentDataMap}
+       toolResultMap={historicalToolResults}
+       conversationId={conversationId}
+     />
+   )}
+   ```
+
+   Rationale: historical messages already have their tool results captured in `historicalToolResults` (built from `messages`). They have no use for the live `mergedToolResultMap`, and consuming it forces them to re-render on every new `tool_result` event during streaming. Likewise, `pendingConfirmMap` / `onSandboxConfirm` are only meaningful for the in-flight turn — drop them for history.
+
+3. Leave the streaming render block (currently lines 266–278) unchanged — it still uses `AssistantMessage` with `mergedToolResultMap`, `pendingConfirmMap`, and `onSandboxConfirm`.
+
+- [ ] **Step 5: Run MessageList and related tests to verify no regressions**
+
+Run:
+```bash
+pnpm vitest run __tests__/components/MessageList __tests__/hooks/useMessages __tests__/stores/messageStore
+```
+Expected: all tests PASS. If any test relied on the historical render path receiving `pendingConfirmMap`, update the assertion — historical history doesn't show pending sandbox confirms (those are streaming-only).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/packages/web/components/chat/AssistantMessage.tsx \
+        frontend/packages/web/components/chat/MessageList.tsx \
+        frontend/packages/web/__tests__/components/MessageListMemo.test.tsx
+git commit -m "perf(frontend): memoize history AssistantMessage; pass historical-only tool results"
+```
+
+---
+
+## Task 3: rAF-throttle ResizeObserver auto-scroll
+
+**Files:**
+- Create: `frontend/packages/web/lib/scrollToBottom.ts`
+- Create: `frontend/packages/web/lib/__tests__/scrollToBottom.test.ts`
+- Modify: `frontend/packages/web/components/chat/MessageList.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/packages/web/lib/__tests__/scrollToBottom.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { rafThrottleScrollToBottom } from '../scrollToBottom'
+
+function nextFrame(): Promise<void> {
+  return new Promise((r) => requestAnimationFrame(() => r()))
+}
+
+describe('rafThrottleScrollToBottom', () => {
+  it('coalesces many calls into a single scrollTop write per frame', async () => {
+    const el = { scrollTop: 0, scrollHeight: 500 } as unknown as HTMLElement
+    const scheduler = rafThrottleScrollToBottom(() => el)
+
+    for (let i = 0; i < 50; i++) scheduler()
+    // No write yet — still inside the same task.
+    expect(el.scrollTop).toBe(0)
+
+    await nextFrame()
+    expect(el.scrollTop).toBe(500)
+
+    // A subsequent burst schedules again and writes the latest scrollHeight.
+    ;(el as { scrollHeight: number }).scrollHeight = 800
+    for (let i = 0; i < 30; i++) scheduler()
+    await nextFrame()
+    expect(el.scrollTop).toBe(800)
+  })
+
+  it('is a no-op when the element getter returns null', async () => {
+    const scheduler = rafThrottleScrollToBottom(() => null)
+    expect(() => scheduler()).not.toThrow()
+    await nextFrame()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `frontend/packages/web/`:
+```bash
+pnpm vitest run lib/__tests__/scrollToBottom.test.ts
+```
+Expected: FAIL — `../scrollToBottom` does not exist yet.
+
+- [ ] **Step 3: Implement the throttled helper**
+
+Create `frontend/packages/web/lib/scrollToBottom.ts`:
+
+```ts
+/**
+ * Returns a scheduler that coalesces multiple "scroll to bottom" requests into
+ * a single write per animation frame. The supplied getter is called inside the
+ * rAF callback so the element's latest scrollHeight is read just before the
+ * write — avoiding stale heights when many deltas land in one task.
+ */
+export function rafThrottleScrollToBottom(getElement: () => HTMLElement | null): () => void {
+  let pending = false
+  return () => {
+    if (pending) return
+    pending = true
+    requestAnimationFrame(() => {
+      pending = false
+      const el = getElement()
+      if (!el) return
+      el.scrollTop = el.scrollHeight
+    })
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pnpm vitest run lib/__tests__/scrollToBottom.test.ts
+```
+Expected: both tests PASS.
+
+- [ ] **Step 5: Wire the helper into MessageList**
+
+Edit `frontend/packages/web/components/chat/MessageList.tsx`:
+
+1. Add import near the top:
+   ```tsx
+   import { rafThrottleScrollToBottom } from '@/lib/scrollToBottom'
+   ```
+
+2. Replace the existing ResizeObserver effect (lines 213–225):
+   ```tsx
+   useEffect(() => {
+     const content = contentRef.current
+     const scroller = scrollRef.current
+     if (!content || !scroller) return
+
+     const scheduleScroll = rafThrottleScrollToBottom(() => scrollRef.current)
+     const ro = new ResizeObserver(() => {
+       if (stickToBottom.current) scheduleScroll()
+     })
+     ro.observe(content)
+     return () => ro.disconnect()
+   }, [])
+   ```
+
+   Rationale: bursts of `text_delta` events grow content height many times per animation frame. Writing `scrollTop = scrollHeight` synchronously on every ResizeObserver fire forces a layout each time. Coalescing to one write per frame eliminates the layout thrash without changing the user-visible scroll behavior.
+
+- [ ] **Step 6: Run all MessageList-related tests**
+
+```bash
+pnpm vitest run __tests__/components/MessageList __tests__/components/MessageListMemo lib/__tests__/scrollToBottom
+```
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/packages/web/lib/scrollToBottom.ts \
+        frontend/packages/web/lib/__tests__/scrollToBottom.test.ts \
+        frontend/packages/web/components/chat/MessageList.tsx
+git commit -m "perf(frontend): coalesce streaming auto-scroll into one write per frame"
+```
+
+---
+
+## Task 4: Full type-check, lint, and manual browser verification
+
+**Files:** (none modified in this task)
+
+- [ ] **Step 1: Type-check the web package**
+
+From the worktree root:
+```bash
+cd frontend && pnpm -C packages/web typecheck
+```
+Expected: no errors.
+
+- [ ] **Step 2: Lint the web package**
+
+```bash
+pnpm -C packages/web lint
+```
+Expected: no errors. Fix any new warnings introduced by the changes.
+
+- [ ] **Step 3: Run the full web vitest suite**
+
+```bash
+pnpm -C packages/web test
+```
+Expected: all suites PASS.
+
+- [ ] **Step 4: Start backend and frontend in the worktree**
+
+From the worktree root, two terminals (or `tmux`):
+
+Terminal A (backend):
+```bash
+source .worktree.env
+cd backend && python main.py
+```
+
+Terminal B (frontend):
+```bash
+cd frontend && pnpm dev
+```
+
+Verify the dev server prints `http://localhost:3087`. The wrapper `scripts/with-worktree-env.mjs` injects `PORT=3087` from `.worktree.env`; if you see `:3000` instead, you bypassed the wrapper — restart with plain `pnpm dev` (not `pnpm next dev`).
+
+- [ ] **Step 5: Reproduce the original symptom on a control build, then on the patched build**
+
+Open `http://192.168.1.150:3087/w/<wsId>/conversations/<convId>` (use a long existing conversation — at least 5 assistant turns, ideally with code blocks or KaTeX). The user reported `conv-1fwZQ8u3ZDukx3` in workspace `ws-1cmDVQzDJpWuVG` as a reproducer; if that workspace is not provisioned in the worktree's per-slot DB, fall back to seeding a long conversation in the worktree DB or restoring from a dump.
+
+Open Chrome DevTools → Performance, start recording, send a new message that triggers a long streaming response (many text deltas + at least one tool call). Stop after ~10 seconds.
+
+Expected outcome (after patches): main-thread "Scripting" time during streaming drops from the previous multi-hundred-ms long tasks to short (<50 ms) tasks. No "page unresponsive" dialog. Long historical messages no longer show up under "Component rendering" for `MarkdownWithCitations` in the React DevTools Profiler.
+
+If the symptom persists, do NOT add more fixes — return to systematic-debugging Phase 1 and gather a fresh profiler trace; the bottleneck is elsewhere (likely `WidgetView` if widgets dominate the conversation, or a Zustand selector that is over-subscribing).
+
+- [ ] **Step 6: Commit the verification log (optional)**
+
+If the manual verification produced a saved Chrome Performance trace worth keeping, drop it under `docs/dev/notes/2026-06-02-frontend-stream-perf-verification.md` with a one-paragraph summary of before/after numbers and commit. Skip if not informative.
+
+---
+
+## Out of Scope (deliberate)
+
+- `WidgetView` memoization. The current render does not remount the iframe, and Step 5 verification will tell us whether widgets are still a hot path. Address in a follow-up plan only if profiler evidence implicates it.
+- `rehype-highlight` lazy / viewport-only highlighting. Large workaround for a problem likely solved by Task 1+2.
+- Refactoring `AssistantMessage` into separate `Streaming` / `History` components. The memoized re-export gets the same perf win with a much smaller diff; a real split can wait until the file grows further.
+- Backend changes. The symptom is purely a frontend render-cost issue.

--- a/docs/dev/plans/2026-06-02-frontend-stream-perf.md
+++ b/docs/dev/plans/2026-06-02-frontend-stream-perf.md
@@ -166,10 +166,18 @@ Open `frontend/packages/web/components/chat/AssistantMessage.tsx`. At the very b
 import { memo } from 'react'
 
 /**
- * Memoized wrapper for historical (non-streaming) assistant messages. Props
- * must be reference-stable across stream deltas — MessageList achieves this by
- * passing the message-stable `historicalToolResults` map instead of the live
- * `mergedToolResultMap`, and by omitting streaming-only props.
+ * Memoized wrapper for historical (non-streaming) assistant messages. The
+ * perf win comes from stabilizing `toolResultMap`: MessageList passes the
+ * message-stable `historicalToolResults` (not the live `mergedToolResultMap`,
+ * which mutates on every streaming `tool_result` event).
+ *
+ * `pendingConfirmMap` and `onSandboxConfirm` are still passed in — a sandbox
+ * confirm can outlive a `__commitTurnAndInject` (steer / injected_message),
+ * so historical bubbles must keep rendering the approve/deny card. Those
+ * props are reference-stable across text/reasoning deltas (the map only
+ * mutates on `sandbox_confirm_request` / `_resolved`, and the handler is
+ * useCallback'd with deps that exclude per-delta state), so memo still bails
+ * out on the hot path.
  */
 export const HistoryAssistantMessage = memo(AssistantMessage)
 ```

--- a/docs/dev/plans/2026-06-02-frontend-stream-perf.md
+++ b/docs/dev/plans/2026-06-02-frontend-stream-perf.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Two memoization barriers, plus prop scoping:
 1. Wrap `MarkdownWithCitations` in `React.memo` so unchanged markdown text doesn't re-run remark/rehype/highlight/katex on every parent re-render.
-2. Split historical assistant rendering into a memoized `HistoryAssistantMessage`. Stabilize its props by passing the *historical* tool-result map (not the merged one that mutates on every tool_result event) and by omitting streaming-only props (`pendingConfirmMap`, `onSandboxConfirm`) that historical messages never use.
+2. Split historical assistant rendering into a memoized `HistoryAssistantMessage`. Stabilize its hot-path props by passing the *historical* tool-result map (not the merged one that mutates on every tool_result event). Keep `pendingConfirmMap` and `onSandboxConfirm` for history too — see "Why historical messages still need confirm props" below — those props only change on rare `sandbox_confirm_request` / `sandbox_confirm_resolved` events, not on the text-delta storm, so memo still bails out during streaming.
 3. Throttle `ResizeObserver` auto-scroll with `requestAnimationFrame` to coalesce layout writes across rapid deltas.
 
 After these changes, the streaming-render work per delta drops to roughly: 1 × markdown pipeline (for the current text block), instead of N × all-historical-blocks.
@@ -14,6 +14,24 @@ After these changes, the streaming-render work per delta drops to roughly: 1 × 
 **Tech Stack:** React 19, Next.js 15 (app router), Zustand, react-markdown + remark/rehype plugins, Vitest + React Testing Library.
 
 **Worktree:** `/home/chris/cubebox/.worktrees/feat/frontend-stream-perf` (slot 87, frontend on `:3087`, backend on `:8087`). All paths below are relative to that worktree.
+
+### Why historical messages still need confirm props
+
+`messageStore.ts::__commitTurnAndInject` (lines ~1224–1268) commits the in-flight
+assistant bubble into `messages[conversationId]` and resets `streamAgents`, but it
+does **not** clear `pendingConfirmMap`. So when a steer / `injected_message` lands
+while a sandbox confirm is open, the assistant bubble carrying that `tool_call`
+moves to history while the matching `pendingConfirmMap[tool_call_id]` is still
+populated. If we stripped `pendingConfirmMap` / `onSandboxConfirm` from the
+historical render path, the user would lose the approve/deny card.
+
+The good news for perf: `pendingConfirmMap` and `handleSandboxConfirm` are
+reference-stable across the streaming hot path. The map only changes on
+`sandbox_confirm_request` / `sandbox_confirm_resolved` events, and
+`handleSandboxConfirm` is `useCallback`-memoized with deps
+`[conversationId, streamingConversationId, pendingConfirmMap, workspaceId]` —
+none of which mutate per text/reasoning delta. So memoization of history still
+bails out during the delta storm.
 
 **Pre-flight:** From the worktree root, run `cat .worktree.env` to confirm ports, then `cd frontend && pnpm install --frozen-lockfile` (already done by `new-worktree`, just verify). All `pnpm` commands run from `frontend/packages/web/` unless noted.
 
@@ -227,11 +245,15 @@ Edit `frontend/packages/web/components/chat/MessageList.tsx`:
        subagentDataMap={subagentDataMap}
        toolResultMap={historicalToolResults}
        conversationId={conversationId}
+       pendingConfirmMap={pendingConfirmMap}
+       onSandboxConfirm={handleSandboxConfirm}
      />
    )}
    ```
 
-   Rationale: historical messages already have their tool results captured in `historicalToolResults` (built from `messages`). They have no use for the live `mergedToolResultMap`, and consuming it forces them to re-render on every new `tool_result` event during streaming. Likewise, `pendingConfirmMap` / `onSandboxConfirm` are only meaningful for the in-flight turn — drop them for history.
+   Rationale:
+   - **Drop the live `mergedToolResultMap`** for history. Historical messages already have their tool results captured in `historicalToolResults` (built from `messages`); the merged map mutates on every `tool_result` event during streaming and would force every historical bubble to re-render even with memo.
+   - **Keep `pendingConfirmMap` and `onSandboxConfirm`.** `__commitTurnAndInject` can move a bubble carrying an unresolved sandbox confirm into history; stripping the props would hide the approve/deny card. These props are reference-stable across text/reasoning delta storms (only `sandbox_confirm_request` / `_resolved` mutate the map; `handleSandboxConfirm`'s useCallback deps exclude delta-driven state), so memo still bails out on the hot path.
 
 3. Leave the streaming render block (currently lines 266–278) unchanged — it still uses `AssistantMessage` with `mergedToolResultMap`, `pendingConfirmMap`, and `onSandboxConfirm`.
 
@@ -241,7 +263,7 @@ Run:
 ```bash
 pnpm vitest run __tests__/components/MessageList __tests__/hooks/useMessages __tests__/stores/messageStore
 ```
-Expected: all tests PASS. If any test relied on the historical render path receiving `pendingConfirmMap`, update the assertion — historical history doesn't show pending sandbox confirms (those are streaming-only).
+Expected: all tests PASS.
 
 - [ ] **Step 6: Commit**
 

--- a/frontend/packages/web/__tests__/components/MessageListMemo.test.tsx
+++ b/frontend/packages/web/__tests__/components/MessageListMemo.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import en from '../../messages/en.json'
+import { AssistantMessage, HistoryAssistantMessage } from '@/components/chat/AssistantMessage'
+import type { AssistantMessage as AssistantMessageType } from '@cubebox/core'
+
+const baseMessage = {
+  id: 'msg-1',
+  role: 'assistant',
+  content: [{ type: 'text', text: 'hello world' }],
+  timestamp: 1_700_000_000,
+} as unknown as AssistantMessageType
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <NextIntlClientProvider locale="en" messages={en}>
+      {children}
+    </NextIntlClientProvider>
+  )
+}
+
+describe('HistoryAssistantMessage', () => {
+  it('is a memoized re-export of AssistantMessage', () => {
+    const marker = HistoryAssistantMessage as unknown as {
+      $$typeof?: symbol
+      type?: unknown
+    }
+    expect(marker.$$typeof).toBe(Symbol.for('react.memo'))
+    expect(marker.type).toBe(AssistantMessage)
+  })
+
+  it('still renders the message text', () => {
+    render(
+      <HistoryAssistantMessage
+        message={baseMessage}
+        subagentDataMap={{}}
+        toolResultMap={{}}
+        conversationId="conv-1"
+      />,
+      { wrapper },
+    )
+    expect(screen.getByText('hello world')).toBeInTheDocument()
+  })
+})

--- a/frontend/packages/web/__tests__/hooks/useMessageScopedToolResults.test.ts
+++ b/frontend/packages/web/__tests__/hooks/useMessageScopedToolResults.test.ts
@@ -94,4 +94,59 @@ describe('useMessageScopedToolResults', () => {
     expect(result.current['msg-1']).toBe(result.current['msg-2'])
     expect(Object.keys(result.current['msg-1'])).toHaveLength(0)
   })
+
+  it('includes inner subagent tool_call_ids stored on the matching tool_result message', () => {
+    // Assistant message with one `subagent` tool_call (outer id sa-1).
+    const assistant: Message = {
+      id: 'msg-1',
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_call' as const,
+          id: 'sa-1',
+          name: 'subagent',
+          arguments: { role: 'helper', task: 'do stuff' },
+        },
+      ],
+      timestamp: 0,
+    } as unknown as Message
+
+    // The subagent's tool_result message carries inner tool_call_ids in its
+    // `subagent_events` metadata (this is how buildHistoricalToolResultMap
+    // flattens them into the global historical map).
+    const subagentResult: Message = {
+      id: 'tr-1',
+      role: 'tool_result',
+      tool_call_id: 'sa-1',
+      tool_name: 'subagent',
+      content: [{ type: 'text', text: 'done' }],
+      timestamp: 0,
+      metadata: {
+        subagent_events: {
+          text: 'inner work',
+          tool_calls: [{ name: 'web_fetch', arguments: {}, id: 'inner-x' }],
+          tool_results: [
+            {
+              tool_name: 'web_fetch',
+              tool_call_id: 'inner-x',
+              content: 'inner result',
+            },
+          ],
+          thinking: '',
+        },
+      },
+    } as unknown as Message
+
+    const historical = {
+      'sa-1': { content: 'outer subagent', receivedAt: 1 },
+      'inner-x': { content: 'inner result', receivedAt: 2 },
+    } as Record<string, Entry>
+
+    const { result } = renderHook(() =>
+      useMessageScopedToolResults([assistant, subagentResult], historical, {}),
+    )
+    const subset = result.current['msg-1']
+    expect(subset['sa-1']).toEqual({ content: 'outer subagent', receivedAt: 1 })
+    expect(subset['inner-x']).toEqual({ content: 'inner result', receivedAt: 2 })
+  })
 })

--- a/frontend/packages/web/__tests__/hooks/useMessageScopedToolResults.test.ts
+++ b/frontend/packages/web/__tests__/hooks/useMessageScopedToolResults.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useMessageScopedToolResults } from '@/hooks/useMessageScopedToolResults'
+import type { Message } from '@cubebox/core'
+
+type Entry = { content: string; receivedAt: number }
+
+function assistantMessage(id: string, toolCallIds: string[]): Message {
+  return {
+    id,
+    role: 'assistant',
+    content: [
+      { type: 'text', text: `m-${id}` },
+      ...toolCallIds.map((tcId) => ({
+        type: 'tool_call' as const,
+        id: tcId,
+        name: 'fake',
+        arguments: {},
+      })),
+    ],
+    timestamp: 0,
+  } as unknown as Message
+}
+
+describe('useMessageScopedToolResults', () => {
+  it('returns a stable reference for a message when no relevant entry changes', () => {
+    const m1 = assistantMessage('msg-1', ['tc-a'])
+    const messages = [m1]
+    const historical = { 'tc-a': { content: 'hist', receivedAt: 1 } } as Record<string, Entry>
+
+    const { result, rerender } = renderHook(
+      ({ live }) => useMessageScopedToolResults(messages, historical, live),
+      { initialProps: { live: {} as Record<string, Entry> } },
+    )
+    const first = result.current['msg-1']
+    expect(first).toEqual({ 'tc-a': { content: 'hist', receivedAt: 1 } })
+
+    // New `live` reference but no entry for tc-a: subset is unchanged → same ref.
+    rerender({ live: { 'tc-other': { content: 'x', receivedAt: 9 } } })
+    expect(result.current['msg-1']).toBe(first)
+  })
+
+  it('returns a new reference for a message when a relevant live entry arrives', () => {
+    const m1 = assistantMessage('msg-1', ['tc-a'])
+    const messages = [m1]
+    const historical = {} as Record<string, Entry>
+
+    const { result, rerender } = renderHook(
+      ({ live }) => useMessageScopedToolResults(messages, historical, live),
+      { initialProps: { live: {} as Record<string, Entry> } },
+    )
+    const first = result.current['msg-1']
+    expect(first).toEqual({})
+
+    rerender({ live: { 'tc-a': { content: 'live!', receivedAt: 7 } } })
+    expect(result.current['msg-1']).not.toBe(first)
+    expect(result.current['msg-1']['tc-a']).toEqual({ content: 'live!', receivedAt: 7 })
+  })
+
+  it('live entry wins over historical for the same id', () => {
+    const m1 = assistantMessage('msg-1', ['tc-a'])
+    const messages = [m1]
+    const historical = { 'tc-a': { content: 'hist', receivedAt: 1 } } as Record<string, Entry>
+    const live = { 'tc-a': { content: 'live', receivedAt: 2 } } as Record<string, Entry>
+
+    const { result } = renderHook(() => useMessageScopedToolResults(messages, historical, live))
+    expect(result.current['msg-1']['tc-a']).toEqual({ content: 'live', receivedAt: 2 })
+  })
+
+  it('only the affected message gets a new subset reference', () => {
+    const m1 = assistantMessage('msg-1', ['tc-a'])
+    const m2 = assistantMessage('msg-2', ['tc-b'])
+    const messages = [m1, m2]
+    const historical = {} as Record<string, Entry>
+
+    const { result, rerender } = renderHook(
+      ({ live }) => useMessageScopedToolResults(messages, historical, live),
+      { initialProps: { live: {} as Record<string, Entry> } },
+    )
+    const before1 = result.current['msg-1']
+    const before2 = result.current['msg-2']
+
+    rerender({ live: { 'tc-a': { content: 'a-live', receivedAt: 5 } } })
+    expect(result.current['msg-1']).not.toBe(before1)
+    // msg-2 has no relevant live entry → ref unchanged.
+    expect(result.current['msg-2']).toBe(before2)
+  })
+
+  it('returns the same empty-object reference for messages with no tool calls', () => {
+    const m1 = assistantMessage('msg-1', [])
+    const m2 = assistantMessage('msg-2', [])
+    const { result } = renderHook(() => useMessageScopedToolResults([m1, m2], {}, {}))
+    // Identity-equal — both messages share the singleton EMPTY subset.
+    expect(result.current['msg-1']).toBe(result.current['msg-2'])
+    expect(Object.keys(result.current['msg-1'])).toHaveLength(0)
+  })
+})

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, memo } from 'react'
 import { useTranslations } from 'next-intl'
 import type {
   AssistantMessage as AssistantMessageType,
@@ -624,3 +624,19 @@ export function AssistantMessage({
     </div>
   )
 }
+
+/**
+ * Memoized wrapper for historical (non-streaming) assistant messages. The
+ * perf win comes from stabilizing `toolResultMap`: MessageList passes the
+ * message-stable `historicalToolResults` (not the live `mergedToolResultMap`,
+ * which mutates on every streaming `tool_result` event).
+ *
+ * `pendingConfirmMap` and `onSandboxConfirm` are still passed in — a sandbox
+ * confirm can outlive a `__commitTurnAndInject` (steer / injected_message),
+ * so historical bubbles must keep rendering the approve/deny card. Those
+ * props are reference-stable across text/reasoning deltas (the map only
+ * mutates on `sandbox_confirm_request` / `_resolved`, and the handler is
+ * useCallback'd with deps that exclude per-delta state), so memo still bails
+ * out on the hot path.
+ */
+export const HistoryAssistantMessage = memo(AssistantMessage)

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -232,7 +232,13 @@ export function MessageList({ conversationId }: MessageListProps) {
     const scroller = scrollRef.current
     if (!content || !scroller) return
 
-    const scheduleScroll = rafThrottleScrollToBottom(() => scrollRef.current)
+    // Re-check stickToBottom inside the rAF too: a user scrolling up between
+    // the ResizeObserver fire and the next frame would otherwise be yanked
+    // back to the bottom by a stale decision.
+    const scheduleScroll = rafThrottleScrollToBottom(
+      () => scrollRef.current,
+      () => stickToBottom.current,
+    )
     const ro = new ResizeObserver(() => {
       if (stickToBottom.current) scheduleScroll()
     })

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -21,6 +21,7 @@ import { TokenUsageBar } from './TokenUsageBar'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useMessages } from '@/hooks/useMessages'
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
+import { rafThrottleScrollToBottom } from '@/lib/scrollToBottom'
 
 interface MessageListProps {
   conversationId: string
@@ -215,10 +216,9 @@ export function MessageList({ conversationId }: MessageListProps) {
     const scroller = scrollRef.current
     if (!content || !scroller) return
 
+    const scheduleScroll = rafThrottleScrollToBottom(() => scrollRef.current)
     const ro = new ResizeObserver(() => {
-      if (stickToBottom.current) {
-        scroller.scrollTop = scroller.scrollHeight
-      }
+      if (stickToBottom.current) scheduleScroll()
     })
     ro.observe(content)
     return () => ro.disconnect()

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -14,7 +14,7 @@ import {
 import type { Message, SubagentSummary } from '@cubebox/core'
 import { AlertCircle } from 'lucide-react'
 import { UserMessage } from './UserMessage'
-import { AssistantMessage } from './AssistantMessage'
+import { AssistantMessage, HistoryAssistantMessage } from './AssistantMessage'
 import { AskUserCard } from './AskUserCard'
 import { MessageAttachments } from './MessageAttachments'
 import { TokenUsageBar } from './TokenUsageBar'
@@ -251,10 +251,10 @@ export function MessageList({ conversationId }: MessageListProps) {
               </>
             )}
             {msg.role === 'assistant' && msg.id !== lastAssistantId && (
-              <AssistantMessage
+              <HistoryAssistantMessage
                 message={msg}
                 subagentDataMap={subagentDataMap}
-                toolResultMap={mergedToolResultMap}
+                toolResultMap={historicalToolResults}
                 conversationId={conversationId}
                 pendingConfirmMap={pendingConfirmMap}
                 onSandboxConfirm={handleSandboxConfirm}

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -20,6 +20,7 @@ import { MessageAttachments } from './MessageAttachments'
 import { TokenUsageBar } from './TokenUsageBar'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useMessages } from '@/hooks/useMessages'
+import { useMessageScopedToolResults } from '@/hooks/useMessageScopedToolResults'
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
 import { rafThrottleScrollToBottom } from '@/lib/scrollToBottom'
 
@@ -175,10 +176,25 @@ export function MessageList({ conversationId }: MessageListProps) {
     [messages],
   )
 
-  // Merge: streaming results take precedence over historical
+  // Merge: streaming results take precedence over historical. Used for the
+  // live streaming bubble; history bubbles use per-message scoped subsets
+  // (`messageScopedToolResults`) so memo bails out on most streaming ticks.
   const mergedToolResultMap = useMemo(
     () => ({ ...historicalToolResults, ...toolResultMap }),
     [historicalToolResults, toolResultMap],
+  )
+
+  // Per-message subset of (live ?? historical) tool results, keyed by message
+  // id. Each per-message subset keeps its reference across renders unless one
+  // of that message's tool_call_ids gained or changed an entry — so a
+  // `tool_result` for tool_call X only re-renders the historical bubble that
+  // actually carries X, leaving every other history message memo'd. Fixes the
+  // "committed bubble loses its result until next finalize" case codex P2
+  // flagged on PR #188.
+  const messageScopedToolResults = useMessageScopedToolResults(
+    messages ?? [],
+    historicalToolResults,
+    toolResultMap,
   )
 
   // After streaming completes, the assistant message is appended to history
@@ -254,7 +270,7 @@ export function MessageList({ conversationId }: MessageListProps) {
               <HistoryAssistantMessage
                 message={msg}
                 subagentDataMap={subagentDataMap}
-                toolResultMap={historicalToolResults}
+                toolResultMap={messageScopedToolResults[msg.id] ?? historicalToolResults}
                 conversationId={conversationId}
                 pendingConfirmMap={pendingConfirmMap}
                 onSandboxConfirm={handleSandboxConfirm}

--- a/frontend/packages/web/components/shared/MarkdownWithCitations.tsx
+++ b/frontend/packages/web/components/shared/MarkdownWithCitations.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import ReactMarkdown from 'react-markdown'
+import { memo } from 'react'
 import type { ComponentProps } from 'react'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
@@ -49,7 +50,7 @@ interface MarkdownWithCitationsProps {
  * them as interactive CitationMarker components. Falls back to plain
  * ReactMarkdown when no markers are present.
  */
-export function MarkdownWithCitations({
+function MarkdownWithCitationsImpl({
   children,
   className,
   conversationId: conversationIdProp,
@@ -113,3 +114,5 @@ export function MarkdownWithCitations({
     </div>
   )
 }
+
+export const MarkdownWithCitations = memo(MarkdownWithCitationsImpl)

--- a/frontend/packages/web/components/shared/__tests__/MarkdownWithCitations.memo.test.tsx
+++ b/frontend/packages/web/components/shared/__tests__/MarkdownWithCitations.memo.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MarkdownWithCitations } from '../MarkdownWithCitations'
+
+describe('MarkdownWithCitations memoization', () => {
+  it('is exported as a React.memo component', () => {
+    // React.memo returns an object with $$typeof === Symbol.for('react.memo').
+    // Checking the wrapper marker is the most reliable way to assert the
+    // memoization barrier is in place — DOM-identity checks would pass even
+    // without memo because React reconciliation reuses same-type nodes.
+    const marker = (MarkdownWithCitations as unknown as { $$typeof?: symbol }).$$typeof
+    expect(marker).toBe(Symbol.for('react.memo'))
+  })
+
+  it('still renders markdown correctly', () => {
+    render(
+      <MarkdownWithCitations conversationId="conv-test">hello **world**</MarkdownWithCitations>,
+    )
+    expect(screen.getByText('world')).toBeInTheDocument()
+    expect(screen.getByText('world').tagName).toBe('STRONG')
+  })
+
+  it('updates output when children text changes', () => {
+    const { rerender } = render(
+      <MarkdownWithCitations conversationId="conv-test">alpha</MarkdownWithCitations>,
+    )
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+    rerender(<MarkdownWithCitations conversationId="conv-test">beta</MarkdownWithCitations>)
+    expect(screen.getByText('beta')).toBeInTheDocument()
+  })
+})

--- a/frontend/packages/web/hooks/useMessageScopedToolResults.ts
+++ b/frontend/packages/web/hooks/useMessageScopedToolResults.ts
@@ -1,0 +1,77 @@
+'use client'
+
+import { useMemo, useRef } from 'react'
+import type { Message } from '@cubebox/core'
+
+type ToolResultEntry = {
+  content: string
+  receivedAt: number
+  startedAt?: number
+  contentType?: string
+}
+
+const EMPTY: Record<string, ToolResultEntry> = Object.freeze({}) as Record<string, ToolResultEntry>
+
+/**
+ * Per-message subset of (live ?? historical) tool-result entries, keyed by
+ * message id. Each per-message subset keeps the same object reference across
+ * renders unless one of that message's own tool_call_ids gained or changed
+ * an entry — so a `tool_result` for tool_call X only forces a re-render of
+ * the historical bubble that actually carries X, leaving every other
+ * memo'd history message alone.
+ *
+ * Live wins over historical when both have an entry for the same id: handles
+ * the `__commitTurnAndInject` case where an assistant bubble is moved into
+ * history with an unresolved tool_call and the later `tool_result` lands in
+ * the live store map before the next finalize.
+ *
+ * The render-time `prevRef.current` reads are deliberate — this is the same
+ * render-phase stabilizer pattern as `useStableRecord` in `useMessages.ts`,
+ * and `react-hooks/refs` is configured as `warn` not `error` in the repo
+ * ESLint config exactly because this pattern shows up in a few places.
+ */
+export function useMessageScopedToolResults(
+  messages: Message[],
+  historical: Record<string, ToolResultEntry>,
+  live: Record<string, ToolResultEntry>,
+): Record<string, Record<string, ToolResultEntry>> {
+  const prevRef = useRef<Record<string, Record<string, ToolResultEntry>>>({})
+
+  /* eslint-disable react-hooks/refs --
+   * Deliberate render-phase ref stabilizer pattern (see `useStableRecord` in
+   * `useMessages.ts` for prior art). Reading and writing `prevRef.current`
+   * during render here gives every consumer a stable per-message subset
+   * reference unless that subset's content actually changed, which is the
+   * whole point of this hook.
+   */
+  return useMemo(() => {
+    const prev = prevRef.current
+    const next: Record<string, Record<string, ToolResultEntry>> = {}
+    for (const msg of messages) {
+      if (msg.role !== 'assistant') continue
+      const subset: Record<string, ToolResultEntry> = {}
+      let hasAny = false
+      for (const block of msg.content) {
+        if (block.type === 'tool_call') {
+          const entry = live[block.id] ?? historical[block.id]
+          if (entry) {
+            subset[block.id] = entry
+            hasAny = true
+          }
+        }
+      }
+      if (!hasAny) {
+        next[msg.id] = EMPTY
+        continue
+      }
+      const prevSubset = prev[msg.id]
+      const keys = Object.keys(subset)
+      const sameShape = prevSubset !== undefined && keys.length === Object.keys(prevSubset).length
+      const sameValues = sameShape && keys.every((k) => prevSubset[k] === subset[k])
+      next[msg.id] = sameValues ? prevSubset : subset
+    }
+    prevRef.current = next
+    return next
+  }, [messages, historical, live])
+  /* eslint-enable react-hooks/refs */
+}

--- a/frontend/packages/web/hooks/useMessageScopedToolResults.ts
+++ b/frontend/packages/web/hooks/useMessageScopedToolResults.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo, useRef } from 'react'
+import { getSubagentSummary } from '@cubebox/core'
 import type { Message } from '@cubebox/core'
 
 type ToolResultEntry = {
@@ -8,6 +9,50 @@ type ToolResultEntry = {
   receivedAt: number
   startedAt?: number
   contentType?: string
+}
+
+/**
+ * For each assistant message, the set of tool_call_ids it owns:
+ *   - top-level `tool_call` blocks on the message itself
+ *   - inner tool_call_ids of any `subagent` block (extracted from the
+ *     matching tool_result message's `subagent_events` summary)
+ *
+ * The inner ids matter because `buildHistoricalToolResultMap` indexes them
+ * into the flat `historicalToolResults` map, and `SubAgentCard` later looks
+ * them up when the user expands a completed subagent card. Omitting them
+ * would render those inner tool results as missing.
+ */
+function buildOwnedToolCallIdsByMessage(messages: Message[]): Record<string, Set<string>> {
+  // First pass: outer subagent tool_call_id → inner ids from the matching
+  // tool_result message's subagent_events summary.
+  const innerIdsByOuter: Record<string, string[]> = {}
+  for (const msg of messages) {
+    if (msg.role !== 'tool_result') continue
+    if (msg.tool_name !== 'subagent' || !msg.tool_call_id) continue
+    const summary = getSubagentSummary(msg)
+    if (!summary?.tool_results) continue
+    const inner: string[] = []
+    for (const tr of summary.tool_results) {
+      if (tr.tool_call_id) inner.push(tr.tool_call_id)
+    }
+    if (inner.length > 0) innerIdsByOuter[msg.tool_call_id] = inner
+  }
+
+  const ownedByMsg: Record<string, Set<string>> = {}
+  for (const msg of messages) {
+    if (msg.role !== 'assistant') continue
+    const owned = new Set<string>()
+    for (const block of msg.content) {
+      if (block.type !== 'tool_call') continue
+      owned.add(block.id)
+      if (block.name === 'subagent') {
+        const inner = innerIdsByOuter[block.id]
+        if (inner) for (const id of inner) owned.add(id)
+      }
+    }
+    if (owned.size > 0) ownedByMsg[msg.id] = owned
+  }
+  return ownedByMsg
 }
 
 const EMPTY: Record<string, ToolResultEntry> = Object.freeze({}) as Record<string, ToolResultEntry>
@@ -37,6 +82,8 @@ export function useMessageScopedToolResults(
 ): Record<string, Record<string, ToolResultEntry>> {
   const prevRef = useRef<Record<string, Record<string, ToolResultEntry>>>({})
 
+  const ownedIdsByMessage = useMemo(() => buildOwnedToolCallIdsByMessage(messages), [messages])
+
   /* eslint-disable react-hooks/refs --
    * Deliberate render-phase ref stabilizer pattern (see `useStableRecord` in
    * `useMessages.ts` for prior art). Reading and writing `prevRef.current`
@@ -49,15 +96,18 @@ export function useMessageScopedToolResults(
     const next: Record<string, Record<string, ToolResultEntry>> = {}
     for (const msg of messages) {
       if (msg.role !== 'assistant') continue
+      const owned = ownedIdsByMessage[msg.id]
+      if (!owned) {
+        next[msg.id] = EMPTY
+        continue
+      }
       const subset: Record<string, ToolResultEntry> = {}
       let hasAny = false
-      for (const block of msg.content) {
-        if (block.type === 'tool_call') {
-          const entry = live[block.id] ?? historical[block.id]
-          if (entry) {
-            subset[block.id] = entry
-            hasAny = true
-          }
+      for (const id of owned) {
+        const entry = live[id] ?? historical[id]
+        if (entry) {
+          subset[id] = entry
+          hasAny = true
         }
       }
       if (!hasAny) {
@@ -72,6 +122,6 @@ export function useMessageScopedToolResults(
     }
     prevRef.current = next
     return next
-  }, [messages, historical, live])
+  }, [messages, historical, live, ownedIdsByMessage])
   /* eslint-enable react-hooks/refs */
 }

--- a/frontend/packages/web/lib/__tests__/scrollToBottom.test.ts
+++ b/frontend/packages/web/lib/__tests__/scrollToBottom.test.ts
@@ -29,4 +29,25 @@ describe('rafThrottleScrollToBottom', () => {
     expect(() => scheduler()).not.toThrow()
     await nextFrame()
   })
+
+  it('skips the write when the predicate returns false at rAF time', async () => {
+    const el = { scrollTop: 0, scrollHeight: 500 } as unknown as HTMLElement
+    let stuck = true
+    const scheduler = rafThrottleScrollToBottom(
+      () => el,
+      () => stuck,
+    )
+
+    scheduler()
+    // Simulate the user scrolling away between schedule-time and rAF-fire.
+    stuck = false
+    await nextFrame()
+    expect(el.scrollTop).toBe(0)
+
+    // Flipping back to stuck and rescheduling does write.
+    stuck = true
+    scheduler()
+    await nextFrame()
+    expect(el.scrollTop).toBe(500)
+  })
 })

--- a/frontend/packages/web/lib/__tests__/scrollToBottom.test.ts
+++ b/frontend/packages/web/lib/__tests__/scrollToBottom.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { rafThrottleScrollToBottom } from '../scrollToBottom'
+
+function nextFrame(): Promise<void> {
+  return new Promise((r) => requestAnimationFrame(() => r()))
+}
+
+describe('rafThrottleScrollToBottom', () => {
+  it('coalesces many calls into a single scrollTop write per frame', async () => {
+    const el = { scrollTop: 0, scrollHeight: 500 } as unknown as HTMLElement
+    const scheduler = rafThrottleScrollToBottom(() => el)
+
+    for (let i = 0; i < 50; i++) scheduler()
+    // No write yet — still inside the same task.
+    expect(el.scrollTop).toBe(0)
+
+    await nextFrame()
+    expect(el.scrollTop).toBe(500)
+
+    // A subsequent burst schedules again and writes the latest scrollHeight.
+    ;(el as { scrollHeight: number }).scrollHeight = 800
+    for (let i = 0; i < 30; i++) scheduler()
+    await nextFrame()
+    expect(el.scrollTop).toBe(800)
+  })
+
+  it('is a no-op when the element getter returns null', async () => {
+    const scheduler = rafThrottleScrollToBottom(() => null)
+    expect(() => scheduler()).not.toThrow()
+    await nextFrame()
+  })
+})

--- a/frontend/packages/web/lib/scrollToBottom.ts
+++ b/frontend/packages/web/lib/scrollToBottom.ts
@@ -1,16 +1,25 @@
 /**
  * Returns a scheduler that coalesces multiple "scroll to bottom" requests into
- * a single write per animation frame. The supplied getter is called inside the
- * rAF callback so the element's latest scrollHeight is read just before the
- * write — avoiding stale heights when many deltas land in one task.
+ * a single write per animation frame. Both `getElement` and `shouldRun` are
+ * called inside the rAF callback — the getter reads the element's latest
+ * `scrollHeight` just before the write (avoiding stale heights when many
+ * deltas land in one task), and the predicate gets a chance to bail if the
+ * user scrolled away between the caller-side decision and the frame firing
+ * (`stickToBottom` may have flipped to false in that window). Without the
+ * predicate, high-frequency streaming would snap the user back to the bottom
+ * after every scroll-up attempt.
  */
-export function rafThrottleScrollToBottom(getElement: () => HTMLElement | null): () => void {
+export function rafThrottleScrollToBottom(
+  getElement: () => HTMLElement | null,
+  shouldRun?: () => boolean,
+): () => void {
   let pending = false
   return () => {
     if (pending) return
     pending = true
     requestAnimationFrame(() => {
       pending = false
+      if (shouldRun && !shouldRun()) return
       const el = getElement()
       if (!el) return
       el.scrollTop = el.scrollHeight

--- a/frontend/packages/web/lib/scrollToBottom.ts
+++ b/frontend/packages/web/lib/scrollToBottom.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns a scheduler that coalesces multiple "scroll to bottom" requests into
+ * a single write per animation frame. The supplied getter is called inside the
+ * rAF callback so the element's latest scrollHeight is read just before the
+ * write — avoiding stale heights when many deltas land in one task.
+ */
+export function rafThrottleScrollToBottom(getElement: () => HTMLElement | null): () => void {
+  let pending = false
+  return () => {
+    if (pending) return
+    pending = true
+    requestAnimationFrame(() => {
+      pending = false
+      const el = getElement()
+      if (!el) return
+      el.scrollTop = el.scrollHeight
+    })
+  }
+}


### PR DESCRIPTION
## Summary

Fix the page-unresponsive symptom users hit after several conversation turns during SSE streaming.

**Root cause:** every `text_delta` SSE event produces a fresh \`streamAgents\` reference in the message store → \`MessageList\` re-renders → all historical \`AssistantMessage\` re-render (no memo) → each historical \`MarkdownWithCitations\` re-runs the full remark + rehype + highlight + katex pipeline. With N historical messages and a high delta rate, this dominates the main thread.

**Fix (3 commits, each behind its own \`React.memo\` / helper barrier):**
- \`0edc7b32\` Memoize \`MarkdownWithCitations\` — skip remark/rehype/highlight/katex on equal props.
- \`400e0e5d\` Memoize a \`HistoryAssistantMessage = React.memo(AssistantMessage)\` and switch \`MessageList\` to use it for committed history with \`toolResultMap={historicalToolResults}\` instead of the live \`mergedToolResultMap\`. \`pendingConfirmMap\` and \`onSandboxConfirm\` are deliberately kept — \`messageStore.__commitTurnAndInject\` can move a bubble carrying a pending sandbox confirm into history, so stripping those props would break the approve/deny card. They're reference-stable across the text-delta storm (\`sandbox_confirm_request/resolved\` only), so memo still bails out on the hot path.
- \`8d06e19b\` Coalesce ResizeObserver auto-scroll into one \`scrollTop = scrollHeight\` write per animation frame (\`lib/scrollToBottom.ts\`), removing layout thrash that compounded with the markdown re-renders.

Plan went through two rounds of local \`codex review\` before any code was written. R1 flagged the sandbox-confirm prop drop (HIGH) and R2 caught one stale doc-comment line; both were fixed before implementation. Plan + history under \`docs/dev/plans/2026-06-02-frontend-stream-perf.md\`.

Per-delta cost drops from \`O(history × text_blocks × markdown_pipeline)\` to \`O(1 × current_text_block × markdown_pipeline)\`.

## Test plan
- [x] \`pnpm -C packages/web type-check\` clean
- [x] \`pnpm -C packages/web lint\` clean (one pre-existing warning in \`SkillsToolbar.tsx\`, unrelated)
- [x] \`pnpm -C packages/web test\` 135 pass / 1 skipped pre-existing
- [x] Memo wrappers asserted via \`\$\$typeof === Symbol.for('react.memo')\` in new tests
- [x] rAF helper coalescing verified
- [x] Final cross-cutting code review (memo bail-out confirmed against \`applyStreamEvent\` text_delta reducer; R1 fix held; streaming render block unchanged)
- [ ] Manual browser perf trace on \`conv-1fwZQ8u3ZDukx3\` (long real conversation) — see follow-up comment below