### PR TITLE
perf(chat): cut streaming long-task blocking by 84%

### DIFF
--- a/docs/dev/notes/2026-06-22-chat-streaming-perf.md
+++ b/docs/dev/notes/2026-06-22-chat-streaming-perf.md
@@ -1,0 +1,210 @@
+# Chat streaming perf — long-conversation jank
+
+Date: 2026-06-22
+Worktree: `feat/2026-06-22-chat-streaming-perf` (slot 67)
+Status: optimizations landed locally, awaiting code review
+
+## TL;DR
+
+Streaming a long assistant response used to block the main thread for up to
+**11 seconds** in a single task — long enough to freeze the CSS rotate
+animation on the composer's stop button. Four interaction-preserving fixes
+cut the worst-case blocking task to **~1.7 seconds**, an 84% reduction.
+
+| Metric | Baseline | Optimized | Δ |
+|---|---:|---:|---:|
+| Worst long task (ms) | 11,024 | 1,705 | **−85%** |
+| Worst long frame blocking (ms) | 10,975 | 1,692 | **−85%** |
+| Max single frame gap (ms) | 11,069 | 1,792 | **−84%** |
+| Total long-task blocking (ms) | 35,661 | 19,520 | −45% |
+| Avg long-task length (ms) | 327 | 132 | −60% |
+| Long-task count | 109 | 148 | +36% |
+| Stream wall-clock (s) | 178 | 184 | ~equal |
+| Assistant chars produced | 2,319 | 2,572 | ~equal |
+
+The win is concentrated where it matters: no single chunk of work can starve
+the compositor for long enough to freeze CSS animations. The trade-off shows
+up as a higher count of moderate long tasks — work is **spread** instead of
+**bundled**, which is exactly the goal.
+
+## Symptom
+
+> "测试一个比较长的会话的时候，发现前端渲染结果还是有卡顿， 甚至输入框中那个
+> 转圈的暂停按钮都不转圈了"
+
+`animate-spin` is a Tailwind CSS keyframe `transform: rotate(…)`. It is
+supposed to run on the compositor and stay smooth even when the main thread
+is busy. When it stops advancing, that's a strong signal of **main-thread
+long tasks long enough to delay compositor frame production**.
+
+## Reproduction harness
+
+`frontend/tmp/profile-streaming.mjs` (Playwright over headless Chromium):
+
+1. Register a fresh user, land in their auto-provisioned workspace
+2. Install three `PerformanceObserver`s before navigation:
+   - `long-animation-frame` (script attribution, blocking duration)
+   - `longtask` (>50ms main-thread work)
+   - per-`rAF` deltas (frame-gap distribution → FPS / jank)
+3. Send a fixed prompt asking for a Python LRU-cache implementation with 5
+   examples + 8 pytest tests + a complexity table (deepseek-v4-flash)
+4. Wait for the `stop-button` testid to flip back to `send-button`
+5. Dump raw entries to `tmp/profile-<label>.json` + a digest to
+   `tmp/summary-<label>.json`
+
+Run: `node tmp/profile-streaming.mjs <label>` from `frontend/`.
+
+## Hot path (from baseline run)
+
+Every long frame's top script attribution rooted in
+`ReadableStreamDefaultReader.read.then` — the SSE chunk handler. The
+longest single one also chained into `Scheduler.yield.then`, which is
+React's own cooperative scheduling primitive — meaning React tried to
+yield to the event loop but the resumed continuation itself was huge.
+
+Top-5 baseline long frames:
+
+```
+  dur=11068ms block=10975ms  Scheduler.yield.then dur=11024ms
+  dur=9743ms  block=9642ms   ReadableStreamDefaultReader.read.then dur=9683ms
+  dur=3348ms  block=3248ms   ReadableStreamDefaultReader.read.then dur=3250ms
+  dur=510ms   block=419ms    ReadableStreamDefaultReader.read.then dur=467ms
+  dur=323ms   block=220ms    ReadableStreamDefaultReader.read.then dur=269ms
+```
+
+Confirms what the static read predicted: each SSE delta triggered a full
+re-render of `MarkdownWithCitations` over the accumulated stream text,
+including rehype-highlight + rehype-katex passes over the entire string.
+
+## Optimizations applied (in priority order)
+
+All four preserve the existing chat interaction — no "render plain text
+while streaming, switch to markdown on finalize" trade-offs.
+
+### 1. `useDeferredValue` on the streaming markdown (biggest win)
+
+`packages/web/components/shared/MarkdownWithCitations.tsx`
+
+- Wrapped `children` in `useDeferredValue` at the very top of the body
+- All downstream work (`fixCjkBoldQuotes`, `CITATION_RE.test`, the
+  `<ReactMarkdown>` call) now sees the deferred string
+- Combined with the existing outer `memo`, this lets React drop
+  intermediate token-by-token children when it's busy and re-parse only
+  the latest value once the main thread is idle
+- Also memoized `fixCjkBoldQuotes(deferredChildren)` and
+  `CITATION_RE.test(md)` — these were each running per render
+
+This is the change that breaks up the 11s task. Instead of one giant SSE
+batch driving one giant markdown parse, the parse runs at React's pace,
+catches up when there's slack, and never blocks longer than what one
+parse over the current accumulated text actually costs.
+
+### 2. Lift the citation `components` literal out
+
+`packages/web/components/shared/MarkdownWithCitations.tsx`
+
+The "has citations" branch used to pass a `components={{ p: ..., li: ...
+(11 entries total) }}` *inline literal* on every render. Even with the
+outer `memo` bailing out, every render inside one `AssistantMessage`
+handed `ReactMarkdown` a brand-new components object → invalidated its
+internal component map cache.
+
+`useMemo` keyed on `[sandboxComponents, conversationId]` — both stable
+during a stream → object identity stays the same.
+
+### 3. Stable empty refs + correctly-typed selectors in `useMessages`
+
+`packages/web/hooks/useMessages.ts`
+
+The hook had four selectors with `?? []` / `?? {}` fallbacks that handed
+back a **fresh literal on every store update**, including unrelated
+updates from other conversations. Under Zustand's `===` check, that
+counts as "the slice changed" and forces a re-render of the entire
+MessageList host. Replaced with module-level frozen empties of the
+correct shape (`Message[]`, `MessageStore['toolResultMap']`,
+`Record<string, AgentStream>`).
+
+Concrete effect: a user parked on a different conversation no longer
+gets phantom `useMessages` re-renders every time the streaming
+conversation receives a token.
+
+### 4. Shared 1 Hz tick — kills N parallel setIntervals
+
+`packages/web/hooks/useNowSeconds.ts` (new), consumed by:
+
+- `packages/web/components/chat/ToolCallItem.tsx`
+- `packages/web/components/chat/AssistantMessage.tsx` (ReasoningBlock)
+- `packages/web/components/chat/SubAgentCard.tsx`
+
+Each pending tool call, the reasoning bubble, and every subagent card
+ran their own `setInterval(tick, 1000)` driving local `useState`. With
+several tools pending in parallel during a stream that's N independent
+1 Hz cycles, each scheduling its own render commit at a slightly
+different millisecond → React can't batch them.
+
+`useNowSeconds(active)` is one shared `useSyncExternalStore` that
+publishes a snapshot once per second from one module-level interval.
+When `active` is false, the call sites pay zero subscription cost.
+Result: all per-second elapsed displays advance in a single React
+commit, instead of 10+ commits per second sequentially.
+
+## What's *not* in this round (and why)
+
+- **`messageStore.applyStreamEvent` mutation reduction.** Right now every
+  `text_delta` allocates a fresh `streamAgents` object + fresh
+  `streamAgents[agentKey]` + fresh `blocks` array. That's the
+  responsible-for-the-`mainStream`-selector-always-changing root cause.
+  Fixing it cleanly needs either an immer middleware migration or
+  splitting `streamAgents.main.text` into its own atom so the live
+  bubble subscribes narrowly. Both are bigger refactors than the rest
+  of this PR; deferred to a follow-up. The `useDeferredValue` win cuts
+  the symptom even without this.
+- **List virtualization (`react-virtuoso`).** Only structural fix that
+  makes cost flat in conversation length. Skipped because it's the
+  largest single change in the file (changes scroll behavior + needs
+  measured row heights + tests) and we wanted this round to land
+  without UX shifts.
+- **Streaming-as-plain-text mode** with markdown switching at finalize.
+  Excluded by user request — would change the streaming feel.
+
+## Files changed
+
+| File | Lines | Change |
+|---|---:|---|
+| `frontend/packages/web/components/shared/MarkdownWithCitations.tsx` | +28 / −37 | `useDeferredValue`, memo `fixCjkBoldQuotes` + citation `components` |
+| `frontend/packages/web/hooks/useMessages.ts` | +12 / −4 | stable empties + correctly-typed selectors |
+| `frontend/packages/web/hooks/useNowSeconds.ts` | +50 / 0 | new shared ticker hook |
+| `frontend/packages/web/components/chat/ToolCallItem.tsx` | +4 / −10 | use shared ticker |
+| `frontend/packages/web/components/chat/AssistantMessage.tsx` | +4 / −9 | use shared ticker |
+| `frontend/packages/web/components/chat/SubAgentCard.tsx` | +3 / −9 | use shared ticker |
+
+No tests changed. No store / store API changes. No interaction changes.
+
+## Verifying the win yourself
+
+```bash
+# In the worktree
+cd frontend
+node tmp/profile-streaming.mjs <label>          # e.g. "main" or "branch"
+cat tmp/summary-<label>.json
+```
+
+The `summary-*.json` lines that signal the spinner-stop scenario:
+- `longTaskMaxMs` — any value over ~1500ms will visibly stutter the
+  composer spinner; pre-fix this was 11000+
+- `frameMs_max` — same physical event from the rAF side
+- `longFrameMaxBlockingMs` — the script attribution side
+
+## Variance notes
+
+The flash-tier model's response length varies by ~5× across runs (saw
+2.5k–12k chars on the same prompt). Wall-clock time and total
+work scale roughly linearly with output, so headline metrics like
+`longTaskTotalMs` move with output length. The two metrics that are
+**not** linear in output length and that reliably track the user's
+"spinner freezes" symptom are:
+
+- `longTaskMaxMs`
+- `longFrameMaxBlockingMs`
+
+These are the ones we should track in any future regression watch.

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -22,6 +22,7 @@ import { getWriteFileSummary } from '@/lib/writeFilePreview'
 import { extractWidgetCode, extractJsonStringPrefix } from '@/lib/partialJson'
 import { WidgetView } from '@/components/chat/widget/WidgetView'
 import { MarkdownWithCitations } from '@/components/shared/MarkdownWithCitations'
+import { useNowSeconds } from '@/hooks/useNowSeconds'
 import { SkillSearchResults } from './tool-results/SkillSearchResults'
 
 interface ReasoningBlockProps {
@@ -43,7 +44,6 @@ function formatDuration(ms: number): string {
 function ReasoningBlock({ thinking, isStreaming, startedAt, durationMs }: ReasoningBlockProps) {
   const t = useTranslations('chat')
   const [isExpanded, setIsExpanded] = useState(false)
-  const [elapsed, setElapsed] = useState(0)
   const scrollRef = useRef<HTMLDivElement>(null)
   const prevStreamingRef = useRef(isStreaming)
 
@@ -55,14 +55,9 @@ function ReasoningBlock({ thinking, isStreaming, startedAt, durationMs }: Reason
     prevStreamingRef.current = isStreaming
   }, [isStreaming])
 
-  // Live elapsed timer while streaming
-  useEffect(() => {
-    if (!isStreaming || !startedAt) return
-    const tick = () => setElapsed(Date.now() - startedAt)
-    tick()
-    const interval = setInterval(tick, 1000)
-    return () => clearInterval(interval)
-  }, [isStreaming, startedAt])
+  const tickerActive = isStreaming && startedAt != null
+  const nowMs = useNowSeconds(tickerActive)
+  const elapsed = tickerActive ? Math.max(0, nowMs - (startedAt ?? 0)) : 0
 
   // Auto-scroll to bottom during streaming
   useEffect(() => {

--- a/frontend/packages/web/components/chat/SubAgentCard.tsx
+++ b/frontend/packages/web/components/chat/SubAgentCard.tsx
@@ -7,6 +7,7 @@ import { CheckCircle2, ChevronDown, ChevronRight } from 'lucide-react'
 import type { AgentStream, ContentBlock, ToolCallRef } from '@cubebox/core'
 import { ToolCallItem } from './ToolCallItem'
 import { AgentAvatar } from './AgentAvatar'
+import { useNowSeconds } from '@/hooks/useNowSeconds'
 import { proseClasses } from '@/lib/utils'
 import { getWriteFileSummary } from '@/lib/writeFilePreview'
 
@@ -46,7 +47,6 @@ export const SubAgentCard = memo(function SubAgentCard({
 }: Props) {
   const t = useTranslations('chat')
   const [expanded, setExpanded] = useState(false)
-  const [elapsed, setElapsed] = useState(0)
   const startedAt = useRef(Date.now())
   const scrollRef = useRef<HTMLDivElement>(null)
 
@@ -55,14 +55,8 @@ export const SubAgentCard = memo(function SubAgentCard({
     startedAt.current = Date.now()
   }, [])
 
-  // Live elapsed timer
-  useEffect(() => {
-    if (!isRunning) return
-    const tick = () => setElapsed(Date.now() - startedAt.current)
-    tick()
-    const interval = setInterval(tick, 1000)
-    return () => clearInterval(interval)
-  }, [isRunning])
+  const nowMs = useNowSeconds(isRunning)
+  const elapsed = isRunning ? Math.max(0, nowMs - startedAt.current) : 0
 
   // Auto-scroll streaming content — track all content changes like ReasoningBlock
   const toolCallCount = stream?.toolCalls.length ?? 0

--- a/frontend/packages/web/components/chat/SubAgentCard.tsx
+++ b/frontend/packages/web/components/chat/SubAgentCard.tsx
@@ -55,8 +55,20 @@ export const SubAgentCard = memo(function SubAgentCard({
     startedAt.current = Date.now()
   }, [])
 
+  // Capture the elapsed value at the moment `isRunning` transitions to false so
+  // the finished-but-still-mounted card keeps showing its final duration. The
+  // pre-tick-share version held this in the local elapsed useState; with the
+  // shared ticker we now freeze it explicitly on transition.
   const nowMs = useNowSeconds(isRunning)
-  const elapsed = isRunning ? Math.max(0, nowMs - startedAt.current) : 0
+  const wasRunningRef = useRef(isRunning)
+  const [frozenElapsed, setFrozenElapsed] = useState(0)
+  useEffect(() => {
+    if (wasRunningRef.current && !isRunning) {
+      setFrozenElapsed(Date.now() - startedAt.current)
+    }
+    wasRunningRef.current = isRunning
+  }, [isRunning])
+  const elapsed = isRunning ? Math.max(0, nowMs - startedAt.current) : frozenElapsed
 
   // Auto-scroll streaming content — track all content changes like ReasoningBlock
   const toolCallCount = stream?.toolCalls.length ?? 0

--- a/frontend/packages/web/components/chat/ToolCallItem.tsx
+++ b/frontend/packages/web/components/chat/ToolCallItem.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useState, useEffect, useRef, memo } from 'react'
+import { useEffect, useRef, memo } from 'react'
 import type { MCPToolIcon, PendingConfirm, ToolCallRef } from '@cubebox/core'
 import { CheckCircle2, Circle, PanelRight, Plug } from 'lucide-react'
 import { getToolIcon, getParamSummary } from '@/lib/toolIcons'
 import { useMcpToolRegistryStore, useToolDetailStore } from '@cubebox/core'
+import { useNowSeconds } from '@/hooks/useNowSeconds'
 import { SandboxConfirmCard } from './SandboxConfirmCard'
 
 /** Pick the best icon variant: prefer per-tool over server icon; fall back
@@ -64,7 +65,6 @@ export const ToolCallItem = memo(function ToolCallItem({
   pendingConfirm,
   onSandboxConfirm,
 }: ToolCallItemProps) {
-  const [elapsed, setElapsed] = useState(0)
   const startedAt = useRef(timestamp ? new Date(timestamp).getTime() : Date.now())
   const openPanel = useToolDetailStore((s) => s.open)
 
@@ -74,14 +74,8 @@ export const ToolCallItem = memo(function ToolCallItem({
     }
   }, [timestamp])
 
-  // Live timer while pending
-  useEffect(() => {
-    if (!isPending) return
-    const tick = () => setElapsed(Date.now() - startedAt.current)
-    tick()
-    const interval = setInterval(tick, 1000)
-    return () => clearInterval(interval)
-  }, [isPending])
+  const nowMs = useNowSeconds(isPending)
+  const elapsed = isPending ? Math.max(0, nowMs - startedAt.current) : 0
 
   const duration = toolResult
     ? toolResult.receivedAt - (toolResult.startedAt ?? startedAt.current)

--- a/frontend/packages/web/components/shared/MarkdownWithCitations.tsx
+++ b/frontend/packages/web/components/shared/MarkdownWithCitations.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import ReactMarkdown from 'react-markdown'
-import { memo, useMemo } from 'react'
+import { memo, useDeferredValue, useMemo } from 'react'
 import type { ComponentProps, MouseEvent } from 'react'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
@@ -70,11 +70,35 @@ function MarkdownWithCitationsImpl({
 }: MarkdownWithCitationsProps) {
   const activeId = useConversationStore((s) => s.activeId)
   const conversationId = conversationIdProp ?? activeId ?? ''
-  const md = fixCjkBoldQuotes(children)
-  const hasCitations = CITATION_RE.test(md)
+  // Defer the markdown render during heavy streaming: while React is busy,
+  // intermediate token-by-token children are dropped and only the latest
+  // value is parsed once the main thread is idle. Combined with the outer
+  // `memo`, an unchanged `children` short-circuits before this runs.
+  const deferredChildren = useDeferredValue(children)
+  const md = useMemo(() => fixCjkBoldQuotes(deferredChildren), [deferredChildren])
+  const hasCitations = useMemo(() => CITATION_RE.test(md), [md])
   const sandboxComponents = useMemo(
     () => (sandbox ? buildSandboxComponents(sandbox) : null),
     [sandbox],
+  )
+  const citationComponents = useMemo<MarkdownComponents>(
+    () => ({
+      ...(sandboxComponents ?? {}),
+      p: ({ children: c }) => <p>{renderWithCitations(c, conversationId, CitationMarker)}</p>,
+      li: ({ children: c }) => <li>{renderWithCitations(c, conversationId, CitationMarker)}</li>,
+      td: ({ children: c }) => <td>{renderWithCitations(c, conversationId, CitationMarker)}</td>,
+      th: ({ children: c }) => <th>{renderWithCitations(c, conversationId, CitationMarker)}</th>,
+      blockquote: ({ children: c }) => (
+        <blockquote>{renderWithCitations(c, conversationId, CitationMarker)}</blockquote>
+      ),
+      h1: ({ children: c }) => <h1>{renderWithCitations(c, conversationId, CitationMarker)}</h1>,
+      h2: ({ children: c }) => <h2>{renderWithCitations(c, conversationId, CitationMarker)}</h2>,
+      h3: ({ children: c }) => <h3>{renderWithCitations(c, conversationId, CitationMarker)}</h3>,
+      h4: ({ children: c }) => <h4>{renderWithCitations(c, conversationId, CitationMarker)}</h4>,
+      h5: ({ children: c }) => <h5>{renderWithCitations(c, conversationId, CitationMarker)}</h5>,
+      h6: ({ children: c }) => <h6>{renderWithCitations(c, conversationId, CitationMarker)}</h6>,
+    }),
+    [sandboxComponents, conversationId],
   )
 
   if (!hasCitations) {
@@ -96,40 +120,7 @@ function MarkdownWithCitationsImpl({
       <ReactMarkdown
         remarkPlugins={REMARK_PLUGINS}
         rehypePlugins={REHYPE_PLUGINS}
-        components={{
-          ...(sandboxComponents ?? {}),
-          p: ({ children: c }) => <p>{renderWithCitations(c, conversationId, CitationMarker)}</p>,
-          li: ({ children: c }) => (
-            <li>{renderWithCitations(c, conversationId, CitationMarker)}</li>
-          ),
-          td: ({ children: c }) => (
-            <td>{renderWithCitations(c, conversationId, CitationMarker)}</td>
-          ),
-          th: ({ children: c }) => (
-            <th>{renderWithCitations(c, conversationId, CitationMarker)}</th>
-          ),
-          blockquote: ({ children: c }) => (
-            <blockquote>{renderWithCitations(c, conversationId, CitationMarker)}</blockquote>
-          ),
-          h1: ({ children: c }) => (
-            <h1>{renderWithCitations(c, conversationId, CitationMarker)}</h1>
-          ),
-          h2: ({ children: c }) => (
-            <h2>{renderWithCitations(c, conversationId, CitationMarker)}</h2>
-          ),
-          h3: ({ children: c }) => (
-            <h3>{renderWithCitations(c, conversationId, CitationMarker)}</h3>
-          ),
-          h4: ({ children: c }) => (
-            <h4>{renderWithCitations(c, conversationId, CitationMarker)}</h4>
-          ),
-          h5: ({ children: c }) => (
-            <h5>{renderWithCitations(c, conversationId, CitationMarker)}</h5>
-          ),
-          h6: ({ children: c }) => (
-            <h6>{renderWithCitations(c, conversationId, CitationMarker)}</h6>
-          ),
-        }}
+        components={citationComponents}
       >
         {md}
       </ReactMarkdown>

--- a/frontend/packages/web/hooks/useMessages.ts
+++ b/frontend/packages/web/hooks/useMessages.ts
@@ -2,7 +2,15 @@
 
 import { useRef } from 'react'
 import { useMessageStore } from '@cubebox/core'
-import type { AgentStream } from '@cubebox/core'
+import type { AgentStream, Message, MessageStore } from '@cubebox/core'
+
+// Stable empties returned by selectors when the asked-for slice is absent or
+// inactive. Without these, every selector with a `?? []` / `?? {}` fallback
+// hands back a fresh literal on each store update, marking the slice "changed"
+// under Zustand's `===` and forcing the host component (MessageList) to re-render.
+const EMPTY_MESSAGES: Message[] = []
+const EMPTY_TOOL_RESULTS: MessageStore['toolResultMap'] = {}
+const EMPTY_SUBAGENTS: Record<string, AgentStream> = {}
 
 /**
  * Shallow-compare two Record<string, T> by keys and reference-equal values.
@@ -24,7 +32,7 @@ function useStableRecord<T>(record: Record<string, T>): Record<string, T> {
 }
 
 export function useMessages(conversationId: string) {
-  const messages = useMessageStore((s) => s.messages[conversationId] ?? [])
+  const messages = useMessageStore((s) => s.messages[conversationId] ?? EMPTY_MESSAGES)
   // Only expose streaming state when this conversation is the one streaming
   const isStreamingThis = useMessageStore(
     (s) => s.isStreaming && s.streamingConversationId === conversationId,
@@ -38,7 +46,7 @@ export function useMessages(conversationId: string) {
   const todos = useMessageStore((s) => s.todos)
   const conversationError = useMessageStore((s) => s.errors[conversationId] ?? null)
   const toolResultMap = useMessageStore((s) =>
-    s.streamingConversationId === conversationId ? s.toolResultMap : {},
+    s.streamingConversationId === conversationId ? s.toolResultMap : EMPTY_TOOL_RESULTS,
   )
   const turnUsage = useMessageStore((s) => s.turnUsage[conversationId] ?? null)
   const sessionUsage = useMessageStore((s) => s.sessionUsage[conversationId] ?? null)
@@ -47,7 +55,7 @@ export function useMessages(conversationId: string) {
 
   // Derive subagent streams with stable reference — only for the streaming conversation
   const rawSubAgents = useMessageStore((s) => {
-    if (s.streamingConversationId !== conversationId) return {}
+    if (s.streamingConversationId !== conversationId) return EMPTY_SUBAGENTS
     const agents = s.streamAgents
     const sub: Record<string, AgentStream> = {}
     for (const key in agents) {

--- a/frontend/packages/web/hooks/useNowSeconds.ts
+++ b/frontend/packages/web/hooks/useNowSeconds.ts
@@ -1,0 +1,45 @@
+'use client'
+
+import { useCallback, useSyncExternalStore } from 'react'
+
+// Module-level shared 1 Hz ticker: a single `setInterval` drives every consumer
+// instead of each pending tool / reasoning bubble / subagent card running its
+// own. With ~10 tools in flight during a stream this collapses 10× per-second
+// re-render commits down to a single batched commit — measurable wall-clock win
+// because each commit walks the whole MessageList memo-bailout chain.
+const listeners = new Set<() => void>()
+let timer: ReturnType<typeof setInterval> | null = null
+let snapshotMs = Math.floor(Date.now() / 1000) * 1000
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  if (listeners.size === 1) {
+    timer = setInterval(() => {
+      snapshotMs = Math.floor(Date.now() / 1000) * 1000
+      for (const l of listeners) l()
+    }, 1000)
+  }
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0 && timer) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+}
+
+function getSnapshot(): number {
+  return snapshotMs
+}
+
+const NOOP_UNSUB = (): void => {}
+
+/**
+ * Subscribe to a shared 1 Hz tick. Returns "now" rounded to the most recent
+ * whole second (in ms). When `active` is false the hook reads the current
+ * snapshot once and does not subscribe, so idle call sites don't re-render.
+ */
+export function useNowSeconds(active: boolean): number {
+  const subscribeFn = useCallback((l: () => void) => (active ? subscribe(l) : NOOP_UNSUB), [active])
+  return useSyncExternalStore(subscribeFn, getSnapshot, getSnapshot)
+}


### PR DESCRIPTION
## Summary

- **Worst long task during streaming: 11s → 1.7s** — the spinner-stops-spinning symptom on long conversations is the user-visible artifact of an 11-second single main-thread task. Cut to 1.7s via four orthogonal, non-UX-changing fixes (`useDeferredValue` on streaming markdown, memoized citation `components` literal, stable-empty selector returns, shared 1 Hz ticker). Details + before/after metrics in `docs/dev/notes/2026-06-22-chat-streaming-perf.md`.
- **No store / API / interaction changes.** The `applyStreamEvent`-rebuilds-`streamAgents`-subtree root cause and `react-virtuoso` virtualization are explicit follow-ups; this PR works around them via the deferred markdown render.
- **Local codex review clean** (No CRITICAL/HIGH findings); one LOW (finished `SubAgentCard` lost its elapsed duration after the shared-ticker change) fixed in the second commit.

## Test plan

- [x] `pnpm type-check` clean on source (the auto-generated `.next/dev/types/validator.ts` is unrelated dev-server churn — fresh `next build` succeeds in pre-push)
- [x] `pnpm format:check` + `pnpm lint` clean (pre-commit + pre-push verified)
- [x] Profile harness `tmp/profile-streaming.mjs`: max long task 1,705 ms (baseline 11,024 ms), max long-frame blocking 1,692 ms (baseline 10,975 ms) on the same prompt + model
- [ ] Manual smoke: send a long-output prompt → composer stop-button spinner keeps rotating throughout the stream (no freeze)
- [ ] Manual smoke: kick off a subagent, wait for it to finish → finished card still shows its elapsed duration (regression coverage for the LOW fix)