### PR TITLE
fix: parameterize i18n path + null org_id for system-row preset refs

### DIFF
--- a/backend/cubebox/api/exceptions.py
+++ b/backend/cubebox/api/exceptions.py
@@ -353,7 +353,7 @@ class AttachmentTooManyError(APIException):
 class ModelInUseByPresetError(APIException):
     """409 — model cannot be deleted because caller-org presets reference it."""
 
-    def __init__(self, slug: str, model_id: str, refs: list[dict[str, str]]) -> None:
+    def __init__(self, slug: str, model_id: str, refs: list[dict[str, str | None]]) -> None:
         super().__init__(
             error_code="model_in_use_by_preset",
             message=f"model {slug}/{model_id} is referenced by presets and cannot be deleted",

--- a/backend/cubebox/services/provider_service.py
+++ b/backend/cubebox/services/provider_service.py
@@ -375,7 +375,11 @@ class ProviderService:
                 model_id=m.model_id,
                 refs=[
                     {
-                        "org_id": self.org_id,
+                        # System-row refs are conceptually owned by no org;
+                        # surface that truthfully so consumers branching on
+                        # org_id don't get misled. The `source` field is the
+                        # canonical disambiguator either way.
+                        "org_id": None if r["source"] == "system" else self.org_id,
                         "preset_label": r["preset_label"],
                         "source": r["source"],
                     }

--- a/backend/tests/unit/test_model_delete_guard.py
+++ b/backend/tests/unit/test_model_delete_guard.py
@@ -181,7 +181,8 @@ async def test_delete_blocked_when_only_system_row_references_model(
         await svc.delete_model(pid, mid)
     assert exc.value.status_code == 409
     assert exc.value.refs == [
-        {"org_id": CALLER_ORG, "preset_label": "sys-default", "source": "system"},
+        # System-row refs surface as org_id=None (no org owns the system row).
+        {"org_id": None, "preset_label": "sys-default", "source": "system"},
     ]
     # Model row survives — guard fired before delete.
     assert await ModelRepository(db_session).get(mid) is not None

--- a/frontend/packages/web/components/admin/models/ProviderDetail.tsx
+++ b/frontend/packages/web/components/admin/models/ProviderDetail.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
+
+const PRESETS_ADMIN_PATH = '/admin/presets'
 import { Box, Check, Loader2, Pencil, Plus, RotateCw, Trash2, Zap, X } from 'lucide-react'
 import {
   ApiError,
@@ -410,7 +412,7 @@ export function ProviderDetail({
             <p className="mt-1 text-destructive/90">
               {t('modelInUseByPreset.body')}{' '}
               <Link
-                href="/admin/presets"
+                href={PRESETS_ADMIN_PATH}
                 className="underline underline-offset-2 hover:text-destructive"
               >
                 {t('modelInUseByPreset.linkLabel')}
@@ -433,7 +435,9 @@ export function ProviderDetail({
               </ul>
             )}
             {modelInUseRefs.some((r) => r.source === 'system') && (
-              <p className="mt-2 text-destructive/90">{t('modelInUseByPreset.systemHint')}</p>
+              <p className="mt-2 text-destructive/90">
+                {t('modelInUseByPreset.systemHint', { path: PRESETS_ADMIN_PATH })}
+              </p>
             )}
           </div>
         )}

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -324,7 +324,7 @@
       "linkLabel": "Open Presets",
       "systemSourceLabel": "(system)",
       "orgSourceLabel": "(org)",
-      "systemHint": "Some references are in your organization's default (system) presets. To delete this model, first open /admin/presets, click 'Save' to create an org-level copy, then remove the references."
+      "systemHint": "Some references are in your organization's default (system) presets. To delete this model, first open {path}, click 'Save' to create an org-level copy, then remove the references."
     },
     "test": "Test",
     "testing": "Testing…",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -324,7 +324,7 @@
       "linkLabel": "打开预设管理",
       "systemSourceLabel": "（系统）",
       "orgSourceLabel": "（组织）",
-      "systemHint": "部分引用来自你所在组织的默认（系统）预设。要删除该模型，请先打开 /admin/presets，点击“保存”生成一份组织级副本，再移除其中的引用。"
+      "systemHint": "部分引用来自你所在组织的默认（系统）预设。要删除该模型，请先打开 {path}，点击“保存”生成一份组织级副本，再移除其中的引用。"
     },
     "test": "测试",
     "testing": "测试中…",


### PR DESCRIPTION
## Summary

Two pass-3 nits from #216, follow-up PR.

1. **i18n systemHint hardcoded `/admin/presets`** — translator-visible copy would go stale if the admin route ever moves. Parameterized as `{path}`; component injects `PRESETS_ADMIN_PATH` constant so the route lives in one place (mirrors the adjacent `<Link href={PRESETS_ADMIN_PATH}>`).
2. **`find_preset_refs_to_model` with `source="system"` surfaced `org_id=caller.org_id`** — misleading; no org owns the system row. Now emits `org_id=None` when `source=="system"`; widened `ModelInUseByPresetError` refs type to `list[dict[str, str | None]]`. Test updated to the truthful expectation.

## Test plan
- [x] `tests/unit/test_model_delete_guard.py` — 5 passed
- [x] `pnpm --filter web type-check` — clean
- [x] Pre-push hook (ruff + mypy + pytest + eslint + prettier + i18n parity) — green