### PR TITLE
fix(frontend): surface AssistantMessage error_message when stop_reason=error

### DIFF
--- a/frontend/packages/web/__tests__/components/MessageListMemo.test.tsx
+++ b/frontend/packages/web/__tests__/components/MessageListMemo.test.tsx
@@ -42,4 +42,26 @@ describe('HistoryAssistantMessage', () => {
     )
     expect(screen.getByText('hello world')).toBeInTheDocument()
   })
+
+  it('renders an error alert when stop_reason is "error" and content is empty', () => {
+    const errored = {
+      id: 'msg-err',
+      role: 'assistant',
+      content: [],
+      stop_reason: 'error',
+      error_message: '400 Bad Request: messages.347: empty content',
+      timestamp: 1_700_000_001,
+    } as unknown as AssistantMessageType
+    render(
+      <HistoryAssistantMessage
+        message={errored}
+        subagentDataMap={{}}
+        toolResultMap={{}}
+        conversationId="conv-1"
+      />,
+      { wrapper },
+    )
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent(/messages\.347/)
+  })
 })

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -11,7 +11,7 @@ import type {
 } from '@cubebox/core'
 import type { AgentStream } from '@cubebox/core'
 import { useArtifactStore } from '@cubebox/core'
-import { Bot, ChevronDown, ChevronRight, Brain } from 'lucide-react'
+import { Bot, ChevronDown, ChevronRight, Brain, AlertCircle } from 'lucide-react'
 import { ArtifactCard } from './ArtifactCard'
 import { SubAgentCard } from './SubAgentCard'
 import { SubAgentCluster } from './SubAgentCluster'
@@ -520,6 +520,13 @@ export function AssistantMessage({
   const _hasContent = blocks.length > 0
   const grouped = groupBlocks(blocks)
 
+  // History assistants persisted from a failed turn have stop_reason="error"
+  // and an empty content list — without this branch the bubble renders nothing
+  // and the user sees a silent gap after their question. Surface the upstream
+  // error_message so the failure is at least visible (and addressable).
+  const errorMessage = (message?.error_message ?? '').trim()
+  const showErrorBubble = !isStreaming && message?.stop_reason === 'error' && errorMessage !== ''
+
   // Count subagent blocks for index assignment and cluster display
   let subagentCounter = 0
   const subagentIndexMap = new Map<number, number>()
@@ -573,7 +580,7 @@ export function AssistantMessage({
 
   return (
     <div data-role="assistant" className="space-y-2">
-      {(grouped.length > 0 || totalSubagents >= 2) && (
+      {(grouped.length > 0 || totalSubagents >= 2 || showErrorBubble) && (
         <div className="flex justify-start gap-2.5">
           <div
             className="shrink-0 w-6 h-6 rounded-md border border-border bg-card
@@ -589,6 +596,24 @@ export function AssistantMessage({
               />
             )}
             {grouped.map((item, i) => renderItem(item, i))}
+            {showErrorBubble && (
+              <div
+                role="alert"
+                className="flex items-start gap-2 px-3 py-2.5 rounded-lg
+                  bg-destructive/10 border border-destructive/20 text-destructive text-sm"
+              >
+                <AlertCircle className="size-4 shrink-0 mt-0.5" />
+                <div className="flex-1 min-w-0 space-y-1">
+                  <div className="font-medium">{t('assistantReplyFailed')}</div>
+                  <pre
+                    className="whitespace-pre-wrap break-words font-mono text-xs leading-snug
+                      opacity-90 max-h-48 overflow-auto"
+                  >
+                    {errorMessage}
+                  </pre>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -84,6 +84,7 @@
     "thinkingProcess": "Thinking",
     "sandboxPreparing": "Preparing sandbox environment...",
     "sandboxFailed": "Sandbox creation failed, continuing without sandbox",
+    "assistantReplyFailed": "Reply failed",
     "tasksDone": "{completed}/{total} tasks done",
     "tasksProgress": "Task progress {completed}/{total}",
     "artifacts": "Artifacts",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -84,6 +84,7 @@
     "thinkingProcess": "思考过程",
     "sandboxPreparing": "正在准备沙箱环境...",
     "sandboxFailed": "沙箱环境创建失败，将在无沙箱模式下继续",
+    "assistantReplyFailed": "回复失败",
     "tasksDone": "{completed}/{total} 个任务已完成",
     "tasksProgress": "任务进度 {completed}/{total}",
     "artifacts": "产出物",


### PR DESCRIPTION
## Summary

- A persisted assistant turn with `content=[]` and `stop_reason="error"` rendered as literally nothing in `AssistantMessage.tsx` — the outer container short-circuits on `grouped.length > 0 || totalSubagents >= 2`.
- That's how a single upstream provider failure leaves a silent gap after the user's question. The `error_message` is sitting right there on the persisted message, just never reached the DOM.
- This PR adds a tiny inline alert (icon + localized "Reply failed" + the upstream `error_message` in a scrollable monospace block) when the message is non-streaming, `stop_reason === "error"`, and `error_message` is non-empty.
- Companion: the upstream cubepi mapping fix (cubeplexai/cubepi#142) prevents the dead-end where a persisted empty assistant blocks every subsequent retry with `messages.N: empty content`.

## Test plan

- [x] New unit case in `__tests__/components/MessageListMemo.test.tsx` (red before fix, green after).
- [x] `pnpm vitest run` — 148 passed.
- [x] Pre-commit eslint / prettier / i18n parity clean.