### PR TITLE
chore(deps): bump cubepi pin b2ac341 -> 86a7bbd (Tracer/Meter chain coverage)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -172,7 +172,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "b2ac341865a3e159f99fe2d9df1476bdff69e992" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "86a7bbd6f9614e0b247fe86a80f8a6875990ecc7" }
 
 [dependency-groups]
 dev = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -875,7 +875,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=b2ac341865a3e159f99fe2d9df1476bdff69e992" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=86a7bbd6f9614e0b247fe86a80f8a6875990ecc7" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -922,7 +922,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.9.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=b2ac341865a3e159f99fe2d9df1476bdff69e992#b2ac341865a3e159f99fe2d9df1476bdff69e992" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=86a7bbd6f9614e0b247fe86a80f8a6875990ecc7#86a7bbd6f9614e0b247fe86a80f8a6875990ecc7" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },


### PR DESCRIPTION
## Summary

Bumps cubepi to pick up [cubeplexai/cubepi#170](https://github.com/cubeplexai/cubepi/pull/170): `Recorder.attach()` and `Meter.attach()` now subscribe to every provider in a `FallbackBoundModel` chain.

This closes the known limitation cubebox PR #215 accepted as a follow-up: post-failover chat spans + token/cost metrics for `chain[1..]` were silently missing from the trace / metric stream. They land normally now.

## Test plan
- [x] cubepi import smoke: `chain_providers`, `collect_agent_providers` resolve
- [x] Backend unit suite: 1303 passed (10 pre-existing `test_scheduled_task_service.py` errors unrelated)
- [x] Pre-push hook (ruff + mypy + pytest unit + frontend ci): green