### PR TITLE
fix(sandbox): server-side TTL + kill retry to prevent sandbox leaks

### DIFF
--- a/backend/cubebox/repositories/user_sandbox.py
+++ b/backend/cubebox/repositories/user_sandbox.py
@@ -341,8 +341,8 @@ class UserSandboxRepository(ScopedRepository[UserSandbox]):
         """System-scope query: find expired sandboxes across all workspaces.
 
         Only for background reapers — never expose to user-facing code. Sweeps
-        ``provisioning`` rows too so a crashed reserve can't pin the partial
-        unique slot forever.
+        ``provisioning`` rows (crashed reserve) and ``kill_pending`` rows
+        (failed provider kill) in addition to ``running``.
         """
         stmt = (
             select(UserSandbox)

--- a/backend/cubebox/repositories/user_sandbox.py
+++ b/backend/cubebox/repositories/user_sandbox.py
@@ -325,12 +325,12 @@ class UserSandboxRepository(ScopedRepository[UserSandbox]):
     async def list_expired(self) -> list[UserSandbox]:
         """List sandboxes that have exceeded their TTL since last activity.
 
-        Sweeps both ``running`` and ``provisioning`` rows so a crash mid-create
-        cannot orphan a reserved slot past its TTL.
+        Sweeps ``running``, ``provisioning``, and ``kill_pending`` rows so
+        neither a crash mid-create nor a failed kill can orphan a sandbox.
         """
         stmt = (
             self._scoped_select()
-            .where(UserSandbox.status.in_(self._ACTIVE_STATUSES))  # type: ignore[attr-defined]
+            .where(UserSandbox.status.in_(self._REAPABLE_STATUSES))  # type: ignore[attr-defined]
             .where(text("last_activity_at + ttl_seconds * INTERVAL '1 second' < NOW()"))
         )
         result = await self.session.execute(stmt)

--- a/backend/cubebox/repositories/user_sandbox.py
+++ b/backend/cubebox/repositories/user_sandbox.py
@@ -15,7 +15,7 @@ class UserSandboxRepository(ScopedRepository[UserSandbox]):
 
     model = UserSandbox
 
-    _ACTIVE_STATUSES = ("provisioning", "running")
+    _ACTIVE_STATUSES = ("provisioning", "running", "kill_pending")
 
     async def create(
         self,
@@ -139,6 +139,13 @@ class UserSandboxRepository(ScopedRepository[UserSandbox]):
         record = await self.get(record_id)
         if record:
             record.status = "terminated"
+            await self.session.commit()
+
+    async def mark_kill_pending(self, record_id: str) -> None:
+        """Mark a sandbox as kill_pending (provider kill failed, retry later)."""
+        record = await self.get(record_id)
+        if record:
+            record.status = "kill_pending"
             await self.session.commit()
 
     async def mark_failed_from_transient(self, record_id: str) -> bool:

--- a/backend/cubebox/repositories/user_sandbox.py
+++ b/backend/cubebox/repositories/user_sandbox.py
@@ -15,7 +15,8 @@ class UserSandboxRepository(ScopedRepository[UserSandbox]):
 
     model = UserSandbox
 
-    _ACTIVE_STATUSES = ("provisioning", "running", "kill_pending")
+    _ACTIVE_STATUSES = ("provisioning", "running")
+    _REAPABLE_STATUSES = ("provisioning", "running", "kill_pending")
 
     async def create(
         self,
@@ -345,7 +346,7 @@ class UserSandboxRepository(ScopedRepository[UserSandbox]):
         """
         stmt = (
             select(UserSandbox)
-            .where(UserSandbox.status.in_(cls._ACTIVE_STATUSES))  # type: ignore[attr-defined]
+            .where(UserSandbox.status.in_(cls._REAPABLE_STATUSES))  # type: ignore[attr-defined]
             .where(text("last_activity_at + ttl_seconds * INTERVAL '1 second' < NOW()"))
         )
         result = await session.execute(stmt)

--- a/backend/cubebox/sandbox/base.py
+++ b/backend/cubebox/sandbox/base.py
@@ -116,6 +116,10 @@ class Sandbox(ABC):
         """Suspend this sandbox, preserving state. Override in capable drivers."""
         raise NotImplementedError("pause is not supported by this sandbox backend")
 
+    async def renew(self, timeout_seconds: int) -> None:
+        """Extend the provider-side expiration. No-op for backends without TTL."""
+        return  # no-op default; backends with TTL override
+
     @classmethod
     async def connect_or_resume(cls, sandbox_id: str, **kwargs: object) -> Sandbox:
         """Connect to a sandbox, resuming it from `paused` if necessary, and

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -965,7 +965,10 @@ class SandboxManager:
                 await repo.mark_terminated(record.id)
                 await EgressRefRepository(session).revoke_for_sandbox(record.sandbox_id)
                 raise
-        await self._renew_provider_ttl(record.sandbox_id)
+        try:
+            await backend.renew(self._ttl)
+        except Exception:
+            logger.debug("Provider-side renew failed for {} (non-fatal)", record.sandbox_id)
         return backend
 
     async def _await_stable_status(
@@ -1183,38 +1186,13 @@ class SandboxManager:
                     # reaped. The resume path will manage egress / kill on
                     # its own outcomes.
                     continue
-                # We own the kill. Tell the provider to drop the sandbox and
-                # revoke any egress refs; mark_terminated already landed via
-                # the atomic claim, so no second status flip is needed.
-                raw: opensandbox.Sandbox | None = None
-                try:
-                    raw = await opensandbox.Sandbox.connect(
-                        record.sandbox_id,
-                        connection_config=conn_config,
-                        skip_health_check=True,
-                    )
-                    await raw.kill()
-                    logger.info("Reaped paused sandbox {}", record.sandbox_id)
-                except Exception as exc:
-                    logger.warning(
-                        "Failed to kill reaped paused sandbox {} (may already be gone): {}",
-                        record.sandbox_id,
-                        exc,
-                    )
-                finally:
-                    # G8: pair connect with close on every path so a kill that
-                    # raises mid-flight doesn't leak the httpx transport.
-                    if raw is not None:
-                        try:
-                            await raw.close()
-                        except Exception as exc:
-                            logger.debug(
-                                "Reap-path close failed for {}: {}",
-                                record.sandbox_id,
-                                exc,
-                            )
-                if self._exchange_host:
-                    await EgressRefRepository(session).revoke_for_sandbox(record.sandbox_id)
+                # We own the kill. _kill_record handles the provider kill,
+                # egress revocation, and — on failure — marks kill_pending so
+                # the next cleanup loop retries instead of orphaning. The
+                # claim already set status='terminated'; _kill_record's
+                # mark_terminated is idempotent, and mark_kill_pending
+                # overwrites to 'kill_pending' for retry.
+                await self._kill_record(session, scoped, record, conn_config)
 
     async def reconcile_transients(self, *, claim_timeout: int = 60) -> None:
         """Repair rows stuck in ``pausing``/``resuming`` by reading provider state.
@@ -1253,17 +1231,13 @@ class SandboxManager:
                     info = await raw.get_info()
                     state = (info.status.state if info and info.status else "") or ""
                 except Exception as exc:
-                    # 404 / NOT_FOUND means the provider has GC'd the pod
-                    # out-of-band; the row will never recover, so kill it
-                    # immediately instead of leaving it transient forever
-                    # (which would trap subsequent ``get_or_create`` calls in
-                    # ``_await_stable_status`` until manual cleanup). The error
-                    # body shape was empirically captured during Task 0 — see
-                    # internals-note G4. For non-404 errors (network blips,
-                    # SDK glitches) just bump the check timestamp and try
-                    # again next tick.
-                    msg = str(exc).upper()
-                    if "NOT_FOUND" in msg or "404" in msg:
+                    # 404 means the provider has GC'd the pod out-of-band;
+                    # kill the row so it doesn't trap get_or_create in
+                    # _await_stable_status forever. For non-404 errors
+                    # (network blips, SDK glitches) just bump the check
+                    # timestamp and try again next tick.
+                    is_gone = isinstance(exc, ProviderApiError) and exc.status_code == 404
+                    if is_gone:
                         logger.warning(
                             "Reconciler: provider reports {} gone (404 / "
                             "NOT_FOUND): {}; killing the row",

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -1345,8 +1345,13 @@ class SandboxManager:
         conn_config: ConnectionConfig,
     ) -> None:
         """Kill + revoke egress + mark terminated. Shared by cleanup_expired,
-        pause_idle fallback, and reconciler paths."""
+        pause_idle fallback, and reconciler paths.
+
+        On kill failure, marks the row ``kill_pending`` so the next cleanup loop
+        retries instead of orphaning the provider sandbox.
+        """
         raw: opensandbox.Sandbox | None = None
+        killed = False
         try:
             raw = await opensandbox.Sandbox.connect(
                 record.sandbox_id,
@@ -1355,15 +1360,14 @@ class SandboxManager:
             )
             await raw.kill()
             logger.info("Killed sandbox {}", record.sandbox_id)
+            killed = True
         except Exception as exc:
             logger.warning(
-                "Failed to kill sandbox {} (may already be gone): {}",
+                "Failed to kill sandbox {} (will retry on next loop): {}",
                 record.sandbox_id,
                 exc,
             )
         finally:
-            # G8: pair connect with close on every path so a kill that
-            # raises mid-flight doesn't leak the httpx transport.
             if raw is not None:
                 try:
                     await raw.close()
@@ -1373,9 +1377,12 @@ class SandboxManager:
                         record.sandbox_id,
                         exc,
                     )
-        await scoped_repo.mark_terminated(record.id)
-        if self._exchange_host:
-            await EgressRefRepository(session).revoke_for_sandbox(record.sandbox_id)
+        if killed:
+            await scoped_repo.mark_terminated(record.id)
+            if self._exchange_host:
+                await EgressRefRepository(session).revoke_for_sandbox(record.sandbox_id)
+        else:
+            await scoped_repo.mark_kill_pending(record.id)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -1003,7 +1003,7 @@ class SandboxManager:
                 row = await poll_repo.get(record_id)
                 if row is None:
                     return None
-                if row.status in ("running", "paused", "failed", "terminated"):
+                if row.status in ("running", "paused", "failed", "terminated", "kill_pending"):
                     return row
                 last_status = row.status
             await asyncio.sleep(0.5)

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -22,7 +22,12 @@ from typing import Any
 import opensandbox
 from loguru import logger
 from opensandbox.config import ConnectionConfig
-from opensandbox.exceptions import SandboxException as ProviderSandboxError
+from opensandbox.exceptions import (
+    SandboxApiException as ProviderApiError,
+)
+from opensandbox.exceptions import (
+    SandboxException as ProviderSandboxError,
+)
 from opensandbox.models.sandboxes import PVC, Volume
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -207,6 +212,27 @@ class SandboxManager:
             request_timeout=timedelta(seconds=request_timeout or self._request_timeout),
             use_server_proxy=self._use_server_proxy,
         )
+
+    async def _renew_provider_ttl(self, sandbox_id: str) -> None:
+        """Best-effort extend the provider-side expiration so the OpenSandbox
+        controller won't GC an actively-used sandbox. Non-fatal on failure."""
+        conn_config = self._build_connection_config()
+        raw: opensandbox.Sandbox | None = None
+        try:
+            raw = await opensandbox.Sandbox.connect(
+                sandbox_id,
+                connection_config=conn_config,
+                skip_health_check=True,
+            )
+            await raw.renew(timedelta(seconds=self._ttl))
+        except Exception:
+            logger.debug("Provider-side renew failed for {} (non-fatal)", sandbox_id)
+        finally:
+            if raw is not None:
+                try:
+                    await raw.close()
+                except Exception:
+                    pass
 
     def _build_user_volume(self, workspace_id: str, user_id: str) -> Volume:
         """Build a PVC Volume keyed on (workspace_id, user_id).
@@ -712,25 +738,7 @@ class SandboxManager:
                     sandbox_id, now + timedelta(seconds=self._ttl)
                 )
 
-        # Extend provider-side expiry so the OpenSandbox controller won't GC
-        # an actively-used sandbox.
-        conn_config = self._build_connection_config()
-        raw: opensandbox.Sandbox | None = None
-        try:
-            raw = await opensandbox.Sandbox.connect(
-                sandbox_id,
-                connection_config=conn_config,
-                skip_health_check=True,
-            )
-            await raw.renew(timedelta(seconds=self._ttl))
-        except Exception:
-            logger.debug("Provider-side renew failed for {} (non-fatal)", sandbox_id)
-        finally:
-            if raw is not None:
-                try:
-                    await raw.close()
-                except Exception:
-                    pass
+        await self._renew_provider_ttl(sandbox_id)
 
     async def touch_active(
         self,
@@ -759,7 +767,8 @@ class SandboxManager:
                     record.sandbox_id, datetime.now(UTC) + timedelta(seconds=self._ttl)
                 )
             self._touch_cache[record.sandbox_id] = datetime.now(UTC)
-            return True
+        await self._renew_provider_ttl(record.sandbox_id)
+        return True
 
     async def renew_lease(
         self,
@@ -956,6 +965,7 @@ class SandboxManager:
                 await repo.mark_terminated(record.id)
                 await EgressRefRepository(session).revoke_for_sandbox(record.sandbox_id)
                 raise
+        await self._renew_provider_ttl(record.sandbox_id)
         return backend
 
     async def _await_stable_status(
@@ -1362,11 +1372,15 @@ class SandboxManager:
             logger.info("Killed sandbox {}", record.sandbox_id)
             killed = True
         except Exception as exc:
-            logger.warning(
-                "Failed to kill sandbox {} (will retry on next loop): {}",
-                record.sandbox_id,
-                exc,
-            )
+            if isinstance(exc, ProviderApiError) and exc.status_code == 404:
+                logger.info("Sandbox {} already gone (404)", record.sandbox_id)
+                killed = True
+            else:
+                logger.warning(
+                    "Failed to kill sandbox {} (will retry on next loop): {}",
+                    record.sandbox_id,
+                    exc,
+                )
         finally:
             if raw is not None:
                 try:

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -567,7 +567,7 @@ class SandboxManager:
                 raw_sandbox = await opensandbox.Sandbox.create(
                     policy.default_image,
                     connection_config=create_conn_config,
-                    timeout=None,
+                    timeout=timedelta(seconds=self._ttl),
                     ready_timeout=timedelta(seconds=self._ready_timeout),
                     volumes=volumes,
                     resource={"cpu": self._resource_cpu, "memory": self._resource_memory},
@@ -711,6 +711,26 @@ class SandboxManager:
                 await EgressRefRepository(session).extend_expiry_for_sandbox(
                     sandbox_id, now + timedelta(seconds=self._ttl)
                 )
+
+        # Extend provider-side expiry so the OpenSandbox controller won't GC
+        # an actively-used sandbox.
+        conn_config = self._build_connection_config()
+        raw: opensandbox.Sandbox | None = None
+        try:
+            raw = await opensandbox.Sandbox.connect(
+                sandbox_id,
+                connection_config=conn_config,
+                skip_health_check=True,
+            )
+            await raw.renew(timedelta(seconds=self._ttl))
+        except Exception:
+            logger.debug("Provider-side renew failed for {} (non-fatal)", sandbox_id)
+        finally:
+            if raw is not None:
+                try:
+                    await raw.close()
+                except Exception:
+                    pass
 
     async def touch_active(
         self,

--- a/backend/cubebox/sandbox/opensandbox.py
+++ b/backend/cubebox/sandbox/opensandbox.py
@@ -158,6 +158,10 @@ class OpenSandbox(Sandbox):
         with _as_sandbox_error():
             await self._sandbox.pause()
 
+    async def renew(self, timeout_seconds: int) -> None:
+        with _as_sandbox_error():
+            await self._sandbox.renew(timedelta(seconds=timeout_seconds))
+
     @classmethod
     async def connect_or_resume(  # type: ignore[override]
         cls,

--- a/backend/tests/e2e/test_opensandbox.py
+++ b/backend/tests/e2e/test_opensandbox.py
@@ -40,6 +40,7 @@ async def shared_sandbox_id():
                 domain=config.sandbox.domain,
                 request_timeout=timedelta(seconds=60),
             ),
+            timeout=timedelta(seconds=600),
         )
         _shared_sandbox_id = raw_sandbox.id
         print(f"\n[Module Setup] Created shared sandbox: {_shared_sandbox_id}")

--- a/backend/tests/e2e/test_sandbox_pause_resume.py
+++ b/backend/tests/e2e/test_sandbox_pause_resume.py
@@ -120,6 +120,7 @@ async def shared_sandbox_id() -> AsyncIterator[str]:
             config.get("sandbox.image"),
             connection_config=_build_conn_config(),
             ready_timeout=timedelta(seconds=120),
+            timeout=timedelta(seconds=600),
         )
     except Exception as exc:
         pytest.skip(f"OpenSandbox service not available: {exc}")

--- a/backend/tests/unit/test_kill_pending.py
+++ b/backend/tests/unit/test_kill_pending.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from opensandbox.exceptions import SandboxApiException
 
 from cubebox.sandbox.manager import SandboxManager
 
@@ -119,3 +120,26 @@ async def test_kill_connect_failure_marks_kill_pending() -> None:
 
     repo.mark_kill_pending.assert_called_once_with(record.id)
     repo.mark_terminated.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kill_404_marks_terminated() -> None:
+    """When kill() returns 404 (sandbox already gone), treat as successful kill."""
+    mgr = _make_manager()
+    session = MagicMock()
+    repo = AsyncMock()
+    record = _make_record()
+
+    raw = AsyncMock()
+    raw.kill = AsyncMock(
+        side_effect=SandboxApiException("Not Found", status_code=404),
+    )
+    raw.close = AsyncMock()
+
+    conn_config = mgr._build_connection_config()
+
+    with patch("cubebox.sandbox.manager.opensandbox.Sandbox.connect", return_value=raw):
+        await mgr._kill_record(session, repo, record, conn_config)
+
+    repo.mark_terminated.assert_called_once_with(record.id)
+    repo.mark_kill_pending.assert_not_called()

--- a/backend/tests/unit/test_kill_pending.py
+++ b/backend/tests/unit/test_kill_pending.py
@@ -1,0 +1,121 @@
+"""Unit tests: _kill_record uses kill_pending for retry on failure."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cubebox.sandbox.manager import SandboxManager
+
+
+def _make_manager() -> SandboxManager:
+    factory = MagicMock()
+    encryption = MagicMock()
+    with patch("cubebox.sandbox.manager.config") as mock_config:
+        mock_config.get.side_effect = lambda key, default=None: {
+            "sandbox.domain": "localhost:8090",
+            "sandbox.image": "ubuntu:22.04",
+            "sandbox.api_key": None,
+            "sandbox.request_timeout": 60,
+            "sandbox.create_timeout": 300,
+            "sandbox.ttl": 600,
+            "sandbox.touch_interval": 60,
+            "sandbox.ready_timeout": 60,
+            "sandbox.use_server_proxy": False,
+            "sandbox.secure_access": True,
+            "sandbox.workdir": "/workspace",
+            "sandbox.resource.cpu": "100m",
+            "sandbox.resource.memory": "100Mi",
+            "sandbox.volume.enabled": False,
+            "sandbox.volume.mount_path": "/workspace",
+            "sandbox.volume.pvc_prefix": "cubebox-user",
+            "sandbox.egress_exchange_host": "",
+            "sandbox.pause_on_idle": True,
+            "sandbox.idle_ttl_seconds": 1800,
+            "sandbox.paused_ttl_seconds": 1440,
+            "sandbox.resume_timeout": 30,
+            "sandbox.lease_seconds": 300,
+            "sandbox.pause_attempt_grace_seconds": 5400,
+            "sandbox.reserve_wait_timeout": 30.0,
+            "sandbox.reserve_poll_interval": 0.5,
+        }.get(key, default)
+        mgr = SandboxManager(factory, encryption)
+    return mgr
+
+
+def _make_record(
+    *,
+    record_id: str = "rec-1",
+    sandbox_id: str = "sbx-1",
+    org_id: str = "org-1",
+    workspace_id: str = "ws-1",
+    status: str = "running",
+) -> MagicMock:
+    record = MagicMock()
+    record.id = record_id
+    record.sandbox_id = sandbox_id
+    record.org_id = org_id
+    record.workspace_id = workspace_id
+    record.status = status
+    return record
+
+
+@pytest.mark.asyncio
+async def test_kill_success_marks_terminated() -> None:
+    """When raw.kill() succeeds, the row should end up as terminated."""
+    mgr = _make_manager()
+    session = MagicMock()
+    repo = AsyncMock()
+    record = _make_record()
+
+    raw = AsyncMock()
+    raw.kill = AsyncMock()
+    raw.close = AsyncMock()
+
+    conn_config = mgr._build_connection_config()
+
+    with patch("cubebox.sandbox.manager.opensandbox.Sandbox.connect", return_value=raw):
+        await mgr._kill_record(session, repo, record, conn_config)
+
+    repo.mark_terminated.assert_called_once_with(record.id)
+    repo.mark_kill_pending.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kill_failure_marks_kill_pending() -> None:
+    """When raw.kill() raises, the row should be marked kill_pending (not terminated)."""
+    mgr = _make_manager()
+    session = MagicMock()
+    repo = AsyncMock()
+    record = _make_record()
+
+    raw = AsyncMock()
+    raw.kill = AsyncMock(side_effect=Exception("connection refused"))
+    raw.close = AsyncMock()
+
+    conn_config = mgr._build_connection_config()
+
+    with patch("cubebox.sandbox.manager.opensandbox.Sandbox.connect", return_value=raw):
+        await mgr._kill_record(session, repo, record, conn_config)
+
+    repo.mark_kill_pending.assert_called_once_with(record.id)
+    repo.mark_terminated.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kill_connect_failure_marks_kill_pending() -> None:
+    """When even connect fails, mark kill_pending."""
+    mgr = _make_manager()
+    session = MagicMock()
+    repo = AsyncMock()
+    record = _make_record()
+
+    conn_config = mgr._build_connection_config()
+
+    with patch(
+        "cubebox.sandbox.manager.opensandbox.Sandbox.connect",
+        side_effect=Exception("DNS resolution failed"),
+    ):
+        await mgr._kill_record(session, repo, record, conn_config)
+
+    repo.mark_kill_pending.assert_called_once_with(record.id)
+    repo.mark_terminated.assert_not_called()

--- a/backend/tests/unit/test_manager_egress_injection.py
+++ b/backend/tests/unit/test_manager_egress_injection.py
@@ -509,8 +509,8 @@ async def test_cleanup_expired_revokes_refs(
             "cubebox.repositories.user_sandbox.UserSandboxRepository.mark_terminated",
             new=AsyncMock(return_value=None),
         ),
-        # Stub sandbox kill so no real network call is made
-        patch("opensandbox.Sandbox.connect", side_effect=Exception("no sandbox")),
+        # Stub sandbox connect+kill so no real network call is made
+        patch("opensandbox.Sandbox.connect", return_value=AsyncMock()),
     ):
         await manager.cleanup_expired()
 

--- a/backend/tests/unit/test_sandbox_manager_pause.py
+++ b/backend/tests/unit/test_sandbox_manager_pause.py
@@ -622,7 +622,7 @@ async def test_resume_record_exception_leaves_row_resuming_for_reconciler(
 
 
 @pytest.mark.asyncio
-async def test_kill_record_swallows_kill_failure_and_marks_terminated(
+async def test_kill_record_marks_kill_pending_on_failure(
     mock_encryption_backend: Any,
 ) -> None:
     factory, session = _make_session_factory()
@@ -632,12 +632,14 @@ async def test_kill_record_swallows_kill_failure_and_marks_terminated(
     record = _make_record()
     scoped = MagicMock()
     scoped.mark_terminated = AsyncMock()
+    scoped.mark_kill_pending = AsyncMock()
 
     with patch("cubebox.sandbox.manager.opensandbox") as op:
         op.Sandbox.connect = AsyncMock(side_effect=RuntimeError("gone already"))
         await mgr._kill_record(session, scoped, record, conn_config=MagicMock())
 
-    scoped.mark_terminated.assert_awaited_once_with(record.id)
+    scoped.mark_kill_pending.assert_awaited_once_with(record.id)
+    scoped.mark_terminated.assert_not_awaited()
 
 
 # -------------------------------------------------------------------------

--- a/backend/tests/unit/test_sandbox_reconciler.py
+++ b/backend/tests/unit/test_sandbox_reconciler.py
@@ -18,6 +18,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from opensandbox.exceptions import SandboxApiException
 
 from cubebox.sandbox.manager import SandboxManager
 
@@ -399,23 +400,12 @@ async def test_reconcile_get_info_failure_just_bumps_touch(mock_encryption_backe
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "err_msg",
-    [
-        "404 KUBERNETES::SANDBOX_NOT_FOUND",
-        "kubernetes::sandbox_not_found",
-        "Sandbox 'sbx-x' not found (404)",
-    ],
-)
 @pytest.mark.asyncio
 async def test_reconcile_provider_404_kills_record(
-    err_msg: str, mock_encryption_backend: Any
+    mock_encryption_backend: Any,
 ) -> None:
-    """When the provider returns 404 / NOT_FOUND (pod GC'd out-of-band),
-    the reconciler must kill the row instead of leaving it transient
-    forever — otherwise subsequent ``get_or_create`` calls would time out
-    in ``_await_stable_status`` until manual cleanup.
-    """
+    """When the provider returns 404 (pod GC'd out-of-band), the reconciler
+    must kill the row instead of leaving it transient forever."""
     factory, _session = _make_session_factory()
     mgr = SandboxManager(factory, mock_encryption_backend)
     mgr._exchange_host = ""
@@ -424,7 +414,9 @@ async def test_reconcile_provider_404_kills_record(
     scoped = _scoped_repo()
 
     raw = MagicMock()
-    raw.get_info = AsyncMock(side_effect=RuntimeError(err_msg))
+    raw.get_info = AsyncMock(
+        side_effect=SandboxApiException("Not Found", status_code=404),
+    )
 
     with (
         patch("cubebox.sandbox.manager.UserSandboxRepository") as repo_cls,

--- a/backend/tests/unit/test_touch_renew.py
+++ b/backend/tests/unit/test_touch_renew.py
@@ -1,0 +1,108 @@
+"""Unit tests: touch() calls renew on the provider sandbox."""
+
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cubebox.sandbox.manager import SandboxManager
+
+
+def _make_manager(*, ttl: int = 600, touch_interval: int = 60) -> SandboxManager:
+    factory = MagicMock(name="session_factory")
+    encryption = MagicMock(name="encryption_backend")
+    with patch("cubebox.sandbox.manager.config") as mock_config:
+        config_map: dict[str, Any] = {
+            "sandbox.domain": "localhost:8090",
+            "sandbox.image": "ubuntu:22.04",
+            "sandbox.api_key": None,
+            "sandbox.request_timeout": 60,
+            "sandbox.create_timeout": 300,
+            "sandbox.ttl": ttl,
+            "sandbox.touch_interval": touch_interval,
+            "sandbox.ready_timeout": 60,
+            "sandbox.use_server_proxy": False,
+            "sandbox.secure_access": True,
+            "sandbox.workdir": "/workspace",
+            "sandbox.resource.cpu": "100m",
+            "sandbox.resource.memory": "100Mi",
+            "sandbox.volume.enabled": False,
+            "sandbox.volume.mount_path": "/workspace",
+            "sandbox.volume.pvc_prefix": "cubebox-user",
+            "sandbox.egress_exchange_host": "",
+            "sandbox.pause_on_idle": True,
+            "sandbox.idle_ttl_seconds": 1800,
+            "sandbox.paused_ttl_seconds": 1440,
+            "sandbox.resume_timeout": 30,
+            "sandbox.lease_seconds": 300,
+            "sandbox.pause_attempt_grace_seconds": 5400,
+            "sandbox.reserve_wait_timeout": 30.0,
+            "sandbox.reserve_poll_interval": 0.5,
+        }
+        mock_config.get.side_effect = lambda key, default=None: config_map.get(key, default)
+        mgr = SandboxManager(factory, encryption)
+    return mgr
+
+
+@pytest.mark.asyncio
+async def test_touch_calls_renew_on_provider() -> None:
+    """When touch fires (not throttled), it should call sandbox.renew."""
+    mgr = _make_manager(ttl=600, touch_interval=0)
+
+    mock_session = MagicMock()
+    mock_repo = AsyncMock()
+    mock_raw = AsyncMock()
+    mock_raw.renew = AsyncMock()
+    mock_raw.close = AsyncMock()
+
+    @asynccontextmanager
+    async def _session_cm():
+        yield mock_session
+
+    mgr._session_factory = MagicMock(side_effect=lambda: _session_cm())
+
+    with (
+        patch("cubebox.sandbox.manager.UserSandboxRepository", return_value=mock_repo),
+        patch("cubebox.sandbox.manager.opensandbox.Sandbox.connect", return_value=mock_raw),
+    ):
+        await mgr.touch(
+            "sbx-123",
+            org_id="org-1",
+            workspace_id="ws-1",
+        )
+
+    mock_raw.renew.assert_called_once()
+    call_args = mock_raw.renew.call_args[0]
+    assert call_args[0].total_seconds() == 600
+
+
+@pytest.mark.asyncio
+async def test_touch_renew_failure_is_nonfatal() -> None:
+    """If renew() raises, touch should log a warning and continue (not crash)."""
+    mgr = _make_manager(ttl=600, touch_interval=0)
+
+    mock_session = MagicMock()
+    mock_repo = AsyncMock()
+    mock_raw = AsyncMock()
+    mock_raw.renew = AsyncMock(side_effect=Exception("server unavailable"))
+    mock_raw.close = AsyncMock()
+
+    @asynccontextmanager
+    async def _session_cm():
+        yield mock_session
+
+    mgr._session_factory = MagicMock(side_effect=lambda: _session_cm())
+
+    with (
+        patch("cubebox.sandbox.manager.UserSandboxRepository", return_value=mock_repo),
+        patch("cubebox.sandbox.manager.opensandbox.Sandbox.connect", return_value=mock_raw),
+    ):
+        # Should not raise
+        await mgr.touch(
+            "sbx-123",
+            org_id="org-1",
+            workspace_id="ws-1",
+        )
+
+    mock_repo.update_activity_by_sandbox_id.assert_called_once()


### PR DESCRIPTION
## Summary

- **Server-side TTL at create**: `Sandbox.create()` now passes `timeout=self._ttl` instead of `None`, so OpenSandbox sets a real `expireTime` on the BatchSandbox CR. The controller GC backstop kicks in even if cubebox crashes or a worktree is abandoned.
- **Renew on touch**: `touch()` calls `sandbox.renew(ttl)` on the provider to dynamically extend the expiry with each user activity, keeping the provider TTL in sync with the DB-side `last_activity_at`.
- **kill_pending retry**: `_kill_record()` no longer unconditionally marks rows `terminated` when the provider kill fails. Failed kills go to `kill_pending`, which `cleanup_expired` sweeps on the next loop iteration — preventing the DB/provider desync where DB says "terminated" but the k8s sandbox is still running.
- **E2E test timeout**: Tests that create real sandboxes now pass `timeout=600s` so interrupted test runs don't leak sandboxes forever.
- **Manual cleanup**: Deleted 30 leaked BatchSandbox CRs with `manual-cleanup` label and cleaned up stale DB records in 4 worktree databases.

## Test plan

- [x] New unit tests: `test_touch_renew.py` (2 tests — renew called + failure is non-fatal)
- [x] New unit tests: `test_kill_pending.py` (3 tests — success→terminated, failure→kill_pending, connect failure→kill_pending)
- [x] Updated `test_manager_egress_injection.py` and `test_sandbox_manager_pause.py` for kill_pending behavior
- [x] Full unit test suite: 1461 passed (10 pre-existing errors in `test_scheduled_task_service` unrelated to this change)
- [x] Pre-commit: ruff format + lint + mypy strict all clean
- [ ] E2E sandbox tests (require sandbox service — will validate in staging)