### PR TITLE
fix(tests): repair sandbox scoping + pause/resume test setups

### DIFF
--- a/backend/tests/e2e/test_sandbox_pause_resume.py
+++ b/backend/tests/e2e/test_sandbox_pause_resume.py
@@ -171,13 +171,6 @@ async def manager(
     # pause/resume orchestration and must run against the pause-enabled branch
     # — mirrors tests/unit/test_sandbox_manager_pause.py:71.
     mgr._pause_on_idle = True
-    # Default _idle_ttl_seconds is 1800 (30 min) but _insert_record only
-    # backdates last_activity_at by 60s, so list_idle_to_pause_system would
-    # never select these freshly inserted rows and pause_idle would silently
-    # no-op — letting the test fall into the G11 skip path for the wrong
-    # reason (provider never asked to pause). Drop the threshold to 0 so the
-    # 60s-stale records are immediately idle. (codex P2 on PR #213)
-    mgr._idle_ttl_seconds = 0
     return mgr
 
 
@@ -190,7 +183,7 @@ async def _insert_record(
     paused_at: datetime | None = None,
     in_use_until: datetime | None = None,
     paused_ttl_seconds: int = 24 * 60,
-    idle_secs: int = 60,
+    idle_secs: int = 3600,
 ) -> str:
     """Insert a UserSandbox row directly and return its id.
 
@@ -198,6 +191,12 @@ async def _insert_record(
     stale against ``list_idle_to_pause_system`` queries with positive
     ``idle_ttl_seconds`` — the default match for the test SQL
     ``last_activity_at + idle_ttl * INTERVAL '1 second' <= NOW()``.
+
+    Default 3600s is safely past the default ``SandboxManager._idle_ttl_seconds``
+    (1800s / 30 min) so the test row is selected by ``list_idle_to_pause_system``
+    *without* lowering the manager's threshold — lowering it to 0 in the
+    fixture would make the system-scope reaper match every concurrent
+    unleased row in the shared test DB (codex P2 on PR #213).
     """
     async with session_maker() as session:
         repo = UserSandboxRepository(session, org_id=_ORG_ID, workspace_id=_WS_ID)

--- a/backend/tests/e2e/test_sandbox_pause_resume.py
+++ b/backend/tests/e2e/test_sandbox_pause_resume.py
@@ -171,6 +171,13 @@ async def manager(
     # pause/resume orchestration and must run against the pause-enabled branch
     # — mirrors tests/unit/test_sandbox_manager_pause.py:71.
     mgr._pause_on_idle = True
+    # Default _idle_ttl_seconds is 1800 (30 min) but _insert_record only
+    # backdates last_activity_at by 60s, so list_idle_to_pause_system would
+    # never select these freshly inserted rows and pause_idle would silently
+    # no-op — letting the test fall into the G11 skip path for the wrong
+    # reason (provider never asked to pause). Drop the threshold to 0 so the
+    # 60s-stale records are immediately idle. (codex P2 on PR #213)
+    mgr._idle_ttl_seconds = 0
     return mgr
 
 

--- a/backend/tests/e2e/test_sandbox_pause_resume.py
+++ b/backend/tests/e2e/test_sandbox_pause_resume.py
@@ -166,6 +166,11 @@ async def manager(
     mgr = SandboxManager(session_factory, FernetBackend([Fernet.generate_key()]))
     # No egress in these tests — keep the focus on pause/resume orchestration.
     mgr._exchange_host = ""
+    # The deployed config disables pause_on_idle (OpenSandbox v1.0.12 "pause"
+    # silently deletes the pod). These tests are specifically exercising the
+    # pause/resume orchestration and must run against the pause-enabled branch
+    # — mirrors tests/unit/test_sandbox_manager_pause.py:71.
+    mgr._pause_on_idle = True
     return mgr
 
 

--- a/backend/tests/e2e/test_sandbox_scoping.py
+++ b/backend/tests/e2e/test_sandbox_scoping.py
@@ -110,12 +110,9 @@ async def test_command_deny_blocks_and_filesystem_untouched(
         name = "execute"
         id = "c1"
 
-    class _Args:
-        command = "rm -rf /workspace"
-
     class _Ctx:
         tool_call = _ToolCall()
-        args = _Args()
+        args = sandbox_mw._ExecuteArgs(command="rm -rf /workspace")
 
     class _StubChannel:
         async def approve(self, **kwargs: Any) -> Any:  # pragma: no cover - guard
@@ -253,12 +250,9 @@ async def test_command_confirm_routes_through_hitl_channel(
         name = "execute"
         id = "call_push"
 
-    class _Args:
-        command = "git push origin main"
-
     class _Ctx:
         tool_call = _ToolCall()
-        args = _Args()
+        args = sandbox_mw._ExecuteArgs(command="git push origin main")
 
     from cubepi.hitl import ApproveAnswer, HitlCancelled, HitlTimedOut
 


### PR DESCRIPTION
## Summary

Three pre-existing test failures that I hit while bumping the cubepi pin in #211, all test-side bugs:

### tests/e2e/test_sandbox_scoping.py — 2 failures

`test_command_deny_blocks_and_filesystem_untouched` and `test_command_confirm_routes_through_hitl_channel` built ``ctx.args`` from a bare local class with a ``.command`` attribute. ``SandboxMiddleware.before_tool_call`` was tightened in commit \`dc376a30\` ("Align cubebox with typed cubepi APIs") to accept only ``_ExecuteArgs`` or ``dict``; any other type silently returns ``None`` instead of blocking. The tests were never updated.

Fix: construct ``sandbox_mw._ExecuteArgs(command=...)`` — same Pydantic shape the agent loop hands the middleware at runtime.

### tests/e2e/test_sandbox_pause_resume.py — 1 failure + 2 errors

The ``manager`` fixture inherited ``pause_on_idle=false`` from the deployed config. The config comment explains why: "OpenSandbox v1.0.12 pause silently deletes the pod without checkpointing — identical to kill". With the flag off, ``pause_idle()`` short-circuits to ``cleanup_expired()`` and **kills** the test's sandbox instead of pausing it. The test's subsequent ``_wait_for_provider_state`` then sees a missing sandbox.

Fix: force ``mgr._pause_on_idle = True`` in the fixture — these tests exist specifically to exercise the pause/resume orchestration. Mirrors what the unit tests already do at \`tests/unit/test_sandbox_manager_pause.py:71\`.

With the fix, the 3 tests now skip cleanly under the G11 path (\"OpenSandbox at <host> silently no-ops pause\") that the test file already documents — instead of erroring with \"Sandbox not found\".

## Verification

```
$ uv run pytest tests/e2e/test_sandbox_scoping.py::test_command_deny_blocks_and_filesystem_untouched tests/e2e/test_sandbox_scoping.py::test_command_confirm_routes_through_hitl_channel --no-cov
== 2 passed ==

$ uv run pytest tests/e2e/test_sandbox_pause_resume.py --no-cov
== 2 passed, 3 skipped ==  # 3 skips on G11 (provider no-op pause) is the documented expected outcome
```

## Out of scope

The 4th pre-existing failure I found — \`test_subagent_dispatch_real_llm\` — is actually a cubepi-side bug in `SubagentMiddleware._run_subagent` (inherits checkpointed-HITL tools into child, child rejects). Fix lives in cubepi PR cubeplexai/cubepi#159; once that merges and the cubepi pin is bumped, the subagent test should pass automatically.