### PR TITLE
feat(chat): hide framework-injected synthetic messages in transcript

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -172,7 +172,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "5a8569686a0ee294459a30542bd9b0b2dfd11acd" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "87a302840e39dabfb39d5b13756fca229e2183da" }
 
 [dependency-groups]
 dev = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -875,7 +875,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=5a8569686a0ee294459a30542bd9b0b2dfd11acd" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=87a302840e39dabfb39d5b13756fca229e2183da" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -922,7 +922,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.9.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=5a8569686a0ee294459a30542bd9b0b2dfd11acd#5a8569686a0ee294459a30542bd9b0b2dfd11acd" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=87a302840e39dabfb39d5b13756fca229e2183da#87a302840e39dabfb39d5b13756fca229e2183da" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },

--- a/frontend/packages/core/src/types/message.ts
+++ b/frontend/packages/core/src/types/message.ts
@@ -64,6 +64,11 @@ interface MessageBase {
     subagent_events?: SubagentSummary
     // Set on a steer user message committed mid-run; used for replay idempotency.
     steer_id?: string
+    // Framework-injected user-role message (cubepi synthetic_user_message):
+    // model-facing scaffolding like todo-guard nudges or goal continuations.
+    // Never rendered as a user bubble; synthetic_source is trace-only.
+    synthetic?: boolean
+    synthetic_source?: string
   }
 }
 

--- a/frontend/packages/web/__tests__/components/SyntheticMessage.test.tsx
+++ b/frontend/packages/web/__tests__/components/SyntheticMessage.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+import { NextIntlClientProvider } from 'next-intl'
+import en from '../../messages/en.json'
+import { MessageList } from '@/components/chat/MessageList'
+import { useMessageStore, type Message } from '@cubebox/core'
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <NextIntlClientProvider locale="en" messages={en}>
+      {children}
+    </NextIntlClientProvider>
+  )
+}
+
+const realUserMessage = {
+  id: 'msg-user',
+  role: 'user',
+  content: [{ type: 'text', text: 'real human question' }],
+  timestamp: 1_700_000_000,
+} as unknown as Message
+
+// Mirrors a cubepi synthetic_user_message after the API round-trip
+// (e.g. a todo-guard nudge persisted into history).
+const syntheticMessage = {
+  id: 'msg-synthetic',
+  role: 'user',
+  content: [{ type: 'text', text: 'The todo list still has unfinished items.' }],
+  timestamp: 1_700_000_001,
+  metadata: { synthetic: true, synthetic_source: 'todo_guard' },
+} as unknown as Message
+
+describe('MessageList synthetic message handling', () => {
+  beforeEach(() => {
+    useMessageStore.setState({
+      messages: { 'conv-1': [realUserMessage, syntheticMessage] },
+      loadMessages: vi.fn(async () => {}),
+      isStreaming: false,
+      mainStream: null,
+      subAgentStreams: {},
+    } as never)
+  })
+
+  it('renders real user messages as bubbles but hides synthetic ones', () => {
+    render(<MessageList conversationId="conv-1" />, { wrapper })
+
+    expect(screen.getByText('real human question')).toBeInTheDocument()
+    expect(screen.queryByText('The todo list still has unfinished items.')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -398,7 +398,7 @@ export function MessageList({ conversationId }: MessageListProps) {
       <div ref={contentRef} className="space-y-4 max-w-2xl mx-auto">
         {(messages ?? []).map((msg) => (
           <div key={msg.id}>
-            {msg.role === 'user' && (
+            {msg.role === 'user' && msg.metadata?.synthetic !== true && (
               <>
                 {msg.metadata?.attachments && msg.metadata.attachments.length > 0 && (
                   <MessageAttachments


### PR DESCRIPTION
Downstream half of cubeplexai/cubepi#171 (cubepi side merged in cubeplexai/cubepi#173).

## Problem

cubepi middleware injects user-role nudges (todo guard, goal continuation) into the conversation. They persist into history with no marker, so replay rendered model-facing scaffolding like "The todo list still has unfinished items…" as blue **user** chat bubbles — the user never typed them.

## Changes

- **Bump cubepi pin `5a85696` → `87a3028`**: injected messages now carry `metadata = {"synthetic": true, "synthetic_source": "<tag>"}`.
- **Backend**: pin bump only — `list_messages` already returns cubepi message `metadata` verbatim (`model_dump(mode="json")`), verified.
- **`@cubebox/core`**: type the `synthetic` / `synthetic_source` metadata keys on `MessageBase`.
- **web**: `MessageList` skips user messages with `metadata.synthetic === true`. Hiding (rather than a muted system note) matches the live SSE path, which already drops these injections (`injected_message` events are emitted for steer messages only) — replay and live are now consistent.

## Verification

- Unit: new `SyntheticMessage.test.tsx` renders one real + one synthetic user message; only the real one appears. Full web suite: 204 passed / 1 skipped; type-check + lint clean.
- Live end-to-end: triggered a real todo guard (prompted the model to leave todos unfinished). The messages API returns the two injected messages with `synthetic: true` (`todo_guard`, `todo_validation_error`), and the replayed transcript shows no scaffolding bubbles — just the real user message, todo progress widgets, and the closing assistant note.

## Notes

- Messages persisted **before** this bump carry no marker and still render as before; no backfill (acceptable: pre-release data).
- `synthetic_source` is intentionally unused in UI branching — single-key contract per cubepi#171.