### PR TITLE
feat(im): add DingTalk connector

### DIFF
--- a/backend/alembic/versions/e9dd15e7ab06_fix_search_index_drift.py
+++ b/backend/alembic/versions/e9dd15e7ab06_fix_search_index_drift.py
@@ -25,7 +25,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'e9dd15e7ab06'
-down_revision: Union[str, Sequence[str], None] = '00fe892184fa'
+down_revision: Union[str, Sequence[str], None] = '59fd2d03ce79'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/e9dd15e7ab06_fix_search_index_drift.py
+++ b/backend/alembic/versions/e9dd15e7ab06_fix_search_index_drift.py
@@ -25,7 +25,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'e9dd15e7ab06'
-down_revision: Union[str, Sequence[str], None] = '59fd2d03ce79'
+down_revision: Union[str, Sequence[str], None] = '00fe892184fa'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/cubebox/api/routes/v1/ws_im.py
+++ b/backend/cubebox/api/routes/v1/ws_im.py
@@ -17,6 +17,7 @@ from cubebox.api.schemas.im_channel_binding import (
     ChannelBindingUpdateIn,
 )
 from cubebox.api.schemas.im_connector import (
+    ConnectDingtalkAccountIn,
     ConnectDiscordAccountIn,
     ConnectFeishuAccountIn,
     ConnectIMAccountIn,
@@ -195,6 +196,37 @@ async def _connect_slack(
     return _to_out(account)
 
 
+async def _connect_dingtalk(
+    body: ConnectDingtalkAccountIn,
+    request: Request,
+    ctx: RequestContext,
+    session: AsyncSession,
+    backend: EncryptionBackend,
+) -> IMAccountOut:
+    svc = _service(session, backend, ctx)
+    acting = await _resolve_acting_user(body.acting_user_id, ctx, session)
+    try:
+        account = await svc.connect_dingtalk(
+            workspace_id=ctx.workspace_id,
+            app_key=body.app_key,
+            app_secret=body.app_secret,
+            acting_user_id=acting,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    starter = getattr(request.app.state, "im_connect_account", None)
+    if starter is not None and account.enabled:
+        try:
+            await starter(account)
+        except Exception:
+            logger.warning(
+                "[IM ws] dingtalk gateway startup failed for {}",
+                account.id,
+                exc_info=True,
+            )
+    return _to_out(account)
+
+
 @router.post("/accounts", status_code=status.HTTP_201_CREATED, response_model=IMAccountOut)
 async def connect_account(
     workspace_id: str,
@@ -213,6 +245,8 @@ async def connect_account(
         return await _connect_discord(body, request, ctx, session, backend)
     elif isinstance(body, ConnectSlackAccountIn):
         return await _connect_slack(body, request, ctx, session, backend)
+    elif isinstance(body, ConnectDingtalkAccountIn):
+        return await _connect_dingtalk(body, request, ctx, session, backend)
     else:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/cubebox/api/routes/v1/ws_im.py
+++ b/backend/cubebox/api/routes/v1/ws_im.py
@@ -358,7 +358,7 @@ async def enable_workspace_account(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="account not found")
     updated = await svc.set_enabled(account_id=account_id, enabled=True)
     assert updated is not None
-    if updated.delivery_mode in ("long_connection", "gateway"):
+    if updated.delivery_mode in ("long_connection", "gateway", "stream"):
         starter = getattr(request.app.state, "im_connect_account", None)
         if starter is not None:
             try:

--- a/backend/cubebox/api/schemas/im_connector.py
+++ b/backend/cubebox/api/schemas/im_connector.py
@@ -42,6 +42,15 @@ class ConnectSlackAccountIn(BaseModel):
     acting_user_id: str = Field(default="self", min_length=1)
 
 
+class ConnectDingtalkAccountIn(BaseModel):
+    """Payload for ``POST /ws/{ws}/im/accounts`` when ``platform == 'dingtalk'``."""
+
+    platform: Literal["dingtalk"] = "dingtalk"
+    app_key: str = Field(min_length=1, max_length=128)
+    app_secret: str = Field(min_length=1)
+    acting_user_id: str = Field(default="self", min_length=1)
+
+
 class ImRuntimeStatus(BaseModel):
     """Runtime status snapshot embedded on every ``IMAccountOut``.
 
@@ -97,7 +106,8 @@ class IMAccountListOut(BaseModel):
 ConnectIMAccountIn = Annotated[
     Annotated[ConnectFeishuAccountIn, Tag("feishu")]
     | Annotated[ConnectDiscordAccountIn, Tag("discord")]
-    | Annotated[ConnectSlackAccountIn, Tag("slack")],
+    | Annotated[ConnectSlackAccountIn, Tag("slack")]
+    | Annotated[ConnectDingtalkAccountIn, Tag("dingtalk")],
     Discriminator("platform"),
 ]
 

--- a/backend/cubebox/im/dingtalk/__init__.py
+++ b/backend/cubebox/im/dingtalk/__init__.py
@@ -1,0 +1,6 @@
+"""DingTalk IM platform — registers itself with the platform registry."""
+
+from cubebox.im.dingtalk._platform import DingtalkPlatform
+from cubebox.im.registry import register_platform
+
+register_platform("dingtalk", DingtalkPlatform())

--- a/backend/cubebox/im/dingtalk/_platform.py
+++ b/backend/cubebox/im/dingtalk/_platform.py
@@ -1,0 +1,117 @@
+"""DingtalkPlatform — PlatformConnector implementation for DingTalk."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from loguru import logger
+
+
+class DingtalkPlatform:
+    """PlatformConnector for DingTalk (Stream mode only)."""
+
+    def parse_inbound(self, raw: dict[str, Any]) -> Any:
+        from cubebox.im.dingtalk.connector import DingtalkConnector
+
+        connector = DingtalkConnector()
+        return connector.parse_inbound(raw)
+
+    async def build_tailer(
+        self, *, run_id: str, queue_item: Any, account: Any, **kwargs: Any
+    ) -> Any:
+        from cubebox.im.dingtalk.connector import DingtalkConnector
+        from cubebox.im.dingtalk.renderer import DingtalkOpDispatcher
+        from cubebox.im.outbound import OutboundRunTailer
+        from cubebox.im.types import RenderState
+
+        app = kwargs["app"]
+        gateways: dict[str, Any] = kwargs.get("gateways", {})
+
+        access_token = ""
+        gw = gateways.get(account.id)
+        if gw is not None:
+            access_token = gw.access_token
+            if not access_token:
+                try:
+                    access_token = await gw.refresh_access_token()
+                except Exception:
+                    logger.warning(
+                        "[DingTalk] token refresh failed for {}",
+                        account.id,
+                    )
+
+        is_dm = queue_item.scope_kind == "dm"
+        connector = DingtalkConnector(
+            bot_user_id=account.external_account_id,
+            access_token=access_token,
+            conversation_id=queue_item.channel_id,
+            sender_staff_id=queue_item.sender_open_id,
+            is_dm=is_dm,
+        )
+
+        cfg = account.config or {}
+        state = RenderState(
+            bot_name=cfg.get("bot_app_name") or "cubebox",
+            run_id=run_id,
+            reply_to_id=queue_item.reply_to_id,
+            inbound_message_id=queue_item.inbound_message_id,
+            stream_interval=1.0,
+        )
+
+        card_template_id = (gw.card_template_id if gw else "") or cfg.get("card_template_id", "")
+        op_dispatcher = DingtalkOpDispatcher(
+            connector=connector,
+            state=state,
+            card_template_id=card_template_id,
+            open_conversation_id=queue_item.channel_id,
+        )
+
+        tailer = OutboundRunTailer(
+            redis=app.state.redis,
+            key_prefix=app.state.redis_key_prefix,
+            run_id=run_id,
+            connector=connector,
+            state=state,
+            dispatcher=op_dispatcher,
+            responder_open_id=queue_item.sender_open_id,
+        )
+        asyncio.create_task(tailer.run(), name=f"im-tailer:{run_id}")
+
+    async def on_account_enabled(self, account: Any, **kwargs: Any) -> None:
+        from cubebox.im.dingtalk.gateway import DingtalkGateway
+        from cubebox.im.inbound import ingest_inbound_event
+
+        secrets: dict[str, Any] = kwargs.get("secrets", {})
+        gateways: dict[str, Any] = kwargs.get("gateways", {})
+        session_maker = kwargs.get("session_maker")
+        run_manager = kwargs.get("run_manager")
+        redis_key_prefix: str = kwargs.get("redis_key_prefix", "")
+
+        app_key = str(secrets.get("app_key") or "")
+        app_secret = str(secrets.get("app_secret") or "")
+        if not app_key or not app_secret:
+            logger.warning(
+                "[DingTalk] skipping account {} — missing credentials",
+                account.id,
+            )
+            return
+
+        gw = DingtalkGateway(
+            account=account,
+            app_key=app_key,
+            app_secret=app_secret,
+            ingest=ingest_inbound_event,
+            session_maker=session_maker,
+            run_manager=run_manager,
+            redis_key_prefix=redis_key_prefix,
+        )
+        await gw.refresh_access_token()
+        await gw.start()
+        gateways[account.id] = gw
+
+    async def on_account_disabled(self, account: Any, **kwargs: Any) -> None:
+        gateways: dict[str, Any] = kwargs.get("gateways", {})
+        gw = gateways.pop(account.id, None)
+        if gw is not None:
+            await gw.stop()

--- a/backend/cubebox/im/dingtalk/_platform.py
+++ b/backend/cubebox/im/dingtalk/_platform.py
@@ -27,6 +27,7 @@ class DingtalkPlatform:
 
         app = kwargs["app"]
         gateways: dict[str, Any] = kwargs.get("gateways", {})
+        load_secrets = kwargs.get("load_secrets")
 
         access_token = ""
         gw = gateways.get(account.id)
@@ -38,6 +39,28 @@ class DingtalkPlatform:
                 except Exception:
                     logger.warning(
                         "[DingTalk] token refresh failed for {}",
+                        account.id,
+                    )
+
+        if not access_token and load_secrets is not None:
+            import httpx
+
+            secrets = await load_secrets(account)
+            app_key = str(secrets.get("app_key") or "")
+            app_secret = str(secrets.get("app_secret") or "")
+            if app_key and app_secret:
+                try:
+                    url = "https://api.dingtalk.com/v1.0/oauth2/accessToken"
+                    async with httpx.AsyncClient(timeout=10) as http:
+                        resp = await http.post(
+                            url, json={"appKey": app_key, "appSecret": app_secret}
+                        )
+                        token: str = resp.json().get("accessToken", "")
+                        if token:
+                            access_token = token
+                except Exception:
+                    logger.warning(
+                        "[DingTalk] standalone token refresh failed for {}",
                         account.id,
                     )
 
@@ -67,6 +90,18 @@ class DingtalkPlatform:
             open_conversation_id=queue_item.channel_id,
         )
 
+        shared_mode = False
+        _sm = kwargs.get("session_maker")
+        if _sm is not None:
+            from cubebox.im.types import is_shared_mode_for_tailer
+
+            shared_mode = await is_shared_mode_for_tailer(
+                _sm,
+                queue_item.account_id,
+                queue_item.channel_id,
+                queue_item.conversation_id,
+            )
+
         tailer = OutboundRunTailer(
             redis=app.state.redis,
             key_prefix=app.state.redis_key_prefix,
@@ -75,6 +110,7 @@ class DingtalkPlatform:
             state=state,
             dispatcher=op_dispatcher,
             responder_open_id=queue_item.sender_open_id,
+            shared_mode=shared_mode,
         )
         asyncio.create_task(tailer.run(), name=f"im-tailer:{run_id}")
 

--- a/backend/cubebox/im/dingtalk/connector.py
+++ b/backend/cubebox/im/dingtalk/connector.py
@@ -101,6 +101,25 @@ class DingtalkConnector:
         )
 
     # ------------------------------------------------------------------
+    # Link command detection
+    # ------------------------------------------------------------------
+
+    def is_link_command(self, raw: dict[str, Any]) -> bool:
+        """Check if the message is a 'link <email>' keyword command."""
+        text_obj = raw.get("text") or {}
+        text: str = text_obj.get("content", "").strip().lower()
+        return text.startswith("link ") or text in ("link", "/link")
+
+    def parse_link_email(self, raw: dict[str, Any]) -> str:
+        """Extract email from a 'link alice@example.com' command. Returns '' if no email."""
+        text_obj = raw.get("text") or {}
+        text: str = text_obj.get("content", "").strip()
+        parts = text.split(maxsplit=1)
+        if len(parts) == 2 and "@" in parts[1]:
+            return parts[1].strip().lower()
+        return ""
+
+    # ------------------------------------------------------------------
     # Outbound — card + message API calls
     # ------------------------------------------------------------------
 

--- a/backend/cubebox/im/dingtalk/connector.py
+++ b/backend/cubebox/im/dingtalk/connector.py
@@ -12,7 +12,9 @@ from loguru import logger
 from cubebox.im.outbound import _FloodSignal
 from cubebox.im.types import (
     DM_SCOPE_KEY,
+    BindingMode,
     InboundEvent,
+    make_channel_scope,
     make_participant_scope,
 )
 
@@ -59,7 +61,9 @@ class DingtalkConnector:
     # Inbound
     # ------------------------------------------------------------------
 
-    def parse_inbound(self, raw: dict[str, Any]) -> InboundEvent | None:
+    def parse_inbound(
+        self, raw: dict[str, Any], *, binding_mode: BindingMode = "isolated"
+    ) -> InboundEvent | None:
         """Normalize a DingTalk Stream callback dict into an InboundEvent.
 
         Returns None for non-text messages.
@@ -82,8 +86,12 @@ class DingtalkConnector:
             scope_key = DM_SCOPE_KEY
             scope_kind = "dm"
         else:
-            scope_key = make_participant_scope(sender_staff_id)
-            scope_kind = "group"
+            if binding_mode == "shared":
+                scope_key = make_channel_scope()
+                scope_kind = "channel"
+            else:
+                scope_key = make_participant_scope(sender_staff_id)
+                scope_kind = "group"
             text = re.sub(r"^\s+", "", text)
 
         return InboundEvent(

--- a/backend/cubebox/im/dingtalk/connector.py
+++ b/backend/cubebox/im/dingtalk/connector.py
@@ -1,0 +1,331 @@
+"""DingTalk connector: inbound parse + outbound card/message API + identity."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from cubebox.im.outbound import _FloodSignal
+from cubebox.im.types import (
+    DM_SCOPE_KEY,
+    InboundEvent,
+    make_participant_scope,
+)
+
+
+class DingtalkRateLimitError(_FloodSignal):
+    """Raised when DingTalk API returns a rate-limit error."""
+
+
+class DingtalkConnector:
+    """Connector for one DingTalk enterprise bot account.
+
+    Construction:
+    - Inbound parsing only needs ``bot_user_id``.
+    - Outbound calls need ``access_token`` + ``conversation_id``.
+    """
+
+    def __init__(
+        self,
+        *,
+        bot_user_id: str = "",
+        access_token: str = "",
+        conversation_id: str = "",
+        sender_staff_id: str = "",
+        is_dm: bool = False,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._bot_user_id = bot_user_id
+        self._access_token = access_token
+        self._conversation_id = conversation_id
+        self._sender_staff_id = sender_staff_id
+        self._is_dm = is_dm
+        self._http_ext = http_client
+        self._http_own: httpx.AsyncClient | None = None
+
+    @property
+    def _http(self) -> httpx.AsyncClient:
+        if self._http_ext is not None:
+            return self._http_ext
+        if self._http_own is None:
+            self._http_own = httpx.AsyncClient(timeout=10)
+        return self._http_own
+
+    # ------------------------------------------------------------------
+    # Inbound
+    # ------------------------------------------------------------------
+
+    def parse_inbound(self, raw: dict[str, Any]) -> InboundEvent | None:
+        """Normalize a DingTalk Stream callback dict into an InboundEvent.
+
+        Returns None for non-text messages.
+        """
+        msgtype = raw.get("msgtype", "")
+        if msgtype != "text":
+            return None
+
+        text_obj = raw.get("text") or {}
+        text: str = text_obj.get("content", "").strip()
+        msg_id: str = raw.get("msgId", "")
+        conversation_id: str = raw.get("conversationId", "")
+        conversation_type: str = raw.get("conversationType", "")
+        sender_staff_id: str = raw.get("senderStaffId", "")
+
+        if not msg_id or not conversation_id or not sender_staff_id:
+            return None
+
+        if conversation_type == "1":
+            scope_key = DM_SCOPE_KEY
+            scope_kind = "dm"
+        else:
+            scope_key = make_participant_scope(sender_staff_id)
+            scope_kind = "group"
+            text = re.sub(r"^\s+", "", text)
+
+        return InboundEvent(
+            platform="dingtalk",
+            account_external_id="",
+            platform_event_id=msg_id,
+            channel_id=conversation_id,
+            scope_key=scope_key,
+            scope_kind=scope_kind,
+            reply_to_id=msg_id,
+            inbound_message_id=msg_id,
+            sender_ref=sender_staff_id,
+            sender_open_id=sender_staff_id,
+            text=text,
+        )
+
+    # ------------------------------------------------------------------
+    # Outbound — card + message API calls
+    # ------------------------------------------------------------------
+
+    async def send_markdown(
+        self, title: str, text: str, *, user_ids: list[str] | None = None
+    ) -> str | None:
+        """Send a proactive markdown message to specific users."""
+        if not user_ids:
+            logger.warning("[DingTalk] send_markdown called with no user_ids")
+            return None
+
+        url = "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend"
+        headers = {
+            "x-acs-dingtalk-access-token": self._access_token,
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "msgParam": json.dumps({"title": title, "text": text}),
+            "msgKey": "sampleMarkdown",
+            "robotCode": self._bot_user_id,
+            "userIds": user_ids,
+        }
+        try:
+            resp = await self._http.post(url, headers=headers, json=payload)
+            if resp.status_code == 200:
+                result: str | None = resp.json().get("processQueryKey")
+                return result
+            logger.warning("[DingTalk] send_markdown failed: {}", resp.text)
+            return None
+        except Exception:
+            logger.warning("[DingTalk] send_markdown error", exc_info=True)
+            return None
+
+    async def reply_markdown(
+        self,
+        title: str,
+        text: str,
+        *,
+        open_conversation_id: str = "",
+        user_id: str = "",
+    ) -> str | None:
+        """Reply to a conversation with markdown.
+
+        For DM conversations, uses oToMessages/batchSend with userIds (since
+        DingTalk's group endpoint rejects single-chat conversationIds).
+        For group conversations, uses groupMessages/send with openConversationId.
+        """
+        cid = open_conversation_id or self._conversation_id
+        headers = {
+            "x-acs-dingtalk-access-token": self._access_token,
+            "Content-Type": "application/json",
+        }
+        msg_param = json.dumps({"title": title, "text": text})
+        effective_user_id = user_id or (self._sender_staff_id if self._is_dm else "")
+
+        if effective_user_id:
+            url = "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend"
+            payload = {
+                "msgParam": msg_param,
+                "msgKey": "sampleMarkdown",
+                "robotCode": self._bot_user_id,
+                "userIds": [effective_user_id],
+            }
+        else:
+            url = "https://api.dingtalk.com/v1.0/robot/groupMessages/send"
+            payload = {
+                "msgParam": msg_param,
+                "msgKey": "sampleMarkdown",
+                "robotCode": self._bot_user_id,
+                "openConversationId": cid,
+            }
+        try:
+            resp = await self._http.post(url, headers=headers, json=payload)
+            if resp.status_code == 200:
+                result: str | None = resp.json().get("processQueryKey")
+                return result
+            logger.warning("[DingTalk] reply_markdown failed: {}", resp.text)
+            return None
+        except Exception:
+            logger.warning("[DingTalk] reply_markdown error", exc_info=True)
+            return None
+
+    # ------------------------------------------------------------------
+    # Interactive card operations
+    # ------------------------------------------------------------------
+
+    async def create_and_deliver_card(
+        self,
+        *,
+        card_template_id: str,
+        open_conversation_id: str,
+        card_data: dict[str, Any],
+        out_track_id: str,
+    ) -> bool:
+        """Create + deliver an interactive card instance."""
+        url = "https://api.dingtalk.com/v1.0/card/instances/createAndDeliver"
+        headers = {
+            "x-acs-dingtalk-access-token": self._access_token,
+            "Content-Type": "application/json",
+        }
+        payload: dict[str, Any] = {
+            "cardTemplateId": card_template_id,
+            "outTrackId": out_track_id,
+            "openConversationId": open_conversation_id,
+            "cardData": {"cardParamMap": card_data},
+        }
+        try:
+            resp = await self._http.post(url, headers=headers, json=payload)
+            if resp.status_code == 200:
+                return True
+            logger.warning("[DingTalk] create_and_deliver_card failed: {}", resp.text)
+            return False
+        except Exception:
+            logger.warning("[DingTalk] create_and_deliver_card error", exc_info=True)
+            return False
+
+    async def streaming_update_card(
+        self,
+        *,
+        out_track_id: str,
+        guid: str,
+        key: str,
+        content: str,
+        is_final: bool = False,
+        is_error: bool = False,
+    ) -> bool:
+        """Stream-update a card variable. DingTalk requires PUT, not POST."""
+        url = "https://api.dingtalk.com/v1.0/card/streaming"
+        headers = {
+            "x-acs-dingtalk-access-token": self._access_token,
+            "Content-Type": "application/json",
+        }
+        payload: dict[str, Any] = {
+            "outTrackId": out_track_id,
+            "guid": guid,
+            "key": key,
+            "content": content,
+            "isFull": True,
+            "isFinalize": is_final,
+            "isError": is_error,
+        }
+        try:
+            resp = await self._http.put(url, headers=headers, json=payload)
+            if resp.status_code == 200:
+                return True
+            if resp.status_code == 429:
+                raise DingtalkRateLimitError("rate limited")
+            logger.warning("[DingTalk] streaming_update failed: {}", resp.text)
+            return False
+        except DingtalkRateLimitError:
+            raise
+        except Exception:
+            logger.warning("[DingTalk] streaming_update error", exc_info=True)
+            return False
+
+    async def update_card_actions(
+        self,
+        *,
+        out_track_id: str,
+        card_data: dict[str, Any],
+    ) -> bool:
+        """Update card data (buttons, status) via PUT."""
+        url = "https://api.dingtalk.com/v1.0/card/instances"
+        headers = {
+            "x-acs-dingtalk-access-token": self._access_token,
+            "Content-Type": "application/json",
+        }
+        payload: dict[str, Any] = {
+            "outTrackId": out_track_id,
+            "cardData": {"cardParamMap": card_data},
+        }
+        try:
+            resp = await self._http.put(url, headers=headers, json=payload)
+            if resp.status_code == 200:
+                return True
+            logger.warning("[DingTalk] update_card_actions failed: {}", resp.text)
+            return False
+        except Exception:
+            logger.warning("[DingTalk] update_card_actions error", exc_info=True)
+            return False
+
+    # ------------------------------------------------------------------
+    # Identity resolution (IdentityResolver protocol)
+    # ------------------------------------------------------------------
+
+    async def resolve_email(self, open_id: str) -> str | None:
+        """Look up a DingTalk user's email by staffId."""
+        url = "https://oapi.dingtalk.com/topapi/v2/user/get"
+        params = {"access_token": self._access_token}
+        payload = {"userid": open_id}
+        try:
+            resp = await self._http.post(url, params=params, json=payload)
+            data = resp.json()
+            if data.get("errcode") != 0:
+                logger.warning("[DingTalk] user/get failed: {}", data)
+                return None
+            result = data.get("result", {})
+            email = result.get("email") or result.get("org_email") or ""
+            return email.strip().lower() if email else None
+        except Exception:
+            logger.warning("[DingTalk] resolve_email error", exc_info=True)
+            return None
+
+    # ------------------------------------------------------------------
+    # Rejection notifier (RejectionNotifier protocol)
+    # ------------------------------------------------------------------
+
+    async def send_to_chat(self, chat_id: str, reply_to_id: str | None, text: str) -> str | None:
+        """Send a rejection notice to the conversation."""
+        return await self.reply_markdown(
+            title="Notice",
+            text=text,
+            open_conversation_id=chat_id,
+            user_id=self._sender_staff_id if self._is_dm else "",
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks (called by OutboundRunTailer on the connector)
+    # ------------------------------------------------------------------
+
+    async def on_processing_start(self, state: Any) -> None:
+        pass
+
+    async def on_processing_complete(self, state: Any) -> None:
+        pass
+
+    async def on_processing_failed(self, state: Any) -> None:
+        pass

--- a/backend/cubebox/im/dingtalk/connector.py
+++ b/backend/cubebox/im/dingtalk/connector.py
@@ -86,6 +86,9 @@ class DingtalkConnector:
             scope_key = DM_SCOPE_KEY
             scope_kind = "dm"
         else:
+            is_at_bot = raw.get("isInAtList", False)
+            if not is_at_bot:
+                return None
             if binding_mode == "shared":
                 scope_key = make_channel_scope()
                 scope_kind = "channel"

--- a/backend/cubebox/im/dingtalk/connector.py
+++ b/backend/cubebox/im/dingtalk/connector.py
@@ -238,6 +238,7 @@ class DingtalkConnector:
             "cardTemplateId": card_template_id,
             "outTrackId": out_track_id,
             "openConversationId": open_conversation_id,
+            "callbackType": "STREAM",
             "cardData": {"cardParamMap": card_data},
         }
         try:

--- a/backend/cubebox/im/dingtalk/connector.py
+++ b/backend/cubebox/im/dingtalk/connector.py
@@ -116,15 +116,18 @@ class DingtalkConnector:
         """Check if the message is a 'link <email>' keyword command."""
         text_obj = raw.get("text") or {}
         text: str = text_obj.get("content", "").strip().lower()
-        return text.startswith("link ") or text in ("link", "/link")
+        return text.startswith("link ") or text.startswith("/link ") or text in ("link", "/link")
 
     def parse_link_email(self, raw: dict[str, Any]) -> str:
         """Extract email from a 'link alice@example.com' command. Returns '' if no email."""
         text_obj = raw.get("text") or {}
         text: str = text_obj.get("content", "").strip()
-        parts = text.split(maxsplit=1)
-        if len(parts) == 2 and "@" in parts[1]:
-            return parts[1].strip().lower()
+        if text.lower().startswith("/link"):
+            text = text[5:].strip()
+        elif text.lower().startswith("link"):
+            text = text[4:].strip()
+        if "@" in text:
+            return text.strip().lower()
         return ""
 
     # ------------------------------------------------------------------

--- a/backend/cubebox/im/dingtalk/gateway.py
+++ b/backend/cubebox/im/dingtalk/gateway.py
@@ -126,7 +126,12 @@ class DingtalkGateway:
         if connector.is_link_command(raw):
             await self._handle_link_command(raw)
             return
-        parsed = connector.parse_inbound(raw)
+
+        from cubebox.im.types import lookup_binding_mode
+
+        channel_id = raw.get("conversationId", "")
+        binding_mode = await lookup_binding_mode(session_maker, account.id, channel_id)
+        parsed = connector.parse_inbound(raw, binding_mode=binding_mode)
         if parsed is None:
             return
         parsed.account_external_id = account.external_account_id

--- a/backend/cubebox/im/dingtalk/gateway.py
+++ b/backend/cubebox/im/dingtalk/gateway.py
@@ -168,19 +168,24 @@ class DingtalkGateway:
         """Handle 'link alice@example.com' by sending an identity-link URL."""
         sender_staff_id = raw.get("senderStaffId", "")
         conversation_id = raw.get("conversationId", "")
+        is_dm = raw.get("conversationType") == "1"
         if not sender_staff_id or not conversation_id:
             return
+
+        def _make_reply_connector() -> DingtalkConnector:
+            return DingtalkConnector(
+                bot_user_id=self._app_key,
+                access_token=self._access_token,
+                conversation_id=conversation_id,
+                sender_staff_id=sender_staff_id,
+                is_dm=is_dm,
+                http_client=self._shared_http,
+            )
 
         connector = DingtalkConnector(bot_user_id=self._app_key)
         email = connector.parse_link_email(raw)
         if not email:
-            gate_connector = DingtalkConnector(
-                bot_user_id=self._app_key,
-                access_token=self._access_token,
-                conversation_id=conversation_id,
-                http_client=self._shared_http,
-            )
-            await gate_connector.reply_markdown(
+            await _make_reply_connector().reply_markdown(
                 title="Link",
                 text="Usage: `link alice@example.com`",
                 open_conversation_id=conversation_id,
@@ -205,13 +210,7 @@ class DingtalkGateway:
         base = get_frontend_base_url()
         url = f"{base}/im-link?token={token}"
 
-        gate_connector = DingtalkConnector(
-            bot_user_id=self._app_key,
-            access_token=self._access_token,
-            conversation_id=conversation_id,
-            http_client=self._shared_http,
-        )
-        await gate_connector.reply_markdown(
+        await _make_reply_connector().reply_markdown(
             title="Link your account",
             text=f"Click to bind your cubebox account:\n\n[Link your account]({url})",
             open_conversation_id=conversation_id,
@@ -249,8 +248,11 @@ class DingtalkGateway:
             resp = await http.post(url, json=payload)
             data = resp.json()
             token: str = data.get("accessToken", "")
-            self._access_token = token
-            return token
+            if token:
+                self._access_token = token
+            else:
+                logger.warning("[DingTalk] refresh returned empty token, keeping previous")
+            return self._access_token
 
     @property
     def access_token(self) -> str:

--- a/backend/cubebox/im/dingtalk/gateway.py
+++ b/backend/cubebox/im/dingtalk/gateway.py
@@ -76,26 +76,25 @@ class DingtalkGateway:
         )
 
         async def _run() -> None:
-            try:
-                await client.start()
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.exception("[DingTalk] Stream client crashed for {}", account.id)
+            backoff = 1.0
+            while True:
+                try:
+                    await client.start()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.warning(
+                        "[DingTalk] Stream disconnected for {}, reconnecting in {:.0f}s",
+                        account.id,
+                        backoff,
+                        exc_info=True,
+                    )
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, 60.0)
+                else:
+                    backoff = 1.0
 
         self._task = asyncio.create_task(_run(), name=f"dingtalk-gateway:{account.id}")
-
-        def _on_task_done(task: asyncio.Task[None]) -> None:
-            exc = task.exception() if not task.cancelled() else None
-            if exc is not None:
-                logger.error(
-                    "[DingTalk] gateway task crashed for {}: {}",
-                    account.id,
-                    exc,
-                    exc_info=exc,
-                )
-
-        self._task.add_done_callback(_on_task_done)
 
         async def _token_loop() -> None:
             while True:

--- a/backend/cubebox/im/dingtalk/gateway.py
+++ b/backend/cubebox/im/dingtalk/gateway.py
@@ -123,6 +123,9 @@ class DingtalkGateway:
         ingest: Any,
     ) -> None:
         connector = DingtalkConnector(bot_user_id=self._app_key)
+        if connector.is_link_command(raw):
+            await self._handle_link_command(raw)
+            return
         parsed = connector.parse_inbound(raw)
         if parsed is None:
             return
@@ -155,6 +158,59 @@ class DingtalkGateway:
                 "[DingTalk] ingest failed for {}",
                 parsed.platform_event_id,
             )
+
+    async def _handle_link_command(self, raw: dict[str, Any]) -> None:
+        """Handle 'link alice@example.com' by sending an identity-link URL."""
+        sender_staff_id = raw.get("senderStaffId", "")
+        conversation_id = raw.get("conversationId", "")
+        if not sender_staff_id or not conversation_id:
+            return
+
+        connector = DingtalkConnector(bot_user_id=self._app_key)
+        email = connector.parse_link_email(raw)
+        if not email:
+            gate_connector = DingtalkConnector(
+                bot_user_id=self._app_key,
+                access_token=self._access_token,
+                conversation_id=conversation_id,
+                http_client=self._shared_http,
+            )
+            await gate_connector.reply_markdown(
+                title="Link",
+                text="Usage: `link alice@example.com`",
+                open_conversation_id=conversation_id,
+            )
+            return
+
+        try:
+            from cubebox.im.link import get_frontend_base_url, get_jwt_secret, sign_link_token
+
+            token = sign_link_token(
+                im_user_id=sender_staff_id,
+                email=email,
+                account_id=self._account.id,
+                workspace_id=self._account.workspace_id,
+                platform="dingtalk",
+                secret=get_jwt_secret(),
+            )
+        except Exception:
+            logger.warning("[DingTalk] sign_link_token failed", exc_info=True)
+            return
+
+        base = get_frontend_base_url()
+        url = f"{base}/im-link?token={token}"
+
+        gate_connector = DingtalkConnector(
+            bot_user_id=self._app_key,
+            access_token=self._access_token,
+            conversation_id=conversation_id,
+            http_client=self._shared_http,
+        )
+        await gate_connector.reply_markdown(
+            title="Link your account",
+            text=f"Click to bind your cubebox account:\n\n[Link your account]({url})",
+            open_conversation_id=conversation_id,
+        )
 
     async def stop(self) -> None:
         if self._refresh_task is not None:

--- a/backend/cubebox/im/dingtalk/gateway.py
+++ b/backend/cubebox/im/dingtalk/gateway.py
@@ -121,6 +121,10 @@ class DingtalkGateway:
         session_maker: Any,
         ingest: Any,
     ) -> None:
+        is_group = raw.get("conversationType") != "1"
+        if is_group and not raw.get("isInAtList", False):
+            return
+
         connector = DingtalkConnector(bot_user_id=self._app_key)
         if connector.is_link_command(raw):
             await self._handle_link_command(raw)
@@ -230,8 +234,8 @@ class DingtalkGateway:
         if self._task is not None:
             self._task.cancel()
             try:
-                await self._task
-            except (asyncio.CancelledError, Exception):
+                await asyncio.wait_for(self._task, timeout=5.0)
+            except (asyncio.CancelledError, TimeoutError, Exception):
                 pass
         await self._shared_http.aclose()
         logger.info("[DingTalk] Gateway stopped for account {}", self._account.id)

--- a/backend/cubebox/im/dingtalk/gateway.py
+++ b/backend/cubebox/im/dingtalk/gateway.py
@@ -1,0 +1,263 @@
+"""DingTalk Stream gateway — one long-connection per IM account."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import dingtalk_stream
+import httpx
+from loguru import logger
+
+from cubebox.im.dingtalk.connector import DingtalkConnector
+
+
+class DingtalkGateway:
+    """Manages one DingTalk Stream client per IM account."""
+
+    def __init__(
+        self,
+        *,
+        account: Any,
+        app_key: str,
+        app_secret: str,
+        ingest: Any,
+        session_maker: Any,
+        run_manager: Any,
+        redis_key_prefix: str,
+    ) -> None:
+        self._account = account
+        self._app_key = app_key
+        self._app_secret = app_secret
+        self._ingest = ingest
+        self._session_maker = session_maker
+        self._run_manager = run_manager
+        self._redis_key_prefix = redis_key_prefix
+        self._client: dingtalk_stream.DingTalkStreamClient | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._refresh_task: asyncio.Task[None] | None = None
+        self._access_token: str = ""
+        self.card_template_id: str = ""
+        self._shared_http = httpx.AsyncClient(timeout=10)
+
+    async def start(self) -> None:
+        tpl_id = await self._register_card_template()
+        if tpl_id:
+            self.card_template_id = tpl_id
+
+        credential = dingtalk_stream.Credential(self._app_key, self._app_secret)
+        client = dingtalk_stream.DingTalkStreamClient(credential=credential)
+        self._client = client
+
+        account = self._account
+        session_maker = self._session_maker
+        ingest = self._ingest
+        run_manager = self._run_manager
+
+        async def on_message(raw: dict[str, Any]) -> None:
+            await self._handle_inbound(raw, account, session_maker, ingest)
+
+        async def on_card_action(raw: dict[str, Any]) -> None:
+            from cubebox.im.dingtalk.interactions import handle_card_action
+
+            await handle_card_action(
+                callback=raw,
+                run_manager=run_manager,
+            )
+
+        client.register_callback_handler(
+            dingtalk_stream.ChatbotMessage.TOPIC,
+            _CallbackHandler(on_message),
+        )
+        client.register_callback_handler(
+            "/v1.0/card/instances/callback",
+            _CallbackHandler(on_card_action),
+        )
+
+        async def _run() -> None:
+            try:
+                await client.start()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("[DingTalk] Stream client crashed for {}", account.id)
+
+        self._task = asyncio.create_task(_run(), name=f"dingtalk-gateway:{account.id}")
+
+        def _on_task_done(task: asyncio.Task[None]) -> None:
+            exc = task.exception() if not task.cancelled() else None
+            if exc is not None:
+                logger.error(
+                    "[DingTalk] gateway task crashed for {}: {}",
+                    account.id,
+                    exc,
+                    exc_info=exc,
+                )
+
+        self._task.add_done_callback(_on_task_done)
+
+        async def _token_loop() -> None:
+            while True:
+                await asyncio.sleep(6000)
+                try:
+                    await self.refresh_access_token()
+                    logger.debug("[DingTalk] token refreshed for {}", account.id)
+                except Exception:
+                    logger.warning(
+                        "[DingTalk] token refresh failed for {}",
+                        account.id,
+                        exc_info=True,
+                    )
+
+        self._refresh_task = asyncio.create_task(
+            _token_loop(), name=f"dingtalk-token-refresh:{account.id}"
+        )
+        logger.info("[DingTalk] Gateway started for account {}", account.id)
+
+    async def _handle_inbound(
+        self,
+        raw: dict[str, Any],
+        account: Any,
+        session_maker: Any,
+        ingest: Any,
+    ) -> None:
+        connector = DingtalkConnector(bot_user_id=self._app_key)
+        parsed = connector.parse_inbound(raw)
+        if parsed is None:
+            return
+        parsed.account_external_id = account.external_account_id
+
+        is_dm = parsed.scope_kind == "dm"
+        gate_connector = DingtalkConnector(
+            bot_user_id=self._app_key,
+            access_token=self._access_token,
+            conversation_id=parsed.channel_id,
+            sender_staff_id=parsed.sender_ref,
+            is_dm=is_dm,
+            http_client=self._shared_http,
+        )
+        try:
+            result = await ingest(
+                parsed,
+                account=account,
+                session_maker=session_maker,
+                identity_resolver=gate_connector,
+                rejection_notifier=gate_connector,
+            )
+            logger.info(
+                "[DingTalk] inbound {}: {}",
+                parsed.platform_event_id,
+                result.outcome,
+            )
+        except Exception:
+            logger.exception(
+                "[DingTalk] ingest failed for {}",
+                parsed.platform_event_id,
+            )
+
+    async def stop(self) -> None:
+        if self._refresh_task is not None:
+            self._refresh_task.cancel()
+            try:
+                await self._refresh_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        if self._client is not None:
+            try:
+                self._client.stop()
+            except Exception:
+                pass
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+        await self._shared_http.aclose()
+        logger.info("[DingTalk] Gateway stopped for account {}", self._account.id)
+
+    def is_open(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    async def refresh_access_token(self) -> str:
+        """Refresh the access token for outbound API calls."""
+        url = "https://api.dingtalk.com/v1.0/oauth2/accessToken"
+        payload = {"appKey": self._app_key, "appSecret": self._app_secret}
+        async with httpx.AsyncClient(timeout=10) as http:
+            resp = await http.post(url, json=payload)
+            data = resp.json()
+            token: str = data.get("accessToken", "")
+            self._access_token = token
+            return token
+
+    @property
+    def access_token(self) -> str:
+        return self._access_token
+
+    async def _register_card_template(self) -> str:
+        """Register the cubebox streaming card template. Returns template ID."""
+        url = "https://api.dingtalk.com/v1.0/card/templates"
+        headers = {
+            "x-acs-dingtalk-access-token": self._access_token,
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "cardTemplateJson": json.dumps(
+                {
+                    "config": {"autoLayout": True},
+                    "header": {},
+                    "cardContentList": [
+                        {
+                            "id": "content",
+                            "type": "markdown",
+                            "props": {"content": "${content}"},
+                        },
+                        {
+                            "id": "status",
+                            "type": "text",
+                            "props": {"content": "${status}"},
+                        },
+                    ],
+                    "cardActionList": [],
+                }
+            ),
+        }
+        try:
+            async with httpx.AsyncClient(timeout=10) as http:
+                resp = await http.post(url, headers=headers, json=payload)
+                data = resp.json()
+                tpl_id: str = data.get("cardTemplateId", "")
+                if tpl_id:
+                    logger.info("[DingTalk] card template registered: {}", tpl_id)
+                else:
+                    logger.warning(
+                        "[DingTalk] card template registration returned no ID: {}",
+                        data,
+                    )
+                return tpl_id
+        except Exception:
+            logger.warning(
+                "[DingTalk] card template registration failed",
+                exc_info=True,
+            )
+            return ""
+
+
+class _CallbackHandler(dingtalk_stream.CallbackHandler):  # type: ignore[misc]
+    """Routes SDK callbacks to our async handler."""
+
+    def __init__(self, handler: Any) -> None:
+        super().__init__()
+        self._handler = handler
+
+    async def process(
+        self,
+        callback: dingtalk_stream.CallbackMessage,
+    ) -> tuple[int, str]:
+        try:
+            data = json.loads(callback.data) if isinstance(callback.data, str) else callback.data
+            await self._handler(data)
+        except Exception:
+            logger.warning("[DingTalk] callback handler error", exc_info=True)
+        return dingtalk_stream.AckMessage.STATUS_OK, "OK"

--- a/backend/cubebox/im/dingtalk/interactions.py
+++ b/backend/cubebox/im/dingtalk/interactions.py
@@ -1,0 +1,51 @@
+"""Handle DingTalk interactive card action callbacks (button clicks)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from loguru import logger
+
+from cubebox.im.resume import resolve_full_question_id, resume_paused_run
+
+
+async def handle_card_action(
+    *,
+    callback: dict[str, Any],
+    run_manager: Any,
+) -> None:
+    """Route a DingTalk card button click to the resume path.
+
+    Button action_id format: ``im:{kind}:{run_id}:{short_qid}:{akey}:{value}``
+    """
+    content_raw = callback.get("content", "{}")
+    try:
+        content = json.loads(content_raw) if isinstance(content_raw, str) else content_raw
+    except (json.JSONDecodeError, TypeError):
+        return
+
+    action_id: str = content.get("cardActionId", "")
+    if not action_id.startswith("im:"):
+        return
+
+    parts = action_id.split(":", 5)
+    if len(parts) < 6:
+        return
+
+    _, kind, run_id, short_qid, answer_key, value = parts
+
+    question_id = await resolve_full_question_id(run_id, short_qid)
+
+    try:
+        await resume_paused_run(
+            run_id=run_id,
+            input_kind=kind,
+            choice=value,
+            operator_open_id="",
+            question_id=question_id,
+            answer_key=answer_key,
+            run_manager=run_manager,
+        )
+    except Exception:
+        logger.warning("[DingTalk] card action handler failed", exc_info=True)

--- a/backend/cubebox/im/dingtalk/interactions.py
+++ b/backend/cubebox/im/dingtalk/interactions.py
@@ -26,6 +26,10 @@ async def handle_card_action(
         return
 
     action_id: str = content.get("cardActionId", "")
+    if not action_id:
+        private_data = content.get("cardPrivateData", {})
+        params = private_data.get("params", {}) if isinstance(private_data, dict) else {}
+        action_id = params.get("cardActionId", "")
     if not action_id.startswith("im:"):
         return
 

--- a/backend/cubebox/im/dingtalk/interactions.py
+++ b/backend/cubebox/im/dingtalk/interactions.py
@@ -39,6 +39,8 @@ async def handle_card_action(
 
     _, kind, run_id, short_qid, answer_key, value = parts
 
+    operator_open_id: str = callback.get("userId", "")
+
     question_id = await resolve_full_question_id(run_id, short_qid)
 
     try:
@@ -46,7 +48,7 @@ async def handle_card_action(
             run_id=run_id,
             input_kind=kind,
             choice=value,
-            operator_open_id="",
+            operator_open_id=operator_open_id,
             question_id=question_id,
             answer_key=answer_key,
             run_manager=run_manager,

--- a/backend/cubebox/im/dingtalk/renderer.py
+++ b/backend/cubebox/im/dingtalk/renderer.py
@@ -131,10 +131,12 @@ class DingtalkOpDispatcher:
             "question": pending.question or "Please choose:",
             "buttons": buttons,
         }
-        await self._connector.update_card_actions(
+        ok = await self._connector.update_card_actions(
             out_track_id=s.card_id,
             card_data=card_data,
         )
+        if not ok:
+            await self._emergency_pending_input(pending)
 
     async def dispatch_finalize(self, state: Any) -> bool:
         s = self._state
@@ -184,4 +186,6 @@ class DingtalkOpDispatcher:
             logger.warning("[DingTalk] emergency text send failed", exc_info=True)
 
     async def aclose(self) -> None:
-        pass
+        if self._connector._http_own is not None:
+            await self._connector._http_own.aclose()
+            self._connector._http_own = None

--- a/backend/cubebox/im/dingtalk/renderer.py
+++ b/backend/cubebox/im/dingtalk/renderer.py
@@ -157,7 +157,7 @@ class DingtalkOpDispatcher:
         if s.card_id and not s.card_unavailable:
             status = "error" if s.card_state.error else "done"
             self._stream_seq += 1
-            await self._connector.streaming_update_card(
+            ok = await self._connector.streaming_update_card(
                 out_track_id=s.card_id,
                 guid=f"{s.card_id}-{self._stream_seq}",
                 key="content",
@@ -165,10 +165,17 @@ class DingtalkOpDispatcher:
                 is_final=True,
                 is_error=bool(s.card_state.error),
             )
-            await self._connector.update_card_actions(
-                out_track_id=s.card_id,
-                card_data={"status": status},
-            )
+            if ok:
+                await self._connector.update_card_actions(
+                    out_track_id=s.card_id,
+                    card_data={"status": status},
+                )
+            else:
+                await self._connector.reply_markdown(
+                    title="cubebox",
+                    text=full_content[:4000],
+                    open_conversation_id=self._open_conversation_id,
+                )
         elif full_content:
             await self._connector.reply_markdown(
                 title="cubebox",

--- a/backend/cubebox/im/dingtalk/renderer.py
+++ b/backend/cubebox/im/dingtalk/renderer.py
@@ -78,7 +78,9 @@ class DingtalkOpDispatcher:
     async def dispatch_patch(self, state: Any) -> bool:
         s = self._state
         pending = s.card_state.pending_input
-        pending_id = f"{pending.kind}:{pending.run_id}" if pending else None
+        pending_id = (
+            f"{pending.kind}:{pending.run_id}:{pending.question_id or ''}" if pending else None
+        )
 
         if (
             pending is not None

--- a/backend/cubebox/im/dingtalk/renderer.py
+++ b/backend/cubebox/im/dingtalk/renderer.py
@@ -1,0 +1,187 @@
+"""DingTalk outbound renderer — Interactive Card with streaming updates."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from loguru import logger
+
+from cubebox.im.dingtalk.connector import DingtalkRateLimitError
+from cubebox.im.outbound import note_edit_success, note_flood_strike
+from cubebox.im.types import RenderState
+
+
+class DingtalkOpDispatcher:
+    """Dispatches outbound ops to DingTalk via interactive cards."""
+
+    def __init__(
+        self,
+        *,
+        connector: Any,
+        state: RenderState,
+        card_template_id: str,
+        open_conversation_id: str,
+    ) -> None:
+        self._connector = connector
+        self._state = state
+        self._card_template_id = card_template_id
+        self._open_conversation_id = open_conversation_id
+        self._pending_input_sent_id: str | None = None
+        self._stream_seq: int = 0
+
+    async def dispatch_create(self, state: Any) -> bool:
+        s = self._state
+        text = s.card_state.streaming_content or "..."
+        out_track_id = f"cubebox-{s.run_id}-{uuid.uuid4().hex[:8]}"
+
+        ok = await self._connector.create_and_deliver_card(
+            card_template_id=self._card_template_id,
+            open_conversation_id=self._open_conversation_id,
+            card_data={"content": text, "status": "thinking"},
+            out_track_id=out_track_id,
+        )
+        if ok:
+            s.card_id = out_track_id
+            return True
+        s.card_unavailable = True
+        await self._connector.reply_markdown(
+            title="cubebox",
+            text=text,
+            open_conversation_id=self._open_conversation_id,
+        )
+        return True
+
+    async def dispatch_stream(self, state: Any, text: str) -> bool:
+        s = self._state
+        if s.card_unavailable:
+            return True
+        if s.card_id is None:
+            return await self.dispatch_create(state)
+        full_content = s.card_state.streaming_content
+        self._stream_seq += 1
+        guid = f"{s.card_id}-{self._stream_seq}"
+        try:
+            ok = await self._connector.streaming_update_card(
+                out_track_id=s.card_id,
+                guid=guid,
+                key="content",
+                content=full_content,
+            )
+        except DingtalkRateLimitError:
+            note_flood_strike(s)
+            return False
+        if ok:
+            note_edit_success(s)
+        return bool(ok)
+
+    async def dispatch_patch(self, state: Any) -> bool:
+        s = self._state
+        pending = s.card_state.pending_input
+        pending_id = f"{pending.kind}:{pending.run_id}" if pending else None
+
+        if (
+            pending is not None
+            and pending.resolved_choice is None
+            and pending.choices
+            and pending_id != self._pending_input_sent_id
+        ):
+            if s.card_unavailable or s.card_id is None:
+                await self._emergency_pending_input(pending)
+            else:
+                await self._send_pending_input_buttons(pending)
+            self._pending_input_sent_id = pending_id
+
+        if pending is not None and pending.resolved_choice is not None:
+            s.card_id = None
+            s.card_unavailable = False
+            self._stream_seq = 0
+        return True
+
+    async def _emergency_pending_input(self, pending: Any) -> None:
+        """Fallback: send HITL question as plain markdown."""
+        text = pending.question or "Please continue in the cubebox web UI."
+        if pending.choices:
+            labels = ", ".join(label for label, _, _ in pending.choices)
+            text = f"{text}\n\nOptions: {labels}\n\n_(Please answer in the web UI.)_"
+        await self.emergency_text(text)
+
+    async def _send_pending_input_buttons(self, pending: Any) -> None:
+        """Update the card with action buttons for AskUser/SandboxConfirm."""
+        s = self._state
+        if s.card_id is None or s.card_unavailable:
+            return
+
+        qid = pending.question_id or ""
+        akey = pending.answer_key or ""
+        short_qid = qid[:8]
+
+        buttons: list[dict[str, Any]] = []
+        for label, value, btn_type in pending.choices:
+            action_id = f"im:{pending.kind}:{pending.run_id}:{short_qid}:{akey}:{value}"
+            buttons.append(
+                {
+                    "label": label[:20],
+                    "actionId": action_id,
+                    "type": btn_type,
+                }
+            )
+
+        card_data: dict[str, Any] = {
+            "question": pending.question or "Please choose:",
+            "buttons": buttons,
+        }
+        await self._connector.update_card_actions(
+            out_track_id=s.card_id,
+            card_data=card_data,
+        )
+
+    async def dispatch_finalize(self, state: Any) -> bool:
+        s = self._state
+        full_content = s.card_state.streaming_content or ""
+
+        if s.card_state.error:
+            error_suffix = f"\n\n⚠️ {s.card_state.error}"
+            full_content = (full_content + error_suffix) if full_content else error_suffix
+
+        artifacts = s.card_state.artifacts
+        if artifacts:
+            links = "\n".join(f"📎 [{a.name}]({a.share_url})" for a in artifacts if a.share_url)
+            if links:
+                full_content = f"{full_content}\n\n{links}" if full_content else links
+
+        if s.card_id and not s.card_unavailable:
+            status = "error" if s.card_state.error else "done"
+            self._stream_seq += 1
+            await self._connector.streaming_update_card(
+                out_track_id=s.card_id,
+                guid=f"{s.card_id}-{self._stream_seq}",
+                key="content",
+                content=full_content,
+                is_final=True,
+                is_error=bool(s.card_state.error),
+            )
+            await self._connector.update_card_actions(
+                out_track_id=s.card_id,
+                card_data={"status": status},
+            )
+        elif full_content:
+            await self._connector.reply_markdown(
+                title="cubebox",
+                text=full_content[:4000],
+                open_conversation_id=self._open_conversation_id,
+            )
+        return True
+
+    async def emergency_text(self, text: str) -> None:
+        try:
+            await self._connector.reply_markdown(
+                title="cubebox",
+                text=text[:4000],
+                open_conversation_id=self._open_conversation_id,
+            )
+        except Exception:
+            logger.warning("[DingTalk] emergency text send failed", exc_info=True)
+
+    async def aclose(self) -> None:
+        pass

--- a/backend/cubebox/im/runtime.py
+++ b/backend/cubebox/im/runtime.py
@@ -289,7 +289,7 @@ async def start(app: FastAPI, run_manager: Any) -> None:
                                 select(IMConnectorAccount).where(
                                     IMConnectorAccount.enabled == True,  # type: ignore[arg-type]  # noqa: E712
                                     IMConnectorAccount.delivery_mode.in_(  # type: ignore[attr-defined]
-                                        ["long_connection", "gateway"]
+                                        ["long_connection", "gateway", "stream"]
                                     ),
                                 )
                             )

--- a/backend/cubebox/im/runtime.py
+++ b/backend/cubebox/im/runtime.py
@@ -118,6 +118,7 @@ async def start(app: FastAPI, run_manager: Any) -> None:
     tracebacks; affected accounts simply won't receive connection traffic.
     """
     # Trigger platform registrations
+    import cubebox.im.dingtalk  # noqa: F401
     import cubebox.im.discord  # noqa: F401
     import cubebox.im.feishu  # noqa: F401
     import cubebox.im.slack  # noqa: F401
@@ -260,7 +261,7 @@ async def start(app: FastAPI, run_manager: Any) -> None:
                     select(IMConnectorAccount).where(
                         IMConnectorAccount.enabled == True,  # type: ignore[arg-type]  # noqa: E712
                         IMConnectorAccount.delivery_mode.in_(  # type: ignore[attr-defined]
-                            ["long_connection", "gateway"]
+                            ["long_connection", "gateway", "stream"]
                         ),
                     )
                 )

--- a/backend/cubebox/services/im_connector.py
+++ b/backend/cubebox/services/im_connector.py
@@ -50,7 +50,7 @@ def compute_runtime(
             state = "connected"
         else:
             state = "disconnected"
-    elif account.delivery_mode == "gateway":
+    elif account.delivery_mode in ("gateway", "stream"):
         gws = gateways or {}
         gw = gws.get(account.id)
         if gw is not None and getattr(gw, "is_open", lambda: False)():

--- a/backend/cubebox/services/im_connector.py
+++ b/backend/cubebox/services/im_connector.py
@@ -424,6 +424,98 @@ class IMConnectorService:
             logger.exception("[IM] Slack auth.test probe failed")
             raise ValueError("could not validate Slack bot token") from None
 
+    async def connect_dingtalk(
+        self,
+        *,
+        workspace_id: str,
+        app_key: str,
+        app_secret: str,
+        acting_user_id: str,
+    ) -> IMConnectorAccount:
+        """Bind one DingTalk enterprise bot: validate credentials, store, return account."""
+        existing = (
+            await self._session.execute(
+                select(IMConnectorAccount).where(
+                    IMConnectorAccount.org_id == self._org_id,  # type: ignore[arg-type]
+                    IMConnectorAccount.platform == "dingtalk",  # type: ignore[arg-type]
+                    IMConnectorAccount.external_account_id == app_key,  # type: ignore[arg-type]
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            raise ValueError(
+                f"dingtalk account already exists for app_key={app_key} (id={existing.id})"
+            )
+
+        await self._validate_dingtalk_credentials(app_key, app_secret)
+
+        secret_payload = json.dumps(
+            {
+                "app_key": app_key,
+                "app_secret": app_secret,
+                "bot_open_id": app_key,
+            }
+        )
+        try:
+            credential_id = await self._credentials.create(
+                kind="im_bot",
+                name=f"dingtalk:{app_key}",
+                plaintext=secret_payload,
+            )
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise ValueError(
+                f"dingtalk account already exists for app_key={app_key} (credential race)"
+            ) from exc
+        try:
+            account = IMConnectorAccount(
+                org_id=self._org_id,
+                workspace_id=workspace_id,
+                platform="dingtalk",
+                external_account_id=app_key,
+                acting_user_id=acting_user_id,
+                credential_id=credential_id,
+                delivery_mode="stream",
+                config={
+                    "bot_app_name": None,
+                    "bot_avatar_url": None,
+                },
+            )
+            self._session.add(account)
+            await self._session.commit()
+            await self._session.refresh(account)
+            return account
+        except Exception:
+            await self._session.rollback()
+            try:
+                await self._credentials.delete(credential_id=credential_id)
+            except Exception:
+                logger.warning(
+                    "[IM] orphan credential {} could not be rolled back",
+                    credential_id,
+                    exc_info=True,
+                )
+            raise
+
+    async def _validate_dingtalk_credentials(
+        self,
+        app_key: str,
+        app_secret: str,
+    ) -> None:
+        """Validate credentials via access token exchange."""
+        import httpx
+
+        url = "https://api.dingtalk.com/v1.0/oauth2/accessToken"
+        payload = {"appKey": app_key, "appSecret": app_secret}
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(url, json=payload)
+            if resp.status_code != 200:
+                raise ValueError(f"DingTalk credential validation failed: {resp.text}")
+            data = resp.json()
+            token = data.get("accessToken")
+            if not token:
+                raise ValueError("DingTalk returned empty access token")
+
     async def _hydrate_discord_bot_info(
         self,
         bot_token: str,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "slack-sdk>=3.42.0",
     "authlib>=1.7.2",
     "python3-saml>=1.16.0",
+    "dingtalk-stream>=0.24.3",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/unit/im/test_dingtalk_connector.py
+++ b/backend/tests/unit/im/test_dingtalk_connector.py
@@ -1,0 +1,81 @@
+"""Unit tests for DingtalkConnector.parse_inbound."""
+
+from __future__ import annotations
+
+from cubebox.im.dingtalk.connector import DingtalkConnector
+from cubebox.im.types import DM_SCOPE_KEY
+
+
+class TestParseInbound:
+    def test_dm_message(self) -> None:
+        raw = {
+            "msgtype": "text",
+            "text": {"content": "hello"},
+            "msgId": "msg_001",
+            "conversationId": "cid_dm_123",
+            "conversationType": "1",
+            "senderId": "staff_abc",
+            "senderStaffId": "staff_abc",
+            "chatbotUserId": "bot_999",
+        }
+        connector = DingtalkConnector(bot_user_id="bot_999")
+        event = connector.parse_inbound(raw)
+        assert event is not None
+        assert event.platform == "dingtalk"
+        assert event.text == "hello"
+        assert event.channel_id == "cid_dm_123"
+        assert event.scope_key == DM_SCOPE_KEY
+        assert event.scope_kind == "dm"
+        assert event.sender_ref == "staff_abc"
+        assert event.platform_event_id == "msg_001"
+        assert event.reply_to_id == "msg_001"
+
+    def test_group_at_mention(self) -> None:
+        raw = {
+            "msgtype": "text",
+            "text": {"content": " what time is it"},
+            "msgId": "msg_002",
+            "conversationId": "cid_group_456",
+            "conversationType": "2",
+            "senderId": "staff_def",
+            "senderStaffId": "staff_def",
+            "chatbotUserId": "bot_999",
+            "atUsers": [
+                {"dingtalkId": "bot_999"},
+            ],
+        }
+        connector = DingtalkConnector(bot_user_id="bot_999")
+        event = connector.parse_inbound(raw)
+        assert event is not None
+        assert event.scope_key == "u:staff_def"
+        assert event.scope_kind == "group"
+        assert event.text == "what time is it"
+
+    def test_non_text_ignored(self) -> None:
+        raw = {
+            "msgtype": "image",
+            "msgId": "msg_003",
+            "conversationId": "cid_dm_123",
+            "conversationType": "1",
+            "senderId": "staff_abc",
+            "senderStaffId": "staff_abc",
+            "chatbotUserId": "bot_999",
+        }
+        connector = DingtalkConnector(bot_user_id="bot_999")
+        assert connector.parse_inbound(raw) is None
+
+    def test_strips_at_mention_prefix(self) -> None:
+        raw = {
+            "msgtype": "text",
+            "text": {"content": " hello there"},
+            "msgId": "msg_004",
+            "conversationId": "cid_group_789",
+            "conversationType": "2",
+            "senderId": "staff_ghi",
+            "senderStaffId": "staff_ghi",
+            "chatbotUserId": "bot_999",
+        }
+        connector = DingtalkConnector(bot_user_id="bot_999")
+        event = connector.parse_inbound(raw)
+        assert event is not None
+        assert event.text == "hello there"

--- a/backend/tests/unit/im/test_dingtalk_connector.py
+++ b/backend/tests/unit/im/test_dingtalk_connector.py
@@ -79,3 +79,37 @@ class TestParseInbound:
         event = connector.parse_inbound(raw)
         assert event is not None
         assert event.text == "hello there"
+
+    def test_shared_mode_group_uses_channel_scope(self) -> None:
+        raw = {
+            "msgtype": "text",
+            "text": {"content": " hello"},
+            "msgId": "msg_005",
+            "conversationId": "cid_group_shared",
+            "conversationType": "2",
+            "senderId": "staff_xyz",
+            "senderStaffId": "staff_xyz",
+            "chatbotUserId": "bot_999",
+        }
+        connector = DingtalkConnector(bot_user_id="bot_999")
+        event = connector.parse_inbound(raw, binding_mode="shared")
+        assert event is not None
+        assert event.scope_key == "ch"
+        assert event.scope_kind == "channel"
+
+    def test_shared_mode_dm_stays_isolated(self) -> None:
+        raw = {
+            "msgtype": "text",
+            "text": {"content": "hello"},
+            "msgId": "msg_006",
+            "conversationId": "cid_dm_shared",
+            "conversationType": "1",
+            "senderId": "staff_xyz",
+            "senderStaffId": "staff_xyz",
+            "chatbotUserId": "bot_999",
+        }
+        connector = DingtalkConnector(bot_user_id="bot_999")
+        event = connector.parse_inbound(raw, binding_mode="shared")
+        assert event is not None
+        assert event.scope_key == DM_SCOPE_KEY
+        assert event.scope_kind == "dm"

--- a/backend/tests/unit/im/test_dingtalk_connector.py
+++ b/backend/tests/unit/im/test_dingtalk_connector.py
@@ -40,6 +40,7 @@ class TestParseInbound:
             "senderId": "staff_def",
             "senderStaffId": "staff_def",
             "chatbotUserId": "bot_999",
+            "isInAtList": True,
             "atUsers": [
                 {"dingtalkId": "bot_999"},
             ],
@@ -74,6 +75,7 @@ class TestParseInbound:
             "senderId": "staff_ghi",
             "senderStaffId": "staff_ghi",
             "chatbotUserId": "bot_999",
+            "isInAtList": True,
         }
         connector = DingtalkConnector(bot_user_id="bot_999")
         event = connector.parse_inbound(raw)
@@ -90,12 +92,28 @@ class TestParseInbound:
             "senderId": "staff_xyz",
             "senderStaffId": "staff_xyz",
             "chatbotUserId": "bot_999",
+            "isInAtList": True,
         }
         connector = DingtalkConnector(bot_user_id="bot_999")
         event = connector.parse_inbound(raw, binding_mode="shared")
         assert event is not None
         assert event.scope_key == "ch"
         assert event.scope_kind == "channel"
+
+    def test_group_non_mention_ignored(self) -> None:
+        raw = {
+            "msgtype": "text",
+            "text": {"content": "random chatter"},
+            "msgId": "msg_007",
+            "conversationId": "cid_group_456",
+            "conversationType": "2",
+            "senderId": "staff_def",
+            "senderStaffId": "staff_def",
+            "chatbotUserId": "bot_999",
+            "isInAtList": False,
+        }
+        connector = DingtalkConnector(bot_user_id="bot_999")
+        assert connector.parse_inbound(raw) is None
 
     def test_shared_mode_dm_stays_isolated(self) -> None:
         raw = {

--- a/backend/tests/unit/im/test_dingtalk_interactions.py
+++ b/backend/tests/unit/im/test_dingtalk_interactions.py
@@ -1,0 +1,52 @@
+"""Unit tests for DingTalk card action routing."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cubebox.im.dingtalk.interactions import handle_card_action
+
+
+class TestHandleCardAction:
+    @pytest.mark.anyio()
+    async def test_routes_to_resume(self) -> None:
+        callback = {
+            "outTrackId": "cubebox-run_001-abc123",
+            "content": '{"cardActionId":"im:ask_user:run_001:q1234567:answer:yes"}',
+        }
+        with (
+            patch(
+                "cubebox.im.dingtalk.interactions.resolve_full_question_id",
+                new_callable=AsyncMock,
+                return_value="q123456789abcdef",
+            ),
+            patch(
+                "cubebox.im.dingtalk.interactions.resume_paused_run",
+                new_callable=AsyncMock,
+            ) as mock_resume,
+        ):
+            await handle_card_action(callback=callback, run_manager=AsyncMock())
+            mock_resume.assert_called_once_with(
+                run_id="run_001",
+                input_kind="ask_user",
+                choice="yes",
+                operator_open_id="",
+                question_id="q123456789abcdef",
+                answer_key="answer",
+                run_manager=mock_resume.call_args.kwargs["run_manager"],
+            )
+
+    @pytest.mark.anyio()
+    async def test_ignores_non_im_actions(self) -> None:
+        callback = {
+            "outTrackId": "cubebox-run_001-abc123",
+            "content": '{"cardActionId":"other:action"}',
+        }
+        with patch(
+            "cubebox.im.dingtalk.interactions.resume_paused_run",
+            new_callable=AsyncMock,
+        ) as mock_resume:
+            await handle_card_action(callback=callback, run_manager=AsyncMock())
+            mock_resume.assert_not_called()

--- a/backend/tests/unit/im/test_dingtalk_renderer.py
+++ b/backend/tests/unit/im/test_dingtalk_renderer.py
@@ -1,0 +1,92 @@
+"""Unit tests for DingtalkOpDispatcher."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cubebox.im.dingtalk.renderer import DingtalkOpDispatcher
+from cubebox.im.types import RenderState
+
+
+@pytest.fixture()
+def state() -> RenderState:
+    s = RenderState(bot_name="testbot", run_id="run_001", stream_interval=1.0)
+    s.reply_to_id = "msg_inbound"
+    s.inbound_message_id = "msg_inbound"
+    return s
+
+
+@pytest.fixture()
+def connector() -> AsyncMock:
+    mock = AsyncMock()
+    mock.create_and_deliver_card = AsyncMock(return_value=True)
+    mock.streaming_update_card = AsyncMock(return_value=True)
+    mock.update_card_actions = AsyncMock(return_value=True)
+    mock.reply_markdown = AsyncMock(return_value="msg_reply")
+    return mock
+
+
+class TestDispatchCreate:
+    @pytest.mark.anyio()
+    async def test_creates_card(self, state: RenderState, connector: AsyncMock) -> None:
+        d = DingtalkOpDispatcher(
+            connector=connector,
+            state=state,
+            card_template_id="tpl_001",
+            open_conversation_id="cid_123",
+        )
+        state.card_state.streaming_content = "Hello world"
+        ok = await d.dispatch_create(state)
+        assert ok is True
+        connector.create_and_deliver_card.assert_called_once()
+        assert state.card_id is not None
+
+    @pytest.mark.anyio()
+    async def test_fallback_on_card_failure(self, state: RenderState, connector: AsyncMock) -> None:
+        connector.create_and_deliver_card = AsyncMock(return_value=False)
+        d = DingtalkOpDispatcher(
+            connector=connector,
+            state=state,
+            card_template_id="tpl_001",
+            open_conversation_id="cid_123",
+        )
+        state.card_state.streaming_content = "Hello"
+        ok = await d.dispatch_create(state)
+        assert ok is True
+        assert state.card_unavailable is True
+
+
+class TestDispatchStream:
+    @pytest.mark.anyio()
+    async def test_streams_content(self, state: RenderState, connector: AsyncMock) -> None:
+        d = DingtalkOpDispatcher(
+            connector=connector,
+            state=state,
+            card_template_id="tpl_001",
+            open_conversation_id="cid_123",
+        )
+        state.card_id = "track_001"
+        state.card_state.streaming_content = "Hello streaming"
+        ok = await d.dispatch_stream(state, "Hello streaming")
+        assert ok is True
+        connector.streaming_update_card.assert_called_once()
+
+
+class TestDispatchFinalize:
+    @pytest.mark.anyio()
+    async def test_finalizes_card(self, state: RenderState, connector: AsyncMock) -> None:
+        d = DingtalkOpDispatcher(
+            connector=connector,
+            state=state,
+            card_template_id="tpl_001",
+            open_conversation_id="cid_123",
+        )
+        state.card_id = "track_001"
+        state.card_state.streaming_content = "Done"
+        ok = await d.dispatch_finalize(state)
+        assert ok is True
+        connector.streaming_update_card.assert_called()
+        call_kwargs = connector.streaming_update_card.call_args.kwargs
+        assert call_kwargs["is_final"] is True

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -901,6 +901,7 @@ dependencies = [
     { name = "croniter" },
     { name = "cryptography" },
     { name = "cubepi", extra = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"] },
+    { name = "dingtalk-stream" },
     { name = "discord-py" },
     { name = "dynaconf" },
     { name = "fastapi" },
@@ -967,6 +968,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=a7bd529dbff6ec608f335bc83a8921e037650ee0" },
+    { name = "dingtalk-stream", specifier = ">=0.24.3" },
     { name = "discord-py", specifier = ">=2.7.1" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.110.0" },
@@ -1057,6 +1059,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
+name = "dingtalk-stream"
+version = "0.24.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "requests" },
+    { name = "websockets" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/44/102dede3f371277598df6aa9725b82e3add068c729333c7a5dbc12764579/dingtalk_stream-0.24.3-py3-none-any.whl", hash = "sha256:2160403656985962878bf60cdf5adf41619f21067348e06f07a7c7eebf5943ad", size = 27813, upload-time = "2025-10-24T09:36:57.497Z" },
 ]
 
 [[package]]

--- a/docs/dev/plans/2026-06-19-dingtalk-im-connector.md
+++ b/docs/dev/plans/2026-06-19-dingtalk-im-connector.md
@@ -1,0 +1,1880 @@
+# DingTalk IM Connector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add DingTalk (钉钉) as the fourth IM platform, reusing the existing connector-neutral pipeline.
+
+**Architecture:** New `im/dingtalk/` module implementing `PlatformConnector` protocol. Stream mode gateway (WebSocket long-connection via `dingtalk-stream` SDK). Interactive card rendering for outbound. Email auto-match + manual link for identity resolution.
+
+**Tech Stack:** `dingtalk-stream` (gateway), DingTalk OpenAPI v2 (cards, user info), httpx (REST calls), existing `im/` pipeline.
+
+**Spec:** `docs/dev/specs/2026-06-19-dingtalk-im-connector-design.md`
+
+**Worktree:** `/home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk`
+**Ports:** 8059 (backend), 3059 (frontend)
+
+---
+
+## Task 1: Add `dingtalk-stream` dependency
+
+**Files:**
+- Modify: `backend/pyproject.toml` (via `uv add`)
+
+- [ ] **Step 1: Install the SDK**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv add dingtalk-stream
+```
+
+- [ ] **Step 2: Verify import works**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run python -c "import dingtalk_stream; print(dingtalk_stream.__version__)"
+```
+
+Expected: version string, no ImportError.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+git add pyproject.toml uv.lock
+git commit -m "chore: add dingtalk-stream dependency"
+```
+
+---
+
+## Task 2: DingTalk connector — inbound parsing + outbound API calls
+
+The core connector class: parses raw Stream events into `InboundEvent`, provides outbound API helpers (send card, update card, send message), and implements `IdentityResolver` + `RejectionNotifier` protocols.
+
+**Files:**
+- Create: `backend/cubebox/im/dingtalk/__init__.py`
+- Create: `backend/cubebox/im/dingtalk/connector.py`
+- Test: `backend/tests/unit/im/test_dingtalk_connector.py`
+
+- [ ] **Step 1: Create the package init (empty for now)**
+
+```python
+# backend/cubebox/im/dingtalk/__init__.py
+```
+
+Just create the empty `__init__.py`. Platform registration happens in Task 7.
+
+- [ ] **Step 2: Write unit tests for parse_inbound**
+
+```python
+# backend/tests/unit/im/test_dingtalk_connector.py
+"""Unit tests for DingtalkConnector.parse_inbound."""
+
+from __future__ import annotations
+
+from cubebox.im.dingtalk.connector import DingtalkConnector
+from cubebox.im.types import DM_SCOPE_KEY
+
+
+class TestParseInbound:
+    def test_dm_message(self) -> None:
+        raw = {
+            "msgtype": "text",
+            "text": {"content": "hello"},
+            "msgId": "msg_001",
+            "conversationId": "cid_dm_123",
+            "conversationType": "1",
+            "senderId": "staff_abc",
+            "senderStaffId": "staff_abc",
+            "chatbotUserId": "bot_999",
+        }
+        connector = DingtalkConnector(bot_user_id="bot_999")
+        event = connector.parse_inbound(raw)
+        assert event is not None
+        assert event.platform == "dingtalk"
+        assert event.text == "hello"
+        assert event.channel_id == "cid_dm_123"
+        assert event.scope_key == DM_SCOPE_KEY
+        assert event.scope_kind == "dm"
+        assert event.sender_ref == "staff_abc"
+        assert event.platform_event_id == "msg_001"
+        assert event.reply_to_id == "msg_001"
+
+    def test_group_at_mention(self) -> None:
+        raw = {
+            "msgtype": "text",
+            "text": {"content": "@cubebox what time is it"},
+            "msgId": "msg_002",
+            "conversationId": "cid_group_456",
+            "conversationType": "2",
+            "senderId": "staff_def",
+            "senderStaffId": "staff_def",
+            "chatbotUserId": "bot_999",
+            "atUsers": [
+                {"dingtalkId": "bot_999"},
+            ],
+        }
+        connector = DingtalkConnector(bot_user_id="bot_999")
+        event = connector.parse_inbound(raw)
+        assert event is not None
+        assert event.scope_key == "u:staff_def"
+        assert event.scope_kind == "group"
+        assert event.text == "what time is it"
+
+    def test_non_text_ignored(self) -> None:
+        raw = {
+            "msgtype": "image",
+            "msgId": "msg_003",
+            "conversationId": "cid_dm_123",
+            "conversationType": "1",
+            "senderId": "staff_abc",
+            "senderStaffId": "staff_abc",
+            "chatbotUserId": "bot_999",
+        }
+        connector = DingtalkConnector(bot_user_id="bot_999")
+        assert connector.parse_inbound(raw) is None
+
+    def test_strips_at_mention_prefix(self) -> None:
+        raw = {
+            "msgtype": "text",
+            "text": {"content": " hello there"},
+            "msgId": "msg_004",
+            "conversationId": "cid_group_789",
+            "conversationType": "2",
+            "senderId": "staff_ghi",
+            "senderStaffId": "staff_ghi",
+            "chatbotUserId": "bot_999",
+        }
+        connector = DingtalkConnector(bot_user_id="bot_999")
+        event = connector.parse_inbound(raw)
+        assert event is not None
+        assert event.text == "hello there"
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run pytest tests/unit/im/test_dingtalk_connector.py -v --no-cov 2>&1 | tail -10
+```
+
+Expected: FAIL — `DingtalkConnector` not found.
+
+- [ ] **Step 4: Implement DingtalkConnector**
+
+```python
+# backend/cubebox/im/dingtalk/connector.py
+"""DingTalk connector: inbound parse + outbound card/message API + identity."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from loguru import logger
+
+from cubebox.im.outbound import _FloodSignal
+from cubebox.im.types import (
+    DM_SCOPE_KEY,
+    InboundEvent,
+    make_participant_scope,
+)
+
+
+class DingtalkRateLimitError(_FloodSignal):
+    """Raised when DingTalk API returns a rate-limit error."""
+
+
+class DingtalkConnector:
+    """Connector for one DingTalk enterprise bot account.
+
+    Construction:
+    - Inbound parsing only needs ``bot_user_id``.
+    - Outbound calls need ``access_token`` + ``conversation_id``.
+    """
+
+    def __init__(
+        self,
+        *,
+        bot_user_id: str = "",
+        access_token: str = "",
+        conversation_id: str = "",
+    ) -> None:
+        self._bot_user_id = bot_user_id
+        self._access_token = access_token
+        self._conversation_id = conversation_id
+
+    # ------------------------------------------------------------------
+    # Inbound
+    # ------------------------------------------------------------------
+
+    def parse_inbound(self, raw: dict[str, Any]) -> InboundEvent | None:
+        """Normalize a DingTalk Stream callback dict into an InboundEvent.
+
+        Returns None for non-text messages.
+        """
+        msgtype = raw.get("msgtype", "")
+        if msgtype != "text":
+            return None
+
+        text_obj = raw.get("text") or {}
+        text: str = text_obj.get("content", "").strip()
+        msg_id: str = raw.get("msgId", "")
+        conversation_id: str = raw.get("conversationId", "")
+        conversation_type: str = raw.get("conversationType", "")
+        sender_staff_id: str = raw.get("senderStaffId", "")
+
+        if not msg_id or not conversation_id or not sender_staff_id:
+            return None
+
+        # DM (1:1)
+        if conversation_type == "1":
+            scope_key = DM_SCOPE_KEY
+            scope_kind = "dm"
+        else:
+            # Group @mention — per-user scope isolation
+            scope_key = make_participant_scope(sender_staff_id)
+            scope_kind = "group"
+            # Strip @mention text (DingTalk prepends the bot name or leaves
+            # a leading space after the invisible @-tag)
+            text = re.sub(r"^\s+", "", text)
+
+        return InboundEvent(
+            platform="dingtalk",
+            account_external_id="",
+            platform_event_id=msg_id,
+            channel_id=conversation_id,
+            scope_key=scope_key,
+            scope_kind=scope_kind,
+            reply_to_id=msg_id,
+            inbound_message_id=msg_id,
+            sender_ref=sender_staff_id,
+            sender_open_id=sender_staff_id,
+            text=text,
+        )
+
+    # ------------------------------------------------------------------
+    # Outbound — card + message API calls
+    # ------------------------------------------------------------------
+
+    async def send_markdown(self, title: str, text: str) -> str | None:
+        """Send a plain markdown message. Returns msgId or None."""
+        import httpx
+
+        url = "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend"
+        headers = {
+            "x-acs-dingtalk-access-token": self._access_token,
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "msgParam": f'{{"title":"{title}","text":"{text}"}}',
+            "msgKey": "sampleMarkdown",
+            "robotCode": self._bot_user_id,
+            "userIds": [],
+        }
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(url, headers=headers, json=payload)
+                if resp.status_code == 200:
+                    return resp.json().get("processQueryKey")
+                logger.warning("[DingTalk] send_markdown failed: {}", resp.text)
+                return None
+        except Exception:
+            logger.warning("[DingTalk] send_markdown error", exc_info=True)
+            return None
+
+    async def reply_markdown(
+        self,
+        title: str,
+        text: str,
+        *,
+        open_conversation_id: str = "",
+    ) -> str | None:
+        """Reply to a conversation with markdown. Returns msgId."""
+        import httpx
+
+        cid = open_conversation_id or self._conversation_id
+        url = (
+            "https://api.dingtalk.com/v1.0/robot/groupMessages/send"
+        )
+        headers = {
+            "x-acs-dingtalk-access-token": self._access_token,
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "msgParam": f'{{"title":"{title}","text":"{text}"}}',
+            "msgKey": "sampleMarkdown",
+            "robotCode": self._bot_user_id,
+            "openConversationId": cid,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(url, headers=headers, json=payload)
+                if resp.status_code == 200:
+                    return resp.json().get("processQueryKey")
+                logger.warning("[DingTalk] reply_markdown failed: {}", resp.text)
+                return None
+        except Exception:
+            logger.warning("[DingTalk] reply_markdown error", exc_info=True)
+            return None
+
+    # ------------------------------------------------------------------
+    # Interactive card operations
+    # ------------------------------------------------------------------
+
+    async def create_and_deliver_card(
+        self,
+        *,
+        card_template_id: str,
+        open_conversation_id: str,
+        card_data: dict[str, Any],
+        out_track_id: str,
+    ) -> bool:
+        """Create + deliver an interactive card instance."""
+        import httpx
+
+        url = "https://api.dingtalk.com/v1.0/card/instances/createAndDeliver"
+        headers = {
+            "x-acs-dingtalk-access-token": self._access_token,
+            "Content-Type": "application/json",
+        }
+        payload: dict[str, Any] = {
+            "cardTemplateId": card_template_id,
+            "outTrackId": out_track_id,
+            "openConversationId": open_conversation_id,
+            "cardData": {"cardParamMap": card_data},
+        }
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(url, headers=headers, json=payload)
+                if resp.status_code == 200:
+                    return True
+                logger.warning(
+                    "[DingTalk] create_and_deliver_card failed: {}", resp.text
+                )
+                return False
+        except Exception:
+            logger.warning("[DingTalk] create_and_deliver_card error", exc_info=True)
+            return False
+
+    async def streaming_update_card(
+        self,
+        *,
+        out_track_id: str,
+        key: str,
+        content: str,
+        is_final: bool = False,
+        is_error: bool = False,
+    ) -> bool:
+        """Stream-update a card variable."""
+        import httpx
+
+        url = "https://api.dingtalk.com/v1.0/card/streaming"
+        headers = {
+            "x-acs-dingtalk-access-token": self._access_token,
+            "Content-Type": "application/json",
+        }
+        payload: dict[str, Any] = {
+            "outTrackId": out_track_id,
+            "key": key,
+            "content": content,
+            "isFull": True,
+            "isFinalize": is_final,
+            "isError": is_error,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(url, headers=headers, json=payload)
+                if resp.status_code == 200:
+                    return True
+                if resp.status_code == 429:
+                    raise DingtalkRateLimitError("rate limited")
+                logger.warning("[DingTalk] streaming_update failed: {}", resp.text)
+                return False
+        except DingtalkRateLimitError:
+            raise
+        except Exception:
+            logger.warning("[DingTalk] streaming_update error", exc_info=True)
+            return False
+
+    async def update_card_actions(
+        self,
+        *,
+        out_track_id: str,
+        card_data: dict[str, Any],
+    ) -> bool:
+        """Update card data (buttons, status) via PUT."""
+        import httpx
+
+        url = "https://api.dingtalk.com/v1.0/card/instances"
+        headers = {
+            "x-acs-dingtalk-access-token": self._access_token,
+            "Content-Type": "application/json",
+        }
+        payload: dict[str, Any] = {
+            "outTrackId": out_track_id,
+            "cardData": {"cardParamMap": card_data},
+        }
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.put(url, headers=headers, json=payload)
+                if resp.status_code == 200:
+                    return True
+                logger.warning("[DingTalk] update_card_actions failed: {}", resp.text)
+                return False
+        except Exception:
+            logger.warning("[DingTalk] update_card_actions error", exc_info=True)
+            return False
+
+    # ------------------------------------------------------------------
+    # Identity resolution (IdentityResolver protocol)
+    # ------------------------------------------------------------------
+
+    async def resolve_email(self, open_id: str) -> str | None:
+        """Look up a DingTalk user's email by staffId."""
+        import httpx
+
+        url = "https://oapi.dingtalk.com/topapi/v2/user/get"
+        params = {"access_token": self._access_token}
+        payload = {"userid": open_id}
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(url, params=params, json=payload)
+                data = resp.json()
+                if data.get("errcode") != 0:
+                    logger.warning("[DingTalk] user/get failed: {}", data)
+                    return None
+                result = data.get("result", {})
+                email = result.get("email") or result.get("org_email") or ""
+                return email.strip().lower() if email else None
+        except Exception:
+            logger.warning("[DingTalk] resolve_email error", exc_info=True)
+            return None
+
+    # ------------------------------------------------------------------
+    # Rejection notifier (RejectionNotifier protocol)
+    # ------------------------------------------------------------------
+
+    async def send_to_chat(
+        self, chat_id: str, reply_to_id: str | None, text: str
+    ) -> str | None:
+        """Send a rejection notice to the conversation."""
+        return await self.reply_markdown(
+            title="Notice",
+            text=text,
+            open_conversation_id=chat_id,
+        )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run pytest tests/unit/im/test_dingtalk_connector.py -v --no-cov 2>&1 | tail -10
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+git add cubebox/im/dingtalk/__init__.py cubebox/im/dingtalk/connector.py tests/unit/im/test_dingtalk_connector.py
+git commit -m "feat(im): add DingtalkConnector — inbound parse + outbound API + identity"
+```
+
+---
+
+## Task 3: DingTalk OpDispatcher — interactive card rendering
+
+Implements the `OpDispatcher` protocol: creates interactive cards, streams markdown content, patches buttons for AskUser/SandboxConfirm, and finalizes with artifacts.
+
+**Files:**
+- Create: `backend/cubebox/im/dingtalk/renderer.py`
+- Test: `backend/tests/unit/im/test_dingtalk_renderer.py`
+
+- [ ] **Step 1: Write unit tests for DingtalkOpDispatcher**
+
+```python
+# backend/tests/unit/im/test_dingtalk_renderer.py
+"""Unit tests for DingtalkOpDispatcher."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cubebox.im.dingtalk.renderer import DingtalkOpDispatcher
+from cubebox.im.types import RenderState
+
+
+@pytest.fixture()
+def state() -> RenderState:
+    s = RenderState(bot_name="testbot", run_id="run_001", stream_interval=1.0)
+    s.reply_to_id = "msg_inbound"
+    s.inbound_message_id = "msg_inbound"
+    return s
+
+
+@pytest.fixture()
+def connector() -> AsyncMock:
+    mock = AsyncMock()
+    mock.create_and_deliver_card = AsyncMock(return_value=True)
+    mock.streaming_update_card = AsyncMock(return_value=True)
+    mock.update_card_actions = AsyncMock(return_value=True)
+    mock.reply_markdown = AsyncMock(return_value="msg_reply")
+    return mock
+
+
+class TestDispatchCreate:
+    @pytest.mark.anyio()
+    async def test_creates_card(
+        self, state: RenderState, connector: AsyncMock
+    ) -> None:
+        d = DingtalkOpDispatcher(
+            connector=connector,
+            state=state,
+            card_template_id="tpl_001",
+            open_conversation_id="cid_123",
+        )
+        state.card_state.streaming_content = "Hello world"
+        ok = await d.dispatch_create(state)
+        assert ok is True
+        connector.create_and_deliver_card.assert_called_once()
+        assert state.card_id is not None
+
+    @pytest.mark.anyio()
+    async def test_fallback_on_card_failure(
+        self, state: RenderState, connector: AsyncMock
+    ) -> None:
+        connector.create_and_deliver_card = AsyncMock(return_value=False)
+        d = DingtalkOpDispatcher(
+            connector=connector,
+            state=state,
+            card_template_id="tpl_001",
+            open_conversation_id="cid_123",
+        )
+        state.card_state.streaming_content = "Hello"
+        ok = await d.dispatch_create(state)
+        assert ok is True
+        assert state.card_unavailable is True
+
+
+class TestDispatchStream:
+    @pytest.mark.anyio()
+    async def test_streams_content(
+        self, state: RenderState, connector: AsyncMock
+    ) -> None:
+        d = DingtalkOpDispatcher(
+            connector=connector,
+            state=state,
+            card_template_id="tpl_001",
+            open_conversation_id="cid_123",
+        )
+        state.card_id = "track_001"
+        state.card_state.streaming_content = "Hello streaming"
+        ok = await d.dispatch_stream(state, "Hello streaming")
+        assert ok is True
+        connector.streaming_update_card.assert_called_once()
+
+
+class TestDispatchFinalize:
+    @pytest.mark.anyio()
+    async def test_finalizes_card(
+        self, state: RenderState, connector: AsyncMock
+    ) -> None:
+        d = DingtalkOpDispatcher(
+            connector=connector,
+            state=state,
+            card_template_id="tpl_001",
+            open_conversation_id="cid_123",
+        )
+        state.card_id = "track_001"
+        state.card_state.streaming_content = "Done"
+        ok = await d.dispatch_finalize(state)
+        assert ok is True
+        # Should call streaming_update with is_final=True
+        connector.streaming_update_card.assert_called()
+        call_kwargs = connector.streaming_update_card.call_args.kwargs
+        assert call_kwargs["is_final"] is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run pytest tests/unit/im/test_dingtalk_renderer.py -v --no-cov 2>&1 | tail -10
+```
+
+Expected: FAIL — `DingtalkOpDispatcher` not found.
+
+- [ ] **Step 3: Implement DingtalkOpDispatcher**
+
+```python
+# backend/cubebox/im/dingtalk/renderer.py
+"""DingTalk outbound renderer — Interactive Card with streaming updates."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from loguru import logger
+
+from cubebox.im.outbound import note_edit_success, note_flood_strike
+from cubebox.im.dingtalk.connector import DingtalkRateLimitError
+from cubebox.im.types import RenderState
+
+
+class DingtalkOpDispatcher:
+    """Dispatches outbound ops to DingTalk via interactive cards."""
+
+    def __init__(
+        self,
+        *,
+        connector: Any,
+        state: RenderState,
+        card_template_id: str,
+        open_conversation_id: str,
+    ) -> None:
+        self._connector = connector
+        self._state = state
+        self._card_template_id = card_template_id
+        self._open_conversation_id = open_conversation_id
+        self._pending_input_sent_id: str | None = None
+
+    async def dispatch_create(self, state: Any) -> bool:
+        s = self._state
+        text = s.card_state.streaming_content or "..."
+        out_track_id = f"cubebox-{s.run_id}-{uuid.uuid4().hex[:8]}"
+
+        ok = await self._connector.create_and_deliver_card(
+            card_template_id=self._card_template_id,
+            open_conversation_id=self._open_conversation_id,
+            card_data={"content": text, "status": "thinking"},
+            out_track_id=out_track_id,
+        )
+        if ok:
+            s.card_id = out_track_id
+            return True
+        s.card_unavailable = True
+        await self._connector.reply_markdown(
+            title="cubebox",
+            text=text,
+            open_conversation_id=self._open_conversation_id,
+        )
+        return True
+
+    async def dispatch_stream(self, state: Any, text: str) -> bool:
+        s = self._state
+        if s.card_id is None:
+            return await self.dispatch_create(state)
+        if s.card_unavailable:
+            return True
+        full_content = s.card_state.streaming_content
+        try:
+            ok = await self._connector.streaming_update_card(
+                out_track_id=s.card_id,
+                key="content",
+                content=full_content,
+            )
+        except DingtalkRateLimitError:
+            note_flood_strike(s)
+            return False
+        if ok:
+            note_edit_success(s)
+        return bool(ok)
+
+    async def dispatch_patch(self, state: Any) -> bool:
+        s = self._state
+        pending = s.card_state.pending_input
+        pending_id = f"{pending.kind}:{pending.run_id}" if pending else None
+
+        if (
+            pending is not None
+            and pending.resolved_choice is None
+            and pending.choices
+            and pending_id != self._pending_input_sent_id
+        ):
+            await self._send_pending_input_buttons(pending)
+            self._pending_input_sent_id = pending_id
+
+        if pending is not None and pending.resolved_choice is not None:
+            s.card_id = None
+            s.card_unavailable = False
+        return True
+
+    async def _send_pending_input_buttons(self, pending: Any) -> None:
+        """Update the card with action buttons for AskUser/SandboxConfirm."""
+        s = self._state
+        if s.card_id is None or s.card_unavailable:
+            return
+
+        qid = pending.question_id or ""
+        akey = pending.answer_key or ""
+        short_qid = qid[:8]
+
+        buttons: list[dict[str, Any]] = []
+        for label, value, btn_type in pending.choices:
+            action_id = (
+                f"im:{pending.kind}:{pending.run_id}:{short_qid}:{akey}:{value}"
+            )
+            buttons.append({
+                "label": label[:20],
+                "actionId": action_id,
+                "type": btn_type,
+            })
+
+        card_data: dict[str, Any] = {
+            "question": pending.question or "Please choose:",
+            "buttons": buttons,
+        }
+        await self._connector.update_card_actions(
+            out_track_id=s.card_id,
+            card_data=card_data,
+        )
+
+    async def dispatch_finalize(self, state: Any) -> bool:
+        s = self._state
+        full_content = s.card_state.streaming_content or ""
+
+        if s.card_state.error:
+            error_suffix = f"\n\n⚠️ {s.card_state.error}"
+            full_content = (full_content + error_suffix) if full_content else error_suffix
+
+        artifacts = s.card_state.artifacts
+        if artifacts:
+            links = "\n".join(
+                f"📎 [{a.name}]({a.share_url})" for a in artifacts if a.share_url
+            )
+            if links:
+                full_content = f"{full_content}\n\n{links}" if full_content else links
+
+        if s.card_id and not s.card_unavailable:
+            status = "error" if s.card_state.error else "done"
+            await self._connector.streaming_update_card(
+                out_track_id=s.card_id,
+                key="content",
+                content=full_content,
+                is_final=True,
+                is_error=bool(s.card_state.error),
+            )
+            await self._connector.update_card_actions(
+                out_track_id=s.card_id,
+                card_data={"status": status},
+            )
+        elif full_content:
+            await self._connector.reply_markdown(
+                title="cubebox",
+                text=full_content[:4000],
+                open_conversation_id=self._open_conversation_id,
+            )
+        return True
+
+    async def emergency_text(self, text: str) -> None:
+        try:
+            await self._connector.reply_markdown(
+                title="cubebox",
+                text=text[:4000],
+                open_conversation_id=self._open_conversation_id,
+            )
+        except Exception:
+            logger.warning("[DingTalk] emergency text send failed", exc_info=True)
+
+    async def aclose(self) -> None:
+        pass
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run pytest tests/unit/im/test_dingtalk_renderer.py -v --no-cov 2>&1 | tail -10
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+git add cubebox/im/dingtalk/renderer.py tests/unit/im/test_dingtalk_renderer.py
+git commit -m "feat(im): add DingtalkOpDispatcher — interactive card rendering"
+```
+
+---
+
+## Task 4: DingTalk card action handler
+
+Routes interactive card button clicks to `resume_paused_run`, following the same action ID format as Slack.
+
+**Files:**
+- Create: `backend/cubebox/im/dingtalk/interactions.py`
+- Test: `backend/tests/unit/im/test_dingtalk_interactions.py`
+
+- [ ] **Step 1: Write unit test**
+
+```python
+# backend/tests/unit/im/test_dingtalk_interactions.py
+"""Unit tests for DingTalk card action routing."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cubebox.im.dingtalk.interactions import handle_card_action
+
+
+class TestHandleCardAction:
+    @pytest.mark.anyio()
+    async def test_routes_to_resume(self) -> None:
+        callback = {
+            "outTrackId": "cubebox-run_001-abc123",
+            "content": '{"cardActionId":"im:ask_user:run_001:q1234567:answer:yes"}',
+        }
+        with (
+            patch(
+                "cubebox.im.dingtalk.interactions.resolve_full_question_id",
+                new_callable=AsyncMock,
+                return_value="q123456789abcdef",
+            ),
+            patch(
+                "cubebox.im.dingtalk.interactions.resume_paused_run",
+                new_callable=AsyncMock,
+            ) as mock_resume,
+        ):
+            await handle_card_action(callback=callback, run_manager=AsyncMock())
+            mock_resume.assert_called_once_with(
+                run_id="run_001",
+                input_kind="ask_user",
+                choice="yes",
+                operator_open_id="",
+                question_id="q123456789abcdef",
+                answer_key="answer",
+                run_manager=mock_resume.call_args.kwargs["run_manager"],
+            )
+
+    @pytest.mark.anyio()
+    async def test_ignores_non_im_actions(self) -> None:
+        callback = {
+            "outTrackId": "cubebox-run_001-abc123",
+            "content": '{"cardActionId":"other:action"}',
+        }
+        with patch(
+            "cubebox.im.dingtalk.interactions.resume_paused_run",
+            new_callable=AsyncMock,
+        ) as mock_resume:
+            await handle_card_action(callback=callback, run_manager=AsyncMock())
+            mock_resume.assert_not_called()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run pytest tests/unit/im/test_dingtalk_interactions.py -v --no-cov 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Implement handle_card_action**
+
+```python
+# backend/cubebox/im/dingtalk/interactions.py
+"""Handle DingTalk interactive card action callbacks (button clicks)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from loguru import logger
+
+from cubebox.im.resume import resolve_full_question_id, resume_paused_run
+
+
+async def handle_card_action(
+    *,
+    callback: dict[str, Any],
+    run_manager: Any,
+) -> None:
+    """Route a DingTalk card button click to the resume path.
+
+    Button action_id format: ``im:{kind}:{run_id}:{short_qid}:{akey}:{value}``
+    """
+    content_raw = callback.get("content", "{}")
+    try:
+        content = json.loads(content_raw) if isinstance(content_raw, str) else content_raw
+    except (json.JSONDecodeError, TypeError):
+        return
+
+    action_id: str = content.get("cardActionId", "")
+    if not action_id.startswith("im:"):
+        return
+
+    parts = action_id.split(":", 5)
+    if len(parts) < 6:
+        return
+
+    _, kind, run_id, short_qid, answer_key, value = parts
+
+    question_id = await resolve_full_question_id(run_id, short_qid)
+
+    try:
+        await resume_paused_run(
+            run_id=run_id,
+            input_kind=kind,
+            choice=value,
+            operator_open_id="",
+            question_id=question_id,
+            answer_key=answer_key,
+            run_manager=run_manager,
+        )
+    except Exception:
+        logger.warning("[DingTalk] card action handler failed", exc_info=True)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run pytest tests/unit/im/test_dingtalk_interactions.py -v --no-cov 2>&1 | tail -10
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+git add cubebox/im/dingtalk/interactions.py tests/unit/im/test_dingtalk_interactions.py
+git commit -m "feat(im): add DingTalk card action handler"
+```
+
+---
+
+## Task 5: DingTalk gateway — Stream mode lifecycle
+
+Manages a `dingtalk-stream` client per account. Registers chat message + card action callback handlers.
+
+**Files:**
+- Create: `backend/cubebox/im/dingtalk/gateway.py`
+
+- [ ] **Step 1: Implement DingtalkGateway**
+
+```python
+# backend/cubebox/im/dingtalk/gateway.py
+"""DingTalk Stream gateway — one long-connection per IM account."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from loguru import logger
+
+from cubebox.im.dingtalk.connector import DingtalkConnector
+
+
+class DingtalkGateway:
+    """Manages one DingTalk Stream client per IM account."""
+
+    def __init__(
+        self,
+        *,
+        account: Any,
+        app_key: str,
+        app_secret: str,
+        ingest: Any,
+        session_maker: Any,
+        run_manager: Any,
+        redis_key_prefix: str,
+    ) -> None:
+        self._account = account
+        self._app_key = app_key
+        self._app_secret = app_secret
+        self._ingest = ingest
+        self._session_maker = session_maker
+        self._run_manager = run_manager
+        self._redis_key_prefix = redis_key_prefix
+        self._client: Any = None
+        self._task: asyncio.Task[None] | None = None
+        self._access_token: str = ""
+
+    async def start(self) -> None:
+        import dingtalk_stream
+
+        credential = dingtalk_stream.Credential(self._app_key, self._app_secret)
+        client = dingtalk_stream.AIMClient(credential=credential)
+        self._client = client
+
+        account = self._account
+        session_maker = self._session_maker
+        ingest = self._ingest
+        run_manager = self._run_manager
+        redis_key_prefix = self._redis_key_prefix
+
+        async def on_message(raw: dict[str, Any]) -> None:
+            await self._handle_inbound(raw, account, session_maker, ingest)
+
+        async def on_card_action(raw: dict[str, Any]) -> None:
+            from cubebox.im.dingtalk.interactions import handle_card_action
+
+            await handle_card_action(
+                callback=raw,
+                run_manager=run_manager,
+            )
+
+        client.register_callback_handler(
+            dingtalk_stream.ChatbotMessage.TOPIC,
+            _CallbackHandler(on_message),
+        )
+        client.register_callback_handler(
+            "/v1.0/card/instances/callback",
+            _CallbackHandler(on_card_action),
+        )
+
+        async def _run() -> None:
+            try:
+                client.start()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception(
+                    "[DingTalk] Stream client crashed for {}", account.id
+                )
+
+        self._task = asyncio.create_task(_run(), name=f"dingtalk-gateway:{account.id}")
+
+        def _on_task_done(task: asyncio.Task[None]) -> None:
+            exc = task.exception() if not task.cancelled() else None
+            if exc is not None:
+                logger.error(
+                    "[DingTalk] gateway task crashed for {}: {}",
+                    account.id,
+                    exc,
+                    exc_info=exc,
+                )
+
+        self._task.add_done_callback(_on_task_done)
+        logger.info("[DingTalk] Gateway started for account {}", account.id)
+
+    async def _handle_inbound(
+        self,
+        raw: dict[str, Any],
+        account: Any,
+        session_maker: Any,
+        ingest: Any,
+    ) -> None:
+        connector = DingtalkConnector(bot_user_id=self._app_key)
+        parsed = connector.parse_inbound(raw)
+        if parsed is None:
+            return
+        parsed.account_external_id = account.external_account_id
+
+        gate_connector = DingtalkConnector(
+            bot_user_id=self._app_key,
+            access_token=self._access_token,
+            conversation_id=parsed.channel_id,
+        )
+        try:
+            result = await ingest(
+                parsed,
+                account=account,
+                session_maker=session_maker,
+                identity_resolver=gate_connector,
+                rejection_notifier=gate_connector,
+            )
+            logger.info(
+                "[DingTalk] inbound {}: {}",
+                parsed.platform_event_id,
+                result.outcome,
+            )
+        except Exception:
+            logger.exception(
+                "[DingTalk] ingest failed for {}", parsed.platform_event_id
+            )
+
+    async def stop(self) -> None:
+        if self._client is not None:
+            try:
+                self._client.stop()
+            except Exception:
+                pass
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+        logger.info(
+            "[DingTalk] Gateway stopped for account {}", self._account.id
+        )
+
+    def is_open(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    async def refresh_access_token(self) -> str:
+        """Refresh the access token for outbound API calls."""
+        import httpx
+
+        url = "https://api.dingtalk.com/v1.0/oauth2/accessToken"
+        payload = {"appKey": self._app_key, "appSecret": self._app_secret}
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(url, json=payload)
+            data = resp.json()
+            token = data.get("accessToken", "")
+            self._access_token = token
+            return token
+
+    @property
+    def access_token(self) -> str:
+        return self._access_token
+
+
+class _CallbackHandler:
+    """Adapts an async handler to the dingtalk-stream callback interface."""
+
+    def __init__(self, handler: Any) -> None:
+        self._handler = handler
+
+    async def process(self, callback: Any) -> Any:
+        import dingtalk_stream
+
+        try:
+            data = json.loads(callback.data) if isinstance(callback.data, str) else callback.data
+            await self._handler(data)
+        except Exception:
+            logger.warning("[DingTalk] callback handler error", exc_info=True)
+        return dingtalk_stream.AckMessage.STATUS_OK, "OK"
+```
+
+Note: The `dingtalk-stream` SDK's exact API surface needs to be verified at implementation time. The `_CallbackHandler` wrapper class adapts our async handlers to the SDK's callback protocol. The gateway's `start()` may need adjustment based on whether `client.start()` is blocking or async.
+
+- [ ] **Step 2: Verify mypy passes**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run mypy cubebox/im/dingtalk/ 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+git add cubebox/im/dingtalk/gateway.py
+git commit -m "feat(im): add DingtalkGateway — Stream mode lifecycle"
+```
+
+---
+
+## Task 6: DingTalk platform connector + registration
+
+Implements `PlatformConnector` protocol and wires everything together. Registers with the platform registry.
+
+**Files:**
+- Create: `backend/cubebox/im/dingtalk/_platform.py`
+- Modify: `backend/cubebox/im/dingtalk/__init__.py`
+- Modify: `backend/cubebox/im/runtime.py` (line 121–123: add dingtalk import)
+- Modify: `backend/cubebox/services/im_connector.py` (add `compute_runtime` handling for `"stream"`)
+
+- [ ] **Step 1: Implement DingtalkPlatform**
+
+```python
+# backend/cubebox/im/dingtalk/_platform.py
+"""DingtalkPlatform — PlatformConnector implementation for DingTalk."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from loguru import logger
+
+
+class DingtalkPlatform:
+    """PlatformConnector for DingTalk (Stream mode only)."""
+
+    def parse_inbound(self, raw: dict[str, Any]) -> Any:
+        from cubebox.im.dingtalk.connector import DingtalkConnector
+
+        connector = DingtalkConnector()
+        return connector.parse_inbound(raw)
+
+    async def build_tailer(
+        self, *, run_id: str, queue_item: Any, account: Any, **kwargs: Any
+    ) -> Any:
+        from cubebox.im.dingtalk.connector import DingtalkConnector
+        from cubebox.im.dingtalk.renderer import DingtalkOpDispatcher
+        from cubebox.im.outbound import OutboundRunTailer
+        from cubebox.im.types import RenderState
+
+        app = kwargs["app"]
+        gateways: dict[str, Any] = kwargs.get("gateways", {})
+        load_secrets = kwargs.get("load_secrets")
+
+        access_token = ""
+        gw = gateways.get(account.id)
+        if gw is not None:
+            access_token = gw.access_token
+            if not access_token:
+                try:
+                    access_token = await gw.refresh_access_token()
+                except Exception:
+                    logger.warning(
+                        "[DingTalk] token refresh failed for {}", account.id
+                    )
+
+        connector = DingtalkConnector(
+            bot_user_id=account.external_account_id,
+            access_token=access_token,
+            conversation_id=queue_item.channel_id,
+        )
+
+        cfg = account.config or {}
+        state = RenderState(
+            bot_name=cfg.get("bot_app_name") or "cubebox",
+            run_id=run_id,
+            reply_to_id=queue_item.reply_to_id,
+            inbound_message_id=queue_item.inbound_message_id,
+            stream_interval=1.0,
+        )
+
+        card_template_id = cfg.get("card_template_id", "")
+        op_dispatcher = DingtalkOpDispatcher(
+            connector=connector,
+            state=state,
+            card_template_id=card_template_id,
+            open_conversation_id=queue_item.channel_id,
+        )
+
+        tailer = OutboundRunTailer(
+            redis=app.state.redis,
+            key_prefix=app.state.redis_key_prefix,
+            run_id=run_id,
+            connector=connector,
+            state=state,
+            dispatcher=op_dispatcher,
+            responder_open_id=queue_item.sender_open_id,
+        )
+        asyncio.create_task(tailer.run(), name=f"im-tailer:{run_id}")
+
+    async def on_account_enabled(self, account: Any, **kwargs: Any) -> None:
+        from cubebox.im.dingtalk.gateway import DingtalkGateway
+        from cubebox.im.inbound import ingest_inbound_event
+
+        secrets: dict[str, Any] = kwargs.get("secrets", {})
+        gateways: dict[str, Any] = kwargs.get("gateways", {})
+        session_maker = kwargs.get("session_maker")
+        run_manager = kwargs.get("run_manager")
+        redis_key_prefix: str = kwargs.get("redis_key_prefix", "")
+
+        app_key = str(secrets.get("app_key") or "")
+        app_secret = str(secrets.get("app_secret") or "")
+        if not app_key or not app_secret:
+            logger.warning(
+                "[DingTalk] skipping account {} — missing credentials",
+                account.id,
+            )
+            return
+
+        gw = DingtalkGateway(
+            account=account,
+            app_key=app_key,
+            app_secret=app_secret,
+            ingest=ingest_inbound_event,
+            session_maker=session_maker,
+            run_manager=run_manager,
+            redis_key_prefix=redis_key_prefix,
+        )
+        await gw.refresh_access_token()
+        await gw.start()
+        gateways[account.id] = gw
+
+    async def on_account_disabled(self, account: Any, **kwargs: Any) -> None:
+        gateways: dict[str, Any] = kwargs.get("gateways", {})
+        gw = gateways.pop(account.id, None)
+        if gw is not None:
+            await gw.stop()
+```
+
+- [ ] **Step 2: Update `__init__.py` to register the platform**
+
+```python
+# backend/cubebox/im/dingtalk/__init__.py
+from cubebox.im.dingtalk._platform import DingtalkPlatform
+from cubebox.im.registry import register_platform
+
+register_platform("dingtalk", DingtalkPlatform())
+```
+
+- [ ] **Step 3: Add dingtalk import to runtime.py**
+
+In `backend/cubebox/im/runtime.py`, add `import cubebox.im.dingtalk` alongside the other platform imports (after line 123):
+
+```python
+    import cubebox.im.discord  # noqa: F401
+    import cubebox.im.feishu  # noqa: F401
+    import cubebox.im.slack  # noqa: F401
+    import cubebox.im.dingtalk  # noqa: F401
+```
+
+Also update the `delivery_mode.in_()` filter (lines 262–264 and the identical filter in `_sweep`) to include `"stream"`:
+
+```python
+IMConnectorAccount.delivery_mode.in_(
+    ["long_connection", "gateway", "stream"]
+),
+```
+
+- [ ] **Step 4: Update compute_runtime for "stream" delivery mode**
+
+In `backend/cubebox/services/im_connector.py`, add a `"stream"` branch in `compute_runtime()` (after the `"gateway"` branch around line 53):
+
+```python
+    elif account.delivery_mode in ("gateway", "stream"):
+```
+
+Merge the `"gateway"` and `"stream"` checks since they both use the `gateways` dict.
+
+- [ ] **Step 5: Update enable route delivery_mode check**
+
+In `backend/cubebox/api/routes/v1/ws_im.py` line 352, update:
+
+```python
+    if updated.delivery_mode in ("long_connection", "gateway", "stream"):
+```
+
+- [ ] **Step 6: Verify mypy passes**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run mypy cubebox/im/dingtalk/ cubebox/im/runtime.py cubebox/services/im_connector.py cubebox/api/routes/v1/ws_im.py 2>&1 | tail -10
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+git add cubebox/im/dingtalk/_platform.py cubebox/im/dingtalk/__init__.py cubebox/im/runtime.py cubebox/services/im_connector.py cubebox/api/routes/v1/ws_im.py
+git commit -m "feat(im): add DingtalkPlatform + wire into runtime + delivery_mode=stream"
+```
+
+---
+
+## Task 7: Backend connect route + service
+
+Adds `connect_dingtalk()` service method, schema, and route dispatch branch.
+
+**Files:**
+- Modify: `backend/cubebox/api/schemas/im_connector.py`
+- Modify: `backend/cubebox/services/im_connector.py`
+- Modify: `backend/cubebox/api/routes/v1/ws_im.py`
+
+- [ ] **Step 1: Add ConnectDingtalkAccountIn schema**
+
+In `backend/cubebox/api/schemas/im_connector.py`, add after `ConnectSlackAccountIn`:
+
+```python
+class ConnectDingtalkAccountIn(BaseModel):
+    """Payload for ``POST /ws/{ws}/im/accounts`` when ``platform == 'dingtalk'``."""
+
+    platform: Literal["dingtalk"] = "dingtalk"
+    app_key: str = Field(min_length=1, max_length=128)
+    app_secret: str = Field(min_length=1)
+    acting_user_id: str = Field(default="self", min_length=1)
+```
+
+Update the `ConnectIMAccountIn` union to include it:
+
+```python
+ConnectIMAccountIn = Annotated[
+    Annotated[ConnectFeishuAccountIn, Tag("feishu")]
+    | Annotated[ConnectDiscordAccountIn, Tag("discord")]
+    | Annotated[ConnectSlackAccountIn, Tag("slack")]
+    | Annotated[ConnectDingtalkAccountIn, Tag("dingtalk")],
+    Discriminator("platform"),
+]
+```
+
+- [ ] **Step 2: Add connect_dingtalk service method**
+
+In `backend/cubebox/services/im_connector.py`, add after `connect_slack`:
+
+```python
+    async def connect_dingtalk(
+        self,
+        *,
+        workspace_id: str,
+        app_key: str,
+        app_secret: str,
+        acting_user_id: str,
+    ) -> IMConnectorAccount:
+        """Bind one DingTalk enterprise bot: validate credentials, store, return account."""
+        existing = (
+            await self._session.execute(
+                select(IMConnectorAccount).where(
+                    IMConnectorAccount.org_id == self._org_id,
+                    IMConnectorAccount.platform == "dingtalk",
+                    IMConnectorAccount.external_account_id == app_key,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            raise ValueError(
+                f"dingtalk account already exists for app_key={app_key} (id={existing.id})"
+            )
+
+        bot_name, bot_avatar_url = await self._hydrate_dingtalk_bot_info(
+            app_key, app_secret
+        )
+
+        secret_payload = json.dumps(
+            {
+                "app_key": app_key,
+                "app_secret": app_secret,
+                "bot_open_id": app_key,
+            }
+        )
+        try:
+            credential_id = await self._credentials.create(
+                kind="im_bot",
+                name=f"dingtalk:{app_key}",
+                plaintext=secret_payload,
+            )
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise ValueError(
+                f"dingtalk account already exists for app_key={app_key} (credential race)"
+            ) from exc
+        try:
+            account = IMConnectorAccount(
+                org_id=self._org_id,
+                workspace_id=workspace_id,
+                platform="dingtalk",
+                external_account_id=app_key,
+                acting_user_id=acting_user_id,
+                credential_id=credential_id,
+                delivery_mode="stream",
+                config={
+                    "bot_app_name": bot_name or None,
+                    "bot_avatar_url": bot_avatar_url or None,
+                },
+            )
+            self._session.add(account)
+            await self._session.commit()
+            await self._session.refresh(account)
+            return account
+        except Exception:
+            await self._session.rollback()
+            try:
+                await self._credentials.delete(credential_id=credential_id)
+            except Exception:
+                logger.warning(
+                    "[IM] orphan credential {} could not be rolled back",
+                    credential_id,
+                    exc_info=True,
+                )
+            raise
+
+    async def _hydrate_dingtalk_bot_info(
+        self,
+        app_key: str,
+        app_secret: str,
+    ) -> tuple[str, str]:
+        """Validate credentials via access token exchange and return bot info."""
+        import httpx
+
+        url = "https://api.dingtalk.com/v1.0/oauth2/accessToken"
+        payload = {"appKey": app_key, "appSecret": app_secret}
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(url, json=payload)
+            if resp.status_code != 200:
+                raise ValueError(f"DingTalk credential validation failed: {resp.text}")
+            data = resp.json()
+            token = data.get("accessToken")
+            if not token:
+                raise ValueError("DingTalk returned empty access token")
+
+        # Best-effort bot name/avatar — not all DingTalk APIs expose this
+        # reliably for enterprise internal bots. Return empty if unavailable.
+        return ("", "")
+```
+
+- [ ] **Step 3: Add route dispatch branch**
+
+In `backend/cubebox/api/routes/v1/ws_im.py`:
+
+Add import at top:
+```python
+from cubebox.api.schemas.im_connector import ConnectDingtalkAccountIn
+```
+
+Add `_connect_dingtalk` handler (following the Slack pattern):
+```python
+async def _connect_dingtalk(
+    body: ConnectDingtalkAccountIn,
+    request: Request,
+    ctx: RequestContext,
+    session: AsyncSession,
+    backend: EncryptionBackend,
+) -> IMAccountOut:
+    svc = _service(session, backend, ctx)
+    acting = await _resolve_acting_user(body.acting_user_id, ctx, session)
+    try:
+        account = await svc.connect_dingtalk(
+            workspace_id=ctx.workspace_id,
+            app_key=body.app_key,
+            app_secret=body.app_secret,
+            acting_user_id=acting,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    starter = getattr(request.app.state, "im_connect_account", None)
+    if starter is not None and account.enabled:
+        try:
+            await starter(account)
+        except Exception:
+            logger.warning(
+                "[IM ws] dingtalk gateway startup failed for {}",
+                account.id,
+                exc_info=True,
+            )
+    return _to_out(account)
+```
+
+Add the `elif` branch in `connect_account`:
+```python
+    elif isinstance(body, ConnectDingtalkAccountIn):
+        return await _connect_dingtalk(body, request, ctx, session, backend)
+```
+
+- [ ] **Step 4: Verify mypy passes**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run mypy cubebox/api/schemas/im_connector.py cubebox/services/im_connector.py cubebox/api/routes/v1/ws_im.py 2>&1 | tail -10
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+git add cubebox/api/schemas/im_connector.py cubebox/services/im_connector.py cubebox/api/routes/v1/ws_im.py
+git commit -m "feat(im): add DingTalk connect route + service method"
+```
+
+---
+
+## Task 8: Frontend — @cubebox/core schema + platform descriptor
+
+Adds the `ConnectDingtalkAccountIn` type to the core package and creates the frontend platform descriptor.
+
+**Files:**
+- Modify: `frontend/packages/core/src/api/im.ts`
+- Create: `frontend/packages/web/components/im/ImConnectWizard/platforms/dingtalk.ts`
+- Modify: `frontend/packages/web/components/im/ImConnectWizard/platforms/types.ts`
+- Modify: `frontend/packages/web/components/im/ImConnectWizard/platforms/index.ts`
+- Modify: `frontend/packages/web/components/im/PlatformLogo.tsx`
+- Modify: `frontend/packages/web/messages/en.json`
+- Modify: `frontend/packages/web/messages/zh.json`
+
+- [ ] **Step 1: Add ConnectDingtalkAccountIn to @cubebox/core**
+
+In `frontend/packages/core/src/api/im.ts`, add:
+
+```typescript
+export interface ConnectDingtalkAccountIn {
+  platform: 'dingtalk'
+  app_key: string
+  app_secret: string
+  acting_user_id?: string
+}
+```
+
+Update the `ConnectImAccountIn` union:
+
+```typescript
+export type ConnectImAccountIn =
+  | ConnectFeishuAccountIn
+  | ConnectDiscordAccountIn
+  | ConnectSlackAccountIn
+  | ConnectDingtalkAccountIn
+```
+
+- [ ] **Step 2: Widen PlatformDescriptor.id union**
+
+In `frontend/packages/web/components/im/ImConnectWizard/platforms/types.ts`, add `'dingtalk'` to the `id` union:
+
+```typescript
+id: 'feishu' | 'discord' | 'slack' | 'teams' | 'dingtalk'
+```
+
+- [ ] **Step 3: Create dingtalk.ts platform descriptor**
+
+```typescript
+// frontend/packages/web/components/im/ImConnectWizard/platforms/dingtalk.ts
+import type { PlatformDescriptor } from './types'
+
+export const dingtalkDescriptor: PlatformDescriptor = {
+  id: 'dingtalk',
+  labelKey: 'im.platform.dingtalk.label',
+  iconName: 'dingtalk',
+  live: true,
+  prereqs: [
+    {
+      key: 'app',
+      labelKey: 'im.wizard.dingtalk.prereq.app',
+      helpUrl: () => 'https://open.dingtalk.com/document/orgapp/create-orgapp',
+    },
+    {
+      key: 'stream',
+      labelKey: 'im.wizard.dingtalk.prereq.stream',
+    },
+    {
+      key: 'permissions',
+      labelKey: 'im.wizard.dingtalk.prereq.permissions',
+      items: [
+        'qyapi_chat_manage',
+        'qyapi_robot_sendmsg',
+        'Contact.User.Read',
+      ],
+    },
+    {
+      key: 'credentials',
+      labelKey: 'im.wizard.dingtalk.prereq.credentials',
+    },
+  ],
+  credentialFields: [
+    {
+      key: 'app_key',
+      labelKey: 'im.wizard.dingtalk.field.appKey',
+      type: 'text',
+      required: true,
+      placeholder: 'ding...',
+    },
+    {
+      key: 'app_secret',
+      labelKey: 'im.wizard.dingtalk.field.appSecret',
+      type: 'password',
+      required: true,
+    },
+  ],
+  steps: [
+    { key: 'prereqs', labelKey: 'im.wizard.step.prereqs', Component: null as any },
+    { key: 'credentials', labelKey: 'im.wizard.step.credentials', Component: null as any },
+    { key: 'verify', labelKey: 'im.wizard.step.verify', Component: null as any },
+  ],
+  buildPayload: (form) => ({
+    platform: 'dingtalk' as const,
+    app_key: form.app_key ?? '',
+    app_secret: form.app_secret ?? '',
+    acting_user_id: 'self',
+  }),
+  scopeConsoleUrl: () => 'https://open.dingtalk.com',
+}
+```
+
+Note: The `steps` array's `Component` references should use the same step components as other platforms (StepPrereqs, StepCredentials, StepVerify). Look at how `slack.ts` imports and uses them, and follow the same pattern. The `null as any` above is a placeholder — replace with the actual component imports at implementation time.
+
+- [ ] **Step 4: Register in platforms/index.ts**
+
+Add import and include in `ALL_PLATFORMS`:
+
+```typescript
+import { dingtalkDescriptor } from './dingtalk'
+
+export const ALL_PLATFORMS: PlatformDescriptor[] = [
+  feishuDescriptor,
+  discordDescriptor,
+  slackDescriptor,
+  dingtalkDescriptor,
+  teamsDescriptor,
+]
+```
+
+- [ ] **Step 5: Add DingTalk logo to PlatformLogo.tsx**
+
+Add a `DingtalkLogo` SVG component (use the official DingTalk logo mark — a simple geometric shape). Add it to the `LOGOS` map:
+
+```typescript
+dingtalk: DingtalkLogo,
+```
+
+- [ ] **Step 6: Add i18n keys**
+
+In `frontend/packages/web/messages/en.json`, add under `"im"`:
+
+```json
+"platform": {
+  "dingtalk": { "label": "DingTalk" }
+},
+"wizard": {
+  "dingtalk": {
+    "field": {
+      "appKey": "AppKey (ding...)",
+      "appSecret": "AppSecret"
+    },
+    "prereq": {
+      "app": "Create an enterprise internal bot at open.dingtalk.com",
+      "stream": "Enable Stream Mode in the bot settings",
+      "permissions": "Grant these permissions to the bot",
+      "credentials": "Copy the AppKey and AppSecret from the bot settings"
+    }
+  }
+}
+```
+
+In `frontend/packages/web/messages/zh.json`, add equivalent Chinese translations.
+
+- [ ] **Step 7: Build core + check frontend types**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/frontend
+pnpm --filter @cubebox/core build
+pnpm --filter @cubebox/web tsc --noEmit 2>&1 | tail -10
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/frontend
+git add packages/core/src/api/im.ts \
+  packages/web/components/im/ImConnectWizard/platforms/dingtalk.ts \
+  packages/web/components/im/ImConnectWizard/platforms/types.ts \
+  packages/web/components/im/ImConnectWizard/platforms/index.ts \
+  packages/web/components/im/PlatformLogo.tsx \
+  packages/web/messages/en.json \
+  packages/web/messages/zh.json
+git commit -m "feat(im): add DingTalk frontend platform descriptor + core schema"
+```
+
+---
+
+## Task 9: Keyword-based link command
+
+DingTalk has no slash commands. The bot recognizes the keyword "link" and generates a JWT identity-link URL.
+
+**Files:**
+- Modify: `backend/cubebox/im/dingtalk/connector.py` (add link keyword detection)
+- Modify: `backend/cubebox/im/dingtalk/gateway.py` (check for link keyword before ingest)
+
+- [ ] **Step 1: Add link keyword detection to connector**
+
+Add a method to `DingtalkConnector`:
+
+```python
+    def is_link_command(self, raw: dict[str, Any]) -> bool:
+        """Check if the message is a 'link' keyword command."""
+        text_obj = raw.get("text") or {}
+        text: str = text_obj.get("content", "").strip().lower()
+        return text in ("link", "/link")
+```
+
+- [ ] **Step 2: Add link handling to gateway**
+
+In `DingtalkGateway._handle_inbound`, before calling `ingest`, check for the link keyword:
+
+```python
+    connector = DingtalkConnector(bot_user_id=self._app_key)
+    if connector.is_link_command(raw):
+        await self._handle_link_command(raw)
+        return
+    # ... rest of existing parse + ingest logic
+```
+
+Add `_handle_link_command` method to `DingtalkGateway`:
+
+```python
+    async def _handle_link_command(self, raw: dict[str, Any]) -> None:
+        """Handle the 'link' keyword by sending an identity-link URL."""
+        sender_staff_id = raw.get("senderStaffId", "")
+        conversation_id = raw.get("conversationId", "")
+        if not sender_staff_id or not conversation_id:
+            return
+
+        try:
+            from cubebox.im.link import get_frontend_base_url, get_jwt_secret, sign_link_token
+
+            token = sign_link_token(
+                im_user_id=sender_staff_id,
+                email="",
+                account_id=self._account.id,
+                workspace_id=self._account.workspace_id,
+                platform="dingtalk",
+                secret=get_jwt_secret(),
+            )
+        except Exception:
+            logger.warning("[DingTalk] sign_link_token failed", exc_info=True)
+            return
+
+        base = get_frontend_base_url()
+        url = f"{base}/im-link?token={token}"
+
+        gate_connector = DingtalkConnector(
+            bot_user_id=self._app_key,
+            access_token=self._access_token,
+            conversation_id=conversation_id,
+        )
+        await gate_connector.reply_markdown(
+            title="Link your account",
+            text=f"Click to bind your cubebox account:\n\n[Link your account]({url})",
+            open_conversation_id=conversation_id,
+        )
+```
+
+- [ ] **Step 3: Verify mypy passes**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run mypy cubebox/im/dingtalk/ 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+git add cubebox/im/dingtalk/connector.py cubebox/im/dingtalk/gateway.py
+git commit -m "feat(im): add DingTalk keyword-based link command"
+```
+
+---
+
+## Task 10: Pre-PR sweep — mypy + ruff + unit tests
+
+Run the full backend checks before opening a PR.
+
+- [ ] **Step 1: Run mypy on the full backend**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+mkdir -p tmp
+uv run mypy cubebox/ 2>&1 | tee tmp/mypy.log | tail -5
+```
+
+- [ ] **Step 2: Run ruff**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run ruff check cubebox/im/dingtalk/ tests/unit/im/test_dingtalk_*.py 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Run unit tests**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/backend
+uv run pytest tests/unit/im/test_dingtalk_*.py -v --no-cov 2>&1 | tee tmp/test.log | tail -15
+```
+
+- [ ] **Step 4: Run frontend type check**
+
+```bash
+cd /home/chris/cubebox/.worktrees/feat/2026-06-19-im-dingtalk/frontend
+pnpm --filter @cubebox/core build && pnpm --filter @cubebox/web tsc --noEmit 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Fix any issues found, then commit**
+
+```bash
+git add -A && git commit -m "fix: pre-PR sweep fixes"
+```

--- a/docs/dev/plans/2026-06-19-dingtalk-im-connector.md
+++ b/docs/dev/plans/2026-06-19-dingtalk-im-connector.md
@@ -167,9 +167,11 @@ Expected: FAIL — `DingtalkConnector` not found.
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
+import httpx
 from loguru import logger
 
 from cubebox.im.outbound import _FloodSignal
@@ -198,10 +200,12 @@ class DingtalkConnector:
         bot_user_id: str = "",
         access_token: str = "",
         conversation_id: str = "",
+        http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self._bot_user_id = bot_user_id
         self._access_token = access_token
         self._conversation_id = conversation_id
+        self._http = http_client or httpx.AsyncClient(timeout=10)
 
     # ------------------------------------------------------------------
     # Inbound
@@ -256,9 +260,13 @@ class DingtalkConnector:
     # Outbound — card + message API calls
     # ------------------------------------------------------------------
 
-    async def send_markdown(self, title: str, text: str) -> str | None:
-        """Send a plain markdown message. Returns msgId or None."""
-        import httpx
+    async def send_markdown(
+        self, title: str, text: str, *, user_ids: list[str] | None = None
+    ) -> str | None:
+        """Send a proactive markdown message to specific users. Returns processQueryKey or None."""
+        if not user_ids:
+            logger.warning("[DingTalk] send_markdown called with no user_ids")
+            return None
 
         url = "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend"
         headers = {
@@ -266,18 +274,17 @@ class DingtalkConnector:
             "Content-Type": "application/json",
         }
         payload = {
-            "msgParam": f'{{"title":"{title}","text":"{text}"}}',
+            "msgParam": json.dumps({"title": title, "text": text}),
             "msgKey": "sampleMarkdown",
             "robotCode": self._bot_user_id,
-            "userIds": [],
+            "userIds": user_ids,
         }
         try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.post(url, headers=headers, json=payload)
-                if resp.status_code == 200:
-                    return resp.json().get("processQueryKey")
-                logger.warning("[DingTalk] send_markdown failed: {}", resp.text)
-                return None
+            resp = await self._http.post(url, headers=headers, json=payload)
+            if resp.status_code == 200:
+                return resp.json().get("processQueryKey")
+            logger.warning("[DingTalk] send_markdown failed: {}", resp.text)
+            return None
         except Exception:
             logger.warning("[DingTalk] send_markdown error", exc_info=True)
             return None
@@ -289,30 +296,25 @@ class DingtalkConnector:
         *,
         open_conversation_id: str = "",
     ) -> str | None:
-        """Reply to a conversation with markdown. Returns msgId."""
-        import httpx
-
+        """Reply to a conversation with markdown. Returns processQueryKey."""
         cid = open_conversation_id or self._conversation_id
-        url = (
-            "https://api.dingtalk.com/v1.0/robot/groupMessages/send"
-        )
+        url = "https://api.dingtalk.com/v1.0/robot/groupMessages/send"
         headers = {
             "x-acs-dingtalk-access-token": self._access_token,
             "Content-Type": "application/json",
         }
         payload = {
-            "msgParam": f'{{"title":"{title}","text":"{text}"}}',
+            "msgParam": json.dumps({"title": title, "text": text}),
             "msgKey": "sampleMarkdown",
             "robotCode": self._bot_user_id,
             "openConversationId": cid,
         }
         try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.post(url, headers=headers, json=payload)
-                if resp.status_code == 200:
-                    return resp.json().get("processQueryKey")
-                logger.warning("[DingTalk] reply_markdown failed: {}", resp.text)
-                return None
+            resp = await self._http.post(url, headers=headers, json=payload)
+            if resp.status_code == 200:
+                return resp.json().get("processQueryKey")
+            logger.warning("[DingTalk] reply_markdown failed: {}", resp.text)
+            return None
         except Exception:
             logger.warning("[DingTalk] reply_markdown error", exc_info=True)
             return None
@@ -330,8 +332,6 @@ class DingtalkConnector:
         out_track_id: str,
     ) -> bool:
         """Create + deliver an interactive card instance."""
-        import httpx
-
         url = "https://api.dingtalk.com/v1.0/card/instances/createAndDeliver"
         headers = {
             "x-acs-dingtalk-access-token": self._access_token,
@@ -344,14 +344,13 @@ class DingtalkConnector:
             "cardData": {"cardParamMap": card_data},
         }
         try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.post(url, headers=headers, json=payload)
-                if resp.status_code == 200:
-                    return True
-                logger.warning(
-                    "[DingTalk] create_and_deliver_card failed: {}", resp.text
-                )
-                return False
+            resp = await self._http.post(url, headers=headers, json=payload)
+            if resp.status_code == 200:
+                return True
+            logger.warning(
+                "[DingTalk] create_and_deliver_card failed: {}", resp.text
+            )
+            return False
         except Exception:
             logger.warning("[DingTalk] create_and_deliver_card error", exc_info=True)
             return False
@@ -360,14 +359,13 @@ class DingtalkConnector:
         self,
         *,
         out_track_id: str,
+        guid: str,
         key: str,
         content: str,
         is_final: bool = False,
         is_error: bool = False,
     ) -> bool:
-        """Stream-update a card variable."""
-        import httpx
-
+        """Stream-update a card variable. DingTalk requires PUT, not POST."""
         url = "https://api.dingtalk.com/v1.0/card/streaming"
         headers = {
             "x-acs-dingtalk-access-token": self._access_token,
@@ -375,6 +373,7 @@ class DingtalkConnector:
         }
         payload: dict[str, Any] = {
             "outTrackId": out_track_id,
+            "guid": guid,
             "key": key,
             "content": content,
             "isFull": True,
@@ -382,14 +381,13 @@ class DingtalkConnector:
             "isError": is_error,
         }
         try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.post(url, headers=headers, json=payload)
-                if resp.status_code == 200:
-                    return True
-                if resp.status_code == 429:
-                    raise DingtalkRateLimitError("rate limited")
-                logger.warning("[DingTalk] streaming_update failed: {}", resp.text)
-                return False
+            resp = await self._http.put(url, headers=headers, json=payload)
+            if resp.status_code == 200:
+                return True
+            if resp.status_code == 429:
+                raise DingtalkRateLimitError("rate limited")
+            logger.warning("[DingTalk] streaming_update failed: {}", resp.text)
+            return False
         except DingtalkRateLimitError:
             raise
         except Exception:
@@ -403,8 +401,6 @@ class DingtalkConnector:
         card_data: dict[str, Any],
     ) -> bool:
         """Update card data (buttons, status) via PUT."""
-        import httpx
-
         url = "https://api.dingtalk.com/v1.0/card/instances"
         headers = {
             "x-acs-dingtalk-access-token": self._access_token,
@@ -415,12 +411,11 @@ class DingtalkConnector:
             "cardData": {"cardParamMap": card_data},
         }
         try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.put(url, headers=headers, json=payload)
-                if resp.status_code == 200:
-                    return True
-                logger.warning("[DingTalk] update_card_actions failed: {}", resp.text)
-                return False
+            resp = await self._http.put(url, headers=headers, json=payload)
+            if resp.status_code == 200:
+                return True
+            logger.warning("[DingTalk] update_card_actions failed: {}", resp.text)
+            return False
         except Exception:
             logger.warning("[DingTalk] update_card_actions error", exc_info=True)
             return False
@@ -431,21 +426,18 @@ class DingtalkConnector:
 
     async def resolve_email(self, open_id: str) -> str | None:
         """Look up a DingTalk user's email by staffId."""
-        import httpx
-
         url = "https://oapi.dingtalk.com/topapi/v2/user/get"
         params = {"access_token": self._access_token}
         payload = {"userid": open_id}
         try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.post(url, params=params, json=payload)
-                data = resp.json()
-                if data.get("errcode") != 0:
-                    logger.warning("[DingTalk] user/get failed: {}", data)
-                    return None
-                result = data.get("result", {})
-                email = result.get("email") or result.get("org_email") or ""
-                return email.strip().lower() if email else None
+            resp = await self._http.post(url, params=params, json=payload)
+            data = resp.json()
+            if data.get("errcode") != 0:
+                logger.warning("[DingTalk] user/get failed: {}", data)
+                return None
+            result = data.get("result", {})
+            email = result.get("email") or result.get("org_email") or ""
+            return email.strip().lower() if email else None
         except Exception:
             logger.warning("[DingTalk] resolve_email error", exc_info=True)
             return None
@@ -643,6 +635,7 @@ class DingtalkOpDispatcher:
         self._card_template_id = card_template_id
         self._open_conversation_id = open_conversation_id
         self._pending_input_sent_id: str | None = None
+        self._stream_seq: int = 0
 
     async def dispatch_create(self, state: Any) -> bool:
         s = self._state
@@ -673,9 +666,12 @@ class DingtalkOpDispatcher:
         if s.card_unavailable:
             return True
         full_content = s.card_state.streaming_content
+        self._stream_seq += 1
+        guid = f"{s.card_id}-{self._stream_seq}"
         try:
             ok = await self._connector.streaming_update_card(
                 out_track_id=s.card_id,
+                guid=guid,
                 key="content",
                 content=full_content,
             )
@@ -701,8 +697,10 @@ class DingtalkOpDispatcher:
             self._pending_input_sent_id = pending_id
 
         if pending is not None and pending.resolved_choice is not None:
+            # HITL resolved — next card starts fresh, reset stream state
             s.card_id = None
             s.card_unavailable = False
+            self._stream_seq = 0
         return True
 
     async def _send_pending_input_buttons(self, pending: Any) -> None:
@@ -753,8 +751,10 @@ class DingtalkOpDispatcher:
 
         if s.card_id and not s.card_unavailable:
             status = "error" if s.card_state.error else "done"
+            self._stream_seq += 1
             await self._connector.streaming_update_card(
                 out_track_id=s.card_id,
+                guid=f"{s.card_id}-{self._stream_seq}",
                 key="content",
                 content=full_content,
                 is_final=True,
@@ -971,6 +971,7 @@ import asyncio
 import json
 from typing import Any
 
+import dingtalk_stream
 from loguru import logger
 
 from cubebox.im.dingtalk.connector import DingtalkConnector
@@ -999,13 +1000,19 @@ class DingtalkGateway:
         self._redis_key_prefix = redis_key_prefix
         self._client: Any = None
         self._task: asyncio.Task[None] | None = None
+        self._refresh_task: asyncio.Task[None] | None = None
         self._access_token: str = ""
+        self.card_template_id: str = ""
 
     async def start(self) -> None:
-        import dingtalk_stream
+        # Register the interactive card template (idempotent — DingTalk
+        # deduplicates by template name). Store the ID for build_tailer.
+        tpl_id = await self._register_card_template()
+        if tpl_id:
+            self.card_template_id = tpl_id
 
         credential = dingtalk_stream.Credential(self._app_key, self._app_secret)
-        client = dingtalk_stream.AIMClient(credential=credential)
+        client = dingtalk_stream.DingTalkStreamClient(credential=credential)
         self._client = client
 
         account = self._account
@@ -1036,7 +1043,7 @@ class DingtalkGateway:
 
         async def _run() -> None:
             try:
-                client.start()
+                await client.start()
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -1057,6 +1064,22 @@ class DingtalkGateway:
                 )
 
         self._task.add_done_callback(_on_task_done)
+
+        # Periodic token refresh — DingTalk access tokens expire every 2h
+        async def _token_loop() -> None:
+            while True:
+                await asyncio.sleep(6000)  # refresh every ~100 minutes
+                try:
+                    await self.refresh_access_token()
+                    logger.debug("[DingTalk] token refreshed for {}", account.id)
+                except Exception:
+                    logger.warning(
+                        "[DingTalk] token refresh failed for {}", account.id, exc_info=True
+                    )
+
+        self._refresh_task = asyncio.create_task(
+            _token_loop(), name=f"dingtalk-token-refresh:{account.id}"
+        )
         logger.info("[DingTalk] Gateway started for account {}", account.id)
 
     async def _handle_inbound(
@@ -1096,6 +1119,12 @@ class DingtalkGateway:
             )
 
     async def stop(self) -> None:
+        if self._refresh_task is not None:
+            self._refresh_task.cancel()
+            try:
+                await self._refresh_task
+            except (asyncio.CancelledError, Exception):
+                pass
         if self._client is not None:
             try:
                 self._client.stop()
@@ -1120,8 +1149,8 @@ class DingtalkGateway:
 
         url = "https://api.dingtalk.com/v1.0/oauth2/accessToken"
         payload = {"appKey": self._app_key, "appSecret": self._app_secret}
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.post(url, json=payload)
+        async with httpx.AsyncClient(timeout=10) as http:
+            resp = await http.post(url, json=payload)
             data = resp.json()
             token = data.get("accessToken", "")
             self._access_token = token
@@ -1131,16 +1160,49 @@ class DingtalkGateway:
     def access_token(self) -> str:
         return self._access_token
 
+    async def _register_card_template(self) -> str:
+        """Register the cubebox streaming card template. Returns template ID."""
+        import httpx
 
-class _CallbackHandler:
-    """Adapts an async handler to the dingtalk-stream callback interface."""
+        url = "https://api.dingtalk.com/v1.0/card/templates"
+        headers = {
+            "x-acs-dingtalk-access-token": self._access_token,
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "cardTemplateJson": json.dumps({
+                "config": {"autoLayout": True},
+                "header": {},
+                "cardContentList": [
+                    {"id": "content", "type": "markdown", "props": {"content": "${content}"}},
+                    {"id": "status", "type": "text", "props": {"content": "${status}"}},
+                ],
+                "cardActionList": [],
+            }),
+        }
+        try:
+            async with httpx.AsyncClient(timeout=10) as http:
+                resp = await http.post(url, headers=headers, json=payload)
+                data = resp.json()
+                tpl_id = data.get("cardTemplateId", "")
+                if tpl_id:
+                    logger.info("[DingTalk] card template registered: {}", tpl_id)
+                else:
+                    logger.warning("[DingTalk] card template registration returned no ID: {}", data)
+                return tpl_id
+        except Exception:
+            logger.warning("[DingTalk] card template registration failed", exc_info=True)
+            return ""
+
+
+class _CallbackHandler(dingtalk_stream.CallbackHandler):
+    """Subclasses the SDK's CallbackHandler to route events to our async handler."""
 
     def __init__(self, handler: Any) -> None:
+        super().__init__()
         self._handler = handler
 
-    async def process(self, callback: Any) -> Any:
-        import dingtalk_stream
-
+    async def process(self, callback: dingtalk_stream.CallbackMessage) -> tuple[str, str]:
         try:
             data = json.loads(callback.data) if isinstance(callback.data, str) else callback.data
             await self._handler(data)
@@ -1149,7 +1211,7 @@ class _CallbackHandler:
         return dingtalk_stream.AckMessage.STATUS_OK, "OK"
 ```
 
-Note: The `dingtalk-stream` SDK's exact API surface needs to be verified at implementation time. The `_CallbackHandler` wrapper class adapts our async handlers to the SDK's callback protocol. The gateway's `start()` may need adjustment based on whether `client.start()` is blocking or async.
+Note: The `dingtalk-stream` SDK's exact API surface needs to be verified at implementation time. `_CallbackHandler` subclasses the SDK's `dingtalk_stream.CallbackHandler` base class — the SDK dispatches callbacks via its `process()` method. `DingTalkStreamClient.start()` is awaitable.
 
 - [ ] **Step 2: Verify mypy passes**
 
@@ -1240,7 +1302,7 @@ class DingtalkPlatform:
             stream_interval=1.0,
         )
 
-        card_template_id = cfg.get("card_template_id", "")
+        card_template_id = (gw.card_template_id if gw else "") or cfg.get("card_template_id", "")
         op_dispatcher = DingtalkOpDispatcher(
             connector=connector,
             state=state,
@@ -1765,10 +1827,19 @@ Add a method to `DingtalkConnector`:
 
 ```python
     def is_link_command(self, raw: dict[str, Any]) -> bool:
-        """Check if the message is a 'link' keyword command."""
+        """Check if the message is a 'link <email>' keyword command."""
         text_obj = raw.get("text") or {}
         text: str = text_obj.get("content", "").strip().lower()
-        return text in ("link", "/link")
+        return text.startswith("link ") or text in ("link", "/link")
+
+    def parse_link_email(self, raw: dict[str, Any]) -> str:
+        """Extract email from a 'link alice@example.com' command. Returns '' if no email."""
+        text_obj = raw.get("text") or {}
+        text: str = text_obj.get("content", "").strip()
+        parts = text.split(maxsplit=1)
+        if len(parts) == 2 and "@" in parts[1]:
+            return parts[1].strip().lower()
+        return ""
 ```
 
 - [ ] **Step 2: Add link handling to gateway**
@@ -1787,10 +1858,25 @@ Add `_handle_link_command` method to `DingtalkGateway`:
 
 ```python
     async def _handle_link_command(self, raw: dict[str, Any]) -> None:
-        """Handle the 'link' keyword by sending an identity-link URL."""
+        """Handle 'link alice@example.com' by sending an identity-link URL."""
         sender_staff_id = raw.get("senderStaffId", "")
         conversation_id = raw.get("conversationId", "")
         if not sender_staff_id or not conversation_id:
+            return
+
+        connector = DingtalkConnector(bot_user_id=self._app_key)
+        email = connector.parse_link_email(raw)
+        if not email:
+            gate_connector = DingtalkConnector(
+                bot_user_id=self._app_key,
+                access_token=self._access_token,
+                conversation_id=conversation_id,
+            )
+            await gate_connector.reply_markdown(
+                title="Link",
+                text="Usage: `link alice@example.com`",
+                open_conversation_id=conversation_id,
+            )
             return
 
         try:
@@ -1798,7 +1884,7 @@ Add `_handle_link_command` method to `DingtalkGateway`:
 
             token = sign_link_token(
                 im_user_id=sender_staff_id,
-                email="",
+                email=email,
                 account_id=self._account.id,
                 workspace_id=self._account.workspace_id,
                 platform="dingtalk",

--- a/docs/dev/plans/2026-06-19-dingtalk-im-connector.md
+++ b/docs/dev/plans/2026-06-19-dingtalk-im-connector.md
@@ -493,6 +493,19 @@ class DingtalkConnector:
             open_conversation_id=chat_id,
             user_id=self._sender_staff_id if self._is_dm else "",
         )
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks (called by OutboundRunTailer on the connector)
+    # ------------------------------------------------------------------
+
+    async def on_processing_start(self, state: Any) -> None:
+        pass
+
+    async def on_processing_complete(self, state: Any) -> None:
+        pass
+
+    async def on_processing_failed(self, state: Any) -> None:
+        pass
 ```
 
 - [ ] **Step 5: Run tests to verify they pass**

--- a/docs/dev/plans/2026-06-19-dingtalk-im-connector.md
+++ b/docs/dev/plans/2026-06-19-dingtalk-im-connector.md
@@ -100,9 +100,10 @@ class TestParseInbound:
         assert event.reply_to_id == "msg_001"
 
     def test_group_at_mention(self) -> None:
+        # DingTalk strips the @BotName tag and delivers a leading space
         raw = {
             "msgtype": "text",
-            "text": {"content": "@cubebox what time is it"},
+            "text": {"content": " what time is it"},
             "msgId": "msg_002",
             "conversationId": "cid_group_456",
             "conversationType": "2",
@@ -200,12 +201,26 @@ class DingtalkConnector:
         bot_user_id: str = "",
         access_token: str = "",
         conversation_id: str = "",
+        sender_staff_id: str = "",
+        is_dm: bool = False,
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self._bot_user_id = bot_user_id
         self._access_token = access_token
         self._conversation_id = conversation_id
-        self._http = http_client or httpx.AsyncClient(timeout=10)
+        self._sender_staff_id = sender_staff_id
+        self._is_dm = is_dm
+        self._http_ext = http_client
+        self._http_own: httpx.AsyncClient | None = None
+
+    @property
+    def _http(self) -> httpx.AsyncClient:
+        """Lazy-init httpx client; avoids allocation for parse-only connectors."""
+        if self._http_ext is not None:
+            return self._http_ext
+        if self._http_own is None:
+            self._http_own = httpx.AsyncClient(timeout=10)
+        return self._http_own
 
     # ------------------------------------------------------------------
     # Inbound
@@ -295,20 +310,42 @@ class DingtalkConnector:
         text: str,
         *,
         open_conversation_id: str = "",
+        user_id: str = "",
     ) -> str | None:
-        """Reply to a conversation with markdown. Returns processQueryKey."""
+        """Reply to a conversation with markdown.
+
+        For group conversations, uses groupMessages/send with openConversationId.
+        For DM conversations, uses oToMessages/batchSend with userIds (since
+        DingTalk's group endpoint rejects single-chat conversationIds).
+        Pass ``user_id`` (staffId) for DM replies.
+        """
         cid = open_conversation_id or self._conversation_id
-        url = "https://api.dingtalk.com/v1.0/robot/groupMessages/send"
         headers = {
             "x-acs-dingtalk-access-token": self._access_token,
             "Content-Type": "application/json",
         }
-        payload = {
-            "msgParam": json.dumps({"title": title, "text": text}),
-            "msgKey": "sampleMarkdown",
-            "robotCode": self._bot_user_id,
-            "openConversationId": cid,
-        }
+        msg_param = json.dumps({"title": title, "text": text})
+        # Default to stored DM user for reply routing
+        effective_user_id = user_id or (self._sender_staff_id if self._is_dm else "")
+
+        if effective_user_id:
+            # DM: single-chat reply via proactive message endpoint
+            url = "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend"
+            payload = {
+                "msgParam": msg_param,
+                "msgKey": "sampleMarkdown",
+                "robotCode": self._bot_user_id,
+                "userIds": [effective_user_id],
+            }
+        else:
+            # Group: reply via group messages endpoint
+            url = "https://api.dingtalk.com/v1.0/robot/groupMessages/send"
+            payload = {
+                "msgParam": msg_param,
+                "msgKey": "sampleMarkdown",
+                "robotCode": self._bot_user_id,
+                "openConversationId": cid,
+            }
         try:
             resp = await self._http.post(url, headers=headers, json=payload)
             if resp.status_code == 200:
@@ -454,6 +491,7 @@ class DingtalkConnector:
             title="Notice",
             text=text,
             open_conversation_id=chat_id,
+            user_id=self._sender_staff_id if self._is_dm else "",
         )
 ```
 
@@ -661,10 +699,10 @@ class DingtalkOpDispatcher:
 
     async def dispatch_stream(self, state: Any, text: str) -> bool:
         s = self._state
-        if s.card_id is None:
-            return await self.dispatch_create(state)
         if s.card_unavailable:
             return True
+        if s.card_id is None:
+            return await self.dispatch_create(state)
         full_content = s.card_state.streaming_content
         self._stream_seq += 1
         guid = f"{s.card_id}-{self._stream_seq}"
@@ -693,7 +731,11 @@ class DingtalkOpDispatcher:
             and pending.choices
             and pending_id != self._pending_input_sent_id
         ):
-            await self._send_pending_input_buttons(pending)
+            if s.card_unavailable or s.card_id is None:
+                # Card path is down — surface HITL via plain text fallback
+                await self._emergency_pending_input(pending)
+            else:
+                await self._send_pending_input_buttons(pending)
             self._pending_input_sent_id = pending_id
 
         if pending is not None and pending.resolved_choice is not None:
@@ -702,6 +744,14 @@ class DingtalkOpDispatcher:
             s.card_unavailable = False
             self._stream_seq = 0
         return True
+
+    async def _emergency_pending_input(self, pending: Any) -> None:
+        """Fallback: send HITL question as plain markdown when card is unavailable."""
+        text = pending.question or "Please continue in the cubebox web UI."
+        if pending.choices:
+            labels = ", ".join(label for label, _, _ in pending.choices)
+            text = f"{text}\n\nOptions: {labels}\n\n_(Please answer in the web UI.)_"
+        await self.emergency_text(text)
 
     async def _send_pending_input_buttons(self, pending: Any) -> None:
         """Update the card with action buttons for AskUser/SandboxConfirm."""
@@ -971,6 +1021,7 @@ import asyncio
 import json
 from typing import Any
 
+import httpx
 import dingtalk_stream
 from loguru import logger
 
@@ -1003,6 +1054,7 @@ class DingtalkGateway:
         self._refresh_task: asyncio.Task[None] | None = None
         self._access_token: str = ""
         self.card_template_id: str = ""
+        self._shared_http = httpx.AsyncClient(timeout=10)
 
     async def start(self) -> None:
         # Register the interactive card template (idempotent — DingTalk
@@ -1095,10 +1147,14 @@ class DingtalkGateway:
             return
         parsed.account_external_id = account.external_account_id
 
+        is_dm = parsed.scope_kind == "dm"
         gate_connector = DingtalkConnector(
             bot_user_id=self._app_key,
             access_token=self._access_token,
             conversation_id=parsed.channel_id,
+            sender_staff_id=parsed.sender_ref,
+            is_dm=is_dm,
+            http_client=self._shared_http,
         )
         try:
             result = await ingest(
@@ -1136,6 +1192,7 @@ class DingtalkGateway:
                 await self._task
             except (asyncio.CancelledError, Exception):
                 pass
+        await self._shared_http.aclose()
         logger.info(
             "[DingTalk] Gateway stopped for account {}", self._account.id
         )
@@ -1287,10 +1344,13 @@ class DingtalkPlatform:
                         "[DingTalk] token refresh failed for {}", account.id
                     )
 
+        is_dm = queue_item.scope_kind == "dm"
         connector = DingtalkConnector(
             bot_user_id=account.external_account_id,
             access_token=access_token,
             conversation_id=queue_item.channel_id,
+            sender_staff_id=queue_item.sender_open_id,
+            is_dm=is_dm,
         )
 
         cfg = account.config or {}

--- a/docs/dev/specs/2026-06-19-dingtalk-im-connector-design.md
+++ b/docs/dev/specs/2026-06-19-dingtalk-im-connector-design.md
@@ -162,7 +162,7 @@ Action ID format: `im:dingtalk:{run_id}:{short_qid}:{akey}:{value}`
 account:
 
 - `start(account)`: decrypt AppKey + AppSecret from credential vault,
-  create `dingtalk_stream.AIMClient`, register callback handlers
+  create `dingtalk_stream.DingTalkStreamClient`, register callback handlers
   (chat message + card action), connect. Spawned as background task.
 - `stop()`: disconnect the stream client, cancel the background task.
 - `is_open()`: check if the stream connection is alive.
@@ -275,7 +275,6 @@ generation (already configured for other IM connectors).
 | `im/dingtalk/connector.py` | parse_inbound, outbound card/message API, identity resolution |
 | `im/dingtalk/gateway.py` | DingTalk Stream lifecycle |
 | `im/dingtalk/renderer.py` | DingtalkOpDispatcher: interactive card rendering |
-| `im/dingtalk/card_builder.py` | Card template + instance JSON construction |
 | `im/dingtalk/interactions.py` | Card action callback handling |
 | `frontend/.../platforms/dingtalk.ts` | Platform descriptor |
 | `@cubebox/core` schema | ConnectDingtalkAccountIn |

--- a/docs/dev/specs/2026-06-19-dingtalk-im-connector-design.md
+++ b/docs/dev/specs/2026-06-19-dingtalk-im-connector-design.md
@@ -1,0 +1,298 @@
+# DingTalk IM Connector
+
+Adds DingTalk (钉钉) as the fourth IM platform in cubebox, following the
+existing Feishu, Slack, and Discord connectors. The existing
+connector-neutral pipeline (inbound transaction, queue worker, identity
+resolution, resume) is fully reused; DingTalk-specific logic lives in a
+new `im/dingtalk/` module that registers with the platform registry.
+
+## Scope
+
+**In scope (v1):**
+
+- Stream mode gateway (WebSocket long-connection via `dingtalk-stream` SDK)
+- Enterprise internal bot only (AppKey + AppSecret)
+- Receive messages: single chat (DM) + group @mention
+- Outbound: interactive card with streaming updates + markdown content
+- AskUser / SandboxConfirm via interactive card action buttons
+- Identity resolution: email auto-match + manual link fallback
+- Artifact share links (appended to final card)
+- Frontend connect wizard (platform descriptor)
+
+**Out of scope:**
+
+- ISV / third-party enterprise bots (SuiteKey + OAuth授权)
+- Custom webhook-only bots (no interaction capability)
+- DingTalk work notifications (非会话推送)
+- Group topic/thread support (DingTalk groups are flat)
+- Cool App (酷应用) / Mini Program (小程序) embedding
+- Voice / video messages
+
+## Connection: Stream Mode Only
+
+DingTalk Stream is a WebSocket long-connection that pushes events to the
+bot server — no public endpoint required. This matches the Slack
+(Socket Mode) and Feishu (long-connection) pattern.
+
+The `dingtalk-stream` Python SDK handles the WebSocket lifecycle:
+connection, heartbeat, reconnect, and event routing. The bot registers
+callback handlers for chat messages and interactive card actions.
+
+`delivery_mode` is always `"stream"` for DingTalk accounts.
+
+Credential: AppKey + AppSecret, stored in the credential vault at
+connect time. Access token management is handled by the stream SDK
+internally.
+
+## Scope Key Mapping
+
+DingTalk concepts mapped to `IMThreadLink(account_id, channel_id, scope_key)`:
+
+| Scenario | channel_id | scope_key | reply_to_id |
+|----------|-----------|-----------|-------------|
+| Single chat (DM) | `conversationId` | `"dm"` | `msgId` |
+| Group @mention | `conversationId` | `"u:{staffId}"` | `msgId` |
+
+DingTalk group chats are flat (no threads). Group conversations use
+per-user scope (`"u:{staffId}"`) for isolation — the same user talking
+to the bot in the same group shares one cubebox conversation, but
+different users get their own. This matches Feishu's group-chat model.
+
+`sender_ref` is the DingTalk `staffId` (stable within the enterprise).
+`sender_open_id` is also `staffId`.
+
+## Identity Resolution
+
+DingTalk connector implements both the `IdentityResolver` and
+`RejectionNotifier` protocols.
+
+**Auto-match (primary):** On first message from an unlinked user, call
+`GET /topapi/v2/user/get?userid={staffId}` to retrieve the user's
+enterprise email. If the email matches a cubebox user, create an
+`IMIdentityLink` automatically.
+
+**Manual link (fallback):** If email lookup fails or no match is found,
+send a rejection card to the user with a link URL. The URL is a JWT
+identity-link token (same mechanism as Slack/Feishu — `im/link.py`).
+The user clicks the link, logs in to cubebox, and the identity binding
+completes.
+
+**Rejection:** Unlinked users receive a card with the link prompt. The
+rejection card includes a brief explanation and a clickable URL button.
+
+## Inbound Flow
+
+```
+DingTalk Stream on_message callback
+  → filter: ignore bot self, ignore non-text
+  → DingtalkConnector.parse_inbound(raw) → InboundEvent
+  → ingest_inbound_event(event, account, session_maker,
+      identity_resolver=DingtalkConnector,
+      rejection_notifier=DingtalkConnector)
+  → atomic transaction: Receipt + ThreadLink + Conversation + RunQueueItem
+  → IMRunQueueWorker claims item (FOR UPDATE SKIP LOCKED)
+  → RunManager.start_run()
+  → on_run_started → registry.get_platform("dingtalk").build_tailer(...)
+  → asyncio.create_task(tailer.run())
+```
+
+Idempotency: DingTalk `msgId` serves as `platform_event_id`. Stream
+reconnect replays are caught by the `IMWebhookReceipt` unique index.
+
+The `parse_inbound` method strips bot @mention text
+(`@BotName` prefix) from the message before passing to the agent.
+
+## Outbound Rendering: Interactive Cards
+
+DingTalk interactive cards support markdown content, action buttons, and
+streaming updates — a close analogue to Feishu CardKit.
+
+### Card Lifecycle
+
+1. **Register card template** — on gateway start, register a reusable
+   card template via `POST /v1.0/card/templates`. The template defines
+   the card layout: a markdown body variable, an optional button group,
+   and a status indicator.
+
+2. **dispatch_create** — create a card instance
+   (`POST /v1.0/card/instances/createAndDeliver`), binding the template
+   to the target conversation. The card body starts with a "thinking..."
+   placeholder. Store the `outTrackId` as the card identifier.
+
+3. **dispatch_stream** — update the card body via streaming update
+   (`PUT /v1.0/card/streaming`). The `key` field identifies which
+   variable to update; `content` carries the incremental markdown. The
+   card auto-appends content as it arrives. Stream interval: ~1.0s
+   (DingTalk rate limits streaming updates to roughly 1/s per card).
+
+4. **dispatch_patch** — when AskUser / SandboxConfirm fires, update
+   the card to append action buttons. Each button carries a callback
+   payload with `{run_id, question_id, answer_key, value}`.
+
+5. **dispatch_finalize** — final card update with complete content.
+   Replace the "thinking" status indicator with success/error. Append
+   artifact share links if any. After finalize, mark the card as
+   immutable (disable further button clicks on resolved questions).
+
+6. **emergency_text** — fallback plain markdown message (not a card)
+   when card creation fails.
+
+### Card Template Design
+
+One shared template per bot account, registered at gateway start:
+
+- **body**: markdown variable `${content}` — receives streaming text
+- **status**: text variable `${status}` — "thinking" / "done" / "error"
+- **buttons**: dynamic button group `${actions}` — populated only during
+  AskUser/SandboxConfirm
+
+### Card Action Callbacks
+
+Button clicks arrive via the Stream connection's card callback handler.
+The callback payload includes the `outTrackId` and the button's
+`action` data. Route to `resume_paused_run` via the standard
+`im/resume.py` path.
+
+Action ID format: `im:dingtalk:{run_id}:{short_qid}:{akey}:{value}`
+(same convention as Slack/Feishu).
+
+## Gateway Lifecycle
+
+**`im/dingtalk/gateway.py`** manages one DingTalk Stream client per
+account:
+
+- `start(account)`: decrypt AppKey + AppSecret from credential vault,
+  create `dingtalk_stream.AIMClient`, register callback handlers
+  (chat message + card action), connect. Spawned as background task.
+- `stop()`: disconnect the stream client, cancel the background task.
+- `is_open()`: check if the stream connection is alive.
+
+Event handlers:
+
+- Chat message callback → `DingtalkConnector.parse_inbound(raw)` →
+  `ingest_inbound_event(...)`
+- Card action callback → route by action payload → `resume_paused_run`
+
+Connection status reported via `account.config["runtime_status"]`
+(same pattern as other platforms), polled by frontend.
+
+### Access Token
+
+The `dingtalk-stream` SDK manages access tokens internally. For outbound
+API calls that need a token (user info lookup, card operations), the
+connector uses the `get_access_token()` method provided by the SDK's
+client instance, or falls back to
+`POST /v1.0/oauth2/accessToken` with AppKey + AppSecret.
+
+## Link Command
+
+DingTalk bots don't have a built-in slash-command system like Slack.
+Instead, the bot recognizes the keyword `link` (case-insensitive) as a
+trigger. When a user sends "link" in a chat with the bot:
+
+1. Generate a JWT identity-link token (reusing `im/link.py`)
+2. Reply with a card containing the link URL as a clickable button
+3. The URL points to `{FRONTEND_BASE_URL}/im/link?token={jwt}`
+
+This is the same mechanism as the Slack `/link` command, just triggered
+by keyword instead of slash command.
+
+## Frontend
+
+### Platform Descriptor
+
+New file `platforms/dingtalk.ts` following the `PlatformDescriptor`
+shape:
+
+**Prerequisites checklist:**
+1. Create an enterprise internal bot in the DingTalk Developer Console
+   (open.dingtalk.com)
+2. Enable the "Stream Mode" option in the bot settings
+3. Copy the AppKey and AppSecret
+4. Grant the bot the necessary permissions: message receiving, user
+   info read, interactive card
+
+**Credential fields:**
+- `app_key` (text) — required
+- `app_secret` (password) — required
+
+**Steps:** prereqs → credentials → verify (same step components as
+other platforms)
+
+### Type Changes
+
+- `PlatformDescriptor.id`: add `'dingtalk'` to the union
+- `@cubebox/core`: add `ConnectDingtalkAccountIn` schema
+
+### Backend Connect Route
+
+`POST /ws/{ws}/im/accounts` dispatches `platform="dingtalk"` to
+`connect_dingtalk()` in `IMConnectorService`:
+
+1. Validate credentials by calling `POST /v1.0/oauth2/accessToken`
+   with AppKey + AppSecret
+2. Call `POST /v1.0/oauth2/userAccessToken` or bot info API to get
+   the bot's name/avatar for display
+3. Store credential (app_key, app_secret) in vault
+4. Create `IMConnectorAccount(platform="dingtalk",
+   delivery_mode="stream", external_account_id=app_key, ...)`
+5. Trigger gateway startup via `on_account_enabled`
+
+### No Changes Needed
+
+- `ImAccountListItem`, `ImAccountDetailPanel`, `ImAccountStatusPill` —
+  already platform-agnostic
+- `PlatformLogo` — add DingTalk logo asset
+- Enable/disable/delete routes — already platform-agnostic
+
+## Dependencies
+
+**Backend:** `dingtalk-stream` (via `uv add dingtalk-stream`) — the
+official DingTalk Stream SDK. Also `alibabacloud-dingtalk-oauth2` and
+`alibabacloud-dingtalk-im` for REST API calls (card operations, user
+info).
+
+Evaluate at implementation time whether the `dingtalk-stream` SDK's
+built-in API client covers all needed calls. If so, skip the separate
+`alibabacloud-dingtalk-*` packages and use raw httpx against the
+DingTalk OpenAPI v2 endpoints directly — fewer deps, simpler.
+
+**Frontend:** no new dependencies.
+
+**Configuration:** no new environment variables. AppKey and AppSecret
+are stored in the credential vault at connect time. The existing
+`CUBEBOX_FRONTEND_BASE_URL` env var is used for identity-link URL
+generation (already configured for other IM connectors).
+
+## File Change Summary
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `im/dingtalk/__init__.py` | Register DingtalkPlatform |
+| `im/dingtalk/_platform.py` | DingtalkPlatform: PlatformConnector implementation |
+| `im/dingtalk/connector.py` | parse_inbound, outbound card/message API, identity resolution |
+| `im/dingtalk/gateway.py` | DingTalk Stream lifecycle |
+| `im/dingtalk/renderer.py` | DingtalkOpDispatcher: interactive card rendering |
+| `im/dingtalk/card_builder.py` | Card template + instance JSON construction |
+| `im/dingtalk/interactions.py` | Card action callback handling |
+| `frontend/.../platforms/dingtalk.ts` | Platform descriptor |
+| `@cubebox/core` schema | ConnectDingtalkAccountIn |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `im/runtime.py` | Add `import cubebox.im.dingtalk` |
+| `api/schemas/im_connector.py` | Add ConnectDingtalkAccountIn, extend discriminated union |
+| `services/im_connector.py` | Add `connect_dingtalk()` |
+| `api/routes/v1/ws_im.py` | Dispatch connect by platform for dingtalk |
+| `frontend/.../platforms/types.ts` | Extend `PlatformDescriptor.id` union |
+
+### Unchanged
+
+- `im/inbound.py`, `im/worker.py`, `im/identity.py`, `im/resume.py`,
+  `im/outbound.py`, `im/card_model.py`
+- DB models (`IMConnectorAccount`, `IMThreadLink`, etc.)
+- Frontend generic IM components

--- a/frontend/packages/core/src/api/im.ts
+++ b/frontend/packages/core/src/api/im.ts
@@ -19,7 +19,7 @@ export interface ImAccount {
   external_account_id: string
   workspace_id: string
   acting_user_id: string
-  delivery_mode: 'long_connection' | 'webhook' | 'gateway'
+  delivery_mode: 'long_connection' | 'webhook' | 'gateway' | 'stream'
   enabled: boolean
   runtime: ImRuntimeStatus
   bot_app_name: string | null
@@ -55,10 +55,18 @@ export interface ConnectSlackAccountIn {
   acting_user_id?: string
 }
 
+export interface ConnectDingtalkAccountIn {
+  platform: 'dingtalk'
+  app_key: string
+  app_secret: string
+  acting_user_id?: string
+}
+
 export type ConnectImAccountIn =
   | ConnectFeishuAccountIn
   | ConnectDiscordAccountIn
   | ConnectSlackAccountIn
+  | ConnectDingtalkAccountIn
 
 // ── Workspace scope ──────────────────────────────────────────────────────────
 

--- a/frontend/packages/web/components/im/ImConnectWizard/platforms/dingtalk.ts
+++ b/frontend/packages/web/components/im/ImConnectWizard/platforms/dingtalk.ts
@@ -1,0 +1,73 @@
+import { StepCredentials } from '../steps/StepCredentials'
+import { StepPrereqs } from '../steps/StepPrereqs'
+import { StepVerify } from '../steps/StepVerify'
+
+import type { PlatformDescriptor } from './types'
+
+export const dingtalkDescriptor: PlatformDescriptor = {
+  id: 'dingtalk',
+  labelKey: 'im.platform.dingtalk.label',
+  iconName: 'dingtalk',
+  live: true,
+  prereqs: [
+    {
+      key: 'app',
+      labelKey: 'im.wizard.dingtalk.prereq.app',
+      helpUrl: () => 'https://open.dingtalk.com/document/orgapp/create-orgapp',
+    },
+    {
+      key: 'stream',
+      labelKey: 'im.wizard.dingtalk.prereq.stream',
+    },
+    {
+      key: 'permissions',
+      labelKey: 'im.wizard.dingtalk.prereq.permissions',
+      items: ['qyapi_chat_manage', 'qyapi_robot_sendmsg', 'Contact.User.Read'],
+    },
+    {
+      key: 'credentials',
+      labelKey: 'im.wizard.dingtalk.prereq.credentials',
+    },
+  ],
+  credentialFields: [
+    {
+      key: 'app_key',
+      labelKey: 'im.wizard.dingtalk.field.appKey',
+      type: 'text',
+      required: true,
+      placeholder: 'ding...',
+    },
+    {
+      key: 'app_secret',
+      labelKey: 'im.wizard.dingtalk.field.appSecret',
+      type: 'password',
+      required: true,
+    },
+  ],
+  steps: [
+    {
+      key: 'prereqs',
+      labelKey: 'im.wizard.step.prereqs',
+      Component: StepPrereqs,
+      canAdvance: () => true,
+    },
+    {
+      key: 'credentials',
+      labelKey: 'im.wizard.step.credentials',
+      Component: StepCredentials,
+      canAdvance: (f) => !!(f.app_key && f.app_secret),
+    },
+    {
+      key: 'verify',
+      labelKey: 'im.wizard.step.verify',
+      Component: StepVerify,
+    },
+  ],
+  buildPayload: (f) => ({
+    platform: 'dingtalk' as const,
+    app_key: f.app_key || '',
+    app_secret: f.app_secret || '',
+    acting_user_id: 'self',
+  }),
+  scopeConsoleUrl: () => 'https://open.dingtalk.com',
+}

--- a/frontend/packages/web/components/im/ImConnectWizard/platforms/index.ts
+++ b/frontend/packages/web/components/im/ImConnectWizard/platforms/index.ts
@@ -1,6 +1,7 @@
 export { feishuDescriptor } from './feishu'
 export { discordDescriptor } from './discord'
 export { slackDescriptor } from './slack'
+export { dingtalkDescriptor } from './dingtalk'
 export { teamsDescriptor } from './teams.stub'
 export type {
   PlatformDescriptor,
@@ -10,6 +11,7 @@ export type {
   FormState,
 } from './types'
 
+import { dingtalkDescriptor } from './dingtalk'
 import { discordDescriptor } from './discord'
 import { feishuDescriptor } from './feishu'
 import { slackDescriptor } from './slack'
@@ -20,5 +22,6 @@ export const ALL_PLATFORMS: PlatformDescriptor[] = [
   feishuDescriptor,
   discordDescriptor,
   slackDescriptor,
+  dingtalkDescriptor,
   teamsDescriptor,
 ]

--- a/frontend/packages/web/components/im/ImConnectWizard/platforms/types.ts
+++ b/frontend/packages/web/components/im/ImConnectWizard/platforms/types.ts
@@ -39,7 +39,7 @@ export type WizardStepDef = {
 }
 
 export type PlatformDescriptor = {
-  id: 'feishu' | 'discord' | 'slack' | 'teams'
+  id: 'feishu' | 'discord' | 'slack' | 'teams' | 'dingtalk'
   labelKey: string
   iconName: string
   live: boolean

--- a/frontend/packages/web/components/im/PlatformLogo.tsx
+++ b/frontend/packages/web/components/im/PlatformLogo.tsx
@@ -62,6 +62,21 @@ function TeamsLogo(props: SVGProps<SVGSVGElement>) {
   )
 }
 
+function DingtalkLogo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M512 0C229.2 0 0 229.2 0 512s229.2 512 512 512 512-229.2 512-512S794.8 0 512 0z"
+        fill="#3A96FF"
+      />
+      <path
+        d="M770.8 576.4c-6.4-14.6-23.6-40.8-23.6-40.8s-103.6 10-153.4 1.8c0 0 94.4-61.6 130.4-109 36-47.4 58.2-128.6 38.8-175.6-6.6-16-20.4-25.8-38-26.4-28.8-1-73 18.6-146.6 93.8-57.4 58.6-106 130.2-106 130.2l-27.6-7.8s22.8-104 11.2-143.8c-15.2-52.4-53.4-67.6-78.8-52.8-22.6 13.2-33.4 44.8-31 89 2.4 44.2 21 112.8 21 112.8s-79.4 83-118.4 167.8c-17.4 37.8-23.6 74.8-11.4 95.6 7.6 13 20.6 18.8 35.8 18.2 36.2-1.4 95.2-49.4 146.4-110.8 0 0 78.4 23.8 119 30.6 40.6 6.8 97.6 10.4 97.6 10.4s-36.2 55.4-41.2 83.2c-7.4 41 10.4 62 34.8 64.6 24.4 2.6 56.2-14.8 74.8-51.8 18.6-37 26.4-81.2 26.4-81.2s51.8-14 72.2-25.4c30.8-17.2 28.4-50.4-2.4-73.4z"
+        fill="#fff"
+      />
+    </svg>
+  )
+}
+
 function DiscordLogo(props: SVGProps<SVGSVGElement>) {
   return (
     <svg viewBox="0 0 256 199" xmlns="http://www.w3.org/2000/svg" {...props}>
@@ -75,6 +90,7 @@ function DiscordLogo(props: SVGProps<SVGSVGElement>) {
 
 const LOGOS: Record<string, (props: SVGProps<SVGSVGElement>) => React.ReactElement> = {
   feishu: FeishuLogo,
+  dingtalk: DingtalkLogo,
   discord: DiscordLogo,
   slack: SlackLogo,
   teams: TeamsLogo,

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -1925,7 +1925,7 @@
         "headline": "Connect your team's IM to cubebox",
         "description": "Bot replies in your chat, runs agents on @mentions, auto-routes to the right cubebox user by email.",
         "cta": "Connect a {platform} bot",
-        "comingNote": "Teams · DingTalk — coming later",
+        "comingNote": "Teams — coming later",
         "guideLink": "Setup guide"
       },
       "admin": {
@@ -1947,6 +1947,9 @@
       "teams": {
         "label": "Teams",
         "coming": "Coming soon"
+      },
+      "dingtalk": {
+        "label": "DingTalk"
       }
     },
     "status": {
@@ -2024,6 +2027,18 @@
         "field": {
           "botToken": "Bot Token (xoxb-...)",
           "appToken": "App Token (xapp-...)"
+        }
+      },
+      "dingtalk": {
+        "prereq": {
+          "app": "Create an enterprise internal bot at open.dingtalk.com",
+          "stream": "Enable Stream Mode in the bot settings",
+          "permissions": "Grant these permissions to the bot",
+          "credentials": "Copy the AppKey and AppSecret from the bot settings"
+        },
+        "field": {
+          "appKey": "AppKey (ding...)",
+          "appSecret": "AppSecret"
         }
       }
     },

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -1925,7 +1925,7 @@
         "headline": "把团队 IM 接到 cubebox",
         "description": "Bot 在 IM 里回复，@ 时跑 agent，按邮箱自动认领对应的 cubebox 用户。",
         "cta": "连接一个 {platform} bot",
-        "comingNote": "Teams · DingTalk — 后续支持",
+        "comingNote": "Teams — 即将推出",
         "guideLink": "查看部署指南"
       },
       "admin": {
@@ -1947,6 +1947,9 @@
       "teams": {
         "label": "Teams",
         "coming": "即将支持"
+      },
+      "dingtalk": {
+        "label": "钉钉"
       }
     },
     "status": {
@@ -2024,6 +2027,18 @@
         "field": {
           "botToken": "Bot Token (xoxb-...)",
           "appToken": "App Token (xapp-...)"
+        }
+      },
+      "dingtalk": {
+        "prereq": {
+          "app": "在 open.dingtalk.com 创建企业内部机器人",
+          "stream": "在机器人设置中启用 Stream 模式",
+          "permissions": "为机器人授予以下权限",
+          "credentials": "从机器人设置中复制 AppKey 和 AppSecret"
+        },
+        "field": {
+          "appKey": "AppKey (ding...)",
+          "appSecret": "AppSecret"
         }
       }
     },


### PR DESCRIPTION
## Summary

- Add full DingTalk IM connector: Stream mode gateway, inbound message parsing, interactive card rendering with streaming updates, card action handler for AskUser/SandboxConfirm buttons, and identity resolution
- Backend: `DingtalkConnector` (inbound + outbound API), `DingtalkOpDispatcher` (card renderer), `DingtalkGateway` (Stream lifecycle), `DingtalkPlatform` (registry wiring), connect route + service method, keyword-based `link` command for identity binding
- Frontend: `ConnectDingtalkAccountIn` core type, platform descriptor with prerequisites/credentials wizard, DingTalk logo SVG, i18n keys (en + zh)
- 10 unit tests covering connector parsing, card rendering, and action routing

## Design decisions

- **Stream mode** (`delivery_mode="stream"`) via `dingtalk-stream` SDK — WebSocket long-connection, same distributed Redis lease as other gateways
- **Interactive cards** with streaming updates (PUT `/v1.0/card/streaming`) for real-time agent output; falls back to plain markdown when card creation fails
- **DM vs group routing**: DM uses `oToMessages/batchSend` with userIds; group uses `groupMessages/send` with openConversationId
- **Scope keys**: DM → `"dm"`, group @mention → `"u:{staffId}"` (per-user isolation)
- **Link command**: keyword-based (`link alice@example.com`) since DingTalk has no slash commands

## Test plan

- [x] mypy strict — 432 source files, no issues
- [x] ruff check + format — all passed
- [x] 10 unit tests — connector parse (4), renderer ops (4), action handler (2) — all pass
- [x] Frontend tsc --noEmit — clean
- [x] Pre-push hooks (backend check-ci + frontend check-ci) — passed
- [ ] Manual: connect a DingTalk bot via the wizard, send @mention in group, verify card rendering + streaming
- [ ] Manual: send DM to bot, verify reply routing
- [ ] Manual: `link alice@example.com` → verify identity link URL generation