### PR TITLE
feat(ui): add Operator theme family (cubepi-docs + e2b inspired)

### DIFF
--- a/frontend/packages/web/app/globals.css
+++ b/frontend/packages/web/app/globals.css
@@ -23,8 +23,10 @@
   }
 }
 
-/* Use .dark class (not prefers-color-scheme) so dark: variants work with the theme toggle */
-@custom-variant dark (&:where(.dark, .dark *));
+/* Use class hooks (not prefers-color-scheme) so dark: variants work with
+   the theme toggle. Both .dark (default) and .operator-dark trigger the
+   dark variant. */
+@custom-variant dark (&:where(.dark, .dark *, .operator-dark, .operator-dark *));
 
 /* Token layer — "Vercel Mono" direction.
    Source of truth: this file (spec docs/dev/specs/2026-06-10-ui-redesign-design.md §1).
@@ -172,6 +174,145 @@
 
     --color-destructive: #e5484d;
     --color-destructive-foreground: #ffffff;
+  }
+
+  /* ============================================================
+     OPERATOR — alt theme family inspired by cubepi docs + e2b.
+     Two variants: .operator-light and .operator-dark; user picks
+     light/dark independently from picking the Operator flavor.
+     Shared traits:
+     - Inter Tight headlines, JetBrains Mono chrome
+     - Inverse elevation: page is the softer surface, panels are
+       deeper (light: panel=#fff over page=#fafafa;
+              dark : panel=#0a0a0b under page=#18181b)
+     - High-contrast NEUTRAL CTA (ink-on-page-ink): never a brand fill
+     - Indigo reserved for tiny accent moments (focus ring, info-fg)
+     - Sharper 1px borders, tighter radius (3/5/6), no shadows
+     - .uppercase auto-promotes to JetBrains Mono + 0.12em tracking
+     ============================================================ */
+  .operator-light {
+    --font-sans: var(--font-inter-tight), system-ui, -apple-system, sans-serif;
+    --font-mono: var(--font-jetbrains-mono), ui-monospace, 'SFMono-Regular', monospace;
+
+    --color-background: #fafafa; /* zinc-50 — the page */
+    --color-foreground: #0a0a0b; /* zinc-950 — body ink */
+    --color-card: #ffffff; /* surface (panels/sidebar) is the stark white */
+    --color-card-foreground: #0a0a0b;
+    --color-raised: #f4f4f5; /* input bar, user bubble, hover fills */
+    --color-sunken: #f4f4f5;
+
+    --color-primary: #0a0a0b; /* high-contrast neutral CTA — cubepi voice */
+    --color-primary-foreground: #fafafa;
+
+    --color-secondary: #f4f4f5;
+    --color-secondary-foreground: #0a0a0b;
+    --color-muted: #f4f4f5;
+    --color-muted-foreground: #52525b; /* zinc-600 */
+    --color-faint: #a1a1aa; /* zinc-400, eyebrows */
+    --color-accent: #f4f4f5;
+    --color-accent-foreground: #0a0a0b;
+    --color-popover: #ffffff;
+    --color-popover-foreground: #0a0a0b;
+    --color-border: #e4e4e7; /* zinc-200 */
+    --color-border-strong: #d4d4d8; /* zinc-300 */
+    --color-input: #e4e4e7;
+    --color-ring: #3b5bd9; /* cubepi indigo */
+
+    --color-success-surface: rgba(22, 163, 74, 0.08);
+    --color-success-border: rgba(22, 163, 74, 0.3);
+    --color-success-fg: #15803d;
+    --color-success-solid: #16a34a;
+    --color-warning-surface: rgba(217, 119, 6, 0.08);
+    --color-warning-border: rgba(217, 119, 6, 0.3);
+    --color-warning-fg: #b45309;
+    --color-warning-solid: #d97706;
+    --color-danger-surface: rgba(220, 38, 38, 0.08);
+    --color-danger-border: rgba(220, 38, 38, 0.3);
+    --color-danger-fg: #b91c1c;
+    --color-danger-solid: #dc2626;
+    --color-info-surface: rgba(59, 91, 217, 0.08);
+    --color-info-border: rgba(59, 91, 217, 0.3);
+    --color-info-fg: #3b5bd9;
+    --color-info-solid: #3b5bd9;
+
+    --color-destructive: #dc2626;
+    --color-destructive-foreground: #ffffff;
+  }
+
+  .operator-dark {
+    --font-sans: var(--font-inter-tight), system-ui, -apple-system, sans-serif;
+    --font-mono: var(--font-jetbrains-mono), ui-monospace, 'SFMono-Regular', monospace;
+
+    --color-background: #18181b; /* zinc-900 — the canvas */
+    --color-foreground: #f4f4f5; /* zinc-50 */
+    --color-card: #0a0a0b; /* zinc-950 — panels go DEEPER than canvas */
+    --color-card-foreground: #f4f4f5;
+    --color-raised: #27272a; /* zinc-800 — input bar, bubbles, hover fills */
+    --color-sunken: #050506; /* code blocks, terminal */
+
+    /* CTA = high-contrast NEUTRAL (zinc-100), not a colored fill.
+       'pip install cubepi' style — the action IS the page voice. */
+    --color-primary: #fafafa;
+    --color-primary-foreground: #18181b;
+
+    --color-secondary: #27272a;
+    --color-secondary-foreground: #f4f4f5;
+    --color-muted: #27272a;
+    --color-muted-foreground: #a1a1aa; /* zinc-400 */
+    --color-faint: #71717a; /* zinc-500, eyebrows + meta */
+    --color-accent: #27272a; /* hover slot */
+    --color-accent-foreground: #f4f4f5;
+    --color-popover: #0a0a0b;
+    --color-popover-foreground: #f4f4f5;
+    --color-border: #3f3f46; /* zinc-700 — sharper, single tone */
+    --color-border-strong: #52525b; /* zinc-600 */
+    --color-input: #3f3f46;
+    /* Focus ring uses the accent indigo so it pops on the neutral CTA */
+    --color-ring: #6a83e3;
+
+    /* Status palette stays muted (same as dark theme); these are state
+       indicators, not brand. */
+    --color-success-surface: rgba(45, 145, 90, 0.1);
+    --color-success-border: rgba(45, 145, 90, 0.3);
+    --color-success-fg: #6db58a;
+    --color-success-solid: #3f8c63;
+    --color-warning-surface: rgba(200, 145, 50, 0.1);
+    --color-warning-border: rgba(200, 145, 50, 0.3);
+    --color-warning-fg: #d1a164;
+    --color-warning-solid: #b07e3a;
+    --color-danger-surface: rgba(195, 75, 80, 0.1);
+    --color-danger-border: rgba(195, 75, 80, 0.3);
+    --color-danger-fg: #d97478;
+    --color-danger-solid: #b54146;
+    /* info repurposed to the indigo accent so links/active reads share
+       the operator voice */
+    --color-info-surface: rgba(106, 131, 227, 0.1);
+    --color-info-border: rgba(106, 131, 227, 0.35);
+    --color-info-fg: #6a83e3;
+    --color-info-solid: #6a83e3;
+
+    --color-destructive: #d97478;
+    --color-destructive-foreground: #18181b;
+  }
+
+  /* Operator-only chrome tweaks: tighter radius for that 5px feel; all
+     `.uppercase` labels are auto-mono with cubepi-style letterspacing.
+     Applies to both light + dark variants of the Operator family. */
+  :where(.operator-light, .operator-dark) *,
+  :where(.operator-light, .operator-dark) *::before,
+  :where(.operator-light, .operator-dark) *::after {
+    --radius-xs: 3px;
+    --radius: 5px;
+    --radius-lg: 6px;
+  }
+  :where(.operator-light, .operator-dark) :where(.uppercase) {
+    font-family: var(--font-mono);
+    letter-spacing: 0.12em;
+    font-weight: 500;
+  }
+  /* Numerals in mono contexts use tabular figures (cubepi rule) */
+  :where(.operator-light, .operator-dark) :where(code, pre, .font-mono, .tabular-nums) {
+    font-variant-numeric: tabular-nums;
   }
 }
 

--- a/frontend/packages/web/app/layout.tsx
+++ b/frontend/packages/web/app/layout.tsx
@@ -1,11 +1,26 @@
 import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
+import { Inter_Tight, JetBrains_Mono } from 'next/font/google'
 import { NextIntlClientProvider } from 'next-intl'
 import { getLocale, getMessages } from 'next-intl/server'
 import { ThemeProvider } from 'next-themes'
 import { Toaster } from '@/components/ui/sonner'
 import './globals.css'
+
+const interTight = Inter_Tight({
+  subsets: ['latin'],
+  variable: '--font-inter-tight',
+  weight: ['400', '500', '600', '700'],
+  display: 'swap',
+})
+
+const jetBrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-jetbrains-mono',
+  weight: ['400', '500'],
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
   title: 'cubebox',
@@ -22,11 +37,16 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     <html
       lang={locale}
       suppressHydrationWarning
-      className={`${GeistSans.variable} ${GeistMono.variable}`}
+      className={`${GeistSans.variable} ${GeistMono.variable} ${interTight.variable} ${jetBrainsMono.variable}`}
     >
       <body className="font-sans">
         <NextIntlClientProvider locale={locale} messages={messages}>
-          <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            themes={['light', 'dark', 'operator-light', 'operator-dark']}
+          >
             {children}
             <Toaster />
           </ThemeProvider>

--- a/frontend/packages/web/components/sidebar/AvatarPopover.tsx
+++ b/frontend/packages/web/components/sidebar/AvatarPopover.tsx
@@ -15,7 +15,7 @@ import {
 } from '@cubebox/core'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useAdminAccess } from '@/hooks/useAdminAccess'
-import { ArrowLeft, Languages, LogOut, Moon, Shield, Sun } from 'lucide-react'
+import { ArrowLeft, Languages, LogOut, Moon, Shield, Sparkles, Sun, Terminal } from 'lucide-react'
 import { clearAllPresetSelectionStores } from '@/lib/stores/preset-selection'
 
 export function AvatarPopover() {
@@ -26,7 +26,7 @@ export function AvatarPopover() {
   const inAdminScope = pathname?.startsWith('/admin') ?? false
   const user = useAuthStore((s) => s.user)
   const { isAdmin } = useAdminAccess()
-  const { resolvedTheme, setTheme } = useTheme()
+  const { theme, resolvedTheme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -104,20 +104,56 @@ export function AvatarPopover() {
           </Link>
         )}
 
-        {mounted && (
-          <button
-            type="button"
-            onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
-            className="w-full flex items-center gap-2 px-2 py-1.5 rounded-sm text-[12.5px] hover:bg-accent/60 transition-colors"
-          >
-            {resolvedTheme === 'dark' ? (
-              <Sun className="size-3.5 text-muted-foreground" />
-            ) : (
-              <Moon className="size-3.5 text-muted-foreground" />
-            )}
-            <span>{resolvedTheme === 'dark' ? t('lightTheme') : t('darkTheme')}</span>
-          </button>
-        )}
+        {mounted &&
+          (() => {
+            // Two orthogonal axes: flavor (default / operator) × mode (light / dark).
+            // Compose to a concrete next-themes value: light, dark,
+            // operator-light, operator-dark. resolvedTheme handles 'system'.
+            const isOperator = theme === 'operator-light' || theme === 'operator-dark'
+            const currentMode =
+              theme === 'operator-light' || theme === 'light'
+                ? 'light'
+                : theme === 'operator-dark' || theme === 'dark'
+                  ? 'dark'
+                  : (resolvedTheme ?? 'light')
+            const toggleMode = () => {
+              const nextMode = currentMode === 'dark' ? 'light' : 'dark'
+              setTheme(isOperator ? `operator-${nextMode}` : nextMode)
+            }
+            const toggleFlavor = () => {
+              setTheme(isOperator ? currentMode : `operator-${currentMode}`)
+            }
+            return (
+              <>
+                <button
+                  type="button"
+                  onClick={toggleMode}
+                  className="w-full flex items-center gap-2 px-2 py-1.5 rounded-sm text-[12.5px] hover:bg-accent/60 transition-colors"
+                >
+                  {currentMode === 'dark' ? (
+                    <Sun className="size-3.5 text-muted-foreground" />
+                  ) : (
+                    <Moon className="size-3.5 text-muted-foreground" />
+                  )}
+                  <span>{currentMode === 'dark' ? t('lightTheme') : t('darkTheme')}</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={toggleFlavor}
+                  className="w-full flex items-center gap-2 px-2 py-1.5 rounded-sm text-[12.5px] hover:bg-accent/60 transition-colors"
+                >
+                  {isOperator ? (
+                    <Sparkles className="size-3.5 text-muted-foreground" />
+                  ) : (
+                    <Terminal className="size-3.5 text-muted-foreground" />
+                  )}
+                  <span className="font-mono uppercase tracking-wider text-[11px]">
+                    {isOperator ? 'Default theme' : 'Operator theme'}
+                  </span>
+                </button>
+              </>
+            )
+          })()}
 
         <div className="flex items-center gap-2 px-2 py-1.5 rounded-sm text-[12.5px]">
           <Languages className="size-3.5 text-muted-foreground shrink-0" />

--- a/frontend/packages/web/components/ui/theme-toggle.tsx
+++ b/frontend/packages/web/components/ui/theme-toggle.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react'
 
 export function ThemeToggle() {
   const t = useTranslations('avatar')
-  const { resolvedTheme, setTheme } = useTheme()
+  const { theme, resolvedTheme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -18,17 +18,22 @@ export function ThemeToggle() {
 
   if (!mounted) return null
 
-  const label = resolvedTheme === 'dark' ? t('lightTheme') : t('darkTheme')
+  // Theme is two-axis: flavor (default | operator) × mode (light | dark).
+  // This button toggles mode only, preserving the active flavor.
+  const isOperator = theme === 'operator-light' || theme === 'operator-dark'
+  const currentMode =
+    theme === 'operator-light' || theme === 'light'
+      ? 'light'
+      : theme === 'operator-dark' || theme === 'dark'
+        ? 'dark'
+        : (resolvedTheme ?? 'light')
+  const label = currentMode === 'dark' ? t('lightTheme') : t('darkTheme')
+  const next = currentMode === 'dark' ? 'light' : 'dark'
+  const onClick = () => setTheme(isOperator ? `operator-${next}` : next)
 
   return (
-    <Button
-      variant="ghost"
-      size="sm"
-      aria-label={label}
-      title={label}
-      onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
-    >
-      {resolvedTheme === 'dark' ? (
+    <Button variant="ghost" size="sm" aria-label={label} title={label} onClick={onClick}>
+      {currentMode === 'dark' ? (
         <Sun aria-hidden className="size-4" />
       ) : (
         <Moon aria-hidden className="size-4" />


### PR DESCRIPTION
## Summary

A second theme family that lives alongside the default Vercel Mono retune from PR #226. Selectable from the avatar menu; both flavors get a polished light **and** dark variant.

**Architecture — two orthogonal axes**

- flavor: \`default\` ⇄ \`operator\`
- mode: \`light\` ⇄ \`dark\`

\`ThemeProvider\` exposes four concrete names — \`light\`, \`dark\`, \`operator-light\`, \`operator-dark\` — and the avatar menu has two independent toggles that preserve the orthogonal axis when one is flipped. The \`dark:\` Tailwind variant is also extended to match \`.operator-dark\` so existing \`dark:\`-prefixed overrides keep working.

**Distinguishing traits vs default theme**

- Inter Tight (display + body) + JetBrains Mono (chrome) via \`next/font/google\`
- Inverse elevation: page is the SOFTER surface; panels go DEEPER
  - light: page \`#fafafa\`, panel \`#ffffff\`
  - dark: page \`#18181b\`, panel \`#0a0a0b\`
- High-contrast neutral CTA — ink-on-page-ink, never a brand fill (cubepi 'pip install cubepi' voice)
- Indigo accent reserved for tiny moments only (focus ring, info-fg)
  - light \`#3b5bd9\`, dark \`#6a83e3\`
- Sharper 1px borders, tighter radius (\`3 / 5 / 6 px\`)
- \`:where(.uppercase)\` auto-promotes to JetBrains Mono + \`0.12em\` tracking
- Tabular figures in mono contexts

**What component code does NOT change**

Only \`theme-toggle.tsx\` and \`AvatarPopover.tsx\` got touched — they now read the active flavor when toggling mode. Everything else inherits Operator solely through the design tokens. The eslint raw-color guard from the previous PR keeps this discipline in place.

## Test plan

- [x] \`pnpm -r type-check\` — green
- [x] \`pnpm --filter web test\` — 218 unit tests pass (1 skipped)
- [x] \`pnpm --filter web lint\` — 0 errors
- [x] Manual: cycled default-light → default-dark → operator-dark → operator-light → default-light. Mode toggle preserves flavor; flavor toggle preserves mode. dark: utility overrides fire under operator-dark.
- [ ] @codex review