### PR TITLE
fix(e2e): stamp FauxProvider.provider_id with slug in image E2E

### DIFF
--- a/backend/tests/e2e/test_generate_image_e2e.py
+++ b/backend/tests/e2e/test_generate_image_e2e.py
@@ -227,11 +227,17 @@ async def generate_image_client(
     )
 
     # Monkeypatch cubebox.llm.builder.build_provider to return our FauxProvider
-    # regardless of the snapshot's resolved provider slug.
-    monkeypatch.setattr(
-        "cubebox.llm.builder.build_provider",
-        lambda snap, slug, **kw: faux_provider,
-    )
+    # regardless of the snapshot's resolved provider slug. We dynamically stamp
+    # faux_provider.provider_id with the requested slug so downstream lookups
+    # like `snap.providers[this_run_model.spec.provider_id]` resolve back to a
+    # real key in the snapshot (run_manager:_build_agent_for_conversation does
+    # exactly this when reading model max_tokens / reasoning). Without the
+    # stamp, FauxProvider defaults to provider_id="" → KeyError("") at lookup.
+    def _build_faux_provider(snap: object, slug: str, **kw: object) -> object:
+        faux_provider.provider_id = slug
+        return faux_provider
+
+    monkeypatch.setattr("cubebox.llm.builder.build_provider", _build_faux_provider)
 
     # --- 5. Create temp sandbox directory ---
     with tempfile.TemporaryDirectory(prefix="cubebox_e2e_img_") as tmpdir:


### PR DESCRIPTION
## Summary

\`test_generate_image_creates_artifact\` has been failing on \`main\` since the Spec 1 snapshot refactor (PR #215).

### Root cause

\`run_manager._build_agent_for_conversation\` extracts \`provider_name = this_run_model.spec.provider_id\` and uses it as a key into the snapshot:

\`\`\`python
provider_config = snap.providers[provider_name]
\`\`\`

The test monkeypatched \`cubebox.llm.builder.build_provider\` to return a \`FauxProvider()\` constructed with the default \`provider_id=\"\"\`. So:

- \`build_chain_model\` → \`build_bound_model\` → \`build_provider(...)\` returns \`FauxProvider(provider_id=\"\")\`
- \`provider.model(model_id)\` produces \`BoundModel\` with \`spec.provider_id = \"\"\`
- \`snap.providers[\"\"]\` → \`KeyError(\"\")\`
- The run wrapper caught \`Exception\`, classified as \`internal_error\`, and emitted a generic error event with \`details: \"''\"\`
- Test assertion \`no error events\` fired

### Fix

Test-side: dynamically set \`faux_provider.provider_id = slug\` inside the monkeypatch lambda so the downstream snapshot lookup resolves back to a real key. Original \"any slug returns our faux provider\" intent preserved.

## Test plan

- [x] \`tests/e2e/test_generate_image_e2e.py::test_generate_image_creates_artifact\` — passes
- [x] Full E2E suite verified separately (507 passed before fix with this one failing; this PR resolves the last failure)