### PR TITLE
fix(im): auto-cancel paused HITL when user sends new message

### DIFF
--- a/backend/cubebox/im/worker.py
+++ b/backend/cubebox/im/worker.py
@@ -45,6 +45,7 @@ class _RunStarter(Protocol):
         content: str,
         attachments: list[str] | None,
         ctx: RunContext,
+        cancel_pending_hitl: bool = False,
     ) -> str: ...
 
 
@@ -122,6 +123,7 @@ async def process_one_queue_item(
                 workspace_id=captured["workspace_id"],
                 trigger="im",
             ),
+            cancel_pending_hitl=True,
         )
     except Exception as exc:
         # ``RunManager.start_run`` raises a plain RuntimeError when the

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -794,6 +794,7 @@ class RunManager:
         run_id: str | None = None,
         preset_label: str | None = None,
         thinking: ThinkingLevel = "off",
+        cancel_pending_hitl: bool = False,
     ) -> str:
         """Create and start a new background run.
 
@@ -816,13 +817,17 @@ class RunManager:
         from cubebox.agents.checkpointer import init_checkpointer
 
         async with init_checkpointer() as _cp:
-            _db_pending = await _cp.load_pending_request(conversation_id)
+            _db_pending = await _cp.load_pending(conversation_id)
         if _db_pending is not None:
-            raise RuntimeError(
-                f"Conversation {conversation_id} has a pending HITL request "
-                f"(question_id={_db_pending.question_id}); "
-                f"answer or cancel before starting a new turn"
-            )
+            if not cancel_pending_hitl:
+                _pending_req = _db_pending[0]
+                raise RuntimeError(
+                    f"Conversation {conversation_id} has a pending HITL request "
+                    f"(question_id={_pending_req.question_id}); "
+                    f"answer or cancel before starting a new turn"
+                )
+            _pending_req, _old_run_id = _db_pending
+            await self._force_cancel_hitl(conversation_id, _old_run_id)
 
         created_run = await create_run(
             self._redis,
@@ -1083,6 +1088,58 @@ class RunManager:
         self._tasks[run_id] = task
         task.add_done_callback(lambda _: self._on_task_done(run_id))
         return run_id
+
+    async def _force_cancel_hitl(
+        self,
+        conversation_id: str,
+        old_run_id: str | None,
+    ) -> None:
+        """Silently cancel a paused HITL so a new run can start.
+
+        Clears the DB pending request, backfills synthetic tool_results for
+        the dangling tool_use, and tears down the Redis active-run lock.
+        Emits a terminal DoneEvent so any live OutboundRunTailer exits
+        cleanly instead of polling until TTL expiry.
+        """
+        from cubebox.agents.checkpointer import init_checkpointer
+
+        async with init_checkpointer() as cp:
+            await cp.save_pending_request(conversation_id, None)
+
+        await _repair_dangling_tool_calls(conversation_id)
+
+        if old_run_id is not None:
+            await update_run_meta(
+                self._redis,
+                prefix=self._key_prefix,
+                run_id=old_run_id,
+                status="cancelled",
+            )
+            await self._append_event(
+                old_run_id,
+                conversation_id,
+                DoneEvent(
+                    timestamp=datetime.now(UTC).isoformat(),
+                    data={},
+                ),
+            )
+            await clear_active_run(
+                self._redis,
+                prefix=self._key_prefix,
+                conversation_id=conversation_id,
+                run_id=old_run_id,
+            )
+            await expire_run_data(
+                self._redis,
+                prefix=self._key_prefix,
+                run_id=old_run_id,
+                ttl_seconds=self._run_event_ttl_seconds,
+            )
+        logger.info(
+            "[RunManager] force-cancelled paused HITL for conversation {} (old run {})",
+            conversation_id,
+            old_run_id,
+        )
 
     async def dispatch_cancel_steer(self, run_id: str, steer_id: str) -> str:
         agent = self._agents.get(run_id)

--- a/backend/tests/unit/test_run_manager_start_run_paused.py
+++ b/backend/tests/unit/test_run_manager_start_run_paused.py
@@ -9,7 +9,7 @@ Two guards, exercised independently here:
 2. DB-side: Redis has no active row (meta aged out, or was never written
    because the worker crashed between ``save_pending_request`` and the
    ``update_run_meta(status='paused_hitl')`` write). The new guard
-   consults ``PostgresCheckpointer.load_pending_request`` and refuses
+   consults ``PostgresCheckpointer.load_pending`` and refuses
    when a pending HITL request still lives in the DB.
 
 The happy path — no active row, no DB pending — must still spawn the
@@ -51,7 +51,7 @@ def redis() -> fakeredis.aioredis.FakeRedis:
 
 @pytest.fixture
 def stub_no_db_pending(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Patch ``init_checkpointer`` so ``load_pending_request`` returns None.
+    """Patch ``init_checkpointer`` so ``load_pending`` returns None.
 
     Used by tests that should NOT raise on the DB-pending guard. The guard
     only runs on the conflict branch (when ``create_run`` returns None),
@@ -59,7 +59,7 @@ def stub_no_db_pending(monkeypatch: pytest.MonkeyPatch) -> None:
     accidental DB connection attempt.
     """
     cp = MagicMock()
-    cp.load_pending_request = AsyncMock(return_value=None)
+    cp.load_pending = AsyncMock(return_value=None)
 
     @asynccontextmanager
     async def _fake_cm() -> Any:
@@ -120,7 +120,7 @@ async def test_start_run_rejects_when_db_pending_present(
     pending.question_id = "q_abc"
 
     cp = MagicMock()
-    cp.load_pending_request = AsyncMock(return_value=pending)
+    cp.load_pending = AsyncMock(return_value=(pending, "old_run_1"))
 
     @asynccontextmanager
     async def _fake_cm() -> Any:
@@ -154,7 +154,7 @@ async def test_start_run_rejects_when_db_pending_present(
             ctx=_ctx(),
         )
     assert "q_abc" in str(ei.value)
-    cp.load_pending_request.assert_awaited_once_with("c1")
+    cp.load_pending.assert_awaited_once_with("c1")
 
 
 async def test_start_run_succeeds_when_no_pending(
@@ -168,7 +168,7 @@ async def test_start_run_succeeds_when_no_pending(
     exiting to avoid event-loop warnings.
     """
     cp = MagicMock()
-    cp.load_pending_request = AsyncMock(return_value=None)
+    cp.load_pending = AsyncMock(return_value=None)
 
     @asynccontextmanager
     async def _fake_cm() -> Any:
@@ -195,7 +195,7 @@ async def test_start_run_succeeds_when_no_pending(
     # Up-front DB-pending guard runs unconditionally — the durability
     # claim depends on it (a TTL-expired Redis lock could otherwise let
     # a new turn slip past while DB pending lingers). One read per start.
-    cp.load_pending_request.assert_awaited_once()
+    cp.load_pending.assert_awaited_once()
 
     # Drain the spawned task before the loop closes.
     task = rm._tasks.get(run_id)


### PR DESCRIPTION
## Summary

- When an IM user ignores AskUser/SandboxConfirm buttons and sends a new message, the worker was stuck in a silent rewind loop — `start_run()` refused to proceed while a HITL was pending, so the new message queued forever with no response
- Added `cancel_pending_hitl` param to `start_run()`. The IM worker passes `True`, which force-cancels the stale HITL (clears DB pending, repairs dangling tool_use, releases Redis lock, emits terminal DoneEvent for tailer cleanup) before starting the new run
- Web UI unaffected — defaults to `False` and continues to block input via the frontend InputBar disabled state
- Old Discord buttons gracefully show "操作已过期或已被处理" if clicked after auto-cancel

## Test plan
- [x] Existing unit tests updated and passing (`test_run_manager_start_run_paused`, cancel, resume)
- [x] mypy strict clean
- [x] Full pre-push check passed (1826 tests)
- [ ] Manual Discord test: trigger AskUser → ignore buttons → send new message → verify bot responds normally
- [ ] Manual Discord test: after auto-cancel, click old button → verify ephemeral "操作已过期" message