### PR TITLE
chore(cubepi): bump pin to 808b2d5 for friendly ValidationError translation

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -172,11 +172,14 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-# 1686eed is cubepi main HEAD: v3 HITL run_id support — CheckpointedChannel
-# after the full agent run completes (before AgentEndEvent), enabling end-of-run
-# memory reflection. On top of prior OpenAI double-finish_reason guard (262a33f),
-# HITL channel (b03813e), subagent-span-nesting (#122), steer-cancel (#120).
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "8202479" }
+# 808b2d5 is cubepi main HEAD: friendly ValidationError translation in the
+# tool-execution path (cubepi#136) — pydantic errors now surface as
+# field-path-anchored lines the LLM can act on (named discriminator key,
+# allowed values, etc.) instead of the raw `str(ValidationError)` URL prose.
+# On top of prior v3 HITL run_id support (1686eed), OpenAI double-finish_reason
+# guard (262a33f), HITL channel (b03813e), subagent-span-nesting (#122),
+# steer-cancel (#120).
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "808b2d5" }
 
 [dependency-groups]
 dev = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -875,7 +875,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=8202479" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=808b2d5" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -922,7 +922,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.6.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=8202479#82024793a0202b8379788f261a20ce648c7326b3" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=808b2d5#808b2d553b82fa4074f7e91462081f1bbb7ee31e" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },


### PR DESCRIPTION
Bumps cubepi rev 8202479 → 808b2d5 to pull in cubepi#136 (friendly ValidationError translation in the tool-execution path).

Companion to #193. Cross-model live verify on #193 showed kimi-k2.6 dropping 3 → 2 round-trips with this applied; deepseek-v4-flash and -pro already first-call correct without it.

## Test plan
- [x] uv lock clean update
- [x] Backend unit suite 1232 passed
- [x] backend-check-ci + frontend-check-ci clean on push
- [x] Inline smoke confirms new error format