### PR TITLE
fix(web): first-turn thinking dropped + drop minimal level

### DIFF
--- a/backend/cubebox/llm/catalog/data/capabilities.yaml
+++ b/backend/cubebox/llm/catalog/data/capabilities.yaml
@@ -7,7 +7,7 @@ anthropic-native:
   reasoning_level:
     path: thinking.budget_tokens
     kind: int_budget
-    level_budgets: { "off": 0, minimal: 1024, low: 2048, medium: 8192, high: 16384, xhigh: 16384 }
+    level_budgets: { "off": 0, low: 2048, medium: 8192, high: 16384, xhigh: 16384 }
   temperature: { mode: free, min: 0.0, max: 1.0, default: 1.0 }
   max_tokens_field: max_tokens
   supports_tools: true
@@ -20,7 +20,7 @@ openai-responses:
   reasoning_level:
     path: reasoning.effort
     kind: effort
-    level_to_effort: { minimal: minimal, low: low, medium: medium, high: high, xhigh: high }
+    level_to_effort: { low: low, medium: medium, high: high, xhigh: high }
   temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
   max_tokens_field: max_tokens
   supports_tools: true
@@ -52,7 +52,7 @@ deepseek-anthropic:
   reasoning_level:
     path: output_config.effort
     kind: effort
-    level_to_effort: { minimal: minimal, low: low, medium: medium, high: high, xhigh: max }
+    level_to_effort: { low: low, medium: medium, high: high, xhigh: max }
   temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
 
 deepseek-openai:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -172,7 +172,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "87a302840e39dabfb39d5b13756fca229e2183da" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "c25946e" }
 
 [dependency-groups]
 dev = [

--- a/backend/tests/unit/llm/catalog/data/flat_providers_snapshot.yaml
+++ b/backend/tests/unit/llm/catalog/data/flat_providers_snapshot.yaml
@@ -18,7 +18,7 @@
       kind: int_budget
       # Aligned with cubepi.providers.base.ThinkingBudgets so AnthropicProvider's
       # capability=None default-capability reproduces today's wire bytes.
-      level_budgets: { "off": 0, minimal: 1024, low: 2048, medium: 8192, high: 16384, xhigh: 16384 }
+      level_budgets: { "off": 0, low: 2048, medium: 8192, high: 16384, xhigh: 16384 }
     temperature: { mode: free, min: 0.0, max: 1.0, default: 1.0 }
     max_tokens_field: max_tokens
     supports_tools: true
@@ -50,7 +50,7 @@
     reasoning_level:
       path: reasoning.effort
       kind: effort
-      level_to_effort: { minimal: minimal, low: low, medium: medium, high: high, xhigh: high }
+      level_to_effort: { low: low, medium: medium, high: high, xhigh: high }
     temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
     max_tokens_field: max_tokens
     supports_tools: true
@@ -144,7 +144,7 @@
       # https://api-docs.deepseek.com/guides/thinking_mode
       path: output_config.effort
       kind: effort
-      level_to_effort: { minimal: minimal, low: low, medium: medium, high: high, xhigh: max }
+      level_to_effort: { low: low, medium: medium, high: high, xhigh: max }
     # DeepSeek's Anthropic-shape endpoint accepts temperature in [0.0, 2.0]
     # (broader than vanilla Anthropic's [0.0, 1.0]).
     temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
@@ -496,7 +496,7 @@
     reasoning_level:
       path: thinking.budget_tokens
       kind: int_budget
-      level_budgets: { "off": 0, minimal: 1024, low: 2048, medium: 8192, high: 16384, xhigh: 16384 }
+      level_budgets: { "off": 0, low: 2048, medium: 8192, high: 16384, xhigh: 16384 }
     temperature: { mode: free, min: 0.0, max: 1.0, default: 1.0 }
     max_tokens_field: max_tokens
     supports_tools: true
@@ -521,7 +521,7 @@
     reasoning_level:
       path: reasoning.effort
       kind: effort
-      level_to_effort: { minimal: minimal, low: low, medium: medium, high: high, xhigh: high }
+      level_to_effort: { low: low, medium: medium, high: high, xhigh: high }
     temperature: { mode: free, min: 0.0, max: 2.0, default: 1.0 }
     max_tokens_field: max_tokens
     supports_tools: true

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -875,7 +875,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=87a302840e39dabfb39d5b13756fca229e2183da" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=c25946e" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -921,8 +921,8 @@ dev = [
 
 [[package]]
 name = "cubepi"
-version = "0.9.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=87a302840e39dabfb39d5b13756fca229e2183da#87a302840e39dabfb39d5b13756fca229e2183da" }
+version = "0.10.0"
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=c25946e#c25946e119ef6e0685890ff5dfe7026af06246c6" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },

--- a/frontend/packages/core/src/types/events.ts
+++ b/frontend/packages/core/src/types/events.ts
@@ -74,7 +74,7 @@ export type AgentEventType =
  * and the SSE event types share one source of truth — the web package
  * (`@/lib/types/presets`) re-uses this directly.
  */
-export type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+export type ThinkingLevel = 'off' | 'low' | 'medium' | 'high' | 'xhigh'
 
 /**
  * Emitted by the backend ``FallbackBoundModel`` chain when a leg fails and

--- a/frontend/packages/web/__tests__/components/ThinkingBadge.test.tsx
+++ b/frontend/packages/web/__tests__/components/ThinkingBadge.test.tsx
@@ -24,7 +24,7 @@ describe('ThinkingBadge', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it.each<ThinkingLevel>(['minimal', 'low', 'medium', 'high', 'xhigh'])(
+  it.each<ThinkingLevel>(['low', 'medium', 'high', 'xhigh'])(
     'renders the badge when thinking === %s',
     (level) => {
       getPresetSelectionStore(`ws_${level}`).getState().setThinking(level)

--- a/frontend/packages/web/__tests__/components/WorkspaceHomePage.test.tsx
+++ b/frontend/packages/web/__tests__/components/WorkspaceHomePage.test.tsx
@@ -135,6 +135,11 @@ describe('WorkspaceHomePage', () => {
         '',
         ['file-1'],
         expect.any(Array),
+        // The home page now forwards the composer's preset + thinking choice
+        // on the first send (mirrors InputBar.handleSubmit), so the bug where
+        // turn-1 silently shipped `thinking: "off"` while turn-2 honored the
+        // dropdown can't recur.
+        { preset_label: null, thinking: 'off' },
       )
     })
     expect(storeMocks.push).toHaveBeenCalledWith('/w/ws-1/conversations/conv-1')

--- a/frontend/packages/web/app/(app)/w/[wsId]/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/page.tsx
@@ -10,6 +10,7 @@ import {
   useMessageStore,
 } from '@cubebox/core'
 import { InputBar } from '@/components/layout/InputBar'
+import { getPresetSelectionStore } from '@/lib/stores/preset-selection'
 import { Box } from 'lucide-react'
 
 export default function WorkspaceHomePage({
@@ -75,9 +76,23 @@ export default function WorkspaceHomePage({
       }
 
       useAttachmentStore.getState().clear(convId)
-      send(client, convId, content, attachedIds, optimisticAttachments).catch((err) => {
-        console.error('Failed to send message:', err)
-      })
+      // Mirror InputBar.handleSubmit: the composer's preset + thinking choice
+      // is a per-message field, so the home page's first-send path must read
+      // and forward it too. Without this, the first message after opening a
+      // new conversation always shipped as `thinking: "off"` regardless of
+      // the dropdown — subsequent sends went through InputBar's own handler
+      // and looked correct, which made the bug look like "the model picked
+      // a different mode between turns."
+      const selection = getPresetSelectionStore(wsId).getState()
+      const sendOptions = {
+        preset_label: selection.presetLabel,
+        thinking: selection.thinking,
+      }
+      send(client, convId, content, attachedIds, optimisticAttachments, sendOptions).catch(
+        (err) => {
+          console.error('Failed to send message:', err)
+        },
+      )
       router.push(`/w/${wsId}/conversations/${convId}`)
     } catch (err) {
       console.error('Failed to create conversation:', err)

--- a/frontend/packages/web/components/chat/ThinkingControl.tsx
+++ b/frontend/packages/web/components/chat/ThinkingControl.tsx
@@ -20,7 +20,6 @@ interface ThinkingControlProps {
 
 const LEVEL_KEYS = [
   { value: 'off', labelKey: 'thinkingLevelOff' },
-  { value: 'minimal', labelKey: 'thinkingLevelMinimal' },
   { value: 'low', labelKey: 'thinkingLevelLow' },
   { value: 'medium', labelKey: 'thinkingLevelMedium' },
   { value: 'high', labelKey: 'thinkingLevelHigh' },

--- a/frontend/packages/web/lib/stores/preset-selection.ts
+++ b/frontend/packages/web/lib/stores/preset-selection.ts
@@ -65,6 +65,16 @@ export function getPresetSelectionStore(
           presetLabel: state.presetLabel,
           thinking: state.thinking,
         }),
+        // v2 dropped the `minimal` level (deepseek's schema doesn't accept it
+        // and we never had a sensible mapping for the other providers either).
+        // Rewrite stale persisted values so the dropdown doesn't render an
+        // orphan selection after upgrade.
+        version: 2,
+        migrate: (persisted, _version) => {
+          const p = (persisted as Partial<PresetSelectionState>) ?? {}
+          if ((p.thinking as string) === 'minimal') p.thinking = 'low'
+          return p as PresetSelectionState
+        },
       },
     ),
   )

--- a/frontend/packages/web/lib/types/presets.ts
+++ b/frontend/packages/web/lib/types/presets.ts
@@ -1,4 +1,4 @@
-export type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+export type ThinkingLevel = 'off' | 'low' | 'medium' | 'high' | 'xhigh'
 export type TaskPresetKey = 'title' | 'compaction' | 'summarize'
 
 export interface AdminPresetEntry {

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -106,7 +106,6 @@
     "defaultPresetBadge": "default",
     "thinkingAriaLabel": "Thinking level",
     "thinkingLevelOff": "Standard",
-    "thinkingLevelMinimal": "Minimal",
     "thinkingLevelLow": "Low",
     "thinkingLevelMedium": "Medium",
     "thinkingLevelHigh": "High",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -106,7 +106,6 @@
     "defaultPresetBadge": "默认",
     "thinkingAriaLabel": "思考深度",
     "thinkingLevelOff": "标准",
-    "thinkingLevelMinimal": "最少",
     "thinkingLevelLow": "低",
     "thinkingLevelMedium": "中",
     "thinkingLevelHigh": "高",


### PR DESCRIPTION
## Summary

- **Bug fix**: the workspace home page's first-turn `handleSubmit` called `useMessageStore.send()` without the per-message `options` arg, so the very first message of a new conversation always shipped as `thinking: "off"` regardless of the composer dropdown. Subsequent turns went through `InputBar`'s own `handleSubmit` (which reads `getPresetSelectionStore`) and looked correct — the asymmetry surfaced as "the model switched mode mid-conversation" in traces. Home page now mirrors `InputBar.handleSubmit` and forwards `{ preset_label, thinking }`.
- **Drop `minimal` thinking level** end-to-end. DeepSeek's Anthropic-shape endpoint only accepts `high/low/medium/max/xhigh` on `output_config.effort`, so the old `level_to_effort: { minimal: minimal }` mapping caused any "Minimal" pick to trip a 400 + silent fallback to qwen. Removed from the `ThinkingLevel` literal (web + core), `ThinkingControl` dropdown, en/zh i18n strings, `capabilities.yaml` (3 caps), the flat snapshot fixture, and the `ThinkingBadge` test enumeration.
- **Migration**: bumped `preset-selection-v1` persist to `version: 2` with a `migrate` that rewrites stale localStorage `"minimal"` → `"low"` so the dropdown doesn't render an orphan selection after upgrade.

Pairs with cubeplexai/cubepi `drop-thinking-minimal` (which drops the literal upstream). Bump the cubepi pin after that PR merges.

## Test plan

- [x] `pnpm vitest run` — 202 passed
- [x] `tsc --noEmit` — clean
- [x] backend `pytest tests/unit/llm tests/test_provider_capability_factory.py` — 71 passed
- [ ] manual: open `/w/<wsId>` home page, set Thinking → Low, send first message, confirm request body carries `thinking: "low"` (trace `chat <model>` span; previous traces showed `thinking: disabled` on turn 1)
- [ ] manual: existing localStorage `"minimal"` selection migrates to `"low"` on next load