### PR TITLE
ci(claude-review): grant pull-requests write so review comments can post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # `write` (not `read`) is required for the action's post step to
+      # actually publish the buffered inline review comments. With `read`
+      # the API call returns 403 silently and the comments never appear
+      # on the PR — even when Claude found something.
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -36,6 +40,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Surface the full tool-call stream so we can diagnose empty-buffer
+          # runs (the `permission_denials_count` from the SDK summary is
+          # otherwise opaque). Drop this once the review is reliably posting.
+          show_full_output: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary

The Claude Code Review workflow on PR #249 finished with exit code 0 and \$7.48 of token spend but posted nothing. Job log: https://github.com/xfgong/cubebox/actions/runs/27738148711/job/82059284996

Two changes to fix the failure mode:

### 1. \`permissions.pull-requests: read → write\` (+ \`issues: write\`)

The action's post step (\`post-buffered-inline-comments.ts\`) calls GitHub's review-comments API to publish the buffer. With \`read\`, that API call returns 403 silently — the job logs success but no comments land on the PR.

### 2. \`show_full_output: true\`

The SDK summary on the failing run reported \`permission_denials_count: 32\` with no visibility into which tools were denied — that's why the inline-comment buffer ended up empty (\`No buffered inline comments\` in the logs). Surfacing the full tool-call stream is needed to diagnose whether the denials hit \`Agent\` (subagent dispatch the code-review plugin relies on) or the inline-comment buffer tool itself. Will drop this flag once review is reliably posting.

## Test plan

- [ ] Merge this PR
- [ ] Re-run the Claude Code Review workflow on PR #249 (\`gh workflow run\` or push an empty commit)
- [ ] Confirm either: review comments appear, OR the full-output log explains the 32 denials