### PR TITLE
fix(memory): improve per-turn reflection quality — tool context, conservative bias, existing memory

### DIFF
--- a/backend/cubebox/prompts/reflection_system.py
+++ b/backend/cubebox/prompts/reflection_system.py
@@ -1,35 +1,36 @@
-"""System prompt for the detached memory-reflection agent.
-
-The reflection agent runs in isolation after a main conversation turn
-completes. It sees only the last turn (user msg + assistant reply + tool
-summaries) plus the current memory snapshot. Its job: extract anything
-worth remembering and call memory_save / memory_update once.
-"""
+"""System prompt for the detached memory-reflection agent."""
 
 REFLECTION_SYSTEM_PROMPT: str = """\
 You are a memory-curation assistant. Your only job is to review the last \
 turn of a conversation and decide whether anything new is worth remembering.
+
+Most turns contain nothing worth saving. When in doubt, do not save.
 
 You have three tools:
 - memory_search: check whether a fact is already stored.
 - memory_save:   add a new memory.
 - memory_update: refine an existing memory.
 
-Heuristics for what to save:
-- The user expressed a preference ("I prefer X", "always do Y", "I like…").
-- The user corrected you, or pushed back on something you did.
-- The user stated a durable fact about themselves, their team, or their project \
-that would change how you respond next time.
-- The user shared a decision that should outlast this conversation.
+Before calling memory_save, always call memory_search to check whether a \
+closely related item already exists. If one does, call memory_update instead, \
+or skip entirely if the existing item already covers it.
+
+Save only when ALL of the following are true:
+- The user expressed a clear preference, correction, or durable fact about \
+themselves, their team, or their project.
+- It would change how you respond in a future conversation.
+- It is NOT already covered by an item in the current memory shown above.
 
 Do NOT save:
-- Restatements of facts you already have (search first).
-- Ephemeral context that only matters for this run.
+- Preferences or facts already present in the memory block above.
+- Temporary state, one-off task steps, or in-progress status.
+- Ephemeral values (device codes, one-time URLs, transient error messages).
 - Speculative or low-confidence inferences.
+- Restatements of what the assistant just did.
 
 Scope: use 'personal' unless the user explicitly said to share with the team.
 
 Output: call memory_search / memory_save / memory_update as needed, then end. \
-If nothing is worth saving, end immediately without calling any tool. Do not \
-explain — the user will not see your text.
+If nothing is worth saving, end immediately without calling any tool. \
+Do not explain — the user will not see your text.
 """

--- a/backend/cubebox/repositories/memory.py
+++ b/backend/cubebox/repositories/memory.py
@@ -89,6 +89,7 @@ class MemoryRepository:
         source_conversation_id: str | None = None,
         limit: int = 200,
         offset: int = 0,
+        order_by_recent: bool = False,
     ) -> list[MemoryItem]:
         stmt = select(MemoryItem).where(self._scope_filter(scope))
         stmt = stmt.where(MemoryItem.status == status)  # type: ignore[arg-type]
@@ -98,7 +99,16 @@ class MemoryRepository:
             stmt = stmt.where(MemoryItem.content.ilike(f"%{q}%"))  # type: ignore[attr-defined]
         if source_conversation_id is not None:
             stmt = stmt.where(MemoryItem.source_conversation_id == source_conversation_id)  # type: ignore[arg-type]
-        stmt = stmt.order_by(MemoryItem.created_at.asc()).limit(limit).offset(offset)  # type: ignore[attr-defined]
+        if order_by_recent:
+            # last_used_at DESC NULLS LAST, created_at DESC — used by reflection to
+            # fetch the most recently relevant items when there are many memories.
+            stmt = stmt.order_by(
+                MemoryItem.last_used_at.desc().nulls_last(),  # type: ignore[union-attr]
+                MemoryItem.created_at.desc(),  # type: ignore[attr-defined]
+            )
+        else:
+            stmt = stmt.order_by(MemoryItem.created_at.asc())  # type: ignore[attr-defined]
+        stmt = stmt.limit(limit).offset(offset)
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 

--- a/backend/cubebox/services/reflection_runner.py
+++ b/backend/cubebox/services/reflection_runner.py
@@ -27,6 +27,8 @@ from cubebox.services.user_event import PublishUserEventInput, UserEventService
 
 logger = logging.getLogger(__name__)
 
+_CONTENT_TRUNCATE = 200  # max chars per existing memory item in seed
+
 
 @dataclass
 class ReflectionTurn:
@@ -43,6 +45,8 @@ class ReflectionInput:
     user_id: str
     workspace_id: str | None
     turn: ReflectionTurn
+    existing_memory_items: list[tuple[str, str, str]] = field(default_factory=list)
+    # each: (memory_id, type_value, content)
 
 
 # Agent factory signature: given a ReflectionInput, build & return an Agent
@@ -88,7 +92,7 @@ class ReflectionRunner:
 
     async def _reflect_impl(self, inp: ReflectionInput) -> None:
         agent = self._make_agent(inp)
-        seed = self._build_seed_prompt(inp.turn)
+        seed = self._build_seed_prompt(inp)
 
         items: list[dict[str, Any]] = []
 
@@ -136,16 +140,30 @@ class ReflectionRunner:
             )
         )
 
-    def _build_seed_prompt(self, turn: ReflectionTurn) -> str:
-        # Pack the last turn into a single user-message string. The reflection
-        # system prompt frames the task; this just gives it the material.
+    def _build_seed_prompt(self, inp: ReflectionInput) -> str:
+        turn = inp.turn
+
+        memory_block = ""
+        if inp.existing_memory_items:
+            lines = [
+                f"- [{mid}] ({mtype}) {mcontent[:_CONTENT_TRUNCATE]}"
+                for mid, mtype, mcontent in inp.existing_memory_items
+            ]
+            memory_block = (
+                "Your current memory for this user (personal, active):\n"
+                + "\n".join(lines)
+                + "\n\n"
+            )
+
         tools_block = ""
         if turn.tool_summaries:
             tools_block = "\n\nTools called in this turn:\n" + "\n".join(
                 f"- {t['name']}({t.get('args_summary', '')}) -> {t.get('outcome', 'ok')}"
                 for t in turn.tool_summaries
             )
+
         return (
+            f"{memory_block}"
             "Last turn for review:\n\n"
             f"USER: {turn.user_message}\n\n"
             f"ASSISTANT: {turn.assistant_message}"

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1567,6 +1567,44 @@ class RunManager:
                             if not last_assistant:
                                 return
                             user_msg_text = _stringify_user_msg(user_msg_ref)
+                            # Load the user's active personal memory so the reflection agent
+                            # knows what's already stored before deciding what to save.
+                            _existing_items: list[tuple[str, str, str]] = []
+                            try:
+                                import datetime
+
+                                from cubebox.models.memory import MemoryScope, MemoryStatus
+                                from cubebox.repositories.memory import MemoryRepository
+
+                                async with _ue_session_maker() as _mem_session:
+                                    _mem_repo = MemoryRepository(
+                                        _mem_session,
+                                        user_id=ctx.user_id,
+                                        org_id=ctx.org_id,
+                                        workspace_id=ctx.workspace_id,
+                                    )
+                                    _all_personal = await _mem_repo.list(
+                                        scope=MemoryScope.PERSONAL,
+                                        status=MemoryStatus.ACTIVE,
+                                        limit=200,
+                                    )
+                                _sorted = sorted(
+                                    _all_personal,
+                                    key=lambda m: (
+                                        m.last_used_at
+                                        or datetime.datetime.min.replace(tzinfo=datetime.UTC),
+                                        m.created_at,
+                                    ),
+                                    reverse=True,
+                                )[:40]
+                                _existing_items = [(m.id, m.type.value, m.content) for m in _sorted]
+                            except Exception:
+                                logger.warning(
+                                    "reflection: failed to load existing memory for run_id={}",
+                                    run_id,
+                                    exc_info=True,
+                                )
+
                             inp = ReflectionInput(
                                 conversation_id=conversation_id,
                                 run_id=run_id,
@@ -1579,6 +1617,7 @@ class RunManager:
                                         agent_ref.state.messages
                                     ),
                                 ),
+                                existing_memory_items=_existing_items,
                             )
                             async with _ue_session_maker() as _session:
                                 _repo = UserEventRepository(_session)

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -636,6 +636,61 @@ def _build_cancel_answer(payload: Any, reason: str) -> dict[str, Any]:
     return {"_cancelled": True, "_reason": reason}
 
 
+def _extract_tool_summaries(messages: list[Any]) -> list[dict[str, str]]:
+    """Build compact tool-call summaries from a turn's message list.
+
+    Collects all ToolResultMessages that appear after the last UserMessage,
+    paired with their corresponding ToolCall arguments. Capped at 10 entries;
+    args and error text truncated to 150 chars each.
+    """
+    from cubepi.providers.base import (
+        AssistantMessage,
+        TextContent,
+        ToolCall,
+        ToolResultMessage,
+        UserMessage,
+    )
+
+    _ARGS_LIMIT = 150
+    _RESULT_LIMIT = 150
+    _MAX_SUMMARIES = 10
+
+    last_user_idx = -1
+    for i, msg in enumerate(messages):
+        if isinstance(msg, UserMessage):
+            last_user_idx = i
+    if last_user_idx == -1:
+        return []
+
+    tool_args: dict[str, str] = {}
+    for msg in messages[last_user_idx + 1 :]:
+        if isinstance(msg, AssistantMessage):
+            for part in msg.content:
+                if isinstance(part, ToolCall):
+                    args_str = ", ".join(f"{k}={repr(v)}" for k, v in part.arguments.items())
+                    tool_args[part.id] = args_str[:_ARGS_LIMIT]
+
+    summaries: list[dict[str, str]] = []
+    for msg in messages[last_user_idx + 1 :]:
+        if not isinstance(msg, ToolResultMessage):
+            continue
+        if len(summaries) >= _MAX_SUMMARIES:
+            break
+        result_text = "".join(c.text for c in msg.content if isinstance(c, TextContent))
+        if msg.is_error:
+            outcome = f"error: {result_text[:_RESULT_LIMIT]}"
+        else:
+            outcome = "ok"
+        summaries.append(
+            {
+                "name": msg.tool_name,
+                "args_summary": tool_args.get(msg.tool_call_id, ""),
+                "outcome": outcome,
+            }
+        )
+    return summaries
+
+
 class RunManager:
     """Owns background run execution and Redis persistence."""
 
@@ -1520,7 +1575,9 @@ class RunManager:
                                 turn=ReflectionTurn(
                                     user_message=user_msg_text,
                                     assistant_message=last_assistant,
-                                    tool_summaries=[],
+                                    tool_summaries=_extract_tool_summaries(
+                                        agent_ref.state.messages
+                                    ),
                                 ),
                             )
                             async with _ue_session_maker() as _session:

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1581,20 +1581,15 @@ class RunManager:
                                         org_id=ctx.org_id,
                                         workspace_id=ctx.workspace_id,
                                     )
-                                    _all_personal = await _mem_repo.list(
+                                    _personal = await _mem_repo.list(
                                         scope=MemoryScope.PERSONAL,
                                         status=MemoryStatus.ACTIVE,
-                                        limit=200,
+                                        order_by_recent=True,
+                                        limit=40,
                                     )
-                                _sorted = sorted(
-                                    _all_personal,
-                                    key=lambda m: (
-                                        m.last_used_at or datetime.min.replace(tzinfo=UTC),
-                                        m.created_at,
-                                    ),
-                                    reverse=True,
-                                )[:40]
-                                _existing_items = [(m.id, m.type.value, m.content) for m in _sorted]
+                                _existing_items = [
+                                    (m.id, m.type.value, m.content) for m in _personal
+                                ]
                             except Exception:
                                 logger.warning(
                                     "reflection: failed to load existing memory for run_id={}",

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -636,12 +636,18 @@ def _build_cancel_answer(payload: Any, reason: str) -> dict[str, Any]:
     return {"_cancelled": True, "_reason": reason}
 
 
-def _extract_tool_summaries(messages: list[Any]) -> list[dict[str, str]]:
+def _extract_tool_summaries(
+    messages: list[Any], *, from_idx: int | None = None
+) -> list[dict[str, str]]:
     """Build compact tool-call summaries from a turn's message list.
 
-    Collects all ToolResultMessages that appear after the last UserMessage,
+    Collects ToolResultMessages that appear after the run's UserMessage,
     paired with their corresponding ToolCall arguments. Capped at 10 entries;
     args and error text truncated to 150 chars each.
+
+    from_idx: index of the original user message for this run. When provided,
+    all tool calls after that index are captured, including those that precede
+    mid-run steer UserMessages. Falls back to last-UserMessage scan when None.
     """
     from cubepi.providers.base import (
         AssistantMessage,
@@ -655,15 +661,18 @@ def _extract_tool_summaries(messages: list[Any]) -> list[dict[str, str]]:
     _RESULT_LIMIT = 150
     _MAX_SUMMARIES = 10
 
-    last_user_idx = -1
-    for i, msg in enumerate(messages):
-        if isinstance(msg, UserMessage):
-            last_user_idx = i
-    if last_user_idx == -1:
+    if from_idx is not None:
+        start = from_idx
+    else:
+        start = -1
+        for i, msg in enumerate(messages):
+            if isinstance(msg, UserMessage):
+                start = i
+    if start == -1:
         return []
 
     tool_args: dict[str, str] = {}
-    for msg in messages[last_user_idx + 1 :]:
+    for msg in messages[start + 1 :]:
         if isinstance(msg, AssistantMessage):
             for part in msg.content:
                 if isinstance(part, ToolCall):
@@ -671,7 +680,7 @@ def _extract_tool_summaries(messages: list[Any]) -> list[dict[str, str]]:
                     tool_args[part.id] = args_str[:_ARGS_LIMIT]
 
     summaries: list[dict[str, str]] = []
-    for msg in messages[last_user_idx + 1 :]:
+    for msg in messages[start + 1 :]:
         if not isinstance(msg, ToolResultMessage):
             continue
         if len(summaries) >= _MAX_SUMMARIES:
@@ -1597,6 +1606,14 @@ class RunManager:
                                     exc_info=True,
                                 )
 
+                            # Locate the original user message by identity so
+                            # tool summaries include calls before mid-run steers.
+                            _user_start: int | None = None
+                            for _mi, _mm in enumerate(agent_ref.state.messages):
+                                if _mm is user_msg_ref:
+                                    _user_start = _mi
+                                    break
+
                             inp = ReflectionInput(
                                 conversation_id=conversation_id,
                                 run_id=run_id,
@@ -1606,7 +1623,8 @@ class RunManager:
                                     user_message=user_msg_text,
                                     assistant_message=last_assistant,
                                     tool_summaries=_extract_tool_summaries(
-                                        agent_ref.state.messages
+                                        agent_ref.state.messages,
+                                        from_idx=_user_start,
                                     ),
                                 ),
                                 existing_memory_items=_existing_items,

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1571,8 +1571,6 @@ class RunManager:
                             # knows what's already stored before deciding what to save.
                             _existing_items: list[tuple[str, str, str]] = []
                             try:
-                                import datetime
-
                                 from cubebox.models.memory import MemoryScope, MemoryStatus
                                 from cubebox.repositories.memory import MemoryRepository
 
@@ -1591,8 +1589,7 @@ class RunManager:
                                 _sorted = sorted(
                                     _all_personal,
                                     key=lambda m: (
-                                        m.last_used_at
-                                        or datetime.datetime.min.replace(tzinfo=datetime.UTC),
+                                        m.last_used_at or datetime.min.replace(tzinfo=UTC),
                                         m.created_at,
                                     ),
                                     reverse=True,

--- a/backend/tests/unit/test_reflection_runner.py
+++ b/backend/tests/unit/test_reflection_runner.py
@@ -239,3 +239,69 @@ async def test_reflect_idempotency(
 
     assert factory_call_count == 1
     assert user_event_service_mock.publish.call_count == 1
+
+
+class TestBuildSeedPrompt:
+    """Unit tests for _build_seed_prompt — no async needed."""
+
+    def _runner(self) -> ReflectionRunner:
+        return ReflectionRunner(
+            user_event_service=MagicMock(),
+            agent_factory=MagicMock(),
+        )
+
+    def _inp(
+        self,
+        *,
+        existing: list[tuple[str, str, str]] | None = None,
+        tool_summaries: list[dict[str, str]] | None = None,
+    ) -> ReflectionInput:
+        return ReflectionInput(
+            conversation_id="c",
+            run_id="r",
+            user_id="u",
+            workspace_id=None,
+            turn=ReflectionTurn(
+                user_message="USER MSG",
+                assistant_message="ASST MSG",
+                tool_summaries=tool_summaries or [],
+            ),
+            existing_memory_items=existing or [],
+        )
+
+    def test_no_existing_memory_no_memory_block(self) -> None:
+        seed = self._runner()._build_seed_prompt(self._inp())
+        assert "current memory" not in seed
+        assert "USER MSG" in seed
+        assert "ASST MSG" in seed
+
+    def test_existing_memory_renders_block(self) -> None:
+        items = [
+            ("mem-abc", "preference", "用户偏好中文交流"),
+            ("mem-def", "project_fact", "CubePi 是 Agent 框架"),
+        ]
+        seed = self._runner()._build_seed_prompt(self._inp(existing=items))
+        assert "current memory" in seed
+        assert "[mem-abc]" in seed
+        assert "(preference)" in seed
+        assert "用户偏好中文交流" in seed
+        assert "[mem-def]" in seed
+        # memory block appears BEFORE the turn
+        assert seed.index("current memory") < seed.index("Last turn")
+
+    def test_existing_memory_content_truncated_to_200_chars(self) -> None:
+        long_content = "x" * 300
+        items = [("mem-xyz", "project_fact", long_content)]
+        seed = self._runner()._build_seed_prompt(self._inp(existing=items))
+        assert long_content not in seed
+        assert "x" * 200 in seed
+
+    def test_tool_summaries_rendered(self) -> None:
+        summaries = [
+            {"name": "execute", "args_summary": "pip install foo", "outcome": "ok"},
+            {"name": "execute", "args_summary": "twitter whoami", "outcome": "error: HTTP 403"},
+        ]
+        seed = self._runner()._build_seed_prompt(self._inp(tool_summaries=summaries))
+        assert "Tools called" in seed
+        assert "execute(pip install foo) -> ok" in seed
+        assert "execute(twitter whoami) -> error: HTTP 403" in seed

--- a/backend/tests/unit/test_reflection_tool_summaries.py
+++ b/backend/tests/unit/test_reflection_tool_summaries.py
@@ -1,0 +1,110 @@
+"""Unit tests for the _extract_tool_summaries helper in run_manager."""
+
+from __future__ import annotations
+
+from cubepi.providers.base import (
+    AssistantMessage,
+    TextContent,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
+
+from cubebox.streams.run_manager import _extract_tool_summaries
+
+
+def _user(text: str = "hi") -> UserMessage:
+    return UserMessage(content=[TextContent(text=text)])
+
+
+def _assistant_with_calls(*calls: tuple[str, str, dict]) -> AssistantMessage:
+    content = [ToolCall(id=cid, name=name, arguments=args) for cid, name, args in calls]
+    return AssistantMessage(content=content)  # type: ignore[arg-type]
+
+
+def _result(
+    call_id: str, tool_name: str, text: str, *, is_error: bool = False
+) -> ToolResultMessage:
+    return ToolResultMessage(
+        tool_call_id=call_id,
+        tool_name=tool_name,
+        content=[TextContent(text=text)],
+        is_error=is_error,
+    )
+
+
+def test_empty_messages_returns_empty() -> None:
+    assert _extract_tool_summaries([]) == []
+
+
+def test_no_tool_calls_returns_empty() -> None:
+    msgs = [_user("hello"), AssistantMessage(content=[TextContent(text="hi")])]
+    assert _extract_tool_summaries(msgs) == []
+
+
+def test_single_tool_call_ok() -> None:
+    msgs = [
+        _user("run something"),
+        _assistant_with_calls(("tc1", "execute", {"command": "pip install foo"})),
+        _result("tc1", "execute", "Successfully installed foo"),
+    ]
+    summaries = _extract_tool_summaries(msgs)
+    assert len(summaries) == 1
+    assert summaries[0]["name"] == "execute"
+    assert "pip install foo" in summaries[0]["args_summary"]
+    assert summaries[0]["outcome"] == "ok"
+
+
+def test_error_result_prefixes_error() -> None:
+    msgs = [
+        _user("test"),
+        _assistant_with_calls(("tc1", "execute", {"command": "twitter whoami"})),
+        _result("tc1", "execute", "HTTP 403", is_error=True),
+    ]
+    summaries = _extract_tool_summaries(msgs)
+    assert summaries[0]["outcome"].startswith("error:")
+    assert "HTTP 403" in summaries[0]["outcome"]
+
+
+def test_args_truncated_to_150_chars() -> None:
+    long_cmd = "x" * 300
+    msgs = [
+        _user("run"),
+        _assistant_with_calls(("tc1", "execute", {"command": long_cmd})),
+        _result("tc1", "execute", "ok"),
+    ]
+    summaries = _extract_tool_summaries(msgs)
+    assert len(summaries[0]["args_summary"]) <= 150
+
+
+def test_outcome_truncated_to_150_chars() -> None:
+    long_output = "y" * 300
+    msgs = [
+        _user("run"),
+        _assistant_with_calls(("tc1", "execute", {"command": "cmd"})),
+        _result("tc1", "execute", long_output, is_error=True),
+    ]
+    summaries = _extract_tool_summaries(msgs)
+    assert len(summaries[0]["outcome"]) <= len("error: ") + 150
+
+
+def test_capped_at_10_summaries() -> None:
+    calls = [(f"tc{i}", "execute", {"command": f"cmd{i}"}) for i in range(15)]
+    results = [_result(f"tc{i}", "execute", f"out{i}") for i in range(15)]
+    msgs = [_user("run many"), _assistant_with_calls(*calls)] + results
+    summaries = _extract_tool_summaries(msgs)
+    assert len(summaries) <= 10
+
+
+def test_only_tools_after_last_user_message() -> None:
+    msgs = [
+        _user("first"),
+        _assistant_with_calls(("old_tc", "execute", {"command": "old"})),
+        _result("old_tc", "execute", "old result"),
+        _user("second"),
+        _assistant_with_calls(("new_tc", "execute", {"command": "new"})),
+        _result("new_tc", "execute", "new result"),
+    ]
+    summaries = _extract_tool_summaries(msgs)
+    assert len(summaries) == 1
+    assert "new" in summaries[0]["args_summary"]

--- a/backend/tests/unit/test_reflection_tool_summaries.py
+++ b/backend/tests/unit/test_reflection_tool_summaries.py
@@ -108,3 +108,28 @@ def test_only_tools_after_last_user_message() -> None:
     summaries = _extract_tool_summaries(msgs)
     assert len(summaries) == 1
     assert "new" in summaries[0]["args_summary"]
+
+
+def test_from_idx_captures_tools_before_steer() -> None:
+    # Simulates a steered run: tool calls happen before a mid-run UserMessage
+    # injected by _handle_control. from_idx pins the original prompt boundary
+    # so all tool calls in the run are captured.
+    msgs = [
+        _user("original prompt"),  # index 0 — original prompt
+        _assistant_with_calls(("tc1", "execute", {"command": "before-steer"})),
+        _result("tc1", "execute", "result-before"),
+        _user("steer message"),  # index 3 — mid-run steer (UserMessage)
+        _assistant_with_calls(("tc2", "execute", {"command": "after-steer"})),
+        _result("tc2", "execute", "result-after"),
+    ]
+    # Without from_idx: only sees tools after the last UserMessage (steer)
+    summaries_default = _extract_tool_summaries(msgs)
+    assert len(summaries_default) == 1
+    assert "after-steer" in summaries_default[0]["args_summary"]
+
+    # With from_idx=0: captures all tools from the original prompt onward
+    summaries_anchored = _extract_tool_summaries(msgs, from_idx=0)
+    assert len(summaries_anchored) == 2
+    names = [s["args_summary"] for s in summaries_anchored]
+    assert any("before-steer" in n for n in names)
+    assert any("after-steer" in n for n in names)

--- a/docs/dev/plans/2026-06-03-memory-reflection-quality.md
+++ b/docs/dev/plans/2026-06-03-memory-reflection-quality.md
@@ -1,0 +1,776 @@
+# Memory Reflection Quality Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three structural gaps in the per-turn reflection agent so it stores fewer duplicates, sees tool results, and knows what's already in memory before deciding what to save.
+
+**Architecture:** Three independent edits across two service files and one prompt file. No new tables, no migrations, no API changes. Each task is self-contained and has its own unit tests. Work in worktree `feat/memory-reflection-quality` (backend port 8071).
+
+**Tech Stack:** Python 3.13, FastAPI, SQLModel, cubepi Agent, pytest-asyncio
+
+**Spec:** `docs/dev/specs/2026-06-03-memory-reflection-quality-design.md`
+
+---
+
+## File Map
+
+| File | What changes |
+|---|---|
+| `backend/cubebox/prompts/reflection_system.py` | Rewrite prompt — conservative bias + mandatory search-first |
+| `backend/cubebox/services/reflection_runner.py` | `ReflectionInput` gets `existing_memory_items`; `_build_seed_prompt` renders it |
+| `backend/cubebox/streams/run_manager.py` | Extract tool summaries from agent messages; load personal memory before spawning reflection |
+| `backend/tests/unit/test_reflection_runner.py` | Extend with seed-prompt and existing-memory tests |
+| `backend/tests/unit/test_reflection_tool_summaries.py` | New — unit tests for tool-summary extraction |
+
+---
+
+## Task 1: Rewrite reflection_system.py prompt (C2)
+
+**Files:**
+- Modify: `backend/cubebox/prompts/reflection_system.py`
+- Test: `backend/tests/unit/test_reflection_runner.py` (smoke — verify prompt is importable and non-empty)
+
+- [ ] **Step 1: Replace the prompt**
+
+Replace the entire content of `backend/cubebox/prompts/reflection_system.py`:
+
+```python
+"""System prompt for the detached memory-reflection agent."""
+
+REFLECTION_SYSTEM_PROMPT: str = """\
+You are a memory-curation assistant. Your only job is to review the last \
+turn of a conversation and decide whether anything new is worth remembering.
+
+Most turns contain nothing worth saving. When in doubt, do not save.
+
+You have three tools:
+- memory_search: check whether a fact is already stored.
+- memory_save:   add a new memory.
+- memory_update: refine an existing memory.
+
+Before calling memory_save, always call memory_search to check whether a \
+closely related item already exists. If one does, call memory_update instead, \
+or skip entirely if the existing item already covers it.
+
+Save only when ALL of the following are true:
+- The user expressed a clear preference, correction, or durable fact about \
+themselves, their team, or their project.
+- It would change how you respond in a future conversation.
+- It is NOT already covered by an item in the current memory shown above.
+
+Do NOT save:
+- Preferences or facts already present in the memory block above.
+- Temporary state, one-off task steps, or in-progress status.
+- Ephemeral values (device codes, one-time URLs, transient error messages).
+- Speculative or low-confidence inferences.
+- Restatements of what the assistant just did.
+
+Scope: use 'personal' unless the user explicitly said to share with the team.
+
+Output: call memory_search / memory_save / memory_update as needed, then end. \
+If nothing is worth saving, end immediately without calling any tool. \
+Do not explain — the user will not see your text.
+"""
+```
+
+- [ ] **Step 2: Verify import and run existing tests**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality/backend
+uv run pytest tests/unit/test_reflection_runner.py -v
+```
+
+Expected: all existing tests pass (no behavioural change yet — tests don't inspect the prompt string).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality
+git add backend/cubebox/prompts/reflection_system.py
+git commit -m "fix(memory): add conservative bias and mandatory search-first to reflection prompt"
+```
+
+---
+
+## Task 2: Add existing_memory_items to ReflectionInput and seed prompt (C3 — runner side)
+
+**Files:**
+- Modify: `backend/cubebox/services/reflection_runner.py`
+- Modify: `backend/tests/unit/test_reflection_runner.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `backend/tests/unit/test_reflection_runner.py`:
+
+```python
+from cubebox.services.reflection_runner import ReflectionRunner
+
+
+class TestBuildSeedPrompt:
+    """Unit tests for _build_seed_prompt — no async needed."""
+
+    def _runner(self) -> ReflectionRunner:
+        return ReflectionRunner(
+            user_event_service=MagicMock(),
+            agent_factory=MagicMock(),
+        )
+
+    def _inp(
+        self,
+        *,
+        existing: list[tuple[str, str, str]] | None = None,
+        tool_summaries: list[dict[str, str]] | None = None,
+    ) -> ReflectionInput:
+        return ReflectionInput(
+            conversation_id="c",
+            run_id="r",
+            user_id="u",
+            workspace_id=None,
+            turn=ReflectionTurn(
+                user_message="USER MSG",
+                assistant_message="ASST MSG",
+                tool_summaries=tool_summaries or [],
+            ),
+            existing_memory_items=existing or [],
+        )
+
+    def test_no_existing_memory_no_memory_block(self) -> None:
+        seed = self._runner()._build_seed_prompt(self._inp())
+        assert "current memory" not in seed
+        assert "USER MSG" in seed
+        assert "ASST MSG" in seed
+
+    def test_existing_memory_renders_block(self) -> None:
+        items = [
+            ("mem-abc", "preference", "用户偏好中文交流"),
+            ("mem-def", "project_fact", "CubePi 是 Agent 框架"),
+        ]
+        seed = self._runner()._build_seed_prompt(self._inp(existing=items))
+        assert "current memory" in seed
+        assert "[mem-abc]" in seed
+        assert "(preference)" in seed
+        assert "用户偏好中文交流" in seed
+        assert "[mem-def]" in seed
+        # memory block appears BEFORE the turn
+        assert seed.index("current memory") < seed.index("Last turn")
+
+    def test_existing_memory_content_truncated_to_200_chars(self) -> None:
+        long_content = "x" * 300
+        items = [("mem-xyz", "project_fact", long_content)]
+        seed = self._runner()._build_seed_prompt(self._inp(existing=items))
+        assert long_content not in seed
+        assert "x" * 200 in seed
+
+    def test_tool_summaries_rendered(self) -> None:
+        summaries = [
+            {"name": "execute", "args_summary": "pip install foo", "outcome": "ok"},
+            {"name": "execute", "args_summary": "twitter whoami", "outcome": "error: HTTP 403"},
+        ]
+        seed = self._runner()._build_seed_prompt(self._inp(tool_summaries=summaries))
+        assert "Tools called" in seed
+        assert "execute(pip install foo) -> ok" in seed
+        assert "execute(twitter whoami) -> error: HTTP 403" in seed
+```
+
+- [ ] **Step 2: Run to confirm tests fail**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality/backend
+uv run pytest tests/unit/test_reflection_runner.py::TestBuildSeedPrompt -v
+```
+
+Expected: `AttributeError` or `TypeError` — `ReflectionInput` has no `existing_memory_items` and `_build_seed_prompt` takes `turn` not `inp`.
+
+- [ ] **Step 3: Implement the changes**
+
+Replace `reflection_runner.py` with:
+
+```python
+"""Out-of-band memory reflection — runs after AgentEndEvent.
+
+Spawns a detached cubepi Agent (cheap model, memory tools only) seeded with
+the last conversation turn plus the current memory snapshot. Captures any
+memory_save / memory_update tool executions and publishes a UserEvent so
+the frontend can surface the change.
+
+Failure semantics: fire-and-forget. Timeout, LLM errors, and memory write
+errors are logged and swallowed; never propagate to the main conversation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from cubepi import Agent
+from cubepi.agent.types import AgentEvent
+
+from cubebox.models.user_event import UserEventType
+from cubebox.services.reflection_context import set_reflection_source
+from cubebox.services.user_event import PublishUserEventInput, UserEventService
+
+logger = logging.getLogger(__name__)
+
+_CONTENT_TRUNCATE = 200  # max chars per existing memory item in seed
+
+
+@dataclass
+class ReflectionTurn:
+    user_message: str
+    assistant_message: str
+    tool_summaries: list[dict[str, str]] = field(default_factory=list)
+    # each: {"name": "...", "args_summary": "...", "outcome": "ok"|"error"}
+
+
+@dataclass
+class ReflectionInput:
+    conversation_id: str
+    run_id: str
+    user_id: str
+    workspace_id: str | None
+    turn: ReflectionTurn
+    existing_memory_items: list[tuple[str, str, str]] = field(default_factory=list)
+    # each: (memory_id, type_value, content)
+
+
+# Agent factory signature: given a ReflectionInput, build & return an Agent
+# whose tools include memory_save/memory_update/memory_search bound to the
+# user's MemoryService. Concrete factory wired in run_manager / DI setup.
+AgentFactory = Callable[[ReflectionInput], "Agent[Any]"]
+
+
+class ReflectionRunner:
+    def __init__(
+        self,
+        *,
+        user_event_service: UserEventService,
+        agent_factory: AgentFactory,
+        timeout_sec: float = 30.0,
+    ) -> None:
+        self._svc = user_event_service
+        self._make_agent = agent_factory
+        self._timeout = timeout_sec
+        self._seen_runs: set[str] = set()  # idempotency
+
+    async def reflect(self, inp: ReflectionInput) -> None:
+        if inp.run_id in self._seen_runs:
+            logger.debug("reflection already completed for run_id=%s, skipping", inp.run_id)
+            return
+        try:
+            await asyncio.wait_for(self._reflect_impl(inp), timeout=self._timeout)
+        except TimeoutError:
+            logger.warning(
+                "reflection timed out for run_id=%s conversation_id=%s",
+                inp.run_id,
+                inp.conversation_id,
+            )
+            return
+        except Exception:
+            logger.exception(
+                "reflection failed for run_id=%s conversation_id=%s",
+                inp.run_id,
+                inp.conversation_id,
+            )
+            return
+        self._seen_runs.add(inp.run_id)
+
+    async def _reflect_impl(self, inp: ReflectionInput) -> None:
+        agent = self._make_agent(inp)
+        seed = self._build_seed_prompt(inp)
+
+        items: list[dict[str, Any]] = []
+
+        # cubepi calls listeners with (event, signal) — accept both positionally.
+        def listener(event: AgentEvent, signal: Any = None) -> None:
+            if event.type != "tool_execution_end":
+                return
+            name = getattr(event, "tool_name", None)
+            if name not in ("memory_save", "memory_update"):
+                return
+            payload = self._extract_memory_result(event)
+            if payload is not None:
+                items.append(
+                    {
+                        "op": "save" if name == "memory_save" else "update",
+                        **payload,
+                    }
+                )
+
+        unsub = agent.subscribe(listener)
+        try:
+            # Keep the ContextVar active across wait_for_idle: cubepi can
+            # execute memory tool calls after prompt() returns (they finish
+            # during the idle drain), and tool callbacks must see
+            # reflection_source_active() == True to tag writes correctly.
+            with set_reflection_source():
+                await agent.prompt(seed)
+                await agent.wait_for_idle()
+        finally:
+            unsub()
+
+        if not items:
+            return
+
+        await self._svc.publish(
+            PublishUserEventInput(
+                user_id=inp.user_id,
+                workspace_id=inp.workspace_id,
+                type=UserEventType.MEMORY_UPDATED,
+                payload={
+                    "conversation_id": inp.conversation_id,
+                    "run_id": inp.run_id,
+                    "items": items,
+                },
+            )
+        )
+
+    def _build_seed_prompt(self, inp: ReflectionInput) -> str:
+        turn = inp.turn
+
+        memory_block = ""
+        if inp.existing_memory_items:
+            lines = [
+                f"- [{mid}] ({mtype}) {mcontent[:_CONTENT_TRUNCATE]}"
+                for mid, mtype, mcontent in inp.existing_memory_items
+            ]
+            memory_block = (
+                "Your current memory for this user (personal, active):\n"
+                + "\n".join(lines)
+                + "\n\n"
+            )
+
+        tools_block = ""
+        if turn.tool_summaries:
+            tools_block = "\n\nTools called in this turn:\n" + "\n".join(
+                f"- {t['name']}({t.get('args_summary', '')}) -> {t.get('outcome', 'ok')}"
+                for t in turn.tool_summaries
+            )
+
+        return (
+            f"{memory_block}"
+            "Last turn for review:\n\n"
+            f"USER: {turn.user_message}\n\n"
+            f"ASSISTANT: {turn.assistant_message}"
+            f"{tools_block}"
+        )
+
+    def _extract_memory_result(self, event: AgentEvent) -> dict[str, Any] | None:
+        # tool_execution_end carries the AgentToolResult; memory_save returns
+        # {"status": "saved", "memory_id": "..."} and memory_update returns
+        # {"status": "updated", "memory_id": "..."} as JSON text content.
+        try:
+            result = getattr(event, "result", None)
+            if result is None or not result.content:
+                return None
+            text = result.content[0].text
+            obj = json.loads(text)
+        except Exception:
+            return None
+        if obj.get("status") not in ("saved", "updated"):
+            return None
+        memory_id = obj.get("memory_id")
+        if not memory_id:
+            return None
+        return {"memory_id": memory_id}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality/backend
+uv run pytest tests/unit/test_reflection_runner.py -v
+```
+
+Expected: all tests pass including the new `TestBuildSeedPrompt` class.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality
+git add backend/cubebox/services/reflection_runner.py \
+        backend/tests/unit/test_reflection_runner.py
+git commit -m "feat(memory): inject existing personal memory into reflection seed prompt"
+```
+
+---
+
+## Task 3: Extract tool summaries from agent state messages (C1)
+
+**Files:**
+- Modify: `backend/cubebox/streams/run_manager.py`
+- Create: `backend/tests/unit/test_reflection_tool_summaries.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `backend/tests/unit/test_reflection_tool_summaries.py`:
+
+```python
+"""Unit tests for the _extract_tool_summaries helper extracted from run_manager."""
+
+from __future__ import annotations
+
+import pytest
+from cubepi.providers.base import (
+    AssistantMessage,
+    TextContent,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
+
+# Import the helper once it's been extracted into a testable location.
+# It lives as a module-level function in run_manager; we import it directly.
+from cubebox.streams.run_manager import _extract_tool_summaries
+
+
+def _user(text: str = "hi") -> UserMessage:
+    return UserMessage(content=[TextContent(text=text)])
+
+
+def _assistant_with_calls(*calls: tuple[str, str, dict]) -> AssistantMessage:
+    # calls: (call_id, tool_name, arguments)
+    content = [ToolCall(id=cid, name=name, arguments=args) for cid, name, args in calls]
+    return AssistantMessage(content=content)  # type: ignore[arg-type]
+
+
+def _result(call_id: str, tool_name: str, text: str, *, is_error: bool = False) -> ToolResultMessage:
+    return ToolResultMessage(
+        tool_call_id=call_id,
+        tool_name=tool_name,
+        content=[TextContent(text=text)],
+        is_error=is_error,
+    )
+
+
+def test_empty_messages_returns_empty() -> None:
+    assert _extract_tool_summaries([]) == []
+
+
+def test_no_tool_calls_returns_empty() -> None:
+    msgs = [_user("hello"), AssistantMessage(content=[TextContent(text="hi")])]
+    assert _extract_tool_summaries(msgs) == []
+
+
+def test_single_tool_call_ok() -> None:
+    msgs = [
+        _user("run something"),
+        _assistant_with_calls(("tc1", "execute", {"command": "pip install foo"})),
+        _result("tc1", "execute", "Successfully installed foo"),
+    ]
+    summaries = _extract_tool_summaries(msgs)
+    assert len(summaries) == 1
+    assert summaries[0]["name"] == "execute"
+    assert "pip install foo" in summaries[0]["args_summary"]
+    assert summaries[0]["outcome"] == "ok"
+
+
+def test_error_result_prefixes_error() -> None:
+    msgs = [
+        _user("test"),
+        _assistant_with_calls(("tc1", "execute", {"command": "twitter whoami"})),
+        _result("tc1", "execute", "HTTP 403", is_error=True),
+    ]
+    summaries = _extract_tool_summaries(msgs)
+    assert summaries[0]["outcome"].startswith("error:")
+    assert "HTTP 403" in summaries[0]["outcome"]
+
+
+def test_args_truncated_to_150_chars() -> None:
+    long_cmd = "x" * 300
+    msgs = [
+        _user("run"),
+        _assistant_with_calls(("tc1", "execute", {"command": long_cmd})),
+        _result("tc1", "execute", "ok"),
+    ]
+    summaries = _extract_tool_summaries(msgs)
+    assert len(summaries[0]["args_summary"]) <= 150
+
+
+def test_outcome_truncated_to_150_chars() -> None:
+    long_output = "y" * 300
+    msgs = [
+        _user("run"),
+        _assistant_with_calls(("tc1", "execute", {"command": "cmd"})),
+        _result("tc1", "execute", long_output, is_error=True),
+    ]
+    summaries = _extract_tool_summaries(msgs)
+    assert len(summaries[0]["outcome"]) <= len("error: ") + 150
+
+
+def test_capped_at_10_summaries() -> None:
+    calls = [(f"tc{i}", "execute", {"command": f"cmd{i}"}) for i in range(15)]
+    results = [_result(f"tc{i}", "execute", f"out{i}") for i in range(15)]
+    msgs = [_user("run many")] + [_assistant_with_calls(*calls)] + results
+    summaries = _extract_tool_summaries(msgs)
+    assert len(summaries) <= 10
+
+
+def test_only_tools_after_last_user_message() -> None:
+    # Tools before the last UserMessage should be ignored
+    msgs = [
+        _user("first"),
+        _assistant_with_calls(("old_tc", "execute", {"command": "old"})),
+        _result("old_tc", "execute", "old result"),
+        _user("second"),
+        _assistant_with_calls(("new_tc", "execute", {"command": "new"})),
+        _result("new_tc", "execute", "new result"),
+    ]
+    summaries = _extract_tool_summaries(msgs)
+    assert len(summaries) == 1
+    assert "new" in summaries[0]["args_summary"]
+```
+
+- [ ] **Step 2: Run to confirm import fails**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality/backend
+uv run pytest tests/unit/test_reflection_tool_summaries.py -v 2>&1 | head -20
+```
+
+Expected: `ImportError` — `_extract_tool_summaries` does not exist yet.
+
+- [ ] **Step 3: Add `_extract_tool_summaries` to run_manager and wire it**
+
+In `backend/cubebox/streams/run_manager.py`, add the following module-level helper near the top of the file (after imports, before the class definition). Find the `class RunManager` line and insert above it:
+
+```python
+def _extract_tool_summaries(messages: list[Any]) -> list[dict[str, str]]:
+    """Build compact tool-call summaries from a turn's message list.
+
+    Collects all ToolResultMessages that appear after the last UserMessage,
+    paired with their corresponding ToolCall arguments. Capped at 10 entries;
+    args and error text truncated to 150 chars each.
+    """
+    from cubepi.providers.base import (
+        AssistantMessage,
+        TextContent,
+        ToolCall,
+        ToolResultMessage,
+        UserMessage,
+    )
+
+    _ARGS_LIMIT = 150
+    _RESULT_LIMIT = 150
+    _MAX_SUMMARIES = 10
+
+    # Find the last UserMessage index
+    last_user_idx = -1
+    for i, msg in enumerate(messages):
+        if isinstance(msg, UserMessage):
+            last_user_idx = i
+    if last_user_idx == -1:
+        return []
+
+    # Index tool call args by call_id from AssistantMessages after last user msg
+    tool_args: dict[str, str] = {}
+    for msg in messages[last_user_idx + 1 :]:
+        if isinstance(msg, AssistantMessage):
+            for part in msg.content:
+                if isinstance(part, ToolCall):
+                    args_str = ", ".join(
+                        f"{k}={repr(v)}" for k, v in part.arguments.items()
+                    )
+                    tool_args[part.id] = args_str[:_ARGS_LIMIT]
+
+    # Build summaries from ToolResultMessages
+    summaries: list[dict[str, str]] = []
+    for msg in messages[last_user_idx + 1 :]:
+        if not isinstance(msg, ToolResultMessage):
+            continue
+        if len(summaries) >= _MAX_SUMMARIES:
+            break
+        result_text = "".join(
+            c.text for c in msg.content if isinstance(c, TextContent)
+        )
+        if msg.is_error:
+            outcome = f"error: {result_text[:_RESULT_LIMIT]}"
+        else:
+            outcome = "ok"
+        summaries.append(
+            {
+                "name": msg.tool_name,
+                "args_summary": tool_args.get(msg.tool_call_id, ""),
+                "outcome": outcome,
+            }
+        )
+    return summaries
+```
+
+Then in the `_run_reflection` closure (around line 1511), replace the `tool_summaries=[]` hardcode:
+
+```python
+# was:
+turn=ReflectionTurn(
+    user_message=user_msg_text,
+    assistant_message=last_assistant,
+    tool_summaries=[],
+),
+
+# becomes:
+turn=ReflectionTurn(
+    user_message=user_msg_text,
+    assistant_message=last_assistant,
+    tool_summaries=_extract_tool_summaries(agent_ref.state.messages),
+),
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality/backend
+uv run pytest tests/unit/test_reflection_tool_summaries.py -v
+```
+
+Expected: all 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality
+git add backend/cubebox/streams/run_manager.py \
+        backend/tests/unit/test_reflection_tool_summaries.py
+git commit -m "feat(memory): populate tool_summaries in reflection turn from agent message history"
+```
+
+---
+
+## Task 4: Load personal memory in run_manager and pass to reflection (C3 — run_manager side)
+
+**Files:**
+- Modify: `backend/cubebox/streams/run_manager.py`
+
+No new unit test file needed — the runner-side rendering is already covered by Task 2's tests. This task wires the DB load.
+
+- [ ] **Step 1: Add memory load inside `_run_reflection`**
+
+In `backend/cubebox/streams/run_manager.py`, inside the `_run_reflection` async closure, add a memory load block after `last_assistant` is confirmed non-empty and before the `ReflectionInput` is constructed. The full updated closure body (from `last_assistant = ...` to `await _runner.reflect(inp)`) becomes:
+
+```python
+last_assistant = _last_assistant_text(agent_ref.state.messages)
+if not last_assistant:
+    return
+user_msg_text = _stringify_user_msg(user_msg_ref)
+
+# Load the user's active personal memory to give the reflection
+# agent a complete picture before it decides what to save.
+_existing_items: list[tuple[str, str, str]] = []
+try:
+    import datetime
+
+    from cubebox.models.memory import MemoryScope, MemoryStatus
+    from cubebox.repositories.memory import MemoryRepository
+
+    async with _ue_session_maker() as _mem_session:
+        _mem_repo = MemoryRepository(
+            _mem_session,
+            user_id=ctx.user_id,
+            org_id=ctx.org_id,
+            workspace_id=ctx.workspace_id,
+        )
+        _all_personal = await _mem_repo.list(
+            scope=MemoryScope.PERSONAL,
+            status=MemoryStatus.ACTIVE,
+            limit=200,
+        )
+    # Sort by recency of use, then creation; take top 40.
+    _sorted = sorted(
+        _all_personal,
+        key=lambda m: (
+            m.last_used_at or datetime.datetime.min.replace(tzinfo=datetime.UTC),
+            m.created_at,
+        ),
+        reverse=True,
+    )[:40]
+    _existing_items = [(m.id, m.type.value, m.content) for m in _sorted]
+except Exception:
+    logger.warning(
+        "reflection: failed to load existing memory for run_id={}", run_id, exc_info=True
+    )
+
+inp = ReflectionInput(
+    conversation_id=conversation_id,
+    run_id=run_id,
+    user_id=ctx.user_id,
+    workspace_id=ctx.workspace_id,
+    turn=ReflectionTurn(
+        user_message=user_msg_text,
+        assistant_message=last_assistant,
+        tool_summaries=_extract_tool_summaries(agent_ref.state.messages),
+    ),
+    existing_memory_items=_existing_items,
+)
+async with _ue_session_maker() as _session:
+    _repo = UserEventRepository(_session)
+    _svc = UserEventService(repo=_repo, bus=bus)
+    _runner = ReflectionRunner(
+        user_event_service=_svc,
+        agent_factory=agent_factory,
+    )
+    await _runner.reflect(inp)
+```
+
+- [ ] **Step 2: Run mypy to confirm types**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality/backend
+uv run mypy cubebox/streams/run_manager.py cubebox/services/reflection_runner.py cubebox/prompts/reflection_system.py --ignore-missing-imports 2>&1 | tail -10
+```
+
+Expected: `Success: no issues found` (or only pre-existing errors unrelated to these files).
+
+- [ ] **Step 3: Run the full unit test suite for changed modules**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality/backend
+uv run pytest tests/unit/test_reflection_runner.py \
+             tests/unit/test_reflection_tool_summaries.py \
+             tests/unit/test_reflection_context.py \
+             tests/unit/test_reflection_factory.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality
+git add backend/cubebox/streams/run_manager.py
+git commit -m "feat(memory): load personal memory snapshot into reflection input before spawning agent"
+```
+
+---
+
+## Task 5: Pre-PR sweep
+
+- [ ] **Step 1: Run full unit test suite**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality/backend
+uv run pytest tests/unit/ -v 2>&1 | tail -20
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run mypy on all changed files**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality/backend
+uv run mypy cubebox/ --ignore-missing-imports 2>&1 | grep -E "error:|Success"
+```
+
+Expected: no new errors.
+
+- [ ] **Step 3: Run ruff**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/memory-reflection-quality/backend
+uv run ruff check cubebox/prompts/reflection_system.py \
+                  cubebox/services/reflection_runner.py \
+                  cubebox/streams/run_manager.py
+```
+
+Expected: no issues.

--- a/docs/dev/specs/2026-06-03-memory-reflection-quality-design.md
+++ b/docs/dev/specs/2026-06-03-memory-reflection-quality-design.md
@@ -1,0 +1,201 @@
+# Memory Reflection Quality Improvements
+
+**Date:** 2026-06-03  
+**Branch:** feat/memory-reflection-quality  
+**Status:** Draft
+
+## Background
+
+The per-turn reflection agent extracts memories after each agent run and saves
+them via `memory_save` / `memory_update`. Analysis of a real conversation
+(`conv-1fwZQ8u3ZDukx3`) revealed three structural problems that cause low-quality
+memory output:
+
+1. The reflection agent never sees what tools were called or what they returned.
+2. It has no conservative "store less" bias — so kimi-k2.6 (and other verbose
+   models) over-save, storing the same preference 6+ times.
+3. It has no view of what's already in memory when it starts, forcing it to call
+   `memory_search` unprompted — a step it frequently skips.
+
+The consolidation layer (Layer 2) is the designed safety net, but it runs at
+most once per 5 runs and its `max_tokens=1500` budget makes it hard to merge 6
+nearly-identical preference entries in one pass. Fixing Layer 1 (reflection) is
+the right lever.
+
+## Problem Details
+
+### P1: tool_summaries always empty
+
+`run_manager.py` constructs `ReflectionTurn` with `tool_summaries=[]` hardcoded:
+
+```python
+turn=ReflectionTurn(
+    user_message=user_msg_text,
+    assistant_message=last_assistant,
+    tool_summaries=[],   # never populated
+)
+```
+
+The reflection agent's seed prompt therefore looks like:
+
+```
+Last turn for review:
+
+USER: 时间过期了重新生成一个 code
+
+ASSISTANT: 好的，重新生成了一个设备码：6EFB-EB07
+```
+
+It can infer facts from the assistant's text, but it cannot see:
+- Which tools ran
+- What they returned (e.g. a twitter-cli auth test returning HTTP 403)
+- Whether a tool errored
+
+This causes two failure modes:
+- Facts that only appear in tool results (not in the assistant summary) are
+  missed entirely.
+- The assistant sometimes summarises tool output incorrectly; the reflection
+  agent has no ground truth to check against.
+
+### P2: No conservative extraction bias
+
+The current `REFLECTION_SYSTEM_PROMPT` lists what to save and what to skip, but
+gives no default stance. A verbose model that is uncertain will save rather than
+skip. Supermemory's prompt (from hermes-agent) explicitly states:
+
+> "Only extract things useful in future conversations. Most messages are not
+> worth remembering. … When in doubt, store less."
+
+This single line changes the default decision from "save if unsure" to "skip if
+unsure." The cubebox prompt has no equivalent.
+
+### P3: No existing memory in reflection seed
+
+The consolidation pass correctly injects existing memory items before the LLM
+runs:
+
+```python
+existing_text = "\n".join(f"- [{m.id}] ({m.type.value}) {m.content}" for m in existing)
+prompt = f"Existing personal memory items:\n{existing_text}\n\nConversation transcript:..."
+```
+
+The reflection runner does not. The reflection agent must call `memory_search`
+itself, but the system prompt only encourages this ("search first") without
+enforcing it. Models frequently skip the search and call `memory_save` directly,
+producing duplicates.
+
+## Proposed Changes
+
+### C1: Populate tool_summaries in run_manager
+
+After the main agent becomes idle, iterate over the turn's tool executions and
+build a compact summary for each: tool name, a short args digest, and the
+outcome (ok / error / truncated result excerpt).
+
+The summary format mirrors what `ReflectionTurn.tool_summaries` already
+supports:
+
+```python
+{"name": "execute", "args_summary": "pip install twitter-cli", "outcome": "ok"}
+{"name": "execute", "args_summary": "twitter whoami", "outcome": "error: HTTP 403"}
+```
+
+The reflection seed prompt already renders these:
+
+```
+Tools called in this turn:
+- execute(pip install twitter-cli) -> ok
+- execute(twitter whoami) -> error: HTTP 403
+```
+
+**Scope:** `run_manager.py` — the `_run_reflection` closure that builds
+`ReflectionTurn`. The agent's `state.messages` already contains the tool
+execution results; extract them there.
+
+**Limits:** Cap at 10 tool summaries per turn; truncate args and result text to
+150 chars each. This keeps the reflection prompt bounded.
+
+### C2: Add conservative bias to REFLECTION_SYSTEM_PROMPT
+
+Add two sentences that shift the default from "save if unsure" to "skip if unsure":
+
+```
+Most turns contain nothing worth saving. When in doubt, do not save.
+```
+
+Also make the "search first" instruction more concrete — require calling
+`memory_search` before any `memory_save`:
+
+```
+Before calling memory_save, always call memory_search to check whether
+a closely related item already exists. If one does, call memory_update
+instead, or skip if the existing item already covers it.
+```
+
+**Scope:** `cubebox/prompts/reflection_system.py` only.
+
+### C3: Inject top personal memory items into reflection seed
+
+Load the user's active personal memory items and prepend them to the seed
+prompt, the same way the consolidation pass does. The reflection agent then has
+the full picture without needing to search.
+
+Seed prompt becomes:
+
+```
+Your current memory for this user (personal, active):
+- [mem-abc] (preference) 用户偏好中文交流
+- [mem-def] (project_fact) CubePi 项目，开发者是 xfgong ...
+...
+
+Last turn for review:
+
+USER: ...
+ASSISTANT: ...
+Tools called in this turn:
+- ...
+```
+
+**Scope:**
+- `ReflectionTurn` gets an optional `existing_memory_items` field
+  (list of `(id, type, content)` tuples).
+- `ReflectionRunner._build_seed_prompt` renders them when present.
+- `run_manager.py` loads personal memory via `MemoryRepository` before spawning
+  the reflection task and passes them through.
+
+**Limits:** Cap at 40 items, 200 chars per item content. If the user has more
+than 40 active personal items, take the 40 most recently used
+(`last_used_at DESC, created_at DESC`). This is consistent with the relevance
+tier's snapshot budget.
+
+## What This Does Not Change
+
+- The consolidation layer (Layer 2) is unchanged. It remains the long-period
+  cleanup pass that can merge/archive across the full history.
+- The exact-content deduplication in `MemoryService.create` is unchanged. It
+  catches mechanical exact-duplicate writes regardless of the reflection prompt.
+- The memory middleware (how memories are injected into the main agent's context)
+  is unchanged.
+- The reflection model selection is unchanged (stays coupled to the main agent's
+  model). A separate cheap-model config is a future concern.
+
+## File Inventory
+
+| File | Change |
+|---|---|
+| `cubebox/prompts/reflection_system.py` | C2: rewrite prompt |
+| `cubebox/services/reflection_runner.py` | C1+C3: add `existing_memory_items` to `ReflectionTurn`; update `_build_seed_prompt` |
+| `cubebox/streams/run_manager.py` | C1: extract tool summaries; C3: load and pass memory items |
+
+No new tables, no migrations, no API changes.
+
+## Success Criteria
+
+- A re-run of a conversation similar to `conv-1fwZQ8u3ZDukx3` should not produce
+  more than one memory item expressing the same preference (e.g. "prefers
+  Chinese") over 20 turns.
+- Tool-result facts (e.g. "twitter-cli returned HTTP 403") should appear in
+  saved memories when the assistant's text alone does not contain that
+  information.
+- A turn where the user expresses no new information should result in zero
+  `memory_save` calls from the reflection agent.


### PR DESCRIPTION
## Summary

Three structural fixes to the per-turn memory reflection agent that prevent duplicate memory writes and give the agent full context before it decides what to save:

- **Conservative prompt bias**: Add "most turns contain nothing worth saving — when in doubt, do not save" and make `memory_search` mandatory before any `memory_save`
- **Tool result context**: Extract actual tool call summaries from the agent's message history (was hardcoded `[]`) so the reflection agent sees what tools ran and what they returned
- **Existing memory injection**: Load the user's top-40 active personal memory items and prepend them to the reflection seed, so the agent can avoid duplicates without needing to call `memory_search` unprompted

**Root cause:** analysis of a real 26-turn conversation (`conv-1fwZQ8u3ZDukx3`) showed the preference "user communicates in Chinese" being saved 6+ times across turns because each reflection agent started cold with no memory context and no conservative default.

**No schema changes.** No API changes. Three files touched: `prompts/reflection_system.py`, `services/reflection_runner.py`, `streams/run_manager.py`.

## Test plan

- [ ] All existing unit tests pass (`tests/unit/test_reflection_runner.py` — 8 tests)
- [ ] New unit tests for `_extract_tool_summaries` pass (`tests/unit/test_reflection_tool_summaries.py` — 8 tests)
- [ ] `ReflectionInput.existing_memory_items` renders correctly in seed (4 new tests in `TestBuildSeedPrompt`)
- [ ] mypy strict passes on all changed files
- [ ] Manual: observe that a new conversation no longer saves the same preference multiple times across turns