### PR TITLE
feat(deploy): replace minio with rustfs in k8s helm chart

### DIFF
--- a/deploy/docker-compose/compose.yaml
+++ b/deploy/docker-compose/compose.yaml
@@ -71,9 +71,7 @@ services:
     volumes:
       - rustfs-data:/data
     healthcheck:
-      # rustfs exposes a similar health probe to minio; if a future image
-      # drops it, replace with a TCP-only probe.
-      test: ["CMD-SHELL", "wget -qO- http://localhost:9000/minio/health/ready || wget -qO- http://localhost:9000/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9000/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 12

--- a/deploy/kubernetes/INSTALL.md
+++ b/deploy/kubernetes/INSTALL.md
@@ -57,7 +57,7 @@ Namespace: cubebox
 │  frontend Deployment (1 replica)                              │
 │    Next.js standalone runtime (node server.js)                │
 ├──────────────┬─────────────┬───────────────┬──────────────────┤
-│ postgres SS  │ redis SS    │ minio SS      │ opensandbox      │
+│ postgres SS  │ redis SS    │ rustfs SS     │ opensandbox      │
 │  + PVC       │  + PVC      │  + PVC + Job  │ (optional        │
 │              │             │  (bucket init)│  subchart)       │
 └──────────────┴─────────────┴───────────────┴──────────────────┘
@@ -299,12 +299,12 @@ redis:
   auth:
     password: "..."     # openssl rand -hex 16
 
-minio:
+rustfs:
   auth:
-    rootPassword: "..." # openssl rand -hex 16 — note: rootPassword, not password
+    secretKey: "..."   # openssl rand -hex 16
 ```
 
-To use **external** Postgres / Redis / MinIO instead, disable the bundled
+To use **external** Postgres / Redis / RustFS instead, disable the bundled
 ones and point the backend at the external endpoints:
 
 ```yaml
@@ -322,7 +322,7 @@ backend:
       password: "..."
 ```
 
-(same pattern for redis / minio).
+(same pattern for redis / rustfs).
 
 ### 4.7 Ingress
 
@@ -373,7 +373,7 @@ postgres:
 redis:
   persistence:
     storageClass: "fast-ssd"
-minio:
+rustfs:
   persistence:
     storageClass: "fast-ssd"
 ```
@@ -660,11 +660,11 @@ redis:
   persistence: { storageClass, size }
   resources: { ... }
 
-minio:
+rustfs:
   enabled: true
-  image: "minio/minio:..."
+  image: "rustfs/rustfs:1.0.0-beta.4"
   mcImage: "minio/mc:..."
-  auth: { rootUser, rootPassword }
+  auth: { accessKey, secretKey }
   defaultBucket: "cubebox"
   persistence: { storageClass, size }
   resources: { ... }
@@ -704,7 +704,7 @@ backend:
 
 postgres: { auth: { password: "<openssl rand -hex 16>" } }
 redis:    { auth: { password: "<openssl rand -hex 16>" } }
-minio:    { auth: { rootPassword: "<openssl rand -hex 16>" } }
+rustfs:   { auth: { secretKey: "<openssl rand -hex 16>" } }
 
 opensandbox:
   enabled: false

--- a/deploy/kubernetes/charts/cubebox/Chart.yaml
+++ b/deploy/kubernetes/charts/cubebox/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "0.1.0"
 
 kubeVersion: ">=1.21.0-0"
 
-# Postgres / Redis / MinIO are rendered from this chart's own templates
+# Postgres / Redis / RustFS are rendered from this chart's own templates
 # (templates/infra-*.yaml) — minimal single-node StatefulSets, no bitnami
 # dependency. Keeping it self-contained avoids fetching from chart repos
 # at install time on networks where Docker OCI is unreliable.

--- a/deploy/kubernetes/charts/cubebox/templates/_helpers.tpl
+++ b/deploy/kubernetes/charts/cubebox/templates/_helpers.tpl
@@ -56,6 +56,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- printf "%s-redis-master" .Release.Name -}}
 {{- end -}}
 
-{{- define "cubebox.minio.host" -}}
-{{- printf "%s-minio" .Release.Name -}}
+{{- define "cubebox.rustfs.host" -}}
+{{- printf "%s-rustfs" .Release.Name -}}
 {{- end -}}

--- a/deploy/kubernetes/charts/cubebox/templates/backend-configmap.yaml
+++ b/deploy/kubernetes/charts/cubebox/templates/backend-configmap.yaml
@@ -1,6 +1,6 @@
 {{- $pgHost := include "cubebox.postgresql.host" . -}}
 {{- $redisHost := include "cubebox.redis.host" . -}}
-{{- $minioHost := include "cubebox.minio.host" . -}}
+{{- $rustfsHost := include "cubebox.rustfs.host" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,8 +21,8 @@ data:
         name: {{ .Values.postgres.auth.database | quote }}
       objectstore:
         provider: "s3"
-        endpoint: {{ printf "http://%s:9000" $minioHost | quote }}
-        bucket: {{ .Values.minio.defaultBucket | quote }}
+        endpoint: {{ printf "http://%s:9000" $rustfsHost | quote }}
+        bucket: {{ .Values.rustfs.defaultBucket | quote }}
         region: "us-east-1"
       sandbox:
         # Decoupled from the opensandbox subchart toggle so operators can

--- a/deploy/kubernetes/charts/cubebox/templates/backend-secret.yaml
+++ b/deploy/kubernetes/charts/cubebox/templates/backend-secret.yaml
@@ -3,8 +3,8 @@
 {{- $vault := required "backend.secrets.auth.vault_key must be set in values.local.yaml (Fernet key)" .Values.backend.secrets.auth.vault_key -}}
 {{- $pgPass := required "postgres.auth.password must be set in values.local.yaml" .Values.postgres.auth.password -}}
 {{- $redisPass := required "redis.auth.password must be set in values.local.yaml" .Values.redis.auth.password -}}
-{{- $minioUser := .Values.minio.auth.rootUser -}}
-{{- $minioPass := required "minio.auth.rootPassword must be set in values.local.yaml" .Values.minio.auth.rootPassword -}}
+{{- $rustfsAccessKey := .Values.rustfs.auth.accessKey -}}
+{{- $rustfsSecretKey := required "rustfs.auth.secretKey must be set in values.local.yaml" .Values.rustfs.auth.secretKey -}}
 {{- $sandbox := .Values.backend.secrets.sandbox -}}
 {{- $llm := .Values.backend.secrets.llm -}}
 apiVersion: v1
@@ -27,8 +27,8 @@ stringData:
       redis:
         url: {{ printf "redis://:%s@%s:6379/0" $redisPass (include "cubebox.redis.host" .) | quote }}
       objectstore:
-        access_key: {{ $minioUser | quote }}
-        access_secret: {{ $minioPass | quote }}
+        access_key: {{ $rustfsAccessKey | quote }}
+        access_secret: {{ $rustfsSecretKey | quote }}
       sandbox:
         domain: {{ $sandbox.domain | quote }}
         image: {{ $sandbox.image | quote }}

--- a/deploy/kubernetes/charts/cubebox/templates/infra-rustfs.yaml
+++ b/deploy/kubernetes/charts/cubebox/templates/infra-rustfs.yaml
@@ -1,24 +1,24 @@
-{{- if .Values.minio.enabled -}}
-{{- $minioPass := required "minio.auth.rootPassword must be set in values.local.yaml" .Values.minio.auth.rootPassword -}}
+{{- if .Values.rustfs.enabled -}}
+{{- $secretKey := required "rustfs.auth.secretKey must be set in values.local.yaml" .Values.rustfs.auth.secretKey -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-minio
+  name: {{ .Release.Name }}-rustfs
   labels:
     {{- include "cubebox.labels" . | nindent 4 }}
-    app.kubernetes.io/component: minio
+    app.kubernetes.io/component: rustfs
 type: Opaque
 stringData:
-  MINIO_ROOT_USER: {{ .Values.minio.auth.rootUser | quote }}
-  MINIO_ROOT_PASSWORD: {{ $minioPass | quote }}
+  RUSTFS_ACCESS_KEY: {{ .Values.rustfs.auth.accessKey | quote }}
+  RUSTFS_SECRET_KEY: {{ $secretKey | quote }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-minio
+  name: {{ .Release.Name }}-rustfs
   labels:
     {{- include "cubebox.labels" . | nindent 4 }}
-    app.kubernetes.io/component: minio
+    app.kubernetes.io/component: rustfs
 spec:
   type: ClusterIP
   ports:
@@ -31,37 +31,45 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "cubebox.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: minio
+    app.kubernetes.io/component: rustfs
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-minio
+  name: {{ .Release.Name }}-rustfs
   labels:
     {{- include "cubebox.labels" . | nindent 4 }}
-    app.kubernetes.io/component: minio
+    app.kubernetes.io/component: rustfs
 spec:
   replicas: 1
-  serviceName: {{ .Release.Name }}-minio
+  serviceName: {{ .Release.Name }}-rustfs
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "cubebox.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: minio
+      app.kubernetes.io/component: rustfs
   template:
     metadata:
       labels:
         {{- include "cubebox.labels" . | nindent 8 }}
-        app.kubernetes.io/component: minio
+        app.kubernetes.io/component: rustfs
     spec:
       containers:
-        - name: minio
-          image: {{ .Values.minio.image }}
+        - name: rustfs
+          image: {{ .Values.rustfs.image }}
           imagePullPolicy: IfNotPresent
-          args: ["server", "/data", "--console-address", ":9001"]
+          env:
+            - name: RUSTFS_ADDRESS
+              value: ":9000"
+            - name: RUSTFS_CONSOLE_ENABLE
+              value: "true"
+            - name: RUSTFS_CONSOLE_ADDRESS
+              value: ":9001"
+            - name: RUSTFS_VOLUMES
+              value: /data
           envFrom:
             - secretRef:
-                name: {{ .Release.Name }}-minio
+                name: {{ .Release.Name }}-rustfs
           ports:
             - name: s3
               containerPort: 9000
@@ -69,18 +77,18 @@ spec:
               containerPort: 9001
           readinessProbe:
             httpGet:
-              path: /minio/health/ready
+              path: /health
               port: s3
             initialDelaySeconds: 10
             periodSeconds: 5
           livenessProbe:
             httpGet:
-              path: /minio/health/live
+              path: /health
               port: s3
             initialDelaySeconds: 30
             periodSeconds: 15
           resources:
-            {{- toYaml .Values.minio.resources | nindent 12 }}
+            {{- toYaml .Values.rustfs.resources | nindent 12 }}
           volumeMounts:
             - name: data
               mountPath: /data
@@ -89,19 +97,20 @@ spec:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
-        storageClassName: {{ .Values.minio.persistence.storageClass }}
+        storageClassName: {{ .Values.rustfs.persistence.storageClass }}
         resources:
           requests:
-            storage: {{ .Values.minio.persistence.size }}
+            storage: {{ .Values.rustfs.persistence.size }}
 ---
 # One-shot Job that creates the default bucket using mc client.
+# mc speaks S3 so it works against rustfs's S3-compatible API.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-minio-bucket
+  name: {{ .Release.Name }}-rustfs-bucket
   labels:
     {{- include "cubebox.labels" . | nindent 4 }}
-    app.kubernetes.io/component: minio-bucket
+    app.kubernetes.io/component: rustfs-bucket
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
@@ -113,33 +122,33 @@ spec:
     metadata:
       labels:
         {{- include "cubebox.labels" . | nindent 8 }}
-        app.kubernetes.io/component: minio-bucket
+        app.kubernetes.io/component: rustfs-bucket
     spec:
       restartPolicy: OnFailure
       containers:
         - name: mc
-          image: {{ .Values.minio.mcImage }}
+          image: {{ .Values.rustfs.mcImage }}
           imagePullPolicy: IfNotPresent
           env:
-            - name: MINIO_ROOT_USER
+            - name: RUSTFS_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-minio
-                  key: MINIO_ROOT_USER
-            - name: MINIO_ROOT_PASSWORD
+                  name: {{ .Release.Name }}-rustfs
+                  key: RUSTFS_ACCESS_KEY
+            - name: RUSTFS_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-minio
-                  key: MINIO_ROOT_PASSWORD
+                  name: {{ .Release.Name }}-rustfs
+                  key: RUSTFS_SECRET_KEY
             - name: BUCKET
-              value: {{ .Values.minio.defaultBucket | quote }}
+              value: {{ .Values.rustfs.defaultBucket | quote }}
           command:
             - /bin/sh
             - -c
             - |
               set -e
-              until mc alias set local http://{{ .Release.Name }}-minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
-                echo "waiting for minio..."; sleep 3
+              until mc alias set local http://{{ .Release.Name }}-rustfs:9000 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY"; do
+                echo "waiting for rustfs..."; sleep 3
               done
               mc mb --ignore-existing local/"$BUCKET"
               echo "bucket $BUCKET ready"

--- a/deploy/kubernetes/charts/cubebox/templates/infra-rustfs.yaml
+++ b/deploy/kubernetes/charts/cubebox/templates/infra-rustfs.yaml
@@ -33,6 +33,9 @@ spec:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: rustfs
 ---
+# NOTE: upgrading from the previous minio-based chart renames the PVC from
+# data-<release>-minio-0 to data-<release>-rustfs-0. Existing object data
+# must be migrated manually before upgrading if preservation is needed.
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -54,6 +57,10 @@ spec:
         {{- include "cubebox.labels" . | nindent 8 }}
         app.kubernetes.io/component: rustfs
     spec:
+      securityContext:
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
       containers:
         - name: rustfs
           image: {{ .Values.rustfs.image }}

--- a/deploy/kubernetes/charts/cubebox/values.local.yaml.example
+++ b/deploy/kubernetes/charts/cubebox/values.local.yaml.example
@@ -55,9 +55,9 @@ redis:
   auth:
     password: "REPLACE_ME"
 
-minio:
+rustfs:
   auth:
-    rootPassword: "REPLACE_ME"
+    secretKey: "REPLACE_ME"
 
 # ── Egress secret-injection (opt-in) ─────────────────────────────────────
 # Enables the MITM webhook + backend mTLS exchange. Requires building one

--- a/deploy/kubernetes/charts/cubebox/values.yaml
+++ b/deploy/kubernetes/charts/cubebox/values.yaml
@@ -134,7 +134,7 @@ redis:
 
 rustfs:
   enabled: true
-  image: rustfs/rustfs:latest
+  image: rustfs/rustfs:1.0.0-beta.4
   mcImage: minio/mc:RELEASE.2025-04-08T15-39-49Z
   auth:
     accessKey: cubebox

--- a/deploy/kubernetes/charts/cubebox/values.yaml
+++ b/deploy/kubernetes/charts/cubebox/values.yaml
@@ -132,13 +132,13 @@ redis:
       cpu: "500m"
       memory: "512Mi"
 
-minio:
+rustfs:
   enabled: true
-  image: minio/minio:RELEASE.2025-04-08T15-41-24Z
+  image: rustfs/rustfs:latest
   mcImage: minio/mc:RELEASE.2025-04-08T15-39-49Z
   auth:
-    rootUser: cubebox
-    rootPassword: ""  # required in values.local.yaml
+    accessKey: cubebox
+    secretKey: ""  # required in values.local.yaml
   defaultBucket: cubebox
   persistence:
     storageClass: cubebox-work-hostpath

--- a/deploy/kubernetes/scripts/e2e.sh
+++ b/deploy/kubernetes/scripts/e2e.sh
@@ -75,7 +75,7 @@ step "6. POST message → run_id"
 MSG=$(curl -fsS "${CURL_OPTS[@]}" -b "$CK" \
   -H "Content-Type: application/json" \
   -H "X-CSRF-Token: $CSRF" \
-  -d "$(python3 -c 'import json,os; print(json.dumps({"content": os.environ["PROMPT"]}))')" \
+  -d "$(python3 -c 'import json,sys; print(json.dumps({"content": sys.argv[1]}))' "$PROMPT")" \
   "$BASE/api/v1/ws/$WS/conversations/$CONV_ID/messages")
 RUN_ID=$(echo "$MSG" | python3 -c 'import json,sys; print(json.load(sys.stdin)["run_id"])')
 echo "  run_id=$RUN_ID"

--- a/deploy/kubernetes/scripts/smoke-test.sh
+++ b/deploy/kubernetes/scripts/smoke-test.sh
@@ -27,8 +27,8 @@ kubectl -n "$NAMESPACE" rollout status \
 kubectl -n "$NAMESPACE" rollout status \
   "deploy/${RELEASE}-frontend" --timeout=300s
 
-step "2. Postgres / Redis / MinIO ready"
-for app in postgresql redis-master minio; do
+step "2. Postgres / Redis / RustFS ready"
+for app in postgresql redis-master rustfs; do
   if kubectl -n "$NAMESPACE" get sts "${RELEASE}-${app}" >/dev/null 2>&1; then
     kubectl -n "$NAMESPACE" rollout status "sts/${RELEASE}-${app}" --timeout=300s
   elif kubectl -n "$NAMESPACE" get deploy "${RELEASE}-${app}" >/dev/null 2>&1; then

--- a/docs/dev/notes/2026-06-11-deploy-test-environment.md
+++ b/docs/dev/notes/2026-06-11-deploy-test-environment.md
@@ -126,7 +126,8 @@ bash /tmp/sb-e2e.sh   # the script the manual e2e ran from; see the
 | `host.docker.internal` unreachable from cubebox-backend container | Linux Docker engines don't auto-resolve it. The compose.opensandbox.yaml overlay sets `extra_hosts: host.docker.internal:host-gateway` on backend. |
 | `secureAccess is not supported when runtime.type=docker` (HTTP 400) | docker runtime rejects secureAccess. Set `sandbox.secure_access: false` (new in commit `509ebe91`). k8s-mode keeps the default `true`. |
 | `init-pvc` pod on the cluster ErrImagePull-ing `openebs/linux-utils:3.5.0` | preload once: `docker pull openebs/linux-utils:3.5.0` then `kubectl -n openebs rollout restart deploy/openebs-localpv-provisioner` |
-| `helm dependency update` failing on bitnami subcharts | the chart does NOT depend on bitnami — postgres/redis/minio are self-rendered. If you see this error you're on a branch from before that refactor. |
+| `helm dependency update` failing on bitnami subcharts | the chart does NOT depend on bitnami — postgres/redis/rustfs are self-rendered. If you see this error you're on a branch from before that refactor. |
+| rustfs pod stuck `0/1` with readiness probe 403 on `/minio/health/ready` | older chart version used `/minio/health/ready`; rustfs exposes `/health` only. Fixed in `feat/rustfs-k8s`: probe path changed to `/health`. |
 
 ## How to re-run the docker-runtime OpenSandbox e2e from scratch
 


### PR DESCRIPTION
## Summary

- Replace bundled minio StatefulSet with rustfs in the Helm chart, consistent with docker-compose mode
- Update all references: Secret/Service/StatefulSet names, env vars (`MINIO_*` → `RUSTFS_*`), values keys (`minio.*` → `rustfs.*`), helper function name
- Fix health probe path: rustfs exposes `/health` (not `/minio/health/ready`)
- Fix e2e.sh: pass PROMPT via `sys.argv` instead of `os.environ` (bash vars aren't exported to subprocesses)

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders correctly — rustfs StatefulSet, Service, bucket-init Job, objectstore config in backend Secret/ConfigMap
- [x] `helm upgrade` on node-1 (192.168.1.101): minio → rustfs, all pods `1/1 Running`
- [x] smoke-test.sh: rollouts + health probes + ingress + frontend HTML ✓
- [x] e2e.sh: register → login → conversation → LLM round-trip → `E2E PASSED`