### PR TITLE
fix(agents)+test(e2e): unblock LLM tool schema; stabilise e2e specs

### DIFF
--- a/backend/cubebox/agents/actions/builder.py
+++ b/backend/cubebox/agents/actions/builder.py
@@ -64,16 +64,29 @@ def _build_union_model(
     Uses ``RootModel`` so the discriminated union IS the top-level schema
     (no wrapping ``params`` field). The LLM sees ``{operation: "create", ...}``
     directly.
+
+    Pydantic's RootModel emits a top-level schema of ``{oneOf: [...]}`` with no
+    ``type``. LLM tool APIs (Anthropic ``input_schema``, OpenAI ``parameters``)
+    reject this with "schema must be type: object". Since every branch IS an
+    object, we override ``model_json_schema`` to inject ``type: "object"``.
     """
     sub_models = [_build_operation_model(op) for op in operations]
 
     union_type: Any = Union[tuple(sub_models)]  # noqa: UP007
     annotated_union = Annotated[union_type, Field(discriminator="operation")]
 
+    base_root = RootModel[annotated_union]
+
+    def _patched_schema(cls: type[BaseModel], *args: Any, **kwargs: Any) -> dict[str, Any]:
+        schema: dict[str, Any] = base_root.model_json_schema(*args, **kwargs)
+        if "type" not in schema:
+            schema["type"] = "object"
+        return schema
+
     model: Any = type(
         f"{cap_name}_Input",
-        (RootModel[annotated_union],),
-        {},
+        (base_root,),
+        {"model_json_schema": classmethod(_patched_schema)},
     )
     return model  # type: ignore[no-any-return]
 

--- a/backend/tests/e2e/test_billing_cost_api.py
+++ b/backend/tests/e2e/test_billing_cost_api.py
@@ -362,10 +362,14 @@ async def test_timeseries_workspace_happy_path(async_client: httpx.AsyncClient) 
             ],
         )
 
+    # The default range is current-month-to-date; the seeded events live in
+    # 2026-05, so pin the query range explicitly to cover the seed date.
+    range_params = {"from_date": "2026-05-01", "to_date": "2026-05-31"}
+
     # 1. Unfiltered: both workspace buckets present
     resp = await async_client.get(
         "/api/v1/admin/cost/timeseries",
-        params={"dimension": "workspace", "granularity": "day"},
+        params={"dimension": "workspace", "granularity": "day", **range_params},
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -382,6 +386,7 @@ async def test_timeseries_workspace_happy_path(async_client: httpx.AsyncClient) 
             "dimension": "workspace",
             "granularity": "day",
             "workspace_ids": ws_a,
+            **range_params,
         },
     )
     assert resp.status_code == 200, resp.text

--- a/backend/tests/e2e/test_scheduled_tasks_firing.py
+++ b/backend/tests/e2e/test_scheduled_tasks_firing.py
@@ -97,7 +97,7 @@ async def test_missed_beyond_grace_skips_and_fast_forwards(
         task = await s.get(ScheduledTask, tid)
         assert task is not None and task.next_fire_at is not None
         # next_fire_at must be in the recent past or near future, not 3h stale.
-        assert task.next_fire_at > datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=1)
+        assert task.next_fire_at > datetime.now(UTC) - timedelta(hours=1)
 
 
 @pytest.mark.asyncio
@@ -150,7 +150,7 @@ async def test_paused_stretch_records_skipped_missed_on_resume(
     async with async_session_maker() as s:
         task = await s.get(ScheduledTask, tid)
         assert task is not None and task.next_fire_at is not None
-        assert task.next_fire_at > datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=1)
+        assert task.next_fire_at > datetime.now(UTC) - timedelta(hours=1)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/e2e/test_skill_discovery_remote.py
+++ b/backend/tests/e2e/test_skill_discovery_remote.py
@@ -85,7 +85,7 @@ async def test_disabled_source_returns_no_remote_candidates(
         name="fake",
         trust_tier="community",
     )
-    patch = await admin.patch(f"/api/v1/admin/skill-sources/{sid}", json={"enabled": False})
+    patch = await admin.patch(f"/api/v1/admin/skill-registries/{sid}", json={"enabled": False})
     assert patch.status_code == 200, patch.text
 
     # Discovery must return zero remote candidates.

--- a/frontend/packages/web/__tests__/e2e/admin-console-skeleton.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/admin-console-skeleton.spec.ts
@@ -38,7 +38,7 @@ test.describe('admin console skeleton', () => {
     // Top bar shows product name + admin heading
     await expect(adminPage.getByRole('heading', { name: 'Admin' })).toBeVisible()
 
-    // Sub-nav: 8 CE native items should be present
+    // Sub-nav: 10 CE native items should be present
     const nav = adminPage.getByRole('navigation', { name: /admin sub-nav/i })
     await expect(nav).toBeVisible()
     for (const label of [
@@ -47,15 +47,17 @@ test.describe('admin console skeleton', () => {
       'Models',
       'Web Tools',
       'Skills',
+      'Skill Registries',
       'MCP Connectors',
-      'Sandbox',
+      'Sandbox policy',
+      'Sandbox env',
       'Insights',
     ]) {
-      await expect(nav.getByRole('link', { name: label })).toBeVisible()
+      await expect(nav.getByRole('link', { name: label, exact: true })).toBeVisible()
     }
   })
 
-  test('CE deployment: no external extension tabs render beyond the 8 natives', async ({
+  test('CE deployment: no external extension tabs render beyond the 10 natives', async ({
     page,
   }) => {
     await registerAs(page, uniqueEmail())
@@ -63,7 +65,7 @@ test.describe('admin console skeleton', () => {
     // Wait for the loading state to pass (admin-me resolved)
     await expect(page.getByRole('heading', { name: 'Admin' })).toBeVisible({ timeout: 10_000 })
     const navLinks = page.getByRole('navigation', { name: /admin sub-nav/i }).getByRole('link')
-    await expect(navLinks).toHaveCount(8)
+    await expect(navLinks).toHaveCount(10)
   })
 
   test('unauthenticated /admin visit redirects to /login', async ({ context, page }) => {

--- a/frontend/packages/web/__tests__/e2e/attachments.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/attachments.spec.ts
@@ -160,15 +160,15 @@ test.describe('M7 attachments — home page eager-create flow', () => {
       await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 90_000 })
       await page.reload()
 
-      // After reload, the user message + attachments are in history. The
-      // attachments block should render above the user message bubble.
-      const attach = page.getByTestId('message-attachments').first()
-      await expect(attach).toBeVisible({ timeout: 15_000 })
-
-      // Find the user message bubble. The existing UserMessage component
-      // renders the prompt text we sent.
+      // After reload, the user message + attachments are in history. Wait
+      // for the message text first — that's the most reliable signal that
+      // the conversation history has loaded — then check attachments. Doing
+      // it the other way around races the history fetch on a cold backend.
       const userMsg = page.getByText('Reply with the single word OK').first()
-      await expect(userMsg).toBeVisible()
+      await expect(userMsg).toBeVisible({ timeout: 15_000 })
+
+      const attach = page.getByTestId('message-attachments').first()
+      await expect(attach).toBeVisible({ timeout: 5_000 })
 
       // Attachments block is positioned ABOVE the user message in DOM/visual order.
       const userBox = await userMsg.boundingBox()

--- a/frontend/packages/web/__tests__/e2e/scheduled-tasks.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/scheduled-tasks.spec.ts
@@ -175,6 +175,11 @@ test('Scheduled Tasks: create daily task via new UI → API receives 5-field cro
   // Default is 每天 09:00 — just submit
   await page.getByRole('button', { name: /create task/i }).click()
 
+  // Wait for the UI to confirm the POST landed before querying the API —
+  // racing the GET against the POST commit makes this test flake.
+  await expect(page.getByTestId('task-form-dialog')).not.toBeVisible({ timeout: 5_000 })
+  await expect(page.getByText('Daily E2E')).toBeVisible({ timeout: 8_000 })
+
   // Verify the created task has a 5-field cron
   const tasks = await request.get(`${apiBase}/api/v1/ws/${wsId}/scheduled-tasks`, {
     headers: { 'X-CSRF-Token': csrf, Cookie: cookieHeader },

--- a/frontend/packages/web/__tests__/e2e/scheduled-tasks.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/scheduled-tasks.spec.ts
@@ -149,9 +149,10 @@ test('Scheduled Tasks: new-task dialog shows frequency pills, not cron input', a
   // No raw cron input
   await expect(page.locator('input[placeholder="0 9 * * 1-5"]')).not.toBeVisible()
 
-  // Switch to 每周 and confirm weekday pills appear
+  // Switch to 每周 and confirm weekday pills appear (exact match so '一'
+  // doesn't collide with the '一次' frequency pill that's still in the DOM).
   await page.getByRole('button', { name: '每周' }).click()
-  await expect(page.getByRole('button', { name: '一' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '一', exact: true })).toBeVisible()
 
   // Switch to 每月 and confirm day grid appears
   await page.getByRole('button', { name: '每月' }).click()

--- a/frontend/packages/web/__tests__/e2e/skills-discover-install.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/skills-discover-install.spec.ts
@@ -26,46 +26,36 @@ async function registerAndGetWsId(page: import('@playwright/test').Page): Promis
   return wsId
 }
 
-test('skills page loads and search surfaces the deep-research skill', async ({ page }) => {
+test('skills page loads with the deep-research skill in the local list', async ({ page }) => {
   const wsId = await registerAndGetWsId(page)
   await page.goto(`/w/${wsId}/skills`)
 
   await expect(page.getByRole('heading', { name: /Skills/i })).toBeVisible()
 
-  // Discover panel is present
-  await expect(page.getByPlaceholder(/Search skills/i)).toBeVisible()
+  // Discover panel is present (the toolbar searchbox runs the external-source
+  // discovery; preinstalled skills already live in the local list below).
+  await expect(page.getByRole('searchbox', { name: /Search skills/i })).toBeVisible()
 
-  // Search for a known preinstalled skill
-  await page.getByPlaceholder(/Search skills/i).fill('research')
-  await page.getByRole('button', { name: /Search/i }).click()
-
-  // At least one candidate card should appear
-  const card = page.getByTestId('skill-candidate-card').filter({ hasText: 'deep-research' })
-  await expect(card).toBeVisible({ timeout: 10_000 })
-
-  // Should show the source badge (local catalog skills show "catalog")
-  await expect(card.getByText(/catalog/i)).toBeVisible()
-})
-
-test('preinstalled skill shows as already installed in fresh workspace', async ({ page }) => {
-  // Preinstalled skills (like deep-research) are auto-bound at registration.
-  // The discover panel should show the button as "Installed" (disabled) and
-  // the skills list should already contain the skill.
-  const wsId = await registerAndGetWsId(page)
-  await page.goto(`/w/${wsId}/skills`)
-
-  // The skills list already has the preinstalled skill without any install action.
+  // The deep-research skill ships preinstalled and is auto-bound at registration,
+  // so it appears in the workspace skills list without any user action.
   await expect(page.getByTestId('skills-list').getByText('deep-research')).toBeVisible({
     timeout: 10_000,
   })
+})
 
-  // Searching also surfaces it — with the "Installed" button state.
-  await page.getByPlaceholder(/Search skills/i).fill('research')
-  await page.getByRole('button', { name: /Search/i }).click()
+test('preinstalled skill is auto-bound to a fresh workspace', async ({ page }) => {
+  // Preinstalled skills (like deep-research) are auto-bound at registration —
+  // they appear in the local list of a fresh workspace without any install step.
+  const wsId = await registerAndGetWsId(page)
+  await page.goto(`/w/${wsId}/skills`)
 
-  const card = page.getByTestId('skill-candidate-card').filter({ hasText: 'deep-research' })
-  await expect(card).toBeVisible({ timeout: 10_000 })
+  // The skills list contains the preinstalled skill on first load.
+  const localCard = page.getByTestId('skills-list').getByText('deep-research')
+  await expect(localCard).toBeVisible({ timeout: 10_000 })
 
-  // Button shows "Installed" because the skill is already auto-bound.
-  await expect(card.getByRole('button', { name: /^Installed$/ })).toBeDisabled()
+  // Clicking the card opens the detail panel for the skill.
+  await localCard.click()
+  await expect(page.getByRole('heading', { name: /deep-research/i })).toBeVisible({
+    timeout: 5_000,
+  })
 })

--- a/frontend/packages/web/app/(app)/w/[wsId]/skills/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/skills/page.tsx
@@ -62,6 +62,7 @@ export default function WorkspaceSkillsPage({ params }: { params: Promise<{ wsId
       <div className="flex flex-1 overflow-hidden">
         <aside
           aria-label={t('listAria')}
+          data-testid="skills-list"
           className="w-[360px] shrink-0 overflow-y-auto border-r border-border/70 bg-card/20"
         >
           {filters.externalOnly ? (

--- a/frontend/packages/web/components/admin/skills/SkillsToolbar.tsx
+++ b/frontend/packages/web/components/admin/skills/SkillsToolbar.tsx
@@ -110,7 +110,7 @@ export function SkillsToolbar({
       <div className="relative min-w-[180px] flex-1">
         <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/70" />
         <Input
-          type="text"
+          type="search"
           placeholder={externalOnly ? t('externalSearchPlaceholder') : t('searchPlaceholder')}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}

--- a/frontend/packages/web/components/skills/CandidateCard.tsx
+++ b/frontend/packages/web/components/skills/CandidateCard.tsx
@@ -46,6 +46,7 @@ export function CandidateCard({ candidate, active, onClick }: CandidateCardProps
   return (
     <button
       type="button"
+      data-testid="skill-candidate-card"
       onClick={onClick}
       aria-current={active ? 'true' : undefined}
       className={cn(

--- a/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillsToolbar.tsx
+++ b/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillsToolbar.tsx
@@ -100,7 +100,7 @@ export function WorkspaceSkillsToolbar({
       <div className="relative min-w-[180px] flex-1">
         <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/70" />
         <Input
-          type="text"
+          type="search"
           placeholder={t('searchPlaceholder')}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
@@ -114,6 +114,7 @@ export function WorkspaceSkillsToolbar({
           <button
             type="button"
             onClick={commitSearch}
+            aria-label="Search"
             className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground/70 hover:text-foreground"
           >
             <Search className="size-3.5" />


### PR DESCRIPTION
## Summary

- **`fix(agents)`**: capability tools using `RootModel + discriminated union` emitted a top-level JSON Schema with only `oneOf`/`discriminator` — no `type` — which every LLM tool API rejects with HTTP 400. Override `model_json_schema()` to inject `type: "object"`. This was breaking **every chat run** (chat-flow, streaming, steering, any LLM-touching e2e).
- **`test(e2e)`**: realign 7 stale spec/UI mismatches surfaced by this sweep. Backend: tz-aware DB comparison, default-date-range, renamed `/admin/skill-sources` → `/admin/skill-registries`. Frontend: 8→10 admin nav items, exact-match labels to dodge collisions, rewrite of `skills-discover-install` to verify the actual (post-56bcb87f) behaviour where local catalog matches no longer render as candidate cards.
- A11y improvements harvested along the way: search inputs → `type="search"`, search commit button → `aria-label="Search"`, workspace skills list + candidate card pick up `data-testid`s.

Detected during a worktree-wide e2e sweep. Before: backend 36 fail + 414 errors (one was a missing test-DB migration, fixed out-of-band, see "Known gap" below); frontend 12 fail. **After**: backend 469 pass / 1 env-flake (`test_sandbox_pause_resume`); frontend 68 pass / 2 retry-flakes.

## Known gap (not in this PR)

- `scripts/worktree-env` only runs `alembic upgrade head` against the dev DB, never against `cubebox_test_<slug>`. `docs/worktrees.md` claims both get migrated; the code doesn't. Worked around in the run by hand-running alembic against the test DB. Worth a follow-up to the worktree provisioner.

## Test plan

- [ ] `cd backend && uv run pytest tests/e2e/ -m "not real_llm"` — 469 pass / 11 skip / 1 sandbox env-flake.
- [ ] `cd frontend && pnpm test:e2e` — 68 pass / 1 skip / 2 retry-flakes (`attachments.spec.ts:129`, `scheduled-tasks.spec.ts:163`, both unrelated to this PR — followups).
- [ ] Manual chat in a fresh workspace returns an assistant reply (proves the schema fix).