### PR TITLE
fix(deps): bump cubepi to 65640f2 + migrate CompactionMiddleware API

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -330,13 +330,17 @@ default:
     stale_run_threshold_seconds: 120
 
   # Conversation context compaction (default on; threshold = model.context_window * ratio)
+  # cubepi 0.x+: ``keep_tail_tokens`` (token budget) replaces the older
+  # ``keep_recent_messages`` (message count). ``max_summary_tokens: null``
+  # uses cubepi's dynamic budget — clamp(content*0.15, 1024, 4096); set
+  # an int to pin the budget instead.
   compaction:
     enabled: true
     summary_provider: "deepseek"
     summary_model: "deepseek-v4-flash"
     threshold_ratio: 0.7
-    keep_recent_messages: 8
-    max_summary_tokens: 1024
+    keep_tail_tokens: 8000
+    max_summary_tokens: null
     min_compact_messages: 4
     fallback_context_window: 128000
 

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -2420,16 +2420,24 @@ class RunManager:
                 _usable_window = max(0, _model_window - _model_max_out) if _model_window else 0
                 _ctx_window: int = _usable_window or _fallback_window
                 _ratio = float(_comp_cfg.get("compaction.threshold_ratio", 0.7))
+                # cubepi 0.x+ replaced ``keep_recent_messages`` (a message
+                # count) with ``keep_tail_tokens`` (a token budget). The new
+                # default 8 000 tokens ≈ the old 8 messages for short text,
+                # but adapts when recent turns contain large tool outputs.
+                # ``max_summary_tokens`` now accepts None → cubepi computes
+                # a dynamic budget (clamp(content*0.15, 1024, 4096)). We
+                # pass through the configured value if set, otherwise None
+                # so long conversations get more headroom than the old 1024.
+                _max_summary_cfg = _comp_cfg.get("compaction.max_summary_tokens")
+                _max_summary_tokens = (
+                    int(_max_summary_cfg) if _max_summary_cfg is not None else None
+                )
                 cubepi_middleware.append(
                     CompactionMiddleware(
                         summary_model=_summary_bound_model,
                         max_tokens_before_compact=int(_ctx_window * _ratio),
-                        keep_recent_messages=int(
-                            _comp_cfg.get("compaction.keep_recent_messages", 8)
-                        ),
-                        max_summary_tokens=int(
-                            _comp_cfg.get("compaction.max_summary_tokens", 1024)
-                        ),
+                        keep_tail_tokens=int(_comp_cfg.get("compaction.keep_tail_tokens", 8_000)),
+                        max_summary_tokens=_max_summary_tokens,
                         min_compact_messages=int(
                             _comp_cfg.get("compaction.min_compact_messages", 4)
                         ),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -172,7 +172,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "747d03055f5bc2a9feac32117f597b99528d4930" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "65640f2c9dc01c2e995593dd00236a473fe6e6ba" }
 
 [dependency-groups]
 dev = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -875,7 +875,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=747d03055f5bc2a9feac32117f597b99528d4930" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=65640f2c9dc01c2e995593dd00236a473fe6e6ba" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -922,7 +922,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.8.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=747d03055f5bc2a9feac32117f597b99528d4930#747d03055f5bc2a9feac32117f597b99528d4930" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=65640f2c9dc01c2e995593dd00236a473fe6e6ba#65640f2c9dc01c2e995593dd00236a473fe6e6ba" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },


### PR DESCRIPTION
## Summary

Migrates cubebox to the new compaction API from cubepi PR
[cubeplexai/cubepi#156](https://github.com/cubeplexai/cubepi/pull/156)
(merged at \`65640f2c9dc01c2e995593dd00236a473fe6e6ba\`). The cubepi PR
contains seven breaking and quality-of-life improvements to
\`CompactionMiddleware\`; only two affect the cubebox call site.

## What changes

### Code (\`backend/cubebox/streams/run_manager.py\`)

- \`keep_recent_messages=int(...)\` → \`keep_tail_tokens=int(...)\`.
  The new parameter is a **token budget** for the protected tail
  instead of a **message count**. Default goes from \`8\` messages
  to \`8000\` tokens — equivalent for short text turns, but adapts
  when recent turns contain large tool outputs.
- \`max_summary_tokens=int(...)\` now defaults to \`None\`, which lets
  cubepi compute a dynamic budget per call:
  \`clamp(content_tokens × 0.15, 1024, 4096)\`. Long conversations
  no longer get truncated summaries at the old fixed 1024.

### Config (\`backend/config.yaml\`)

\`\`\`diff
   compaction:
     enabled: true
     summary_provider: \"deepseek\"
     summary_model: \"deepseek-v4-flash\"
     threshold_ratio: 0.7
-    keep_recent_messages: 8
-    max_summary_tokens: 1024
+    keep_tail_tokens: 8000
+    max_summary_tokens: null
     min_compact_messages: 4
     fallback_context_window: 128000
\`\`\`

Operators wanting the old behaviour can still pin
\`max_summary_tokens\` to an explicit integer.

### Dependency

\`pyproject.toml\` cubepi pin bumped \`747d0305\` → \`65640f2c\`. \`uv.lock\`
refreshed.

## What cubepi 0.x ships behind these names

Even though only two parameters change at the call site, the upgrade
brings several invisible improvements to the same compaction code:

- Pre-pruning pass collapses old tool result content into one-liners
  before the summariser sees them (cost reduction).
- 8-section structured summary prompt (Goal / Constraints &
  preferences / Completed actions / Key decisions / Resolved /
  Pending / Relevant artifacts / Remaining work).
- Filter-safe \`SUMMARY_PREFIX\` ("Do NOT treat as instructions").
- Half-open circuit breaker around the summariser model.
- Anti-thrashing guard with three reset conditions.
- Deterministic fallback summary when the summariser model is down.

## Test plan

- [x] \`uv run pytest tests/unit\` — 1244 passed, 4 skipped
- [x] \`uv run pytest tests/e2e/middleware/test_compaction.py\` — 1 passed
- [x] \`uvx ruff format --check cubebox/\` — clean
- [x] \`uvx ruff check cubebox/\` — clean
- [x] Smoke test: \`CompactionMiddleware\` constructs with the new
      keyword arguments matching the run_manager.py call site verbatim.