### PR TITLE
fix(alembic): linearize im_channel_bindings onto search drift fix

### DIFF
--- a/backend/alembic/versions/00fe892184fa_add_im_channel_bindings_table.py
+++ b/backend/alembic/versions/00fe892184fa_add_im_channel_bindings_table.py
@@ -1,7 +1,7 @@
 """add im_channel_bindings table
 
 Revision ID: 00fe892184fa
-Revises: 59fd2d03ce79
+Revises: e9dd15e7ab06
 Create Date: 2026-06-19 00:02:22.225347
 
 """
@@ -14,7 +14,10 @@ import sqlmodel  # noqa: F401  (referenced by sqlmodel.sql.sqltypes.AutoString i
 
 # revision identifiers, used by Alembic.
 revision: str = '00fe892184fa'
-down_revision: Union[str, Sequence[str], None] = '59fd2d03ce79'
+# Chained off e9dd15e7ab06 (search-tables drift fix, PR #254) instead of
+# 59fd2d03ce79 — PR #255 merged after #254 without rebasing, leaving main
+# with two alembic heads. Linearizing here so `alembic upgrade head` works.
+down_revision: Union[str, Sequence[str], None] = 'e9dd15e7ab06'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

Both #254 (search index drift fix, migration `e9dd15e7ab06`) and #255 (`im_channel_bindings`, migration `00fe892184fa`) merged with `down_revision='59fd2d03ce79'` without rebasing onto each other, leaving `main` with two alembic heads. `alembic upgrade head` errors out as a result:

```
ERROR [alembic.util.messaging] Multiple head revisions are present for given argument 'head';
please specify a specific target revision, '<branchname>@head' to narrow to a specific head,
or 'heads' for all heads
```

Per `CLAUDE.md` ("Migration head conflicts after rebase: edit the branch's first migration file to change its `down_revision` to main's new head"), chain the later-merged #255 migration onto the earlier-merged #254. Single-file change.

## Why this happened

Workflow gap: when #255 was rebased onto main right before its final merge, my #254 had already been merged but wasn't picked up — the rebase preserved its original `down_revision`. Worth a follow-up note in the worktrees doc, but out of scope for this PR.

## Test plan

- [x] `alembic heads` → single head (`00fe892184fa`)
- [x] `alembic history` → linear chain `59fd2d03ce79 → e9dd15e7ab06 → 00fe892184fa`
- [x] `upgrade head` → `downgrade -1` → `upgrade head` round-trip clean
- [x] Post-upgrade `alembic revision --autogenerate` produces empty diff
- [x] 17 IM channel-binding tests pass (`tests/e2e/test_im_channel_binding_crud.py`, `tests/e2e/test_im_shared_mode_ingest.py`, `tests/unit/im/test_im_scope_key_selection.py`)

cc @codex