### PR TITLE
deps(cubepi): bump to bfd6b84 (anthropic empty-content fix + summarizer trace) + dedupe tools

### DIFF
--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -2633,6 +2633,26 @@ class RunManager:
             len(cubepi_middleware),
             len(all_tools),
         )
+        # cubepi.Agent.__init__ auto-appends each middleware's own `.tools`
+        # to the caller-provided list (cubepi/agent/agent.py:165-169). cubebox
+        # also extracts middleware-contributed tools into the matching
+        # `_sandbox_tools` / `_artifact_tools` / `_todo_tools` /
+        # `_subagent_tools` lists so they sit at a specific position relative
+        # to the builtins for cache-prefix stability. Without this strip,
+        # those tools land on the wire twice and shape-compatible providers
+        # reject the request with "Tool names must be unique."
+        # (deepseek-anthropic-shape). Drop them from the caller list so the
+        # only copy reaching the wire is the one cubepi appends from the
+        # middleware itself — order becomes "all_tools (sans middleware
+        # contributions) then middleware tools in middleware order".
+        _mw_tool_names: set[str] = set()
+        for _mw in cubepi_middleware:
+            for _t in getattr(_mw, "tools", []) or []:
+                _mw_tool_names.add(getattr(_t, "name", repr(_t)))
+        if _mw_tool_names:
+            all_tools = [
+                _t for _t in all_tools if getattr(_t, "name", repr(_t)) not in _mw_tool_names
+            ]
 
         agent = create_cubebox_agent(
             provider=provider,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -172,9 +172,13 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-# 23eee32 is cubepi PR #140: public API type tightening + mypy check. It
-# includes Tracer.oneshot(), cubepi middleware core, and typed provider errors.
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "23eee32674856f838c0e4c299864568050640b8e" }
+# 1363163 is cubepi PR #142: anthropic-shape providers (deepseek etc.) stop
+# 400ing on a replayed history that ends in an empty error AssistantMessage.
+# stream() now strips trailing empty-content error assistants before both the
+# API conversion and the cache-policy query, and synthesises a placeholder
+# for any mid-history empty assistant so user→assistant→user alternation
+# stays intact.
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "1363163" }
 
 [dependency-groups]
 dev = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -172,13 +172,17 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-# 1363163 is cubepi PR #142: anthropic-shape providers (deepseek etc.) stop
-# 400ing on a replayed history that ends in an empty error AssistantMessage.
-# stream() now strips trailing empty-content error assistants before both the
-# API conversion and the cache-policy query, and synthesises a placeholder
-# for any mid-history empty assistant so user→assistant→user alternation
-# stays intact.
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "1363163" }
+# bfd6b84 includes:
+#   * PR #142 — anthropic-shape providers (deepseek etc.) stop 400ing on a
+#     replayed history that ends in an empty error AssistantMessage. stream()
+#     strips trailing empty-content error assistants before both the API
+#     conversion and the cache-policy query; mid-history empties get a
+#     placeholder so user→assistant→user alternation stays intact.
+#   * PR #143 — Middleware.extra_llm_calls() so CompactionMiddleware's
+#     summarizer chat span lands in the agent run's trace, with model-based
+#     gating that keeps the root invoke_agent attribution on the agent's
+#     own (provider, model).
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "bfd6b84" }
 
 [dependency-groups]
 dev = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -875,7 +875,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=1363163" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=bfd6b84" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -922,7 +922,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.6.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=1363163#13631637e06c0342eb07843d2aab4e067eed3f9e" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=bfd6b84#bfd6b845db3657dcd7afc5bd31f8bc02aec9ecda" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -875,7 +875,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=23eee32674856f838c0e4c299864568050640b8e" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=1363163" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -922,7 +922,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.6.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=23eee32674856f838c0e4c299864568050640b8e#23eee32674856f838c0e4c299864568050640b8e" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=1363163#13631637e06c0342eb07843d2aab4e067eed3f9e" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },


### PR DESCRIPTION
## Summary

Bumps the cubepi pin to `bfd6b84` and adds one defensive cubebox-side change. Two upstream commits land:

* **cubepi PR #142** — anthropic-shape providers (deepseek etc.) stop 400ing on a replayed history that ends in an empty error `AssistantMessage`. `stream()` trims trailing empty-content error assistants before both the API conversion and the cache-policy query; mid-history empties get a placeholder so user→assistant→user alternation stays intact.
* **cubepi PR #143** — `Middleware.extra_llm_calls()` so `CompactionMiddleware`'s summarizer LLM call lands in the agent run's trace (previously invisible). Root `invoke_agent` attribution is gated by `(provider, model)` so the summarizer keeps its own chat span without overwriting the run's provider/system-prompt/tool attribution — including the shared-provider "reuse the client, swap the model" case.

Cubebox-side: `run_manager.py:_build_agent_for_conversation` now dedupes `all_tools` against the names each middleware contributes via its own `.tools`. `cubepi.Agent.__init__` auto-appends `mw.tools` to the caller list, and cubebox was already extracting those same tools into the matching `_sandbox_tools` / `_artifact_tools` / `_todo_tools` / `_subagent_tools` lists for cache-prefix stability. Without the strip, every middleware-contributed tool reached the wire twice and shape-compatible providers rejected the request with `Tool names must be unique.` (deepseek-anthropic-shape).

## Test plan

End-to-end against a clone of main's DB on the previously-stuck twitter-运营 conversation:

- [x] **Pre-existing compaction failure fixed.** `CompactionMiddleware enabled` logs and engages; the prompt now reaches deepseek-v4-flash; the agent loop completes (text/thinking → tool_use/result → text "ok"); next-turn input `cache_read=319872 tokens` confirms prompt cache prefix stable.
- [x] **Compaction summarizer actually triggers.** Forced `CUBEBOX_COMPACTION__THRESHOLD_RATIO=0.001` with `summary_provider=deepseek summary_model=deepseek-v4-flash`: input went from ~330k tokens to ~21k, `cubepi_threads.extra.compaction.{summary, summarized_message_refs, compaction_until_msg_index}` populated, no `messages.N empty content` errors.
- [x] **No more "Tool names must be unique." 400** after the dedupe.
- [x] `mypy` / `ruff` / `pre-commit` clean.