### PR TITLE
fix(compaction): reuse DB-aware LLMFactory for summary provider

### DIFF
--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -2397,14 +2397,15 @@ class RunManager:
             from cubepi.middleware.compaction import CompactionMiddleware
 
             from cubebox.config import config as _comp_cfg
-            from cubebox.llm.factory import LLMFactory as _CompLLMFactory
 
             if _comp_cfg.get("compaction.enabled", False):
                 _summary_provider = _comp_cfg.get("compaction.summary_provider")
                 _summary_model_id = _comp_cfg.get("compaction.summary_model")
-                _comp_factory = _CompLLMFactory()
-                _summary_provider_config = _comp_factory.llm_config.providers[_summary_provider]
-                _summary_provider_inst = _comp_factory.build_cubepi_provider(
+                # Reuse the DB-aware factory built above so admin-managed providers
+                # in the model registry are visible. A bare LLMFactory() only sees
+                # config.yaml — providers configured via the admin UI would miss.
+                _summary_provider_config = factory.llm_config.providers[_summary_provider]
+                _summary_provider_inst = factory.build_cubepi_provider(
                     _summary_provider_config, cache_policy=None
                 )
                 _summary_model = _CompModel(id=_summary_model_id, provider=_summary_provider)


### PR DESCRIPTION
## Summary

- `_build_agent_for_conversation` was constructing a throwaway `LLMFactory()` (no `session` / `org_id` / `encryption_backend`) just for the compaction block, so its `llm_config.providers` only contained the static `config.yaml` providers.
- Since the model registry moved to DB-managed providers, the `compaction.summary_provider` value (e.g. `deepseek`) lives in the admin DB, not in `config.yaml`. The throwaway factory raised `KeyError: 'deepseek'`, the surrounding `except Exception` downgraded it to `WARNING | CompactionMiddleware not loaded: 'deepseek'`, and the agent then ran without compaction — which is how an already-bloated conversation ended up making a giant request and silently failing on the frontend.
- Fix: reuse the DB-aware `factory` built earlier in the same method (line ~1958), which already runs `_load_db_provider_configs` + `_build_merged_config` against the admin registry. `build_cubepi_provider` is the same factory method, just called on the right instance.

## Test plan

- [x] mypy / ruff / pre-commit all pass.
- [x] Dumped main DB into the worktree DB (admin-configured `deepseek` provider present), started backend with `.worktree.env`, logged in as the target user, sent a message to the previously-broken conversation. `CompactionMiddleware enabled (threshold=…, model_window=1000000, max_out=32768)` now appears in the log; the old `WARNING | CompactionMiddleware not loaded: 'deepseek'` is gone. Middleware stack count went from 10 → 11.
- [x] Forced `CUBEBOX_COMPACTION__THRESHOLD_RATIO=0.001` to trip compaction on the same conversation: `cubepi.middleware.compaction:transform_context` is invoked and calls the configured summary provider via the merged factory (only failed due to a transient upstream 502 from the internal model gateway, which is unrelated).
- [ ] Out of scope for this PR: a separate, pre-existing cubepi → anthropic mapping bug surfaces when the conversation history is sent to the `deepseek-anthropic-shape` provider (`messages.N: all messages must have non-empty content`). It existed before this fix and reproduces with or without compaction loaded; will be addressed upstream in cubepi.