### PR TITLE
feat(skill-ux): surface publish errors via hover popover and confirm dialog

### DIFF
--- a/frontend/packages/web/components/chat/ArtifactCard.tsx
+++ b/frontend/packages/web/components/chat/ArtifactCard.tsx
@@ -10,6 +10,7 @@ import { getArtifactIcon, getArtifactLabel } from '@/components/panel/artifact/a
 import { buildDownloadUrl } from '@/components/panel/artifact/previewUtils'
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
 import { usePublishSkill } from '@/hooks/usePublishSkill'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
 
 interface ArtifactCardProps {
@@ -25,13 +26,14 @@ function SkillInstallButton({
   artifactId: string
   label: string
 }) {
+  const t = useTranslations('chatExtras')
   const { publish, isPublishing, result, reset } = usePublishSkill(workspaceId, artifactId)
 
   // Auto-reset success state after 1.5s
   useEffect(() => {
     if (result?.ok) {
-      const t = setTimeout(reset, 1500)
-      return () => clearTimeout(t)
+      const tm = setTimeout(reset, 1500)
+      return () => clearTimeout(tm)
     }
   }, [result, reset])
 
@@ -66,16 +68,42 @@ function SkillInstallButton({
   }
 
   if (result && !result.ok) {
-    const errMsg =
-      result.message === 'VERSION_EXISTS' ? label + ' (version exists)' : result.message
+    const detail =
+      result.message === 'VERSION_EXISTS' ? t('addToWorkspaceVersionExists') : result.message
     return (
-      <button
-        onClick={handleClick}
-        title={errMsg}
-        className="flex size-8 items-center justify-center rounded-md text-destructive transition-colors hover:bg-destructive/10"
-      >
-        <AlertCircle className="size-4" />
-      </button>
+      <Popover>
+        <PopoverTrigger
+          openOnHover
+          delay={150}
+          closeDelay={150}
+          onClick={(e) => e.stopPropagation()}
+          className="flex size-8 items-center justify-center rounded-md text-destructive
+            transition-colors hover:bg-destructive/10"
+        >
+          <AlertCircle className="size-4" />
+        </PopoverTrigger>
+        <PopoverContent
+          side="top"
+          align="end"
+          sideOffset={4}
+          className="w-72 p-3"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex flex-col gap-2">
+            <div className="text-sm font-medium text-destructive">{t('addToWorkspaceFailed')}</div>
+            <p className="break-words text-xs text-muted-foreground">{detail}</p>
+            <div className="flex justify-end">
+              <button
+                onClick={handleClick}
+                className="rounded-md border border-border bg-background px-2.5 py-1
+                  text-xs font-medium text-foreground transition-colors hover:bg-muted"
+              >
+                {t('retry')}
+              </button>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
     )
   }
 

--- a/frontend/packages/web/components/panel/artifact/SkillArtifactPreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/SkillArtifactPreview.tsx
@@ -30,7 +30,7 @@ export function SkillArtifactPreview({
 }) {
   const t = useTranslations('adminSkills')
   const [confirmOpen, setConfirmOpen] = useState(false)
-  const { publish, isPublishing, result } = usePublishSkill(workspaceId, artifact.id)
+  const { publish, isPublishing, result, reset } = usePublishSkill(workspaceId, artifact.id)
 
   const skillMdUrl = buildPreviewUrl(artifact, 'SKILL.md', version, workspaceId)
   const { data: skillMd, isLoading } = useSWR<string>(skillMdUrl, fetchText, {
@@ -38,8 +38,13 @@ export function SkillArtifactPreview({
   })
 
   async function handleConfirmPublish(): Promise<void> {
-    await publish()
-    setConfirmOpen(false)
+    const r = await publish()
+    if (r?.ok) setConfirmOpen(false)
+  }
+
+  function handleOpenChange(next: boolean): void {
+    setConfirmOpen(next)
+    if (!next && result && !result.ok) reset()
   }
 
   const resultMessage =
@@ -58,20 +63,12 @@ export function SkillArtifactPreview({
           <span className="text-xs text-muted-foreground">v{artifact.version}</span>
         </header>
 
-        {result && (
+        {result?.ok && (
           <div
-            className={cn(
-              'flex items-start gap-2 rounded-md border-l-4 px-3 py-2.5 text-sm font-medium',
-              result.ok
-                ? 'border-green-500 bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300'
-                : 'border-destructive bg-destructive/10 text-destructive',
-            )}
+            className="flex items-start gap-2 rounded-md border-l-4 border-green-500 bg-green-50
+              px-3 py-2.5 text-sm font-medium text-green-700 dark:bg-green-950 dark:text-green-300"
           >
-            {result.ok ? (
-              <CheckCircle2 className="mt-0.5 size-4 shrink-0" />
-            ) : (
-              <AlertCircle className="mt-0.5 size-4 shrink-0" />
-            )}
+            <CheckCircle2 className="mt-0.5 size-4 shrink-0" />
             <span>{resultMessage}</span>
           </div>
         )}
@@ -93,7 +90,7 @@ export function SkillArtifactPreview({
         </Button>
       </div>
 
-      <DialogPrimitive.Root open={confirmOpen} onOpenChange={setConfirmOpen}>
+      <DialogPrimitive.Root open={confirmOpen} onOpenChange={handleOpenChange}>
         <DialogPrimitive.Portal>
           <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 transition-opacity duration-200" />
           <DialogPrimitive.Popup
@@ -120,11 +117,21 @@ export function SkillArtifactPreview({
               />
             </div>
             <p className="mt-3 text-sm text-muted-foreground">{t('publishDesc')}</p>
+            {result && !result.ok && (
+              <div
+                role="alert"
+                className="mt-3 flex items-start gap-2 rounded-md border-l-4 border-destructive
+                  bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
+              >
+                <AlertCircle className="mt-0.5 size-4 shrink-0" />
+                <span className="break-words">{resultMessage}</span>
+              </div>
+            )}
             <div className="mt-4 flex justify-end gap-2">
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => setConfirmOpen(false)}
+                onClick={() => handleOpenChange(false)}
                 disabled={isPublishing}
               >
                 {t('cancel')}

--- a/frontend/packages/web/hooks/usePublishSkill.ts
+++ b/frontend/packages/web/hooks/usePublishSkill.ts
@@ -12,9 +12,10 @@ export function usePublishSkill(workspaceId: string, artifactId: string) {
   const [isPublishing, setIsPublishing] = useState(false)
   const [result, setResult] = useState<PublishResult | null>(null)
 
-  const publish = useCallback(async () => {
+  const publish = useCallback(async (): Promise<PublishResult> => {
     setIsPublishing(true)
     setResult(null)
+    let out: PublishResult
     try {
       const res = await fetch(`/api/v1/ws/${workspaceId}/skills/publish`, {
         method: 'POST',
@@ -23,14 +24,14 @@ export function usePublishSkill(workspaceId: string, artifactId: string) {
         body: JSON.stringify({ artifact_id: artifactId }),
       })
       if (res.status === 409) {
-        setResult({ ok: false, message: 'VERSION_EXISTS' })
-        return
+        out = { ok: false, message: 'VERSION_EXISTS' }
+      } else if (!res.ok) {
+        out = { ok: false, message: await readApiError(res) }
+      } else {
+        out = { ok: true, message: 'SUCCESS' }
       }
-      if (!res.ok) {
-        setResult({ ok: false, message: await readApiError(res) })
-        return
-      }
-      setResult({ ok: true, message: 'SUCCESS' })
+      setResult(out)
+      return out
     } finally {
       setIsPublishing(false)
     }

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -910,7 +910,10 @@
     },
     "preview": "Preview",
     "download": "Download",
-    "addToWorkspace": "Add to workspace"
+    "addToWorkspace": "Add to workspace",
+    "addToWorkspaceFailed": "Add to workspace failed",
+    "addToWorkspaceVersionExists": "Version already exists. Bump the version in SKILL.md and try again.",
+    "retry": "Retry"
   },
   "workspaceCreate": {
     "nameLabel": "New workspace name",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -910,7 +910,10 @@
     },
     "preview": "预览",
     "download": "下载",
-    "addToWorkspace": "添加到工作空间"
+    "addToWorkspace": "添加到工作空间",
+    "addToWorkspaceFailed": "添加到工作空间失败",
+    "addToWorkspaceVersionExists": "版本已存在，请先在 SKILL.md 中 bump version 后重试。",
+    "retry": "重试"
   },
   "workspaceCreate": {
     "nameLabel": "新工作区名称",


### PR DESCRIPTION
## Summary
- ArtifactCard SkillInstallButton: replace the native `title` tooltip on the failure `AlertCircle` with a base-ui `Popover` (hover + click) that shows the localized error message and a Retry button. VERSION_EXISTS now displays a translated, actionable hint.
- SkillArtifactPreview: keep the confirm dialog open on failure and render the error inline below the description; close only on success. Outer banner narrowed to the success state to avoid duplication. `usePublishSkill.publish()` now returns the `PublishResult` so callers can branch on outcome.
- i18n: add `chatExtras.addToWorkspaceFailed`, `addToWorkspaceVersionExists`, `retry` in en + zh.

## Background
The previous publish-failure UX surfaced errors only via the browser-native `title` attribute (slow, plain-text, no retry path) on artifact cards, and the preview-page confirm dialog closed on every click — success or failure — so users never saw why a publish actually failed.

## Test plan
- [ ] Visual: trigger a VERSION_EXISTS failure on an artifact card → hover (!) icon → popover shows translated message + Retry button.
- [ ] Visual: open Skill preview → click "添加到工作空间" → confirm dialog stays open on failure with red inline alert; closes on success.
- [ ] Cancel/close the failed dialog → outer banner does not show stale error.
- [ ] zh and en both render the new strings.