### PR TITLE
feat: upgrade cubepi + migrate capability tools to deferred per-op groups

### DIFF
--- a/backend/cubebox/agents/actions/builder.py
+++ b/backend/cubebox/agents/actions/builder.py
@@ -1,4 +1,10 @@
-"""Build a single cubepi AgentTool from an AgentCapability definition."""
+"""Build per-operation cubepi AgentTools from an AgentCapability declaration.
+
+Each capability operation becomes its own AgentTool named ``<cap_name>_<op_name>``
+(e.g. ``scheduled_tasks_create``). Tools from the same capability are then
+grouped under a :class:`DeferredToolGroup` by the caller; the model only sees
+the group catalog until it calls ``load_tools``.
+"""
 
 from __future__ import annotations
 
@@ -7,12 +13,12 @@ import json
 import logging
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
-from typing import Annotated, Any, Literal, Union
+from typing import Any
 
 from cubepi.agent.types import AgentTool, AgentToolResult
 from cubepi.providers.base import TextContent
 from cubepi.types import StructuredValue
-from pydantic import BaseModel, Field, RootModel, create_model
+from pydantic import BaseModel
 
 from cubebox.agents.actions.context import ScopeContext
 from cubebox.agents.actions.types import (
@@ -28,106 +34,14 @@ logger = logging.getLogger(__name__)
 ContextFactory = Callable[[], AbstractAsyncContextManager[tuple[ScopeContext, Any]]]
 
 
-def _make_literal_type(value: str) -> Any:
-    """Create ``Literal["value"]`` at runtime (opaque to static analysis)."""
-    # Literal subscript with a runtime string is valid at runtime but
-    # cannot be tracked statically — the Any return communicates that.
-    return Literal[value]  # noqa: F821 – runtime subscript
-
-
-def _build_operation_model(op: AgentOperation) -> type[BaseModel]:
-    """Create a wrapper model with a fixed ``operation`` discriminator field.
-
-    The wrapper inherits all fields from the operation's ``input_model`` and
-    prepends an ``operation: Literal["<name>"]`` discriminator.
-    """
-    op_literal = _make_literal_type(op.name)
-    field_definitions: dict[str, Any] = {
-        "operation": (op_literal, ...),
-    }
-    for field_name, field_info in op.input_model.model_fields.items():
-        field_definitions[field_name] = (
-            field_info.annotation,
-            field_info,
-        )
-    model: Any = create_model(
-        f"Op_{op.name}",
-        **field_definitions,
-    )
-    # Surface the operation's description into the generated JSON Schema —
-    # pydantic v2 reads __doc__ as the schema's "description" field, which
-    # tool-calling LLMs (Anthropic / OpenAI) render alongside each oneOf
-    # variant. Without this, per-op example payloads in AgentOperation
-    # never reach the model.
-    model.__doc__ = op.description
-    return model  # type: ignore[no-any-return]
-
-
-def _build_union_model(
+def _make_op_tool(
     cap_name: str,
-    operations: list[AgentOperation],
-) -> type[BaseModel]:
-    """Build a discriminated-union input model over multiple operations.
-
-    Uses ``RootModel`` so the discriminated union IS the top-level schema
-    (no wrapping ``params`` field). The LLM sees ``{operation: "create", ...}``
-    directly.
-
-    Pydantic's RootModel emits a top-level schema of ``{oneOf: [...]}`` with no
-    ``type``. LLM tool APIs (Anthropic ``input_schema``, OpenAI ``parameters``)
-    reject this with "schema must be type: object". Since every branch IS an
-    object, we override ``model_json_schema`` to inject ``type: "object"``.
-    """
-    sub_models = [_build_operation_model(op) for op in operations]
-
-    union_type: Any = Union[tuple(sub_models)]  # noqa: UP007
-    annotated_union = Annotated[union_type, Field(discriminator="operation")]
-
-    base_root = RootModel[annotated_union]
-
-    def _patched_schema(cls: type[BaseModel], *args: Any, **kwargs: Any) -> dict[str, Any]:
-        schema: dict[str, Any] = base_root.model_json_schema(*args, **kwargs)
-        if "type" not in schema:
-            schema["type"] = "object"
-        return schema
-
-    model: Any = type(
-        f"{cap_name}_Input",
-        (base_root,),
-        {"model_json_schema": classmethod(_patched_schema)},
-    )
-    return model  # type: ignore[no-any-return]
-
-
-def build_capability_tool(
-    cap: AgentCapability,
+    op: AgentOperation,
     context_factory: ContextFactory,
-    *,
-    allow_mutations: bool,
-) -> AgentTool[Any] | None:
-    """Convert an :class:`AgentCapability` into a cubepi :class:`AgentTool`.
+) -> AgentTool[Any]:
+    """Wrap one AgentOperation as a standalone AgentTool."""
 
-    Returns ``None`` when no operations survive the mutation gate (e.g. all
-    operations mutate and ``allow_mutations=False``).
-    """
-    surviving: list[AgentOperation] = [
-        op for op in cap.operations if allow_mutations or not op.mutates
-    ]
-    if not surviving:
-        return None
-
-    # Build the handler lookup.
-    ops_by_name: dict[str, AgentOperation] = {op.name: op for op in surviving}
-
-    # Single-operation optimisation: expose the operation's own model
-    # directly (no discriminated wrapper).
-    single = len(surviving) == 1
-
-    if single:
-        the_op = surviving[0]
-        params_model: type[BaseModel] = the_op.input_model
-    else:
-        params_model = _build_union_model(cap.name, surviving)
+    full_name = f"{cap_name}_{op.name}"
 
     async def _execute(
         tool_call_id: str,
@@ -138,20 +52,9 @@ def build_capability_tool(
     ) -> AgentToolResult:
         del tool_call_id, signal, on_update
 
-        # Determine which operation was called.
-        if single:
-            op = surviving[0]
-            parsed = args
-        else:
-            # RootModel: the discriminated payload is ``.root``.
-            inner = args.root  # type: ignore[attr-defined]
-            op_name: str = inner.operation
-            op = ops_by_name[op_name]
-            parsed = inner
-
         try:
             async with context_factory() as (ctx, session):
-                result = await op.handler(ctx, session, parsed)
+                result = await op.handler(ctx, session, args)
         except (
             ActionNotFound,
             ActionPermissionDenied,
@@ -162,19 +65,31 @@ def build_capability_tool(
                 is_error=True,
             )
 
-        # Serialize the handler result to JSON text.
         if isinstance(result, BaseModel):
             text = result.model_dump_json()
         else:
             text = json.dumps(result, default=str)
 
-        return AgentToolResult(
-            content=[TextContent(text=text)],
-        )
+        return AgentToolResult(content=[TextContent(text=text)])
 
     return AgentTool(
-        name=cap.name,
-        description=cap.description,
-        parameters=params_model,
+        name=full_name,
+        description=op.description,
+        parameters=op.input_model,
         execute=_execute,
     )
+
+
+def build_capability_tools(
+    cap: AgentCapability,
+    context_factory: ContextFactory,
+    *,
+    allow_mutations: bool,
+) -> list[AgentTool[Any]]:
+    """One AgentTool per operation that survives the mutation gate.
+
+    Returns an empty list when no operations survive — callers should skip
+    building a DeferredToolGroup in that case.
+    """
+    surviving = [op for op in cap.operations if allow_mutations or not op.mutates]
+    return [_make_op_tool(cap.name, op, context_factory) for op in surviving]

--- a/backend/cubebox/agents/actions/capabilities/scheduled_tasks.py
+++ b/backend/cubebox/agents/actions/capabilities/scheduled_tasks.py
@@ -297,20 +297,14 @@ async def _handle_delete(ctx: ScopeContext, session: AsyncSession, inp: DeleteIn
 SCHEDULED_TASKS_CAPABILITY = AgentCapability(
     name="scheduled_tasks",
     description=(
-        "Manage scheduled tasks in the current workspace. Each task runs a prompt on "
-        "a cron, interval, or one-shot schedule. The discriminator field is "
-        "`operation` (one of: list, get, list_runs, create, update, pause, resume, "
-        "delete). Every operation has an example payload in its own description — "
-        "use those. Only mutate tasks (create / update / pause / resume / delete) "
+        "Manage scheduled tasks in the current workspace. Each task runs a "
+        "prompt on a cron, interval, or one-shot schedule. Only mutate tasks "
         "when the user has explicitly asked you to."
     ),
     operations=[
         AgentOperation(
             name="list",
-            description=(
-                "List all scheduled tasks in the workspace. Takes no arguments. "
-                'Example: {"operation":"list"}'
-            ),
+            description="List all scheduled tasks in the workspace. Takes no arguments.",
             input_model=ListInput,
             handler=_handle_list,
             mutates=False,
@@ -319,7 +313,7 @@ SCHEDULED_TASKS_CAPABILITY = AgentCapability(
             name="get",
             description=(
                 "Get details for a single scheduled task by ID. "
-                'Example: {"operation":"get","task_id":"stask-1gBGEPTNA5c1Ou"}'
+                'Example: {"task_id":"stask-1gBGEPTNA5c1Ou"}'
             ),
             input_model=GetInput,
             handler=_handle_get,
@@ -329,7 +323,7 @@ SCHEDULED_TASKS_CAPABILITY = AgentCapability(
             name="list_runs",
             description=(
                 "List recent execution history for a scheduled task. "
-                'Example: {"operation":"list_runs","task_id":"stask-1gBGEPTNA5c1Ou"}'
+                'Example: {"task_id":"stask-1gBGEPTNA5c1Ou"}'
             ),
             input_model=ListRunsInput,
             handler=_handle_list_runs,
@@ -342,13 +336,13 @@ SCHEDULED_TASKS_CAPABILITY = AgentCapability(
                 "object keyed by `kind` (cron | interval | once); pass the fields that "
                 "go with the chosen kind. Examples:\n"
                 "  cron daily 09:00 UTC:\n"
-                '    {"operation":"create","name":"morning-reply","prompt":"...",'
+                '    {"name":"morning-reply","prompt":"...",'
                 '"schedule":{"kind":"cron","cron_expr":"0 9 * * *"}}\n'
                 "  every 30 minutes:\n"
-                '    {"operation":"create","name":"poll","prompt":"...",'
+                '    {"name":"poll","prompt":"...",'
                 '"schedule":{"kind":"interval","interval_seconds":1800}}\n'
                 "  one-shot at a specific time:\n"
-                '    {"operation":"create","name":"remind","prompt":"...",'
+                '    {"name":"remind","prompt":"...",'
                 '"schedule":{"kind":"once","run_at":"2026-06-10T15:00:00Z"}}\n'
                 "To bind the task to the conversation this tool was called from, add "
                 '`"target":"current_conversation"`. You do not need to know the '
@@ -368,13 +362,12 @@ SCHEDULED_TASKS_CAPABILITY = AgentCapability(
                 "as create); there is no partial-schedule update. `target` uses the "
                 "same sentinel as create. Examples:\n"
                 "  rename only:\n"
-                '    {"operation":"update","task_id":"stask-1gBGEPTNA5c1Ou",'
-                '"name":"renamed"}\n'
+                '    {"task_id":"stask-1gBGEPTNA5c1Ou","name":"renamed"}\n'
                 "  switch to a different cron:\n"
-                '    {"operation":"update","task_id":"stask-1gBGEPTNA5c1Ou",'
+                '    {"task_id":"stask-1gBGEPTNA5c1Ou",'
                 '"schedule":{"kind":"cron","cron_expr":"0 10 * * *"}}\n'
                 "  pin to the current conversation:\n"
-                '    {"operation":"update","task_id":"stask-1gBGEPTNA5c1Ou",'
+                '    {"task_id":"stask-1gBGEPTNA5c1Ou",'
                 '"target":"current_conversation"}\n'
                 "Only call when the user has explicitly asked."
             ),
@@ -386,7 +379,7 @@ SCHEDULED_TASKS_CAPABILITY = AgentCapability(
             name="pause",
             description=(
                 "Pause a scheduled task so it stops firing. "
-                'Example: {"operation":"pause","task_id":"stask-1gBGEPTNA5c1Ou"} '
+                'Example: {"task_id":"stask-1gBGEPTNA5c1Ou"} '
                 "Only call when the user has explicitly asked."
             ),
             input_model=PauseInput,
@@ -397,7 +390,7 @@ SCHEDULED_TASKS_CAPABILITY = AgentCapability(
             name="resume",
             description=(
                 "Resume a paused scheduled task. "
-                'Example: {"operation":"resume","task_id":"stask-1gBGEPTNA5c1Ou"} '
+                'Example: {"task_id":"stask-1gBGEPTNA5c1Ou"} '
                 "Only call when the user has explicitly asked."
             ),
             input_model=ResumeInput,
@@ -408,7 +401,7 @@ SCHEDULED_TASKS_CAPABILITY = AgentCapability(
             name="delete",
             description=(
                 "Soft-delete a scheduled task (it will no longer fire). "
-                'Example: {"operation":"delete","task_id":"stask-1gBGEPTNA5c1Ou"} '
+                'Example: {"task_id":"stask-1gBGEPTNA5c1Ou"} '
                 "Only call when the user has explicitly asked."
             ),
             input_model=DeleteInput,

--- a/backend/cubebox/agents/actions/capabilities/skills.py
+++ b/backend/cubebox/agents/actions/capabilities/skills.py
@@ -143,8 +143,8 @@ async def _handle_find_impl(
         "hint": (
             "To use an 'enabled' candidate now, call load_skill(canonical_name). "
             "To install an 'in_catalog' or 'available' candidate: present it to the "
-            "user with skills(operation='preview', candidate_id=...) so they can see "
-            "what it does, then call skills(operation='install', candidate_id=...) "
+            "user with platform_skills_preview(candidate_id=...) so they can see "
+            "what it does, then call platform_skills_install(candidate_id=...) "
             "only when the user explicitly asks to install. Never install silently."
         ),
     }

--- a/backend/cubebox/agents/actions/capabilities/skills.py
+++ b/backend/cubebox/agents/actions/capabilities/skills.py
@@ -291,11 +291,10 @@ def build_skills_capability(deps: SkillDeps) -> AgentCapability:
         return await _handle_publish_skill_impl(deps, ctx, session, inp)
 
     return AgentCapability(
-        name="skills",
+        name="platform_skills",
         description=(
-            "Search, preview, and install skills available to this workspace. "
-            "Typical flow: find → preview → install. Each operation requires the "
-            "`operation` field. See per-operation examples."
+            "Search, preview, install, and publish skills available to this "
+            "workspace. Typical flow: find → preview → install."
         ),
         operations=[
             AgentOperation(
@@ -303,7 +302,7 @@ def build_skills_capability(deps: SkillDeps) -> AgentCapability:
                 description=(
                     "Search available skills by plain-language need. Returns candidates "
                     "with install_state and candidate_id. Read-only; never installs. "
-                    'Example: {"operation":"find","query":"web search"}'
+                    'Example: {"query":"web search"}'
                 ),
                 input_model=FindInput,
                 handler=find_handler,
@@ -314,7 +313,7 @@ def build_skills_capability(deps: SkillDeps) -> AgentCapability:
                 description=(
                     "Fetch the full SKILL.md for a candidate so you can describe it "
                     "to the user before suggesting installation. Use after find. "
-                    'Example: {"operation":"preview","candidate_id":"<candidate_id from find>"}'
+                    'Example: {"candidate_id":"<candidate_id from find>"}'
                 ),
                 input_model=PreviewInput,
                 handler=preview_handler,
@@ -325,7 +324,7 @@ def build_skills_capability(deps: SkillDeps) -> AgentCapability:
                 description=(
                     "Install a skill candidate into the current workspace. "
                     "Only call when the user has explicitly asked to install. "
-                    'Example: {"operation":"install","candidate_id":"<candidate_id from find>"}'
+                    'Example: {"candidate_id":"<candidate_id from find>"}'
                 ),
                 input_model=InstallInput,
                 handler=install_handler,
@@ -337,7 +336,7 @@ def build_skills_capability(deps: SkillDeps) -> AgentCapability:
                     "Publish a skill artifact to the current workspace so it becomes "
                     "available via load_skill. Use after save_artifact produces an artifact "
                     "with artifact_type='skill'. "
-                    'Example: {"operation":"publish_skill","artifact_id":"art-1abc..."}'
+                    'Example: {"artifact_id":"art-1abc..."}'
                 ),
                 input_model=PublishSkillInput,
                 handler=publish_skill_handler,

--- a/backend/cubebox/agents/actions/registry.py
+++ b/backend/cubebox/agents/actions/registry.py
@@ -1,12 +1,19 @@
-"""Agent capability registry — the single entry point for run_manager."""
+"""Agent capability registry — the single entry point for run_manager.
+
+Each capability is exposed to the model as a :class:`DeferredToolGroup`. The
+catalog (group_id, display_name, description, tool_names) lives in the system
+prompt; the actual tool schemas only ship when the model calls
+``load_tools(group_id)``.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
 from cubepi.agent.types import AgentTool
+from cubepi.deferred import DeferredToolGroup
 
-from cubebox.agents.actions.builder import ContextFactory, build_capability_tool
+from cubebox.agents.actions.builder import ContextFactory, build_capability_tools
 from cubebox.agents.actions.capabilities.scheduled_tasks import SCHEDULED_TASKS_CAPABILITY
 from cubebox.agents.actions.capabilities.skills import SkillDeps, build_skills_capability
 from cubebox.agents.actions.types import AgentCapability
@@ -16,32 +23,58 @@ AGENT_CAPABILITIES: list[AgentCapability] = [
 ]
 
 
+def _make_group(cap: AgentCapability, tools: list[AgentTool[Any]]) -> DeferredToolGroup:
+    """Build a DeferredToolGroup whose loader returns the pre-built per-op tools.
+
+    The loader is called once per run when the model expands the group; we
+    pre-build the tools at run-assembly time because their handlers close over
+    cheap context — there is no expensive setup to defer.
+    """
+
+    async def _loader() -> list[AgentTool[Any]]:
+        return tools
+
+    return DeferredToolGroup(
+        group_id=f"cubebox:{cap.name}",
+        display_name=cap.name,
+        description=cap.description,
+        tool_names=[t.name for t in tools],
+        loader=_loader,
+    )
+
+
 def tools_for_run(
     context_factory: ContextFactory,
     *,
     allow_mutations: bool,
     skill_deps: SkillDeps | None = None,
-) -> list[AgentTool[Any]]:
-    """Build agent tools for all registered capabilities.
+) -> list[DeferredToolGroup]:
+    """Build deferred groups for all registered capabilities.
 
-    Static capabilities (declared in AGENT_CAPABILITIES) are built unconditionally.
-    The skills capability is dynamic: built only when skill_deps is supplied,
-    because its handlers must close over run-scoped catalog / registry / session.
+    Static capabilities (declared in AGENT_CAPABILITIES) are built
+    unconditionally. The skills capability is dynamic: built only when
+    skill_deps is supplied, because its handlers must close over run-scoped
+    catalog / registry / session.
+
+    Groups whose mutation gate drops every operation are omitted entirely
+    (e.g. an automated run with a mutation-only capability would see no
+    catalog entry for it).
     """
-    tools: list[AgentTool[Any]] = []
+    groups: list[DeferredToolGroup] = []
+
     for cap in AGENT_CAPABILITIES:
-        tool = build_capability_tool(cap, context_factory, allow_mutations=allow_mutations)
-        if tool is not None:
-            tools.append(tool)
+        tools = build_capability_tools(cap, context_factory, allow_mutations=allow_mutations)
+        if tools:
+            groups.append(_make_group(cap, tools))
 
     if skill_deps is not None:
         skills_cap = build_skills_capability(skill_deps)
-        skills_tool = build_capability_tool(
+        skills_tools = build_capability_tools(
             skills_cap,
             context_factory,
             allow_mutations=allow_mutations,
         )
-        if skills_tool is not None:
-            tools.append(skills_tool)
+        if skills_tools:
+            groups.append(_make_group(skills_cap, skills_tools))
 
-    return tools
+    return groups

--- a/backend/cubebox/agents/actions/registry.py
+++ b/backend/cubebox/agents/actions/registry.py
@@ -1,13 +1,19 @@
 """Agent capability registry — the single entry point for run_manager.
 
-Each capability is exposed to the model as a :class:`DeferredToolGroup`. The
-catalog (group_id, display_name, description, tool_names) lives in the system
-prompt; the actual tool schemas only ship when the model calls
-``load_tools(group_id)``.
+Each capability is exposed to the **main** agent as a
+:class:`DeferredToolGroup`: the catalog (group_id, display_name, description,
+tool_names) lives in the system prompt, and the actual tool schemas only ship
+when the model calls ``load_tools(group_id)``.
+
+The same per-operation AgentTools are also exposed flat (no deferred wrapper)
+so callers that need eager access — primarily ``SubagentMiddleware`` —
+can pass them as ``shared_tools`` to short-lived child agents where the
+catalog round-trip overhead would dominate.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from cubepi.agent.types import AgentTool
@@ -21,6 +27,22 @@ from cubebox.agents.actions.types import AgentCapability
 AGENT_CAPABILITIES: list[AgentCapability] = [
     SCHEDULED_TASKS_CAPABILITY,
 ]
+
+
+@dataclass(frozen=True)
+class CapabilityToolSet:
+    """Both views of the same per-op AgentTools.
+
+    ``groups`` is what the main agent sees — one DeferredToolGroup per
+    capability, schemas hidden until ``load_tools`` is called. ``flat_tools``
+    is the union of every per-op tool across every group, ready to be
+    passed eagerly to a subagent's ``shared_tools``. The two views reference
+    the same AgentTool instances, so executing through either resolves to
+    the same handler closure.
+    """
+
+    groups: list[DeferredToolGroup]
+    flat_tools: list[AgentTool[Any]]
 
 
 def _make_group(cap: AgentCapability, tools: list[AgentTool[Any]]) -> DeferredToolGroup:
@@ -48,33 +70,32 @@ def tools_for_run(
     *,
     allow_mutations: bool,
     skill_deps: SkillDeps | None = None,
-) -> list[DeferredToolGroup]:
-    """Build deferred groups for all registered capabilities.
+) -> CapabilityToolSet:
+    """Build deferred groups + flat per-op tools for all registered capabilities.
 
     Static capabilities (declared in AGENT_CAPABILITIES) are built
     unconditionally. The skills capability is dynamic: built only when
     skill_deps is supplied, because its handlers must close over run-scoped
     catalog / registry / session.
 
-    Groups whose mutation gate drops every operation are omitted entirely
-    (e.g. an automated run with a mutation-only capability would see no
-    catalog entry for it).
+    Capabilities whose mutation gate drops every operation are omitted
+    entirely (e.g. an automated run with a mutation-only capability would
+    see no catalog entry and no flat tools for it).
     """
     groups: list[DeferredToolGroup] = []
+    flat_tools: list[AgentTool[Any]] = []
+
+    def _add(cap: AgentCapability) -> None:
+        tools = build_capability_tools(cap, context_factory, allow_mutations=allow_mutations)
+        if not tools:
+            return
+        groups.append(_make_group(cap, tools))
+        flat_tools.extend(tools)
 
     for cap in AGENT_CAPABILITIES:
-        tools = build_capability_tools(cap, context_factory, allow_mutations=allow_mutations)
-        if tools:
-            groups.append(_make_group(cap, tools))
+        _add(cap)
 
     if skill_deps is not None:
-        skills_cap = build_skills_capability(skill_deps)
-        skills_tools = build_capability_tools(
-            skills_cap,
-            context_factory,
-            allow_mutations=allow_mutations,
-        )
-        if skills_tools:
-            groups.append(_make_group(skills_cap, skills_tools))
+        _add(build_skills_capability(skill_deps))
 
-    return groups
+    return CapabilityToolSet(groups=groups, flat_tools=flat_tools)

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -2343,6 +2343,9 @@ class RunManager:
 
         # Platform action tools (scheduled_tasks, skills, etc.) — via the
         # capability registry. Automated runs get read-only tools (mutation gate).
+        # Initialized to [] so a setup failure leaves SubagentMiddleware able
+        # to build (just without action tools).
+        _action_flat_tools: list[Any] = []
         try:
             from cubebox.agents.actions.capabilities.skills import SkillDeps
             from cubebox.agents.actions.registry import (
@@ -2416,13 +2419,16 @@ class RunManager:
                             _skill_exc,
                         )
 
-                _deferred_groups.extend(
-                    _action_tools_for_run(
-                        _action_ctx_factory,
-                        allow_mutations=(trigger == "interactive"),
-                        skill_deps=_skill_deps,
-                    )
+                _action_toolset = _action_tools_for_run(
+                    _action_ctx_factory,
+                    allow_mutations=(trigger == "interactive"),
+                    skill_deps=_skill_deps,
                 )
+                _deferred_groups.extend(_action_toolset.groups)
+                # Subagents (built below) need the per-op tools eagerly —
+                # SubagentMiddleware takes shared_tools, not deferred groups,
+                # and the catalog round-trip would dominate a child run.
+                _action_flat_tools.extend(_action_toolset.flat_tools)
         except Exception as _exc:
             logger.warning(
                 "platform action tools unavailable for cubepi run: {}",
@@ -2674,11 +2680,13 @@ class RunManager:
             subagent_mw = SubagentMiddleware(
                 subagents={},
                 default_model=subagent_model,
-                # Pass all tools (sandbox + artifact + builtin) collected so far
-                # as shared tools for subagent spawning, minus show_widget
-                # (top-level only in v1).
+                # Pass all tools (sandbox + artifact + builtin + per-op action)
+                # collected so far as shared tools for subagent spawning, minus
+                # show_widget (top-level only in v1). Action tools live in the
+                # main agent's deferred groups; subagents get them eagerly
+                # because catalog round-trips would dominate a child run.
                 shared_tools=_subagent_shared_tools(
-                    _sandbox_tools + _artifact_tools + _builtin_tools
+                    _sandbox_tools + _artifact_tools + _builtin_tools + _action_flat_tools
                 ),
                 inherited_middleware=_cost_mw_for_inherit,
                 excluded_tool_names={"subagent", "load_skill"},

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -2416,7 +2416,7 @@ class RunManager:
                             _skill_exc,
                         )
 
-                _builtin_tools.extend(
+                _deferred_groups.extend(
                     _action_tools_for_run(
                         _action_ctx_factory,
                         allow_mutations=(trigger == "interactive"),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -172,7 +172,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "c25946e" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "088fa660b05b373f70d90900ba687e1934497c7e" }
 
 [dependency-groups]
 dev = [

--- a/backend/tests/e2e/test_mcp_disclosure_runtime.py
+++ b/backend/tests/e2e/test_mcp_disclosure_runtime.py
@@ -228,9 +228,10 @@ class TestMiddlewareIntegration:
             extra_ref=lambda: extra,
         )
 
-        # Middleware contributes load_tools to agent tools
-        assert len(mw.tools) == 1
-        assert mw.tools[0].name == "load_tools"
+        # Middleware contributes load_tools + deferred_tool_call dispatcher
+        # (dispatch mode is the default in cubepi >= 0.11).
+        tool_names = {t.name for t in mw.tools}
+        assert tool_names == {"load_tools", "deferred_tool_call"}
 
         # System prompt includes catalog with group IDs
         ctx = AsyncMock()
@@ -441,6 +442,9 @@ class TestCachePrefixStability:
         ctx = AsyncMock()
         ctx.tools = list(mw.tools)
 
+        # Baseline system prompt before any expansion.
+        prompt_turn0 = await mw.transform_system_prompt("Base.", ctx=ctx, signal=None)
+
         # Turn 1: expand GitHub
         await mw._expand(group_id="mcp:GitHub", tool_names=None, context=ctx)
         prompt_turn1 = await mw.transform_system_prompt("Base.", ctx=ctx, signal=None)
@@ -449,15 +453,9 @@ class TestCachePrefixStability:
         await mw._expand(group_id="mcp:Slack", tool_names=None, context=ctx)
         prompt_turn2 = await mw.transform_system_prompt("Base.", ctx=ctx, signal=None)
 
-        # Extract the expanded-schemas section from both prompts.
-        marker = "# Expanded tool groups"
-        assert marker in prompt_turn1
-        assert marker in prompt_turn2
-        schemas_turn1 = prompt_turn1[prompt_turn1.index(marker) :]
-        schemas_turn2 = prompt_turn2[prompt_turn2.index(marker) :]
-
-        # Turn-2's expanded section starts with turn-1's expanded section.
-        assert schemas_turn2.startswith(schemas_turn1)
-        # The Slack schema block is the appended portion.
-        appended = schemas_turn2[len(schemas_turn1) :]
-        assert "Slack__send_message" in appended
+        # Dispatch mode: schemas live in load_tools tool_results, never in the
+        # system prompt. The catalog text (tool names + descriptions) is
+        # byte-stable across expansions so the prompt-cache prefix never
+        # invalidates.
+        assert prompt_turn0 == prompt_turn1 == prompt_turn2
+        assert "# Expanded tool groups" not in prompt_turn2

--- a/backend/tests/unit/test_agent_action_builder.py
+++ b/backend/tests/unit/test_agent_action_builder.py
@@ -1,4 +1,8 @@
-"""Tests for the generic capability tool builder."""
+"""Tests for the per-operation capability tool builder.
+
+Each operation in an AgentCapability becomes a standalone AgentTool named
+``<cap_name>_<op_name>``; the umbrella+discriminator pattern is gone.
+"""
 
 from __future__ import annotations
 
@@ -9,7 +13,7 @@ from unittest.mock import AsyncMock
 
 from pydantic import BaseModel
 
-from cubebox.agents.actions.builder import build_capability_tool
+from cubebox.agents.actions.builder import build_capability_tools
 from cubebox.agents.actions.context import ScopeContext
 from cubebox.agents.actions.types import (
     ActionInvalidInput,
@@ -19,10 +23,6 @@ from cubebox.agents.actions.types import (
     AgentOperation,
 )
 from cubebox.models.membership import Role
-
-# ---------------------------------------------------------------------------
-# Fixtures / helpers
-# ---------------------------------------------------------------------------
 
 FAKE_CTX = ScopeContext(
     org_id="org_1",
@@ -50,11 +50,6 @@ class DeleteInput(BaseModel):
     item_id: str
 
 
-# ---------------------------------------------------------------------------
-# Mutation gate
-# ---------------------------------------------------------------------------
-
-
 class TestMutationGate:
     def test_allow_mutations_includes_all(self) -> None:
         list_op = AgentOperation(
@@ -76,13 +71,8 @@ class TestMutationGate:
             description="Item management",
             operations=[list_op, create_op],
         )
-        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
-        assert tool is not None
-        # The union model should contain both operations.
-        schema = tool.parameters.model_json_schema()
-        # Both sub-models should appear under $defs.
-        assert "Op_list" in str(schema)
-        assert "Op_create" in str(schema)
+        tools = build_capability_tools(cap, fake_context_factory, allow_mutations=True)
+        assert [t.name for t in tools] == ["items_list", "items_create"]
 
     def test_deny_mutations_drops_mutating(self) -> None:
         list_op = AgentOperation(
@@ -104,12 +94,10 @@ class TestMutationGate:
             description="Item management",
             operations=[list_op, create_op],
         )
-        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=False)
-        assert tool is not None
-        # Single surviving op → no union wrapper, model is ListInput.
-        assert tool.parameters is ListInput
+        tools = build_capability_tools(cap, fake_context_factory, allow_mutations=False)
+        assert [t.name for t in tools] == ["items_list"]
 
-    def test_deny_mutations_all_mutating_returns_none(self) -> None:
+    def test_deny_mutations_all_mutating_returns_empty(self) -> None:
         create_op = AgentOperation(
             name="create",
             description="Create item",
@@ -129,55 +117,24 @@ class TestMutationGate:
             description="Item management",
             operations=[create_op, delete_op],
         )
-        result = build_capability_tool(cap, fake_context_factory, allow_mutations=False)
-        assert result is None
+        tools = build_capability_tools(cap, fake_context_factory, allow_mutations=False)
+        assert tools == []
 
 
-# ---------------------------------------------------------------------------
-# Dispatch
-# ---------------------------------------------------------------------------
-
-
-class TestDispatch:
-    async def test_single_op_dispatches_correctly(self) -> None:
-        handler = AsyncMock(return_value={"status": "ok"})
+class TestSchema:
+    def test_per_op_parameters_is_the_op_input_model(self) -> None:
         list_op = AgentOperation(
             name="list",
             description="List items",
             input_model=ListInput,
-            handler=handler,
-            mutates=False,
-        )
-        cap = AgentCapability(
-            name="items",
-            description="Item management",
-            operations=[list_op],
-        )
-        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
-        assert tool is not None
-
-        # Build input matching the single-op model (ListInput directly).
-        args = ListInput(page=3)
-        result = await tool.execute("call_1", args)
-
-        assert result.is_error is None
-        handler.assert_awaited_once_with(FAKE_CTX, "fake-session", args)
-
-    async def test_multi_op_dispatches_to_correct_handler(self) -> None:
-        list_handler = AsyncMock(return_value={"items": []})
-        create_handler = AsyncMock(return_value={"id": "new_1"})
-        list_op = AgentOperation(
-            name="list",
-            description="List items",
-            input_model=ListInput,
-            handler=list_handler,
+            handler=AsyncMock(),
             mutates=False,
         )
         create_op = AgentOperation(
             name="create",
             description="Create item",
             input_model=CreateInput,
-            handler=create_handler,
+            handler=AsyncMock(),
             mutates=True,
         )
         cap = AgentCapability(
@@ -185,24 +142,50 @@ class TestDispatch:
             description="Item management",
             operations=[list_op, create_op],
         )
-        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
-        assert tool is not None
+        tools = build_capability_tools(cap, fake_context_factory, allow_mutations=True)
+        by_name = {t.name: t for t in tools}
+        # The model sees the operation's own input model directly — no
+        # discriminator wrapper, no Op_<name> sub-model.
+        assert by_name["items_list"].parameters is ListInput
+        assert by_name["items_create"].parameters is CreateInput
 
-        # Call the "create" operation via the union model.
-        args = tool.parameters.model_validate({"operation": "create", "title": "My Item"})
-        result = await tool.execute("call_2", args)
+    def test_per_op_description_lands_on_the_tool(self) -> None:
+        list_op = AgentOperation(
+            name="list",
+            description="List items. Example: {}",
+            input_model=ListInput,
+            handler=AsyncMock(),
+            mutates=False,
+        )
+        cap = AgentCapability(
+            name="items",
+            description="Item management",
+            operations=[list_op],
+        )
+        tools = build_capability_tools(cap, fake_context_factory, allow_mutations=True)
+        assert tools[0].description == "List items. Example: {}"
+
+
+class TestDispatch:
+    async def test_call_routes_to_op_handler(self) -> None:
+        handler = AsyncMock(return_value={"status": "ok"})
+        op = AgentOperation(
+            name="list",
+            description="List items",
+            input_model=ListInput,
+            handler=handler,
+            mutates=False,
+        )
+        cap = AgentCapability(name="items", description="Items", operations=[op])
+        tools = build_capability_tools(cap, fake_context_factory, allow_mutations=True)
+
+        args = ListInput(page=3)
+        result = await tools[0].execute("call_1", args)
 
         assert result.is_error is None
-        create_handler.assert_awaited_once()
-        # Verify the handler received (ctx, session, parsed_input).
-        call_args = create_handler.call_args
-        assert call_args[0][0] is FAKE_CTX
-        assert call_args[0][1] == "fake-session"
-        inner = call_args[0][2]
-        assert inner.title == "My Item"
+        handler.assert_awaited_once_with(FAKE_CTX, "fake-session", args)
 
-    async def test_handler_receives_correct_arguments(self) -> None:
-        """Verify the handler receives (ctx, session, parsed_input)."""
+    async def test_handler_receives_ctx_session_input(self) -> None:
         handler = AsyncMock(return_value={"ok": True})
         op = AgentOperation(
             name="create",
@@ -211,27 +194,16 @@ class TestDispatch:
             handler=handler,
             mutates=True,
         )
-        cap = AgentCapability(
-            name="things",
-            description="Things",
-            operations=[op],
-        )
-        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
-        assert tool is not None
+        cap = AgentCapability(name="things", description="Things", operations=[op])
+        tools = build_capability_tools(cap, fake_context_factory, allow_mutations=True)
 
-        args = CreateInput(title="Test")
-        await tool.execute("call_3", args)
+        await tools[0].execute("call_3", CreateInput(title="Test"))
 
         ctx_arg, session_arg, input_arg = handler.call_args[0]
         assert ctx_arg is FAKE_CTX
         assert session_arg == "fake-session"
         assert isinstance(input_arg, CreateInput)
         assert input_arg.title == "Test"
-
-
-# ---------------------------------------------------------------------------
-# Error mapping
-# ---------------------------------------------------------------------------
 
 
 class TestErrorMapping:
@@ -243,15 +215,10 @@ class TestErrorMapping:
             input_model=ListInput,
             handler=handler,
         )
-        cap = AgentCapability(
-            name="items",
-            description="Items",
-            operations=[op],
-        )
-        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
-        assert tool is not None
+        cap = AgentCapability(name="items", description="Items", operations=[op])
+        tools = build_capability_tools(cap, fake_context_factory, allow_mutations=True)
 
-        result = await tool.execute("call_err1", ListInput())
+        result = await tools[0].execute("call_err1", ListInput())
         assert result.is_error is True
         text = result.content[0].text  # type: ignore[union-attr]
         assert "ActionNotFound" in text
@@ -266,15 +233,10 @@ class TestErrorMapping:
             handler=handler,
             mutates=True,
         )
-        cap = AgentCapability(
-            name="items",
-            description="Items",
-            operations=[op],
-        )
-        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
-        assert tool is not None
+        cap = AgentCapability(name="items", description="Items", operations=[op])
+        tools = build_capability_tools(cap, fake_context_factory, allow_mutations=True)
 
-        result = await tool.execute("call_err2", DeleteInput(item_id="x"))
+        result = await tools[0].execute("call_err2", DeleteInput(item_id="x"))
         assert result.is_error is True
         text = result.content[0].text  # type: ignore[union-attr]
         assert "ActionPermissionDenied" in text
@@ -289,55 +251,11 @@ class TestErrorMapping:
             handler=handler,
             mutates=True,
         )
-        cap = AgentCapability(
-            name="items",
-            description="Items",
-            operations=[op],
-        )
-        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
-        assert tool is not None
+        cap = AgentCapability(name="items", description="Items", operations=[op])
+        tools = build_capability_tools(cap, fake_context_factory, allow_mutations=True)
 
-        result = await tool.execute("call_err3", CreateInput(title="bad"))
+        result = await tools[0].execute("call_err3", CreateInput(title="bad"))
         assert result.is_error is True
         text = result.content[0].text  # type: ignore[union-attr]
         assert "ActionInvalidInput" in text
         assert "bad cron expression" in text
-
-
-class TestSchemaDescriptions:
-    """Each operation's description must reach the generated JSON Schema.
-
-    The LLM only sees `tool.description` (capability-level) plus
-    `tool.parameters` (JSON Schema). If `AgentOperation.description` is not
-    serialized into a per-variant `description` field on the Op_* sub-model,
-    the per-op example payloads we author never reach the model.
-    """
-
-    def test_each_op_description_lands_in_schema(self) -> None:
-        list_op = AgentOperation(
-            name="list",
-            description="List items. Example: {'operation':'list'}",
-            input_model=ListInput,
-            handler=AsyncMock(),
-            mutates=False,
-        )
-        create_op = AgentOperation(
-            name="create",
-            description="Create item. Example: {'operation':'create','title':'x'}",
-            input_model=CreateInput,
-            handler=AsyncMock(),
-            mutates=True,
-        )
-        cap = AgentCapability(
-            name="items",
-            description="Item management",
-            operations=[list_op, create_op],
-        )
-        tool = build_capability_tool(cap, fake_context_factory, allow_mutations=True)
-        assert tool is not None
-        schema = tool.parameters.model_json_schema()
-
-        op_list = schema["$defs"]["Op_list"]
-        op_create = schema["$defs"]["Op_create"]
-        assert op_list.get("description") == list_op.description
-        assert op_create.get("description") == create_op.description

--- a/backend/tests/unit/test_scheduled_tasks_capability.py
+++ b/backend/tests/unit/test_scheduled_tasks_capability.py
@@ -276,11 +276,16 @@ def _op(name: str) -> AgentOperation:
 
 
 def test_each_operation_description_contains_example_payload() -> None:
-    # Every non-trivial op should show a JSON-shaped example the model can copy.
-    for op_name in ("list", "create", "update", "pause", "resume", "delete", "get", "list_runs"):
+    # Every op (except list, which is no-arg) should show a JSON-shaped
+    # example payload the model can copy as direct tool input.
+    for op_name in ("create", "update", "pause", "resume", "delete", "get", "list_runs"):
         desc = _op(op_name).description
         assert "Example" in desc or "example" in desc, f"{op_name} description has no example"
-        assert '"operation"' in desc, f"{op_name} description omits the operation discriminator"
+        # The umbrella "operation" discriminator is gone — examples are the
+        # bare input payload now.
+        assert '"operation"' not in desc, (
+            f"{op_name} description still mentions the old operation discriminator"
+        )
 
 
 def test_create_description_documents_all_three_schedule_kinds() -> None:
@@ -299,12 +304,12 @@ def test_create_description_documents_target_sentinel() -> None:
     ), "create description must tell the model it doesn't need to pass a conversation ID"
 
 
-def test_capability_description_is_short_and_points_to_operations() -> None:
+def test_capability_description_is_short() -> None:
+    # The capability description is the DeferredToolGroup catalog blurb —
+    # one-line summary, no per-op detail.
     cap_desc = SCHEDULED_TASKS_CAPABILITY.description
-    # Capability-level description shouldn't duplicate per-op examples (token cost).
-    assert len(cap_desc) < 600
-    # But it should mention that each operation has its own example.
-    assert "operation" in cap_desc.lower()
+    assert len(cap_desc) < 400
+    assert "scheduled" in cap_desc.lower()
 
 
 def test_list_description_states_no_arguments() -> None:

--- a/backend/tests/unit/test_skills_capability.py
+++ b/backend/tests/unit/test_skills_capability.py
@@ -270,7 +270,7 @@ async def test_install_error_raises_invalid_input(monkeypatch: pytest.MonkeyPatc
 from collections.abc import AsyncIterator  # noqa: E402
 from contextlib import asynccontextmanager  # noqa: E402
 
-from cubebox.agents.actions.builder import build_capability_tool  # noqa: E402
+from cubebox.agents.actions.builder import build_capability_tools  # noqa: E402
 from cubebox.agents.actions.capabilities.skills import build_skills_capability  # noqa: E402
 
 
@@ -282,30 +282,32 @@ async def _fake_ctx_factory() -> AsyncIterator[tuple[ScopeContext, Any]]:
 def test_skills_capability_mutation_gate() -> None:
     deps = _make_deps()
     cap = build_skills_capability(deps)
-    # Sanity: 4 operations declared
+    # Sanity: 4 operations declared, capability is renamed to platform_skills
+    # (disambiguates from load_skill's prompt-content disclosure system).
+    assert cap.name == "platform_skills"
     assert {op.name for op in cap.operations} == {"find", "preview", "install", "publish_skill"}
     assert next(op for op in cap.operations if op.name == "install").mutates is True
     assert next(op for op in cap.operations if op.name == "find").mutates is False
     assert next(op for op in cap.operations if op.name == "preview").mutates is False
     assert next(op for op in cap.operations if op.name == "publish_skill").mutates is False
 
-    # With mutations allowed, the schema should mention all four ops.
-    tool_full = build_capability_tool(cap, _fake_ctx_factory, allow_mutations=True)
-    assert tool_full is not None
-    schema_full = str(tool_full.parameters.model_json_schema())
-    assert "Op_find" in schema_full
-    assert "Op_preview" in schema_full
-    assert "Op_install" in schema_full
-    assert "Op_publish_skill" in schema_full
+    # With mutations allowed, every op becomes its own AgentTool named
+    # platform_skills_<op>.
+    tools_full = build_capability_tools(cap, _fake_ctx_factory, allow_mutations=True)
+    assert {t.name for t in tools_full} == {
+        "platform_skills_find",
+        "platform_skills_preview",
+        "platform_skills_install",
+        "platform_skills_publish_skill",
+    }
 
-    # Without mutations, install is dropped but publish_artifact (non-mutating) remains.
-    tool_ro = build_capability_tool(cap, _fake_ctx_factory, allow_mutations=False)
-    assert tool_ro is not None
-    schema_ro = str(tool_ro.parameters.model_json_schema())
-    assert "Op_install" not in schema_ro
-    assert "Op_find" in schema_ro
-    assert "Op_preview" in schema_ro
-    assert "Op_publish_skill" in schema_ro
+    # Without mutations, install is dropped; the rest survive.
+    tools_ro = build_capability_tools(cap, _fake_ctx_factory, allow_mutations=False)
+    assert {t.name for t in tools_ro} == {
+        "platform_skills_find",
+        "platform_skills_preview",
+        "platform_skills_publish_skill",
+    }
 
 
 # --- publish_artifact tests ---

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -875,7 +875,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=c25946e" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=088fa660b05b373f70d90900ba687e1934497c7e" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0" },
@@ -922,7 +922,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.10.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=c25946e#c25946e119ef6e0685890ff5dfe7026af06246c6" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=088fa660b05b373f70d90900ba687e1934497c7e#088fa660b05b373f70d90900ba687e1934497c7e" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },

--- a/docs/dev/specs/2026-06-11-cubepi-upgrade-deferred-capabilities-design.md
+++ b/docs/dev/specs/2026-06-11-cubepi-upgrade-deferred-capabilities-design.md
@@ -1,0 +1,200 @@
+# cubepi upgrade + capability tools → deferred groups
+
+**Status:** draft
+**Branch:** `feat/cubepi-upgrade-deferred`
+**Author:** xfgong
+**Date:** 2026-06-11
+
+## Context
+
+cubebox currently pins cubepi at `c25946e` (released as 0.10.0). Since that pin,
+cubepi shipped 23 commits, headlined by a new **dispatch strategy** for
+`DeferredToolGroup` that delivers tool schemas via `load_tools` tool results
+instead of injecting them into the model-visible tools array. This keeps the
+tools array and system prompt byte-stable across expansions — group expansion
+no longer invalidates the prompt cache.
+
+cubebox already uses `DeferredToolGroup` for one thing: per-server grouping of
+MCP tools (`cubebox/mcp/disclosure.py`, gated by `progressive_disclosure.*`
+config). Everything else (calculator, datetime, memory, view_images,
+show_widget, generate_image, load_skill, scheduled_tasks, skills) is loaded
+eagerly.
+
+Separately, cubebox has its own bespoke "umbrella tool + operation
+discriminator" pattern at `cubebox/agents/actions/builder.py`. Each
+`AgentCapability` (scheduled_tasks: 8 ops; skills: 4 ops) is collapsed into one
+`AgentTool` whose input is a discriminated union over operations. The umbrella
+exists because cubepi 0.10's `inject` strategy invalidated the prompt cache
+every time tools were added — so eager-load-many-tools was the only safe
+option, and umbrella+operation was the way to pack many ops into one cache-stable
+schema.
+
+dispatch strategy makes that workaround unnecessary. A `DeferredToolGroup` with
+per-operation `AgentTool`s gives the same token efficiency (catalog instead of
+full schemas) **plus** native tool-calling semantics: `before_tool_call`,
+tracing, widgets, and audit logs see the real operation name instead of
+`scheduled_tasks(operation="create")`.
+
+## Goals
+
+1. Bump cubepi pin from `c25946e` to current `main` (HEAD `088fa66` at time of
+   writing).
+2. Verify MCP tools still work under the new default `dispatch` strategy —
+   citation wiring, sandbox middleware, artifact middleware, and tracing all
+   see the real tool name through the deferred dispatcher.
+3. Replace the umbrella+operation pattern for `scheduled_tasks` and `skills`
+   capabilities with per-operation `AgentTool`s grouped under
+   `DeferredToolGroup`s. Delete `cubebox/agents/actions/builder.py`'s union /
+   discriminator machinery when no callers remain.
+
+## Non-goals
+
+- **load_skill / find_skills do NOT migrate.** They are not tool-schema
+  delivery; they load SKILL.md *markdown content* that `SkillsMiddleware`
+  splices into the next system prompt. cubepi's `load_tools` returns
+  `{name, description, parameters}` JSON — wrong shape for prose. The skills
+  catalog in the system prompt + `load_skill` tool is its own progressive
+  disclosure system and stays as-is.
+- **generate_image stays eager.** Single-tool deferred groups have poor
+  cost/benefit — the catalog line plus the `load_tools` round-trip cancel most
+  of the schema savings on the rare runs where it would help. Revisit when a
+  second sandbox-image tool appears (video / edit / audio) and a `cubebox:media`
+  group becomes natural.
+- **calculator / datetime / write_todos / subagent / memory_* stay eager.**
+  Used on most turns; deferring just adds a round-trip with no token win.
+- **view_images / show_widget stay eager.** Small schemas, deferring saves
+  almost nothing.
+- This change does not introduce expanded-group cross-run replay
+  (`prepare_resumed_state`). cubebox doesn't restore deferred-group state on
+  resume today (only MCP runs hit it, and MCP groups are re-built fresh each
+  run). Out of scope for this work.
+
+## Phase 1 — pin bump + MCP verification
+
+Bump `backend/pyproject.toml` cubepi rev to current `main`. `uv lock` rewrites
+`backend/uv.lock`.
+
+Breaking changes to absorb:
+
+| Change | cubebox impact |
+|---|---|
+| `deferred_tool_strategy` default `inject` → `dispatch` | MCP groups switch behavior. Tool calls now flow through `deferred_tool_call(tool_name, arguments)` and cubepi unwraps before the middleware pipeline. |
+| `resumed_schemas` removed; `prepare_resumed_state(strategy=)` required | Not used in cubebox — no edits needed. |
+| `inject` mode no longer renders schemas into system prompt | Not used in cubebox — no edits needed. |
+
+Verification matrix (E2E, not unit):
+
+1. **MCP tool name in `before_tool_call`** — add a temporary log line to
+   `_compose.py`, run an MCP-enabled conversation, confirm the hook receives
+   the real namespaced tool name (e.g. `github_create_issue`), not
+   `deferred_tool_call`.
+2. **Citation wiring** — `_deferred_citations` is populated when loader runs.
+   Confirm citation middleware finds its config under the real tool name.
+3. **Tracing** — `cubepi trace view` on a run that expanded a group should
+   show the real tool name in the tool-call span, not the dispatcher
+   envelope.
+4. **Frontend widgets** — `toolcall_start` / `toolcall_end` events streamed to
+   the frontend carry the real tool name (frontend tool-call widget logic
+   does name-based dispatch).
+
+If any verification fails, the issue is in cubepi `_dispatch_tool.py` or
+`middleware.py`; fix upstream in `~/cubepi`, push, bump the pin again.
+
+## Phase 2 — capability migration
+
+Two capabilities to migrate, in this order (skills depends on per-run deps so
+it's the harder one):
+
+### 2a. scheduled_tasks
+
+Current: `SCHEDULED_TASKS_CAPABILITY` (8 ops: list, get, create, update,
+delete, pause, resume, get_run_history) → 1 umbrella `AgentTool` named
+`scheduled_tasks`.
+
+Target: 8 `AgentTool`s named after each op (`scheduled_tasks_list`,
+`scheduled_tasks_create`, etc., or just `list_scheduled_tasks` —
+naming-bikeshed decision in implementation), grouped as:
+
+```python
+DeferredToolGroup(
+    group_id="cubebox:scheduled_tasks",
+    display_name="Scheduled tasks",
+    description="Create, list, update, pause, resume, and delete scheduled agent tasks.",
+    tool_names=[...],  # the 8 op names
+    loader=...,        # zero-arg async → list[AgentTool] with deps closed over
+)
+```
+
+Mutation gating (`allow_mutations=False` for automated runs) moves from
+`build_capability_tool` into the loader — the loader returns only ops that
+survive the gate. Read-only runs see 3 tools (list, get, get_run_history);
+interactive runs see 8.
+
+### 2b. skills capability
+
+Current: dynamically built per-run via `build_skills_capability(deps)` because
+handlers close over `catalog`, `registry`, `session`, etc.
+
+Target: same per-run construction, but the resulting tools become a
+`DeferredToolGroup` with `group_id="cubebox:platform_skills"`. Loader closes
+over `SkillDeps` the same way today's `_skills_cap` closes over them.
+
+### 2c. delete the umbrella machinery
+
+When no callers remain:
+
+- `cubebox/agents/actions/builder.py` — delete `_build_union_model`,
+  `_build_operation_model`, `_make_literal_type`. `build_capability_tool` either
+  goes away entirely or shrinks to a thin "build per-op AgentTools from an
+  AgentCapability" helper.
+- `cubebox/agents/actions/types.py` — `AgentCapability` / `AgentOperation`
+  either stay as a convenient declaration shape (and we add a `to_tools()`
+  helper) or get inlined per-capability. Decision deferred to implementation.
+
+## Risks
+
+- **MCP middleware compatibility** — dispatch mode is supposed to be
+  middleware-transparent, but cubebox has 11 middleware including bespoke
+  citation / artifact / sandbox layers. Worst case: cubepi needs a fix.
+  Caught by Phase 1 verification before any Phase 2 work begins.
+- **Tool name collisions** — splitting `scheduled_tasks` into 8 tools risks
+  colliding with other tool names. Resolve by prefix:
+  `scheduled_tasks_list` etc.
+- **Cache-prefix discipline** — the existing memory `loaded_skills`-style
+  cache-prefix order documented in `run_manager.py:2094-2096` assumes a
+  specific eager order. With more tools moving to deferred groups, the eager
+  prefix shrinks, which is strictly good for cache stability — no regression
+  expected, but spot-check with a trace.
+
+## Out of scope (explicit)
+
+- generate_image deferral (see Non-goals)
+- load_skill / find_skills migration (see Non-goals)
+- expanded-group cross-run replay
+- frontend-side changes to tool-call widget rendering (real tool names already
+  flow through the existing widget path)
+
+## Naming
+
+Per-op tool names use the **group-prefix form**: `<group>_<op>`. Examples:
+`scheduled_tasks_create`, `scheduled_tasks_list`, `scheduled_tasks_pause`,
+`scheduled_tasks_get_run_history`, `platform_skills_find`,
+`platform_skills_install`.
+
+Rationale:
+
+1. Matches cubebox's existing MCP namespacing
+   (`cubebox/mcp/cubepi_runtime.py:_build_namespaced_name_with_prefix` produces
+   `<server_slug>_<tool>` e.g. `github_create_issue`). The deferred catalog
+   then lists cubebox-side and MCP-side groups in the same shape.
+2. Trace / log queries that currently match `scheduled_tasks*` keep working.
+3. Sidesteps singular/plural inconsistency
+   (`create_scheduled_task` vs `list_scheduled_tasks`).
+
+Anthropic / OpenAI tool-name limit is 64 chars; longest projected name
+(`scheduled_tasks_get_run_history`, 31 chars) is well within.
+
+## Rollout
+
+No gray-launch / dispatch-vs-inject side-by-side. Dispatch is a strict cache-hit
+improvement and a pin revert is the rollback path if something regresses.

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -198,17 +198,23 @@ function subagentSummaryToStream(summary: SubagentSummary): AgentStream {
   }
 }
 
-/** True when a tool_call invokes the `skills` capability with operation='find'.
+/** True when a tool_call invokes the platform-skills "find" operation.
  *
- * The legacy `find_skills` tool was renamed to `skills(operation='find', ...)`
- * after the agent platform actions migration. The skill discovery card
- * renderer keys off this predicate so users still see install/preview cards
- * for the new tool name. */
+ * History: `find_skills` → `skills(operation='find', ...)` → `platform_skills_find`.
+ * The capability was migrated to per-operation deferred tools in the cubepi
+ * dispatch upgrade, so the tool name now carries the operation directly and
+ * the umbrella `operation` argument is gone. We still match the legacy
+ * shape so streamed messages persisted from older runs keep rendering the
+ * candidate-card UI. */
 function isSkillsFindCall(block: ContentBlock): boolean {
   if (block.type !== 'tool_call') return false
-  if (block.name !== 'skills') return false
-  const args = (block.arguments ?? {}) as { operation?: unknown }
-  return args.operation === 'find'
+  if (block.name === 'platform_skills_find') return true
+  // Legacy umbrella shape — kept for historical messages.
+  if (block.name === 'skills') {
+    const args = (block.arguments ?? {}) as { operation?: unknown }
+    return args.operation === 'find'
+  }
+  return false
 }
 
 function ContentBlockRenderer({


### PR DESCRIPTION
## Summary

- Bump cubepi pin `c25946e → 088fa66` — picks up the new **dispatch strategy** for `DeferredToolGroup` (default in cubepi main). Tool schemas now ship via `load_tools` tool_results; the tools array and system prompt stay byte-stable across group expansions, so MCP group expansion no longer invalidates the prompt cache.
- Replace cubebox's bespoke **umbrella `AgentTool` + `operation` discriminator** pattern (`agents/actions/builder.py`) with **per-operation AgentTools grouped under `DeferredToolGroup`**. Each operation becomes its own tool named `<cap_name>_<op_name>` (e.g. `scheduled_tasks_create`, `platform_skills_find`).
- Skills capability renamed `skills → platform_skills` to disambiguate from `load_skill` (which loads SKILL.md *prompt content*, not tool schemas — a different progressive-disclosure axis).

Spec: `docs/dev/specs/2026-06-11-cubepi-upgrade-deferred-capabilities-design.md`.

## Why now

cubebox shipped the umbrella+operation pattern in `builder.py` because cubepi 0.10's then-default `inject` strategy invalidated the prompt cache every time a deferred group was expanded. With dispatch as the new default, that workaround is redundant — `DeferredToolGroup` is now the canonical pattern for the same job, with native tool-calling ergonomics:

- `before_tool_call` / tracing / events all see the **real per-op tool name** (verified end-to-end via cubepi tracing, see trace evidence below), not the `deferred_tool_call` envelope.
- Schema validation errors auto-include the tool's schema in the error result, so the model self-corrects in one round trip.
- One canonical pattern across cubebox-builtin capability tools and MCP tools.

## What does NOT migrate (explicit non-goals)

- **`load_skill` / `find_skills`** — these load SKILL.md *markdown content* that `SkillsMiddleware` splices into the next system prompt. Different abstraction (prompt-content disclosure, not tool-schema disclosure). They stay eager.
- **calculator / datetime / write_todos / subagent / memory_*** — used on most turns; deferring just adds a round-trip with no token win.
- **view_images / show_widget** — small schemas, deferring saves nothing.
- **generate_image** — single-tool deferred groups have poor cost/benefit. Revisit if a second sandbox-image tool appears (`cubebox:media`).
- **Cross-run expanded-group replay** — cubebox doesn't currently restore deferred-group state on resume; out of scope.

## Verification (already done locally)

- Real conversation through the new dispatch path (via `backend/scripts/dev/verify_dispatch_trace.py`, not committed — `backend/scripts/dev/` is gitignored). Trace evidence:
  - `before_tool_call` sees `tool_call.name='get_weather'` (real name), not `deferred_tool_call`
  - `tool_execution_start/end` events carry the real tool name + args as the validated pydantic model
  - Trace spans show `execute_tool get_weather`, no envelope anywhere
- mypy strict on whole repo: clean
- ruff format + lint: clean
- Direct tests: `tests/unit/test_agent_action_builder.py` + `tests/unit/test_scheduled_tasks_capability.py` + `tests/unit/test_skills_capability.py` 40/40
- `tests/e2e/test_mcp_disclosure_runtime.py` 12/12 (with 2 expectation updates for dispatch-mode behavior)
- Full unit suite: 1327 passed (10 unrelated errors from `test_scheduled_task_service.py` — missing `organizations` table in this worktree's test DB, a pre-existing migration-setup issue tracked separately)

## Test plan

- [ ] CI passes (full unit + E2E)
- [ ] Manually drive a `scheduled_tasks_create` call through the UI to confirm tool-call widget renders the real per-op name
- [ ] Manually drive a `platform_skills_find` + `platform_skills_install` flow
- [ ] Spot-check an MCP-enabled conversation to confirm dispatch-mode MCP works end-to-end with the citation middleware