### PR TITLE
feat(im): Discord IM connector

### DIFF
--- a/backend/cubebox/im/discord/interactions.py
+++ b/backend/cubebox/im/discord/interactions.py
@@ -9,6 +9,32 @@ import discord
 from loguru import logger
 
 
+async def _resolve_full_question_id(run_id: str, short_qid: str) -> str:
+    """Map truncated question_id back to the full value from DB pending.
+
+    The Discord custom_id only carries the first 8 chars of the question_id
+    to stay within the 100-char limit.  ``resume_run_with_answer`` does an
+    exact match, so we need the full hash.
+    """
+    try:
+        from cubebox.im.resume import _resolve_run_context
+
+        resolved = await _resolve_run_context(run_id)
+        if resolved is None:
+            return short_qid
+        conversation_id = resolved[0]
+
+        from cubebox.agents.checkpointer import init_checkpointer
+
+        async with init_checkpointer() as cp:
+            pending = await cp.load_pending_request(conversation_id)
+        if pending is not None and pending.question_id.startswith(short_qid):
+            return pending.question_id
+    except Exception:
+        logger.warning("[Discord] _resolve_full_question_id failed", exc_info=True)
+    return short_qid
+
+
 async def handle_component_interaction(
     interaction: discord.Interaction,
     *,
@@ -17,8 +43,11 @@ async def handle_component_interaction(
 ) -> None:
     """Route a button click to the resume path.
 
-    Button custom_id format: ``im:{kind}:{run_id}:{value}``
+    Button custom_id format: ``im:{kind}:{run_id}:{short_qid}:{akey}:{value}``
     where kind is ``ask_user`` or ``sandbox_confirm``.
+    ``short_qid`` is a truncated question_id (first 8 chars) — the full
+    value is loaded from the DB pending so the resume path sees an exact
+    match.
     """
     raw_data: Any = interaction.data
     custom_id: str = raw_data.get("custom_id", "") if raw_data else ""
@@ -30,7 +59,12 @@ async def handle_component_interaction(
         await interaction.response.send_message("Invalid button.", ephemeral=True)
         return
 
-    _, kind, run_id, question_id, answer_key, value = parts
+    _, kind, run_id, short_qid, answer_key, value = parts
+
+    # The custom_id carries a truncated question_id (8 chars) to stay
+    # within Discord's 100-char limit.  Load the full question_id from
+    # the DB pending so resume_run_with_answer sees an exact match.
+    question_id = await _resolve_full_question_id(run_id, short_qid)
 
     from cubebox.im.resume import resume_paused_run
 

--- a/backend/cubebox/im/discord/renderer.py
+++ b/backend/cubebox/im/discord/renderer.py
@@ -129,13 +129,19 @@ class DiscordOpDispatcher:
         view = discord.ui.View(timeout=600)
         qid = pending.question_id or ""
         akey = pending.answer_key or ""
+        # Discord custom_id max is 100 chars.  Full question_id can be
+        # 33+ chars; combined with run_id (36) and answer_key the id
+        # overflows, truncating value and making all buttons identical
+        # (→ 400).  Cap qid to 8 chars; the interaction handler loads
+        # the full question_id from the DB pending.
+        short_qid = qid[:8]
         for label, value, btn_type in pending.choices:
             style = discord.ButtonStyle.primary
             if btn_type == "danger":
                 style = discord.ButtonStyle.danger
             elif btn_type == "default":
                 style = discord.ButtonStyle.secondary
-            cid = f"im:{pending.kind}:{pending.run_id}:{qid}:{akey}:{value}"
+            cid = f"im:{pending.kind}:{pending.run_id}:{short_qid}:{akey}:{value}"
             if len(cid) > 100:
                 cid = cid[:100]
             button: discord.ui.Button[discord.ui.View] = discord.ui.Button(

--- a/backend/cubebox/im/worker.py
+++ b/backend/cubebox/im/worker.py
@@ -45,6 +45,7 @@ class _RunStarter(Protocol):
         content: str,
         attachments: list[str] | None,
         ctx: RunContext,
+        cancel_pending_hitl: bool = False,
     ) -> str: ...
 
 
@@ -122,6 +123,7 @@ async def process_one_queue_item(
                 workspace_id=captured["workspace_id"],
                 trigger="im",
             ),
+            cancel_pending_hitl=True,
         )
     except Exception as exc:
         # ``RunManager.start_run`` raises a plain RuntimeError when the

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -794,6 +794,7 @@ class RunManager:
         run_id: str | None = None,
         preset_label: str | None = None,
         thinking: ThinkingLevel = "off",
+        cancel_pending_hitl: bool = False,
     ) -> str:
         """Create and start a new background run.
 
@@ -816,13 +817,17 @@ class RunManager:
         from cubebox.agents.checkpointer import init_checkpointer
 
         async with init_checkpointer() as _cp:
-            _db_pending = await _cp.load_pending_request(conversation_id)
+            _db_pending = await _cp.load_pending(conversation_id)
         if _db_pending is not None:
-            raise RuntimeError(
-                f"Conversation {conversation_id} has a pending HITL request "
-                f"(question_id={_db_pending.question_id}); "
-                f"answer or cancel before starting a new turn"
-            )
+            if not cancel_pending_hitl:
+                _pending_req = _db_pending[0]
+                raise RuntimeError(
+                    f"Conversation {conversation_id} has a pending HITL request "
+                    f"(question_id={_pending_req.question_id}); "
+                    f"answer or cancel before starting a new turn"
+                )
+            _pending_req, _old_run_id = _db_pending
+            await self._force_cancel_hitl(conversation_id, _old_run_id)
 
         created_run = await create_run(
             self._redis,
@@ -1083,6 +1088,58 @@ class RunManager:
         self._tasks[run_id] = task
         task.add_done_callback(lambda _: self._on_task_done(run_id))
         return run_id
+
+    async def _force_cancel_hitl(
+        self,
+        conversation_id: str,
+        old_run_id: str | None,
+    ) -> None:
+        """Silently cancel a paused HITL so a new run can start.
+
+        Clears the DB pending request, backfills synthetic tool_results for
+        the dangling tool_use, and tears down the Redis active-run lock.
+        Emits a terminal DoneEvent so any live OutboundRunTailer exits
+        cleanly instead of polling until TTL expiry.
+        """
+        from cubebox.agents.checkpointer import init_checkpointer
+
+        async with init_checkpointer() as cp:
+            await cp.save_pending_request(conversation_id, None)
+
+        await _repair_dangling_tool_calls(conversation_id)
+
+        if old_run_id is not None:
+            await update_run_meta(
+                self._redis,
+                prefix=self._key_prefix,
+                run_id=old_run_id,
+                status="cancelled",
+            )
+            await self._append_event(
+                old_run_id,
+                conversation_id,
+                DoneEvent(
+                    timestamp=datetime.now(UTC).isoformat(),
+                    data={},
+                ),
+            )
+            await clear_active_run(
+                self._redis,
+                prefix=self._key_prefix,
+                conversation_id=conversation_id,
+                run_id=old_run_id,
+            )
+            await expire_run_data(
+                self._redis,
+                prefix=self._key_prefix,
+                run_id=old_run_id,
+                ttl_seconds=self._run_event_ttl_seconds,
+            )
+        logger.info(
+            "[RunManager] force-cancelled paused HITL for conversation {} (old run {})",
+            conversation_id,
+            old_run_id,
+        )
 
     async def dispatch_cancel_steer(self, run_id: str, steer_id: str) -> str:
         agent = self._agents.get(run_id)

--- a/backend/tests/unit/test_run_manager_start_run_paused.py
+++ b/backend/tests/unit/test_run_manager_start_run_paused.py
@@ -9,7 +9,7 @@ Two guards, exercised independently here:
 2. DB-side: Redis has no active row (meta aged out, or was never written
    because the worker crashed between ``save_pending_request`` and the
    ``update_run_meta(status='paused_hitl')`` write). The new guard
-   consults ``PostgresCheckpointer.load_pending_request`` and refuses
+   consults ``PostgresCheckpointer.load_pending`` and refuses
    when a pending HITL request still lives in the DB.
 
 The happy path — no active row, no DB pending — must still spawn the
@@ -51,7 +51,7 @@ def redis() -> fakeredis.aioredis.FakeRedis:
 
 @pytest.fixture
 def stub_no_db_pending(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Patch ``init_checkpointer`` so ``load_pending_request`` returns None.
+    """Patch ``init_checkpointer`` so ``load_pending`` returns None.
 
     Used by tests that should NOT raise on the DB-pending guard. The guard
     only runs on the conflict branch (when ``create_run`` returns None),
@@ -59,7 +59,7 @@ def stub_no_db_pending(monkeypatch: pytest.MonkeyPatch) -> None:
     accidental DB connection attempt.
     """
     cp = MagicMock()
-    cp.load_pending_request = AsyncMock(return_value=None)
+    cp.load_pending = AsyncMock(return_value=None)
 
     @asynccontextmanager
     async def _fake_cm() -> Any:
@@ -120,7 +120,7 @@ async def test_start_run_rejects_when_db_pending_present(
     pending.question_id = "q_abc"
 
     cp = MagicMock()
-    cp.load_pending_request = AsyncMock(return_value=pending)
+    cp.load_pending = AsyncMock(return_value=(pending, "old_run_1"))
 
     @asynccontextmanager
     async def _fake_cm() -> Any:
@@ -154,7 +154,7 @@ async def test_start_run_rejects_when_db_pending_present(
             ctx=_ctx(),
         )
     assert "q_abc" in str(ei.value)
-    cp.load_pending_request.assert_awaited_once_with("c1")
+    cp.load_pending.assert_awaited_once_with("c1")
 
 
 async def test_start_run_succeeds_when_no_pending(
@@ -168,7 +168,7 @@ async def test_start_run_succeeds_when_no_pending(
     exiting to avoid event-loop warnings.
     """
     cp = MagicMock()
-    cp.load_pending_request = AsyncMock(return_value=None)
+    cp.load_pending = AsyncMock(return_value=None)
 
     @asynccontextmanager
     async def _fake_cm() -> Any:
@@ -195,7 +195,7 @@ async def test_start_run_succeeds_when_no_pending(
     # Up-front DB-pending guard runs unconditionally — the durability
     # claim depends on it (a TTL-expired Redis lock could otherwise let
     # a new turn slip past while DB pending lingers). One read per start.
-    cp.load_pending_request.assert_awaited_once()
+    cp.load_pending.assert_awaited_once()
 
     # Drain the spawned task before the loop closes.
     task = rm._tasks.get(run_id)


### PR DESCRIPTION
## Summary

- Full Discord IM integration: bot gateway, message parsing, streaming reply rendering, interactive buttons (AskUser / SandboxConfirm), slash commands (`/new`, `/reset`), per-user conversation isolation
- Platform registry + distributed Redis lease so multiple IM platforms (Feishu, Discord) start/stop independently with leader election
- Shared `CardState` / `PendingInput` model extracted from Feishu card_model into reusable `im/card_model.py`; `OpDispatcher` protocol so each platform implements its own rendering
- Frontend: Discord connect wizard (bot token + guild ID), platform logos, i18n keys
- Auto-cancel stale HITL when IM user sends a new message while a previous ask_user is pending
- Fix Discord `custom_id` 100-char limit: truncate `question_id` to 8 chars in button payload, resolve full value from DB on interaction

## Test plan

- [ ] Unit tests for Discord connector, renderer, registry, card_model lift, gateway lease, OpDispatcher protocol
- [ ] E2E: connect Discord bot via workspace settings wizard → verify bot appears in account list
- [ ] E2E: send message in Discord channel → bot replies with streamed content
- [ ] E2E: trigger AskUser with long answer_key (e.g. `morning_routine`) → buttons render (not plain text fallback)
- [ ] E2E: click AskUser button → run resumes correctly
- [ ] E2E: send new message while AskUser is pending → old HITL auto-cancelled, new run starts
- [ ] E2E: `/new` and `/reset` slash commands create new conversations