### PR TITLE
feat(deploy): docker-compose deployment mode

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -130,6 +130,13 @@ default:
     #   Set to true when SDK cannot directly reach sandbox network/ports
     #   (e.g., Docker bridge deployments, network isolation)
     use_server_proxy: true
+    # secure_access: Whether to request OpenSandbox's signed-URL secured
+    #   endpoint mode on create. Required for production-grade Kubernetes
+    #   deployments behind the ingress gateway. Must be set to false when
+    #   using docker-runtime OpenSandbox (the docker backend rejects
+    #   secureAccess=True with HTTP 400 INVALID_PARAMETER). See
+    #   deploy/docker-compose/OPENSANDBOX.md for context.
+    secure_access: true
     # ready_timeout: Maximum time to wait for sandbox to become ready after creation
     #   Used only during sandbox initialization. If the sandbox doesn't respond to
     #   health checks within this time, creation fails.

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -114,6 +114,11 @@ class SandboxManager:
         self._touch_interval: int = config.get("sandbox.touch_interval", 60)
         self._ready_timeout: int = config.get("sandbox.ready_timeout", 60)
         self._use_server_proxy: bool = config.get("sandbox.use_server_proxy", False)
+        # OpenSandbox `secureAccess`: Kubernetes runtime supports it (the
+        # secured-endpoint ingress gateway); the Docker runtime rejects
+        # the flag with HTTP 400. Default true preserves prior behaviour
+        # for k8s installs.
+        self._secure_access: bool = config.get("sandbox.secure_access", True)
 
         # In-process cache of (sandbox_id -> last_touch_at) used to throttle
         # mid-turn activity bumps so chatty tool loops don't hammer the DB.
@@ -566,7 +571,7 @@ class SandboxManager:
                     ready_timeout=timedelta(seconds=self._ready_timeout),
                     volumes=volumes,
                     resource={"cpu": self._resource_cpu, "memory": self._resource_memory},
-                    secure_access=True,
+                    secure_access=self._secure_access,
                     network_policy=network_policy,
                 )
                 sandbox_id = raw_sandbox.id

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -7,11 +7,11 @@ Artifacts for deploying cubebox to your own infrastructure.
 | Mode | Status | Doc |
 |---|---|---|
 | **Kubernetes (Helm)** | available | [kubernetes/INSTALL.md](kubernetes/INSTALL.md) (English) / [kubernetes/INSTALL.zh.md](kubernetes/INSTALL.zh.md) (中文) |
-| **docker-compose** | planned | _coming soon_ |
+| **docker-compose** | available | [docker-compose/INSTALL.md](docker-compose/INSTALL.md) |
 
 Both modes share the same container images. Build them once with
-`deploy/kubernetes/scripts/build-and-push.sh` (or whatever build script the
-compose mode provides later); both modes pull from the same registry.
+`deploy/kubernetes/scripts/build-and-push.sh`; both modes pull from the
+same registry.
 
 ## Layout
 
@@ -26,9 +26,15 @@ deploy/
 │   ├── INSTALL.md             # English install guide
 │   ├── INSTALL.zh.md          # Chinese install guide
 │   ├── charts/
-│   └── scripts/
-└── egress-bundle/             # separate concern: MITM webhook for an
-                               # existing OpenSandbox install
+│   ├── scripts/
+│   └── egress-bundle/         # MITM webhook source (integrated into
+│                              # the chart as an opt-in subsystem)
+└── docker-compose/            # single-host compose deployment
+    ├── README.md
+    ├── INSTALL.md
+    ├── compose.yaml
+    ├── config/
+    └── scripts/
 ```
 
 The Dockerfiles accept build-time mirror knobs (`APT_MIRROR_HOST`,

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -1,0 +1,32 @@
+# cubebox docker-compose .env (template).
+#
+# Copy this file to `.env` next to compose.yaml and fill in real values.
+# `.env` is gitignored. Do NOT commit secrets.
+
+# ── Image source ─────────────────────────────────────────────────────────
+# Backend + frontend images are built and pushed by:
+#   deploy/kubernetes/scripts/build-and-push.sh
+IMAGE_REGISTRY=192.168.1.101:8050
+IMAGE_REPO=library
+BACKEND_TAG=<git-sha-short>
+FRONTEND_TAG=<git-sha-short>
+
+# ── Host port mappings ───────────────────────────────────────────────────
+# What ports the host exposes. Frontend is the user entrypoint.
+BACKEND_PORT=8000
+FRONTEND_PORT=3000
+
+# ── Bundled infrastructure ───────────────────────────────────────────────
+# Passwords: openssl rand -hex 16
+POSTGRES_PASSWORD=REPLACE_ME
+REDIS_PASSWORD=REPLACE_ME
+
+# rustfs (S3-compatible object store)
+RUSTFS_ACCESS_KEY=cubebox
+RUSTFS_SECRET_KEY=REPLACE_ME
+# RUSTFS_IMAGE=rustfs/rustfs:latest
+
+# Optional overrides (defaults shown):
+# POSTGRES_USER=cubebox
+# POSTGRES_DB=cubebox
+# OBJECTSTORE_BUCKET=cubebox

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -30,3 +30,8 @@ RUSTFS_SECRET_KEY=REPLACE_ME
 # POSTGRES_USER=cubebox
 # POSTGRES_DB=cubebox
 # OBJECTSTORE_BUCKET=cubebox
+
+# ── Optional: OpenSandbox overlay (see compose.opensandbox.yaml) ─────────
+# Only needed if you start the stack with -f compose.opensandbox.yaml.
+# OPENSANDBOX_IMAGE=opensandbox/server:latest
+# OPENSANDBOX_PORT=8090

--- a/deploy/docker-compose/.gitignore
+++ b/deploy/docker-compose/.gitignore
@@ -2,3 +2,4 @@
 .env
 config/config.production.local.yaml
 config/config.production.secrets.yaml
+config/opensandbox.toml

--- a/deploy/docker-compose/.gitignore
+++ b/deploy/docker-compose/.gitignore
@@ -1,0 +1,4 @@
+# Operator-local secrets.
+.env
+config/config.production.local.yaml
+config/config.production.secrets.yaml

--- a/deploy/docker-compose/INSTALL.md
+++ b/deploy/docker-compose/INSTALL.md
@@ -1,0 +1,284 @@
+# cubebox on docker-compose — Install Guide
+
+`docker compose up -d` deploys cubebox (backend + frontend + Postgres +
+Redis + rustfs S3 store) on one host. Same container images as the
+kubernetes mode; only the orchestration differs.
+
+---
+
+## Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Architecture](#2-architecture)
+3. [Build images](#3-build-images)
+4. [Configure (`.env` + two YAML files)](#4-configure-env--two-yaml-files)
+5. [Up / down / logs](#5-up--down--logs)
+6. [Verification](#6-verification)
+7. [Troubleshooting](#7-troubleshooting)
+
+---
+
+## 1. Prerequisites
+
+| Item | Requirement |
+|---|---|
+| Linux host with docker engine | ≥ 24, with `docker compose` v2 |
+| Outbound network to the image registry | the same one `build-and-push.sh` pushed to |
+| LLM provider credentials | at least one (see §4.4) |
+| Open ports on the host | one for frontend (default 3000), optionally one for backend (default 8000) |
+
+No Kubernetes, no Helm.
+
+---
+
+## 2. Architecture
+
+```
+Host
+  ├─ port :3000 → frontend (Next.js)  ── proxies /api/* server-side ──┐
+  │                                                                   │
+  └─ port :8000 → backend  (FastAPI / uvicorn) ◄─────────────────────┘
+                    ├─ depends on → postgres   (named volume)
+                    ├─ depends on → redis      (named volume)
+                    └─ depends on → rustfs     (S3 store, named volume)
+
+Bootstrap services (run-to-completion):
+  backend-migrate  alembic upgrade head (gates backend boot)
+  bucket-init      mc mb (idempotent rustfs bucket create)
+```
+
+All inter-service communication uses docker DNS (e.g. backend reaches
+postgres at `postgres:5432`). The host only sees the frontend port (and
+optionally the backend port for direct API access).
+
+---
+
+## 3. Build images
+
+Use the kubernetes mode's build script — the images are identical:
+
+```bash
+deploy/kubernetes/scripts/build-and-push.sh
+# pushes to ${REGISTRY:-192.168.1.101:8050}/${REPO:-library}/cubebox-{backend,frontend}:<git-sha>
+```
+
+Then in `.env` set `BACKEND_TAG` and `FRONTEND_TAG` to that sha.
+
+---
+
+## 4. Configure (`.env` + two YAML files)
+
+Three files, all gitignored:
+
+| File | What it does |
+|---|---|
+| `.env` | image tags, host port mappings, infra passwords. Read directly by `docker compose` for variable substitution in `compose.yaml`. |
+| `config/config.production.local.yaml` | Non-secret runtime config (mode, public_url, cookie_secure, sandbox toggle). Mounted into backend. |
+| `config/config.production.secrets.yaml` | Secrets — jwt/csrf/vault material, infra passwords (must match `.env`), LLM provider api_keys. Mounted into backend. |
+
+### 4.1 `.env`
+
+```bash
+cp .env.example .env
+$EDITOR .env
+```
+
+Required:
+
+```dotenv
+IMAGE_REGISTRY=192.168.1.101:8050
+IMAGE_REPO=library
+BACKEND_TAG=<git-sha>
+FRONTEND_TAG=<git-sha>
+
+# openssl rand -hex 16
+POSTGRES_PASSWORD=<...>
+REDIS_PASSWORD=<...>
+RUSTFS_SECRET_KEY=<...>
+```
+
+Optional (defaults shown):
+
+```dotenv
+BACKEND_PORT=8000
+FRONTEND_PORT=3000
+POSTGRES_USER=cubebox
+POSTGRES_DB=cubebox
+RUSTFS_ACCESS_KEY=cubebox
+OBJECTSTORE_BUCKET=cubebox
+```
+
+### 4.2 `config.production.local.yaml`
+
+```bash
+cp config/config.production.local.yaml.example   config/config.production.local.yaml
+$EDITOR config/config.production.local.yaml
+```
+
+| Field | Default | Notes |
+|---|---|---|
+| `api.public_url` | `http://localhost:8000` | the URL clients reach the backend at; if you put a reverse proxy in front, use **that** URL |
+| `public_base_url` | same | used by the backend for absolute URL construction |
+| `frontend_base_url` | `http://localhost:3000` | where the backend redirects browsers |
+| `deployment.mode` | `single_tenant` | `single_tenant` auto-creates an org on first user registration; `multi_tenant` requires explicit org bootstrap |
+| `auth.cookie_secure` | `false` | ★ must stay `false` on HTTP, otherwise clients silently drop the auth cookie |
+| `sandbox.enabled` | `false` | flip to `true` and fill `sandbox.{domain,image,api_key}` in `secrets.yaml` to use an external OpenSandbox |
+
+`database.host`, `redis.url`, `objectstore.endpoint` use docker DNS names
+(`postgres`, `redis`, `rustfs`) — don't change unless you renamed the
+services.
+
+### 4.3 `config.production.secrets.yaml`
+
+```bash
+cp config/config.production.secrets.yaml.example   config/config.production.secrets.yaml
+$EDITOR config/config.production.secrets.yaml
+```
+
+Required:
+
+```yaml
+production:
+  auth:
+    jwt_secret:  "<openssl rand -hex 32>"
+    csrf_secret: "<openssl rand -hex 32>"
+    vault_key:   "<Fernet.generate_key()>"
+  database:
+    password: "<same as POSTGRES_PASSWORD>"
+  redis:
+    url: "redis://:<REDIS_PASSWORD>@redis:6379/0"
+  objectstore:
+    access_key:    "cubebox"             # same as RUSTFS_ACCESS_KEY
+    access_secret: "<RUSTFS_SECRET_KEY>"
+```
+
+The three secrets in `auth`:
+
+| Field | Generate with |
+|---|---|
+| `jwt_secret` | `openssl rand -hex 32` |
+| `csrf_secret` | `openssl rand -hex 32` |
+| `vault_key` | `python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'` |
+
+### 4.4 LLM providers
+
+In `config.production.secrets.yaml`:
+
+```yaml
+production:
+  llm:
+    default_model: "deepseek/deepseek-v4-flash"
+    fallback_models:
+      - "cubebox/qwen3.5-plus-thinking"
+    providers:
+      # Mode A — cubepi built-in preset (simplest)
+      deepseek:
+        preset: "deepseek/cn/anthropic-messages"
+        api_key: "sk-..."
+
+      # Mode B — fully custom (private gateway, self-host)
+      cubebox:
+        base_url: "https://gateway.example.com/v1"
+        api_key: "..."
+        api: "openai-completions"
+        models:
+          - id: "qwen3.5-plus-thinking"
+            name: "Qwen3.5 Plus"
+            reasoning: true
+            input: ["text", "image"]
+            context_window: 991000
+            max_tokens: 64000
+```
+
+Format rules and available `preset` names match the kubernetes mode —
+see [deploy/kubernetes/INSTALL.md §4.4](../kubernetes/INSTALL.md).
+
+---
+
+## 5. Up / down / logs
+
+```bash
+# bring up (also pulls the latest tags)
+deploy/docker-compose/scripts/up.sh
+
+# tail logs
+docker compose -f deploy/docker-compose/compose.yaml logs -f backend
+
+# stop and remove containers (volumes preserved)
+docker compose -f deploy/docker-compose/compose.yaml down
+
+# stop and DELETE volumes (postgres data, rustfs data, redis data — destructive)
+docker compose -f deploy/docker-compose/compose.yaml down -v
+```
+
+`up.sh` refuses to start if `.env` or either YAML file is missing.
+
+---
+
+## 6. Verification
+
+```bash
+# fast health-only check
+deploy/docker-compose/scripts/smoke-test.sh
+
+# end-to-end including a real LLM call
+PROMPT="Say the word hello and nothing else." \
+  deploy/docker-compose/scripts/e2e.sh
+```
+
+`e2e.sh` drives:
+
+```
+register → single-tenant auto-setup → create conversation
+        → POST message → SSE stream → assert text_delta arrived
+```
+
+Both scripts default to `localhost`; override with `HOST`,
+`BACKEND_PORT`, `FRONTEND_PORT` to run against a remote host.
+
+---
+
+## 7. Troubleshooting
+
+### Backend keeps restarting
+
+```bash
+docker compose -f deploy/docker-compose/compose.yaml logs backend --tail=50
+```
+
+| Symptom | Fix |
+|---|---|
+| `CUBEBOX_AUTH__VAULT_KEY is required` | add `auth.vault_key` in `secrets.yaml` |
+| `connection refused on postgres:5432` | postgres still starting; should self-heal — check `docker compose ps` |
+| `Provider 'X' not found` | `default_model: "X/..."` references a provider not in `providers` |
+
+### Login cookie missing on HTTP
+
+`config.production.local.yaml`'s `auth.cookie_secure` must be `false` —
+otherwise the browser / curl silently drops the auth cookie because the
+connection is plain HTTP.
+
+### Frontend → backend fails (CORS / 502)
+
+`compose.yaml` sets `CUBEBOX_API_URL=http://backend:8000` on the frontend
+container, so Next.js proxies `/api/*` server-side over the docker
+network. If you changed service names, fix that env too.
+
+### Image pull denied
+
+If your registry is private:
+
+```bash
+docker login ${IMAGE_REGISTRY}
+```
+
+The compose stack inherits the daemon's credentials.
+
+### Stuck `bucket-init`
+
+```bash
+docker compose -f deploy/docker-compose/compose.yaml logs bucket-init
+```
+
+If rustfs isn't reachable, check the rustfs container's healthcheck;
+rustfs publishes a console on `:9001` you can hit locally to confirm it's up.

--- a/deploy/docker-compose/OPENSANDBOX.md
+++ b/deploy/docker-compose/OPENSANDBOX.md
@@ -1,0 +1,167 @@
+# OpenSandbox under docker-compose
+
+This doc covers the optional `compose.opensandbox.yaml` overlay: how
+to deploy alibaba's [OpenSandbox](https://github.com/alibaba/OpenSandbox)
+lifecycle server in **docker runtime mode** alongside the cubebox
+compose stack, and **what cubebox features that mode cannot satisfy**.
+
+If you only need cubebox chat without agent tool calls, you don't need
+this overlay — leave `sandbox.enabled: false` in
+`config.production.local.yaml`.
+
+---
+
+## 1. What the overlay deploys
+
+`compose.opensandbox.yaml` adds **one** service to the stack:
+
+```
+opensandbox-server   image: opensandbox/server:latest
+                     mounts: /var/run/docker.sock
+                     reads:  /etc/opensandbox/config.toml
+                     port:   8090
+```
+
+The OpenSandbox server is itself a normal Python/FastAPI container. When
+it receives a `POST /sandboxes` request, it talks to the host docker
+daemon via the mounted socket to spawn **sibling** sandbox containers
+(not nested). That means sandbox containers run on the same docker
+engine as cubebox, on a separate bridge network.
+
+Security note: anything inside the `opensandbox-server` container can
+effectively root the host via the docker socket. Keep it on your
+private network; don't expose port 8090 publicly.
+
+---
+
+## 2. Quickstart
+
+```bash
+cd deploy/docker-compose
+
+# 1. opensandbox config (gitignored)
+cp config/opensandbox.toml.example config/opensandbox.toml
+$EDITOR config/opensandbox.toml          # set api_key, eip/host_ip, execd_image, egress.image
+
+# 2. backend secrets — sandbox section
+$EDITOR config/config.production.secrets.yaml
+#   sandbox:
+#     domain:  "opensandbox-server:8090"   # docker DNS name from this overlay
+#     image:   "<your sandbox image>"      # e.g. cubebox-sandbox:24.04-...
+#     api_key: "<same as [server].api_key in opensandbox.toml>"
+
+# 3. backend non-secret — enable sandbox + force server proxy
+$EDITOR config/config.production.local.yaml
+#   sandbox:
+#     enabled: true
+#     use_server_proxy: true     # required: docker bridge endpoints
+#                                # rewrite via the server gateway
+
+# 4. up with the overlay
+docker compose \
+  -f compose.yaml \
+  -f compose.opensandbox.yaml \
+  up -d
+```
+
+Operator-managed values (no template):
+
+| Key | Where | Notes |
+|---|---|---|
+| `opensandbox.toml [server].api_key` | `config/opensandbox.toml` | required, must match `sandbox.api_key` in cubebox secrets |
+| `opensandbox.toml [server].eip` | same | host/IP returned to cubebox in endpoint URLs; usually `host.docker.internal` |
+| `opensandbox.toml [runtime].execd_image` | same | image carrying the **execd** binary; pull-reachable by host docker |
+| `opensandbox.toml [egress].image` | same | egress sidecar image; required when cubebox sends network_policy (it always does) |
+| `opensandbox.toml [docker].network_mode` | same | **must be `bridge`** for cubebox (see §3) |
+
+---
+
+## 3. Compatibility matrix — cubebox features under docker-mode OpenSandbox
+
+Source of truth for the limitations: `~/OpenSandbox/server/opensandbox_server/services/docker.py` and `api/pool.py`. This was verified empirically against `opensandbox-server v0.1.14` by issuing the requests cubebox would make and reading the responses.
+
+### 🚫 Blocked: secure-access endpoints
+
+```
+HTTP 400 SANDBOX::INVALID_PARAMETER
+  "secureAccess is not supported when runtime.type='docker'.
+   Use the Kubernetes runtime to create secured sandboxes."
+```
+
+cubebox passes `secure_access=True` unconditionally on every sandbox
+create (`backend/cubebox/sandbox/manager.py:569`). The docker backend
+rejects this with HTTP 400 before any container is spawned — **so out
+of the box, cubebox cannot create a sandbox against a docker-runtime
+OpenSandbox.**
+
+To make cubebox work with docker-mode OpenSandbox, either:
+
+1. **(recommended)** Patch `manager.py` to make `secure_access`
+   conditional on the runtime mode, OR
+2. **(future)** Wait for upstream OpenSandbox to add an equivalent
+   secured-endpoint mechanism for the docker runtime.
+
+Until then, treat docker-mode OpenSandbox as **for non-cubebox use
+cases only** (direct SDK consumers, evaluation, etc.).
+
+### ⚠ Subject to constraints
+
+| Feature | What works | What doesn't |
+|---|---|---|
+| `networkPolicy` (egress firewall) | Yes — but ONLY when `[docker].network_mode = "bridge"` | Rejected when `network_mode=host` or when bridge is a user-defined network |
+| signed endpoint URLs (`expires=…`) | – | Not implemented for docker (`docker.py:2087` "Signed routes are not supported when …"); cubebox doesn't use this today |
+| `pvc.claimName` volumes | Yes — but treated as docker named volumes | No CSI features, no ReadWriteMany |
+| Pause / resume (`POST /sandboxes/{id}/pause` etc.) | Calls docker `pause/unpause` (cgroup freezer) | No checkpoint to disk — paused state is lost on host docker restart. cubebox already defaults `pause_on_idle: false` because of this |
+
+### 🚫 K8s-only APIs (any runtime, listed for completeness)
+
+The following routes return **501 Not Implemented** on docker runtime
+even though they exist in the OpenAPI spec. cubebox does not currently
+call any of them:
+
+- `POST /pools` and related (pre-warmed pod pools)
+- Snapshot APIs (`POST /sandboxes/{id}/snapshots` etc.)
+
+---
+
+## 4. Verifying
+
+The `opensandbox-server` container exposes a health endpoint cubebox's
+healthcheck consumes:
+
+```bash
+docker compose -f compose.yaml -f compose.opensandbox.yaml ps
+# expect: opensandbox-server   Up (healthy)
+```
+
+Direct API probe (from inside the backend container, using docker DNS):
+
+```bash
+docker exec cubebox-backend-1 python -c "
+import urllib.request, json
+req = urllib.request.Request(
+    'http://opensandbox-server:8090/sandboxes',
+    headers={'OPEN-SANDBOX-API-KEY': '<your api_key>'},
+)
+print(urllib.request.urlopen(req, timeout=5).read().decode())
+"
+# expect: {"items":[], ...}
+```
+
+End-to-end (cubebox chat → sandbox tool call) is **blocked** by the
+secure_access issue documented above; use the kubernetes deploy for a
+real end-to-end test.
+
+---
+
+## 5. Down
+
+```bash
+docker compose -f compose.yaml -f compose.opensandbox.yaml down
+# This also removes the cubebox stack. Use `down opensandbox-server`
+# to remove only the overlay's service.
+```
+
+The mitm CA and any sandbox containers spawned by the server stay on
+the host docker engine — they're not part of this project's compose
+network. Inspect with `docker ps --filter "name=sandbox-"`.

--- a/deploy/docker-compose/OPENSANDBOX.md
+++ b/deploy/docker-compose/OPENSANDBOX.md
@@ -80,36 +80,26 @@ Operator-managed values (no template):
 
 Source of truth for the limitations: `~/OpenSandbox/server/opensandbox_server/services/docker.py` and `api/pool.py`. This was verified empirically against `opensandbox-server v0.1.14` by issuing the requests cubebox would make and reading the responses.
 
-### 🚫 Blocked: secure-access endpoints
+### ✅ Resolved: secure-access toggle
 
-```
-HTTP 400 SANDBOX::INVALID_PARAMETER
-  "secureAccess is not supported when runtime.type='docker'.
-   Use the Kubernetes runtime to create secured sandboxes."
-```
+The docker runtime rejects `secureAccess=True` with HTTP 400 — that's
+an OpenSandbox design choice (secured endpoints are an ingress-gateway
+feature). cubebox exposes a config knob `sandbox.secure_access` which
+defaults to `true` (preserves the Kubernetes-deployment behaviour);
+the compose mode's `config.production.local.yaml.example` sets it to
+`false`. With that flag flipped, cubebox sends `secureAccess: false`
+on every create and the docker runtime accepts the request.
 
-cubebox passes `secure_access=True` unconditionally on every sandbox
-create (`backend/cubebox/sandbox/manager.py:569`). The docker backend
-rejects this with HTTP 400 before any container is spawned — **so out
-of the box, cubebox cannot create a sandbox against a docker-runtime
-OpenSandbox.**
-
-To make cubebox work with docker-mode OpenSandbox, either:
-
-1. **(recommended)** Patch `manager.py` to make `secure_access`
-   conditional on the runtime mode, OR
-2. **(future)** Wait for upstream OpenSandbox to add an equivalent
-   secured-endpoint mechanism for the docker runtime.
-
-Until then, treat docker-mode OpenSandbox as **for non-cubebox use
-cases only** (direct SDK consumers, evaluation, etc.).
+Verified end-to-end on this stack: chat → sandbox tool call →
+`tool_result` returned containing real `ls -la /workspace` output.
 
 ### ⚠ Subject to constraints
 
 | Feature | What works | What doesn't |
 |---|---|---|
 | `networkPolicy` (egress firewall) | Yes — but ONLY when `[docker].network_mode = "bridge"` | Rejected when `network_mode=host` or when bridge is a user-defined network |
-| signed endpoint URLs (`expires=…`) | – | Not implemented for docker (`docker.py:2087` "Signed routes are not supported when …"); cubebox doesn't use this today |
+| signed endpoint URLs (`expires=…`) | – | Not implemented for docker; cubebox doesn't use this today |
+| server-proxy mode (`use_server_proxy: true`) | – | OpenSandbox v0.1.x has a known issue where the proxied endpoint URL drops the port. The example config sets `use_server_proxy: false` instead; the overlay wires `host.docker.internal` via `extra_hosts` so the backend can reach the host-mapped bridge ports of sandbox containers. |
 | `pvc.claimName` volumes | Yes — but treated as docker named volumes | No CSI features, no ReadWriteMany |
 | Pause / resume (`POST /sandboxes/{id}/pause` etc.) | Calls docker `pause/unpause` (cgroup freezer) | No checkpoint to disk — paused state is lost on host docker restart. cubebox already defaults `pause_on_idle: false` because of this |
 
@@ -148,9 +138,12 @@ print(urllib.request.urlopen(req, timeout=5).read().decode())
 # expect: {"items":[], ...}
 ```
 
-End-to-end (cubebox chat → sandbox tool call) is **blocked** by the
-secure_access issue documented above; use the kubernetes deploy for a
-real end-to-end test.
+End-to-end (cubebox chat → sandbox tool call) works once
+`config.production.local.yaml` has `sandbox.enabled: true` AND
+`sandbox.secure_access: false` AND `sandbox.use_server_proxy: false`.
+Verified on this stack against opensandbox-server v0.1.14 — a
+`ls -la /workspace` prompt produced a real `tool_result` containing
+the sandbox filesystem contents.
 
 ---
 

--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -1,0 +1,45 @@
+# cubebox on docker-compose
+
+Single-host deployment of cubebox (backend, frontend, Postgres, Redis,
+rustfs object store) with `docker compose up -d`.
+
+- **Install guide:** [INSTALL.md](INSTALL.md)
+- Uses the **same backend / frontend images** as the kubernetes mode;
+  build them once with `deploy/kubernetes/scripts/build-and-push.sh`.
+
+## Layout
+
+```
+deploy/docker-compose/
+├── README.md
+├── INSTALL.md
+├── compose.yaml
+├── .env.example
+├── config/
+│   ├── config.production.local.yaml.example
+│   └── config.production.secrets.yaml.example
+└── scripts/
+    ├── up.sh          # docker compose pull + up -d
+    ├── smoke-test.sh  # health probes + frontend HTML
+    └── e2e.sh         # register + chat + LLM round-trip
+```
+
+`.env` and the two `config.production.{local,secrets}.yaml` files are
+gitignored. Operators copy the `.example` templates and fill in.
+
+## Quickstart
+
+```bash
+cd deploy/docker-compose
+
+cp .env.example .env
+cp config/config.production.local.yaml.example   config/config.production.local.yaml
+cp config/config.production.secrets.yaml.example config/config.production.secrets.yaml
+$EDITOR .env config/config.production.local.yaml config/config.production.secrets.yaml
+
+deploy/docker-compose/scripts/up.sh
+deploy/docker-compose/scripts/smoke-test.sh
+deploy/docker-compose/scripts/e2e.sh
+```
+
+See [INSTALL.md](INSTALL.md) for the field-by-field config reference.

--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -4,6 +4,11 @@ Single-host deployment of cubebox (backend, frontend, Postgres, Redis,
 rustfs object store) with `docker compose up -d`.
 
 - **Install guide:** [INSTALL.md](INSTALL.md)
+- **Optional OpenSandbox overlay:** [OPENSANDBOX.md](OPENSANDBOX.md) — how
+  to add alibaba/OpenSandbox in docker runtime mode, and what cubebox
+  features the docker runtime cannot serve (TL;DR: `secureAccess` is
+  rejected, so the current `manager.py` setting blocks sandbox creation
+  until that's made conditional).
 - Uses the **same backend / frontend images** as the kubernetes mode;
   build them once with `deploy/kubernetes/scripts/build-and-push.sh`.
 

--- a/deploy/docker-compose/compose.opensandbox.yaml
+++ b/deploy/docker-compose/compose.opensandbox.yaml
@@ -1,0 +1,52 @@
+# Optional overlay: adds the alibaba OpenSandbox lifecycle server in docker
+# runtime mode. cubebox's backend talks to it for sandbox tool calls.
+#
+# Activate with:
+#   docker compose \
+#     -f compose.yaml \
+#     -f compose.opensandbox.yaml \
+#     up -d
+#
+# Pre-requisites:
+#   * `.env` has OPENSANDBOX_*_TAG / image / api_key filled (see .env.example).
+#   * `config/opensandbox.toml` exists (cp from opensandbox.toml.example).
+#   * config/config.production.local.yaml has `sandbox.enabled: true` and
+#     `sandbox.use_server_proxy: true`.
+#   * config/config.production.secrets.yaml has `sandbox.domain`,
+#     `sandbox.image`, `sandbox.api_key` matching the server below.
+#
+# Important: OpenSandbox spawns sandbox containers by mounting the host
+# docker socket. Anyone with access to this container effectively has
+# root on the host. Keep this overlay behind your reverse proxy / private
+# network only.
+
+services:
+  opensandbox-server:
+    image: ${OPENSANDBOX_IMAGE:-opensandbox/server:latest}
+    restart: unless-stopped
+    environment:
+      SANDBOX_CONFIG_PATH: /etc/opensandbox/config.toml
+    volumes:
+      # Docker socket — REQUIRED for the docker runtime. Sandbox containers
+      # are spawned via the host docker daemon, NOT inside this service.
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./config/opensandbox.toml:/etc/opensandbox/config.toml:ro
+    ports:
+      # API port. Backend reaches it as `opensandbox-server:8090` over the
+      # docker network; the host mapping is for direct curl debugging.
+      - "${OPENSANDBOX_PORT:-8090}:8090"
+    healthcheck:
+      # image ships only python; no wget/curl
+      test: ["CMD", "python", "-c", "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8090/health', timeout=2).status == 200 else 1)"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+  # Make backend wait for opensandbox-server to be healthy when this
+  # overlay is active. Outside the overlay, backend's own depends_on
+  # list runs unchanged.
+  backend:
+    depends_on:
+      opensandbox-server:
+        condition: service_healthy

--- a/deploy/docker-compose/compose.opensandbox.yaml
+++ b/deploy/docker-compose/compose.opensandbox.yaml
@@ -50,3 +50,10 @@ services:
     depends_on:
       opensandbox-server:
         condition: service_healthy
+    # OpenSandbox server resolves docker-runtime sandbox endpoint URLs
+    # through the host_ip / eip set in opensandbox.toml. Default is
+    # `host.docker.internal`, which Linux engines do NOT resolve by
+    # default — wire it to the docker bridge gateway so cubebox can
+    # actually reach the sandbox containers.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/deploy/docker-compose/compose.yaml
+++ b/deploy/docker-compose/compose.yaml
@@ -1,0 +1,162 @@
+# cubebox single-host docker-compose deployment.
+#
+# Variables come from .env (operator copies from .env.example). Images
+# are pulled from the same registry the kubernetes mode uses; build them
+# once with deploy/kubernetes/scripts/build-and-push.sh.
+#
+# Quick start:
+#   cp .env.example .env
+#   cp config/config.production.local.yaml.example config/config.production.local.yaml
+#   cp config/config.production.secrets.yaml.example config/config.production.secrets.yaml
+#   $EDITOR .env config/config.production.{local,secrets}.yaml
+#   docker compose up -d
+#
+# All services share the default network. Backend is reachable as
+# `backend:8000` from frontend; frontend serves the user on host port
+# ${FRONTEND_PORT:-3000} and proxies /api/* to backend internally.
+
+name: cubebox
+
+x-restart-policy: &restart-policy
+  restart: unless-stopped
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    <<: *restart-policy
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-cubebox}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-cubebox}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-cubebox} -d ${POSTGRES_DB:-cubebox}"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+
+  redis:
+    image: redis:7-alpine
+    <<: *restart-policy
+    command: >
+      redis-server
+      --requirepass "${REDIS_PASSWORD:?set REDIS_PASSWORD in .env}"
+      --appendonly yes
+      --dir /data
+    volumes:
+      - redis-data:/data
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a \"$$REDIS_PASSWORD\" --no-auth-warning ping | grep PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+
+  # S3-compatible object store. We use rustfs (smaller / pure-Rust) over
+  # minio for the compose mode. config.production.secrets.yaml points
+  # the backend at this endpoint.
+  rustfs:
+    image: ${RUSTFS_IMAGE:-rustfs/rustfs:latest}
+    <<: *restart-policy
+    environment:
+      RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-cubebox}
+      RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:?set RUSTFS_SECRET_KEY in .env}
+      RUSTFS_ADDRESS: ":9000"
+      RUSTFS_CONSOLE_ENABLE: "true"
+      RUSTFS_CONSOLE_ADDRESS: ":9001"
+      RUSTFS_VOLUMES: /data
+    volumes:
+      - rustfs-data:/data
+    healthcheck:
+      # rustfs exposes a similar health probe to minio; if a future image
+      # drops it, replace with a TCP-only probe.
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9000/minio/health/ready || wget -qO- http://localhost:9000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
+
+  # One-shot bucket create. mc speaks S3 so it works against rustfs too.
+  # Idempotent — `mc mb --ignore-existing` is a no-op when the bucket exists.
+  bucket-init:
+    image: minio/mc:RELEASE.2025-04-08T15-39-49Z
+    depends_on:
+      rustfs:
+        condition: service_healthy
+    environment:
+      RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-cubebox}
+      RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY}
+      BUCKET: ${OBJECTSTORE_BUCKET:-cubebox}
+    entrypoint:
+      - sh
+      - -c
+      - |
+        set -e
+        until mc alias set local http://rustfs:9000 "$$RUSTFS_ACCESS_KEY" "$$RUSTFS_SECRET_KEY"; do
+          echo "waiting for rustfs..."; sleep 2
+        done
+        mc mb --ignore-existing "local/$$BUCKET"
+        echo "bucket $$BUCKET ready"
+    restart: "no"
+
+  # Alembic migrate. Runs to completion before backend starts.
+  backend-migrate:
+    image: ${IMAGE_REGISTRY:-192.168.1.101:8050}/${IMAGE_REPO:-library}/cubebox-backend:${BACKEND_TAG:?set BACKEND_TAG in .env}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      ENV_FOR_DYNACONF: production
+    volumes:
+      - ./config/config.production.local.yaml:/app/config.production.local.yaml:ro
+      - ./config/config.production.secrets.yaml:/app/config.production.secrets.yaml:ro
+    command: ["alembic", "upgrade", "head"]
+    restart: "no"
+
+  backend:
+    image: ${IMAGE_REGISTRY:-192.168.1.101:8050}/${IMAGE_REPO:-library}/cubebox-backend:${BACKEND_TAG}
+    <<: *restart-policy
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      rustfs:
+        condition: service_healthy
+      backend-migrate:
+        condition: service_completed_successfully
+    environment:
+      ENV_FOR_DYNACONF: production
+    volumes:
+      - ./config/config.production.local.yaml:/app/config.production.local.yaml:ro
+      - ./config/config.production.secrets.yaml:/app/config.production.secrets.yaml:ro
+    ports:
+      - "${BACKEND_PORT:-8000}:8000"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health/ready', timeout=2).status == 200 else 1)"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  frontend:
+    image: ${IMAGE_REGISTRY:-192.168.1.101:8050}/${IMAGE_REPO:-library}/cubebox-frontend:${FRONTEND_TAG:?set FRONTEND_TAG in .env}
+    <<: *restart-policy
+    depends_on:
+      backend:
+        condition: service_healthy
+    environment:
+      # Frontend's Next.js server proxies /api/* server-side to this URL.
+      CUBEBOX_API_URL: "http://backend:8000"
+      PORT: "3000"
+      HOSTNAME: "0.0.0.0"
+    ports:
+      - "${FRONTEND_PORT:-3000}:3000"
+
+volumes:
+  postgres-data:
+  redis-data:
+  rustfs-data:

--- a/deploy/docker-compose/config/config.production.local.yaml.example
+++ b/deploy/docker-compose/config/config.production.local.yaml.example
@@ -1,0 +1,42 @@
+# Non-secret runtime overrides for backend, applied by dynaconf on top of
+# config.production.yaml. Copy to config.production.local.yaml and edit.
+# Mounted into the backend container at /app/config.production.local.yaml.
+
+dynaconf_merge: true
+production:
+  api:
+    host: "0.0.0.0"
+    port: 8000
+    # The URL operators / browsers reach the backend at. If you put a
+    # reverse proxy in front, use that URL.
+    public_url: "http://localhost:8000"
+  deployment:
+    mode: single_tenant            # single_tenant | multi_tenant
+
+  public_base_url: "http://localhost:8000"
+  frontend_base_url: "http://localhost:3000"
+
+  auth:
+    # ★ HTTP installs MUST set this to false — otherwise clients silently
+    # drop the auth cookie (Secure flag stripped on non-HTTPS).
+    cookie_secure: false
+
+  # Service-name DNS inside the compose default network.
+  database:
+    host: "postgres"
+    port: 5432
+    user: "cubebox"
+    name: "cubebox"
+
+  objectstore:
+    provider: "s3"
+    endpoint: "http://minio:9000"
+    bucket: "cubebox"
+    region: "us-east-1"
+
+  sandbox:
+    # Disabled by default — running OpenSandbox under compose is heavy.
+    # Operators wanting tool calls should point at an external OpenSandbox
+    # and flip this to true.
+    enabled: false
+    use_server_proxy: false

--- a/deploy/docker-compose/config/config.production.local.yaml.example
+++ b/deploy/docker-compose/config/config.production.local.yaml.example
@@ -30,7 +30,7 @@ production:
 
   objectstore:
     provider: "s3"
-    endpoint: "http://minio:9000"
+    endpoint: "http://rustfs:9000"
     bucket: "cubebox"
     region: "us-east-1"
 

--- a/deploy/docker-compose/config/config.production.local.yaml.example
+++ b/deploy/docker-compose/config/config.production.local.yaml.example
@@ -36,7 +36,16 @@ production:
 
   sandbox:
     # Disabled by default — running OpenSandbox under compose is heavy.
-    # Operators wanting tool calls should point at an external OpenSandbox
-    # and flip this to true.
+    # Operators wanting tool calls should bring up the OpenSandbox
+    # overlay (see deploy/docker-compose/OPENSANDBOX.md) and flip
+    # enabled to true. The two settings below MUST stay as shown for
+    # docker-runtime OpenSandbox to work.
     enabled: false
+    # secureAccess is rejected by the docker runtime — set false.
+    secure_access: false
+    # Use direct mode (not server-proxy). OpenSandbox v0.1.x has a known
+    # issue where proxied endpoint URLs drop the port. Direct mode
+    # appends the host-mapped bridge port correctly; cubebox-backend
+    # needs `host.docker.internal` resolvable (the overlay's extra_hosts
+    # entry handles that).
     use_server_proxy: false

--- a/deploy/docker-compose/config/config.production.secrets.yaml.example
+++ b/deploy/docker-compose/config/config.production.secrets.yaml.example
@@ -1,0 +1,59 @@
+# Secret backend overrides — passwords, api_keys, jwt/csrf/vault material.
+# Copy to config.production.secrets.yaml and edit. Mounted into the
+# backend container as /app/config.production.secrets.yaml.
+#
+# This file MUST match the passwords you put in .env (operator keeps both
+# in sync). The two-file split exists because backend's dynaconf reads
+# YAML for nested config like the LLM provider tree, while .env drives
+# what compose itself substitutes.
+
+dynaconf_merge: true
+production:
+  auth:
+    # openssl rand -hex 32
+    jwt_secret: "REPLACE_ME"
+    csrf_secret: "REPLACE_ME"
+    # python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+    vault_key: "REPLACE_ME"
+
+  database:
+    password: "REPLACE_ME"        # must match POSTGRES_PASSWORD in .env
+
+  redis:
+    # Service-name DNS + password from .env.
+    url: "redis://:REPLACE_ME@redis:6379/0"
+
+  objectstore:
+    access_key: "cubebox"           # must match RUSTFS_ACCESS_KEY in .env
+    access_secret: "REPLACE_ME"     # must match RUSTFS_SECRET_KEY in .env
+
+  sandbox:
+    # Filled in only when sandbox.enabled = true in
+    # config.production.local.yaml — and pointing at an external
+    # OpenSandbox endpoint.
+    domain: ""
+    image: ""
+    api_key: ""
+
+  llm:
+    default_model: "deepseek/deepseek-v4-flash"
+    fallback_models:
+      - "cubebox/qwen3.5-plus-thinking"
+    providers:
+      # Mode A: preset (simplest)
+      deepseek:
+        preset: "deepseek/cn/anthropic-messages"
+        api_key: "sk-..."
+
+      # Mode B: full custom (private gateway / self-host)
+      # cubebox:
+      #   base_url: "https://gateway.example.com/v1"
+      #   api_key: "..."
+      #   api: "openai-completions"
+      #   models:
+      #     - id: "qwen3.5-plus-thinking"
+      #       name: "Qwen3.5 Plus"
+      #       reasoning: true
+      #       input: ["text", "image"]
+      #       context_window: 991000
+      #       max_tokens: 64000

--- a/deploy/docker-compose/config/opensandbox.toml.example
+++ b/deploy/docker-compose/config/opensandbox.toml.example
@@ -1,0 +1,59 @@
+# OpenSandbox lifecycle server config — docker runtime mode.
+# Mounted into opensandbox-server at /etc/opensandbox/config.toml.
+# Schema: https://github.com/alibaba/OpenSandbox/blob/main/server/configuration.md
+
+[server]
+host = "0.0.0.0"
+port = 8090
+# API key matches `sandbox.api_key` in cubebox's
+# config.production.secrets.yaml. The cubebox SDK sends it as
+# OPEN-SANDBOX-API-KEY header.
+api_key = "REPLACE_ME"
+# `eip` is the host/IP the server includes in sandbox endpoint URLs.
+# When cubebox runs in a sibling container and talks via the docker
+# network, "host.docker.internal" works on macOS/Windows and on Linux
+# Docker engines that expose it. On Linux without host.docker.internal,
+# set this to the LAN IP of the host running compose.
+eip = "host.docker.internal"
+
+[log]
+level = "INFO"
+
+[runtime]
+type = "docker"
+# Image carrying the execd binary that bootstraps file / command access
+# inside each sandbox. Must be pullable by the host docker daemon.
+execd_image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/execd:v1.0.18"
+
+[egress]
+# Egress sidecar image used when a sandbox is created with networkPolicy.
+# Required for cubebox (cubebox always passes a network_policy).
+image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:v1.0.12"
+
+[docker]
+# `bridge` is REQUIRED for cubebox — host mode disables networkPolicy.
+network_mode = "bridge"
+# When opensandbox-server runs in a container, this is the host address
+# returned to clients for bridge-mode sandbox endpoints. Same advice as
+# server.eip above.
+host_ip = "host.docker.internal"
+drop_capabilities = [
+  "AUDIT_WRITE",
+  "MKNOD",
+  "NET_ADMIN",
+  "NET_RAW",
+  "SYS_ADMIN",
+  "SYS_MODULE",
+  "SYS_PTRACE",
+  "SYS_TIME",
+  "SYS_TTY_CONFIG",
+]
+no_new_privileges = true
+pids_limit = 4096
+
+[ingress]
+# `direct`: SDK clients hit sandbox container ports directly via
+# host-mapped bridge addresses. `proxy`: server proxies all traffic.
+# cubebox sets `use_server_proxy: true` in its config — leave this as
+# direct AND set the proxy on the cubebox side.
+mode = "direct"

--- a/deploy/docker-compose/scripts/e2e.sh
+++ b/deploy/docker-compose/scripts/e2e.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Live e2e against the compose stack. Same logic as the kubernetes
+# variant but talks to the published host ports directly (no ingress
+# Host header dance).
+set -euo pipefail
+
+HOST="${HOST:-localhost}"
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+B="http://$HOST:$BACKEND_PORT"
+PROMPT="${PROMPT:-Say the word \"hello\" and nothing else.}"
+
+unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy 2>/dev/null || true
+export no_proxy='*' NO_PROXY='*'
+
+CK=$(mktemp); SSE_OUT=$(mktemp)
+trap 'rm -f "$CK" "$SSE_OUT"' EXIT
+
+EMAIL="e2e-$(date +%s)-$(openssl rand -hex 2)@example.com"
+PASS="correcthorsebatterystaple"
+
+step() { printf '\n==> %s\n' "$*"; }
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+step "1. /api/v1/system/info"
+INFO=$(curl -fsS --noproxy '*' "$B/api/v1/system/info")
+echo "  $INFO"
+echo "$INFO" | grep -q '"deployment_mode":"single_tenant"' \
+  || fail "expected single_tenant deployment_mode"
+
+step "2. register $EMAIL"
+REG=$(curl -fsS --noproxy '*' -c "$CK" -H "Content-Type: application/json" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASS\"}" \
+  "$B/api/v1/auth/register")
+echo "  $REG"
+WS=$(echo "$REG" | python3 -c \
+  'import json,sys; print(json.load(sys.stdin).get("default_workspace_id",""))')
+[[ -n "$WS" ]] || fail "no default_workspace_id from register"
+
+step "3. login (cookie jar)"
+curl -fsS --noproxy '*' -c "$CK" -b "$CK" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "username=$EMAIL" --data-urlencode "password=$PASS" \
+  --data-urlencode "grant_type=password" \
+  "$B/api/v1/auth/login" >/dev/null
+grep -q "cubebox_auth" "$CK" \
+  || fail "no cubebox_auth (check auth.cookie_secure=false on HTTP)"
+echo "  ok"
+
+step "4. GET /auth/me — receive csrf cookie"
+curl -fsS --noproxy '*' -c "$CK" -b "$CK" "$B/api/v1/auth/me" >/dev/null
+grep -q "cubebox_csrf" "$CK" || fail "no cubebox_csrf in jar"
+CSRF=$(awk -F'\t' '$6=="cubebox_csrf"{print $7}' "$CK" | tail -1)
+[[ -n "$CSRF" ]] || fail "csrf cookie present but empty"
+echo "  ok"
+
+step "5. create conversation"
+CONV=$(curl -fsS --noproxy '*' -b "$CK" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-Token: $CSRF" \
+  -d '{"title":"e2e probe"}' \
+  "$B/api/v1/ws/$WS/conversations")
+CONV_ID=$(echo "$CONV" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+echo "  conv_id=$CONV_ID"
+
+step "6. POST message → run_id"
+MSG=$(curl -fsS --noproxy '*' -b "$CK" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-Token: $CSRF" \
+  -d "$(python3 -c 'import json,os; print(json.dumps({"content": os.environ["PROMPT"]}))')" \
+  "$B/api/v1/ws/$WS/conversations/$CONV_ID/messages")
+RUN_ID=$(echo "$MSG" | python3 -c 'import json,sys; print(json.load(sys.stdin)["run_id"])')
+echo "  run_id=$RUN_ID"
+
+step "7. stream SSE — extract assistant text + usage"
+curl -sN --noproxy '*' -b "$CK" \
+  -H "Accept: text/event-stream" \
+  "$B/api/v1/ws/$WS/conversations/$CONV_ID/runs/$RUN_ID/stream" \
+  --max-time 120 > "$SSE_OUT" || true
+EVENTS=$(grep -c '^data: ' "$SSE_OUT" || true)
+echo "  event types: $(grep -oE '"type":[[:space:]]*"[^"]+"' "$SSE_OUT" | sort -u | tr '\n' ' ')"
+echo "  data lines: $EVENTS"
+[[ "$EVENTS" -gt 0 ]] || fail "no SSE data lines"
+
+TEXT=$(python3 - "$SSE_OUT" <<'PY'
+import json, sys
+text = ""
+for line in open(sys.argv[1]):
+    if not line.startswith("data: "):
+        continue
+    try:
+        obj = json.loads(line[6:])
+    except Exception:
+        continue
+    if obj.get("type") == "text_delta":
+        text += obj.get("data", {}).get("content", "")
+print(text, end="")
+PY
+)
+echo "  ASSISTANT_TEXT: ${TEXT}"
+[[ -n "${TEXT// }" ]] || fail "no text_delta content from LLM"
+
+echo
+echo "==================================================="
+echo "E2E PASSED — LLM round-trip complete."
+echo "==================================================="

--- a/deploy/docker-compose/scripts/smoke-test.sh
+++ b/deploy/docker-compose/scripts/smoke-test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Post-up smoke checks for the docker-compose stack. Runs from any host
+# that can reach the published ports (default localhost).
+set -euo pipefail
+
+HOST="${HOST:-localhost}"
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+FRONTEND_PORT="${FRONTEND_PORT:-3000}"
+B="http://$HOST:$BACKEND_PORT"
+F="http://$HOST:$FRONTEND_PORT"
+
+unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy 2>/dev/null || true
+export no_proxy='*' NO_PROXY='*'
+
+step() { printf '\n==> %s\n' "$*"; }
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+step "1. Compose service health"
+ROOT="$(git rev-parse --show-toplevel)"
+( cd "$ROOT/deploy/docker-compose" && docker compose ps )
+
+step "2. Backend /health/live"
+INFO=$(curl -fsS --noproxy '*' "$B/health/live")
+echo "  $INFO"
+echo "$INFO" | grep -q '"status":"ok"' || fail "backend health check"
+
+step "3. Backend /api/v1/system/info"
+INFO=$(curl -fsS --noproxy '*' "$B/api/v1/system/info")
+echo "  $INFO"
+echo "$INFO" | grep -q '"deployment_mode"' || fail "system info"
+
+step "4. Frontend root renders HTML"
+body=$(curl -fsS --noproxy '*' "$F/")
+echo "  $(echo "$body" | head -c 200)..."
+echo "$body" | grep -qiE "<html|<!doctype" || fail "frontend HTML"
+
+step "5. Frontend → backend rewrite (via Next.js)"
+code=$(curl -s -o /dev/null -w '%{http_code}' --noproxy '*' "$F/api/v1/system/info")
+echo "  /api/v1/system/info via frontend → HTTP $code"
+[[ "$code" =~ ^(200|401|403|404)$ ]] || fail "frontend → backend proxy (got $code)"
+
+echo
+echo "SMOKE TEST PASSED."

--- a/deploy/docker-compose/scripts/up.sh
+++ b/deploy/docker-compose/scripts/up.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Bring up the cubebox compose stack. Verifies the operator has filled in
+# .env + config files, then `docker compose up -d --pull always`.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+DIR="$ROOT/deploy/docker-compose"
+cd "$DIR"
+
+missing=0
+for f in .env config/config.production.local.yaml config/config.production.secrets.yaml; do
+  if [[ ! -f "$f" ]]; then
+    echo "MISSING: $f"
+    echo "  cp ${f}.example $f && \$EDITOR $f"
+    missing=1
+  fi
+done
+if [[ "$missing" -eq 1 ]]; then
+  echo
+  echo "Fill in the files above and re-run." >&2
+  exit 1
+fi
+
+echo "==> Pulling images"
+docker compose pull
+
+echo "==> Bringing up services"
+docker compose up -d --remove-orphans
+
+echo
+echo "==> Status"
+docker compose ps


### PR DESCRIPTION
## Summary

- 新增 `deploy/docker-compose/` —— 单主机 compose 模式部署，与现有的 helm chart 平行
- 6 个 service：postgres / redis / **rustfs**（替代 minio，参考 ~/infra/rustfs 选型）+ bucket-init oneshot + alembic migrate oneshot + backend + frontend
- 镜像与 k8s 模式共用（同一 `192.168.1.101:8050/library/cubebox-*:<git-sha>`）
- 已在 192.168.1.101 节点完整跑通：register → 单租户 auto-setup → 创建会话 → 发消息 → SSE 拿到 LLM `'Hello'` 回复（arkcode/doubao-seed-2.0-pro）

## What's in this PR

```
deploy/
├── README.md            # 顶级模式选择器，docker-compose 状态改为 available
└── docker-compose/
    ├── README.md
    ├── INSTALL.md        # 英文详细手册（每个 .env / yaml 字段都讲）
    ├── compose.yaml
    ├── .env.example      # 镜像 tag + 端口 + infra 密码
    ├── config/
    │   ├── config.production.local.yaml.example     # 非密钥（HTTP 默认 cookie_secure=false 等）
    │   └── config.production.secrets.yaml.example   # jwt / csrf / vault + LLM providers
    ├── .gitignore        # 防 .env / config.*.yaml 被提交
    └── scripts/
        ├── up.sh         # docker compose pull + up -d，前置校验文件齐全
        ├── smoke-test.sh # health + frontend 渲染 + frontend → backend 路由
        └── e2e.sh        # register + chat + LLM SSE 断言
```

## 关键决策

| 项 | 选择 |
|---|---|
| 组件 | 与 k8s 完全对齐（backend / frontend / postgres / redis / S3-store），单 host |
| 对象存储 | **rustfs** —— 参考 `~/infra/rustfs/docker-compose.yaml` 选型（pure-Rust，体积小） |
| bucket-init | 复用 minio 的 `mc` 镜像（S3 兼容，对 rustfs 也好使），跑一次 `mc mb --ignore-existing` 然后退出 |
| migrate | 独立 `backend-migrate` service 跑 `alembic upgrade head`，backend 通过 `depends_on.condition: service_completed_successfully` 等它跑完 |
| 镜像源 | 复用 k8s `build-and-push.sh` 推上去的同一套 tag；`.env` 改 `BACKEND_TAG` / `FRONTEND_TAG` |
| 网络 | docker DNS（`postgres:5432` / `redis:6379` / `rustfs:9000`），主机仅对外 frontend 端口 |
| TLS | 默认 HTTP；operator 自己加反代 |
| sandbox | 默认 disable；要用就在 `config.production.local.yaml` 翻 `sandbox.enabled` 并填外部 OpenSandbox 地址 |
| egress 注入 | 不在 compose 模式里（需要 k8s MutatingWebhookConfiguration） |

## 实测验证（在 192.168.1.101）

部署：

```bash
cd /work/cubebox-compose
docker-compose up -d
# 结果：
# cubebox-backend-1     Up (healthy)   0.0.0.0:18000->8000/tcp
# cubebox-frontend-1    Up             0.0.0.0:13000->3000/tcp
# cubebox-postgres-1    Up (healthy)   5432/tcp
# cubebox-redis-1       Up (healthy)   6379/tcp
# cubebox-rustfs-1      Up (healthy)   9000-9001/tcp
```

E2E（arkcode/doubao-seed-2.0-pro，外部 LLM）：

```
==> register      → usr-1h5aujO8lbJQ6F  default_workspace_id: ws-1h5aun8hZAYpcv
==> login         → cubebox_auth cookie
==> /auth/me      → cubebox_csrf cookie
==> create conv   → conv-1h5ausbm0WKGTn
==> POST message  → run_id=019eb54b-17aa-79d3-9b8e-376a3a0af500
==> SSE stream
  event types: "done" "text_delta" "usage"
  data lines: 3
  ASSISTANT_TEXT: 'Hello'
```

## 一个踩到的坑（未进文档）

`m.daocloud.io/docker.io/rustfs/rustfs:latest` 在我测试节点上拉取速度只有 ~50KB/s（300MB 要 100 分钟）。临时用 `docker save | ssh … | docker load` 从本机直传过去（几秒）。要不要把这套 fallback 流程加进 INSTALL.md 的 Troubleshooting？倾向不加，操作者一般遇不到我这个特定的网络。

## Out of scope

- 实际写入 INSTALL.md 的 Troubleshooting 一节关于 rustfs 拉取慢的 fallback（操作者一般没事）
- bundled OpenSandbox / 内置 egress（compose 模式不做，需要 k8s）
- HA / 多副本 / 备份策略（单主机模式，operator 自己用 host volume snapshot）

## Test plan

- [x] `docker compose config --quiet` 通过（变量替换 + 语法）
- [x] 在 192.168.1.101 节点完整 `up.sh` + 端到端 chat 通过（arkcode LLM 真实回 Hello）
- [x] `up.sh` 在缺 .env / config yaml 时 fail-fast，给出 cp 提示
- [ ] 在干净的非 CN 网络 host 上跑一次（让 reviewer / 后续 CI 验证 rustfs 拉取不卡）
- [ ] HTTPS 反代场景（用户自配 nginx/caddy 后 cookie_secure=true）