### PR TITLE
feat(web): IM connect quick-pick + non-dismissible form dialogs

### DIFF
--- a/frontend/packages/web/app/(app)/w/[wsId]/scheduled-tasks/components/ScheduledTaskFormDialog.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/scheduled-tasks/components/ScheduledTaskFormDialog.tsx
@@ -122,7 +122,7 @@ export function ScheduledTaskFormDialog({
   }
 
   return (
-    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+    <DialogPrimitive.Root open={open} disablePointerDismissal onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
         <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 transition-opacity duration-200" />
         <DialogPrimitive.Popup

--- a/frontend/packages/web/components/im/ImConnectWizard/index.tsx
+++ b/frontend/packages/web/components/im/ImConnectWizard/index.tsx
@@ -11,6 +11,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 
 import { StepPlatform } from './steps/StepPlatform'
 import { useConnectMutation } from './useConnectMutation'
+import { ALL_PLATFORMS } from './platforms'
 import type { FormState, PlatformDescriptor } from './platforms/types'
 
 type DynamicT = (key: string, values?: Record<string, string | number>) => string
@@ -18,14 +19,26 @@ type DynamicT = (key: string, values?: Record<string, string | number>) => strin
 interface Props {
   wsId: string
   open: boolean
+  /** When set to a live platform id, skip the platform-picker and open its config directly. */
+  initialPlatformId?: string
   onClose: () => void
   onSuccess: () => void
 }
 
-export function ImConnectWizard({ wsId, open, onClose, onSuccess }: Props): React.ReactElement {
+export function ImConnectWizard({
+  wsId,
+  open,
+  initialPlatformId,
+  onClose,
+  onSuccess,
+}: Props): React.ReactElement {
   const t = useTranslations() as unknown as DynamicT
   const client = useMemo(() => createApiClient(''), [])
-  const [platform, setPlatform] = useState<PlatformDescriptor | null>(null)
+  const [platform, setPlatform] = useState<PlatformDescriptor | null>(() => {
+    if (!initialPlatformId) return null
+    const p = ALL_PLATFORMS.find((x) => x.id === initialPlatformId)
+    return p && p.live ? p : null
+  })
   const [stepIdx, setStepIdx] = useState(0)
   const [form, setForm] = useState<FormState>({})
   const mut = useConnectMutation(client, wsId)
@@ -53,7 +66,7 @@ export function ImConnectWizard({ wsId, open, onClose, onSuccess }: Props): Reac
   }
 
   return (
-    <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
+    <Dialog open={open} disablePointerDismissal onOpenChange={(o) => !o && handleClose()}>
       <DialogContent role="dialog" aria-labelledby="wizard-title">
         <DialogHeader>
           <DialogTitle id="wizard-title">{t('im.wizard.title')}</DialogTitle>

--- a/frontend/packages/web/components/triggers/TriggerForm.tsx
+++ b/frontend/packages/web/components/triggers/TriggerForm.tsx
@@ -107,7 +107,7 @@ export function TriggerForm({ wsId, open, onOpenChange, onCreated, onSubmit }: T
   const canSubmit = name.trim() && webhookSecret && promptTemplate && runAsUserId
 
   return (
-    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+    <DialogPrimitive.Root open={open} disablePointerDismissal onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
         <DialogPrimitive.Backdrop
           className={cn(

--- a/frontend/packages/web/components/workspace-settings/ImPanel.tsx
+++ b/frontend/packages/web/components/workspace-settings/ImPanel.tsx
@@ -50,6 +50,7 @@ export function ImPanel({ wsId }: Props): React.ReactElement {
   const [deleteCandidate, setDeleteCandidate] = useState<ImAccount | null>(null)
   const [deleteText, setDeleteText] = useState('')
   const wizardOpen = search?.get('action') === 'connect'
+  const connectPlatform = search?.get('platform') ?? undefined
   const selectedId = search?.get('account') ?? null
 
   const load = useCallback(async () => {
@@ -83,7 +84,11 @@ export function ImPanel({ wsId }: Props): React.ReactElement {
         title={t('nav.workspaceTab')}
         description={t('panel.description')}
         action={
-          <Button size="sm" className="gap-1.5" onClick={() => updateUrl({ action: 'connect' })}>
+          <Button
+            size="sm"
+            className="gap-1.5"
+            onClick={() => updateUrl({ action: 'connect', platform: null })}
+          >
             <Plus className="size-3.5" />
             {t('action.connect')}
           </Button>
@@ -110,7 +115,9 @@ export function ImPanel({ wsId }: Props): React.ReactElement {
                       <button
                         key={platform.id}
                         disabled={!platform.live}
-                        onClick={() => platform.live && updateUrl({ action: 'connect' })}
+                        onClick={() =>
+                          platform.live && updateUrl({ action: 'connect', platform: platform.id })
+                        }
                         className={cn(
                           'flex w-28 flex-col items-center gap-2 rounded-xl border px-5 py-4 transition-all',
                           platform.live
@@ -179,9 +186,10 @@ export function ImPanel({ wsId }: Props): React.ReactElement {
         <ImConnectWizard
           wsId={wsId}
           open
-          onClose={() => updateUrl({ action: null })}
+          initialPlatformId={connectPlatform}
+          onClose={() => updateUrl({ action: null, platform: null })}
           onSuccess={() => {
-            updateUrl({ action: null })
+            updateUrl({ action: null, platform: null })
             void load()
           }}
         />


### PR DESCRIPTION
Two small workspace-UI fixes, frontend only.

## IM connect — open the picked platform directly
On the IM empty state, clicking a platform logo (Lark/Feishu) now opens
**that platform's** config wizard directly, instead of popping the wizard and
asking you to pick the IM type again. `ImConnectWizard` accepts an
`initialPlatformId`; the empty-state cards pass the platform via the URL, and
the header **Connect** button still opens the generic picker.

## Form dialogs no longer close on an outside click
Multi-field form dialogs were dismissed by a click anywhere outside them,
which silently discarded a half-filled form. They now close only via the
close button / Esc, using base-ui's `disablePointerDismissal`:
- IM connect wizard
- Create trigger
- Create scheduled task

Confirm-style dialogs (which lose nothing) keep click-outside-to-close.

## Checks
type-check (incl. backend mypy) · eslint `--max-warnings=0` · prettier · i18n
parity · frontend check-ci (build + vitest + next build) — all green on push.
Verified in-browser: Feishu logo opens straight to its prereqs; outside-click
keeps the wizard open; close button closes it.