### PR TITLE
chore(deps): bump cubepi pin 65640f2 -> 4d06411

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -172,7 +172,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "65640f2c9dc01c2e995593dd00236a473fe6e6ba" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "4d06411" }
 
 [dependency-groups]
 dev = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -875,7 +875,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=65640f2c9dc01c2e995593dd00236a473fe6e6ba" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=4d06411" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -922,7 +922,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.8.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=65640f2c9dc01c2e995593dd00236a473fe6e6ba#65640f2c9dc01c2e995593dd00236a473fe6e6ba" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=4d06411#4d064110db364f9e2c4936bed6a06e48bb928859" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },


### PR DESCRIPTION
Brings in:

- cubeplexai/cubepi#159 (subagent HITL strip): SubagentMiddleware now strips checkpointed-HITL elements from child agent's inherited tools and middleware (including tools nested inside middleware.tools). Unblocks cubebox's ``test_subagent_dispatch_real_llm`` which was raising "Agent has checkpointed HITL elements bound to run_ids ..." because cubebox's ask_user_tool reached the child.
- FallbackBoundModel and DEFAULT_TRIGGER_ERRORS exported from ``cubepi.providers`` — available but not adopted by cubebox yet.
- Various compaction reliability fixes already absorbed via e1c36e1e.

Verification:
- ``uv run mypy cubebox/`` → 0 errors
- ``uv run pytest tests/e2e/middleware/test_subagent.py::test_subagent_dispatch_real_llm`` → PASSED (was FAILED on 65640f2)