### PR TITLE
feat(panel): navigable sandbox markdown links across previews

### DIFF
--- a/frontend/packages/core/src/stores/panelStore.ts
+++ b/frontend/packages/core/src/stores/panelStore.ts
@@ -56,7 +56,7 @@ export type PanelView =
       type: 'attachment'
       info: AttachmentPanelInfo
     }
-  | { type: 'sandbox' }
+  | { type: 'sandbox'; initialFilePath?: string; revision?: number }
   | { type: 'skill-candidate'; candidateId: string; repo: string | null; sourceName: string }
 
 export interface PanelStore {
@@ -77,12 +77,15 @@ export interface PanelStore {
 
   openSandbox: () => void
 
+  openSandboxFile: (path: string) => void
+
   openSkillCandidate: (candidateId: string, repo: string | null, sourceName: string) => void
 
   close: () => void
 }
 
 let highlightCounter = 0
+let sandboxRevisionCounter = 0
 
 export const usePanelStore = create<PanelStore>((set) => ({
   view: { type: 'closed' },
@@ -112,6 +115,11 @@ export const usePanelStore = create<PanelStore>((set) => ({
     }),
 
   openSandbox: () => set({ view: { type: 'sandbox' } }),
+
+  openSandboxFile: (path) =>
+    set({
+      view: { type: 'sandbox', initialFilePath: path, revision: ++sandboxRevisionCounter },
+    }),
 
   openSkillCandidate: (candidateId, repo, sourceName) =>
     set({ view: { type: 'skill-candidate', candidateId, repo, sourceName } }),

--- a/frontend/packages/web/__tests__/lib/sandboxLinks.test.ts
+++ b/frontend/packages/web/__tests__/lib/sandboxLinks.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { resolveSandboxHref } from '@/lib/sandboxLinks'
+
+const BASE = '/workspace/docs/index.md'
+
+describe('resolveSandboxHref', () => {
+  it('resolves sibling file', () => {
+    expect(resolveSandboxHref(BASE, '06-rollout/README.md')).toEqual({
+      kind: 'sandbox',
+      path: '/workspace/docs/06-rollout/README.md',
+      hash: null,
+    })
+  })
+
+  it('resolves explicit ./ prefix', () => {
+    expect(resolveSandboxHref(BASE, './notes.md')).toEqual({
+      kind: 'sandbox',
+      path: '/workspace/docs/notes.md',
+      hash: null,
+    })
+  })
+
+  it('resolves parent traversal', () => {
+    expect(resolveSandboxHref(BASE, '../other/file.md')).toEqual({
+      kind: 'sandbox',
+      path: '/workspace/other/file.md',
+      hash: null,
+    })
+  })
+
+  it('treats leading slash as workspace-root', () => {
+    expect(resolveSandboxHref(BASE, '/top.md')).toEqual({
+      kind: 'sandbox',
+      path: '/workspace/top.md',
+      hash: null,
+    })
+  })
+
+  it('preserves fragment in sandbox links', () => {
+    expect(resolveSandboxHref(BASE, 'guide.md#install')).toEqual({
+      kind: 'sandbox',
+      path: '/workspace/docs/guide.md',
+      hash: '#install',
+    })
+  })
+
+  it('flags absolute URLs as external', () => {
+    expect(resolveSandboxHref(BASE, 'https://example.com/x')).toEqual({
+      kind: 'external',
+      href: 'https://example.com/x',
+    })
+  })
+
+  it('flags mailto/tel as external', () => {
+    expect(resolveSandboxHref(BASE, 'mailto:a@b.co')).toEqual({
+      kind: 'external',
+      href: 'mailto:a@b.co',
+    })
+  })
+
+  it('flags protocol-relative URLs as external', () => {
+    expect(resolveSandboxHref(BASE, '//cdn.example.com/x.png')).toEqual({
+      kind: 'external',
+      href: '//cdn.example.com/x.png',
+    })
+  })
+
+  it('returns anchor for in-page fragments', () => {
+    expect(resolveSandboxHref(BASE, '#section')).toEqual({
+      kind: 'anchor',
+      hash: '#section',
+    })
+  })
+})

--- a/frontend/packages/web/__tests__/lib/sandboxLinks.test.ts
+++ b/frontend/packages/web/__tests__/lib/sandboxLinks.test.ts
@@ -111,4 +111,12 @@ describe('resolveSandboxHref', () => {
       hash: null,
     })
   })
+
+  it('clamps encoded-slash traversal hidden inside one raw segment', () => {
+    expect(resolveSandboxHref(BASE, '%2e%2e%2f%2e%2e%2f%2e%2e%2fetc/passwd')).toEqual({
+      kind: 'sandbox',
+      path: '/workspace',
+      hash: null,
+    })
+  })
 })

--- a/frontend/packages/web/__tests__/lib/sandboxLinks.test.ts
+++ b/frontend/packages/web/__tests__/lib/sandboxLinks.test.ts
@@ -71,4 +71,36 @@ describe('resolveSandboxHref', () => {
       hash: '#section',
     })
   })
+
+  it('decodes percent-escaped filenames', () => {
+    expect(resolveSandboxHref(BASE, 'Roadmap%202026.md')).toEqual({
+      kind: 'sandbox',
+      path: '/workspace/docs/Roadmap 2026.md',
+      hash: null,
+    })
+  })
+
+  it('strips query string but keeps fragment', () => {
+    expect(resolveSandboxHref(BASE, 'assets/flow.png?v=1#top')).toEqual({
+      kind: 'sandbox',
+      path: '/workspace/docs/assets/flow.png',
+      hash: '#top',
+    })
+  })
+
+  it('keeps invalid percent escapes literal instead of throwing', () => {
+    expect(resolveSandboxHref(BASE, 'bad%2.md')).toEqual({
+      kind: 'sandbox',
+      path: '/workspace/docs/bad%2.md',
+      hash: null,
+    })
+  })
+
+  it('clamps parent traversal past workspace root', () => {
+    expect(resolveSandboxHref(BASE, '../../../../etc/passwd')).toEqual({
+      kind: 'sandbox',
+      path: '/workspace',
+      hash: null,
+    })
+  })
 })

--- a/frontend/packages/web/__tests__/lib/sandboxLinks.test.ts
+++ b/frontend/packages/web/__tests__/lib/sandboxLinks.test.ts
@@ -103,4 +103,12 @@ describe('resolveSandboxHref', () => {
       hash: null,
     })
   })
+
+  it('clamps encoded parent traversal', () => {
+    expect(resolveSandboxHref(BASE, '%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd')).toEqual({
+      kind: 'sandbox',
+      path: '/workspace',
+      hash: null,
+    })
+  })
 })

--- a/frontend/packages/web/components/panel/FileReadView.tsx
+++ b/frontend/packages/web/components/panel/FileReadView.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'next-intl'
 import { MarkdownWithCitations } from '@/components/shared/MarkdownWithCitations'
 import { getFileVisual } from '@/lib/fileIcons'
 import { cn } from '@/lib/utils'
+import { useSandboxMarkdownContext } from '@/hooks/useSandboxMarkdownContext'
 
 interface Props {
   args: Record<string, unknown>
@@ -107,7 +108,7 @@ export function FileReadView({
         </div>
       </header>
       <MetaStrip parsed={parsed} args={args} />
-      <Body parsed={parsed} highlightText={highlightText} highlightKey={highlightKey} />
+      <Body parsed={parsed} path={path} highlightText={highlightText} highlightKey={highlightKey} />
     </div>
   )
 }
@@ -175,15 +176,18 @@ function Chip({
 
 function Body({
   parsed,
+  path,
   highlightText,
   highlightKey,
 }: {
   parsed: FileReadResult | null
+  path: string
   highlightText?: string | null
   highlightKey?: number
 }): React.ReactElement {
   const t = useTranslations('panel.fileRead')
   const bodyRef = useRef<HTMLDivElement>(null)
+  const sandboxCtx = useSandboxMarkdownContext(path || null)
   useEffect(() => {
     if (!highlightText || !bodyRef.current) return
     const el = bodyRef.current
@@ -205,7 +209,10 @@ function Body({
   if (parsed.kind === 'text') {
     return (
       <div ref={bodyRef} className="flex-1 overflow-y-auto p-4">
-        <MarkdownWithCitations className="prose prose-sm dark:prose-invert max-w-none">
+        <MarkdownWithCitations
+          className="prose prose-sm dark:prose-invert max-w-none"
+          sandbox={sandboxCtx ?? undefined}
+        >
           {(parsed as TextOutput).content}
         </MarkdownWithCitations>
       </div>
@@ -221,7 +228,10 @@ function Body({
               {cell.cell_type === 'code' ? `In [${i + 1}]` : cell.cell_type}
             </div>
             {cell.cell_type === 'markdown' ? (
-              <MarkdownWithCitations className="prose prose-sm dark:prose-invert max-w-none">
+              <MarkdownWithCitations
+                className="prose prose-sm dark:prose-invert max-w-none"
+                sandbox={sandboxCtx ?? undefined}
+              >
                 {cell.source}
               </MarkdownWithCitations>
             ) : (

--- a/frontend/packages/web/components/panel/WriteFilePreviewView.tsx
+++ b/frontend/packages/web/components/panel/WriteFilePreviewView.tsx
@@ -6,6 +6,7 @@ import type { ToolCallRef } from '@cubebox/core'
 import { proseClasses } from '@/lib/utils'
 import { MarkdownWithCitations } from '@/components/shared/MarkdownWithCitations'
 import { parseWriteFileArgs, resolveLiveWriteFile } from '@/lib/writeFilePreview'
+import { useSandboxMarkdownContext } from '@/hooks/useSandboxMarkdownContext'
 
 interface WriteFilePreviewViewProps {
   args: Record<string, unknown>
@@ -209,6 +210,7 @@ export function WriteFilePreviewView({ args, result, toolRef }: WriteFilePreview
   const mode = detectMode(filePath)
   const language = detectLanguage(filePath)
   const isStreaming = parsed.status === 'streaming_args'
+  const sandboxCtx = useSandboxMarkdownContext(parsed.filePath || null)
 
   const handleScroll = useCallback(() => {
     const el = scrollRef.current
@@ -249,7 +251,12 @@ export function WriteFilePreviewView({ args, result, toolRef }: WriteFilePreview
         </div>
 
         {mode === 'markdown' ? (
-          <MarkdownWithCitations className={`p-4 ${proseClasses}`}>{content}</MarkdownWithCitations>
+          <MarkdownWithCitations
+            className={`p-4 ${proseClasses}`}
+            sandbox={sandboxCtx ?? undefined}
+          >
+            {content}
+          </MarkdownWithCitations>
         ) : mode === 'code' ? (
           <CodePreview code={content} language={language} />
         ) : (

--- a/frontend/packages/web/components/panel/sandbox/SandboxFilePreview.tsx
+++ b/frontend/packages/web/components/panel/sandbox/SandboxFilePreview.tsx
@@ -6,6 +6,7 @@ import { csrfHeaders } from '@/lib/csrf'
 import { useSandboxFileContent } from '@/hooks/useSandboxFileContent'
 import type { SandboxFileEntry } from '@/hooks/useSandboxFiles'
 import { PreviewLoading } from '@/components/panel/artifact/PreviewLoading'
+import { MarkdownWithCitations } from '@/components/shared/MarkdownWithCitations'
 
 const OFFICE_EXTENSIONS = new Set(['.docx', '.xlsx', '.pptx'])
 const TEXT_EXTENSIONS = new Set([
@@ -72,12 +73,14 @@ interface SandboxFilePreviewProps {
   entry: SandboxFileEntry
   workspaceId: string
   conversationId?: string | null
+  onNavigate?: (path: string) => void
 }
 
 export function SandboxFilePreview({
   entry,
   workspaceId,
   conversationId,
+  onNavigate,
 }: SandboxFilePreviewProps) {
   const ext = getExtension(entry.name)
 
@@ -91,12 +94,74 @@ export function SandboxFilePreview({
       <HtmlFilePreview entry={entry} workspaceId={workspaceId} conversationId={conversationId} />
     )
   }
+  if (ext === '.md' && onNavigate) {
+    return (
+      <MarkdownFilePreview
+        entry={entry}
+        workspaceId={workspaceId}
+        conversationId={conversationId}
+        onNavigate={onNavigate}
+      />
+    )
+  }
   if (isTextFile(entry.name)) {
     return (
       <TextFilePreview entry={entry} workspaceId={workspaceId} conversationId={conversationId} />
     )
   }
   return <FallbackPreview entry={entry} workspaceId={workspaceId} conversationId={conversationId} />
+}
+
+function MarkdownFilePreview({
+  entry,
+  workspaceId,
+  conversationId,
+  onNavigate,
+}: {
+  entry: SandboxFileEntry
+  workspaceId: string
+  conversationId?: string | null
+  onNavigate: (path: string) => void
+}) {
+  const { content, error, loading } = useSandboxFileContent(workspaceId, entry.path, conversationId)
+
+  const resolveAssetUrl = useCallback(
+    (path: string) => {
+      const convQs = conversationId ? `&conversation_id=${encodeURIComponent(conversationId)}` : ''
+      return (
+        `/api/v1/ws/${workspaceId}` +
+        `/sandbox/files/download` +
+        `?path=${encodeURIComponent(path)}${convQs}`
+      )
+    },
+    [workspaceId, conversationId],
+  )
+
+  if (loading) return <PreviewLoading />
+  if (error?.message === 'FILE_TOO_LARGE') {
+    return (
+      <FallbackPreview entry={entry} workspaceId={workspaceId} conversationId={conversationId} />
+    )
+  }
+  if (error) {
+    return <div className="p-4 text-sm text-destructive">Failed to load: {error.message}</div>
+  }
+  if (content == null) return null
+
+  return (
+    <div className="h-full overflow-auto">
+      <MarkdownWithCitations
+        className="prose prose-sm dark:prose-invert max-w-none p-4"
+        sandbox={{
+          filePath: entry.path,
+          onNavigate,
+          resolveAssetUrl,
+        }}
+      >
+        {content}
+      </MarkdownWithCitations>
+    </div>
+  )
 }
 
 function TextFilePreview({

--- a/frontend/packages/web/components/panel/sandbox/SandboxFilesView.tsx
+++ b/frontend/packages/web/components/panel/sandbox/SandboxFilesView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
 import { SandboxFileTree } from './SandboxFileTree'
 import { SandboxFilePreview } from './SandboxFilePreview'
@@ -9,10 +9,40 @@ import type { SandboxFileEntry } from '@/hooks/useSandboxFiles'
 interface SandboxFilesViewProps {
   workspaceId: string
   conversationId?: string | null
+  initialFilePath?: string | null
+  initialFilePathRevision?: number | null
 }
 
-export function SandboxFilesView({ workspaceId, conversationId }: SandboxFilesViewProps) {
-  const [selectedFile, setSelectedFile] = useState<SandboxFileEntry | null>(null)
+function makeStubEntry(path: string): SandboxFileEntry {
+  return {
+    path,
+    name: path.slice(path.lastIndexOf('/') + 1),
+    is_dir: false,
+    size: 0,
+    modified_at: '',
+  }
+}
+
+export function SandboxFilesView({
+  workspaceId,
+  conversationId,
+  initialFilePath,
+  initialFilePathRevision,
+}: SandboxFilesViewProps) {
+  const [selectedFile, setSelectedFile] = useState<SandboxFileEntry | null>(() =>
+    initialFilePath ? makeStubEntry(initialFilePath) : null,
+  )
+
+  // Re-select whenever the panel store hands us a fresh navigation target
+  // (revision changes on every openSandboxFile call, even with same path).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing from external panel store
+    if (initialFilePath) setSelectedFile(makeStubEntry(initialFilePath))
+  }, [initialFilePath, initialFilePathRevision])
+
+  const handleNavigate = useCallback((path: string) => {
+    setSelectedFile(makeStubEntry(path))
+  }, [])
 
   return (
     <ResizablePanelGroup orientation="horizontal" className="h-full">
@@ -33,6 +63,7 @@ export function SandboxFilesView({ workspaceId, conversationId }: SandboxFilesVi
               entry={selectedFile}
               workspaceId={workspaceId}
               conversationId={conversationId}
+              onNavigate={handleNavigate}
             />
           </ResizablePanel>
         </>

--- a/frontend/packages/web/components/panel/sandbox/SandboxPanel.tsx
+++ b/frontend/packages/web/components/panel/sandbox/SandboxPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { FolderOpen, Globe, Loader2, TerminalSquare, RefreshCw, X } from 'lucide-react'
 import { usePanelStore } from '@cubebox/core'
 import { useSWRConfig } from 'swr'
@@ -31,9 +31,17 @@ export function SandboxPanel({ workspaceId, conversationId }: SandboxPanelProps)
   const [activeTab, setActiveTab] = useState<SandboxTab>('files')
   const [refreshing, setRefreshing] = useState(false)
   const close = usePanelStore((s) => s.close)
+  const sandboxView = usePanelStore((s) => (s.view.type === 'sandbox' ? s.view : null))
+  const initialFilePath = sandboxView?.initialFilePath ?? null
+  const sandboxRevision = sandboxView?.revision ?? null
   const { mutate } = useSWRConfig()
   const browserRefreshRef = useRef<(() => void) | null>(null)
   const terminalRefreshRef = useRef<(() => Promise<unknown>) | null>(null)
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing from external panel store
+    if (initialFilePath) setActiveTab('files')
+  }, [initialFilePath, sandboxRevision])
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true)
@@ -102,7 +110,12 @@ export function SandboxPanel({ workspaceId, conversationId }: SandboxPanelProps)
           </div>
         )}
         {activeTab === 'files' && (
-          <SandboxFilesView workspaceId={workspaceId} conversationId={conversationId} />
+          <SandboxFilesView
+            workspaceId={workspaceId}
+            conversationId={conversationId}
+            initialFilePath={initialFilePath}
+            initialFilePathRevision={sandboxRevision}
+          />
         )}
         {activeTab === 'browser' && (
           <BrowserView

--- a/frontend/packages/web/components/shared/MarkdownWithCitations.tsx
+++ b/frontend/packages/web/components/shared/MarkdownWithCitations.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import ReactMarkdown from 'react-markdown'
-import { memo } from 'react'
-import type { ComponentProps } from 'react'
+import { memo, useMemo } from 'react'
+import type { ComponentProps, MouseEvent } from 'react'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
 import remarkMath from 'remark-math'
@@ -13,6 +13,7 @@ import 'katex/dist/katex.min.css'
 import { useConversationStore } from '@cubebox/core'
 import { renderWithCitations } from '@/lib/citations'
 import { CitationMarker } from '@/components/chat/CitationMarker'
+import { resolveSandboxHref } from '@/lib/sandboxLinks'
 
 const CITATION_RE = /【\d+-\d+】/
 
@@ -39,10 +40,21 @@ function fixCjkBoldQuotes(text: string): string {
     .replace(/(["\u201d\u300d])\s*\*\*/g, '**$1')
 }
 
+export interface SandboxMarkdownContext {
+  /** Absolute sandbox path of the markdown file being rendered. */
+  filePath: string
+  /** Called when the user clicks a link that resolves to another sandbox file. */
+  onNavigate: (path: string) => void
+  /** Translates an asset path inside the sandbox into a fetchable URL (used for images). */
+  resolveAssetUrl: (path: string) => string
+}
+
 interface MarkdownWithCitationsProps {
   children: string
   className?: string
   conversationId?: string
+  /** When set, links/images that resolve inside the sandbox become navigable / fetchable. */
+  sandbox?: SandboxMarkdownContext
 }
 
 /**
@@ -54,16 +66,25 @@ function MarkdownWithCitationsImpl({
   children,
   className,
   conversationId: conversationIdProp,
+  sandbox,
 }: MarkdownWithCitationsProps) {
   const activeId = useConversationStore((s) => s.activeId)
   const conversationId = conversationIdProp ?? activeId ?? ''
   const md = fixCjkBoldQuotes(children)
   const hasCitations = CITATION_RE.test(md)
+  const sandboxComponents = useMemo(
+    () => (sandbox ? buildSandboxComponents(sandbox) : null),
+    [sandbox],
+  )
 
   if (!hasCitations) {
     return (
       <div className={className}>
-        <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS}>
+        <ReactMarkdown
+          remarkPlugins={REMARK_PLUGINS}
+          rehypePlugins={REHYPE_PLUGINS}
+          components={sandboxComponents ?? undefined}
+        >
           {md}
         </ReactMarkdown>
       </div>
@@ -76,6 +97,7 @@ function MarkdownWithCitationsImpl({
         remarkPlugins={REMARK_PLUGINS}
         rehypePlugins={REHYPE_PLUGINS}
         components={{
+          ...(sandboxComponents ?? {}),
           p: ({ children: c }) => <p>{renderWithCitations(c, conversationId, CitationMarker)}</p>,
           li: ({ children: c }) => (
             <li>{renderWithCitations(c, conversationId, CitationMarker)}</li>
@@ -116,3 +138,55 @@ function MarkdownWithCitationsImpl({
 }
 
 export const MarkdownWithCitations = memo(MarkdownWithCitationsImpl)
+
+type MarkdownComponents = NonNullable<ComponentProps<typeof ReactMarkdown>['components']>
+
+function buildSandboxComponents(sandbox: SandboxMarkdownContext): MarkdownComponents {
+  return {
+    a: ({ href, children, ...rest }) => {
+      if (!href) return <a {...rest}>{children}</a>
+      const resolved = resolveSandboxHref(sandbox.filePath, href)
+      if (resolved.kind === 'sandbox') {
+        const onClick = (e: MouseEvent<HTMLAnchorElement>) => {
+          if (e.defaultPrevented) return
+          if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return
+          e.preventDefault()
+          sandbox.onNavigate(resolved.path)
+        }
+        return (
+          <a
+            {...rest}
+            href={sandbox.resolveAssetUrl(resolved.path) + (resolved.hash ?? '')}
+            onClick={onClick}
+            data-sandbox-link={resolved.path}
+          >
+            {children}
+          </a>
+        )
+      }
+      if (resolved.kind === 'anchor') {
+        return (
+          <a {...rest} href={resolved.hash}>
+            {children}
+          </a>
+        )
+      }
+      return (
+        <a {...rest} href={resolved.href}>
+          {children}
+        </a>
+      )
+    },
+    img: ({ src, alt, ...rest }) => {
+      // sandbox-served images are dynamic, same-origin authed URLs — next/image doesn't apply.
+      /* eslint-disable @next/next/no-img-element */
+      if (typeof src !== 'string' || !src) return <img src={src} alt={alt} {...rest} />
+      const resolved = resolveSandboxHref(sandbox.filePath, src)
+      if (resolved.kind === 'sandbox') {
+        return <img {...rest} src={sandbox.resolveAssetUrl(resolved.path)} alt={alt} />
+      }
+      return <img {...rest} src={src} alt={alt} />
+      /* eslint-enable @next/next/no-img-element */
+    },
+  }
+}

--- a/frontend/packages/web/hooks/useSandboxMarkdownContext.ts
+++ b/frontend/packages/web/hooks/useSandboxMarkdownContext.ts
@@ -1,0 +1,45 @@
+'use client'
+
+import { useCallback, useMemo } from 'react'
+import { usePanelStore, useConversationStore } from '@cubebox/core'
+import type { SandboxMarkdownContext } from '@/components/shared/MarkdownWithCitations'
+import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
+
+/**
+ * Build a `sandbox` context for `<MarkdownWithCitations>` so relative links
+ * inside a sandbox-resident markdown file (e.g. agent-written `index.md`)
+ * navigate to the target file's sandbox preview instead of 404-ing through
+ * the Next router.
+ *
+ * Returns null when we can't anchor the file in a sandbox (missing workspace
+ * or unknown file path), so the markdown renders with default link behaviour.
+ */
+export function useSandboxMarkdownContext(
+  filePath: string | null | undefined,
+): SandboxMarkdownContext | null {
+  const { workspaceId } = useWorkspaceContext()
+  const conversationId = useConversationStore((s) => s.activeId)
+  const openSandboxFile = usePanelStore((s) => s.openSandboxFile)
+
+  const resolveAssetUrl = useCallback(
+    (path: string) => {
+      if (!workspaceId) return path
+      const convQs = conversationId ? `&conversation_id=${encodeURIComponent(conversationId)}` : ''
+      return (
+        `/api/v1/ws/${workspaceId}` +
+        `/sandbox/files/download` +
+        `?path=${encodeURIComponent(path)}${convQs}`
+      )
+    },
+    [workspaceId, conversationId],
+  )
+
+  return useMemo(() => {
+    if (!workspaceId || !filePath) return null
+    return {
+      filePath,
+      onNavigate: openSandboxFile,
+      resolveAssetUrl,
+    }
+  }, [workspaceId, filePath, openSandboxFile, resolveAssetUrl])
+}

--- a/frontend/packages/web/lib/sandboxLinks.ts
+++ b/frontend/packages/web/lib/sandboxLinks.ts
@@ -19,12 +19,21 @@ export function resolveSandboxHref(filePath: string, href: string): SandboxHref 
   if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return { kind: 'external', href }
   if (href.startsWith('//')) return { kind: 'external', href }
 
-  const [rawPath, ...hashParts] = href.split('#')
+  const [beforeHash, ...hashParts] = href.split('#')
   const hash = hashParts.length > 0 ? '#' + hashParts.join('#') : null
+  // Drop query string — sandbox file lookup doesn't accept ?key=value, and
+  // markdown usually embeds query only for cache-busting on assets.
+  const rawPath = beforeHash.split('?', 1)[0]
 
   const baseDir = filePath.includes('/') ? filePath.slice(0, filePath.lastIndexOf('/')) : ''
   const joined = rawPath.startsWith('/') ? `${SANDBOX_ROOT}${rawPath}` : `${baseDir}/${rawPath}`
-  const path = normalizePath(joined)
+  const normalized = normalizePath(joined)
+  // Clamp to sandbox root: a malformed href like `../../../../etc/passwd` should
+  // not produce a path the rest of the UI tries to fetch from outside /workspace.
+  const path =
+    normalized === SANDBOX_ROOT || normalized.startsWith(`${SANDBOX_ROOT}/`)
+      ? normalized
+      : SANDBOX_ROOT
   return { kind: 'sandbox', path, hash }
 }
 
@@ -36,7 +45,17 @@ function normalizePath(p: string): string {
       if (stack.length > 0) stack.pop()
       continue
     }
-    stack.push(seg)
+    // Decode percent-escapes so filenames with spaces (`Roadmap%202026.md`)
+    // become real filesystem paths; consumers re-encode when building URLs.
+    stack.push(safeDecode(seg))
   }
   return '/' + stack.join('/')
+}
+
+function safeDecode(s: string): string {
+  try {
+    return decodeURIComponent(s)
+  } catch {
+    return s
+  }
 }

--- a/frontend/packages/web/lib/sandboxLinks.ts
+++ b/frontend/packages/web/lib/sandboxLinks.ts
@@ -39,15 +39,17 @@ export function resolveSandboxHref(filePath: string, href: string): SandboxHref 
 
 function normalizePath(p: string): string {
   const stack: string[] = []
-  for (const seg of p.split('/')) {
-    if (seg === '' || seg === '.') continue
+  for (const rawSeg of p.split('/')) {
+    if (rawSeg === '') continue
+    // Decode FIRST so encoded `%2e%2e` is recognised as `..` instead of
+    // being pushed as a literal segment that slips past the traversal check.
+    const seg = safeDecode(rawSeg)
+    if (seg === '.') continue
     if (seg === '..') {
       if (stack.length > 0) stack.pop()
       continue
     }
-    // Decode percent-escapes so filenames with spaces (`Roadmap%202026.md`)
-    // become real filesystem paths; consumers re-encode when building URLs.
-    stack.push(safeDecode(seg))
+    stack.push(seg)
   }
   return '/' + stack.join('/')
 }

--- a/frontend/packages/web/lib/sandboxLinks.ts
+++ b/frontend/packages/web/lib/sandboxLinks.ts
@@ -24,9 +24,14 @@ export function resolveSandboxHref(filePath: string, href: string): SandboxHref 
   // Drop query string — sandbox file lookup doesn't accept ?key=value, and
   // markdown usually embeds query only for cache-busting on assets.
   const rawPath = beforeHash.split('?', 1)[0]
+  // Decode the whole path BEFORE splitting on `/` so encoded slashes
+  // (`%2f`) and encoded dots (`%2e`) can't smuggle traversal inside a
+  // single raw segment. Falls back to the literal string on a malformed
+  // escape; backend remains the security boundary either way.
+  const decoded = safeDecode(rawPath)
 
   const baseDir = filePath.includes('/') ? filePath.slice(0, filePath.lastIndexOf('/')) : ''
-  const joined = rawPath.startsWith('/') ? `${SANDBOX_ROOT}${rawPath}` : `${baseDir}/${rawPath}`
+  const joined = decoded.startsWith('/') ? `${SANDBOX_ROOT}${decoded}` : `${baseDir}/${decoded}`
   const normalized = normalizePath(joined)
   // Clamp to sandbox root: a malformed href like `../../../../etc/passwd` should
   // not produce a path the rest of the UI tries to fetch from outside /workspace.
@@ -39,12 +44,8 @@ export function resolveSandboxHref(filePath: string, href: string): SandboxHref 
 
 function normalizePath(p: string): string {
   const stack: string[] = []
-  for (const rawSeg of p.split('/')) {
-    if (rawSeg === '') continue
-    // Decode FIRST so encoded `%2e%2e` is recognised as `..` instead of
-    // being pushed as a literal segment that slips past the traversal check.
-    const seg = safeDecode(rawSeg)
-    if (seg === '.') continue
+  for (const seg of p.split('/')) {
+    if (seg === '' || seg === '.') continue
     if (seg === '..') {
       if (stack.length > 0) stack.pop()
       continue

--- a/frontend/packages/web/lib/sandboxLinks.ts
+++ b/frontend/packages/web/lib/sandboxLinks.ts
@@ -1,0 +1,42 @@
+export const SANDBOX_ROOT = '/workspace'
+
+export type SandboxHref =
+  | { kind: 'sandbox'; path: string; hash: string | null }
+  | { kind: 'external'; href: string }
+  | { kind: 'anchor'; hash: string }
+
+/**
+ * Resolve a markdown `href` relative to the markdown file's sandbox path.
+ *
+ * - `http(s)://…`, `mailto:`, `tel:`, data/blob URIs → external (open in new tab)
+ * - `#section` → in-page anchor
+ * - `/foo/bar.md` → absolute under SANDBOX_ROOT (so users can write workspace-root paths)
+ * - everything else → relative to the markdown file's directory
+ */
+export function resolveSandboxHref(filePath: string, href: string): SandboxHref {
+  if (!href) return { kind: 'external', href }
+  if (href.startsWith('#')) return { kind: 'anchor', hash: href }
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return { kind: 'external', href }
+  if (href.startsWith('//')) return { kind: 'external', href }
+
+  const [rawPath, ...hashParts] = href.split('#')
+  const hash = hashParts.length > 0 ? '#' + hashParts.join('#') : null
+
+  const baseDir = filePath.includes('/') ? filePath.slice(0, filePath.lastIndexOf('/')) : ''
+  const joined = rawPath.startsWith('/') ? `${SANDBOX_ROOT}${rawPath}` : `${baseDir}/${rawPath}`
+  const path = normalizePath(joined)
+  return { kind: 'sandbox', path, hash }
+}
+
+function normalizePath(p: string): string {
+  const stack: string[] = []
+  for (const seg of p.split('/')) {
+    if (seg === '' || seg === '.') continue
+    if (seg === '..') {
+      if (stack.length > 0) stack.pop()
+      continue
+    }
+    stack.push(seg)
+  }
+  return '/' + stack.join('/')
+}


### PR DESCRIPTION
## Summary

- Sandbox-resident markdown files often link to sibling pages with relative hrefs (e.g. `[Rollout](06-rollout/README.md)`). Previously those hrefs hit the Next workspace route and 404'd, and the `.md` panel preview rendered as `<pre>` instead of markdown. This PR makes intra-sandbox links navigate to the target's preview across three surfaces — Sandbox Files tab, plus the chat panel's `write_file` and `file_read` previews — by reusing the same `MarkdownWithCitations` renderer with an opt-in `sandbox` context.
- New `resolveSandboxHref(filePath, href)` classifies an href as sandbox / external / anchor under `SANDBOX_ROOT = /workspace`. Whole-path `decodeURIComponent` before splitting (so `%20`, `%2e%2e`, `%2e%2e%2f` all behave the same as their literal forms); query string stripped; result clamped under `SANDBOX_ROOT` as defense in depth.
- `panelStore.openSandboxFile(path)` + `view.initialFilePath` (with a `revision` counter so repeat clicks still re-select) let chat-side clicks jump into the Sandbox Files tab and pre-select the target file. `useSandboxMarkdownContext` wires it in for `WriteFilePreviewView` and `FileReadView`.

## Local checks

- `pnpm type-check` ✓
- `pnpm lint` ✓ 0 warnings
- `pnpm test` ✓ 45 files / 230 pass / 1 skipped (15 resolver cases covering sibling / `./` / `..` / leading-slash / fragment / external / mailto / protocol-relative / pure anchor / `%20` decoding / `?query+#fragment` / invalid escape / `..` clamp / `%2e%2e` clamp / `%2e%2e%2f` clamp)
- Local codex review: 4 rounds, R4 clean. R1 MEDIUM (encoded paths/query → fixed), R2/R3 LOW (encoded `..` / encoded `/` traversal smuggling → fixed and clamped)

## Test plan

- [ ] Open a sandbox with a multi-file markdown set; in the Sandbox Files tab, open `index.md` and click a sibling-page link → preview switches in-place to the target md (no 404, no full-page nav)
- [ ] In a conversation where the agent has just used `write_file` to write an `index.md`, open the Write preview from the message → click a sibling link → panel switches to Sandbox Files tab, target md selected, rendered through the same `prose` styling
- [ ] Same flow via `file_read` tool result
- [ ] External links (`https://...`, `mailto:...`) still open in a new tab via `rehypeExternalLinks`
- [ ] `#anchor` links scroll within the rendered markdown, no panel switch
- [ ] Cmd/ctrl/middle-click on a sandbox link falls back to opening the raw file download URL (intentional)
- [ ] Filenames with spaces (e.g. `Roadmap 2026.md` linked as `Roadmap%202026.md`) resolve to the real file