### PR TITLE
feat(memory): trace memory consolidation via Tracer.oneshot()

### DIFF
--- a/backend/cubebox/services/memory_consolidation.py
+++ b/backend/cubebox/services/memory_consolidation.py
@@ -226,15 +226,24 @@ async def run_consolidation(
     user_id: str,
     org_id: str | None,
     workspace_id: str | None,
-    one_shot: Any,
+    provider: Any,
+    model: Any,
     session_maker: Any,
+    tracer: Any | None = None,
     min_hours: float = DEFAULT_MIN_HOURS,
     min_runs: int = DEFAULT_MIN_RUNS,
 ) -> None:
-    """Best-effort per-conversation consolidation. Never raises into the caller."""
-    from cubepi.providers.base import TextContent, UserMessage
+    """Best-effort per-conversation consolidation. Never raises into the caller.
+
+    When ``tracer`` is provided, the consolidation LLM call is wrapped in
+    ``tracer.oneshot(operation="consolidate_memory", metadata={...})`` so the
+    run appears in ``cubepi trace ls`` alongside agent runs, with
+    ``conversation_id`` / ``user_id`` metadata searchable via ``--meta``.
+    """
+    from cubepi.providers.base import Message, TextContent, UserMessage
 
     from cubebox.agents.checkpointer import init_checkpointer
+    from cubebox.llm.oneshot import OneShotLLM
     from cubebox.repositories.memory import MemoryRepository
 
     token = await acquire_lock(redis, prefix, conversation_id, ttl_s=LOCK_TTL_S)
@@ -263,11 +272,34 @@ async def run_consolidation(
             f"Existing personal memory items:\n{existing_text or '(none)'}\n\n"
             f"Conversation transcript:\n{history_text}"
         )
-        raw = await one_shot.generate_once(
-            system=CONSOLIDATION_SYSTEM,
-            messages=[UserMessage(content=[TextContent(text=prompt)])],
-            max_output_tokens=EXTRACT_MODEL_MAX_TOKENS,
-        )
+        messages: list[Message] = [UserMessage(content=[TextContent(text=prompt)])]
+        meta: dict[str, str | int | float | bool] = {
+            "conversation_id": conversation_id,
+            "user_id": user_id,
+        }
+        if workspace_id is not None:
+            meta["workspace_id"] = workspace_id
+        if org_id is not None:
+            meta["org_id"] = org_id
+
+        if tracer is not None:
+            async with tracer.oneshot(
+                provider=provider,
+                model=model,
+                operation="consolidate_memory",
+                metadata=meta,
+            ) as session:
+                raw = await session.generate(
+                    system=CONSOLIDATION_SYSTEM,
+                    messages=messages,
+                    max_output_tokens=EXTRACT_MODEL_MAX_TOKENS,
+                )
+        else:
+            raw = await OneShotLLM(provider, model).generate_once(
+                system=CONSOLIDATION_SYSTEM,
+                messages=messages,
+                max_output_tokens=EXTRACT_MODEL_MAX_TOKENS,
+            )
         ops = parse_ops(raw, max_ops=MAX_OPS)
         if ops is None:
             # Malformed / over-cap LLM output = a FAILED pass. Do NOT advance the

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -2620,7 +2620,6 @@ class RunManager:
 
             from cubebox.db.engine import async_session_maker
             from cubebox.llm.factory import LLMFactory
-            from cubebox.llm.oneshot import OneShotLLM
 
             async with async_session_maker() as _llm_session:
                 factory = LLMFactory(
@@ -2635,7 +2634,12 @@ class RunManager:
                 ) = await factory.resolve_default_provider_and_config()
                 await _llm_session.commit()
             provider = factory.build_cubepi_provider(provider_config, cache_policy=None)
-            one_shot = OneShotLLM(provider, Model(id=model_id, provider=provider_name))
+            model = Model(id=model_id, provider=provider_name)
+            # Tracer is optional — pass None to run_consolidation when tracing
+            # is disabled, otherwise the background LLM call is wrapped in
+            # tracer.oneshot() so it shows up in `cubepi trace ls` filterable
+            # by conversation_id / user_id / oneshot_operation.
+            tracer = getattr(self._app.state, "tracer", None)
 
             task = asyncio.create_task(
                 mc.run_consolidation(
@@ -2645,7 +2649,9 @@ class RunManager:
                     user_id=ctx.user_id,
                     org_id=ctx.org_id,
                     workspace_id=ctx.workspace_id,
-                    one_shot=one_shot,
+                    provider=provider,
+                    model=model,
+                    tracer=tracer,
                     session_maker=async_session_maker,
                     min_hours=min_hours,
                     min_runs=min_runs,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -172,14 +172,16 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-# 808b2d5 is cubepi main HEAD: friendly ValidationError translation in the
-# tool-execution path (cubepi#136) — pydantic errors now surface as
-# field-path-anchored lines the LLM can act on (named discriminator key,
-# allowed values, etc.) instead of the raw `str(ValidationError)` URL prose.
-# On top of prior v3 HITL run_id support (1686eed), OpenAI double-finish_reason
-# guard (262a33f), HITL channel (b03813e), subagent-span-nesting (#122),
-# steer-cancel (#120).
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "808b2d5" }
+# 707f95b adds Tracer.oneshot() (cubepi#137) — an instrumented one-shot
+# LLM call context manager that produces a full invoke_agent trace with a
+# chat child span, without an Agent loop. Used by run_manager's memory
+# consolidation pass so background LLM calls land in cubepi-traces and are
+# searchable via `cubepi trace ls --meta oneshot_operation=consolidate_memory`
+# and `--meta conversation_id=...` alongside normal agent runs. Built on
+# friendly ValidationError translation (cubepi#136), v3 HITL run_id support
+# (1686eed), OpenAI double-finish_reason guard (262a33f), HITL channel
+# (b03813e), subagent-span-nesting (#122), steer-cancel (#120).
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "707f95b" }
 
 [dependency-groups]
 dev = [

--- a/backend/tests/unit/test_memory_consolidation_pass.py
+++ b/backend/tests/unit/test_memory_consolidation_pass.py
@@ -90,3 +90,92 @@ async def test_apply_ops_skips_non_personal_or_missing_targets():
     await mc.apply_ops(svc, ops, conversation_id="conv1", run_id=None)
     assert svc.updated == []
     assert svc.archived == []
+
+
+@pytest.mark.asyncio
+async def test_run_consolidation_uses_tracer_oneshot_when_provided(monkeypatch):
+    """run_consolidation must route the LLM call through ``tracer.oneshot()`` when
+    a tracer is provided, so the call is recorded with conversation_id/user_id
+    metadata and the oneshot_operation label."""
+    import contextlib
+    from unittest.mock import AsyncMock, MagicMock
+
+    # Skip checkpointer / DB paths by patching the no-history short-circuit.
+    @contextlib.asynccontextmanager
+    async def _fake_init_checkpointer():
+        cp = MagicMock()
+        cp.load = AsyncMock(return_value=MagicMock(messages=[]))
+        yield cp
+
+    monkeypatch.setattr("cubebox.agents.checkpointer.init_checkpointer", _fake_init_checkpointer)
+
+    # Lock helpers — return a token so we pass acquire_lock guard.
+    monkeypatch.setattr(mc, "acquire_lock", AsyncMock(return_value="tok"))
+    monkeypatch.setattr(mc, "release_lock", AsyncMock())
+    monkeypatch.setattr(mc, "mark_consolidated", AsyncMock())
+    monkeypatch.setattr(mc, "_counter", AsyncMock(return_value=0))
+
+    # Fake tracer.oneshot() that records being called with the right metadata.
+    captured: dict[str, object] = {}
+
+    @contextlib.asynccontextmanager
+    async def _fake_oneshot(*, provider, model, operation, metadata, **_kw):
+        captured["operation"] = operation
+        captured["metadata"] = dict(metadata)
+        session = MagicMock()
+        session.generate = AsyncMock(return_value='{"ops": []}')
+        yield session
+
+    fake_tracer = MagicMock()
+    fake_tracer.oneshot = _fake_oneshot
+
+    # data.messages is empty → run_consolidation marks consolidated and
+    # returns before hitting the LLM. Force a non-empty path by giving
+    # the checkpointer one fake message.
+    @contextlib.asynccontextmanager
+    async def _fake_init_checkpointer_nonempty():
+        cp = MagicMock()
+        data = MagicMock()
+        data.messages = [MagicMock(role="user", content=[])]
+        cp.load = AsyncMock(return_value=data)
+        yield cp
+
+    monkeypatch.setattr(
+        "cubebox.agents.checkpointer.init_checkpointer",
+        _fake_init_checkpointer_nonempty,
+    )
+
+    # Stub MemoryRepository.list so the "existing items" SQL never runs.
+    class _StubRepo:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        async def list(self, **_kw):
+            return []
+
+    monkeypatch.setattr("cubebox.repositories.memory.MemoryRepository", _StubRepo)
+
+    # Session maker that just yields a MagicMock async-context.
+    @contextlib.asynccontextmanager
+    async def _fake_session_maker():
+        yield MagicMock()
+
+    await mc.run_consolidation(
+        redis=MagicMock(),
+        prefix="test",
+        conversation_id="conv-xyz",
+        user_id="usr-abc",
+        org_id="org-1",
+        workspace_id="ws-2",
+        provider=MagicMock(),
+        model=MagicMock(),
+        tracer=fake_tracer,
+        session_maker=_fake_session_maker,
+    )
+
+    assert captured.get("operation") == "consolidate_memory"
+    meta = captured.get("metadata") or {}
+    assert meta["conversation_id"] == "conv-xyz"
+    assert meta["user_id"] == "usr-abc"
+    assert meta["workspace_id"] == "ws-2"
+    assert meta["org_id"] == "org-1"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -875,7 +875,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=808b2d5" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=707f95b" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -922,7 +922,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.6.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=808b2d5#808b2d553b82fa4074f7e91462081f1bbb7ee31e" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=707f95b#707f95b3cf583322efe93b818f16bab42fe5a77c" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },


### PR DESCRIPTION
## Summary

- Memory consolidation (Layer 2) was calling \`OneShotLLM.generate_once()\` → \`Provider.stream()\` directly, producing **no trace** — background runs were invisible to \`cubepi trace ls\`
- Now wraps the LLM call in \`tracer.oneshot(operation='consolidate_memory', metadata={conversation_id, user_id, ...})\` so each consolidation pass shows up alongside agent runs in the trace files
- Falls back to \`OneShotLLM\` when tracer is None (tracing disabled)
- Bumps cubepi pin to \`707f95b\` which adds \`Tracer.oneshot()\` ([cubepi#137](https://github.com/cubeplexai/cubepi/pull/137))

## How to verify

After this lands, consolidation runs are searchable:

\`\`\`bash
# All consolidation runs for a conversation, alongside its agent runs
cubepi trace ls --meta conversation_id=conv-xxx

# Just consolidation runs (any conversation)
cubepi trace ls --meta oneshot_operation=consolidate_memory
\`\`\`

Each consolidation produces a flat trace tree:

\`\`\`
invoke_agent  [cubepi.oneshot.operation=consolidate_memory, conversation_id=...]
  └── chat <model>  [tok input/output, ttft]
\`\`\`

## Test plan

- [x] Unit test \`test_run_consolidation_uses_tracer_oneshot_when_provided\` verifies the operation name and metadata keys
- [x] Existing consolidation tests (parse_ops / apply_ops / gate logic) still pass
- [x] mypy + ruff clean