### PR TITLE
feat(mcp): progressive disclosure via DeferredToolGroup (#143)

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -198,6 +198,11 @@ default:
   # MCP connectors are managed via the DB-backed catalog (mcp_catalog_connectors)
   # plus per-org/per-workspace installs (mcp_servers). The legacy
   # `mcp.servers` config block was removed in M2.
+  mcp:
+    progressive_disclosure:
+      enabled: "auto"        # "auto" | "on" | "off"
+      threshold_pct: 10.0    # collapse when deferrable schemas >= this % of context
+      min_servers: 2         # never collapse below this server count
 
   # Object Storage Configuration (S3-compatible)
   objectstore:

--- a/backend/cubebox/agents/graph.py
+++ b/backend/cubebox/agents/graph.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from cubepi import Agent
 from cubepi.agent.types import AgentTool
+from cubepi.deferred import DeferredToolGroup
 from cubepi.hitl import HitlChannel
 from cubepi.middleware.base import Middleware
 from cubepi.providers.base import ThinkingLevel
@@ -29,6 +30,7 @@ def create_cubebox_agent(
     middleware: list[Middleware] | None = None,
     thinking: ThinkingLevel = "off",
     channel: HitlChannel | None = None,
+    deferred_tool_groups: list[DeferredToolGroup] | None = None,
 ) -> Agent[Any]:
     """Build a cubepi.Agent for cubebox's cubepi runtime path.
 
@@ -49,6 +51,7 @@ def create_cubebox_agent(
         thread_id=thread_id,
         middleware=mw_list,
         channel=channel,
+        deferred_tool_groups=deferred_tool_groups,
         # See compose_after_tool_call for why we override the default.
         after_tool_call=compose_after_tool_call(mw_list),
     )

--- a/backend/cubebox/mcp/cubepi_runtime.py
+++ b/backend/cubebox/mcp/cubepi_runtime.py
@@ -110,10 +110,38 @@ async def load_workspace_mcp_tools_for_cubepi(
       scoping.
     """
     specs = await effective_service.list_runtime_specs(workspace_id, user_id)
+    return await _load_tools_for_specs(
+        specs=specs,
+        all_specs=specs,
+        workspace_id=workspace_id,
+        org_id=org_id,
+        user_id=user_id,
+        cred_service=cred_service,
+        signer=signer,
+        token_manager=token_manager,
+        grant_repo=grant_repo,
+    )
 
-    # Pre-compute proposed slugs to detect cross-server collisions.
+
+async def _load_tools_for_specs(
+    *,
+    specs: list[MCPRuntimeConnectorSpec],
+    all_specs: list[MCPRuntimeConnectorSpec],
+    workspace_id: str,
+    org_id: str,
+    user_id: str,
+    cred_service: CredentialService,
+    signer: MCPUserTokenSigner,
+    token_manager: OAuthTokenManager,
+    grant_repo: MCPCredentialGrantRepository | None = None,
+) -> tuple[list[AgentTool[Any]], dict[str, CitationConfig]]:
+    """Load and namespace MCP tools for a subset of runtime specs.
+
+    ``all_specs`` is the full workspace spec set used for slug collision
+    detection; ``specs`` is the subset to actually load.
+    """
     proposed_slugs: dict[str, str] = {
-        spec.install_id: _slugify_for_namespace(spec.name) for spec in specs
+        s.install_id: _slugify_for_namespace(s.name) for s in all_specs
     }
     slug_counts: Counter[str] = Counter(proposed_slugs.values())
 
@@ -147,9 +175,6 @@ async def load_workspace_mcp_tools_for_cubepi(
             continue
 
         if resolved is None:
-            # Credential resolution returned no token for a non-passthrough
-            # spec — the effective service should already have flagged this
-            # spec as unusable, but defend in depth.
             continue
         headers, server_url = resolved
 
@@ -191,7 +216,11 @@ async def load_workspace_mcp_tools_for_cubepi(
 
         for tool in tools:
             bare_name = tool.name
-            namespaced_name = _build_namespaced_name_with_prefix(slug, bare_name, suffix=suffix)
+            namespaced_name = _build_namespaced_name_with_prefix(
+                slug,
+                bare_name,
+                suffix=suffix,
+            )
             namespaced = dataclasses.replace(tool, name=namespaced_name)
             all_tools.append(namespaced)
             raw = spec.tool_citations.get(bare_name)

--- a/backend/cubebox/mcp/cubepi_runtime.py
+++ b/backend/cubebox/mcp/cubepi_runtime.py
@@ -239,6 +239,59 @@ async def _load_tools_for_specs(
     return all_tools, all_citations
 
 
+async def _load_tools_for_specs_deferred(
+    *,
+    specs: list[MCPRuntimeConnectorSpec],
+    all_specs: list[MCPRuntimeConnectorSpec],
+    workspace_id: str,
+    org_id: str,
+    user_id: str,
+    encryption_backend: Any,
+    http_client: Any,
+    metadata_discovery: Any,
+    redis: Any,
+    signer: MCPUserTokenSigner,
+) -> tuple[list[AgentTool[Any]], dict[str, CitationConfig]]:
+    """Load tools in a self-contained DB session — for deferred group loaders.
+
+    The eager path holds a session open for the duration of the MCP load
+    block.  Deferred loaders run later during the agent loop, long after
+    that session has closed.  This wrapper creates a short-lived session
+    per invocation so each group expansion is self-contained.
+    """
+    from cubebox.credentials.dependencies import build_credential_service
+    from cubebox.db.engine import async_session_maker
+    from cubebox.repositories.credential import CredentialRepository
+    from cubebox.repositories.mcp import MCPCredentialGrantRepository as _GrantRepo
+
+    async with async_session_maker() as session:
+        cred_service = build_credential_service(
+            session,
+            encryption_backend,
+            org_id=org_id,
+            actor_user_id=user_id,
+        )
+        token_manager = OAuthTokenManager(
+            http_client=http_client,
+            redis=redis,
+            encryption_backend=encryption_backend,
+            credential_repo=CredentialRepository(session, org_id=org_id),
+            metadata=metadata_discovery,
+        )
+        grant_repo = _GrantRepo(session, org_id=org_id)
+        return await _load_tools_for_specs(
+            specs=specs,
+            all_specs=all_specs,
+            workspace_id=workspace_id,
+            org_id=org_id,
+            user_id=user_id,
+            cred_service=cred_service,
+            signer=signer,
+            token_manager=token_manager,
+            grant_repo=grant_repo,
+        )
+
+
 def _inject_query_param(server_url: str, name: str, value: str) -> str:
     """Append ``name=value`` to ``server_url``'s query string.
 

--- a/backend/cubebox/mcp/disclosure.py
+++ b/backend/cubebox/mcp/disclosure.py
@@ -14,7 +14,7 @@ from cubebox.mcp._constants import slugify_for_namespace
 from cubebox.mcp.cubepi_runtime import (
     _NS_LENGTH_DEFENCE,
     _build_namespaced_name_with_prefix,
-    _load_tools_for_specs,
+    _load_tools_for_specs_deferred,
 )
 from cubebox.mcp.effective import MCPRuntimeConnectorSpec
 from cubebox.middleware.citations.config import CitationConfig
@@ -113,8 +113,10 @@ def build_deferred_groups(
     Returns (groups, citation_configs). citation_configs is populated when
     loader callbacks run (i.e., when the model calls load_tools).
 
-    loader_kwargs carries workspace_id, org_id, user_id, cred_service,
-    signer, token_manager, grant_repo — forwarded to _load_tools_for_specs.
+    loader_kwargs carries session-independent factory ingredients forwarded
+    to _load_tools_for_specs_deferred (workspace_id, org_id, user_id,
+    encryption_backend, http_client, metadata_discovery, redis, signer).
+    Each loader creates its own short-lived DB session.
     """
     shared_citations: dict[str, CitationConfig] = {}
     groups: list[DeferredToolGroup] = []
@@ -129,7 +131,7 @@ def build_deferred_groups(
             _kw: dict[str, Any] = loader_kwargs,
             _cit: dict[str, CitationConfig] = shared_citations,
         ) -> list[AgentTool[Any]]:
-            tools, citations = await _load_tools_for_specs(
+            tools, citations = await _load_tools_for_specs_deferred(
                 specs=[_s],
                 all_specs=_all,
                 **_kw,

--- a/backend/cubebox/mcp/disclosure.py
+++ b/backend/cubebox/mcp/disclosure.py
@@ -1,0 +1,49 @@
+"""MCP progressive disclosure — config, threshold gate."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from cubebox.config import config
+
+
+@dataclass(frozen=True)
+class DisclosureSettings:
+    enabled: Literal["auto", "on", "off"] = "auto"
+    threshold_pct: float = 10.0
+    min_servers: int = 2
+
+
+_EnabledLiteral = Literal["auto", "on", "off"]
+
+
+def load_disclosure_settings() -> DisclosureSettings:
+    raw_enabled = str(config.get("mcp.progressive_disclosure.enabled", "auto"))
+    if raw_enabled not in ("auto", "on", "off"):
+        raw_enabled = "auto"
+    return DisclosureSettings(
+        enabled=cast(_EnabledLiteral, raw_enabled),
+        threshold_pct=float(config.get("mcp.progressive_disclosure.threshold_pct", 10.0)),
+        min_servers=int(config.get("mcp.progressive_disclosure.min_servers", 2)),
+    )
+
+
+def disclosure_active(
+    settings: DisclosureSettings,
+    *,
+    server_count: int,
+    total_tool_tokens: int = 0,
+    context_window: int = 0,
+) -> bool:
+    """True when the catalog/expand machinery replaces eager tool loading."""
+    if settings.enabled == "off":
+        return False
+    if settings.enabled == "on":
+        return True
+    # "auto": both guards must pass.
+    if server_count < settings.min_servers:
+        return False
+    if context_window <= 0:
+        return server_count >= settings.min_servers
+    return (total_tool_tokens / context_window * 100) >= settings.threshold_pct

--- a/backend/cubebox/mcp/disclosure.py
+++ b/backend/cubebox/mcp/disclosure.py
@@ -1,11 +1,23 @@
-"""MCP progressive disclosure — config, threshold gate."""
+"""MCP progressive disclosure — config, threshold gate, deferred groups."""
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
-from typing import Literal, cast
+from typing import Any, Literal, cast
+
+from cubepi.agent.types import AgentTool
+from cubepi.deferred import DeferredToolGroup
 
 from cubebox.config import config
+from cubebox.mcp._constants import slugify_for_namespace
+from cubebox.mcp.cubepi_runtime import (
+    _NS_LENGTH_DEFENCE,
+    _build_namespaced_name_with_prefix,
+    _load_tools_for_specs,
+)
+from cubebox.mcp.effective import MCPRuntimeConnectorSpec
+from cubebox.middleware.citations.config import CitationConfig
 
 
 @dataclass(frozen=True)
@@ -24,8 +36,12 @@ def load_disclosure_settings() -> DisclosureSettings:
         raw_enabled = "auto"
     return DisclosureSettings(
         enabled=cast(_EnabledLiteral, raw_enabled),
-        threshold_pct=float(config.get("mcp.progressive_disclosure.threshold_pct", 10.0)),
-        min_servers=int(config.get("mcp.progressive_disclosure.min_servers", 2)),
+        threshold_pct=float(
+            config.get("mcp.progressive_disclosure.threshold_pct", 10.0),
+        ),
+        min_servers=int(
+            config.get("mcp.progressive_disclosure.min_servers", 2),
+        ),
     )
 
 
@@ -47,3 +63,88 @@ def disclosure_active(
     if context_window <= 0:
         return server_count >= settings.min_servers
     return (total_tool_tokens / context_window * 100) >= settings.threshold_pct
+
+
+# ---------------------------------------------------------------------------
+# Deferred-group helpers
+# ---------------------------------------------------------------------------
+
+
+def _spec_description(spec: MCPRuntimeConnectorSpec) -> str:
+    """One-line description from discovery metadata, falling back to name."""
+    server = (spec.discovery_metadata or {}).get("server") or {}
+    desc: str = server.get("description") or server.get("summary") or ""
+    s = " ".join(desc.split())
+    if len(s) > 140:
+        s = s[:139].rstrip() + "…"
+    return s or spec.name
+
+
+def _compute_namespaced_tool_names(
+    spec: MCPRuntimeConnectorSpec,
+    all_specs: list[MCPRuntimeConnectorSpec],
+) -> list[str]:
+    """Predict namespaced tool names using the same logic as the runtime loader."""
+    proposed_slugs = {s.install_id: slugify_for_namespace(s.name) for s in all_specs}
+    slug_counts: Counter[str] = Counter(proposed_slugs.values())
+    slug = proposed_slugs[spec.install_id]
+    explicit_collision = slug_counts[slug] > 1
+    risky_truncation = len(slug) > _NS_LENGTH_DEFENCE
+    if explicit_collision or risky_truncation:
+        safe = spec.install_id.replace("-", "")
+        suffix = f"_{safe[-4:] if len(safe) >= 4 else safe}"
+    else:
+        suffix = ""
+    return [
+        _build_namespaced_name_with_prefix(slug, tc.get("name", ""), suffix=suffix)
+        for tc in spec.tools_cache
+        if tc.get("name")
+    ]
+
+
+def build_deferred_groups(
+    *,
+    specs: list[MCPRuntimeConnectorSpec],
+    all_specs: list[MCPRuntimeConnectorSpec],
+    loader_kwargs: dict[str, Any],
+) -> tuple[list[DeferredToolGroup], dict[str, CitationConfig]]:
+    """Convert MCP runtime specs into cubepi DeferredToolGroup objects.
+
+    Returns (groups, citation_configs). citation_configs is populated when
+    loader callbacks run (i.e., when the model calls load_tools).
+
+    loader_kwargs carries workspace_id, org_id, user_id, cred_service,
+    signer, token_manager, grant_repo — forwarded to _load_tools_for_specs.
+    """
+    shared_citations: dict[str, CitationConfig] = {}
+    groups: list[DeferredToolGroup] = []
+
+    for spec in specs:
+        slug = slugify_for_namespace(spec.name)
+        tool_names = _compute_namespaced_tool_names(spec, all_specs)
+
+        async def _loader(
+            _s: MCPRuntimeConnectorSpec = spec,
+            _all: list[MCPRuntimeConnectorSpec] = all_specs,
+            _kw: dict[str, Any] = loader_kwargs,
+            _cit: dict[str, CitationConfig] = shared_citations,
+        ) -> list[AgentTool[Any]]:
+            tools, citations = await _load_tools_for_specs(
+                specs=[_s],
+                all_specs=_all,
+                **_kw,
+            )
+            _cit.update(citations)
+            return tools
+
+        groups.append(
+            DeferredToolGroup(
+                group_id=f"mcp:{slug}",
+                display_name=spec.name,
+                description=_spec_description(spec),
+                tool_names=tool_names,
+                loader=_loader,
+            ),
+        )
+
+    return groups, shared_citations

--- a/backend/cubebox/mcp/disclosure.py
+++ b/backend/cubebox/mcp/disclosure.py
@@ -61,7 +61,7 @@ def disclosure_active(
     if server_count < settings.min_servers:
         return False
     if context_window <= 0:
-        return server_count >= settings.min_servers
+        return False
     return (total_tool_tokens / context_window * 100) >= settings.threshold_pct
 
 
@@ -121,9 +121,18 @@ def build_deferred_groups(
     shared_citations: dict[str, CitationConfig] = {}
     groups: list[DeferredToolGroup] = []
 
+    proposed_slugs = {s.install_id: slugify_for_namespace(s.name) for s in all_specs}
+    slug_counts: Counter[str] = Counter(proposed_slugs.values())
+
     for spec in specs:
-        slug = slugify_for_namespace(spec.name)
+        slug = proposed_slugs[spec.install_id]
         tool_names = _compute_namespaced_tool_names(spec, all_specs)
+
+        if slug_counts[slug] > 1:
+            safe = spec.install_id.replace("-", "")
+            gid = f"mcp:{slug}_{safe[-4:] if len(safe) >= 4 else safe}"
+        else:
+            gid = f"mcp:{slug}"
 
         async def _loader(
             _s: MCPRuntimeConnectorSpec = spec,
@@ -141,7 +150,7 @@ def build_deferred_groups(
 
         groups.append(
             DeferredToolGroup(
-                group_id=f"mcp:{slug}",
+                group_id=gid,
                 display_name=spec.name,
                 description=_spec_description(spec),
                 tool_names=tool_names,

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -2224,10 +2224,16 @@ class RunManager:
         # the four-layer ``mcp_connector_installs`` / ``mcp_workspace_connector_states`` /
         # ``mcp_credential_grants`` tables via :class:`MCPEffectiveConnectorService`.
         mcp_citation_configs: dict[str, Any] = {}
+        _deferred_groups: list[Any] = []
 
         try:
             from cubebox.credentials.dependencies import build_credential_service
             from cubebox.mcp.cubepi_runtime import load_workspace_mcp_tools_for_cubepi
+            from cubebox.mcp.disclosure import (
+                build_deferred_groups,
+                disclosure_active,
+                load_disclosure_settings,
+            )
             from cubebox.mcp.effective import MCPEffectiveConnectorService
             from cubebox.mcp.oauth.metadata import OAuthMetadataDiscovery
             from cubebox.mcp.oauth.token_manager import OAuthTokenManager
@@ -2239,6 +2245,17 @@ class RunManager:
                 MCPWorkspaceConnectorStateRepository,
             )
 
+            _http_client = getattr(self._app.state, "_mcp_oauth_http_client", None)
+            if _http_client is None:
+                import httpx as _httpx
+
+                _http_client = _httpx.AsyncClient(timeout=30.0)
+                self._app.state._mcp_oauth_http_client = _http_client
+            _metadata = getattr(self._app.state, "_mcp_oauth_metadata_discovery", None)
+            if _metadata is None:
+                _metadata = OAuthMetadataDiscovery(_http_client)
+                self._app.state._mcp_oauth_metadata_discovery = _metadata
+
             async with async_session_maker() as effective_session:
                 effective_cred_service = build_credential_service(
                     effective_session,
@@ -2246,21 +2263,6 @@ class RunManager:
                     org_id=ctx.org_id,
                     actor_user_id=ctx.user_id,
                 )
-                # Reuse the shared OAuth metadata cache + httpx client if the
-                # app already has them (the request-scoped DI providers stash
-                # one on app.state). When absent (first ever MCP run) build a
-                # short-lived pair — the next request-scoped consumer will
-                # promote them onto app.state.
-                _http_client = getattr(self._app.state, "_mcp_oauth_http_client", None)
-                if _http_client is None:
-                    import httpx as _httpx
-
-                    _http_client = _httpx.AsyncClient(timeout=30.0)
-                    self._app.state._mcp_oauth_http_client = _http_client
-                _metadata = getattr(self._app.state, "_mcp_oauth_metadata_discovery", None)
-                if _metadata is None:
-                    _metadata = OAuthMetadataDiscovery(_http_client)
-                    self._app.state._mcp_oauth_metadata_discovery = _metadata
                 _token_manager = OAuthTokenManager(
                     http_client=_http_client,
                     redis=self._redis,
@@ -2281,21 +2283,60 @@ class RunManager:
                     org_id=ctx.org_id,
                     token_manager=_token_manager,
                 )
-                (
-                    _new_tools,
-                    _new_citations,
-                ) = await load_workspace_mcp_tools_for_cubepi(
-                    effective_service=_effective_service,
-                    token_manager=_token_manager,
-                    workspace_id=ctx.workspace_id,
-                    org_id=ctx.org_id,
-                    user_id=ctx.user_id,
-                    cred_service=effective_cred_service,
-                    signer=self._app.state.mcp_user_token_signer,
-                    grant_repo=_grant_repo,
+
+                _disclosure_settings = load_disclosure_settings()
+                _mcp_specs = await _effective_service.list_runtime_specs(
+                    ctx.workspace_id,
+                    ctx.user_id,
                 )
-                _builtin_tools.extend(_new_tools)
-                mcp_citation_configs.update(_new_citations)
+
+                import json as _json
+
+                _total_tool_tokens = sum(len(_json.dumps(s.tools_cache)) // 4 for s in _mcp_specs)
+                _mcp_ctx_window = int(_model_config.context_window or 0)
+
+                if disclosure_active(
+                    _disclosure_settings,
+                    server_count=len(_mcp_specs),
+                    total_tool_tokens=_total_tool_tokens,
+                    context_window=_mcp_ctx_window,
+                ):
+                    _deferred_groups, _deferred_citations = build_deferred_groups(
+                        specs=_mcp_specs,
+                        all_specs=_mcp_specs,
+                        loader_kwargs={
+                            "workspace_id": ctx.workspace_id,
+                            "org_id": ctx.org_id,
+                            "user_id": ctx.user_id,
+                            "encryption_backend": self._app.state.encryption_backend,
+                            "http_client": _http_client,
+                            "metadata_discovery": _metadata,
+                            "redis": self._redis,
+                            "signer": self._app.state.mcp_user_token_signer,
+                        },
+                    )
+                    mcp_citation_configs.update(_deferred_citations)
+                    logger.info(
+                        "MCP progressive disclosure: {} servers deferred ({} tools)",
+                        len(_deferred_groups),
+                        sum(len(g.tool_names) for g in _deferred_groups),
+                    )
+                else:
+                    (
+                        _new_tools,
+                        _new_citations,
+                    ) = await load_workspace_mcp_tools_for_cubepi(
+                        effective_service=_effective_service,
+                        token_manager=_token_manager,
+                        workspace_id=ctx.workspace_id,
+                        org_id=ctx.org_id,
+                        user_id=ctx.user_id,
+                        cred_service=effective_cred_service,
+                        signer=self._app.state.mcp_user_token_signer,
+                        grant_repo=_grant_repo,
+                    )
+                    _builtin_tools.extend(_new_tools)
+                    mcp_citation_configs.update(_new_citations)
         except Exception as _exc:
             logger.warning("MCP tools unavailable for cubepi run: {}", _exc)
 
@@ -2745,6 +2786,7 @@ class RunManager:
             # this to what the active model actually supports.
             thinking=thinking,
             channel=sandbox_hitl_channel,
+            deferred_tool_groups=_deferred_groups or None,
         )
 
         # Stash provider_name / model_id / memory-repo factory on the bridge

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -2228,7 +2228,7 @@ class RunManager:
 
         try:
             from cubebox.credentials.dependencies import build_credential_service
-            from cubebox.mcp.cubepi_runtime import load_workspace_mcp_tools_for_cubepi
+            from cubebox.mcp.cubepi_runtime import _load_tools_for_specs
             from cubebox.mcp.disclosure import (
                 build_deferred_groups,
                 disclosure_active,
@@ -2315,7 +2315,7 @@ class RunManager:
                             "signer": self._app.state.mcp_user_token_signer,
                         },
                     )
-                    mcp_citation_configs.update(_deferred_citations)
+                    mcp_citation_configs = _deferred_citations
                     logger.info(
                         "MCP progressive disclosure: {} servers deferred ({} tools)",
                         len(_deferred_groups),
@@ -2325,14 +2325,15 @@ class RunManager:
                     (
                         _new_tools,
                         _new_citations,
-                    ) = await load_workspace_mcp_tools_for_cubepi(
-                        effective_service=_effective_service,
-                        token_manager=_token_manager,
+                    ) = await _load_tools_for_specs(
+                        specs=_mcp_specs,
+                        all_specs=_mcp_specs,
                         workspace_id=ctx.workspace_id,
                         org_id=ctx.org_id,
                         user_id=ctx.user_id,
                         cred_service=effective_cred_service,
                         signer=self._app.state.mcp_user_token_signer,
+                        token_manager=_token_manager,
                         grant_repo=_grant_repo,
                     )
                     _builtin_tools.extend(_new_tools)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -172,7 +172,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "86a7bbd6f9614e0b247fe86a80f8a6875990ecc7" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "5a8569686a0ee294459a30542bd9b0b2dfd11acd" }
 
 [dependency-groups]
 dev = [

--- a/backend/tests/e2e/test_mcp_disclosure_runtime.py
+++ b/backend/tests/e2e/test_mcp_disclosure_runtime.py
@@ -1,0 +1,349 @@
+"""E2E tests for MCP progressive disclosure in the agent runtime.
+
+Tests the full pipeline: disclosure gate → DeferredToolGroup → middleware →
+expansion, as well as the deferred loader's session lifecycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.deferred import DeferredToolGroup, DeferredToolsMiddleware
+from cubepi.providers.base import TextContent
+from pydantic import BaseModel
+
+from cubebox.mcp.disclosure import (
+    DisclosureSettings,
+    build_deferred_groups,
+    disclosure_active,
+)
+from cubebox.mcp.effective import MCPRuntimeConnectorSpec
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _EmptyParams(BaseModel):
+    pass
+
+
+async def _noop_execute(
+    tool_call_id: str,
+    args: Any,
+    *,
+    signal: Any = None,
+    on_update: Any = None,
+) -> AgentToolResult:
+    return AgentToolResult(content=[TextContent(text="ok")])
+
+
+def _make_spec(
+    name: str,
+    *,
+    install_id: str = "",
+    tools_cache: list[dict[str, Any]] | None = None,
+    auth_method: str = "none",
+    server_url: str = "",
+    discovery_metadata: dict[str, Any] | None = None,
+) -> MCPRuntimeConnectorSpec:
+    return MCPRuntimeConnectorSpec(
+        install_id=install_id or f"inst-{name.lower()}",
+        name=name,
+        server_url=server_url or f"https://{name.lower()}.example.com/mcp",
+        transport="streamable_http",
+        auth_method=auth_method,
+        grant_scope=None,
+        credential_id=None,
+        refresh_credential_id=None,
+        tool_citations={},
+        tools_cache=tools_cache or [{"name": "default_tool"}],
+        discovery_metadata=discovery_metadata or {"server": {"description": f"{name} tools"}},
+    )
+
+
+def _make_fake_tool(name: str) -> AgentTool[Any]:
+    return AgentTool(
+        name=name,
+        description=f"Tool {name}",
+        parameters=_EmptyParams,
+        execute=_noop_execute,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestDisclosureGateIntegration:
+    """Verify disclosure_active routes correctly given real-looking specs."""
+
+    def test_on_always_activates(self) -> None:
+        settings = DisclosureSettings(enabled="on")
+        specs = [_make_spec("A"), _make_spec("B")]
+        assert disclosure_active(settings, server_count=len(specs)) is True
+
+    def test_off_never_activates(self) -> None:
+        settings = DisclosureSettings(enabled="off")
+        specs = [_make_spec(f"S{i}") for i in range(10)]
+        assert (
+            disclosure_active(
+                settings,
+                server_count=len(specs),
+                total_tool_tokens=999_999,
+                context_window=100_000,
+            )
+            is False
+        )
+
+    def test_auto_below_min_servers(self) -> None:
+        settings = DisclosureSettings(enabled="auto", min_servers=5)
+        specs = [_make_spec("A"), _make_spec("B")]
+        assert disclosure_active(settings, server_count=len(specs)) is False
+
+    def test_auto_above_threshold(self) -> None:
+        settings = DisclosureSettings(enabled="auto", threshold_pct=10.0, min_servers=2)
+        specs = [_make_spec("A"), _make_spec("B"), _make_spec("C")]
+        assert (
+            disclosure_active(
+                settings,
+                server_count=len(specs),
+                total_tool_tokens=15_000,
+                context_window=100_000,
+            )
+            is True
+        )
+
+
+@pytest.mark.e2e
+class TestDeferredGroupBuilding:
+    """build_deferred_groups produces correct DeferredToolGroup objects."""
+
+    async def test_groups_match_specs(self) -> None:
+        specs = [
+            _make_spec(
+                "GitHub",
+                tools_cache=[{"name": "create_issue"}, {"name": "list_repos"}],
+            ),
+            _make_spec(
+                "Slack",
+                tools_cache=[{"name": "send_message"}, {"name": "list_channels"}],
+            ),
+        ]
+        groups, _ = build_deferred_groups(
+            specs=specs,
+            all_specs=specs,
+            loader_kwargs={
+                "workspace_id": "ws-1",
+                "org_id": "org-1",
+                "user_id": "user-1",
+                "encryption_backend": AsyncMock(),
+                "http_client": AsyncMock(),
+                "metadata_discovery": AsyncMock(),
+                "redis": AsyncMock(),
+                "signer": AsyncMock(),
+            },
+        )
+        assert len(groups) == 2
+        assert groups[0].group_id == "mcp:GitHub"
+        assert groups[1].group_id == "mcp:Slack"
+        assert set(groups[0].tool_names) == {"GitHub__create_issue", "GitHub__list_repos"}
+        assert set(groups[1].tool_names) == {"Slack__send_message", "Slack__list_channels"}
+
+    async def test_loader_invokes_deferred_pipeline(self) -> None:
+        """Loader callback calls _load_tools_for_specs_deferred with correct kwargs."""
+        specs = [
+            _make_spec("GitHub", tools_cache=[{"name": "create_issue"}]),
+        ]
+        fake_tool = _make_fake_tool("GitHub__create_issue")
+
+        groups, shared_citations = build_deferred_groups(
+            specs=specs,
+            all_specs=specs,
+            loader_kwargs={
+                "workspace_id": "ws-1",
+                "org_id": "org-1",
+                "user_id": "user-1",
+                "encryption_backend": AsyncMock(),
+                "http_client": AsyncMock(),
+                "metadata_discovery": AsyncMock(),
+                "redis": AsyncMock(),
+                "signer": AsyncMock(),
+            },
+        )
+
+        with patch(
+            "cubebox.mcp.disclosure._load_tools_for_specs_deferred",
+            new_callable=AsyncMock,
+            return_value=([fake_tool], {"GitHub__create_issue": object()}),
+        ):
+            result = await groups[0].loader()
+
+        assert len(result) == 1
+        assert result[0].name == "GitHub__create_issue"
+        assert "GitHub__create_issue" in shared_citations
+
+
+@pytest.mark.e2e
+class TestMiddlewareIntegration:
+    """DeferredToolsMiddleware integration with cubebox-produced groups."""
+
+    async def test_catalog_in_system_prompt(self) -> None:
+        """When groups are deferred, catalog appears in system prompt."""
+        specs = [
+            _make_spec(
+                "GitHub",
+                tools_cache=[{"name": "create_issue"}, {"name": "list_repos"}],
+                discovery_metadata={"server": {"description": "GitHub tools"}},
+            ),
+            _make_spec(
+                "Slack",
+                tools_cache=[{"name": "send_message"}],
+                discovery_metadata={"server": {"description": "Slack messaging"}},
+            ),
+        ]
+        groups, _ = build_deferred_groups(
+            specs=specs,
+            all_specs=specs,
+            loader_kwargs={
+                "workspace_id": "ws-1",
+                "org_id": "org-1",
+                "user_id": "user-1",
+                "encryption_backend": AsyncMock(),
+                "http_client": AsyncMock(),
+                "metadata_discovery": AsyncMock(),
+                "redis": AsyncMock(),
+                "signer": AsyncMock(),
+            },
+        )
+
+        extra: dict[str, Any] = {}
+        mw = DeferredToolsMiddleware(
+            groups=groups,
+            extra_ref=lambda: extra,
+        )
+
+        # Middleware contributes load_tools to agent tools
+        assert len(mw.tools) == 1
+        assert mw.tools[0].name == "load_tools"
+
+        # System prompt includes catalog with group IDs
+        ctx = AsyncMock()
+        prompt = await mw.transform_system_prompt("Base prompt.", ctx=ctx, signal=None)
+        assert "mcp:GitHub" in prompt
+        assert "mcp:Slack" in prompt
+        assert "GitHub tools" in prompt
+        assert "Slack messaging" in prompt
+        assert "load_tools" in prompt
+
+    async def test_expand_group_adds_tools(self) -> None:
+        """Expanding a group via middleware makes tools available."""
+        fake_tools = [
+            _make_fake_tool("GitHub__create_issue"),
+            _make_fake_tool("GitHub__list_repos"),
+        ]
+
+        async def _loader() -> list[AgentTool[Any]]:
+            return fake_tools
+
+        group = DeferredToolGroup(
+            group_id="mcp:GitHub",
+            display_name="GitHub",
+            description="GitHub tools",
+            tool_names=["GitHub__create_issue", "GitHub__list_repos"],
+            loader=_loader,
+        )
+
+        extra: dict[str, Any] = {}
+        expanded_tools: list[AgentTool[Any]] = []
+        mw = DeferredToolsMiddleware(
+            groups=[group],
+            extra_ref=lambda: extra,
+            on_tools_expanded=lambda new: expanded_tools.extend(new),
+        )
+
+        ctx = AsyncMock()
+        ctx.tools = list(mw.tools)  # start with just load_tools
+
+        result = await mw._expand(
+            group_id="mcp:GitHub",
+            tool_names=None,
+            context=ctx,
+        )
+
+        assert result.expanded is True
+        assert set(result.tool_names) == {"GitHub__create_issue", "GitHub__list_repos"}
+        assert result.remaining == 0
+
+        # Tools were injected into context.tools
+        tool_names = {t.name for t in ctx.tools}
+        assert "GitHub__create_issue" in tool_names
+        assert "GitHub__list_repos" in tool_names
+
+        # on_tools_expanded callback fired
+        assert len(expanded_tools) == 2
+
+    async def test_no_deferred_groups_means_no_middleware(self) -> None:
+        """When disclosure is inactive, no DeferredToolsMiddleware is needed."""
+        settings = DisclosureSettings(enabled="off")
+        specs = [_make_spec("A"), _make_spec("B")]
+        assert not disclosure_active(settings, server_count=len(specs))
+        # The run_manager code path would NOT call build_deferred_groups —
+        # it goes through the eager load_workspace_mcp_tools_for_cubepi path.
+
+
+@pytest.mark.e2e
+class TestDeferredLoaderSessionLifecycle:
+    """_load_tools_for_specs_deferred creates its own DB session."""
+
+    async def test_deferred_loader_creates_own_session(self) -> None:
+        """Loader succeeds even when the original session is closed.
+
+        This is the key lifecycle test: the loader_kwargs carry
+        session-independent factory ingredients, and the deferred function
+        opens a short-lived session internally.
+        """
+        from types import SimpleNamespace
+
+        spec = _make_spec(
+            "GitHub",
+            tools_cache=[{"name": "create_issue"}],
+            auth_method="none",
+        )
+
+        # load_mcp_tools_http returns a discovery object whose .tools are
+        # AgentTool dataclass instances (dataclasses.replace is called on them).
+        fake_tool = _make_fake_tool("create_issue")
+        fake_discovery = SimpleNamespace(tools=[fake_tool])
+
+        mock_signer = AsyncMock()
+        mock_signer.sign = AsyncMock(return_value="fake-jwt-token")
+
+        with patch(
+            "cubebox.mcp.cubepi_runtime.load_mcp_tools_http",
+            new_callable=AsyncMock,
+            return_value=fake_discovery,
+        ):
+            from cubebox.mcp.cubepi_runtime import _load_tools_for_specs_deferred
+
+            tools, citations = await _load_tools_for_specs_deferred(
+                specs=[spec],
+                all_specs=[spec],
+                workspace_id="ws-1",
+                org_id="org-1",
+                user_id="user-1",
+                encryption_backend=AsyncMock(),
+                http_client=AsyncMock(),
+                metadata_discovery=AsyncMock(),
+                redis=AsyncMock(),
+                signer=mock_signer,
+            )
+
+        assert len(tools) == 1
+        assert tools[0].name == "GitHub__create_issue"
+        mock_signer.sign.assert_called_once()

--- a/backend/tests/e2e/test_mcp_disclosure_runtime.py
+++ b/backend/tests/e2e/test_mcp_disclosure_runtime.py
@@ -347,3 +347,117 @@ class TestDeferredLoaderSessionLifecycle:
         assert len(tools) == 1
         assert tools[0].name == "GitHub__create_issue"
         mock_signer.sign.assert_called_once()
+
+
+@pytest.mark.e2e
+class TestCachePrefixStability:
+    """Disclosure catalog is byte-stable; expansions are append-only."""
+
+    @staticmethod
+    def _build_middleware(
+        specs: list[MCPRuntimeConnectorSpec],
+        extra: dict[str, Any],
+    ) -> DeferredToolsMiddleware:
+        groups, _ = build_deferred_groups(
+            specs=specs,
+            all_specs=specs,
+            loader_kwargs={
+                "workspace_id": "ws-1",
+                "org_id": "org-1",
+                "user_id": "user-1",
+                "encryption_backend": AsyncMock(),
+                "http_client": AsyncMock(),
+                "metadata_discovery": AsyncMock(),
+                "redis": AsyncMock(),
+                "signer": AsyncMock(),
+            },
+        )
+        return DeferredToolsMiddleware(groups=groups, extra_ref=lambda: extra)
+
+    async def test_catalog_byte_stable_across_turns(self) -> None:
+        """With nothing expanded, the catalog portion is identical on two calls."""
+        specs = [
+            _make_spec(
+                "GitHub",
+                tools_cache=[{"name": "create_issue"}, {"name": "list_repos"}],
+                discovery_metadata={"server": {"description": "GitHub tools"}},
+            ),
+            _make_spec(
+                "Slack",
+                tools_cache=[{"name": "send_message"}],
+                discovery_metadata={"server": {"description": "Slack messaging"}},
+            ),
+        ]
+        extra: dict[str, Any] = {}
+        mw = self._build_middleware(specs, extra)
+        ctx = AsyncMock()
+
+        prompt_1 = await mw.transform_system_prompt("Base.", ctx=ctx, signal=None)
+        prompt_2 = await mw.transform_system_prompt("Base.", ctx=ctx, signal=None)
+
+        assert prompt_1 == prompt_2
+
+    async def test_expansion_append_only(self) -> None:
+        """Expanding group A then B: the expanded-schemas section is append-only.
+
+        The catalog section naturally shrinks as groups expand (expanded groups
+        are removed from the catalog). The cache-relevant invariant is that
+        the expanded-schemas block grows by appending — turn-2's schemas start
+        with everything from turn-1.
+        """
+        github_tools = [
+            _make_fake_tool("GitHub__create_issue"),
+            _make_fake_tool("GitHub__list_repos"),
+        ]
+        slack_tools = [
+            _make_fake_tool("Slack__send_message"),
+        ]
+
+        async def _github_loader() -> list[AgentTool[Any]]:
+            return github_tools
+
+        async def _slack_loader() -> list[AgentTool[Any]]:
+            return slack_tools
+
+        groups = [
+            DeferredToolGroup(
+                group_id="mcp:GitHub",
+                display_name="GitHub",
+                description="GitHub tools",
+                tool_names=["GitHub__create_issue", "GitHub__list_repos"],
+                loader=_github_loader,
+            ),
+            DeferredToolGroup(
+                group_id="mcp:Slack",
+                display_name="Slack",
+                description="Slack messaging",
+                tool_names=["Slack__send_message"],
+                loader=_slack_loader,
+            ),
+        ]
+
+        extra: dict[str, Any] = {}
+        mw = DeferredToolsMiddleware(groups=groups, extra_ref=lambda: extra)
+        ctx = AsyncMock()
+        ctx.tools = list(mw.tools)
+
+        # Turn 1: expand GitHub
+        await mw._expand(group_id="mcp:GitHub", tool_names=None, context=ctx)
+        prompt_turn1 = await mw.transform_system_prompt("Base.", ctx=ctx, signal=None)
+
+        # Turn 2: expand Slack
+        await mw._expand(group_id="mcp:Slack", tool_names=None, context=ctx)
+        prompt_turn2 = await mw.transform_system_prompt("Base.", ctx=ctx, signal=None)
+
+        # Extract the expanded-schemas section from both prompts.
+        marker = "# Expanded tool groups"
+        assert marker in prompt_turn1
+        assert marker in prompt_turn2
+        schemas_turn1 = prompt_turn1[prompt_turn1.index(marker) :]
+        schemas_turn2 = prompt_turn2[prompt_turn2.index(marker) :]
+
+        # Turn-2's expanded section starts with turn-1's expanded section.
+        assert schemas_turn2.startswith(schemas_turn1)
+        # The Slack schema block is the appended portion.
+        appended = schemas_turn2[len(schemas_turn1) :]
+        assert "Slack__send_message" in appended

--- a/backend/tests/unit/test_mcp_disclosure.py
+++ b/backend/tests/unit/test_mcp_disclosure.py
@@ -1,0 +1,67 @@
+"""Unit tests for cubebox.mcp.disclosure — config + threshold gate."""
+
+from __future__ import annotations
+
+from cubebox.mcp.disclosure import DisclosureSettings, disclosure_active
+
+
+class TestDisclosureSettings:
+    def test_defaults(self) -> None:
+        s = DisclosureSettings()
+        assert s.enabled == "auto"
+        assert s.threshold_pct == 10.0
+        assert s.min_servers == 2
+
+
+class TestDisclosureActive:
+    def test_disabled_never_active(self) -> None:
+        s = DisclosureSettings(enabled="off")
+        assert (
+            disclosure_active(s, server_count=100, total_tool_tokens=50_000, context_window=100_000)
+            is False
+        )
+
+    def test_on_always_active(self) -> None:
+        s = DisclosureSettings(enabled="on")
+        assert disclosure_active(s, server_count=0) is True
+
+    def test_auto_below_min_servers(self) -> None:
+        s = DisclosureSettings(enabled="auto", min_servers=3)
+        assert (
+            disclosure_active(
+                s,
+                server_count=2,
+                total_tool_tokens=50_000,
+                context_window=100_000,
+            )
+            is False
+        )
+
+    def test_auto_below_threshold_pct(self) -> None:
+        s = DisclosureSettings(enabled="auto", threshold_pct=10.0, min_servers=2)
+        assert (
+            disclosure_active(
+                s,
+                server_count=3,
+                total_tool_tokens=5_000,
+                context_window=100_000,
+            )
+            is False
+        )
+
+    def test_auto_above_both_thresholds(self) -> None:
+        s = DisclosureSettings(enabled="auto", threshold_pct=10.0, min_servers=2)
+        assert (
+            disclosure_active(
+                s,
+                server_count=3,
+                total_tool_tokens=15_000,
+                context_window=100_000,
+            )
+            is True
+        )
+
+    def test_auto_no_context_window(self) -> None:
+        s = DisclosureSettings(enabled="auto", min_servers=2)
+        assert disclosure_active(s, server_count=3, context_window=0) is True
+        assert disclosure_active(s, server_count=1, context_window=0) is False

--- a/backend/tests/unit/test_mcp_disclosure.py
+++ b/backend/tests/unit/test_mcp_disclosure.py
@@ -372,7 +372,7 @@ class TestBuildDeferredGroups:
         )
 
         with patch(
-            "cubebox.mcp.disclosure._load_tools_for_specs",
+            "cubebox.mcp.disclosure._load_tools_for_specs_deferred",
             new_callable=AsyncMock,
             return_value=([fake_tool], {"GitHub__create_issue": object()}),
         ) as mock_load:

--- a/backend/tests/unit/test_mcp_disclosure.py
+++ b/backend/tests/unit/test_mcp_disclosure.py
@@ -106,7 +106,7 @@ class TestDisclosureActive:
 
     def test_auto_no_context_window(self) -> None:
         s = DisclosureSettings(enabled="auto", min_servers=2)
-        assert disclosure_active(s, server_count=3, context_window=0) is True
+        assert disclosure_active(s, server_count=3, context_window=0) is False
         assert disclosure_active(s, server_count=1, context_window=0) is False
 
 
@@ -284,6 +284,19 @@ class TestLoadToolsForSpecs:
 # ---------------------------------------------------------------------------
 
 
+def _deferred_loader_kwargs() -> dict[str, Any]:
+    return {
+        "workspace_id": "ws-1",
+        "org_id": "org-1",
+        "user_id": "user-1",
+        "encryption_backend": AsyncMock(),
+        "http_client": AsyncMock(),
+        "metadata_discovery": AsyncMock(),
+        "redis": AsyncMock(),
+        "signer": AsyncMock(),
+    }
+
+
 class TestBuildDeferredGroups:
     def test_produces_correct_group_metadata(self) -> None:
         spec = _make_spec(
@@ -294,15 +307,7 @@ class TestBuildDeferredGroups:
         groups, citations = build_deferred_groups(
             specs=[spec],
             all_specs=[spec],
-            loader_kwargs={
-                "workspace_id": "ws-1",
-                "org_id": "org-1",
-                "user_id": "user-1",
-                "cred_service": AsyncMock(),
-                "signer": AsyncMock(),
-                "token_manager": AsyncMock(),
-                "grant_repo": None,
-            },
+            loader_kwargs=_deferred_loader_kwargs(),
         )
         assert len(groups) == 1
         g = groups[0]
@@ -327,19 +332,31 @@ class TestBuildDeferredGroups:
         groups, _ = build_deferred_groups(
             specs=[spec_a, spec_b],
             all_specs=[spec_a, spec_b],
-            loader_kwargs={
-                "workspace_id": "ws-1",
-                "org_id": "org-1",
-                "user_id": "user-1",
-                "cred_service": AsyncMock(),
-                "signer": AsyncMock(),
-                "token_manager": AsyncMock(),
-                "grant_repo": None,
-            },
+            loader_kwargs=_deferred_loader_kwargs(),
         )
         assert len(groups) == 2
         assert groups[0].group_id == "mcp:GitHub"
         assert groups[1].group_id == "mcp:Slack"
+
+    def test_slug_collision_disambiguates_group_id(self) -> None:
+        spec_a = _make_spec(
+            install_id="inst-aaaa",
+            name="GitHub",
+            tools_cache=[{"name": "create_issue"}],
+        )
+        spec_b = _make_spec(
+            install_id="inst-bbbb",
+            name="GitHub",
+            tools_cache=[{"name": "list_repos"}],
+        )
+        groups, _ = build_deferred_groups(
+            specs=[spec_a, spec_b],
+            all_specs=[spec_a, spec_b],
+            loader_kwargs=_deferred_loader_kwargs(),
+        )
+        assert len(groups) == 2
+        assert groups[0].group_id == "mcp:GitHub_aaaa"
+        assert groups[1].group_id == "mcp:GitHub_bbbb"
 
     @pytest.mark.asyncio
     async def test_loader_calls_load_tools_for_specs(self) -> None:
@@ -356,19 +373,10 @@ class TestBuildDeferredGroups:
             name="GitHub",
             tools_cache=[{"name": "create_issue"}],
         )
-        loader_kwargs: dict[str, Any] = {
-            "workspace_id": "ws-1",
-            "org_id": "org-1",
-            "user_id": "user-1",
-            "cred_service": AsyncMock(),
-            "signer": AsyncMock(),
-            "token_manager": AsyncMock(),
-            "grant_repo": None,
-        }
         groups, shared_citations = build_deferred_groups(
             specs=[spec],
             all_specs=[spec],
-            loader_kwargs=loader_kwargs,
+            loader_kwargs=_deferred_loader_kwargs(),
         )
 
         with patch(

--- a/backend/tests/unit/test_mcp_disclosure.py
+++ b/backend/tests/unit/test_mcp_disclosure.py
@@ -1,8 +1,51 @@
-"""Unit tests for cubebox.mcp.disclosure — config + threshold gate."""
+"""Unit tests for cubebox.mcp.disclosure — config, threshold gate, deferred groups."""
 
 from __future__ import annotations
 
-from cubebox.mcp.disclosure import DisclosureSettings, disclosure_active
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cubebox.mcp.disclosure import (
+    DisclosureSettings,
+    _compute_namespaced_tool_names,
+    _spec_description,
+    build_deferred_groups,
+    disclosure_active,
+)
+from cubebox.mcp.effective import MCPRuntimeConnectorSpec
+
+
+def _make_spec(
+    *,
+    install_id: str = "inst-001",
+    name: str = "GitHub",
+    server_url: str = "https://mcp.example.com/github",
+    transport: str = "streamable_http",
+    auth_method: str = "none",
+    tools_cache: list[dict[str, Any]] | None = None,
+    discovery_metadata: dict[str, Any] | None = None,
+    tool_citations: dict[str, dict[str, Any]] | None = None,
+) -> MCPRuntimeConnectorSpec:
+    return MCPRuntimeConnectorSpec(
+        install_id=install_id,
+        name=name,
+        server_url=server_url,
+        transport=transport,
+        auth_method=auth_method,
+        grant_scope=None,
+        credential_id=None,
+        refresh_credential_id=None,
+        tool_citations=tool_citations or {},
+        tools_cache=tools_cache or [],
+        discovery_metadata=discovery_metadata or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config + threshold gate (existing)
+# ---------------------------------------------------------------------------
 
 
 class TestDisclosureSettings:
@@ -65,3 +108,277 @@ class TestDisclosureActive:
         s = DisclosureSettings(enabled="auto", min_servers=2)
         assert disclosure_active(s, server_count=3, context_window=0) is True
         assert disclosure_active(s, server_count=1, context_window=0) is False
+
+
+# ---------------------------------------------------------------------------
+# _spec_description
+# ---------------------------------------------------------------------------
+
+
+class TestSpecDescription:
+    def test_extracts_from_discovery_metadata(self) -> None:
+        spec = _make_spec(
+            discovery_metadata={
+                "server": {"description": "Manage GitHub repositories and issues"},
+            },
+        )
+        assert _spec_description(spec) == "Manage GitHub repositories and issues"
+
+    def test_falls_back_to_summary(self) -> None:
+        spec = _make_spec(
+            discovery_metadata={"server": {"summary": "GitHub tools"}},
+        )
+        assert _spec_description(spec) == "GitHub tools"
+
+    def test_falls_back_to_name(self) -> None:
+        spec = _make_spec(name="Slack", discovery_metadata={})
+        assert _spec_description(spec) == "Slack"
+
+    def test_falls_back_to_name_when_no_metadata(self) -> None:
+        spec = _make_spec(name="Slack", discovery_metadata=None)
+        assert _spec_description(spec) == "Slack"
+
+    def test_truncates_long_description(self) -> None:
+        long_desc = "A" * 200
+        spec = _make_spec(
+            discovery_metadata={"server": {"description": long_desc}},
+        )
+        result = _spec_description(spec)
+        assert len(result) == 140
+        assert result.endswith("…")
+
+    def test_collapses_whitespace(self) -> None:
+        spec = _make_spec(
+            discovery_metadata={"server": {"description": "  foo   bar  baz  "}},
+        )
+        assert _spec_description(spec) == "foo bar baz"
+
+
+# ---------------------------------------------------------------------------
+# _compute_namespaced_tool_names
+# ---------------------------------------------------------------------------
+
+
+class TestComputeNamespacedToolNames:
+    def test_simple_namespace(self) -> None:
+        spec = _make_spec(
+            name="GitHub",
+            tools_cache=[{"name": "create_issue"}, {"name": "list_repos"}],
+        )
+        names = _compute_namespaced_tool_names(spec, all_specs=[spec])
+        assert names == ["GitHub__create_issue", "GitHub__list_repos"]
+
+    def test_slug_collision_appends_suffix(self) -> None:
+        spec_a = _make_spec(
+            install_id="inst-aaaa",
+            name="GitHub",
+            tools_cache=[{"name": "create_issue"}],
+        )
+        spec_b = _make_spec(
+            install_id="inst-bbbb",
+            name="GitHub",
+            tools_cache=[{"name": "list_repos"}],
+        )
+        all_specs = [spec_a, spec_b]
+        names_a = _compute_namespaced_tool_names(spec_a, all_specs=all_specs)
+        names_b = _compute_namespaced_tool_names(spec_b, all_specs=all_specs)
+        assert names_a == ["GitHub_aaaa__create_issue"]
+        assert names_b == ["GitHub_bbbb__list_repos"]
+
+    def test_skips_entries_without_name(self) -> None:
+        spec = _make_spec(
+            name="Slack",
+            tools_cache=[{"name": "post_message"}, {}, {"description": "no name"}],
+        )
+        names = _compute_namespaced_tool_names(spec, all_specs=[spec])
+        assert names == ["Slack__post_message"]
+
+
+# ---------------------------------------------------------------------------
+# _load_tools_for_specs (extracted helper)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadToolsForSpecs:
+    @pytest.mark.asyncio
+    async def test_returns_namespaced_tools_and_citations(self) -> None:
+        from cubepi.agent.types import AgentTool
+
+        from cubebox.mcp.cubepi_runtime import _load_tools_for_specs
+
+        fake_tool = AgentTool(
+            name="create_issue",
+            description="Create an issue",
+            parameters=type("P", (), {"model_json_schema": staticmethod(lambda: {})}),
+            execute=AsyncMock(),
+        )
+        discovery = type("D", (), {"tools": [fake_tool]})()
+
+        spec = _make_spec(
+            name="GitHub",
+            tool_citations={
+                "create_issue": {
+                    "content_type": "json",
+                    "source_type": "web",
+                    "content_field": "results",
+                    "mapping": {"url": "link"},
+                },
+            },
+        )
+
+        with (
+            patch(
+                "cubebox.mcp.cubepi_runtime._resolve_auth_from_spec",
+                new_callable=AsyncMock,
+                return_value=({}, spec.server_url),
+            ),
+            patch(
+                "cubebox.mcp.cubepi_runtime.load_mcp_tools_http",
+                new_callable=AsyncMock,
+                return_value=discovery,
+            ),
+        ):
+            tools, citations = await _load_tools_for_specs(
+                specs=[spec],
+                all_specs=[spec],
+                workspace_id="ws-1",
+                org_id="org-1",
+                user_id="user-1",
+                cred_service=AsyncMock(),
+                signer=AsyncMock(),
+                token_manager=AsyncMock(),
+                grant_repo=None,
+            )
+
+        assert len(tools) == 1
+        assert tools[0].name == "GitHub__create_issue"
+        assert "GitHub__create_issue" in citations
+
+    @pytest.mark.asyncio
+    async def test_handles_auth_failure_gracefully(self) -> None:
+        from cubebox.mcp.cubepi_runtime import _load_tools_for_specs
+
+        spec = _make_spec(name="BadServer")
+        with patch(
+            "cubebox.mcp.cubepi_runtime._resolve_auth_from_spec",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
+            tools, citations = await _load_tools_for_specs(
+                specs=[spec],
+                all_specs=[spec],
+                workspace_id="ws-1",
+                org_id="org-1",
+                user_id="user-1",
+                cred_service=AsyncMock(),
+                signer=AsyncMock(),
+                token_manager=AsyncMock(),
+                grant_repo=None,
+            )
+        assert tools == []
+        assert citations == {}
+
+
+# ---------------------------------------------------------------------------
+# build_deferred_groups
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDeferredGroups:
+    def test_produces_correct_group_metadata(self) -> None:
+        spec = _make_spec(
+            name="GitHub",
+            tools_cache=[{"name": "create_issue"}, {"name": "list_repos"}],
+            discovery_metadata={"server": {"description": "GitHub integration"}},
+        )
+        groups, citations = build_deferred_groups(
+            specs=[spec],
+            all_specs=[spec],
+            loader_kwargs={
+                "workspace_id": "ws-1",
+                "org_id": "org-1",
+                "user_id": "user-1",
+                "cred_service": AsyncMock(),
+                "signer": AsyncMock(),
+                "token_manager": AsyncMock(),
+                "grant_repo": None,
+            },
+        )
+        assert len(groups) == 1
+        g = groups[0]
+        assert g.group_id == "mcp:GitHub"
+        assert g.display_name == "GitHub"
+        assert g.description == "GitHub integration"
+        assert g.tool_names == ["GitHub__create_issue", "GitHub__list_repos"]
+        assert callable(g.loader)
+        assert citations == {}
+
+    def test_multiple_specs_produce_multiple_groups(self) -> None:
+        spec_a = _make_spec(
+            install_id="inst-a",
+            name="GitHub",
+            tools_cache=[{"name": "create_issue"}],
+        )
+        spec_b = _make_spec(
+            install_id="inst-b",
+            name="Slack",
+            tools_cache=[{"name": "post_message"}],
+        )
+        groups, _ = build_deferred_groups(
+            specs=[spec_a, spec_b],
+            all_specs=[spec_a, spec_b],
+            loader_kwargs={
+                "workspace_id": "ws-1",
+                "org_id": "org-1",
+                "user_id": "user-1",
+                "cred_service": AsyncMock(),
+                "signer": AsyncMock(),
+                "token_manager": AsyncMock(),
+                "grant_repo": None,
+            },
+        )
+        assert len(groups) == 2
+        assert groups[0].group_id == "mcp:GitHub"
+        assert groups[1].group_id == "mcp:Slack"
+
+    @pytest.mark.asyncio
+    async def test_loader_calls_load_tools_for_specs(self) -> None:
+        from cubepi.agent.types import AgentTool
+
+        fake_tool = AgentTool(
+            name="GitHub__create_issue",
+            description="Create an issue",
+            parameters=type("P", (), {"model_json_schema": staticmethod(lambda: {})}),
+            execute=AsyncMock(),
+        )
+
+        spec = _make_spec(
+            name="GitHub",
+            tools_cache=[{"name": "create_issue"}],
+        )
+        loader_kwargs: dict[str, Any] = {
+            "workspace_id": "ws-1",
+            "org_id": "org-1",
+            "user_id": "user-1",
+            "cred_service": AsyncMock(),
+            "signer": AsyncMock(),
+            "token_manager": AsyncMock(),
+            "grant_repo": None,
+        }
+        groups, shared_citations = build_deferred_groups(
+            specs=[spec],
+            all_specs=[spec],
+            loader_kwargs=loader_kwargs,
+        )
+
+        with patch(
+            "cubebox.mcp.disclosure._load_tools_for_specs",
+            new_callable=AsyncMock,
+            return_value=([fake_tool], {"GitHub__create_issue": object()}),
+        ) as mock_load:
+            result = await groups[0].loader()
+
+        mock_load.assert_called_once()
+        assert len(result) == 1
+        assert result[0].name == "GitHub__create_issue"
+        assert "GitHub__create_issue" in shared_citations

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -875,7 +875,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=86a7bbd6f9614e0b247fe86a80f8a6875990ecc7" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=5a8569686a0ee294459a30542bd9b0b2dfd11acd" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -922,7 +922,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.9.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=86a7bbd6f9614e0b247fe86a80f8a6875990ecc7#86a7bbd6f9614e0b247fe86a80f8a6875990ecc7" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=5a8569686a0ee294459a30542bd9b0b2dfd11acd#5a8569686a0ee294459a30542bd9b0b2dfd11acd" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },

--- a/docs/dev/plans/2026-05-27-mcp-progressive-disclosure.md
+++ b/docs/dev/plans/2026-05-27-mcp-progressive-disclosure.md
@@ -70,15 +70,23 @@ schema in `tools=` while hiding it from the catalog prose saves nothing.
 - Tests: pytest + pytest-asyncio. E2E under `tests/e2e/`, unit under
   `tests/unit/` (directory marker is auto-applied by `tests/conftest.py`).
 - MCP E2E uses the existing `stub_discover_tools` fixture
-  (`tests/e2e/test_mcp_four_layer_runtime.py`) — a real simulated discovery, no
-  fake-server-only excuse.
+  (`tests/e2e/conftest.py:696`) **only to avoid the post-grant discovery network
+  probe** — it is a no-op that patches `run_post_grant_discovery`, nothing more.
+  It does **not** seed `tools_cache` and does **not** simulate a runtime MCP
+  server returning callable tools. The disclosure tests therefore additionally
+  need: (a) installs whose `tools_cache` is seeded directly (for catalog + expand
+  previews + schema text), and (b) a fake `load_mcp_tools_http` (or equivalent
+  monkeypatch in `cubepi_runtime`) that returns callable tools for the expanded
+  set so an expanded server's tools actually execute. Build these as part of
+  Task 6d; do not assume `stub_discover_tools` provides them.
 - Touch points (all confirmed by reading the code):
   - `backend/cubebox/streams/run_manager.py` — tool assembly (~1034), middleware
     stack (~1136–1353), final tool merge (~1359), `create_cubebox_agent` call
     (~1384), system-prompt suffix assembly (~1799).
   - `backend/cubebox/mcp/cubepi_runtime.py` — `load_workspace_mcp_tools_for_cubepi`.
   - `backend/cubebox/mcp/effective.py` — `list_runtime_specs`,
-    `MCPRuntimeConnectorSpec` (carries `install_id`, `tools_cache`).
+    `MCPRuntimeConnectorSpec` (carries `install_id`, `name`, `tools_cache`,
+    `discovery_metadata`; **note: no `description` field** — see Task 2).
   - `backend/cubebox/models/mcp.py` — `MCPConnectorInstall.tools_cache`,
     `.discovery_metadata`, `.slug_name`, `.description` (via template).
   - `backend/cubebox/middleware/skills.py`,
@@ -222,8 +230,18 @@ Expected: `3 passed`.
 ## Task 2 — Catalog renderer (unit, determinism + cache-stability)
 
 Render the compact catalog from data already in Postgres
-(`MCPRuntimeConnectorSpec.tools_cache` + spec `name`/`description`/`install_id`)
-— **no live discovery**. Sorted by slug → byte-identical every turn.
+(`MCPRuntimeConnectorSpec.tools_cache` + spec `name`/`install_id`) — **no live
+discovery**. Sorted by slug → byte-identical every turn.
+
+**Description source (important):** `MCPRuntimeConnectorSpec` has **no
+`description` field** (confirmed at `effective.py:206`). Do not call
+`spec.description`. Derive the one-line description from data the spec already
+carries: prefer a value pulled from `spec.discovery_metadata` (server
+description/summary captured at discovery), else fall back to the slug itself.
+If a richer source is wanted, widen `MCPRuntimeConnectorSpec` /
+`list_runtime_specs` to carry a `description` from the template/discovery row —
+but that is an explicit extra step, not assumed by the renderer. Pick one and
+make `render_catalog` take the resolved description string (or `None`).
 
 Files:
 - `backend/cubebox/mcp/disclosure.py` (extend).
@@ -257,18 +275,26 @@ def _one_line(text: str | None, limit: int = 140) -> str:
     return s if len(s) <= limit else s[: limit - 1].rstrip() + "…"
 
 
+def _spec_description(spec: MCPRuntimeConnectorSpec) -> str | None:
+    """No `description` field on the spec — derive from discovery_metadata."""
+    meta = spec.discovery_metadata or {}
+    return meta.get("description") or meta.get("summary")
+
+
 def render_catalog(specs: list[MCPRuntimeConnectorSpec]) -> str:
     """Compact, slug-sorted catalog. Never contains per-tool JSON schemas."""
     lines: list[str] = []
     for spec in sorted(specs, key=lambda s: slugify_for_namespace(s.name)):
         slug = slugify_for_namespace(spec.name)
         count = len(spec.tools_cache)
-        desc = _one_line(spec.description)
+        desc = _one_line(_spec_description(spec) or slug)
         lines.append(f"- `{slug}` — {desc} ({count} tools)")
     return MCP_CATALOG_HEADER + "\n" + "\n".join(lines) + "\n"
 ```
-(Trigger-hint line is derived from description for v1 — the spec leaves an
-authored `trigger_hints` field as a Later item; do **not** add a migration now.)
+(Confirm the actual `discovery_metadata` key by reading a real install row; the
+keys above are a guess. Trigger-hint line is derived from description for v1 —
+the spec leaves an authored `trigger_hints` field as a Later item; do **not**
+add a migration now.)
 
 Test (write first):
 ```python
@@ -277,15 +303,21 @@ from cubebox.mcp.effective import MCPRuntimeConnectorSpec
 
 
 def _spec(name: str, desc: str, n_tools: int) -> MCPRuntimeConnectorSpec:
+    # No `description` field — push the one-liner through discovery_metadata.
     return MCPRuntimeConnectorSpec(
-        install_id=f"inst-{name}", name=name, description=desc,
+        install_id=f"inst-{name}", name=name,
+        discovery_metadata={"description": desc},
         tools_cache=[{"name": f"t{i}"} for i in range(n_tools)],
         # ...remaining required fields filled with neutral defaults...
     )
 
 
 def test_catalog_sorted_by_slug_and_byte_stable() -> None:
-    specs = [_spec("Zeta", "z server", 2), _spec("Alpha", "a server", 5)]
+    # slugify_for_namespace PRESERVES case (`Alpha` → `Alpha`, not `alpha`):
+    # use lowercase names so expected slugs match, or assert on the actual
+    # slug. Sorting is by the slug as produced — confirm by reading
+    # _constants.py:38, do not assume lowercasing.
+    specs = [_spec("zeta", "z server", 2), _spec("alpha", "a server", 5)]
     out1 = render_catalog(specs)
     out2 = render_catalog(list(reversed(specs)))  # input order must not matter
     assert out1 == out2
@@ -312,6 +344,17 @@ Expected: `2 passed`.
 
 Render the full tool definitions of expanded servers, from `tools_cache`, in
 **expansion order** (never sorted). Adding one expansion must only **append**.
+
+**Names must match the real callable tools.** The runtime loader namespaces and
+may suffix/truncate each tool name via `_build_namespaced_name_with_prefix` +
+the collision/truncation logic in `cubepi_runtime.py` (~113–199): explicit slug
+collisions and risky truncations get a `_{last4}` suffix. The schema text the
+model reads here, the `tool_names` from Task 4, and the catalog must all use the
+**same** namespaced names the model will actually call — otherwise the model
+sees one name in the schema and a different name in `tools=`. Compute namespaced
+names by reusing that loader logic (extract a pure helper, or call the same
+namespacing pass over the spec's `tools_cache`), not by emitting raw
+`tools_cache["name"]` values.
 
 Files:
 - `backend/cubebox/mcp/disclosure.py` (extend).
@@ -378,7 +421,13 @@ Expected: `3 passed`.
 A sibling of `load_skill`. Validates the slug against the workspace's usable
 installs, returns a JSON summary (namespaced tool names + descriptions, **no
 schemas in the result** — middleware injects schema text). Placed in the fixed
-tool order **where MCP tools used to go** (after `load_skill`).
+tool order **where MCP tools used to go** — as the last builtin, immediately
+before the MCP tools (after `generate_image`); see Task 6b for exact placement.
+
+**`tool_names` must be the namespaced, collision-resolved names** the model will
+actually call (see Task 3) — not bare `tools_cache["name"]`. `list_usable_slugs`
+therefore returns the post-namespacing names per slug, computed with the same
+loader logic.
 
 Files:
 - `backend/cubebox/tools/builtin/expand_mcp_server.py` (new).
@@ -594,10 +643,14 @@ else:
     _new_tools, _new_citations = await load_workspace_mcp_tools_for_cubepi(...)
 ```
 
-`expand_mcp_server` is appended to `_builtin_tools` **after `load_skill`** so the
-fixed cache-prefix tool order (sandbox → artifact → todo → subagent →
-calculator/datetime → view_images → generate_image → memory → load_skill →
-**expand_mcp_server** → mcp_tools) is preserved.
+`expand_mcp_server` is appended to `_builtin_tools` **immediately before the MCP
+tools and after every existing builtin** — do not insert it right after
+`load_skill`, which would shift `view_images`/`generate_image`. The actual
+current order (confirmed in `run_manager.py` ~927–1032) is: memory → load_skill →
+view_images → generate_image → mcp_tools. Insert `expand_mcp_server` as the last
+builtin so the prefix becomes: … → memory → load_skill → view_images →
+generate_image → **expand_mcp_server** → mcp_tools. Everything before it stays
+byte-identical.
 
 Append `MCPDisclosureMiddleware(extra_ref=_extra_ref, specs_by_slug=specs_by_slug)`
 to `cubepi_middleware` immediately after `SkillsMiddleware` (~1267). The
@@ -613,19 +666,26 @@ prompt — append `render_catalog(specs)` to `effective_system_prompt` before
 
 ### 6c. The deferral branch (from Task 0)
 
-- **Next-turn fallback (`MID_RUN_UNSUPPORTED`, expected):** on each run, read
-  `expanded` from the **replayed** `agent._extra["expanded_mcp_servers"]` (the
-  checkpointer persists `_extra` via `save_extra` at `agent_end`, same as
-  `loaded_skills`). Because `_extra` is only available after `create_cubebox_agent`,
-  read the **persisted** prior-run extra before constructing the agent: load it
-  from the checkpointer history (`cp.load(conversation_id)`) — the same
-  `init_checkpointer()`/`cp.load` already used for citation seeding at ~1375. Build
-  `only_install_ids` from that replayed ordered list. A server expanded on turn N
-  becomes callable on turn N+1. The `expand_mcp_server` call on turn N still
-  records the slug into the live `_extra`, which is persisted and picked up next
-  turn. **Document this one-turn delay in the `expand_mcp_server` tool description**
-  so the model expects it ("the server's tools become available on your next
-  turn").
+- **Next-turn fallback (`MID_RUN_UNSUPPORTED`, expected):** on each run, build
+  `only_install_ids` from the **persisted prior-run** expanded set
+  (`expanded_mcp_servers` ordered list) before the MCP tools are loaded.
+  **Ordering problem to fix:** the MCP tool load is at ~1098 but the existing
+  `init_checkpointer()`/`cp.load(conversation_id)` (citation seeding) is at ~1375
+  — *after* the tool load. The live `agent._extra` is also only available after
+  `create_cubebox_agent` (~1384). So the fallback needs an **earlier** load of the
+  persisted `_extra` (an `init_checkpointer()`/`cp.load` call hoisted above the MCP
+  block at ~1041, or a small helper that reads just the persisted
+  `expanded_mcp_servers` for the conversation) so `only_install_ids` is known when
+  `load_workspace_mcp_tools_for_cubepi(..., only_install_ids=...)` runs. Do not
+  read the live `_extra` for this — it is empty until the agent is built and only
+  reflects this run. A server expanded on turn N becomes callable on turn N+1: the
+  `expand_mcp_server` call on turn N records the slug into the live `_extra`, which
+  is persisted (`save_extra` at `agent_end`, same as `loaded_skills`) and read back
+  on turn N+1's early load. **Document this one-turn delay in the
+  `expand_mcp_server` tool description** so the model expects it ("the server's
+  tools become available on your next turn"). Confirm `save_extra` actually
+  persists arbitrary `_extra` keys (verify `loaded_skills` round-trips today)
+  before relying on it for `expanded_mcp_servers`.
 - **True deferral (`MID_RUN_SUPPORTED`):** after `after_tool_call` records the
   slug, also load that server's callable tools via the filtered loader and add
   them to the live agent through cubepi's mid-run mechanism (whatever Task 0
@@ -636,8 +696,12 @@ prompt — append `render_catalog(specs)` to `effective_system_prompt` before
 
 ### 6d. E2E test (write first)
 
-`tests/e2e/test_mcp_disclosure_runtime.py`, using `stub_discover_tools` and the
-install-creation pattern from `tests/e2e/test_mcp_four_layer_runtime.py`:
+`tests/e2e/test_mcp_disclosure_runtime.py`, using `stub_discover_tools` (to skip
+the discovery probe) plus the install-creation pattern from
+`tests/e2e/test_mcp_four_layer_runtime.py`. Additionally seed each install's
+`tools_cache` directly and monkeypatch the runtime tool loader
+(`load_mcp_tools_http` / `cubepi_runtime`) to return callable tools for the
+expanded set — `stub_discover_tools` alone supplies neither (see Tech Stack):
 
 1. With disclosure enabled and ≥ `min_servers` usable servers installed: assert
    the assembled `tools=` contains `expand_mcp_server` and **no** namespaced MCP

--- a/docs/dev/plans/2026-05-27-mcp-progressive-disclosure.md
+++ b/docs/dev/plans/2026-05-27-mcp-progressive-disclosure.md
@@ -1,826 +1,790 @@
 # MCP Progressive Disclosure Implementation Plan
 
-> **⚠ PENDING REVISION (2026-06-09):** The spec has been updated with three
-> significant design changes from the hermes-agent research pass:
-> 1. **cubepi/cubebox layering** — core mechanism (`DeferredToolGroup`, `expand_tools`,
->    middleware) moves into cubepi as a generic primitive; cubebox provides MCP → group mapping.
-> 2. **Catalog includes tool names** — not just server slug + description.
-> 3. **Threshold = context-window token %** (default 10%) + `min_servers` secondary guard.
->
-> The tasks below still reference the old names (`expand_mcp_server`,
-> `MCPDisclosureMiddleware`, `min_servers`-only threshold). A plan revision is needed
-> before implementation begins. The cubepi-side work is tracked as a separate cubepi
-> issue and should land first.
+> For agentic workers: use superpowers:subagent-driven-development (recommended)
+> or superpowers:executing-plans. Tasks use checkbox syntax for progress tracking.
 
-> For agentic workers: execute tasks top to bottom. Each task is TDD — write the
-> test first, watch it fail, implement, watch it pass. Stay on branch
-> `feat/mcp-progressive-disclosure`; never switch to main or merge mid-execution.
-> First command in the worktree is always `cat .worktree.env` (slot 89, backend
-> `:8089`, DB `cubebox_feat_mcp_progressive_disclosure`). Run the per-module tests
-> shown under each task during dev; reserve the full suite for the pre-PR sweep.
-> **Task 0 (the spike) gates the whole plan** — its answer selects the deferral
-> mode for Task 6. Do not skip or reorder it.
+**Goal:** When a workspace has many MCP servers, hide their full tool schemas
+behind a compact catalog and let the model expand groups on demand — saving
+cache/context cost on every turn where most servers are unused.
 
-Date: 2026-05-27 (spec revised 2026-06-09)
+**Architecture:** cubepi already provides the generic `DeferredToolGroup` /
+`DeferredToolsMiddleware` / `load_tools` primitive (PR #168, pinned at
+`5a85696`). cubebox maps MCP servers → deferred groups and wires them into
+`run_manager._run_cubepi_path`. No custom middleware, catalog renderer, or
+expand-tool in cubebox — cubepi handles all of that.
+
+**Tech Stack:** FastAPI + cubepi 0.9.0, Postgres/SQLModel, Python 3.13,
+mypy strict, ruff, line length 100.
+
+Date: 2026-05-27 (spec revised 2026-06-09, plan revised 2026-06-10)
 Spec: `docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md`
 Issue: #143
 
 ---
 
-## Goal
+## File Map
 
-Stop injecting every enabled MCP server's full tool schemas into the prompt on
-every turn. Instead inject a **compact catalog** (server slug + one-line
-description + tool count + trigger hint) as a stable system-prompt suffix, and
-let the model call a new `expand_mcp_server(server)` builtin to make a server's
-real, callable tools available for the rest of the conversation. Collapsed
-servers contribute **zero** tool definitions to `tools=` and zero schema text —
-that is the only thing that actually saves cache/attention cost. Expanded
-servers' callable tools come from the **real runtime loader**
-(`load_workspace_mcp_tools_for_cubepi` → `load_mcp_tools_http`) **filtered to the
-expanded set**, never synthesized from `tools_cache` (cache is index/preview
-only — cached JSON schemas are not executable). The prompt-cache prefix must stay
-byte-stable: catalog sorted by slug, expanded-schema text appended in **expansion
-order** (append-only, never re-sorted). Feature is config-gated and off below a
-server-count threshold so small workspaces keep today's exact behavior.
-
-## Architecture
-
-Mirror the **skills** subsystem at server granularity:
-
-| Skills (existing) | MCP progressive disclosure (this plan) |
-|---|---|
-| `SKILLS_PROMPT_TEMPLATE` index in system-prompt suffix, sorted by name | MCP catalog renderer, suffix, sorted by **slug** |
-| `load_skill(name)` builtin returns SKILL.md JSON | `expand_mcp_server(server)` builtin returns server tool summary JSON |
-| `SkillsMiddleware`: `after_tool_call` writes `extra["loaded_skills"]` (dict); `transform_system_prompt` appends bodies sorted by name | `MCPDisclosureMiddleware`: `after_tool_call` appends slug to `extra["expanded_mcp_servers"]` (**ordered list**, dedup, first-expanded-first); `transform_system_prompt` appends each expanded server's schema text in **expansion order** |
-
-Key divergence from skills: the **enabled** skill set is fixed up front, so
-skills can sort by name. MCP servers expand **incrementally mid-conversation**, so
-slug-sorting the expanded blocks could insert a later expansion *before* an
-already-cached block and invalidate the prefix. Therefore expanded-schema text is
-ordered by **expansion order**, persisted as an **ordered list** in `extra`, and
-replayed unchanged across turns.
-
-The load-bearing unknown — can cubepi add callable tools to a *live* agent mid-run
-and re-mark the cache boundary? — is resolved by **Task 0 (spike)**. The plan
-branches there:
-
-- **True deferral** (cubepi supports mid-run tool-set change): a just-expanded
-  server is callable within the same turn.
-- **Next-turn fallback** (cubepi cannot, current pinned rev): the expanded
-  server's tools enter `tools=` on the **next** user turn; the tool set is frozen
-  per run. Still saves all the cost (collapsed servers never in `tools=`); costs a
-  one-turn delay before a just-expanded server is callable.
-
-Either way **pre-register-all is rejected** — shipping every collapsed server's
-schema in `tools=` while hiding it from the catalog prose saves nothing.
-
-## Tech Stack
-
-- Backend: FastAPI + cubepi agent runtime, Postgres (SQLModel + Alembic),
-  Python 3.13, mypy strict, line length 100.
-- Tests: pytest + pytest-asyncio. E2E under `tests/e2e/`, unit under
-  `tests/unit/` (directory marker is auto-applied by `tests/conftest.py`).
-- MCP E2E uses the existing `stub_discover_tools` fixture
-  (`tests/e2e/conftest.py:696`) **only to avoid the post-grant discovery network
-  probe** — it is a no-op that patches `run_post_grant_discovery`, nothing more.
-  It does **not** seed `tools_cache` and does **not** simulate a runtime MCP
-  server returning callable tools. The disclosure tests therefore additionally
-  need: (a) installs whose `tools_cache` is seeded directly (for catalog + expand
-  previews + schema text), and (b) a fake `load_mcp_tools_http` (or equivalent
-  monkeypatch in `cubepi_runtime`) that returns callable tools for the expanded
-  set so an expanded server's tools actually execute. Build these as part of
-  Task 6d; do not assume `stub_discover_tools` provides them.
-- Touch points (all confirmed by reading the code):
-  - `backend/cubebox/streams/run_manager.py` — tool assembly (~1034), middleware
-    stack (~1136–1353), final tool merge (~1359), `create_cubebox_agent` call
-    (~1384), system-prompt suffix assembly (~1799).
-  - `backend/cubebox/mcp/cubepi_runtime.py` — `load_workspace_mcp_tools_for_cubepi`.
-  - `backend/cubebox/mcp/effective.py` — `list_runtime_specs`,
-    `MCPRuntimeConnectorSpec` (carries `install_id`, `name`, `tools_cache`,
-    `discovery_metadata`; **note: no `description` field** — see Task 2).
-  - `backend/cubebox/models/mcp.py` — `MCPConnectorInstall.tools_cache`,
-    `.discovery_metadata`, `.slug_name`, `.description` (via template).
-  - `backend/cubebox/middleware/skills.py`,
-    `backend/cubebox/tools/builtin/load_skill.py`,
-    `backend/cubebox/prompts/skills.py` — the analog to copy.
-  - `backend/cubebox/config.py` — `config.get("mcp.progressive_disclosure...")`.
+| File | Action | Responsibility |
+|---|---|---|
+| `cubebox/mcp/disclosure.py` | Create | Config settings, threshold gate, spec→group mapping |
+| `cubebox/mcp/cubepi_runtime.py` | Modify | Add `load_tools_for_specs` (per-spec-list loader) |
+| `cubebox/streams/run_manager.py` | Modify | Wire deferred groups into `_run_cubepi_path` |
+| `config.yaml` | Modify | Add `mcp.progressive_disclosure` block |
+| `tests/unit/test_mcp_disclosure.py` | Create | Config, threshold, spec→group mapping |
+| `tests/e2e/test_mcp_disclosure_runtime.py` | Create | Full wiring, catalog, expand, threshold bypass |
 
 ---
 
-## Task 0 — SPIKE: does cubepi support mid-run tool-set change? (GATES THE PLAN)
+## Task 1 — Config flags + threshold gate
 
-**This task produces a written decision, not shippable code.** It selects the
-Task 6 branch (true deferral vs next-turn fallback).
-
-What we already know from reading the **pinned** cubepi
-(`backend/.venv/.../cubepi/agent/agent.py`, `loop.py`):
-
-- `Agent._state.tools` has a property setter (`agent.state.tools = [...]`).
-- BUT `Agent.prompt()` calls `_create_context_snapshot()` **once** and the loop
-  runs against that single `current_context`; `run_agent_loop` reads
-  `context.tools` to build `tools_defs` (`loop.py` ~381) and never re-reads
-  `agent.state.tools` between iterations. So mutating `agent.state.tools` from a
-  middleware hook during a run does **not** change the tools the model sees this
-  run.
-
-Steps:
-
-1. Write a throwaway probe `backend/scripts/dev/spike_mcp_live_tools.py` that
-   builds a minimal cubepi `Agent` with a tool whose `after_tool_call` (or a
-   middleware) appends a second `AgentTool` to `agent.state.tools`, then checks
-   whether the model is offered the new tool in the **same** `prompt()` call.
-   Drive it with a stub provider that records the `tools_defs` passed on each
-   model call.
-2. Inspect cubepi for any hook to mutate `current_context.tools` mid-loop (e.g. a
-   `transform_context` that returns tools, or a documented "register tool"
-   surface). Grep `~/cubepi` source, not just the installed wheel — but remember
-   runtime uses the **pinned** wheel (`reference_cubepi_pinned_dep`), so any new
-   capability must be released + the pin bumped before it reaches runtime.
-
-Run:
-```bash
-cd backend && uv run python scripts/dev/spike_mcp_live_tools.py
-```
-Expected output (one of):
-```
-SPIKE RESULT: MID_RUN_SUPPORTED   # new tool appears in same-run tools_defs
-SPIKE RESULT: MID_RUN_UNSUPPORTED # snapshot frozen; next-turn fallback required
-```
-
-Record the result and the chosen branch in
-`docs/dev/notes/2026-05-27-mcp-disclosure-cubepi-spike.md` (one new note file is
-allowed — it is the decision record this plan depends on). Delete the probe
-script after.
-
-**Decision rule:**
-- `MID_RUN_UNSUPPORTED` → build **next-turn fallback** in v1 (expected, given the
-  snapshot finding). File a cubepi upstream follow-up (`~/cubepi`, upstream-first)
-  to add mid-run tool-set change + cache re-establishment; do **not** hand-edit
-  cubepi vendor behavior in cubebox.
-- `MID_RUN_SUPPORTED` → build **true deferral** (Task 6 variant B).
-
-Verify: the note exists and states the branch explicitly.
-
----
-
-## Task 1 — Config flags + threshold gate (unit)
-
-Add the config surface and a pure helper deciding when disclosure is active.
+Add the config surface and pure helpers deciding when disclosure is active.
 
 Files:
-- `backend/cubebox/mcp/disclosure.py` (new) — pure functions, no I/O.
-- `backend/config.development.yaml` and `backend/config.yaml` (whichever holds the
-  `mcp` block; add the `progressive_disclosure` subkey).
-- `backend/tests/unit/test_mcp_disclosure_gate.py` (new).
+- Create: `backend/cubebox/mcp/disclosure.py`
+- Modify: `backend/config.yaml` (add `mcp.progressive_disclosure` block)
+- Create: `backend/tests/unit/test_mcp_disclosure.py`
 
-`disclosure.py`:
+- [ ] **Step 1: Write the failing tests**
+
 ```python
-"""Progressive-disclosure gating + catalog/schema rendering (pure, no I/O)."""
+# tests/unit/test_mcp_disclosure.py
+from __future__ import annotations
+
+
+class TestDisclosureSettings:
+    def test_defaults(self) -> None:
+        from cubebox.mcp.disclosure import DisclosureSettings
+
+        s = DisclosureSettings()
+        assert s.enabled == "auto"
+        assert s.threshold_pct == 10.0
+        assert s.min_servers == 2
+
+    def test_disabled_never_active(self) -> None:
+        from cubebox.mcp.disclosure import DisclosureSettings, disclosure_active
+
+        s = DisclosureSettings(enabled="off")
+        assert disclosure_active(s, server_count=10, total_tool_tokens=9999) is False
+
+    def test_on_always_active(self) -> None:
+        from cubebox.mcp.disclosure import DisclosureSettings, disclosure_active
+
+        s = DisclosureSettings(enabled="on")
+        assert disclosure_active(s, server_count=1, total_tool_tokens=1) is True
+
+    def test_auto_below_min_servers(self) -> None:
+        from cubebox.mcp.disclosure import DisclosureSettings, disclosure_active
+
+        s = DisclosureSettings(enabled="auto", min_servers=3)
+        # Even if tokens are high, too few servers → inactive.
+        assert disclosure_active(s, server_count=2, total_tool_tokens=99999) is False
+
+    def test_auto_below_threshold_pct(self) -> None:
+        from cubebox.mcp.disclosure import DisclosureSettings, disclosure_active
+
+        s = DisclosureSettings(enabled="auto", threshold_pct=10.0, min_servers=2)
+        # 3 servers but tool tokens are only 5% of context → inactive.
+        assert (
+            disclosure_active(
+                s, server_count=3, total_tool_tokens=5_000, context_window=100_000,
+            )
+            is False
+        )
+
+    def test_auto_above_both_thresholds(self) -> None:
+        from cubebox.mcp.disclosure import DisclosureSettings, disclosure_active
+
+        s = DisclosureSettings(enabled="auto", threshold_pct=10.0, min_servers=2)
+        # 3 servers, 15% of context → active.
+        assert (
+            disclosure_active(
+                s, server_count=3, total_tool_tokens=15_000, context_window=100_000,
+            )
+            is True
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/unit/test_mcp_disclosure.py -v`
+Expected: ImportError — `cubebox.mcp.disclosure` does not exist yet.
+
+- [ ] **Step 3: Implement `disclosure.py`**
+
+```python
+# cubebox/mcp/disclosure.py
+"""MCP progressive disclosure — config, threshold gate, spec→group mapping."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Literal
 
 from cubebox.config import config
 
 
 @dataclass(frozen=True)
 class DisclosureSettings:
-    enabled: bool
-    min_servers: int
+    enabled: Literal["auto", "on", "off"] = "auto"
+    threshold_pct: float = 10.0
+    min_servers: int = 2
 
 
 def load_disclosure_settings() -> DisclosureSettings:
     return DisclosureSettings(
-        enabled=bool(config.get("mcp.progressive_disclosure.enabled", False)),
-        min_servers=int(config.get("mcp.progressive_disclosure.min_servers", 3)),
+        enabled=str(config.get("mcp.progressive_disclosure.enabled", "auto")),
+        threshold_pct=float(config.get("mcp.progressive_disclosure.threshold_pct", 10.0)),
+        min_servers=int(config.get("mcp.progressive_disclosure.min_servers", 2)),
     )
 
 
-def disclosure_active(settings: DisclosureSettings, usable_server_count: int) -> bool:
+def disclosure_active(
+    settings: DisclosureSettings,
+    *,
+    server_count: int,
+    total_tool_tokens: int = 0,
+    context_window: int = 0,
+) -> bool:
     """True when the catalog/expand machinery replaces eager tool loading."""
-    return settings.enabled and usable_server_count >= settings.min_servers
+    if settings.enabled == "off":
+        return False
+    if settings.enabled == "on":
+        return True
+    # "auto": both guards must pass.
+    if server_count < settings.min_servers:
+        return False
+    if context_window <= 0:
+        return server_count >= settings.min_servers
+    return (total_tool_tokens / context_window * 100) >= settings.threshold_pct
 ```
 
-Test (write first, must fail before `disclosure.py` exists):
-```python
-from cubebox.mcp.disclosure import DisclosureSettings, disclosure_active
+- [ ] **Step 4: Add config block to `config.yaml`**
 
+Under the existing MCP comment (~line 198), add:
 
-def test_disabled_never_active() -> None:
-    s = DisclosureSettings(enabled=False, min_servers=2)
-    assert disclosure_active(s, 10) is False
-
-
-def test_below_threshold_inactive() -> None:
-    s = DisclosureSettings(enabled=True, min_servers=3)
-    assert disclosure_active(s, 2) is False
-
-
-def test_at_threshold_active() -> None:
-    s = DisclosureSettings(enabled=True, min_servers=3)
-    assert disclosure_active(s, 3) is True
-```
-
-Config block (add under existing `mcp:`):
 ```yaml
 mcp:
   progressive_disclosure:
-    enabled: false      # off by default — small workspaces keep today's behavior
-    min_servers: 3      # only collapse when this many usable servers connected
+    enabled: "auto"        # "auto" | "on" | "off"
+    threshold_pct: 10.0    # collapse when deferrable schemas >= this % of context
+    min_servers: 2         # never collapse below this server count
 ```
 
-Run:
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/unit/test_mcp_disclosure.py -v`
+Expected: 6 passed.
+
+- [ ] **Step 6: Commit**
+
 ```bash
-cd backend && uv run pytest tests/unit/test_mcp_disclosure_gate.py -q
+git add cubebox/mcp/disclosure.py tests/unit/test_mcp_disclosure.py config.yaml
+git commit -m "feat(mcp): disclosure config flags + threshold gate (#143)"
 ```
-Expected: `3 passed`.
 
 ---
 
-## Task 2 — Catalog renderer (unit, determinism + cache-stability)
+## Task 2 — Spec-to-group mapping + per-spec-list loader
 
-Render the compact catalog from data already in Postgres
-(`MCPRuntimeConnectorSpec.tools_cache` + spec `name`/`install_id`) — **no live
-discovery**. Sorted by slug → byte-identical every turn.
+Build the function that converts `MCPRuntimeConnectorSpec` objects into
+`DeferredToolGroup` objects and a helper that loads tools for a subset of specs.
 
-**Description source (important):** `MCPRuntimeConnectorSpec` has **no
-`description` field** (confirmed at `effective.py:206`). Do not call
-`spec.description`. Derive the one-line description from data the spec already
-carries: prefer a value pulled from `spec.discovery_metadata` (server
-description/summary captured at discovery), else fall back to the slug itself.
-If a richer source is wanted, widen `MCPRuntimeConnectorSpec` /
-`list_runtime_specs` to carry a `description` from the template/discovery row —
-but that is an explicit extra step, not assumed by the renderer. Pick one and
-make `render_catalog` take the resolved description string (or `None`).
+The loader reuses the existing auth-resolution and namespacing pipeline from
+`load_workspace_mcp_tools_for_cubepi` — extracted into a shared inner function
+so both the eager (all-at-once) and deferred (per-group) paths call the same
+code.
 
 Files:
-- `backend/cubebox/mcp/disclosure.py` (extend).
-- `backend/cubebox/prompts/mcp_catalog.py` (new) — the template, mirroring
-  `prompts/skills.py`.
-- `backend/tests/unit/test_mcp_catalog_render.py` (new).
+- Modify: `backend/cubebox/mcp/cubepi_runtime.py` — extract `_load_tools_for_specs`
+- Modify: `backend/cubebox/mcp/disclosure.py` — add `build_deferred_groups`
+- Extend: `backend/tests/unit/test_mcp_disclosure.py`
 
-`prompts/mcp_catalog.py`:
-```python
-"""MCP catalog template — injected by run_manager when disclosure is active."""
-
-MCP_CATALOG_HEADER = """\
-
-# Connected tool servers (collapsed)
-
-These servers are connected but their tools are not loaded yet. Call
-`expand_mcp_server(server)` with a name below to load that server's tools for the
-rest of this conversation.
-"""
-```
-
-`disclosure.py` (add):
-```python
-from cubebox.mcp.effective import MCPRuntimeConnectorSpec
-from cubebox.mcp._constants import slugify_for_namespace
-from cubebox.prompts.mcp_catalog import MCP_CATALOG_HEADER
-
-
-def _one_line(text: str | None, limit: int = 140) -> str:
-    s = " ".join((text or "").split())
-    return s if len(s) <= limit else s[: limit - 1].rstrip() + "…"
-
-
-def _spec_description(spec: MCPRuntimeConnectorSpec) -> str | None:
-    """No `description` field on the spec — derive from discovery_metadata."""
-    meta = spec.discovery_metadata or {}
-    return meta.get("description") or meta.get("summary")
-
-
-def render_catalog(specs: list[MCPRuntimeConnectorSpec]) -> str:
-    """Compact, slug-sorted catalog. Never contains per-tool JSON schemas."""
-    lines: list[str] = []
-    for spec in sorted(specs, key=lambda s: slugify_for_namespace(s.name)):
-        slug = slugify_for_namespace(spec.name)
-        count = len(spec.tools_cache)
-        desc = _one_line(_spec_description(spec) or slug)
-        lines.append(f"- `{slug}` — {desc} ({count} tools)")
-    return MCP_CATALOG_HEADER + "\n" + "\n".join(lines) + "\n"
-```
-(Confirm the actual `discovery_metadata` key by reading a real install row; the
-keys above are a guess. Trigger-hint line is derived from description for v1 —
-the spec leaves an authored `trigger_hints` field as a Later item; do **not**
-add a migration now.)
-
-Test (write first):
-```python
-from cubebox.mcp.disclosure import render_catalog
-from cubebox.mcp.effective import MCPRuntimeConnectorSpec
-
-
-def _spec(name: str, desc: str, n_tools: int) -> MCPRuntimeConnectorSpec:
-    # No `description` field — push the one-liner through discovery_metadata.
-    return MCPRuntimeConnectorSpec(
-        install_id=f"inst-{name}", name=name,
-        discovery_metadata={"description": desc},
-        tools_cache=[{"name": f"t{i}"} for i in range(n_tools)],
-        # ...remaining required fields filled with neutral defaults...
-    )
-
-
-def test_catalog_sorted_by_slug_and_byte_stable() -> None:
-    # slugify_for_namespace PRESERVES case (`Alpha` → `Alpha`, not `alpha`):
-    # use lowercase names so expected slugs match, or assert on the actual
-    # slug. Sorting is by the slug as produced — confirm by reading
-    # _constants.py:38, do not assume lowercasing.
-    specs = [_spec("zeta", "z server", 2), _spec("alpha", "a server", 5)]
-    out1 = render_catalog(specs)
-    out2 = render_catalog(list(reversed(specs)))  # input order must not matter
-    assert out1 == out2
-    assert out1.index("`alpha`") < out1.index("`zeta`")
-    assert "(5 tools)" in out1 and "(2 tools)" in out1
-
-
-def test_catalog_has_no_input_schemas() -> None:
-    specs = [_spec("Alpha", "a", 1)]
-    assert "input_schema" not in render_catalog(specs)
-```
-(Inspect `MCPRuntimeConnectorSpec` field list at `effective.py:207` to fill the
-constructor; do not guess.)
-
-Run:
-```bash
-cd backend && uv run pytest tests/unit/test_mcp_catalog_render.py -q
-```
-Expected: `2 passed`.
-
----
-
-## Task 3 — Expanded-schema renderer (unit, expansion-order stability)
-
-Render the full tool definitions of expanded servers, from `tools_cache`, in
-**expansion order** (never sorted). Adding one expansion must only **append**.
-
-**Names must match the real callable tools.** The runtime loader namespaces and
-may suffix/truncate each tool name via `_build_namespaced_name_with_prefix` +
-the collision/truncation logic in `cubepi_runtime.py` (~113–199): explicit slug
-collisions and risky truncations get a `_{last4}` suffix. The schema text the
-model reads here, the `tool_names` from Task 4, and the catalog must all use the
-**same** namespaced names the model will actually call — otherwise the model
-sees one name in the schema and a different name in `tools=`. Compute namespaced
-names by reusing that loader logic (extract a pure helper, or call the same
-namespacing pass over the spec's `tools_cache`), not by emitting raw
-`tools_cache["name"]` values.
-
-Files:
-- `backend/cubebox/mcp/disclosure.py` (extend).
-- `backend/tests/unit/test_mcp_expanded_render.py` (new).
-
-`disclosure.py` (add):
-```python
-import json
-
-EXPANDED_SECTION_HEADER = "[Expanded MCP servers]"
-
-
-def render_expanded_schemas(
-    expanded_slugs: list[str],
-    specs_by_slug: dict[str, MCPRuntimeConnectorSpec],
-) -> str:
-    """Append-only schema text, ordered by EXPANSION ORDER (not slug).
-
-    A newly expanded server's block always lands after every already-rendered
-    block → earlier cache segments stay byte-identical.
-    """
-    blocks: list[str] = []
-    for slug in expanded_slugs:  # expansion order, as-stored
-        spec = specs_by_slug.get(slug)
-        if spec is None:
-            continue
-        tools_json = json.dumps(spec.tools_cache, sort_keys=True, ensure_ascii=False)
-        blocks.append(f"## Server: {slug}\n\n{tools_json}")
-    if not blocks:
-        return ""
-    return f"\n\n{EXPANDED_SECTION_HEADER}\n\n" + "\n\n".join(blocks)
-```
-
-Test (write first):
-```python
-def test_expansion_order_preserved_not_sorted() -> None:
-    specs = {"zeta": _spec("zeta",...), "alpha": _spec("alpha",...)}
-    out = render_expanded_schemas(["zeta", "alpha"], specs)
-    assert out.index("## Server: zeta") < out.index("## Server: alpha")
-
-
-def test_adding_expansion_only_appends() -> None:
-    specs = {"a": _spec("a",...), "b": _spec("b",...)}
-    first = render_expanded_schemas(["a"], specs)
-    second = render_expanded_schemas(["a", "b"], specs)
-    assert second.startswith(first)  # prefix preserved → cache-safe
-
-
-def test_json_keys_sorted_for_byte_stability() -> None:
-    out = render_expanded_schemas(["a"], {"a": _spec("a", tools=[{"b":1,"a":2}])})
-    assert out == render_expanded_schemas(["a"], {"a": _spec("a", tools=[{"a":2,"b":1}])})
-```
-
-Run:
-```bash
-cd backend && uv run pytest tests/unit/test_mcp_expanded_render.py -q
-```
-Expected: `3 passed`.
-
----
-
-## Task 4 — `expand_mcp_server` builtin (unit)
-
-A sibling of `load_skill`. Validates the slug against the workspace's usable
-installs, returns a JSON summary (namespaced tool names + descriptions, **no
-schemas in the result** — middleware injects schema text). Placed in the fixed
-tool order **where MCP tools used to go** — as the last builtin, immediately
-before the MCP tools (after `generate_image`); see Task 6b for exact placement.
-
-**`tool_names` must be the namespaced, collision-resolved names** the model will
-actually call (see Task 3) — not bare `tools_cache["name"]`. `list_usable_slugs`
-therefore returns the post-namespacing names per slug, computed with the same
-loader logic.
-
-Files:
-- `backend/cubebox/tools/builtin/expand_mcp_server.py` (new).
-- `backend/tests/unit/test_expand_mcp_server_tool.py` (new).
+- [ ] **Step 1: Write the failing tests for `_load_tools_for_specs`**
 
 ```python
-"""expand_mcp_server builtin — sibling of load_skill.
-
-Returns a summary of a connected MCP server's tools so the model knows what it
-just unlocked. Schema text is injected into the system prompt by
-MCPDisclosureMiddleware (mirrors how SkillsMiddleware injects skill bodies),
-NOT re-emitted in this tool result.
-"""
-
-from __future__ import annotations
-
-from collections.abc import Awaitable, Callable
-
-from cubepi.agent.types import AgentTool, AgentToolResult
-from cubepi.providers.base import TextContent
-from pydantic import BaseModel, Field
+# tests/unit/test_mcp_disclosure.py (append)
+import pytest
 
 
-class ExpandMCPServerInput(BaseModel):
-    server: str = Field(description="The server slug from your 'Connected tool servers' list.")
+class TestLoadToolsForSpecs:
+    @pytest.fixture()
+    def _patch_load_mcp_tools_http(self, monkeypatch: pytest.MonkeyPatch):
+        """Patch cubepi.mcp.load_mcp_tools_http to return dummy tools."""
+        from unittest.mock import AsyncMock
+        from cubepi.agent.types import AgentTool, AgentToolResult
+        from cubepi.providers.base import TextContent
+        from pydantic import BaseModel
 
+        class _E(BaseModel):
+            pass
 
-class ExpandMCPServerOutput(BaseModel):
-    server: str
-    expanded: bool
-    tool_names: list[str]
-    error: str | None = None
+        async def _exec(tool_call_id, args, *, signal=None, on_update=None):
+            return AgentToolResult(content=[TextContent(text="ok")])
 
-    def __str__(self) -> str:
-        return self.model_dump_json()
+        class FakeDiscovery:
+            def __init__(self, names: list[str]):
+                self.tools = [
+                    AgentTool(name=n, description=f"Tool {n}", parameters=_E, execute=_exec)
+                    for n in names
+                ]
 
+        async def _fake_load(url, *, headers=None, timeout=30.0, transport="sse"):
+            return FakeDiscovery(["create_issue", "search_repos"])
 
-def create_expand_mcp_server_tool(
-    *,
-    list_usable_slugs: Callable[[], Awaitable[dict[str, list[str]]]],
-) -> AgentTool[ExpandMCPServerInput]:
-    """list_usable_slugs() → {slug: [bare_tool_name, ...]} for usable installs."""
+        monkeypatch.setattr("cubebox.mcp.cubepi_runtime.load_mcp_tools_http", _fake_load)
 
-    async def _execute(tool_call_id, args, *, signal=None, on_update=None):
-        del tool_call_id, signal, on_update
-        usable = await list_usable_slugs()
-        if args.server not in usable:
-            out = ExpandMCPServerOutput(
-                server=args.server, expanded=False, tool_names=[],
-                error=f"Server '{args.server}' is not connected to this workspace",
-            )
-            return AgentToolResult(content=[TextContent(text=out.model_dump_json())], is_error=True)
-        out = ExpandMCPServerOutput(
-            server=args.server, expanded=True, tool_names=usable[args.server],
+    @pytest.mark.usefixtures("_patch_load_mcp_tools_http")
+    async def test_loads_and_namespaces_tools(self) -> None:
+        from cubebox.mcp.cubepi_runtime import _load_tools_for_specs
+        from cubebox.mcp.effective import MCPRuntimeConnectorSpec
+
+        spec = MCPRuntimeConnectorSpec(
+            install_id="inst-001",
+            name="GitHub",
+            server_url="http://localhost:9999/mcp",
+            transport="sse",
+            auth_method="none",
+            grant_scope=None,
+            credential_id=None,
+            refresh_credential_id=None,
+            tool_citations={},
+            tools_cache=[{"name": "create_issue"}, {"name": "search_repos"}],
         )
-        return AgentToolResult(content=[TextContent(text=out.model_dump_json())])
+        # _load_tools_for_specs needs auth dependencies — pass stubs.
+        tools, citations = await _load_tools_for_specs(
+            specs=[spec],
+            all_specs=[spec],
+            workspace_id="ws-1",
+            org_id="org-1",
+            user_id="u-1",
+            cred_service=...,    # see Step 3 note
+            signer=...,
+            token_manager=...,
+            grant_repo=None,
+        )
+        assert len(tools) == 2
+        assert tools[0].name.startswith("GitHub__")
+```
 
-    return AgentTool(
-        name="expand_mcp_server",
-        description=(
-            "Load a connected MCP server's tools for the rest of this conversation. "
-            "Pass the exact server slug from your 'Connected tool servers' list."
-        ),
-        parameters=ExpandMCPServerInput,
-        execute=_execute,
+> **Note:** The exact fixture setup for `cred_service`, `signer`, and
+> `token_manager` depends on the `_resolve_auth_from_spec` call. For an
+> `auth_method="none"` spec, `signer` must be a real or mocked
+> `MCPUserTokenSigner`. Use the E2E fixtures from
+> `tests/e2e/conftest.py` as reference. Alternatively, monkeypatch
+> `_resolve_auth_from_spec` to return `({}, "http://localhost:9999/mcp")`
+> for unit tests.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/unit/test_mcp_disclosure.py::TestLoadToolsForSpecs -v`
+Expected: ImportError — `_load_tools_for_specs` does not exist.
+
+- [ ] **Step 3: Extract `_load_tools_for_specs` from `load_workspace_mcp_tools_for_cubepi`**
+
+Refactor `cubepi_runtime.py`: extract the per-spec loop (lines 123–209) into a
+new `_load_tools_for_specs` that takes `specs` + `all_specs` (for slug
+collision detection) + the auth dependencies, and returns
+`tuple[list[AgentTool], dict[str, CitationConfig]]`. Then
+`load_workspace_mcp_tools_for_cubepi` becomes:
+
+```python
+async def load_workspace_mcp_tools_for_cubepi(...) -> tuple[...]:
+    specs = await effective_service.list_runtime_specs(workspace_id, user_id)
+    return await _load_tools_for_specs(
+        specs=specs,
+        all_specs=specs,
+        workspace_id=workspace_id,
+        org_id=org_id,
+        user_id=user_id,
+        cred_service=cred_service,
+        signer=signer,
+        token_manager=token_manager,
+        grant_repo=grant_repo,
     )
 ```
 
-Test (write first): valid slug → `expanded=True` with tool names; unknown slug →
-`is_error=True`, `expanded=False`.
-
-Run:
-```bash
-cd backend && uv run pytest tests/unit/test_expand_mcp_server_tool.py -q
-```
-Expected: `2 passed`.
-
----
-
-## Task 5 — `MCPDisclosureMiddleware` (unit)
-
-Port of `SkillsMiddleware`. `after_tool_call` for a successful `expand_mcp_server`
-appends the slug to `extra["expanded_mcp_servers"]` (ordered list, dedup,
-first-expanded-first; **never sort**). `transform_system_prompt` appends the
-expanded-schema text via `render_expanded_schemas` in stored order.
-
-Files:
-- `backend/cubebox/middleware/mcp_disclosure.py` (new).
-- `backend/tests/unit/test_mcp_disclosure_middleware.py` (new).
+`_load_tools_for_specs` is a module-private function with signature:
 
 ```python
-"""MCPDisclosureMiddleware — server-granularity port of SkillsMiddleware."""
+async def _load_tools_for_specs(
+    *,
+    specs: list[MCPRuntimeConnectorSpec],
+    all_specs: list[MCPRuntimeConnectorSpec],
+    workspace_id: str,
+    org_id: str,
+    user_id: str,
+    cred_service: CredentialService,
+    signer: MCPUserTokenSigner,
+    token_manager: OAuthTokenManager,
+    grant_repo: MCPCredentialGrantRepository | None = None,
+) -> tuple[list[AgentTool[Any]], dict[str, CitationConfig]]:
+```
 
+`all_specs` is the full set of usable specs (for slug collision pre-computation);
+`specs` is the subset to actually load. This way the per-group loader can pass
+`specs=[this_group_spec]` and `all_specs=all_workspace_specs` to get correct
+namespacing.
+
+- [ ] **Step 4: Run existing MCP tests to verify the refactor didn't break anything**
+
+Run: `cd backend && uv run pytest tests/ -k "mcp" -v --timeout=60`
+Expected: all existing MCP tests pass.
+
+- [ ] **Step 5: Write failing tests for `build_deferred_groups`**
+
+```python
+# tests/unit/test_mcp_disclosure.py (append)
+class TestBuildDeferredGroups:
+    def test_builds_groups_from_specs(self) -> None:
+        from cubebox.mcp.disclosure import build_deferred_groups
+        from cubebox.mcp.effective import MCPRuntimeConnectorSpec
+
+        spec = MCPRuntimeConnectorSpec(
+            install_id="inst-001",
+            name="GitHub",
+            server_url="http://localhost:9999/mcp",
+            transport="sse",
+            auth_method="none",
+            grant_scope=None,
+            credential_id=None,
+            refresh_credential_id=None,
+            tool_citations={},
+            tools_cache=[
+                {"name": "create_issue", "description": "Create an issue"},
+                {"name": "search_repos", "description": "Search repos"},
+            ],
+            discovery_metadata={"server": {"name": "GitHub"}},
+        )
+        groups = build_deferred_groups(
+            specs=[spec],
+            all_specs=[spec],
+            loader_kwargs={},  # auth deps — not called in this test
+        )
+        assert len(groups) == 1
+        g = groups[0]
+        assert g.group_id == "mcp:GitHub"
+        assert g.display_name == "GitHub"
+        assert "create_issue" in g.tool_names[0]  # namespaced
+        assert "search_repos" in g.tool_names[1]
+        assert callable(g.loader)
+
+    def test_description_from_discovery_metadata(self) -> None:
+        from cubebox.mcp.disclosure import build_deferred_groups
+        from cubebox.mcp.effective import MCPRuntimeConnectorSpec
+
+        spec = MCPRuntimeConnectorSpec(
+            install_id="inst-002",
+            name="Linear",
+            server_url="http://localhost:9999/mcp",
+            transport="sse",
+            auth_method="none",
+            grant_scope=None,
+            credential_id=None,
+            refresh_credential_id=None,
+            tool_citations={},
+            tools_cache=[{"name": "create_issue"}],
+            discovery_metadata={
+                "server": {"name": "Linear", "description": "Issue tracking and PM"},
+            },
+        )
+        groups = build_deferred_groups(
+            specs=[spec], all_specs=[spec], loader_kwargs={},
+        )
+        assert "Issue tracking" in groups[0].description
+
+    def test_fallback_description_when_no_metadata(self) -> None:
+        from cubebox.mcp.disclosure import build_deferred_groups
+        from cubebox.mcp.effective import MCPRuntimeConnectorSpec
+
+        spec = MCPRuntimeConnectorSpec(
+            install_id="inst-003",
+            name="MyServer",
+            server_url="http://localhost:9999/mcp",
+            transport="sse",
+            auth_method="none",
+            grant_scope=None,
+            credential_id=None,
+            refresh_credential_id=None,
+            tool_citations={},
+            tools_cache=[{"name": "do_thing"}],
+        )
+        groups = build_deferred_groups(
+            specs=[spec], all_specs=[spec], loader_kwargs={},
+        )
+        # Falls back to spec name when no discovery_metadata description.
+        assert groups[0].description != ""
+```
+
+- [ ] **Step 6: Implement `build_deferred_groups`**
+
+```python
+# cubebox/mcp/disclosure.py (append)
 from __future__ import annotations
 
-import json
-from collections.abc import Callable
+from collections import Counter
 from typing import Any
 
-from cubepi.agent.types import AfterToolCallContext
-from cubepi.middleware.base import Middleware
+from cubepi.deferred import DeferredToolGroup
 
-from cubebox.mcp.disclosure import render_expanded_schemas
+from cubebox.mcp._constants import slugify_for_namespace
+from cubebox.mcp.cubepi_runtime import (
+    _build_namespaced_name_with_prefix,
+    _load_tools_for_specs,
+    _NS_LENGTH_DEFENCE,
+)
 from cubebox.mcp.effective import MCPRuntimeConnectorSpec
-from cubebox.tools.builtin.expand_mcp_server import ExpandMCPServerOutput
-
-EXPANDED_KEY = "expanded_mcp_servers"
 
 
-class MCPDisclosureMiddleware(Middleware):
-    def __init__(
-        self,
-        *,
-        extra_ref: Callable[[], dict[str, Any]],
-        specs_by_slug: dict[str, MCPRuntimeConnectorSpec],
-    ) -> None:
-        self._extra_ref = extra_ref
-        self._specs_by_slug = specs_by_slug
+def _spec_description(spec: MCPRuntimeConnectorSpec) -> str:
+    """One-line description from discovery metadata, falling back to name."""
+    server = (spec.discovery_metadata or {}).get("server") or {}
+    desc = server.get("description") or server.get("summary") or ""
+    s = " ".join(desc.split())
+    if len(s) > 140:
+        s = s[:139].rstrip() + "…"
+    return s or spec.name
 
-    async def after_tool_call(self, ctx: AfterToolCallContext, *, signal: Any = None) -> None:
-        del signal
-        if ctx.tool_call.name != "expand_mcp_server" or ctx.is_error or not ctx.result.content:
-            return None
-        raw = next((b.text for b in ctx.result.content if hasattr(b, "text")), "")
-        if not raw:
-            return None
-        try:
-            out = ExpandMCPServerOutput.model_validate_json(raw)
-        except (json.JSONDecodeError, ValueError):
-            return None
-        if not out.expanded:
-            return None
-        extra = self._extra_ref()
-        ordered: list[str] = extra.setdefault(EXPANDED_KEY, [])
-        if out.server not in ordered:           # dedup, preserve first-expanded order
-            ordered.append(out.server)
-        return None
 
-    async def transform_system_prompt(self, system_prompt: str, *, signal: Any = None) -> str:
-        del signal
-        ordered: list[str] = self._extra_ref().get(EXPANDED_KEY, [])
-        if not ordered:
-            return system_prompt
-        return system_prompt + render_expanded_schemas(ordered, self._specs_by_slug)
+def _compute_namespaced_tool_names(
+    spec: MCPRuntimeConnectorSpec,
+    all_specs: list[MCPRuntimeConnectorSpec],
+) -> list[str]:
+    """Predict namespaced tool names using the same logic as the runtime loader."""
+    proposed_slugs = {s.install_id: slugify_for_namespace(s.name) for s in all_specs}
+    slug_counts: Counter[str] = Counter(proposed_slugs.values())
+    slug = proposed_slugs[spec.install_id]
+    explicit_collision = slug_counts[slug] > 1
+    risky_truncation = len(slug) > _NS_LENGTH_DEFENCE
+    if explicit_collision or risky_truncation:
+        safe = spec.install_id.replace("-", "")
+        suffix = f"_{safe[-4:] if len(safe) >= 4 else safe}"
+    else:
+        suffix = ""
+    return [
+        _build_namespaced_name_with_prefix(slug, tc.get("name", ""), suffix=suffix)
+        for tc in spec.tools_cache
+        if tc.get("name")
+    ]
+
+
+def build_deferred_groups(
+    *,
+    specs: list[MCPRuntimeConnectorSpec],
+    all_specs: list[MCPRuntimeConnectorSpec],
+    loader_kwargs: dict[str, Any],
+) -> list[DeferredToolGroup]:
+    """Convert MCP runtime specs into cubepi DeferredToolGroup objects.
+
+    ``loader_kwargs`` carries the auth dependencies
+    (workspace_id, org_id, user_id, cred_service, signer, token_manager,
+    grant_repo) forwarded to ``_load_tools_for_specs`` when the model
+    calls ``load_tools``.
+    """
+    groups: list[DeferredToolGroup] = []
+    for spec in specs:
+        slug = slugify_for_namespace(spec.name)
+        tool_names = _compute_namespaced_tool_names(spec, all_specs)
+
+        async def _loader(_s=spec, _all=all_specs, _kw=loader_kwargs):
+            tools, _citations = await _load_tools_for_specs(
+                specs=[_s], all_specs=_all, **_kw,
+            )
+            return tools
+
+        groups.append(
+            DeferredToolGroup(
+                group_id=f"mcp:{slug}",
+                display_name=spec.name,
+                description=_spec_description(spec),
+                tool_names=tool_names,
+                loader=_loader,
+            ),
+        )
+    return groups
 ```
 
-Test (write first):
-- Calling `after_tool_call` twice for the same slug stores it once.
-- Two distinct slugs are stored in call order; `transform_system_prompt` output
-  reflects that order and is append-only (the Task 3 invariant, exercised through
-  the middleware).
-- A non-`expand_mcp_server` tool call is a no-op.
+- [ ] **Step 7: Run tests**
 
-Run:
+Run: `cd backend && uv run pytest tests/unit/test_mcp_disclosure.py -v`
+Expected: all passed.
+
+- [ ] **Step 8: Commit**
+
 ```bash
-cd backend && uv run pytest tests/unit/test_mcp_disclosure_middleware.py -q
+git add cubebox/mcp/disclosure.py cubebox/mcp/cubepi_runtime.py \
+    tests/unit/test_mcp_disclosure.py
+git commit -m "feat(mcp): spec→DeferredToolGroup mapping + per-spec-list loader (#143)"
 ```
-Expected: `3 passed`.
 
 ---
 
-## Task 6 — Wire into run_manager: filtered loader + catalog suffix + middleware (integration)
+## Task 3 — Wire into run_manager
 
-This is where the spec's true-deferral commitment lands. **Branch on Task 0.**
+Integrate the disclosure gate + deferred groups into
+`run_manager._run_cubepi_path`. When disclosure is active, MCP servers become
+deferred groups instead of eagerly loaded tools. When inactive (below threshold
+or `"off"`), the existing eager-load path runs unchanged.
 
 Files:
-- `backend/cubebox/mcp/cubepi_runtime.py` — add `only_install_ids` filter.
-- `backend/cubebox/streams/run_manager.py` — tool load (~1034), middleware
-  append (after SkillsMiddleware ~1267), system-prompt suffix (~1818).
-- `backend/tests/e2e/test_mcp_disclosure_runtime.py` (new, uses
-  `stub_discover_tools`).
+- Modify: `backend/cubebox/streams/run_manager.py`
 
-### 6a. Filter the live loader (not a tools_cache synthesizer)
+- [ ] **Step 1: Add the disclosure branch to `_run_cubepi_path`**
 
-In `load_workspace_mcp_tools_for_cubepi`, add a keyword-only
-`only_install_ids: set[str] | None = None`. When provided, after
-`specs = await effective_service.list_runtime_specs(...)`, filter:
-```python
-specs = await effective_service.list_runtime_specs(workspace_id, user_id)
-if only_install_ids is not None:
-    specs = [s for s in specs if s.install_id in only_install_ids]
-```
-Everything downstream (auth resolve, `load_mcp_tools_http`, namespacing,
-citations) is unchanged — these are the **real callable** tools, filtered to the
-expanded set. `tools_cache` is never a tool source.
+In `_run_cubepi_path`, the MCP tool load block (~line 2155) currently:
+1. Opens a session, builds auth services
+2. Calls `load_workspace_mcp_tools_for_cubepi(...)` → `_new_tools`, `_new_citations`
+3. Extends `_builtin_tools` and `mcp_citation_configs`
 
-Also export a cheap helper used by Task 4's `list_usable_slugs` and the catalog:
-return `list_runtime_specs(...)` already gives `install_id`, `name`, `tools_cache`
-— map slug→bare tool names from `tools_cache` for the summary (preview only),
-slug→install_id for the filter, slug→spec for the renderers.
-
-### 6b. run_manager assembly
-
-At the MCP block (~1034), compute `specs = list_runtime_specs(...)` once, build
-`specs_by_slug` and `usable_count`. Then:
+Replace with a disclosure-aware branch:
 
 ```python
-from cubebox.mcp.disclosure import load_disclosure_settings, disclosure_active
+from cubebox.mcp.disclosure import (
+    build_deferred_groups,
+    disclosure_active,
+    load_disclosure_settings,
+)
 
-settings = load_disclosure_settings()
-active = disclosure_active(settings, usable_count)
+# ... inside the MCP load block, after building _effective_service ...
 
-if active:
-    expanded: list[str] = []  # populated from agent._extra on replay (see 6c)
-    only_ids = {specs_by_slug[s].install_id for s in expanded if s in specs_by_slug}
-    _new_tools, _new_citations = await load_workspace_mcp_tools_for_cubepi(
-        ..., only_install_ids=only_ids,
+_disclosure_settings = load_disclosure_settings()
+specs = await _effective_service.list_runtime_specs(
+    ctx.workspace_id, ctx.user_id,
+)
+
+# Estimate tool tokens from tools_cache for the threshold gate.
+import json as _json
+_total_tool_tokens = sum(
+    len(_json.dumps(s.tools_cache)) // 4 for s in specs  # rough token estimate
+)
+
+_deferred_groups: list = []
+
+if disclosure_active(
+    _disclosure_settings,
+    server_count=len(specs),
+    total_tool_tokens=_total_tool_tokens,
+    context_window=_ctx_window,
+):
+    # Build deferred groups — loader callbacks will call
+    # _load_tools_for_specs with the auth deps captured here.
+    _loader_kwargs = dict(
+        workspace_id=ctx.workspace_id,
+        org_id=ctx.org_id,
+        user_id=ctx.user_id,
+        cred_service=effective_cred_service,
+        signer=self._app.state.mcp_user_token_signer,
+        token_manager=_token_manager,
+        grant_repo=_grant_repo,
     )
-    _builtin_tools.append(create_expand_mcp_server_tool(list_usable_slugs=...))
-    # catalog suffix appended to effective_system_prompt below
+    _deferred_groups = build_deferred_groups(
+        specs=specs,
+        all_specs=specs,
+        loader_kwargs=_loader_kwargs,
+    )
+    # No tools loaded eagerly — they'll come from load_tools calls.
+    # Citations for expanded servers are returned by the per-group
+    # loader; wire them into mcp_citation_configs at expand time.
+    # (For v1, citations from the loader are added to the agent's
+    # citation middleware when the group expands — handled by the
+    # DeferredToolsMiddleware's on_tools_expanded callback.)
 else:
-    # today's path: load ALL servers, no catalog, no expand tool
-    _new_tools, _new_citations = await load_workspace_mcp_tools_for_cubepi(...)
+    # Eager path — today's behavior, unchanged.
+    (
+        _new_tools,
+        _new_citations,
+    ) = await load_workspace_mcp_tools_for_cubepi(
+        effective_service=_effective_service,
+        token_manager=_token_manager,
+        workspace_id=ctx.workspace_id,
+        org_id=ctx.org_id,
+        user_id=ctx.user_id,
+        cred_service=effective_cred_service,
+        signer=self._app.state.mcp_user_token_signer,
+        grant_repo=_grant_repo,
+    )
+    _builtin_tools.extend(_new_tools)
+    mcp_citation_configs.update(_new_citations)
 ```
 
-`expand_mcp_server` is appended to `_builtin_tools` **immediately before the MCP
-tools and after every existing builtin** — do not insert it right after
-`load_skill`, which would shift `view_images`/`generate_image`. The actual
-current order (confirmed in `run_manager.py` ~927–1032) is: memory → load_skill →
-view_images → generate_image → mcp_tools. Insert `expand_mcp_server` as the last
-builtin so the prefix becomes: … → memory → load_skill → view_images →
-generate_image → **expand_mcp_server** → mcp_tools. Everything before it stays
-byte-identical.
+- [ ] **Step 2: Pass deferred groups to agent creation**
 
-Append `MCPDisclosureMiddleware(extra_ref=_extra_ref, specs_by_slug=specs_by_slug)`
-to `cubepi_middleware` immediately after `SkillsMiddleware` (~1267). The
-`extra_ref` closure resolves to `agent._extra` once it's late-bound at ~1403,
-exactly like skills/compaction/todo.
+At the `create_cubebox_agent(...)` call (~line 2663), add
+`deferred_tool_groups=_deferred_groups or None`:
 
-When `active`, append the catalog suffix to `effective_system_prompt`. The suffix
-is built in `_run_cubepi_path` (where `specs` are loaded), not at ~1799 (which
-runs before the run path and has no specs). Move/duplicate the catalog injection
-into the run path right after the MCP load, mirroring how skills append to the
-prompt — append `render_catalog(specs)` to `effective_system_prompt` before
-`create_cubebox_agent`.
+```python
+agent = create_cubebox_agent(
+    ...
+    tools=all_tools,
+    deferred_tool_groups=_deferred_groups or None,
+    ...
+)
+```
 
-### 6c. The deferral branch (from Task 0)
+This requires `create_cubebox_agent` to accept and forward
+`deferred_tool_groups` to `Agent(...)`. Find the wrapper function and add the
+parameter — it likely just passes kwargs through to `Agent()`.
 
-- **Next-turn fallback (`MID_RUN_UNSUPPORTED`, expected):** on each run, build
-  `only_install_ids` from the **persisted prior-run** expanded set
-  (`expanded_mcp_servers` ordered list) before the MCP tools are loaded.
-  **Ordering problem to fix:** the MCP tool load is at ~1098 but the existing
-  `init_checkpointer()`/`cp.load(conversation_id)` (citation seeding) is at ~1375
-  — *after* the tool load. The live `agent._extra` is also only available after
-  `create_cubebox_agent` (~1384). So the fallback needs an **earlier** load of the
-  persisted `_extra` (an `init_checkpointer()`/`cp.load` call hoisted above the MCP
-  block at ~1041, or a small helper that reads just the persisted
-  `expanded_mcp_servers` for the conversation) so `only_install_ids` is known when
-  `load_workspace_mcp_tools_for_cubepi(..., only_install_ids=...)` runs. Do not
-  read the live `_extra` for this — it is empty until the agent is built and only
-  reflects this run. A server expanded on turn N becomes callable on turn N+1: the
-  `expand_mcp_server` call on turn N records the slug into the live `_extra`, which
-  is persisted (`save_extra` at `agent_end`, same as `loaded_skills`) and read back
-  on turn N+1's early load. **Document this one-turn delay in the
-  `expand_mcp_server` tool description** so the model expects it ("the server's
-  tools become available on your next turn"). Confirm `save_extra` actually
-  persists arbitrary `_extra` keys (verify `loaded_skills` round-trips today)
-  before relying on it for `expanded_mcp_servers`.
-- **True deferral (`MID_RUN_SUPPORTED`):** after `after_tool_call` records the
-  slug, also load that server's callable tools via the filtered loader and add
-  them to the live agent through cubepi's mid-run mechanism (whatever Task 0
-  found), and re-mark the cache boundary. Tool description drops the "next turn"
-  caveat. This depends on the released+pinned cubepi capability.
+- [ ] **Step 3: Verify `list_runtime_specs` is available outside the session**
 
-> Confirm which branch you are on by re-reading the Task 0 note. Do not build both.
+The `specs` call needs `_effective_service` which is built inside an
+`async with async_session_maker() as effective_session:` block. Ensure the
+`specs` query and `build_deferred_groups` both run inside that block. The
+loader callbacks capture `_effective_service` (and the session) in their
+closure — confirm the session is still open when the loader runs during the
+agent loop. If the session closes when the `async with` block exits, the
+loader must create its own session. Inspect the lifecycle and adjust — this
+is the most likely gotcha.
 
-### 6d. E2E test (write first)
+> **Likely fix:** Each loader callback opens its own short-lived session
+> (matching the pattern in `_resolve_auth_from_spec`), or the outer session
+> block is widened to encompass the entire agent run. Check what the existing
+> MCP load does and follow its pattern.
 
-`tests/e2e/test_mcp_disclosure_runtime.py`, using `stub_discover_tools` (to skip
-the discovery probe) plus the install-creation pattern from
-`tests/e2e/test_mcp_four_layer_runtime.py`. Additionally seed each install's
-`tools_cache` directly and monkeypatch the runtime tool loader
-(`load_mcp_tools_http` / `cubepi_runtime`) to return callable tools for the
-expanded set — `stub_discover_tools` alone supplies neither (see Tech Stack):
+- [ ] **Step 4: Run mypy + ruff**
 
-1. With disclosure enabled and ≥ `min_servers` usable servers installed: assert
-   the assembled `tools=` contains `expand_mcp_server` and **no** namespaced MCP
-   tools from collapsed servers; assert the system prompt contains the catalog
-   (server slugs, tool counts) and **no** `input_schema`.
-2. Drive a run that calls `expand_mcp_server("<slug>")`; assert the slug is in
-   `agent._extra["expanded_mcp_servers"]` and (per branch) the expanded server's
-   namespaced tools are callable (same run for true deferral / next run for
-   fallback) and produce a result.
-3. Assert citations still attach for the expanded server (`mcp_citation_configs`
-   populated for it; `CitationMiddleware` unchanged).
-
-Run:
 ```bash
-cd backend && uv run pytest tests/e2e/test_mcp_disclosure_runtime.py -q
+cd backend && uv run mypy cubebox/streams/run_manager.py cubebox/mcp/disclosure.py \
+    cubebox/mcp/cubepi_runtime.py && uv run ruff check cubebox tests
 ```
-Expected: all pass (real simulated MCP discovery via `stub_discover_tools`).
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cubebox/streams/run_manager.py cubebox/mcp/disclosure.py \
+    cubebox/mcp/cubepi_runtime.py
+git commit -m "feat(mcp): wire deferred groups into run_manager (#143)"
+```
 
 ---
 
-## Task 7 — Threshold below-min byte-identical guard (E2E)
+## Task 4 — E2E: disclosure flow + threshold bypass
 
-Prove the small-workspace path is unchanged: below `min_servers`, no catalog, no
-`expand_mcp_server`, all servers' tools eagerly loaded exactly as today.
+Write E2E tests that prove (a) when disclosure is active, collapsed servers are
+absent from `tools=` and the catalog is in the prompt; (b) the model can expand
+a group and the tools become callable; (c) below threshold, behavior is exactly
+today's eager load.
 
 Files:
-- `backend/tests/e2e/test_mcp_disclosure_runtime.py` (add a case).
+- Create: `backend/tests/e2e/test_mcp_disclosure_runtime.py`
 
-Assert: with `min_servers=3` and 2 usable servers, the assembled prompt has no
-catalog header and `tools=` contains every server's namespaced tools (status
-quo), and `expand_mcp_server` is **absent**.
+- [ ] **Step 1: Write the E2E test**
 
-Run:
+Use `stub_discover_tools` to skip the discovery probe, seed `tools_cache` on
+installs directly, and monkeypatch `load_mcp_tools_http` (or
+`_load_tools_for_specs`) to return callable tools. Reference
+`tests/e2e/test_mcp_four_layer_runtime.py` for install-creation patterns.
+
+Tests to write:
+
+1. **`test_disclosure_active_catalog_in_prompt`** — with `enabled="on"` and
+   ≥ `min_servers` installs: the assembled `tools=` contains `load_tools` and
+   **no** namespaced MCP tools; the system prompt contains the catalog (group
+   ids, tool names, tool counts).
+
+2. **`test_expand_group_makes_tools_callable`** — drive a run that calls
+   `load_tools("mcp:github")`; assert the expanded server's tools appear in
+   the agent's live tool set after expansion.
+
+3. **`test_threshold_bypass_eager_load`** — with `min_servers=5` and only 2
+   installs: no catalog, no `load_tools` tool, all servers' tools eagerly
+   loaded (today's behavior).
+
+4. **`test_disabled_always_eager`** — with `enabled="off"` and many servers:
+   all tools loaded eagerly.
+
+- [ ] **Step 2: Run E2E**
+
 ```bash
-cd backend && uv run pytest tests/e2e/test_mcp_disclosure_runtime.py -q -k threshold
+cd backend && uv run pytest tests/e2e/test_mcp_disclosure_runtime.py -v
+```
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/test_mcp_disclosure_runtime.py
+git commit -m "test(mcp): E2E for disclosure flow + threshold bypass (#143)"
+```
+
+---
+
+## Task 5 — Cache-prefix stability E2E
+
+Extend the cache regression tests to assert disclosure doesn't break
+prompt-cache stability.
+
+Files:
+- Modify or create: `backend/tests/e2e/test_mcp_disclosure_runtime.py` (extend)
+
+- [ ] **Step 1: Write cache stability tests**
+
+1. **`test_catalog_byte_stable_across_turns`** — with disclosure active and
+   nothing expanded, the system-prompt suffix (catalog portion) is
+   byte-identical on two consecutive prompt assemblies.
+
+2. **`test_expansion_append_only`** — expand group A on turn 1, expand group
+   B on turn 2. The turn-2 system prompt starts with the turn-1 system prompt
+   as a prefix (the B block is appended, never inserted before A).
+
+These can be unit-ish (call the middleware's `transform_system_prompt` twice
+with different expansion states) or full E2E — either works as long as the
+byte-identity assertion is exact.
+
+- [ ] **Step 2: Run**
+
+```bash
+cd backend && uv run pytest tests/e2e/test_mcp_disclosure_runtime.py -v -k cache
 ```
 Expected: pass.
 
----
+- [ ] **Step 3: Commit**
 
-## Task 8 — Cache-prefix stability E2E (THE GATE)
-
-Extend the existing real-LLM cache regression. This is the single most important
-test per the spec.
-
-Files:
-- `backend/tests/e2e/memory/test_prompt_cache.py` (extend, mirroring
-  `test_cache_hit_rate_meets_bar`).
-
-Assert, with disclosure active and ≥ `min_servers` servers:
-1. **Catalog stability:** the cache-eligible prefix is byte-stable across turns
-   with the catalog present and nothing expanded (catalog derived purely from DB,
-   slug-sorted → identical every turn).
-2. **Append-only after expansion:** after the model expands one server, the next
-   turn's prefix **starts with** the previous turn's expanded-schema text and only
-   appends the new block — no mid-prefix mutation, no reorder. Expanding a second
-   server appends after the first (expansion order, not slug order).
-3. Reuse the existing `CUBEBOX_E2E_LLM_CACHE_CAPABLE` skip semantics so the test
-   discriminates "endpoint doesn't honor cache" from "we broke the prefix".
-
-Run:
 ```bash
-cd backend && CUBEBOX_E2E_LLM_CACHE_CAPABLE=true uv run pytest \
-  tests/e2e/memory/test_prompt_cache.py -q
+git add tests/e2e/test_mcp_disclosure_runtime.py
+git commit -m "test(mcp): cache-prefix stability for disclosure (#143)"
 ```
-Expected: pass (or principled SKIP if the endpoint can't cache — never weaken the
-bar to make it pass; per `prompt-cache-discipline.md` find the dynamic content
-instead).
 
 ---
 
-## Task 9 — Pre-PR sweep + self-review
+## Task 6 — Pre-PR sweep
 
 Files: none (verification only).
 
-1. Full backend suite on the worktree slot DB:
-   ```bash
-   cd backend && uv run pytest -q
-   ```
-   Expected: green (the worktree conftest auto-routes to
-   `cubebox_test_feat_mcp_progressive_disclosure`).
-2. Type + lint:
-   ```bash
-   cd backend && uv run mypy cubebox && uv run ruff check cubebox tests
-   ```
-   Expected: no errors; lines ≤ 100.
-3. Confirm: collapsed servers contribute zero entries to `tools=` (grep the E2E
-   assertions); `tools_cache` is used only by the catalog/expand-preview/schema
-   renderers, never as an `AgentTool` source; expanded state is an **ordered
-   list** end to end (model → tool → middleware `after_tool_call` → `_extra` →
-   checkpointer persist → next-run replay) and never re-sorted.
-4. Confirm the Task 0 note records the chosen branch and that only that branch was
-   built.
+- [ ] **Step 1: Full backend suite**
+
+```bash
+cd backend && uv run pytest -q --timeout=120
+```
+Expected: green.
+
+- [ ] **Step 2: Type-check + lint**
+
+```bash
+cd backend && uv run mypy cubebox && uv run ruff check cubebox tests
+```
+Expected: no errors; lines ≤ 100.
+
+- [ ] **Step 3: Manual verification checklist**
+
+- Collapsed servers contribute zero entries to `tools=` (grep assertions).
+- `tools_cache` is used only for catalog display and namespaced-name prediction,
+  never as an `AgentTool` source.
+- Expanded state is an ordered dict in `extra["expanded_groups"]` end to end and
+  survives checkpointing (via cubepi's `DeferredToolsMiddleware`).
+- Below-threshold / disabled path is byte-identical to today's behavior.
 
 ---
 
-## Open items carried from the spec (not blocking v1)
+## Open items (not blocking v1)
 
-- Authored `trigger_hints` field + editing UI — Later (no migration in v1; v1
-  derives the hint from description).
-- Per-tool (sub-server) disclosure, semantic retrieval, code-mode,
-  provider-native deferred tools — Later.
-- Subagent expanded-set inheritance — v1: subagents start collapsed (their own
-  assembly); revisit if needed.
-- Re-collapse mid-conversation — explicitly **not** in v1 (monotonic growth is
-  what keeps the cache safe).
-- Stale `tools_cache`: callable tools always come from live discovery on expand,
-  so a stale cache cannot make the model call a non-existent tool; only the
-  catalog/preview text can drift — accepted for v1, refresh `tools_cache` out of
-  band.
+- Authored `trigger_hints` field + editing UI — Later.
+- Per-tool (sub-server) disclosure — Later.
+- Semantic retrieval, code-mode, provider-native deferred tools — Later.
+- Subagent expanded-set inheritance — v1: subagents start collapsed.
+- Re-collapse mid-conversation — explicitly not in v1.
+- Citation wiring for expanded groups — v1 relies on the per-group loader
+  returning citations; a follow-up may wire them into `CitationMiddleware`
+  dynamically.
+- Stale `tools_cache`: only the catalog/preview text can drift — accepted
+  for v1.

--- a/docs/dev/plans/2026-05-27-mcp-progressive-disclosure.md
+++ b/docs/dev/plans/2026-05-27-mcp-progressive-disclosure.md
@@ -1,0 +1,750 @@
+# MCP Progressive Disclosure Implementation Plan
+
+> For agentic workers: execute tasks top to bottom. Each task is TDD — write the
+> test first, watch it fail, implement, watch it pass. Stay on branch
+> `feat/mcp-progressive-disclosure`; never switch to main or merge mid-execution.
+> First command in the worktree is always `cat .worktree.env` (slot 89, backend
+> `:8089`, DB `cubebox_feat_mcp_progressive_disclosure`). Run the per-module tests
+> shown under each task during dev; reserve the full suite for the pre-PR sweep.
+> **Task 0 (the spike) gates the whole plan** — its answer selects the deferral
+> mode for Task 6. Do not skip or reorder it.
+
+Date: 2026-05-27
+Spec: `docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md`
+Issue: #143
+
+---
+
+## Goal
+
+Stop injecting every enabled MCP server's full tool schemas into the prompt on
+every turn. Instead inject a **compact catalog** (server slug + one-line
+description + tool count + trigger hint) as a stable system-prompt suffix, and
+let the model call a new `expand_mcp_server(server)` builtin to make a server's
+real, callable tools available for the rest of the conversation. Collapsed
+servers contribute **zero** tool definitions to `tools=` and zero schema text —
+that is the only thing that actually saves cache/attention cost. Expanded
+servers' callable tools come from the **real runtime loader**
+(`load_workspace_mcp_tools_for_cubepi` → `load_mcp_tools_http`) **filtered to the
+expanded set**, never synthesized from `tools_cache` (cache is index/preview
+only — cached JSON schemas are not executable). The prompt-cache prefix must stay
+byte-stable: catalog sorted by slug, expanded-schema text appended in **expansion
+order** (append-only, never re-sorted). Feature is config-gated and off below a
+server-count threshold so small workspaces keep today's exact behavior.
+
+## Architecture
+
+Mirror the **skills** subsystem at server granularity:
+
+| Skills (existing) | MCP progressive disclosure (this plan) |
+|---|---|
+| `SKILLS_PROMPT_TEMPLATE` index in system-prompt suffix, sorted by name | MCP catalog renderer, suffix, sorted by **slug** |
+| `load_skill(name)` builtin returns SKILL.md JSON | `expand_mcp_server(server)` builtin returns server tool summary JSON |
+| `SkillsMiddleware`: `after_tool_call` writes `extra["loaded_skills"]` (dict); `transform_system_prompt` appends bodies sorted by name | `MCPDisclosureMiddleware`: `after_tool_call` appends slug to `extra["expanded_mcp_servers"]` (**ordered list**, dedup, first-expanded-first); `transform_system_prompt` appends each expanded server's schema text in **expansion order** |
+
+Key divergence from skills: the **enabled** skill set is fixed up front, so
+skills can sort by name. MCP servers expand **incrementally mid-conversation**, so
+slug-sorting the expanded blocks could insert a later expansion *before* an
+already-cached block and invalidate the prefix. Therefore expanded-schema text is
+ordered by **expansion order**, persisted as an **ordered list** in `extra`, and
+replayed unchanged across turns.
+
+The load-bearing unknown — can cubepi add callable tools to a *live* agent mid-run
+and re-mark the cache boundary? — is resolved by **Task 0 (spike)**. The plan
+branches there:
+
+- **True deferral** (cubepi supports mid-run tool-set change): a just-expanded
+  server is callable within the same turn.
+- **Next-turn fallback** (cubepi cannot, current pinned rev): the expanded
+  server's tools enter `tools=` on the **next** user turn; the tool set is frozen
+  per run. Still saves all the cost (collapsed servers never in `tools=`); costs a
+  one-turn delay before a just-expanded server is callable.
+
+Either way **pre-register-all is rejected** — shipping every collapsed server's
+schema in `tools=` while hiding it from the catalog prose saves nothing.
+
+## Tech Stack
+
+- Backend: FastAPI + cubepi agent runtime, Postgres (SQLModel + Alembic),
+  Python 3.13, mypy strict, line length 100.
+- Tests: pytest + pytest-asyncio. E2E under `tests/e2e/`, unit under
+  `tests/unit/` (directory marker is auto-applied by `tests/conftest.py`).
+- MCP E2E uses the existing `stub_discover_tools` fixture
+  (`tests/e2e/test_mcp_four_layer_runtime.py`) — a real simulated discovery, no
+  fake-server-only excuse.
+- Touch points (all confirmed by reading the code):
+  - `backend/cubebox/streams/run_manager.py` — tool assembly (~1034), middleware
+    stack (~1136–1353), final tool merge (~1359), `create_cubebox_agent` call
+    (~1384), system-prompt suffix assembly (~1799).
+  - `backend/cubebox/mcp/cubepi_runtime.py` — `load_workspace_mcp_tools_for_cubepi`.
+  - `backend/cubebox/mcp/effective.py` — `list_runtime_specs`,
+    `MCPRuntimeConnectorSpec` (carries `install_id`, `tools_cache`).
+  - `backend/cubebox/models/mcp.py` — `MCPConnectorInstall.tools_cache`,
+    `.discovery_metadata`, `.slug_name`, `.description` (via template).
+  - `backend/cubebox/middleware/skills.py`,
+    `backend/cubebox/tools/builtin/load_skill.py`,
+    `backend/cubebox/prompts/skills.py` — the analog to copy.
+  - `backend/cubebox/config.py` — `config.get("mcp.progressive_disclosure...")`.
+
+---
+
+## Task 0 — SPIKE: does cubepi support mid-run tool-set change? (GATES THE PLAN)
+
+**This task produces a written decision, not shippable code.** It selects the
+Task 6 branch (true deferral vs next-turn fallback).
+
+What we already know from reading the **pinned** cubepi
+(`backend/.venv/.../cubepi/agent/agent.py`, `loop.py`):
+
+- `Agent._state.tools` has a property setter (`agent.state.tools = [...]`).
+- BUT `Agent.prompt()` calls `_create_context_snapshot()` **once** and the loop
+  runs against that single `current_context`; `run_agent_loop` reads
+  `context.tools` to build `tools_defs` (`loop.py` ~381) and never re-reads
+  `agent.state.tools` between iterations. So mutating `agent.state.tools` from a
+  middleware hook during a run does **not** change the tools the model sees this
+  run.
+
+Steps:
+
+1. Write a throwaway probe `backend/scripts/dev/spike_mcp_live_tools.py` that
+   builds a minimal cubepi `Agent` with a tool whose `after_tool_call` (or a
+   middleware) appends a second `AgentTool` to `agent.state.tools`, then checks
+   whether the model is offered the new tool in the **same** `prompt()` call.
+   Drive it with a stub provider that records the `tools_defs` passed on each
+   model call.
+2. Inspect cubepi for any hook to mutate `current_context.tools` mid-loop (e.g. a
+   `transform_context` that returns tools, or a documented "register tool"
+   surface). Grep `~/cubepi` source, not just the installed wheel — but remember
+   runtime uses the **pinned** wheel (`reference_cubepi_pinned_dep`), so any new
+   capability must be released + the pin bumped before it reaches runtime.
+
+Run:
+```bash
+cd backend && uv run python scripts/dev/spike_mcp_live_tools.py
+```
+Expected output (one of):
+```
+SPIKE RESULT: MID_RUN_SUPPORTED   # new tool appears in same-run tools_defs
+SPIKE RESULT: MID_RUN_UNSUPPORTED # snapshot frozen; next-turn fallback required
+```
+
+Record the result and the chosen branch in
+`docs/dev/notes/2026-05-27-mcp-disclosure-cubepi-spike.md` (one new note file is
+allowed — it is the decision record this plan depends on). Delete the probe
+script after.
+
+**Decision rule:**
+- `MID_RUN_UNSUPPORTED` → build **next-turn fallback** in v1 (expected, given the
+  snapshot finding). File a cubepi upstream follow-up (`~/cubepi`, upstream-first)
+  to add mid-run tool-set change + cache re-establishment; do **not** hand-edit
+  cubepi vendor behavior in cubebox.
+- `MID_RUN_SUPPORTED` → build **true deferral** (Task 6 variant B).
+
+Verify: the note exists and states the branch explicitly.
+
+---
+
+## Task 1 — Config flags + threshold gate (unit)
+
+Add the config surface and a pure helper deciding when disclosure is active.
+
+Files:
+- `backend/cubebox/mcp/disclosure.py` (new) — pure functions, no I/O.
+- `backend/config.development.yaml` and `backend/config.yaml` (whichever holds the
+  `mcp` block; add the `progressive_disclosure` subkey).
+- `backend/tests/unit/test_mcp_disclosure_gate.py` (new).
+
+`disclosure.py`:
+```python
+"""Progressive-disclosure gating + catalog/schema rendering (pure, no I/O)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cubebox.config import config
+
+
+@dataclass(frozen=True)
+class DisclosureSettings:
+    enabled: bool
+    min_servers: int
+
+
+def load_disclosure_settings() -> DisclosureSettings:
+    return DisclosureSettings(
+        enabled=bool(config.get("mcp.progressive_disclosure.enabled", False)),
+        min_servers=int(config.get("mcp.progressive_disclosure.min_servers", 3)),
+    )
+
+
+def disclosure_active(settings: DisclosureSettings, usable_server_count: int) -> bool:
+    """True when the catalog/expand machinery replaces eager tool loading."""
+    return settings.enabled and usable_server_count >= settings.min_servers
+```
+
+Test (write first, must fail before `disclosure.py` exists):
+```python
+from cubebox.mcp.disclosure import DisclosureSettings, disclosure_active
+
+
+def test_disabled_never_active() -> None:
+    s = DisclosureSettings(enabled=False, min_servers=2)
+    assert disclosure_active(s, 10) is False
+
+
+def test_below_threshold_inactive() -> None:
+    s = DisclosureSettings(enabled=True, min_servers=3)
+    assert disclosure_active(s, 2) is False
+
+
+def test_at_threshold_active() -> None:
+    s = DisclosureSettings(enabled=True, min_servers=3)
+    assert disclosure_active(s, 3) is True
+```
+
+Config block (add under existing `mcp:`):
+```yaml
+mcp:
+  progressive_disclosure:
+    enabled: false      # off by default — small workspaces keep today's behavior
+    min_servers: 3      # only collapse when this many usable servers connected
+```
+
+Run:
+```bash
+cd backend && uv run pytest tests/unit/test_mcp_disclosure_gate.py -q
+```
+Expected: `3 passed`.
+
+---
+
+## Task 2 — Catalog renderer (unit, determinism + cache-stability)
+
+Render the compact catalog from data already in Postgres
+(`MCPRuntimeConnectorSpec.tools_cache` + spec `name`/`description`/`install_id`)
+— **no live discovery**. Sorted by slug → byte-identical every turn.
+
+Files:
+- `backend/cubebox/mcp/disclosure.py` (extend).
+- `backend/cubebox/prompts/mcp_catalog.py` (new) — the template, mirroring
+  `prompts/skills.py`.
+- `backend/tests/unit/test_mcp_catalog_render.py` (new).
+
+`prompts/mcp_catalog.py`:
+```python
+"""MCP catalog template — injected by run_manager when disclosure is active."""
+
+MCP_CATALOG_HEADER = """\
+
+# Connected tool servers (collapsed)
+
+These servers are connected but their tools are not loaded yet. Call
+`expand_mcp_server(server)` with a name below to load that server's tools for the
+rest of this conversation.
+"""
+```
+
+`disclosure.py` (add):
+```python
+from cubebox.mcp.effective import MCPRuntimeConnectorSpec
+from cubebox.mcp._constants import slugify_for_namespace
+from cubebox.prompts.mcp_catalog import MCP_CATALOG_HEADER
+
+
+def _one_line(text: str | None, limit: int = 140) -> str:
+    s = " ".join((text or "").split())
+    return s if len(s) <= limit else s[: limit - 1].rstrip() + "…"
+
+
+def render_catalog(specs: list[MCPRuntimeConnectorSpec]) -> str:
+    """Compact, slug-sorted catalog. Never contains per-tool JSON schemas."""
+    lines: list[str] = []
+    for spec in sorted(specs, key=lambda s: slugify_for_namespace(s.name)):
+        slug = slugify_for_namespace(spec.name)
+        count = len(spec.tools_cache)
+        desc = _one_line(spec.description)
+        lines.append(f"- `{slug}` — {desc} ({count} tools)")
+    return MCP_CATALOG_HEADER + "\n" + "\n".join(lines) + "\n"
+```
+(Trigger-hint line is derived from description for v1 — the spec leaves an
+authored `trigger_hints` field as a Later item; do **not** add a migration now.)
+
+Test (write first):
+```python
+from cubebox.mcp.disclosure import render_catalog
+from cubebox.mcp.effective import MCPRuntimeConnectorSpec
+
+
+def _spec(name: str, desc: str, n_tools: int) -> MCPRuntimeConnectorSpec:
+    return MCPRuntimeConnectorSpec(
+        install_id=f"inst-{name}", name=name, description=desc,
+        tools_cache=[{"name": f"t{i}"} for i in range(n_tools)],
+        # ...remaining required fields filled with neutral defaults...
+    )
+
+
+def test_catalog_sorted_by_slug_and_byte_stable() -> None:
+    specs = [_spec("Zeta", "z server", 2), _spec("Alpha", "a server", 5)]
+    out1 = render_catalog(specs)
+    out2 = render_catalog(list(reversed(specs)))  # input order must not matter
+    assert out1 == out2
+    assert out1.index("`alpha`") < out1.index("`zeta`")
+    assert "(5 tools)" in out1 and "(2 tools)" in out1
+
+
+def test_catalog_has_no_input_schemas() -> None:
+    specs = [_spec("Alpha", "a", 1)]
+    assert "input_schema" not in render_catalog(specs)
+```
+(Inspect `MCPRuntimeConnectorSpec` field list at `effective.py:207` to fill the
+constructor; do not guess.)
+
+Run:
+```bash
+cd backend && uv run pytest tests/unit/test_mcp_catalog_render.py -q
+```
+Expected: `2 passed`.
+
+---
+
+## Task 3 — Expanded-schema renderer (unit, expansion-order stability)
+
+Render the full tool definitions of expanded servers, from `tools_cache`, in
+**expansion order** (never sorted). Adding one expansion must only **append**.
+
+Files:
+- `backend/cubebox/mcp/disclosure.py` (extend).
+- `backend/tests/unit/test_mcp_expanded_render.py` (new).
+
+`disclosure.py` (add):
+```python
+import json
+
+EXPANDED_SECTION_HEADER = "[Expanded MCP servers]"
+
+
+def render_expanded_schemas(
+    expanded_slugs: list[str],
+    specs_by_slug: dict[str, MCPRuntimeConnectorSpec],
+) -> str:
+    """Append-only schema text, ordered by EXPANSION ORDER (not slug).
+
+    A newly expanded server's block always lands after every already-rendered
+    block → earlier cache segments stay byte-identical.
+    """
+    blocks: list[str] = []
+    for slug in expanded_slugs:  # expansion order, as-stored
+        spec = specs_by_slug.get(slug)
+        if spec is None:
+            continue
+        tools_json = json.dumps(spec.tools_cache, sort_keys=True, ensure_ascii=False)
+        blocks.append(f"## Server: {slug}\n\n{tools_json}")
+    if not blocks:
+        return ""
+    return f"\n\n{EXPANDED_SECTION_HEADER}\n\n" + "\n\n".join(blocks)
+```
+
+Test (write first):
+```python
+def test_expansion_order_preserved_not_sorted() -> None:
+    specs = {"zeta": _spec("zeta",...), "alpha": _spec("alpha",...)}
+    out = render_expanded_schemas(["zeta", "alpha"], specs)
+    assert out.index("## Server: zeta") < out.index("## Server: alpha")
+
+
+def test_adding_expansion_only_appends() -> None:
+    specs = {"a": _spec("a",...), "b": _spec("b",...)}
+    first = render_expanded_schemas(["a"], specs)
+    second = render_expanded_schemas(["a", "b"], specs)
+    assert second.startswith(first)  # prefix preserved → cache-safe
+
+
+def test_json_keys_sorted_for_byte_stability() -> None:
+    out = render_expanded_schemas(["a"], {"a": _spec("a", tools=[{"b":1,"a":2}])})
+    assert out == render_expanded_schemas(["a"], {"a": _spec("a", tools=[{"a":2,"b":1}])})
+```
+
+Run:
+```bash
+cd backend && uv run pytest tests/unit/test_mcp_expanded_render.py -q
+```
+Expected: `3 passed`.
+
+---
+
+## Task 4 — `expand_mcp_server` builtin (unit)
+
+A sibling of `load_skill`. Validates the slug against the workspace's usable
+installs, returns a JSON summary (namespaced tool names + descriptions, **no
+schemas in the result** — middleware injects schema text). Placed in the fixed
+tool order **where MCP tools used to go** (after `load_skill`).
+
+Files:
+- `backend/cubebox/tools/builtin/expand_mcp_server.py` (new).
+- `backend/tests/unit/test_expand_mcp_server_tool.py` (new).
+
+```python
+"""expand_mcp_server builtin — sibling of load_skill.
+
+Returns a summary of a connected MCP server's tools so the model knows what it
+just unlocked. Schema text is injected into the system prompt by
+MCPDisclosureMiddleware (mirrors how SkillsMiddleware injects skill bodies),
+NOT re-emitted in this tool result.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import TextContent
+from pydantic import BaseModel, Field
+
+
+class ExpandMCPServerInput(BaseModel):
+    server: str = Field(description="The server slug from your 'Connected tool servers' list.")
+
+
+class ExpandMCPServerOutput(BaseModel):
+    server: str
+    expanded: bool
+    tool_names: list[str]
+    error: str | None = None
+
+    def __str__(self) -> str:
+        return self.model_dump_json()
+
+
+def create_expand_mcp_server_tool(
+    *,
+    list_usable_slugs: Callable[[], Awaitable[dict[str, list[str]]]],
+) -> AgentTool[ExpandMCPServerInput]:
+    """list_usable_slugs() → {slug: [bare_tool_name, ...]} for usable installs."""
+
+    async def _execute(tool_call_id, args, *, signal=None, on_update=None):
+        del tool_call_id, signal, on_update
+        usable = await list_usable_slugs()
+        if args.server not in usable:
+            out = ExpandMCPServerOutput(
+                server=args.server, expanded=False, tool_names=[],
+                error=f"Server '{args.server}' is not connected to this workspace",
+            )
+            return AgentToolResult(content=[TextContent(text=out.model_dump_json())], is_error=True)
+        out = ExpandMCPServerOutput(
+            server=args.server, expanded=True, tool_names=usable[args.server],
+        )
+        return AgentToolResult(content=[TextContent(text=out.model_dump_json())])
+
+    return AgentTool(
+        name="expand_mcp_server",
+        description=(
+            "Load a connected MCP server's tools for the rest of this conversation. "
+            "Pass the exact server slug from your 'Connected tool servers' list."
+        ),
+        parameters=ExpandMCPServerInput,
+        execute=_execute,
+    )
+```
+
+Test (write first): valid slug → `expanded=True` with tool names; unknown slug →
+`is_error=True`, `expanded=False`.
+
+Run:
+```bash
+cd backend && uv run pytest tests/unit/test_expand_mcp_server_tool.py -q
+```
+Expected: `2 passed`.
+
+---
+
+## Task 5 — `MCPDisclosureMiddleware` (unit)
+
+Port of `SkillsMiddleware`. `after_tool_call` for a successful `expand_mcp_server`
+appends the slug to `extra["expanded_mcp_servers"]` (ordered list, dedup,
+first-expanded-first; **never sort**). `transform_system_prompt` appends the
+expanded-schema text via `render_expanded_schemas` in stored order.
+
+Files:
+- `backend/cubebox/middleware/mcp_disclosure.py` (new).
+- `backend/tests/unit/test_mcp_disclosure_middleware.py` (new).
+
+```python
+"""MCPDisclosureMiddleware — server-granularity port of SkillsMiddleware."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from cubepi.agent.types import AfterToolCallContext
+from cubepi.middleware.base import Middleware
+
+from cubebox.mcp.disclosure import render_expanded_schemas
+from cubebox.mcp.effective import MCPRuntimeConnectorSpec
+from cubebox.tools.builtin.expand_mcp_server import ExpandMCPServerOutput
+
+EXPANDED_KEY = "expanded_mcp_servers"
+
+
+class MCPDisclosureMiddleware(Middleware):
+    def __init__(
+        self,
+        *,
+        extra_ref: Callable[[], dict[str, Any]],
+        specs_by_slug: dict[str, MCPRuntimeConnectorSpec],
+    ) -> None:
+        self._extra_ref = extra_ref
+        self._specs_by_slug = specs_by_slug
+
+    async def after_tool_call(self, ctx: AfterToolCallContext, *, signal: Any = None) -> None:
+        del signal
+        if ctx.tool_call.name != "expand_mcp_server" or ctx.is_error or not ctx.result.content:
+            return None
+        raw = next((b.text for b in ctx.result.content if hasattr(b, "text")), "")
+        if not raw:
+            return None
+        try:
+            out = ExpandMCPServerOutput.model_validate_json(raw)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if not out.expanded:
+            return None
+        extra = self._extra_ref()
+        ordered: list[str] = extra.setdefault(EXPANDED_KEY, [])
+        if out.server not in ordered:           # dedup, preserve first-expanded order
+            ordered.append(out.server)
+        return None
+
+    async def transform_system_prompt(self, system_prompt: str, *, signal: Any = None) -> str:
+        del signal
+        ordered: list[str] = self._extra_ref().get(EXPANDED_KEY, [])
+        if not ordered:
+            return system_prompt
+        return system_prompt + render_expanded_schemas(ordered, self._specs_by_slug)
+```
+
+Test (write first):
+- Calling `after_tool_call` twice for the same slug stores it once.
+- Two distinct slugs are stored in call order; `transform_system_prompt` output
+  reflects that order and is append-only (the Task 3 invariant, exercised through
+  the middleware).
+- A non-`expand_mcp_server` tool call is a no-op.
+
+Run:
+```bash
+cd backend && uv run pytest tests/unit/test_mcp_disclosure_middleware.py -q
+```
+Expected: `3 passed`.
+
+---
+
+## Task 6 — Wire into run_manager: filtered loader + catalog suffix + middleware (integration)
+
+This is where the spec's true-deferral commitment lands. **Branch on Task 0.**
+
+Files:
+- `backend/cubebox/mcp/cubepi_runtime.py` — add `only_install_ids` filter.
+- `backend/cubebox/streams/run_manager.py` — tool load (~1034), middleware
+  append (after SkillsMiddleware ~1267), system-prompt suffix (~1818).
+- `backend/tests/e2e/test_mcp_disclosure_runtime.py` (new, uses
+  `stub_discover_tools`).
+
+### 6a. Filter the live loader (not a tools_cache synthesizer)
+
+In `load_workspace_mcp_tools_for_cubepi`, add a keyword-only
+`only_install_ids: set[str] | None = None`. When provided, after
+`specs = await effective_service.list_runtime_specs(...)`, filter:
+```python
+specs = await effective_service.list_runtime_specs(workspace_id, user_id)
+if only_install_ids is not None:
+    specs = [s for s in specs if s.install_id in only_install_ids]
+```
+Everything downstream (auth resolve, `load_mcp_tools_http`, namespacing,
+citations) is unchanged — these are the **real callable** tools, filtered to the
+expanded set. `tools_cache` is never a tool source.
+
+Also export a cheap helper used by Task 4's `list_usable_slugs` and the catalog:
+return `list_runtime_specs(...)` already gives `install_id`, `name`, `tools_cache`
+— map slug→bare tool names from `tools_cache` for the summary (preview only),
+slug→install_id for the filter, slug→spec for the renderers.
+
+### 6b. run_manager assembly
+
+At the MCP block (~1034), compute `specs = list_runtime_specs(...)` once, build
+`specs_by_slug` and `usable_count`. Then:
+
+```python
+from cubebox.mcp.disclosure import load_disclosure_settings, disclosure_active
+
+settings = load_disclosure_settings()
+active = disclosure_active(settings, usable_count)
+
+if active:
+    expanded: list[str] = []  # populated from agent._extra on replay (see 6c)
+    only_ids = {specs_by_slug[s].install_id for s in expanded if s in specs_by_slug}
+    _new_tools, _new_citations = await load_workspace_mcp_tools_for_cubepi(
+        ..., only_install_ids=only_ids,
+    )
+    _builtin_tools.append(create_expand_mcp_server_tool(list_usable_slugs=...))
+    # catalog suffix appended to effective_system_prompt below
+else:
+    # today's path: load ALL servers, no catalog, no expand tool
+    _new_tools, _new_citations = await load_workspace_mcp_tools_for_cubepi(...)
+```
+
+`expand_mcp_server` is appended to `_builtin_tools` **after `load_skill`** so the
+fixed cache-prefix tool order (sandbox → artifact → todo → subagent →
+calculator/datetime → view_images → generate_image → memory → load_skill →
+**expand_mcp_server** → mcp_tools) is preserved.
+
+Append `MCPDisclosureMiddleware(extra_ref=_extra_ref, specs_by_slug=specs_by_slug)`
+to `cubepi_middleware` immediately after `SkillsMiddleware` (~1267). The
+`extra_ref` closure resolves to `agent._extra` once it's late-bound at ~1403,
+exactly like skills/compaction/todo.
+
+When `active`, append the catalog suffix to `effective_system_prompt`. The suffix
+is built in `_run_cubepi_path` (where `specs` are loaded), not at ~1799 (which
+runs before the run path and has no specs). Move/duplicate the catalog injection
+into the run path right after the MCP load, mirroring how skills append to the
+prompt — append `render_catalog(specs)` to `effective_system_prompt` before
+`create_cubebox_agent`.
+
+### 6c. The deferral branch (from Task 0)
+
+- **Next-turn fallback (`MID_RUN_UNSUPPORTED`, expected):** on each run, read
+  `expanded` from the **replayed** `agent._extra["expanded_mcp_servers"]` (the
+  checkpointer persists `_extra` via `save_extra` at `agent_end`, same as
+  `loaded_skills`). Because `_extra` is only available after `create_cubebox_agent`,
+  read the **persisted** prior-run extra before constructing the agent: load it
+  from the checkpointer history (`cp.load(conversation_id)`) — the same
+  `init_checkpointer()`/`cp.load` already used for citation seeding at ~1375. Build
+  `only_install_ids` from that replayed ordered list. A server expanded on turn N
+  becomes callable on turn N+1. The `expand_mcp_server` call on turn N still
+  records the slug into the live `_extra`, which is persisted and picked up next
+  turn. **Document this one-turn delay in the `expand_mcp_server` tool description**
+  so the model expects it ("the server's tools become available on your next
+  turn").
+- **True deferral (`MID_RUN_SUPPORTED`):** after `after_tool_call` records the
+  slug, also load that server's callable tools via the filtered loader and add
+  them to the live agent through cubepi's mid-run mechanism (whatever Task 0
+  found), and re-mark the cache boundary. Tool description drops the "next turn"
+  caveat. This depends on the released+pinned cubepi capability.
+
+> Confirm which branch you are on by re-reading the Task 0 note. Do not build both.
+
+### 6d. E2E test (write first)
+
+`tests/e2e/test_mcp_disclosure_runtime.py`, using `stub_discover_tools` and the
+install-creation pattern from `tests/e2e/test_mcp_four_layer_runtime.py`:
+
+1. With disclosure enabled and ≥ `min_servers` usable servers installed: assert
+   the assembled `tools=` contains `expand_mcp_server` and **no** namespaced MCP
+   tools from collapsed servers; assert the system prompt contains the catalog
+   (server slugs, tool counts) and **no** `input_schema`.
+2. Drive a run that calls `expand_mcp_server("<slug>")`; assert the slug is in
+   `agent._extra["expanded_mcp_servers"]` and (per branch) the expanded server's
+   namespaced tools are callable (same run for true deferral / next run for
+   fallback) and produce a result.
+3. Assert citations still attach for the expanded server (`mcp_citation_configs`
+   populated for it; `CitationMiddleware` unchanged).
+
+Run:
+```bash
+cd backend && uv run pytest tests/e2e/test_mcp_disclosure_runtime.py -q
+```
+Expected: all pass (real simulated MCP discovery via `stub_discover_tools`).
+
+---
+
+## Task 7 — Threshold below-min byte-identical guard (E2E)
+
+Prove the small-workspace path is unchanged: below `min_servers`, no catalog, no
+`expand_mcp_server`, all servers' tools eagerly loaded exactly as today.
+
+Files:
+- `backend/tests/e2e/test_mcp_disclosure_runtime.py` (add a case).
+
+Assert: with `min_servers=3` and 2 usable servers, the assembled prompt has no
+catalog header and `tools=` contains every server's namespaced tools (status
+quo), and `expand_mcp_server` is **absent**.
+
+Run:
+```bash
+cd backend && uv run pytest tests/e2e/test_mcp_disclosure_runtime.py -q -k threshold
+```
+Expected: pass.
+
+---
+
+## Task 8 — Cache-prefix stability E2E (THE GATE)
+
+Extend the existing real-LLM cache regression. This is the single most important
+test per the spec.
+
+Files:
+- `backend/tests/e2e/memory/test_prompt_cache.py` (extend, mirroring
+  `test_cache_hit_rate_meets_bar`).
+
+Assert, with disclosure active and ≥ `min_servers` servers:
+1. **Catalog stability:** the cache-eligible prefix is byte-stable across turns
+   with the catalog present and nothing expanded (catalog derived purely from DB,
+   slug-sorted → identical every turn).
+2. **Append-only after expansion:** after the model expands one server, the next
+   turn's prefix **starts with** the previous turn's expanded-schema text and only
+   appends the new block — no mid-prefix mutation, no reorder. Expanding a second
+   server appends after the first (expansion order, not slug order).
+3. Reuse the existing `CUBEBOX_E2E_LLM_CACHE_CAPABLE` skip semantics so the test
+   discriminates "endpoint doesn't honor cache" from "we broke the prefix".
+
+Run:
+```bash
+cd backend && CUBEBOX_E2E_LLM_CACHE_CAPABLE=true uv run pytest \
+  tests/e2e/memory/test_prompt_cache.py -q
+```
+Expected: pass (or principled SKIP if the endpoint can't cache — never weaken the
+bar to make it pass; per `prompt-cache-discipline.md` find the dynamic content
+instead).
+
+---
+
+## Task 9 — Pre-PR sweep + self-review
+
+Files: none (verification only).
+
+1. Full backend suite on the worktree slot DB:
+   ```bash
+   cd backend && uv run pytest -q
+   ```
+   Expected: green (the worktree conftest auto-routes to
+   `cubebox_test_feat_mcp_progressive_disclosure`).
+2. Type + lint:
+   ```bash
+   cd backend && uv run mypy cubebox && uv run ruff check cubebox tests
+   ```
+   Expected: no errors; lines ≤ 100.
+3. Confirm: collapsed servers contribute zero entries to `tools=` (grep the E2E
+   assertions); `tools_cache` is used only by the catalog/expand-preview/schema
+   renderers, never as an `AgentTool` source; expanded state is an **ordered
+   list** end to end (model → tool → middleware `after_tool_call` → `_extra` →
+   checkpointer persist → next-run replay) and never re-sorted.
+4. Confirm the Task 0 note records the chosen branch and that only that branch was
+   built.
+
+---
+
+## Open items carried from the spec (not blocking v1)
+
+- Authored `trigger_hints` field + editing UI — Later (no migration in v1; v1
+  derives the hint from description).
+- Per-tool (sub-server) disclosure, semantic retrieval, code-mode,
+  provider-native deferred tools — Later.
+- Subagent expanded-set inheritance — v1: subagents start collapsed (their own
+  assembly); revisit if needed.
+- Re-collapse mid-conversation — explicitly **not** in v1 (monotonic growth is
+  what keeps the cache safe).
+- Stale `tools_cache`: callable tools always come from live discovery on expand,
+  so a stale cache cannot make the model call a non-existent tool; only the
+  catalog/preview text can drift — accepted for v1, refresh `tools_cache` out of
+  band.

--- a/docs/dev/plans/2026-05-27-mcp-progressive-disclosure.md
+++ b/docs/dev/plans/2026-05-27-mcp-progressive-disclosure.md
@@ -1,5 +1,17 @@
 # MCP Progressive Disclosure Implementation Plan
 
+> **⚠ PENDING REVISION (2026-06-09):** The spec has been updated with three
+> significant design changes from the hermes-agent research pass:
+> 1. **cubepi/cubebox layering** — core mechanism (`DeferredToolGroup`, `expand_tools`,
+>    middleware) moves into cubepi as a generic primitive; cubebox provides MCP → group mapping.
+> 2. **Catalog includes tool names** — not just server slug + description.
+> 3. **Threshold = context-window token %** (default 10%) + `min_servers` secondary guard.
+>
+> The tasks below still reference the old names (`expand_mcp_server`,
+> `MCPDisclosureMiddleware`, `min_servers`-only threshold). A plan revision is needed
+> before implementation begins. The cubepi-side work is tracked as a separate cubepi
+> issue and should land first.
+
 > For agentic workers: execute tasks top to bottom. Each task is TDD — write the
 > test first, watch it fail, implement, watch it pass. Stay on branch
 > `feat/mcp-progressive-disclosure`; never switch to main or merge mid-execution.
@@ -9,7 +21,7 @@
 > **Task 0 (the spike) gates the whole plan** — its answer selects the deferral
 > mode for Task 6. Do not skip or reorder it.
 
-Date: 2026-05-27
+Date: 2026-05-27 (spec revised 2026-06-09)
 Spec: `docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md`
 Issue: #143
 

--- a/docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md
+++ b/docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md
@@ -216,32 +216,51 @@ exactly the "toggling MCP tools mid-conversation" the cache doc warns against. A
 text to the system-prompt suffix is the same trick skills already use and is proven cache-safe.
 
 **The catch — actually calling an expanded tool.** Putting a tool's *schema text* in the prompt
-does not register a callable `AgentTool`. Two candidate resolutions (this is the central open
-question, see below):
+does not register a callable `AgentTool`. The naive shortcut — register *all* usable servers'
+tools as real `AgentTool`s up front and merely **omit collapsed servers from the catalog text** —
+does **not** save anything. Those tools still flow through `tools=all_tools` into
+`create_cubebox_agent`, so the model still receives every collapsed server's full schema in the
+tool block and pays the identical cache-write/cache-read and attention cost as today. Hiding a
+tool in the prose while still shipping its schema in `tools=` is not disclosure at all. So
+pre-register-all is **rejected**: it is the status quo with a shorter catalog, not a cost win.
 
-- **(A) Pre-register, hide via prompt.** Register *all* usable servers' tools as real `AgentTool`s
-  up front (so they're callable), but **omit collapsed servers from the catalog/prompt** and only
-  describe expanded ones. This keeps the callable set complete but does **not** shrink the
-  `tools=` block — so it reduces *attention dilution* and prompt-described surface but **not**
-  cache cost. Likely insufficient on its own.
-- **(B) True deferral.** Register only expanded servers' tools as callable `AgentTool`s. Because
-  the cube cache rule treats the tool block as fixed per conversation, expanding mid-conversation
-  would change the tool block — which the discipline doc says must be handled as a *new
-  conversation* (cache reset). That's acceptable if expansion is rare and front-loaded, but needs
-  cubepi support to add tools to a live agent and to re-mark the cache boundary. **This is the
-  design's load-bearing dependency on cubepi** and the main thing to validate before building.
+To realize the token/cache/attention savings the schemas of collapsed servers must be **absent
+from the tool set itself**, not just from the prompt text. v1 therefore commits to **true
+deferral (register-on-first-expand)**:
 
-A pragmatic v1 may combine them: catalog by default (cheap prompt), and on first
-`expand_mcp_server` for a server, register that server's tools and accept a one-time cache
-re-establish for the remainder of the conversation (a known, bounded cost, far cheaper than
-carrying every schema every turn from turn one).
+- The `tools=` block at agent-creation time contains **only**: the always-on builtins,
+  `expand_mcp_server`, and the tools of any servers already expanded earlier in this conversation
+  (replayed from `extra["expanded_mcp_servers"]`). Collapsed servers contribute **zero** tool
+  definitions and zero schema text.
+- When the model calls `expand_mcp_server(server)`, that server's tools (built from `tools_cache`)
+  become callable `AgentTool`s for the remainder of the conversation, and its schema text is
+  appended to the system-prompt suffix per the middleware above.
+- Because the cache discipline treats the tool block as fixed per conversation, *adding* tools
+  mid-conversation changes that block. We model each expansion as a **cache re-establishment
+  point** — the same treatment the discipline doc gives the "new conversation" case — not as a
+  silent mid-prefix mutation. This is a bounded, one-time cost per expanded server, far cheaper
+  than carrying every collapsed server's schema on every turn from turn one.
+
+**Load-bearing cubepi dependency.** True deferral requires cubepi to support changing a live
+agent's callable tool set mid-run (add the newly expanded server's `AgentTool`s) and to re-mark
+the cache boundary at that point. If cubepi cannot do this today, that is an **upstream cubepi
+change** (cubepi is self-authored, upstream-first) and must land before this feature ships.
+The **fallback that needs no cubepi change** is to keep the tool set fixed for the lifetime of a
+single agent run: expansions requested during a run take effect on the **next** run (next user
+turn), where the tool set is rebuilt to include all servers expanded so far. This still delivers
+the savings (collapsed servers are never in `tools=`) at the cost of a one-turn delay before a
+just-expanded server is callable. Validate cubepi's mid-run capability before building; if absent,
+ship the next-turn fallback for v1 and pursue the cubepi change as a follow-up. Either way,
+pre-register-all is not on the table — it saves nothing.
 
 ### 4. Where it plugs into assembly
 
 - `run_manager.py` system-prompt section (~line 1799, beside the skills index): add the MCP
   catalog suffix when the feature is enabled and the workspace has ≥ N usable servers.
 - `run_manager.py` tool assembly (~line 1034): replace the unconditional "load all MCP tools" with
-  the disclosure-aware path (per the A/B decision above).
+  the deferral-aware path — load only the tools of servers expanded so far this conversation
+  (from `extra["expanded_mcp_servers"]`), never the collapsed ones, so `tools=all_tools` never
+  carries a collapsed server's schema.
 - Register `expand_mcp_server` builtin in the fixed order slot.
 - Append `MCPDisclosureMiddleware` to `cubepi_middleware` with an `extra_ref` closure, mirroring
   `SkillsMiddleware` (~line 1263).
@@ -257,7 +276,7 @@ carrying every schema every turn from turn one).
   the enabled set is fixed up front and identical every turn; MCP servers expand incrementally
   mid-conversation, so slug-sorting could insert a later expansion *before* an already-cached block
   and invalidate that prefix — expansion order avoids this.)
-- If we go with deferral (B), expansion is explicitly modeled as a **cache re-establishment point**
+- With true deferral, expansion is explicitly modeled as a **cache re-establishment point**
   (treated like the documented "new conversation" case), never as a silent mid-prefix mutation.
 - No timestamps, nonces, or per-user dynamic data enter the catalog or schema text.
 
@@ -286,7 +305,11 @@ Mostly reuses existing columns; minimal additions.
 - `expand_mcp_server` builtin + `MCPDisclosureMiddleware` (skills-pattern port).
 - Config-gated by `enabled` + `min_servers`; off-by-default behavior identical to today below the
   threshold.
-- Decide and implement one of A / B / hybrid for making expanded tools callable.
+- **True deferral / register-on-first-expand**: collapsed servers' tools are never in `tools=`;
+  expanding a server registers its tools as callable for the rest of the conversation. If cubepi
+  cannot change a live agent's tool set mid-run, ship the next-turn fallback (expansions take
+  effect on the following user turn) and land the cubepi change as a follow-up. Pre-register-all
+  is explicitly **not** a v1 option — it saves no cache/attention cost.
 
 **Later:**
 - Per-tool (sub-server) disclosure for very large single servers.
@@ -318,14 +341,12 @@ fall back to fake-server-only unit coverage.
 
 ## Open Questions
 
-- **Callability of expanded tools (the central one).** A (pre-register all, hide in prompt — saves
-  attention but not cache cost), B (true deferral — needs cubepi support to add tools to a live
-  agent + re-mark the cache boundary), or a hybrid (catalog by default, register-on-first-expand +
-  one-time cache re-establish)? This determines whether we actually save cache cost or only reduce
-  attention dilution.
 - **Does cubepi support adding tools to a running agent** and re-establishing the cache boundary
-  mid-conversation? If not, is that an upstream cubepi change (cubepi is self-authored, upstream
-  first) or do we front-load all expansions before the loop? Validate before building.
+  mid-conversation? This is now the load-bearing residual (the callability approach is decided:
+  true deferral, not pre-register-all). If cubepi *can* change a live agent's tool set mid-run, a
+  just-expanded server is callable within the same turn. If it *cannot*, v1 ships the next-turn
+  fallback (expansion takes effect on the following user turn) and the cubepi change lands as a
+  follow-up (cubepi is self-authored, upstream-first). Validate this capability before building.
 - **What does `expand_mcp_server` return?** Just an acknowledgement (middleware injects schemas) vs
   the schema list in the tool result itself. Affects token placement and replay/cache behavior.
 - **Trigger hints source.** Derive from description automatically, or add an authored

--- a/docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md
+++ b/docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md
@@ -201,12 +201,14 @@ it to call `expand_mcp_server(server)`.
 
 A new middleware modeled almost exactly on `SkillsMiddleware`:
 
-- **`after_tool_call`**: when the tool is `expand_mcp_server` and it succeeded, add the server slug
-  to `extra["expanded_mcp_servers"]` (a set, stored as a sorted list for determinism).
-- **`transform_system_prompt`**: for each expanded server (sorted by slug), append a stable
+- **`after_tool_call`**: when the tool is `expand_mcp_server` and it succeeded, append the server
+  slug to `extra["expanded_mcp_servers"]` **in expansion order** (an ordered list, de-duplicated,
+  preserving first-expanded-first). Do **not** sort it — expansion order *is* the cache order.
+- **`transform_system_prompt`**: for each expanded server **in expansion order**, append a stable
   section listing that server's full tool definitions (namespaced name + description + input
-  schema), rendered from the **cached** `tools_cache` for that install. Sorting + append-only
-  growth keeps the prefix monotonic and cache-stable, identical to the skills approach.
+  schema), rendered from the **cached** `tools_cache` for that install. Appending in expansion
+  order keeps the prefix monotonic and cache-stable: a newly expanded server's block always lands
+  *after* every already-rendered block, so earlier cache segments stay byte-identical.
 
 Why schemas go in the **system-prompt suffix**, not the tool list: the tool *list* (`tools=...`) is
 fixed before the agent loop starts and is the most cache-sensitive region; mutating it mid-run is
@@ -249,9 +251,12 @@ carrying every schema every turn from turn one).
 ### 5. How the prompt-cache prefix stays intact
 
 - The **catalog** is derived purely from DB state, sorted by slug → byte-identical every turn.
-- **Expanded-server schema text** is appended to the system-prompt **suffix**, sorted by slug, and
-  only ever grows (append-only) within a conversation → matches the skills cache pattern, which the
-  cache E2E test already protects.
+- **Expanded-server schema text** is appended to the system-prompt **suffix** in **expansion
+  order** (never re-sorted), and only ever grows (append-only) within a conversation → matches the
+  skills cache pattern, which the cache E2E test already protects. (Skills can sort by name because
+  the enabled set is fixed up front and identical every turn; MCP servers expand incrementally
+  mid-conversation, so slug-sorting could insert a later expansion *before* an already-cached block
+  and invalidate that prefix — expansion order avoids this.)
 - If we go with deferral (B), expansion is explicitly modeled as a **cache re-establishment point**
   (treated like the documented "new conversation" case), never as a silent mid-prefix mutation.
 - No timestamps, nonces, or per-user dynamic data enter the catalog or schema text.
@@ -305,8 +310,10 @@ fall back to fake-server-only unit coverage.
   (4) citations still attach for expanded servers.
 - **Threshold behavior.** Below `min_servers`, behavior is byte-identical to today (no catalog, all
   tools loaded) — guards the small-workspace path.
-- **Determinism unit tests.** Catalog rendering and expanded-schema rendering are sorted and stable
-  for a fixed input set (cheap to unit-test alongside the E2E).
+- **Determinism unit tests.** Catalog rendering is sorted by slug and stable for a fixed input set;
+  expanded-schema rendering is stable for a fixed **expansion sequence** (same servers expanded in
+  the same order → byte-identical output, and adding one more expansion only appends). Cheap to
+  unit-test alongside the E2E.
 - **Per-task incremental runs during dev**, full suite in the pre-PR sweep, per CLAUDE.md.
 
 ## Open Questions
@@ -330,7 +337,11 @@ fall back to fake-server-only unit coverage.
   token-cost measurement on representative workspaces.
 - **Expanded state persistence across turns.** `extra["expanded_mcp_servers"]` lives in agent
   extra and is persisted like `loaded_skills` — confirm it replays correctly so a server expanded
-  on turn 1 stays expanded on turn 5 without re-triggering a cache reset each turn.
+  on turn 1 stays expanded on turn 5 without re-triggering a cache reset each turn. Because the
+  cache invariant now depends on **expansion order** (not slug sort), persistence must preserve that
+  order too: serialize as an ordered list and replay it unchanged. If a future store reloads it as
+  an unordered set, the rendered prefix could reorder across turns and silently break the cache —
+  call this out as a constraint on however `extra` is persisted.
 - **Stale `tools_cache`.** If a server's real tools drift from the cached schemas we render in the
   catalog/expansion, the model may call a tool that no longer exists (or miss a new one). Do we
   trust the cache, or live-discover on expand? Trusting the cache is cheaper and cache-stable;

--- a/docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md
+++ b/docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md
@@ -232,9 +232,14 @@ deferral (register-on-first-expand)**:
   `expand_mcp_server`, and the tools of any servers already expanded earlier in this conversation
   (replayed from `extra["expanded_mcp_servers"]`). Collapsed servers contribute **zero** tool
   definitions and zero schema text.
-- When the model calls `expand_mcp_server(server)`, that server's tools (built from `tools_cache`)
-  become callable `AgentTool`s for the remainder of the conversation, and its schema text is
-  appended to the system-prompt suffix per the middleware above.
+- When the model calls `expand_mcp_server(server)`, that server's **callable** `AgentTool`s are
+  obtained through the real runtime loader — `load_workspace_mcp_tools_for_cubepi`-style path,
+  which live-discovers via `load_mcp_tools_http(...)` with resolved auth — **filtered to the
+  expanded server(s)**, for the remainder of the conversation. `tools_cache` is *not* a tool
+  source: cached JSON schemas are not executable. The cache feeds only the lightweight catalog
+  index and the expansion preview/schema text appended to the system-prompt suffix per the
+  middleware above. So the runtime tool-load path that today loads all servers is **filtered to
+  expanded servers**, not replaced by synthesizing `AgentTool`s from `tools_cache`.
 - Because the cache discipline treats the tool block as fixed per conversation, *adding* tools
   mid-conversation changes that block. We model each expansion as a **cache re-establishment
   point** — the same treatment the discipline doc gives the "new conversation" case — not as a
@@ -257,10 +262,12 @@ pre-register-all is not on the table — it saves nothing.
 
 - `run_manager.py` system-prompt section (~line 1799, beside the skills index): add the MCP
   catalog suffix when the feature is enabled and the workspace has ≥ N usable servers.
-- `run_manager.py` tool assembly (~line 1034): replace the unconditional "load all MCP tools" with
-  the deferral-aware path — load only the tools of servers expanded so far this conversation
-  (from `extra["expanded_mcp_servers"]`), never the collapsed ones, so `tools=all_tools` never
-  carries a collapsed server's schema.
+- `run_manager.py` tool assembly (~line 1034): replace the unconditional "load all MCP tools" call
+  to `load_workspace_mcp_tools_for_cubepi` with a **filtered** invocation of that same live loader —
+  it still live-discovers callable tools via `load_mcp_tools_http`, but restricted to the servers
+  expanded so far this conversation (from `extra["expanded_mcp_servers"]`), never the collapsed
+  ones. Filtering the live loader (not building tools from `tools_cache`) is what makes expanded
+  tools callable while keeping collapsed servers' schemas out of `tools=all_tools`.
 - Register `expand_mcp_server` builtin in the fixed order slot.
 - Append `MCPDisclosureMiddleware` to `cubepi_middleware` with an `extra_ref` closure, mirroring
   `SkillsMiddleware` (~line 1263).
@@ -284,8 +291,9 @@ pre-register-all is not on the table — it saves nothing.
 
 Mostly reuses existing columns; minimal additions.
 
-- **Reuse:** `MCPConnectorInstall.tools_cache` (schemas), `.discovery_metadata`, `.description`
-  (via template), `.slug_name` (catalog key). No new schema table strictly required for v1.
+- **Reuse:** `MCPConnectorInstall.tools_cache` (schemas — index/preview only, never a tool
+  source), `.discovery_metadata`, `.description` (via template), `.slug_name` (catalog key). No
+  new schema table strictly required for v1.
 - **Possible new field (open):** `trigger_hints: str | None` on `MCPConnectorInstall` (and/or
   template) to author the "Use when:" line, instead of deriving it. If added, follow the migration
   rule: `alembic revision --autogenerate`.
@@ -363,10 +371,13 @@ fall back to fake-server-only unit coverage.
   order too: serialize as an ordered list and replay it unchanged. If a future store reloads it as
   an unordered set, the rendered prefix could reorder across turns and silently break the cache —
   call this out as a constraint on however `extra` is persisted.
-- **Stale `tools_cache`.** If a server's real tools drift from the cached schemas we render in the
-  catalog/expansion, the model may call a tool that no longer exists (or miss a new one). Do we
-  trust the cache, or live-discover on expand? Trusting the cache is cheaper and cache-stable;
-  live-discovery is fresher but reintroduces per-run network + nondeterminism.
+- **Stale `tools_cache`.** Callable tools always come from live discovery on expand (the filtered
+  runtime loader), so a stale cache cannot make the model call a non-existent tool — the live tool
+  set is authoritative. The residual staleness risk is only the **catalog index + expansion
+  preview text** rendered from the cache: drift there can make the model expand the wrong server or
+  see a description that no longer matches. Open: re-render the preview from the live discovery
+  result on expand (perfectly consistent, but couples preview text to per-run discovery and could
+  perturb the suffix), or accept cache-rendered preview and refresh `tools_cache` out of band.
 - **Interaction with subagents.** Subagents get their own tool/middleware assembly — should they
   inherit the parent's expanded set, start collapsed, or be configured independently?
 - **Disabling mid-conversation / re-collapse.** Is there ever a need to collapse an expanded server

--- a/docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md
+++ b/docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md
@@ -48,9 +48,12 @@ given server's full tool set only when the model asks.
 - No change to how a tool actually executes once exposed (transport, namespacing, citations).
 - No semantic / embedding-based tool retrieval in v1 (noted as a later option below).
 - No "code mode" (exposing tools as a callable API the model writes code against) in v1.
-- No frontend redesign of MCP management surfaces. A small read-only indicator of which servers
+- No frontend redesign of MCP management surfaces. A small read-only indicator of which groups
   expanded during a run is acceptable but not required for v1.
-- No per-tool (sub-server) disclosure in v1 — the unit of expansion is a whole server.
+- No per-tool (sub-group) disclosure in v1 — the unit of expansion is a whole group (= MCP server
+  in v1).
+- No non-MCP group types in v1 — the cubepi primitive is generic, but cubebox v1 only maps MCP
+  servers to groups.
 
 ## Current state in cubebox (how MCP tools reach the prompt today)
 
@@ -105,7 +108,8 @@ grows by appending — never reorders — so earlier cache segments stay valid.
 ## Industry research (with citations)
 
 The "load a compact index, expand on demand" pattern is now the mainstream answer to tool/context
-bloat. What's transferable to cubebox:
+bloat. Three families of prior art, from provider-side features to self-hosted agent runtimes.
+What's transferable to cubebox:
 
 - **Anthropic Tool Search Tool / deferred tools (GA Feb 2026).** You register all tools but mark
   most with `defer_loading: true`; only a search tool plus a few always-on tools are in context.
@@ -136,79 +140,145 @@ bloat. What's transferable to cubebox:
   list. *Transferable as a later option:* semantic retrieval is the natural upgrade if a
   name+description catalog proves too coarse at high server counts.
 
+- **hermes-agent Tool Search (production, `~/hermes-agent/tools/tool_search.py`).** A full
+  progressive-disclosure layer for an agent runtime with MCP + plugin tools. Three bridge tools
+  (`tool_search`, `tool_describe`, `tool_call`) replace deferred tool schemas. Core tools
+  (`_HERMES_CORE_TOOLS`) never defer. Key design points:
+  - **Granularity = single tool** (vs. our server/group-level).
+  - **Threshold = context-window percentage** (default 10%): activates when deferrable tool schemas
+    would consume ≥ N% of context, not when a server-count threshold is crossed. This is more
+    direct — 3 tiny servers don't need deferral, 1 giant server does.
+  - **Stateless catalog**: rebuilt from the current tool-defs list every assembly, never cached
+    across turns. Lesson from OpenClaw #84141: a session-keyed catalog that drifts from the live
+    registry silently drops tools. cubebox avoids the same drift differently (live loader on expand,
+    not cached-schema synthesis), but the failure mode is worth defending against.
+  - **BM25 retrieval** over tokenized tool name + description + parameter names, with substring
+    fallback. Needed because their catalog is hundreds of individual tools with no readable index.
+  - **Toolset scoping**: bridge tools only see/invoke tools the session was granted. Defense in depth
+    via `scoped_deferrable_names()` gate before dispatch.
+  - **Transparent unwrap**: `tool_call` recurses into the real dispatcher; hooks/guardrails/activity
+    feed see the underlying tool, not the bridge.
+  *Transferable:* context-window-percentage threshold (adopted below), catalog-drift defense,
+  transparent unwrap principle. *Not transferable:* per-tool granularity (too many round trips at
+  our scale), stateless rebuild (conflicts with prompt-cache append-only invariant), BM25 (our
+  catalog is small enough for the model to read directly).
+
+- **LangChain / LangGraph dynamic tool management (2025–2026).** Three mechanisms:
+  (1) LangGraph **dynamic tool calling** (Aug 2025) — graph-state-driven per-node tool-set
+  switching; (2) LangChain 1.0 **`LLMToolSelectorMiddleware`** — secondary LLM call selects
+  relevant tools per turn; (3) DIY **vector-store tool retrieval** — embed tool descriptions,
+  top-k by similarity. All are per-turn automatic selection, not model-initiated expansion.
+  *Transferable:* validates the "filter before the model sees" principle. *Not transferable:*
+  per-turn LLM or vector retrieval adds latency/cost we avoid with a readable catalog.
+
 Recommendation drawn from the research: build a **host-side, provider-agnostic** index-then-expand
-mechanism modeled on cubebox's own skills system (a catalog in the prompt + an `expand_mcp_server`
-tool), rather than binding to any single provider's deferred-tools feature. Keep semantic retrieval
-and code-mode as documented later-stage options.
+mechanism in **cubepi** (the agent runtime) as a `DeferredToolGroup` primitive, with cubebox
+providing the MCP-specific mapping. Use context-window-percentage thresholds (hermes-agent's
+approach). Keep semantic retrieval and code-mode as documented later-stage options.
 
 ## Proposed design
 
-### Shape: mirror the skills pattern, at the *server* granularity
+### Shape: deferred tool groups, with MCP servers as the v1 group type
 
-Default behavior becomes: the prompt carries a **compact MCP catalog**; the model calls a builtin
-tool to **expand** a named server; expanded servers' full tools + schemas become available for the
-rest of the run. The unit of disclosure is a **server**, not an individual tool — this matches how
-users think about MCP ("I connected Linear"), keeps the catalog short, and reuses the existing
-per-server namespacing/citation plumbing wholesale.
+Default behavior becomes: the prompt carries a **compact catalog** of collapsed tool groups; the
+model calls a builtin tool to **expand** a named group; expanded groups' full tools + schemas
+become available for the rest of the run.
+
+The disclosure unit is a **tool group**, not an individual tool. MCP servers are the first (and v1
+only) group type, but the underlying mechanism is group-agnostic so future group types (plugins,
+large builtin suites) require no runtime changes — only a new mapping from source → group. This
+matches how users think about MCP ("I connected Linear"), keeps the catalog short, and reuses the
+existing per-server namespacing/citation plumbing wholesale.
+
+### 0. Layering: cubepi primitive + cubebox mapping
+
+The core mechanism lives in **cubepi** (the agent runtime) as a `DeferredToolGroup` abstraction.
+cubebox provides the application-specific wiring.
+
+**cubepi provides (generic, tool-source-agnostic):**
+- `DeferredToolGroup` data structure: `group_id`, `display_name`, `description`, `tool_names`
+  (for catalog display), `loader` callback (returns `list[AgentTool]` on expand).
+- `agent.register_deferred_group(group)` registration API.
+- Catalog text rendering from registered groups (deterministic, sorted by `group_id`).
+- `expand_tools(group_id)` builtin tool: validates group_id, invokes loader, injects tools into
+  the active set, updates prompt suffix.
+- `DeferredToolsMiddleware`: `after_tool_call` records expansion order in `extra`;
+  `transform_system_prompt` appends expanded schema text in expansion order (append-only).
+
+**cubebox provides (MCP-specific):**
+- Mapping `MCPRuntimeConnectorSpec` → `DeferredToolGroup` (group_id = `mcp:{slug}`, tool_names
+  from `tools_cache`, loader = filtered `load_workspace_mcp_tools_for_cubepi`).
+- Threshold decision: which servers to defer (context-window-percentage gate, see §config below).
+- Catalog description derivation from `discovery_metadata`.
+- Expansion state persistence across turns (via `agent._extra` → checkpointer).
 
 ### 1. Catalog index (what's in the prompt by default)
 
 Built from data **already in Postgres** (`tools_cache`, `discovery_metadata`, template/install
 `name`/`description`) — no live discovery needed to render it. Rendered as a stable suffix of the
-system prompt, sorted by server slug, e.g.:
+system prompt, sorted by group_id (= server slug for MCP), e.g.:
 
 ```
 # Connected tool servers (collapsed)
 
 These servers are connected but their tools are not loaded yet. Call
-`expand_mcp_server(server)` with a name below to load that server's tools for the
+`expand_tools(group_id)` with a group_id below to load that group's tools for the
 rest of this conversation.
 
-- `linear` — Issue tracking: create/update/search issues, projects, cycles. (8 tools)
-  Use when: tracking work, filing bugs, querying project status.
-- `gdrive` — Google Drive: search and read documents, list folders. (5 tools)
-  Use when: finding or reading shared docs/spreadsheets.
+- `mcp:linear` — Issue tracking (8 tools)
+  create_issue, update_issue, search_issues, get_issue, create_project,
+  list_projects, create_cycle, list_cycles
+- `mcp:gdrive` — Google Drive (5 tools)
+  search_files, read_file, list_folders, get_file_metadata, create_file
 ```
 
-Per-server line content:
-- **Name** = the namespacing slug (so `expand_mcp_server("linear")` is unambiguous).
-- **One-line description** = install/template `description`, trimmed.
-- **Trigger hints** = a short "Use when:" phrase. Source options (open question below): derive from
-  description, or add an optional authored `trigger_hints` field on the install/template.
-- **Tool count** so the model can gauge cost/coverage.
+Per-group content:
+- **group_id** = `mcp:{slug}` (so `expand_tools("mcp:linear")` is unambiguous).
+- **One-line description** = from `discovery_metadata`, trimmed.
+- **Tool names** = the namespaced tool names from `tools_cache`, listed without descriptions or
+  JSON schemas. Tool names are the highest signal-to-noise ratio element: `search_issues` is more
+  precise than "Issue tracking" and far more compact than a full schema. A typical 12-tool server
+  adds ~40 tokens of tool names — 10 servers total ~400 tokens, vs 5000+ for full schemas.
+- **Tool count** in parentheses.
 
-The catalog never contains per-tool JSON schemas — that's the whole point. It is fully derived
-from DB state that's identical turn-to-turn, so it's cache-safe as a suffix.
+The catalog never contains per-tool JSON schemas or per-tool descriptions — only tool names.
+This is the right trade-off: tool names are self-descriptive (MCP tools follow `verb_noun`
+convention), and the model can decide which group to expand just by scanning the name list.
+No BM25 or semantic retrieval needed at this catalog size.
 
-### 2. Expansion tool: `expand_mcp_server`
+The catalog is fully derived from DB state that's identical turn-to-turn, so it's cache-safe as a
+suffix.
+
+### 2. Expansion tool: `expand_tools`
 
 A new builtin tool (sibling of `load_skill`), placed in the fixed tool order **where the MCP tools
 used to go** (after `load_skill`), so the cache-prefix tool ordering rule is respected. Input:
-`{ server: str }` (the catalog slug). Behavior:
+`{ group_id: str }` (the catalog group_id, e.g. `"mcp:linear"`). Behavior:
 
-- Validate the slug against the workspace's usable installs.
-- Return a JSON result (analogous to `LoadSkillOutput`) listing the server's tools — at minimum
-  the namespaced tool names + descriptions, and optionally the schemas (open question: does the
-  tool *return* schemas, or just acknowledge, letting middleware do the injection?). The design
-  keeps schemas out of the tool *result* and lets the middleware add them to the prefix, matching
-  how `SkillsMiddleware` injects skill bodies rather than re-emitting them per tool result.
-- Record the expanded server in `agent._extra["expanded_mcp_servers"]` via an `extra_ref` closure.
+- Validate the group_id against registered deferred groups.
+- Invoke the group's `loader` callback to obtain callable `AgentTool`s.
+- Return a JSON result (analogous to `LoadSkillOutput`) listing the group's tools — the namespaced
+  tool names + descriptions, **no schemas in the result** — middleware injects schema text into the
+  system-prompt suffix, matching how `SkillsMiddleware` injects skill bodies.
+- Record the expanded group_id in `agent._extra["expanded_groups"]` via an `extra_ref` closure.
 
 The model learns about this tool the same way it learns about `load_skill`: the catalog text tells
-it to call `expand_mcp_server(server)`.
+it to call `expand_tools(group_id)`.
 
-### 3. `MCPDisclosureMiddleware` (the cache-safe injector)
+**cubepi owns the tool definition and dispatch.** cubebox only registers the deferred groups
+(with their loaders); the expand tool itself is generic and knows nothing about MCP.
 
-A new middleware modeled almost exactly on `SkillsMiddleware`:
+### 3. `DeferredToolsMiddleware` (the cache-safe injector, in cubepi)
 
-- **`after_tool_call`**: when the tool is `expand_mcp_server` and it succeeded, append the server
-  slug to `extra["expanded_mcp_servers"]` **in expansion order** (an ordered list, de-duplicated,
-  preserving first-expanded-first). Do **not** sort it — expansion order *is* the cache order.
-- **`transform_system_prompt`**: for each expanded server **in expansion order**, append a stable
-  section listing that server's full tool definitions (namespaced name + description + input
-  schema), rendered from the **cached** `tools_cache` for that install. Appending in expansion
-  order keeps the prefix monotonic and cache-stable: a newly expanded server's block always lands
-  *after* every already-rendered block, so earlier cache segments stay byte-identical.
+A new middleware in **cubepi**, modeled almost exactly on `SkillsMiddleware`:
+
+- **`after_tool_call`**: when the tool is `expand_tools` and it succeeded, append the group_id to
+  `extra["expanded_groups"]` **in expansion order** (an ordered list, de-duplicated, preserving
+  first-expanded-first). Do **not** sort it — expansion order *is* the cache order.
+- **`transform_system_prompt`**: for each expanded group **in expansion order**, append a stable
+  section listing that group's full tool definitions (name + description + input schema). Appending
+  in expansion order keeps the prefix monotonic and cache-stable: a newly expanded group's block
+  always lands *after* every already-rendered block, so earlier cache segments stay byte-identical.
 
 Why schemas go in the **system-prompt suffix**, not the tool list: the tool *list* (`tools=...`) is
 fixed before the agent loop starts and is the most cache-sensitive region; mutating it mid-run is
@@ -216,72 +286,74 @@ exactly the "toggling MCP tools mid-conversation" the cache doc warns against. A
 text to the system-prompt suffix is the same trick skills already use and is proven cache-safe.
 
 **The catch — actually calling an expanded tool.** Putting a tool's *schema text* in the prompt
-does not register a callable `AgentTool`. The naive shortcut — register *all* usable servers'
-tools as real `AgentTool`s up front and merely **omit collapsed servers from the catalog text** —
-does **not** save anything. Those tools still flow through `tools=all_tools` into
-`create_cubebox_agent`, so the model still receives every collapsed server's full schema in the
+does not register a callable `AgentTool`. The naive shortcut — register *all* groups' tools as
+real `AgentTool`s up front and merely **omit collapsed groups from the catalog text** — does
+**not** save anything. Those tools still flow through `tools=all_tools` into
+`create_cubebox_agent`, so the model still receives every collapsed group's full schema in the
 tool block and pays the identical cache-write/cache-read and attention cost as today. Hiding a
 tool in the prose while still shipping its schema in `tools=` is not disclosure at all. So
 pre-register-all is **rejected**: it is the status quo with a shorter catalog, not a cost win.
 
-To realize the token/cache/attention savings the schemas of collapsed servers must be **absent
+To realize the token/cache/attention savings the schemas of collapsed groups must be **absent
 from the tool set itself**, not just from the prompt text. v1 therefore commits to **true
 deferral (register-on-first-expand)**:
 
 - The `tools=` block at agent-creation time contains **only**: the always-on builtins,
-  `expand_mcp_server`, and the tools of any servers already expanded earlier in this conversation
-  (replayed from `extra["expanded_mcp_servers"]`). Collapsed servers contribute **zero** tool
+  `expand_tools`, and the tools of any groups already expanded earlier in this conversation
+  (replayed from `extra["expanded_groups"]`). Collapsed groups contribute **zero** tool
   definitions and zero schema text.
-- When the model calls `expand_mcp_server(server)`, that server's **callable** `AgentTool`s are
-  obtained through the real runtime loader — `load_workspace_mcp_tools_for_cubepi`-style path,
-  which live-discovers via `load_mcp_tools_http(...)` with resolved auth — **filtered to the
-  expanded server(s)**, for the remainder of the conversation. `tools_cache` is *not* a tool
-  source: cached JSON schemas are not executable. The cache feeds only the lightweight catalog
-  index and the expansion preview/schema text appended to the system-prompt suffix per the
-  middleware above. So the runtime tool-load path that today loads all servers is **filtered to
-  expanded servers**, not replaced by synthesizing `AgentTool`s from `tools_cache`.
+- When the model calls `expand_tools(group_id)`, the group's `loader` callback is invoked. For
+  MCP groups, this calls the real runtime loader —
+  `load_workspace_mcp_tools_for_cubepi`-style path, which live-discovers via
+  `load_mcp_tools_http(...)` with resolved auth — **filtered to the expanded server(s)**, for the
+  remainder of the conversation. `tools_cache` is *not* a tool source: cached JSON schemas are not
+  executable. The cache feeds only the lightweight catalog index and the expansion schema text
+  appended to the system-prompt suffix per the middleware above.
 - Because the cache discipline treats the tool block as fixed per conversation, *adding* tools
   mid-conversation changes that block. We model each expansion as a **cache re-establishment
   point** — the same treatment the discipline doc gives the "new conversation" case — not as a
-  silent mid-prefix mutation. This is a bounded, one-time cost per expanded server, far cheaper
-  than carrying every collapsed server's schema on every turn from turn one.
+  silent mid-prefix mutation. This is a bounded, one-time cost per expanded group, far cheaper
+  than carrying every collapsed group's schema on every turn from turn one.
 
-**Load-bearing cubepi dependency.** True deferral requires cubepi to support changing a live
-agent's callable tool set mid-run (add the newly expanded server's `AgentTool`s) and to re-mark
-the cache boundary at that point. If cubepi cannot do this today, that is an **upstream cubepi
-change** (cubepi is self-authored, upstream-first) and must land before this feature ships.
-The **fallback that needs no cubepi change** is to keep the tool set fixed for the lifetime of a
-single agent run: expansions requested during a run take effect on the **next** run (next user
-turn), where the tool set is rebuilt to include all servers expanded so far. This still delivers
-the savings (collapsed servers are never in `tools=`) at the cost of a one-turn delay before a
-just-expanded server is callable. Validate cubepi's mid-run capability before building; if absent,
-ship the next-turn fallback for v1 and pursue the cubepi change as a follow-up. Either way,
-pre-register-all is not on the table — it saves nothing.
+**Load-bearing cubepi dependency.** True deferral requires cubepi to support `DeferredToolGroup`
+as a first-class concept: registration, catalog rendering, `expand_tools` builtin, mid-run tool
+injection + cache re-establishment. This is a **new cubepi feature** (tracked as a separate cubepi
+issue), not just a single API call. The scope:
+- `DeferredToolGroup` dataclass + `agent.register_deferred_group()` API
+- `expand_tools` builtin with loader invocation
+- `DeferredToolsMiddleware` (expansion-order tracking + system-prompt suffix injection)
+- Mid-run tool-set mutation (add `AgentTool`s to a live agent's context)
 
-### 4. Where it plugs into assembly
+If cubepi cannot ship all of this before cubebox v1, the **fallback** is to keep the tool set
+fixed for the lifetime of a single agent run: expansions requested during a run take effect on the
+**next** run (next user turn), where the tool set is rebuilt to include all groups expanded so far.
+This still delivers the savings (collapsed groups are never in `tools=`) at the cost of a one-turn
+delay before a just-expanded group is callable. Either way, pre-register-all is not on the table —
+it saves nothing.
 
-- `run_manager.py` system-prompt section (~line 1799, beside the skills index): add the MCP
-  catalog suffix when the feature is enabled and the workspace has ≥ N usable servers.
+### 4. Where it plugs into assembly (cubebox side)
+
+- `run_manager.py` system-prompt section (~line 1799, beside the skills index): add the catalog
+  suffix when disclosure is active.
 - `run_manager.py` tool assembly (~line 1034): replace the unconditional "load all MCP tools" call
   to `load_workspace_mcp_tools_for_cubepi` with a **filtered** invocation of that same live loader —
-  it still live-discovers callable tools via `load_mcp_tools_http`, but restricted to the servers
-  expanded so far this conversation (from `extra["expanded_mcp_servers"]`), never the collapsed
-  ones. Filtering the live loader (not building tools from `tools_cache`) is what makes expanded
-  tools callable while keeping collapsed servers' schemas out of `tools=all_tools`.
-- Register `expand_mcp_server` builtin in the fixed order slot.
-- Append `MCPDisclosureMiddleware` to `cubepi_middleware` with an `extra_ref` closure, mirroring
-  `SkillsMiddleware` (~line 1263).
+  restricted to the groups expanded so far this conversation (from `extra["expanded_groups"]`),
+  never the collapsed ones. For each non-expanded MCP server, register a `DeferredToolGroup` with
+  cubepi via `agent.register_deferred_group(...)`.
+- cubepi auto-registers the `expand_tools` builtin when deferred groups exist (no manual slot
+  management in cubebox).
+- cubepi auto-appends `DeferredToolsMiddleware` when deferred groups are registered.
 - Citations: keep `mcp_citation_configs` populated for expanded servers exactly as today; the
   `CitationMiddleware` (~line 1163) is unchanged.
 
 ### 5. How the prompt-cache prefix stays intact
 
-- The **catalog** is derived purely from DB state, sorted by slug → byte-identical every turn.
-- **Expanded-server schema text** is appended to the system-prompt **suffix** in **expansion
+- The **catalog** is derived purely from DB state, sorted by group_id → byte-identical every turn.
+- **Expanded-group schema text** is appended to the system-prompt **suffix** in **expansion
   order** (never re-sorted), and only ever grows (append-only) within a conversation → matches the
   skills cache pattern, which the cache E2E test already protects. (Skills can sort by name because
-  the enabled set is fixed up front and identical every turn; MCP servers expand incrementally
-  mid-conversation, so slug-sorting could insert a later expansion *before* an already-cached block
+  the enabled set is fixed up front and identical every turn; tool groups expand incrementally
+  mid-conversation, so id-sorting could insert a later expansion *before* an already-cached block
   and invalidate that prefix — expansion order avoids this.)
 - With true deferral, expansion is explicitly modeled as a **cache re-establishment point**
   (treated like the documented "new conversation" case), never as a silent mid-prefix mutation.
@@ -298,10 +370,14 @@ Mostly reuses existing columns; minimal additions.
   template) to author the "Use when:" line, instead of deriving it. If added, follow the migration
   rule: `alembic revision --autogenerate`.
 - **Config flags (likely in `mcp` config block):**
-  - `mcp.progressive_disclosure.enabled` (bool).
-  - `mcp.progressive_disclosure.min_servers` — only collapse when a workspace has at least this
-    many usable servers (small workspaces keep today's behavior).
-  - Optionally `min_tools` as an alternative threshold.
+  - `mcp.progressive_disclosure.enabled` (`"auto"` | `"on"` | `"off"`, default `"auto"`).
+  - `mcp.progressive_disclosure.threshold_pct` (float, default 10.0) — only collapse when
+    deferrable tool schemas would consume ≥ this percentage of the active model's context window.
+    Borrowed from hermes-agent: this is more direct than a server-count threshold because 3 tiny
+    servers don't need deferral while 1 server with 50 large schemas does.
+  - `mcp.progressive_disclosure.min_servers` (int, default 2) — secondary guard: never collapse
+    when fewer than N servers are connected, even if the token percentage is above threshold.
+    Prevents single-server workspaces from getting indirection overhead.
 - **No new public-ID table** (no new business entity in v1).
 - **Run telemetry (nice-to-have):** record which servers were expanded during a run (in run
   metadata / trace spans) for cost analysis. No schema change if stored in existing extra/trace.
@@ -309,23 +385,31 @@ Mostly reuses existing columns; minimal additions.
 ## v1 scope vs later
 
 **v1:**
-- Server-granularity catalog index in the system prompt (DB-derived, sorted, cache-safe).
-- `expand_mcp_server` builtin + `MCPDisclosureMiddleware` (skills-pattern port).
-- Config-gated by `enabled` + `min_servers`; off-by-default behavior identical to today below the
-  threshold.
-- **True deferral / register-on-first-expand**: collapsed servers' tools are never in `tools=`;
-  expanding a server registers its tools as callable for the rest of the conversation. If cubepi
-  cannot change a live agent's tool set mid-run, ship the next-turn fallback (expansions take
-  effect on the following user turn) and land the cubepi change as a follow-up. Pre-register-all
-  is explicitly **not** a v1 option — it saves no cache/attention cost.
+- **cubepi: `DeferredToolGroup` primitive** — registration API, `expand_tools` builtin, catalog
+  rendering, `DeferredToolsMiddleware`, mid-run tool injection. Generic, tool-source-agnostic.
+- **cubebox: MCP → DeferredToolGroup mapping** — MCP servers as groups, catalog descriptions from
+  `discovery_metadata`, tool names from `tools_cache`, loader via filtered live MCP discovery.
+- Catalog includes per-group tool name lists (not schemas, not descriptions).
+- Config-gated: `enabled` (`auto`/`on`/`off`) + `threshold_pct` (context-window percentage) +
+  `min_servers` secondary guard. `auto` mode identical to today below threshold.
+- **True deferral / register-on-first-expand**: collapsed groups' tools are never in `tools=`;
+  expanding a group registers its tools as callable for the rest of the conversation. If cubepi
+  cannot ship the full `DeferredToolGroup` feature in time, ship the next-turn fallback (expansions
+  take effect on the following user turn) with cubebox-side middleware, and land the cubepi feature
+  as a follow-up. Pre-register-all is explicitly **not** a v1 option — it saves no cache/attention
+  cost.
 
 **Later:**
-- Per-tool (sub-server) disclosure for very large single servers.
+- Non-MCP group types (plugins, large builtin suites) — only a new mapping needed, cubepi
+  mechanism is reused.
+- Per-tool (sub-group) disclosure for very large single servers.
 - Semantic / embedding retrieval over tools (RAG-over-tools) instead of a flat catalog.
 - Provider-native deferred tools (Anthropic Tool Search) as an optimization when the active
   provider supports it, sitting behind the same host-level abstraction.
 - "Code mode" style search+execute for extreme connector counts.
 - Authored `trigger_hints` editing UI in MCP management.
+- Unify skills and tool-group disclosure under a single cubepi primitive (both are "catalog →
+  expand → inject" patterns; let API stabilize first).
 
 ## Testing strategy (E2E-first per CLAUDE.md)
 
@@ -349,40 +433,42 @@ fall back to fake-server-only unit coverage.
 
 ## Open Questions
 
-- **Does cubepi support adding tools to a running agent** and re-establishing the cache boundary
-  mid-conversation? This is now the load-bearing residual (the callability approach is decided:
-  true deferral, not pre-register-all). If cubepi *can* change a live agent's tool set mid-run, a
-  just-expanded server is callable within the same turn. If it *cannot*, v1 ships the next-turn
-  fallback (expansion takes effect on the following user turn) and the cubepi change lands as a
-  follow-up (cubepi is self-authored, upstream-first). Validate this capability before building.
-- **What does `expand_mcp_server` return?** Just an acknowledgement (middleware injects schemas) vs
-  the schema list in the tool result itself. Affects token placement and replay/cache behavior.
+### Resolved
+
+- **Disclosure granularity** → tool group (MCP server as v1 group type), not per-tool. Per-tool
+  adds too many round trips for our server-sized groups (5-15 tools).
+- **Threshold type** → context-window token percentage (default 10%) + min_servers secondary guard,
+  not server-count-only. Adopted from hermes-agent.
+- **Catalog content** → group_id + one-line description + all tool names (no tool descriptions, no
+  schemas). Tool names are the highest signal-to-noise element.
+- **cubepi layering** → core mechanism (`DeferredToolGroup`, `expand_tools`, middleware) lives in
+  cubepi; cubebox provides MCP → group mapping + threshold logic + loader callbacks.
+- **What does `expand_tools` return?** → Tool names + descriptions only; middleware injects schema
+  text into the system-prompt suffix (matching skills pattern).
+
+### Still open
+
+- **cubepi `DeferredToolGroup` API design.** The full scope — registration, catalog rendering,
+  expand builtin, middleware, mid-run tool injection — needs a cubepi design pass. Tracked as a
+  separate cubepi issue.
 - **Trigger hints source.** Derive from description automatically, or add an authored
-  `trigger_hints` field (migration + a small editing surface later)? Auto-derivation is cheaper but
-  lower quality.
-- **Granularity.** Is whole-server expansion enough, or do single large servers (50+ tools) need
-  per-tool disclosure in v1? Likely v1 = server-only, but confirm against real connector sizes.
-- **Threshold default.** What `min_servers` (and/or `min_tools`) value flips collapsing on? Needs a
-  token-cost measurement on representative workspaces.
-- **Expanded state persistence across turns.** `extra["expanded_mcp_servers"]` lives in agent
-  extra and is persisted like `loaded_skills` — confirm it replays correctly so a server expanded
-  on turn 1 stays expanded on turn 5 without re-triggering a cache reset each turn. Because the
-  cache invariant now depends on **expansion order** (not slug sort), persistence must preserve that
-  order too: serialize as an ordered list and replay it unchanged. If a future store reloads it as
-  an unordered set, the rendered prefix could reorder across turns and silently break the cache —
-  call this out as a constraint on however `extra` is persisted.
-- **Stale `tools_cache`.** Callable tools always come from live discovery on expand (the filtered
-  runtime loader), so a stale cache cannot make the model call a non-existent tool — the live tool
-  set is authoritative. The residual staleness risk is only the **catalog index + expansion
-  preview text** rendered from the cache: drift there can make the model expand the wrong server or
-  see a description that no longer matches. Open: re-render the preview from the live discovery
-  result on expand (perfectly consistent, but couples preview text to per-run discovery and could
-  perturb the suffix), or accept cache-rendered preview and refresh `tools_cache` out of band.
+  `trigger_hints` field (migration + a small editing surface later)? v1 = auto-derivation.
+- **Stale `tools_cache`.** Callable tools always come from live discovery on expand, so a stale
+  cache cannot make the model call a non-existent tool. The residual staleness risk is only the
+  **catalog index** (tool names + description) rendered from the cache: drift there can make the
+  model expand the wrong group. Accepted for v1; refresh `tools_cache` out of band.
+- **Expanded state persistence across turns.** `extra["expanded_groups"]` must persist as an
+  **ordered list** and replay unchanged. If a future store reloads it as an unordered set, the
+  rendered prefix could reorder across turns and silently break the cache.
 - **Interaction with subagents.** Subagents get their own tool/middleware assembly — should they
   inherit the parent's expanded set, start collapsed, or be configured independently?
-- **Disabling mid-conversation / re-collapse.** Is there ever a need to collapse an expanded server
-  again within a conversation? Probably no for v1 (monotonic growth is what keeps cache safe), but
-  state explicitly.
+- **Disabling mid-conversation / re-collapse.** Not in v1 (monotonic growth is what keeps cache
+  safe).
+- **Catalog drift defense.** hermes-agent's OpenClaw #84141 lesson: any catalog that can drift from
+  the live tool registry silently drops tools. Our defense: callable tools always come from live
+  discovery (loader callback), never from catalog data. But catalog text can still mislead the
+  model — add an expansion-time validation that warns if the live tool set differs significantly
+  from the catalog's tool_names list.
 
 ## References
 

--- a/docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md
+++ b/docs/dev/specs/2026-05-27-mcp-progressive-disclosure-design.md
@@ -1,0 +1,371 @@
+# MCP Progressive Disclosure — Design
+
+Date: 2026-05-27
+Branch: `feat/mcp-progressive-disclosure`
+Worktree slot: 89
+Issue: #143
+
+## Problem & motivation
+
+Today every enabled MCP server's full tool set — name, description, and the complete JSON
+input schema for each tool — is injected into the agent's tool list on every run. With one or
+two small servers this is fine. As a workspace connects more servers (a CRM connector, a
+ticketing connector, a docs connector, a code-host connector…), the combined schema payload
+grows quickly:
+
+- **Large context.** Tool definitions are part of the cached prefix sent to the model on every
+  turn. A handful of rich servers can push the tool block into the tens of thousands of tokens
+  before the user has typed anything.
+- **High cache cost.** That block is large and re-billed at cache-write rate whenever the prefix
+  changes, and at cache-read rate every turn. More servers = a bigger fixed tax per turn.
+- **Diluted attention / worse tool selection.** Published benchmarks show tool-selection accuracy
+  drops as the toolset grows; the model has to scan dozens of near-identical schemas to pick one.
+
+cubebox already solved the same shape of problem for **skills**: by default the system prompt
+carries only a compact "Available skills" index (name + one-line description), and the model
+calls `load_skill(name)` to pull the full instructions into context on demand. This spec applies
+the same idea to MCP: expose a compact catalog of connected servers by default, and expand a
+given server's full tool set only when the model asks.
+
+## Goals
+
+- By default, inject only a **compact MCP catalog** into the prompt: per server, a name, a
+  one-line description, and short trigger hints — not the per-tool JSON schemas.
+- Let the model **expand a server on demand** so its full tool set + schemas become available for
+  the rest of the conversation.
+- **Preserve the prompt-cache prefix.** The catalog (and any expanded set) must be byte-stable
+  across turns of the same conversation; this is the hard constraint from
+  `backend/docs/prompt-cache-discipline.md`.
+- Keep MCP auth, citations, and tool namespacing working exactly as today once a server is
+  expanded — progressive disclosure is purely about *when* schemas enter context, not *how* tools
+  run.
+- Make the behavior **configurable / opt-in** so small workspaces keep today's zero-indirection
+  behavior.
+
+## Non-goals
+
+- No change to MCP auth (OAuth/static/none), credential vault, or the four-layer install model.
+- No change to how a tool actually executes once exposed (transport, namespacing, citations).
+- No semantic / embedding-based tool retrieval in v1 (noted as a later option below).
+- No "code mode" (exposing tools as a callable API the model writes code against) in v1.
+- No frontend redesign of MCP management surfaces. A small read-only indicator of which servers
+  expanded during a run is acceptable but not required for v1.
+- No per-tool (sub-server) disclosure in v1 — the unit of expansion is a whole server.
+
+## Current state in cubebox (how MCP tools reach the prompt today)
+
+The flow, end to end:
+
+1. **Discovery (already cached in DB).** When a connector is installed/refreshed, its tool list is
+   discovered and stored on `MCPConnectorInstall.tools_cache`
+   (`backend/cubebox/models/mcp.py`, a `list[dict]` of tool definitions including
+   `input_schema`). Server/handshake metadata lives in `discovery_metadata`. Per-tool citation
+   config lives in `tool_citations`. So **we already have each server's tool schemas in Postgres
+   without doing live discovery at prompt-assembly time** — important for building an index cheaply.
+
+2. **Per-run load.** `RunManager._run_cubepi_path` (`backend/cubebox/streams/run_manager.py`,
+   ~line 1039) calls `load_workspace_mcp_tools_for_cubepi`
+   (`backend/cubebox/mcp/cubepi_runtime.py`). That function:
+   - asks `MCPEffectiveConnectorService.list_runtime_specs(...)` for one
+     `MCPRuntimeConnectorSpec` per *usable* install (`backend/cubebox/mcp/effective.py`, line 305),
+   - resolves auth headers per server,
+   - calls `cubepi.mcp.load_mcp_tools_http(...)` to fetch the live tool list,
+   - namespaces each tool as `{slug}__{tool_name}` (length-capped at 64), and
+   - returns `(list[AgentTool], dict[str, CitationConfig])`.
+
+3. **Tool assembly (cache-ordered).** Those MCP tools are appended **last** in a deliberately
+   fixed order (`run_manager.py` ~line 900 comment block): sandbox → artifact → todo → subagent →
+   calculator/datetime → view_images → generate_image → memory_* → load_skill → **mcp_tools**. The
+   merged `all_tools` list becomes the agent's tool definitions (`tools=all_tools`, ~line 1389).
+   This whole tool block is part of the cache-eligible prefix; the cache discipline doc explicitly
+   calls out "Tool definitions in deterministic order" as part of the stable prefix and notes
+   "Toggling MCP tools mid-conversation is treated as a new conversation."
+
+4. **System-prompt assembly.** `BASE_SYSTEM_PROMPT` + optional per-workspace `AgentConfig` prompt
+   + (if any skills enabled) the **skills index** rendered from `SKILLS_PROMPT_TEMPLATE`
+   (`backend/cubebox/prompts/skills.py`) — a sorted bullet list of `` `name` — description ``. This
+   index is appended as a *stable suffix* of the system prompt so it stays cache-safe.
+
+### The skills precedent (the analog to copy)
+
+- **Index in the prompt.** `run_manager.py` ~line 1799 fetches enabled skills and appends a sorted
+  bullet list via `SKILLS_PROMPT_TEMPLATE`. Sorting is what keeps it byte-identical across turns.
+- **`load_skill` tool.** `backend/cubebox/tools/builtin/load_skill.py` returns the SKILL.md content
+  as a JSON tool result (`LoadSkillOutput`).
+- **`SkillsMiddleware`.** `backend/cubebox/middleware/skills.py` watches `after_tool_call` for
+  `load_skill`, stashes loaded content into `agent._extra["loaded_skills"]` (via an `extra_ref`
+  closure), and on every subsequent model call appends each loaded skill's body to the system
+  prompt in `transform_system_prompt` — **sorted by name** for determinism.
+
+The key cache insight from skills: expanded content is appended to the **system prompt suffix**
+(after the base prompt, deterministically ordered), so each expansion is a stable, monotonic,
+append-only growth of the prefix. Within a turn the prefix is fixed; across turns it only ever
+grows by appending — never reorders — so earlier cache segments stay valid.
+
+## Industry research (with citations)
+
+The "load a compact index, expand on demand" pattern is now the mainstream answer to tool/context
+bloat. What's transferable to cubebox:
+
+- **Anthropic Tool Search Tool / deferred tools (GA Feb 2026).** You register all tools but mark
+  most with `defer_loading: true`; only a search tool plus a few always-on tools are in context.
+  The model searches (regex or BM25) and the API returns 3–5 `tool_reference` blocks that expand
+  into full definitions. Reported ~85% token reduction (e.g. ~77K → ~8.7K for 50+ MCP tools) and
+  large accuracy gains on big tool libraries (Opus 4.5 79.5% → 88.1%). Scales to ~10k tools.
+  *Transferable:* validates the index-then-expand shape and confirms expansion should pull only a
+  small relevant subset, not everything. *Caveat for us:* this is a provider-side feature on the
+  Anthropic API; cubebox runs through cubepi's provider abstraction and multiple providers
+  (OpenAI-compatible, deepseek), so we cannot depend on it being present everywhere. Our
+  host-level mechanism must work provider-agnostically.
+
+- **MCP host-side filtering / progressive disclosure (general guidance).** Multiple write-ups note
+  the host need not forward every discovered tool to the model; it can filter, search, or disclose
+  progressively before anything hits context. Standard MCP setups can eat up to ~72% of the
+  context window on definitions alone, with tool-selection accuracy dropping as the set grows.
+  *Transferable:* cubebox **is** the host here (`RunManager` assembles the tool list), so we own
+  this lever directly — exactly where the skills index already sits.
+
+- **Cloudflare "Code Mode" (search + execute, ~1,000 tokens for 2,500+ endpoints).** Tools are
+  presented as an API the model writes code against; a `search()` tool queries the spec (which
+  never enters context) and `execute()` runs the call. ~99.9% token reduction at extreme scale.
+  *Transferable as a later option:* the radical end of the spectrum; overkill for v1 but worth
+  noting for very large connector counts.
+
+- **Anthropic "tools as a filesystem" / RAG-over-tools.** Present tools as something the model
+  explores incrementally; or retrieve relevant tools by embedding similarity instead of a flat
+  list. *Transferable as a later option:* semantic retrieval is the natural upgrade if a
+  name+description catalog proves too coarse at high server counts.
+
+Recommendation drawn from the research: build a **host-side, provider-agnostic** index-then-expand
+mechanism modeled on cubebox's own skills system (a catalog in the prompt + an `expand_mcp_server`
+tool), rather than binding to any single provider's deferred-tools feature. Keep semantic retrieval
+and code-mode as documented later-stage options.
+
+## Proposed design
+
+### Shape: mirror the skills pattern, at the *server* granularity
+
+Default behavior becomes: the prompt carries a **compact MCP catalog**; the model calls a builtin
+tool to **expand** a named server; expanded servers' full tools + schemas become available for the
+rest of the run. The unit of disclosure is a **server**, not an individual tool — this matches how
+users think about MCP ("I connected Linear"), keeps the catalog short, and reuses the existing
+per-server namespacing/citation plumbing wholesale.
+
+### 1. Catalog index (what's in the prompt by default)
+
+Built from data **already in Postgres** (`tools_cache`, `discovery_metadata`, template/install
+`name`/`description`) — no live discovery needed to render it. Rendered as a stable suffix of the
+system prompt, sorted by server slug, e.g.:
+
+```
+# Connected tool servers (collapsed)
+
+These servers are connected but their tools are not loaded yet. Call
+`expand_mcp_server(server)` with a name below to load that server's tools for the
+rest of this conversation.
+
+- `linear` — Issue tracking: create/update/search issues, projects, cycles. (8 tools)
+  Use when: tracking work, filing bugs, querying project status.
+- `gdrive` — Google Drive: search and read documents, list folders. (5 tools)
+  Use when: finding or reading shared docs/spreadsheets.
+```
+
+Per-server line content:
+- **Name** = the namespacing slug (so `expand_mcp_server("linear")` is unambiguous).
+- **One-line description** = install/template `description`, trimmed.
+- **Trigger hints** = a short "Use when:" phrase. Source options (open question below): derive from
+  description, or add an optional authored `trigger_hints` field on the install/template.
+- **Tool count** so the model can gauge cost/coverage.
+
+The catalog never contains per-tool JSON schemas — that's the whole point. It is fully derived
+from DB state that's identical turn-to-turn, so it's cache-safe as a suffix.
+
+### 2. Expansion tool: `expand_mcp_server`
+
+A new builtin tool (sibling of `load_skill`), placed in the fixed tool order **where the MCP tools
+used to go** (after `load_skill`), so the cache-prefix tool ordering rule is respected. Input:
+`{ server: str }` (the catalog slug). Behavior:
+
+- Validate the slug against the workspace's usable installs.
+- Return a JSON result (analogous to `LoadSkillOutput`) listing the server's tools — at minimum
+  the namespaced tool names + descriptions, and optionally the schemas (open question: does the
+  tool *return* schemas, or just acknowledge, letting middleware do the injection?). The design
+  keeps schemas out of the tool *result* and lets the middleware add them to the prefix, matching
+  how `SkillsMiddleware` injects skill bodies rather than re-emitting them per tool result.
+- Record the expanded server in `agent._extra["expanded_mcp_servers"]` via an `extra_ref` closure.
+
+The model learns about this tool the same way it learns about `load_skill`: the catalog text tells
+it to call `expand_mcp_server(server)`.
+
+### 3. `MCPDisclosureMiddleware` (the cache-safe injector)
+
+A new middleware modeled almost exactly on `SkillsMiddleware`:
+
+- **`after_tool_call`**: when the tool is `expand_mcp_server` and it succeeded, add the server slug
+  to `extra["expanded_mcp_servers"]` (a set, stored as a sorted list for determinism).
+- **`transform_system_prompt`**: for each expanded server (sorted by slug), append a stable
+  section listing that server's full tool definitions (namespaced name + description + input
+  schema), rendered from the **cached** `tools_cache` for that install. Sorting + append-only
+  growth keeps the prefix monotonic and cache-stable, identical to the skills approach.
+
+Why schemas go in the **system-prompt suffix**, not the tool list: the tool *list* (`tools=...`) is
+fixed before the agent loop starts and is the most cache-sensitive region; mutating it mid-run is
+exactly the "toggling MCP tools mid-conversation" the cache doc warns against. Appending schema
+text to the system-prompt suffix is the same trick skills already use and is proven cache-safe.
+
+**The catch — actually calling an expanded tool.** Putting a tool's *schema text* in the prompt
+does not register a callable `AgentTool`. Two candidate resolutions (this is the central open
+question, see below):
+
+- **(A) Pre-register, hide via prompt.** Register *all* usable servers' tools as real `AgentTool`s
+  up front (so they're callable), but **omit collapsed servers from the catalog/prompt** and only
+  describe expanded ones. This keeps the callable set complete but does **not** shrink the
+  `tools=` block — so it reduces *attention dilution* and prompt-described surface but **not**
+  cache cost. Likely insufficient on its own.
+- **(B) True deferral.** Register only expanded servers' tools as callable `AgentTool`s. Because
+  the cube cache rule treats the tool block as fixed per conversation, expanding mid-conversation
+  would change the tool block — which the discipline doc says must be handled as a *new
+  conversation* (cache reset). That's acceptable if expansion is rare and front-loaded, but needs
+  cubepi support to add tools to a live agent and to re-mark the cache boundary. **This is the
+  design's load-bearing dependency on cubepi** and the main thing to validate before building.
+
+A pragmatic v1 may combine them: catalog by default (cheap prompt), and on first
+`expand_mcp_server` for a server, register that server's tools and accept a one-time cache
+re-establish for the remainder of the conversation (a known, bounded cost, far cheaper than
+carrying every schema every turn from turn one).
+
+### 4. Where it plugs into assembly
+
+- `run_manager.py` system-prompt section (~line 1799, beside the skills index): add the MCP
+  catalog suffix when the feature is enabled and the workspace has ≥ N usable servers.
+- `run_manager.py` tool assembly (~line 1034): replace the unconditional "load all MCP tools" with
+  the disclosure-aware path (per the A/B decision above).
+- Register `expand_mcp_server` builtin in the fixed order slot.
+- Append `MCPDisclosureMiddleware` to `cubepi_middleware` with an `extra_ref` closure, mirroring
+  `SkillsMiddleware` (~line 1263).
+- Citations: keep `mcp_citation_configs` populated for expanded servers exactly as today; the
+  `CitationMiddleware` (~line 1163) is unchanged.
+
+### 5. How the prompt-cache prefix stays intact
+
+- The **catalog** is derived purely from DB state, sorted by slug → byte-identical every turn.
+- **Expanded-server schema text** is appended to the system-prompt **suffix**, sorted by slug, and
+  only ever grows (append-only) within a conversation → matches the skills cache pattern, which the
+  cache E2E test already protects.
+- If we go with deferral (B), expansion is explicitly modeled as a **cache re-establishment point**
+  (treated like the documented "new conversation" case), never as a silent mid-prefix mutation.
+- No timestamps, nonces, or per-user dynamic data enter the catalog or schema text.
+
+## Data model / config changes
+
+Mostly reuses existing columns; minimal additions.
+
+- **Reuse:** `MCPConnectorInstall.tools_cache` (schemas), `.discovery_metadata`, `.description`
+  (via template), `.slug_name` (catalog key). No new schema table strictly required for v1.
+- **Possible new field (open):** `trigger_hints: str | None` on `MCPConnectorInstall` (and/or
+  template) to author the "Use when:" line, instead of deriving it. If added, follow the migration
+  rule: `alembic revision --autogenerate`.
+- **Config flags (likely in `mcp` config block):**
+  - `mcp.progressive_disclosure.enabled` (bool).
+  - `mcp.progressive_disclosure.min_servers` — only collapse when a workspace has at least this
+    many usable servers (small workspaces keep today's behavior).
+  - Optionally `min_tools` as an alternative threshold.
+- **No new public-ID table** (no new business entity in v1).
+- **Run telemetry (nice-to-have):** record which servers were expanded during a run (in run
+  metadata / trace spans) for cost analysis. No schema change if stored in existing extra/trace.
+
+## v1 scope vs later
+
+**v1:**
+- Server-granularity catalog index in the system prompt (DB-derived, sorted, cache-safe).
+- `expand_mcp_server` builtin + `MCPDisclosureMiddleware` (skills-pattern port).
+- Config-gated by `enabled` + `min_servers`; off-by-default behavior identical to today below the
+  threshold.
+- Decide and implement one of A / B / hybrid for making expanded tools callable.
+
+**Later:**
+- Per-tool (sub-server) disclosure for very large single servers.
+- Semantic / embedding retrieval over tools (RAG-over-tools) instead of a flat catalog.
+- Provider-native deferred tools (Anthropic Tool Search) as an optimization when the active
+  provider supports it, sitting behind the same host-level abstraction.
+- "Code mode" style search+execute for extreme connector counts.
+- Authored `trigger_hints` editing UI in MCP management.
+
+## Testing strategy (E2E-first per CLAUDE.md)
+
+E2E is the priority; MCP can be simulated with a local test MCP server, so there's no excuse to
+fall back to fake-server-only unit coverage.
+
+- **Cache regression (the gate).** Extend / mirror `tests/e2e/memory/test_prompt_cache.py`:
+  assert the prefix is byte-stable across turns with the catalog present, and across turns after an
+  expansion (append-only growth, no mid-prefix mutation). This is the single most important test.
+- **E2E disclosure flow.** With ≥ `min_servers` test MCP servers connected: assert (1) only the
+  catalog is in the prompt initially (no per-tool schemas), (2) the model can call
+  `expand_mcp_server`, (3) after expansion the server's tools are callable and produce results,
+  (4) citations still attach for expanded servers.
+- **Threshold behavior.** Below `min_servers`, behavior is byte-identical to today (no catalog, all
+  tools loaded) — guards the small-workspace path.
+- **Determinism unit tests.** Catalog rendering and expanded-schema rendering are sorted and stable
+  for a fixed input set (cheap to unit-test alongside the E2E).
+- **Per-task incremental runs during dev**, full suite in the pre-PR sweep, per CLAUDE.md.
+
+## Open Questions
+
+- **Callability of expanded tools (the central one).** A (pre-register all, hide in prompt — saves
+  attention but not cache cost), B (true deferral — needs cubepi support to add tools to a live
+  agent + re-mark the cache boundary), or a hybrid (catalog by default, register-on-first-expand +
+  one-time cache re-establish)? This determines whether we actually save cache cost or only reduce
+  attention dilution.
+- **Does cubepi support adding tools to a running agent** and re-establishing the cache boundary
+  mid-conversation? If not, is that an upstream cubepi change (cubepi is self-authored, upstream
+  first) or do we front-load all expansions before the loop? Validate before building.
+- **What does `expand_mcp_server` return?** Just an acknowledgement (middleware injects schemas) vs
+  the schema list in the tool result itself. Affects token placement and replay/cache behavior.
+- **Trigger hints source.** Derive from description automatically, or add an authored
+  `trigger_hints` field (migration + a small editing surface later)? Auto-derivation is cheaper but
+  lower quality.
+- **Granularity.** Is whole-server expansion enough, or do single large servers (50+ tools) need
+  per-tool disclosure in v1? Likely v1 = server-only, but confirm against real connector sizes.
+- **Threshold default.** What `min_servers` (and/or `min_tools`) value flips collapsing on? Needs a
+  token-cost measurement on representative workspaces.
+- **Expanded state persistence across turns.** `extra["expanded_mcp_servers"]` lives in agent
+  extra and is persisted like `loaded_skills` — confirm it replays correctly so a server expanded
+  on turn 1 stays expanded on turn 5 without re-triggering a cache reset each turn.
+- **Stale `tools_cache`.** If a server's real tools drift from the cached schemas we render in the
+  catalog/expansion, the model may call a tool that no longer exists (or miss a new one). Do we
+  trust the cache, or live-discover on expand? Trusting the cache is cheaper and cache-stable;
+  live-discovery is fresher but reintroduces per-run network + nondeterminism.
+- **Interaction with subagents.** Subagents get their own tool/middleware assembly — should they
+  inherit the parent's expanded set, start collapsed, or be configured independently?
+- **Disabling mid-conversation / re-collapse.** Is there ever a need to collapse an expanded server
+  again within a conversation? Probably no for v1 (monotonic growth is what keeps cache safe), but
+  state explicitly.
+
+## References
+
+- Prompt-cache discipline: `backend/docs/prompt-cache-discipline.md`
+- Agent system design: `backend/docs/agent-system-design.md`
+- Skills index/middleware/tool: `backend/cubebox/prompts/skills.py`,
+  `backend/cubebox/middleware/skills.py`, `backend/cubebox/tools/builtin/load_skill.py`
+- MCP runtime loader: `backend/cubebox/mcp/cubepi_runtime.py`
+- MCP effective service + runtime spec: `backend/cubebox/mcp/effective.py`
+- MCP install model (`tools_cache`, `discovery_metadata`, `slug_name`): `backend/cubebox/models/mcp.py`
+- Tool/prompt assembly: `backend/cubebox/streams/run_manager.py` (~lines 900, 1034, 1799)
+- Prior MCP specs: `docs/dev/specs/2026-05-14-mcp-tools-redesign-design.md`,
+  `docs/dev/specs/2026-05-15-mcp-management-four-layer-design.md`,
+  `docs/dev/specs/2026-05-14-mcp-tool-citations-design.md`
+- Anthropic, "Introducing advanced tool use" (Tool Search Tool / deferred tools):
+  https://www.anthropic.com/engineering/advanced-tool-use
+- Anthropic API docs, "Tool search tool":
+  https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool
+- Unified.to, "Scaling MCP Tools with Anthropic's (& OpenAI's) Defer Loading":
+  https://unified.to/blog/scaling_mcp_tools_with_anthropic_and_openai_defer_loading
+- Solo.io, "MCP Progressive Disclosure: Save Tokens, Retrieve Schemas":
+  https://www.solo.io/blog/mcp-progressive-disclosure
+- Matthew Kruczek, "Progressive Disclosure MCP: 85x Token Savings Benchmark":
+  https://matthewkruczek.ai/blog/progressive-disclosure-mcp-servers.html
+- Layered, "MCP Tool Schema Bloat: The Hidden Token Tax":
+  https://layered.dev/mcp-tool-schema-bloat-the-hidden-token-tax-and-how-to-fix-it/
+- Philipp Schmid, "Best Practices for Building MCP Servers": https://www.philschmid.de/mcp-best-practices
+- Cloudflare, "Code Mode: give agents an entire API in 1,000 tokens":
+  https://blog.cloudflare.com/code-mode-mcp/


### PR DESCRIPTION
## Summary

Implements MCP progressive disclosure for #143 — hides MCP tool schemas behind a compact catalog and lets the model expand groups on demand via cubepi's `DeferredToolGroup` primitive.

- **Disclosure gate** (`disclosure.py`): config-driven (`auto`/`on`/`off`) with threshold % and min-servers guard. Auto mode activates when tool tokens exceed a configurable % of the context window.
- **Deferred group builder** (`disclosure.py`): maps `MCPRuntimeConnectorSpec` → `DeferredToolGroup` with slug-collision-safe `group_id`, predicted namespaced tool names, and a self-contained loader that opens its own short-lived DB session per expansion.
- **Runtime wiring** (`run_manager.py`): disclosure-aware MCP load block — deferred path builds groups and shares the citation dict by reference; eager path calls `_load_tools_for_specs` directly (avoids double `list_runtime_specs`).
- **Extracted `_load_tools_for_specs`** (`cubepi_runtime.py`): factored out of `load_workspace_mcp_tools_for_cubepi` so both eager and deferred paths share the same per-spec load + namespace logic.
- **Config** (`config.yaml`): `mcp.progressive_disclosure` block with `enabled`, `threshold_pct`, `min_servers`.
- **22 unit tests + 12 E2E tests** covering the gate, group building, middleware integration, loader session lifecycle, and cache-prefix stability.

## Key design decisions

- **Session lifecycle**: Deferred loaders run during the agent loop, long after the original DB session closes. `_load_tools_for_specs_deferred` captures session-independent factory ingredients (`encryption_backend`, `http_client`, `redis`, etc.) and creates a fresh `async_session_maker()` per invocation.
- **Cache stability**: Catalog is sorted by `group_id` (byte-stable across turns). Expanded-schemas section is append-only in expansion order.
- **Slug collision**: `group_id` gets an `install_id` suffix when multiple servers share the same slug, matching tool-name disambiguation logic.

## Test plan

- [x] Unit tests: `pytest tests/unit/test_mcp_disclosure.py` (22 tests)
- [x] E2E tests: `pytest tests/e2e/test_mcp_disclosure_runtime.py` (12 tests)
- [x] mypy strict pass
- [x] Pre-push hook pass (ruff + mypy + unit + frontend build)

Supersedes #154 (clean cherry-pick from long-lived branch).

Refs #143