### PR TITLE
fix(search): backfill missing org/ws indexes + state enum on search tables

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -70,6 +70,15 @@ _CHECKPOINT_TABLES = {
     "cubepi_schema_version",
 }
 
+# Hand-crafted PostgreSQL indexes that SQLModel can't declare (HNSW from
+# pgvector, pgroonga full-text). Without this guard autogen proposes to
+# drop them on every run — applying that migration would silently break
+# search. Owned by alembic/versions/fabe1279b9f6_conversation_search_tables.
+_HAND_BUILT_INDEXES = {
+    "ix_chunks_embedding_hnsw",
+    "ix_chunks_text_lexical",
+}
+
 
 def include_object(
     object: object,  # noqa: A002
@@ -78,7 +87,7 @@ def include_object(
     reflected: bool,
     compare_to: object,
 ) -> bool:
-    """Exclude cubepi-checkpointer-owned tables from autogenerate."""
+    """Exclude cubepi-checkpointer tables and hand-built indexes from autogenerate."""
     if type_ == "table" and name is not None:
         if name in _CHECKPOINT_TABLES:
             return False
@@ -86,6 +95,8 @@ def include_object(
             return False
         if name.startswith("cubepi_runs_p"):
             return False
+    if type_ == "index" and name in _HAND_BUILT_INDEXES:
+        return False
     return True
 
 

--- a/backend/alembic/versions/e9dd15e7ab06_fix_search_index_drift.py
+++ b/backend/alembic/versions/e9dd15e7ab06_fix_search_index_drift.py
@@ -1,0 +1,115 @@
+"""fix_search_index_drift
+
+Backfills three pieces of schema drift introduced by the hand-written
+``fabe1279b9f6_conversation_search_tables`` migration:
+
+* ``OrgScopedMixin`` declares ``org_id`` / ``workspace_id`` with
+  ``index=True``, but the hand-written CREATE TABLE skipped those
+  per-column indexes. Add them on ``conversation_chunks``,
+  ``embedding_jobs`` and ``search_backfill_progress``.
+* ``EmbeddingJob.state`` is typed ``EmbeddingJobState`` (StrEnum) in the
+  model, but the column was created as ``VARCHAR(10)``. Convert it to a
+  proper ``embeddingjobstate`` PG enum so the DB enforces the value set
+  and future autogen runs stop reporting drift.
+
+Revision ID: e9dd15e7ab06
+Revises: 59fd2d03ce79
+Create Date: 2026-06-19 00:15:45.816874
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e9dd15e7ab06'
+down_revision: Union[str, Sequence[str], None] = '59fd2d03ce79'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_EMBEDDING_JOB_STATE = sa.Enum(
+    'pending', 'running', 'done', 'dead', name='embeddingjobstate'
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_index(
+        op.f('ix_conversation_chunks_org_id'),
+        'conversation_chunks', ['org_id'], unique=False,
+    )
+    op.create_index(
+        op.f('ix_conversation_chunks_workspace_id'),
+        'conversation_chunks', ['workspace_id'], unique=False,
+    )
+    op.create_index(
+        op.f('ix_embedding_jobs_org_id'),
+        'embedding_jobs', ['org_id'], unique=False,
+    )
+    op.create_index(
+        op.f('ix_embedding_jobs_workspace_id'),
+        'embedding_jobs', ['workspace_id'], unique=False,
+    )
+    op.create_index(
+        op.f('ix_search_backfill_progress_org_id'),
+        'search_backfill_progress', ['org_id'], unique=False,
+    )
+    op.create_index(
+        op.f('ix_search_backfill_progress_workspace_id'),
+        'search_backfill_progress', ['workspace_id'], unique=False,
+    )
+
+    # Drop the old VARCHAR server_default first — PG can't auto-cast a
+    # ``character varying`` default expression when the column type
+    # changes to the new enum.
+    op.execute("ALTER TABLE embedding_jobs ALTER COLUMN state DROP DEFAULT")
+    _EMBEDDING_JOB_STATE.create(op.get_bind(), checkfirst=True)
+    op.alter_column(
+        'embedding_jobs', 'state',
+        existing_type=sa.VARCHAR(length=10),
+        type_=_EMBEDDING_JOB_STATE,
+        existing_nullable=False,
+        postgresql_using='state::text::embeddingjobstate',
+    )
+    op.execute(
+        "ALTER TABLE embedding_jobs ALTER COLUMN state SET DEFAULT 'pending'"
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("ALTER TABLE embedding_jobs ALTER COLUMN state DROP DEFAULT")
+    op.alter_column(
+        'embedding_jobs', 'state',
+        existing_type=_EMBEDDING_JOB_STATE,
+        type_=sa.VARCHAR(length=10),
+        existing_nullable=False,
+        postgresql_using='state::text',
+    )
+    op.execute(
+        "ALTER TABLE embedding_jobs ALTER COLUMN state "
+        "SET DEFAULT 'pending'::character varying"
+    )
+    _EMBEDDING_JOB_STATE.drop(op.get_bind(), checkfirst=True)
+
+    op.drop_index(
+        op.f('ix_search_backfill_progress_workspace_id'),
+        table_name='search_backfill_progress',
+    )
+    op.drop_index(
+        op.f('ix_search_backfill_progress_org_id'),
+        table_name='search_backfill_progress',
+    )
+    op.drop_index(op.f('ix_embedding_jobs_workspace_id'), table_name='embedding_jobs')
+    op.drop_index(op.f('ix_embedding_jobs_org_id'), table_name='embedding_jobs')
+    op.drop_index(
+        op.f('ix_conversation_chunks_workspace_id'),
+        table_name='conversation_chunks',
+    )
+    op.drop_index(
+        op.f('ix_conversation_chunks_org_id'),
+        table_name='conversation_chunks',
+    )

--- a/backend/cubebox/models/conversation_chunk.py
+++ b/backend/cubebox/models/conversation_chunk.py
@@ -3,7 +3,7 @@
 from typing import Any, ClassVar
 
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import BigInteger, Column, Index
+from sqlalchemy import BigInteger, Column, Index, Text
 from sqlmodel import Field
 
 from cubebox.config import config
@@ -35,7 +35,7 @@ class ConversationChunk(CubeboxBase, OrgScopedMixin, table=True):
     chunk_seq: int = Field(ge=0)
     seq_lo: int = Field(sa_column=Column(BigInteger, nullable=False))
     seq_hi: int = Field(sa_column=Column(BigInteger, nullable=False))
-    text: str
+    text: str = Field(sa_column=Column(Text, nullable=False))
     # Nullable: when no embedding provider is configured the worker writes
     # chunks with embedding=NULL so the lexical leg still has rows to query.
     embedding: Any | None = Field(

--- a/backend/cubebox/models/embedding_job.py
+++ b/backend/cubebox/models/embedding_job.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import ClassVar
 
-from sqlalchemy import BigInteger, Column, DateTime, Index
+from sqlalchemy import BigInteger, Column, DateTime, Index, Text
 from sqlmodel import Field
 
 from cubebox.models.mixins import CubeboxBase, OrgScopedMixin
@@ -43,7 +43,7 @@ class EmbeddingJob(CubeboxBase, OrgScopedMixin, table=True):
     )
     state: EmbeddingJobState = Field(default=EmbeddingJobState.pending, max_length=10)
     attempts: int = Field(default=0)
-    last_error: str | None = Field(default=None)
+    last_error: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
     claimed_at: datetime | None = Field(
         default=None,
         sa_column=Column(DateTime(timezone=True), nullable=True),


### PR DESCRIPTION
## Summary

Backfills three pieces of schema drift introduced by the hand-written `fabe1279b9f6_conversation_search_tables` migration:

- **Missing single-column indexes.** `OrgScopedMixin` declares `org_id` / `workspace_id` with `index=True`, but the hand-written CREATE TABLE skipped them on `conversation_chunks`, `embedding_jobs`, `search_backfill_progress`. Six indexes added.
- **`embedding_jobs.state` type mismatch.** Model is `EmbeddingJobState` (StrEnum), DB column was `VARCHAR(10)`. Convert to a real `embeddingjobstate` PG enum so the DB enforces the value set and autogen stops reporting drift.
- **Autogen false-positive on hand-built indexes.** SQLModel can't declare `USING hnsw` / `USING pgroonga` indexes, so autogen kept proposing to drop `ix_chunks_embedding_hnsw` and `ix_chunks_text_lexical` — applying that would silently break vector + full-text search. Added an `include_object` guard in `alembic/env.py` to skip them.

Also pinned `conversation_chunk.text` and `embedding_job.last_error` to `sa_column=Column(Text, ...)` to match the migration and stop generating spurious `TEXT` → `AutoString` drift on every autogen run.

## Migration details

`alembic/versions/e9dd15e7ab06_fix_search_index_drift.py` — autogen'd then hand-tweaked:

- Drops the VARCHAR `server_default` before the `ALTER COLUMN ... TYPE` (PG can't auto-cast a `character varying` default expression to the new enum), then re-adds it as `'pending'::embeddingjobstate`.
- Uses `postgresql_using='state::text::embeddingjobstate'` on the ALTER (autogen omits this).
- Explicit `Enum.create()` / `Enum.drop()` in upgrade / downgrade so the type is materialized / cleaned up correctly.

## Out of scope

Some local DBs that ran the original (pre-squash) `skill_sources` -> `skill_registries` migrations still have stale index names (`ix_skill_sources_org_id`, `skill_sources_pkey`). Fresh DBs aren't affected. Decided not to ship a fixup migration for this — affected DBs can rename via `ALTER INDEX` directly.

## Test plan

- [x] `alembic upgrade head` -> `downgrade -1` -> `upgrade head` round-trip on a fresh DB
- [x] Re-run `alembic revision --autogenerate` post-upgrade -> empty diff (no remaining drift)
- [x] 48 search/embedding tests pass (`tests/e2e/test_conversation_search*` + `tests/services/conversation_search/`)
- [x] `mypy` clean on changed files

cc @codex