### PR TITLE
feat(stream): unwrap deferred_tool_call wrapper end-to-end

### DIFF
--- a/backend/cubebox/agents/stream.py
+++ b/backend/cubebox/agents/stream.py
@@ -588,3 +588,71 @@ def convert_event_to_sse(evt: StreamEvent) -> list[dict[str, Any]]:
 def convert_agent_event_to_sse(evt: AgentEvent) -> list[dict[str, Any]]:
     """One-off translation of a single AgentEvent. See :func:`convert_event_to_sse`."""
     return StreamConverter().convert_agent_event(evt)
+
+
+def unwrap_deferred_in_message_dicts(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Rewrite persisted ``deferred_tool_call`` wrapper blocks to their resolved
+    real tool form, for read-side display.
+
+    cubepi's ``resolve_tool_call`` rewrites the dispatched call at execute time
+    but does NOT mutate the persisted AssistantMessage — the dispatcher block
+    stays in checkpoint history as ``name="deferred_tool_call"`` with the
+    wrapper arguments. The tool_result, by contrast, gets persisted under the
+    resolved name (cubepi emits ``ToolExecutionEndEvent`` with the rewritten
+    ``rtc.name``), so without this read-side fix a reloaded conversation
+    renders mismatched cards (``deferred_tool_call`` request → real-name
+    result) and loses any frontend rendering keyed off real tool names.
+
+    We touch only the dict copy — the underlying cubepi messages remain
+    intact, so model replay still sees the dispatcher block (whichever name
+    is in the prompt cache stays in the prompt cache). Malformed wrappers
+    (inner ``tool_name`` not a string) pass through unchanged so cubepi's
+    "Unknown deferred tool" error chain stays visible in the UI.
+    """
+    out: list[dict[str, Any]] = []
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            out.append(msg)
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            out.append(msg)
+            continue
+        new_content: list[Any] = []
+        rewrote = False
+        for block in content:
+            unwrapped = _unwrap_deferred_block(block)
+            if unwrapped is not block:
+                rewrote = True
+            new_content.append(unwrapped)
+        if not rewrote:
+            out.append(msg)
+            continue
+        new_msg = dict(msg)
+        new_msg["content"] = new_content
+        out.append(new_msg)
+    return out
+
+
+def _unwrap_deferred_block(block: Any) -> Any:
+    if (
+        not isinstance(block, dict)
+        or block.get("type") != "tool_call"
+        or block.get("name") != _DEFERRED_DISPATCH_TOOL_NAME
+    ):
+        return block
+    wrapper = block.get("arguments")
+    if not isinstance(wrapper, dict):
+        return block
+    inner_name = wrapper.get("tool_name")
+    if not isinstance(inner_name, str):
+        return block
+    inner_args = wrapper.get("arguments")
+    if not isinstance(inner_args, dict):
+        inner_args = {}
+    new_block = dict(block)
+    new_block["name"] = inner_name
+    new_block["arguments"] = inner_args
+    return new_block

--- a/backend/cubebox/agents/stream.py
+++ b/backend/cubebox/agents/stream.py
@@ -1,19 +1,26 @@
-"""cubepi event → cubebox SSE event dict translation (M1.3+).
+"""cubepi event → cubebox SSE event dict translation.
 
-Two translation layers:
+Two layers:
 
-1. ``convert_event_to_sse`` — low-level; translates a single
-   cubepi ``StreamEvent`` (provider-level) into 0..1 cubebox SSE dicts.
-   Used when the caller has direct access to the raw provider stream.
+1. ``StreamConverter`` — stateful per-stream translator. Use one instance per
+   agent run when you need progressive unwrap of cubepi's
+   ``deferred_tool_call`` dispatcher (the LLM-streamed deltas carry the
+   wrapper JSON ``{"tool_name": ..., "arguments": ...}``; cubepi rewrites the
+   call at execute time, so the ``tool_result`` arrives under the real name
+   but the streamed ``tool_call_delta`` events would otherwise look like
+   ``deferred_tool_call`` until ``toolcall_end``).
 
-2. ``convert_agent_event_to_sse`` — high-level; translates a
-   cubepi ``AgentEvent`` (agent-loop-level) into 0..N cubebox SSE dicts.
-   Used by the run_manager cubepi dispatch path (M1.5+), which subscribes
-   to the Agent's listener channel and receives AgentEvents.
+2. ``convert_event_to_sse`` / ``convert_agent_event_to_sse`` — stateless
+   one-off wrappers around a fresh ``StreamConverter`` instance. Suitable for
+   tests and any caller that processes a single event in isolation; the
+   deferred unwrap still works for a complete event (e.g. ``toolcall_end``)
+   but cannot stitch deltas across calls.
 
 cubebox SSE event types (consumed by frontend):
     text_delta, reasoning, tool_call, tool_call_delta, tool_result,
-    usage, error, done.
+    usage, error, done, artifact, injected_message,
+    sandbox_confirm_request, sandbox_confirm_resolved,
+    ask_user_request, ask_user_resolved.
 """
 
 from __future__ import annotations
@@ -38,6 +45,12 @@ from cubepi.providers.base import (
     ToolCall,
     UserMessage,
 )
+
+# cubepi's deferred dispatcher exposes this tool name to the model. Matches
+# ``DISPATCH_TOOL_NAME`` in cubepi.deferred._dispatch_tool; pinned by string
+# because it's a wire contract — changing it requires coordinated updates on
+# both sides.
+_DEFERRED_DISPATCH_TOOL_NAME = "deferred_tool_call"
 
 
 def _stringify_tool_result(result: Any) -> tuple[str, Any]:
@@ -99,78 +112,381 @@ def _artifact_event_from_tool_result(
     }
 
 
-def convert_event_to_sse(evt: StreamEvent) -> list[dict[str, Any]]:
-    """Translate a single cubepi StreamEvent into 0..1 cubebox SSE event dicts."""
-    t = evt.type
+# ---------------------------------------------------------------------------
+# Streaming JSON scanner — extracts top-level `tool_name` / `arguments` value
+# spans from a partial deferred-call wrapper while it's being streamed.
+# ---------------------------------------------------------------------------
 
-    if t == "text_delta":
-        return [{"type": "text_delta", "delta": evt.delta or ""}]
 
-    if t == "thinking_delta":
-        return [{"type": "reasoning", "delta": evt.delta or ""}]
+def _scan_string(raw: str, start: int) -> tuple[int, bool]:
+    """Scan a JSON string starting at ``raw[start] == '"'``.
 
-    if t == "toolcall_delta":
-        out: dict[str, Any] = {
-            "type": "tool_call_delta",
-            "delta": evt.delta or "",
-            "index": evt.content_index,
-        }
-        if evt.partial is not None and evt.content_index is not None:
+    Returns ``(end_offset, done)`` where ``end_offset`` points at the closing
+    ``"`` (so ``raw[start:end_offset + 1]`` is the full JSON string literal).
+    ``done`` is True only when the closing quote is present.
+    """
+    n = len(raw)
+    if start >= n or raw[start] != '"':
+        return start, False
+    i = start + 1
+    while i < n:
+        c = raw[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == '"':
+            return i, True
+        i += 1
+    return n, False
+
+
+def _scan_object(raw: str, start: int) -> tuple[int, bool]:
+    """Scan a JSON object starting at ``raw[start] == '{'``.
+
+    Returns ``(end_offset, done)`` where ``end_offset`` is the index JUST PAST
+    the closing ``}`` (so ``raw[start:end_offset]`` is the full object).
+    Tracks string state so braces inside string values don't pop depth early.
+    """
+    n = len(raw)
+    if start >= n or raw[start] != "{":
+        return start, False
+    depth = 1
+    in_string = False
+    i = start + 1
+    while i < n:
+        c = raw[i]
+        if in_string:
+            if c == "\\":
+                i += 2
+                continue
+            if c == '"':
+                in_string = False
+            i += 1
+            continue
+        if c == '"':
+            in_string = True
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1, True
+        i += 1
+    return n, False
+
+
+def _scan_array(raw: str, start: int) -> tuple[int, bool]:
+    n = len(raw)
+    if start >= n or raw[start] != "[":
+        return start, False
+    depth = 1
+    in_string = False
+    i = start + 1
+    while i < n:
+        c = raw[i]
+        if in_string:
+            if c == "\\":
+                i += 2
+                continue
+            if c == '"':
+                in_string = False
+            i += 1
+            continue
+        if c == '"':
+            in_string = True
+        elif c == "[":
+            depth += 1
+        elif c == "]":
+            depth -= 1
+            if depth == 0:
+                return i + 1, True
+        i += 1
+    return n, False
+
+
+def _scan_value(raw: str, start: int) -> tuple[int, bool]:
+    """Skip past any JSON value beginning at ``raw[start]``."""
+    n = len(raw)
+    if start >= n:
+        return start, False
+    c = raw[start]
+    if c == '"':
+        end, done = _scan_string(raw, start)
+        return (end + 1, True) if done else (end, False)
+    if c == "{":
+        return _scan_object(raw, start)
+    if c == "[":
+        return _scan_array(raw, start)
+    for lit in ("true", "false", "null"):
+        if raw.startswith(lit, start):
+            return start + len(lit), True
+    if c == "-" or c.isdigit():
+        i = start
+        if raw[i] == "-":
+            i += 1
+        while i < n and (raw[i].isdigit() or raw[i] in ".eE+-"):
+            i += 1
+        # We can't tell whether a number is "done" mid-stream without lookahead;
+        # treat it as done iff we hit a JSON structural char after digits.
+        if i < n and raw[i] in ",}] \t\n\r":
+            return i, True
+        return i, False
+    return start, False
+
+
+def _scan_deferred_wrapper(raw: str) -> tuple[str | None, int | None, int | None]:
+    """Scan a partial ``deferred_tool_call`` wrapper JSON object.
+
+    Returns ``(tool_name, args_value_start, args_value_end)`` — any field that
+    is not yet resolvable from ``raw`` is ``None``. ``args_value_*`` are byte
+    offsets into ``raw``: ``args_value_start`` points at the inner ``{`` and
+    ``args_value_end`` at the index JUST PAST the inner closing ``}``.
+    """
+    tool_name: str | None = None
+    args_start: int | None = None
+    args_end: int | None = None
+
+    n = len(raw)
+    i = 0
+    while i < n and raw[i] in " \t\n\r":
+        i += 1
+    if i >= n or raw[i] != "{":
+        return None, None, None
+    i += 1
+
+    while i < n:
+        while i < n and raw[i] in " \t\n\r,":
+            i += 1
+        if i >= n or raw[i] == "}":
+            break
+        if raw[i] != '"':
+            break
+        key_end, key_done = _scan_string(raw, i)
+        if not key_done:
+            break
+        try:
+            key = json.loads(raw[i : key_end + 1])
+        except json.JSONDecodeError:
+            break
+        i = key_end + 1
+        while i < n and raw[i] in " \t\n\r":
+            i += 1
+        if i >= n or raw[i] != ":":
+            break
+        i += 1
+        while i < n and raw[i] in " \t\n\r":
+            i += 1
+        if i >= n:
+            break
+
+        if key == "tool_name" and tool_name is None:
+            if raw[i] != '"':
+                break
+            v_end, v_done = _scan_string(raw, i)
+            if not v_done:
+                break
             try:
-                block = evt.partial.content[evt.content_index]
-            except (IndexError, TypeError):
-                block = None
-            if isinstance(block, ToolCall):
-                out["id"] = block.id
-                out["name"] = block.name
-        return [out]
+                tool_name = json.loads(raw[i : v_end + 1])
+            except json.JSONDecodeError:
+                break
+            i = v_end + 1
+        elif key == "arguments" and args_start is None:
+            if raw[i] != "{":
+                break
+            args_start = i
+            v_end, v_done = _scan_object(raw, i)
+            if v_done:
+                args_end = v_end
+                i = v_end
+            else:
+                # Inner object still streaming — start known, end unknown.
+                break
+        else:
+            v_end, v_done = _scan_value(raw, i)
+            if not v_done:
+                break
+            i = v_end
 
-    if t == "toolcall_end":
+    return tool_name, args_start, args_end
+
+
+# ---------------------------------------------------------------------------
+# Streaming converter — holds per-content-index state across deltas so the
+# deferred-call wrapper can be peeled progressively as the LLM streams it.
+# ---------------------------------------------------------------------------
+
+
+class _DeferredCallState:
+    """State for one in-flight deferred_tool_call streaming through the agent."""
+
+    __slots__ = ("raw", "tool_id", "tool_name", "args_value_start", "emitted_inner_chars")
+
+    def __init__(self, tool_id: str) -> None:
+        self.raw: str = ""
+        self.tool_id: str = tool_id
+        self.tool_name: str | None = None
+        self.args_value_start: int | None = None
+        self.emitted_inner_chars: int = 0
+
+
+class StreamConverter:
+    """Stateful translator from cubepi events to cubebox SSE dicts.
+
+    Use one instance per agent run / subscriber listener. The state holds
+    in-progress ``deferred_tool_call`` buffers keyed by ``content_index`` —
+    cubepi's provider emits ``toolcall_delta`` events whose ``partial`` carries
+    the resolved wrapper name (``deferred_tool_call``) but not the raw JSON
+    being streamed inside ``arguments``; that JSON only exists as the
+    concatenation of every ``delta`` chunk we receive. We accumulate locally,
+    pull the inner ``tool_name`` and inner ``arguments`` value span out via
+    :func:`_scan_deferred_wrapper`, and emit synthetic ``tool_call_delta``
+    events whose ``name`` / ``delta`` look like a direct call to the real
+    tool — so the frontend card renders with the real title and only the
+    inner JSON streams into the args view.
+    """
+
+    def __init__(self) -> None:
+        self._deferred: dict[int, _DeferredCallState] = {}
+
+    # ------------------------------------------------------------------
+    # Top-level entrypoints
+
+    def convert(self, evt: StreamEvent) -> list[dict[str, Any]]:
+        """Translate a single cubepi StreamEvent into 0..N cubebox SSE dicts."""
+        t = evt.type
+        if t == "text_delta":
+            return [{"type": "text_delta", "delta": evt.delta or ""}]
+        if t == "thinking_delta":
+            return [{"type": "reasoning", "delta": evt.delta or ""}]
+        if t == "toolcall_delta":
+            return self._on_toolcall_delta(evt)
+        if t == "toolcall_end":
+            return self._on_toolcall_end(evt)
+        if t == "done":
+            return [{"type": "done"}]
+        if t == "error":
+            return [{"type": "error", "error": evt.error_message or "unknown error"}]
+        return []
+
+    def convert_agent_event(self, evt: AgentEvent) -> list[dict[str, Any]]:
+        """Translate a single cubepi AgentEvent into 0..N cubebox SSE dicts."""
+        if isinstance(evt, MessageUpdateEvent):
+            return self.convert(evt.stream_event)
+        return _convert_terminal_agent_event(evt)
+
+    # ------------------------------------------------------------------
+    # toolcall_delta / toolcall_end with deferred unwrap
+
+    def _block_for(self, evt: StreamEvent) -> ToolCall | None:
         if evt.partial is None or evt.content_index is None:
-            return []
+            return None
         try:
             block = evt.partial.content[evt.content_index]
         except (IndexError, TypeError):
+            return None
+        return block if isinstance(block, ToolCall) else None
+
+    def _on_toolcall_delta(self, evt: StreamEvent) -> list[dict[str, Any]]:
+        block = self._block_for(evt)
+        idx = evt.content_index
+        delta_chunk = evt.delta or ""
+
+        if block is None or block.name != _DEFERRED_DISPATCH_TOOL_NAME:
+            out: dict[str, Any] = {
+                "type": "tool_call_delta",
+                "delta": delta_chunk,
+                "index": idx,
+            }
+            if block is not None:
+                out["id"] = block.id
+                out["name"] = block.name
+            return [out]
+
+        assert idx is not None  # _block_for guarantees both partial and index
+        state = self._deferred.setdefault(idx, _DeferredCallState(tool_id=block.id))
+        state.raw += delta_chunk
+
+        tool_name, args_start, args_end = _scan_deferred_wrapper(state.raw)
+        if tool_name is not None and state.tool_name is None:
+            state.tool_name = tool_name
+        if args_start is not None and state.args_value_start is None:
+            state.args_value_start = args_start
+
+        # Emit only once BOTH the real name and the inner-args open brace are
+        # in view — otherwise we'd either label the args under the wrong title
+        # or stream a wrapper prefix the frontend has no use for.
+        if state.tool_name is None or state.args_value_start is None:
             return []
-        if not isinstance(block, ToolCall):
+
+        slice_end = args_end if args_end is not None else len(state.raw)
+        slice_start = state.args_value_start + state.emitted_inner_chars
+        if slice_end <= slice_start:
             return []
+        new_chars = state.raw[slice_start:slice_end]
+        state.emitted_inner_chars += len(new_chars)
+        return [
+            {
+                "type": "tool_call_delta",
+                "delta": new_chars,
+                "index": idx,
+                "id": state.tool_id,
+                "name": state.tool_name,
+            }
+        ]
+
+    def _on_toolcall_end(self, evt: StreamEvent) -> list[dict[str, Any]]:
+        block = self._block_for(evt)
+        if block is None:
+            return []
+        idx = evt.content_index
+        assert idx is not None
+
+        if block.name != _DEFERRED_DISPATCH_TOOL_NAME:
+            self._deferred.pop(idx, None)
+            return [
+                {
+                    "type": "tool_call",
+                    "id": block.id,
+                    "name": block.name,
+                    "arguments": block.arguments,
+                }
+            ]
+
+        # block.arguments at toolcall_end is the parsed wrapper dict:
+        # {"tool_name": "<real>", "arguments": {...}}. cubepi's resolver will
+        # rewrite the call to <real> + inner arguments before execute; we
+        # surface the same shape to the frontend so the tool_call event lines
+        # up with the eventual tool_result event (which uses the real name).
+        wrapper = block.arguments or {}
+        inner_name = wrapper.get("tool_name") if isinstance(wrapper, dict) else None
+        inner_args = wrapper.get("arguments") if isinstance(wrapper, dict) else None
+        self._deferred.pop(idx, None)
+        if not isinstance(inner_name, str):
+            # Malformed wrapper — emit the raw dispatcher call so cubepi's
+            # error fallback ("Unknown deferred tool: ...") still surfaces in
+            # the same card.
+            return [
+                {
+                    "type": "tool_call",
+                    "id": block.id,
+                    "name": block.name,
+                    "arguments": block.arguments,
+                }
+            ]
+        if not isinstance(inner_args, dict):
+            inner_args = {}
         return [
             {
                 "type": "tool_call",
                 "id": block.id,
-                "name": block.name,
-                "arguments": block.arguments,
+                "name": inner_name,
+                "arguments": inner_args,
             }
         ]
 
-    if t == "done":
-        return [{"type": "done"}]
 
-    if t == "error":
-        return [{"type": "error", "error": evt.error_message or "unknown error"}]
-
-    # Silent: start, text_start/end, thinking_start/end, toolcall_start
-    return []
-
-
-def convert_agent_event_to_sse(evt: AgentEvent) -> list[dict[str, Any]]:
-    """Translate a single cubepi AgentEvent into 0..N cubebox SSE event dicts.
-
-    The cubepi Agent exposes AgentEvents via its subscribe() listener channel.
-    AgentEvents are higher-level than StreamEvents:
-
-    - ``MessageUpdateEvent`` wraps a ``stream_event: StreamEvent`` — we unwrap
-      and delegate to ``convert_event_to_sse`` for text/thinking/tool deltas.
-    - ``ToolExecutionEndEvent`` carries the completed tool result — translated to
-      a ``tool_result`` SSE dict.
-    - ``AgentEndEvent`` emits ``done``.
-    - All other AgentEvents (agent_start, turn_start/end, message_start/end,
-      tool_execution_start/update) are silently dropped; they carry no content
-      that cubebox's frontend currently needs.
-    """
-    if isinstance(evt, MessageUpdateEvent):
-        return convert_event_to_sse(evt.stream_event)
-
+def _convert_terminal_agent_event(evt: AgentEvent) -> list[dict[str, Any]]:
+    """Translation for AgentEvents that don't carry streaming state."""
     if isinstance(evt, ToolExecutionEndEvent):
         text, details = _stringify_tool_result(evt.result)
         out: list[dict[str, Any]] = [
@@ -183,9 +499,6 @@ def convert_agent_event_to_sse(evt: AgentEvent) -> list[dict[str, Any]]:
                 "is_error": evt.is_error,
             }
         ]
-        # save_artifact embeds the registered artifact in its result content.
-        # Emit a standalone artifact event so the frontend artifact store is
-        # populated live (not only after a page reload via loadArtifacts).
         artifact_event = _artifact_event_from_tool_result(evt.tool_name, evt.is_error, text)
         if artifact_event is not None:
             out.append(artifact_event)
@@ -237,9 +550,6 @@ def convert_agent_event_to_sse(evt: AgentEvent) -> list[dict[str, Any]]:
         return []
 
     if isinstance(evt, HitlAnswerEvent):
-        # Distinguish ask (dict answer) from approve (ApproveAnswer object).
-        # Cancelled answers (answer=None) default to sandbox_confirm_resolved —
-        # in v1 there is no cancel endpoint so this branch is unreachable.
         if isinstance(evt.answer, dict):
             return [
                 {
@@ -261,8 +571,20 @@ def convert_agent_event_to_sse(evt: AgentEvent) -> list[dict[str, Any]]:
             resolved["reason"] = evt.answer.reason
         return [resolved]
 
-    # Silently drop all other AgentEvent types:
-    # AgentStartEvent, AgentEndEvent (done is emitted by run_manager with usage),
-    # TurnStartEvent, TurnEndEvent, MessageStartEvent,
-    # ToolExecutionStartEvent, ToolExecutionUpdateEvent
     return []
+
+
+def convert_event_to_sse(evt: StreamEvent) -> list[dict[str, Any]]:
+    """One-off translation of a single StreamEvent.
+
+    Allocates a fresh :class:`StreamConverter`, so deferred unwrap works only
+    when the event already carries the complete information (e.g. a
+    ``toolcall_end`` with a parsed wrapper dict). For progressive delta
+    unwrap across multiple events, hold a long-lived ``StreamConverter``.
+    """
+    return StreamConverter().convert(evt)
+
+
+def convert_agent_event_to_sse(evt: AgentEvent) -> list[dict[str, Any]]:
+    """One-off translation of a single AgentEvent. See :func:`convert_event_to_sse`."""
+    return StreamConverter().convert_agent_event(evt)

--- a/backend/cubebox/agents/stream.py
+++ b/backend/cubebox/agents/stream.py
@@ -457,14 +457,13 @@ class StreamConverter:
         # rewrite the call to <real> + inner arguments before execute; we
         # surface the same shape to the frontend so the tool_call event lines
         # up with the eventual tool_result event (which uses the real name).
-        wrapper = block.arguments or {}
-        inner_name = wrapper.get("tool_name") if isinstance(wrapper, dict) else None
-        inner_args = wrapper.get("arguments") if isinstance(wrapper, dict) else None
+        resolved = _resolve_deferred_wrapper(block.arguments)
         self._deferred.pop(idx, None)
-        if not isinstance(inner_name, str):
-            # Malformed wrapper — emit the raw dispatcher call so cubepi's
-            # error fallback ("Unknown deferred tool: ...") still surfaces in
-            # the same card.
+        if resolved is None:
+            # Wrapper failed cubepi's resolver checks (missing/non-str
+            # tool_name, or non-dict non-None arguments) — emit the raw
+            # dispatcher call so cubepi's "Unknown deferred tool" / dispatcher
+            # error fallback still surfaces in the same card.
             return [
                 {
                     "type": "tool_call",
@@ -473,8 +472,7 @@ class StreamConverter:
                     "arguments": block.arguments,
                 }
             ]
-        if not isinstance(inner_args, dict):
-            inner_args = {}
+        inner_name, inner_args = resolved
         return [
             {
                 "type": "tool_call",
@@ -643,16 +641,36 @@ def _unwrap_deferred_block(block: Any) -> Any:
         or block.get("name") != _DEFERRED_DISPATCH_TOOL_NAME
     ):
         return block
-    wrapper = block.get("arguments")
-    if not isinstance(wrapper, dict):
+    resolved = _resolve_deferred_wrapper(block.get("arguments"))
+    if resolved is None:
         return block
-    inner_name = wrapper.get("tool_name")
-    if not isinstance(inner_name, str):
-        return block
-    inner_args = wrapper.get("arguments")
-    if not isinstance(inner_args, dict):
-        inner_args = {}
+    inner_name, inner_args = resolved
     new_block = dict(block)
     new_block["name"] = inner_name
     new_block["arguments"] = inner_args
     return new_block
+
+
+def _resolve_deferred_wrapper(wrapper: Any) -> tuple[str, dict[str, Any]] | None:
+    """Resolve the inner (real_name, args) target from a dispatcher wrapper.
+
+    Mirrors ``cubepi.deferred.middleware.DeferredToolsMiddleware.resolve_tool_call``:
+    ``tool_name`` must be a string; ``arguments`` must be a dict OR ``None``
+    (the latter is the explicit no-arg path cubepi coerces to ``{}``). Any
+    other non-dict ``arguments`` value makes cubepi's resolver return
+    ``None`` so the dispatcher's own ``_execute`` runs and produces an
+    is_error AgentToolResult — UI rewrites must defer to the same fate so
+    the user sees the dispatcher error against the dispatcher name, not a
+    real-name card with empty args masking the failure.
+    """
+    if not isinstance(wrapper, dict):
+        return None
+    name = wrapper.get("tool_name")
+    if not isinstance(name, str):
+        return None
+    args = wrapper.get("arguments")
+    if args is None:
+        args = {}
+    elif not isinstance(args, dict):
+        return None
+    return name, args

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -1475,13 +1475,14 @@ async def _get_history_messages(raw_request: Request, conversation_id: str) -> d
     no cubebox-specific wire conversion layer.
     """
     from cubebox.agents.checkpointer import init_checkpointer
+    from cubebox.agents.stream import unwrap_deferred_in_message_dicts
 
     del raw_request  # checkpointer factory override hook (unused; preserved for future use)
     async with init_checkpointer() as cp:
         data = await cp.load(conversation_id)
     if data is None:
         return {"messages": [], "total": 0}
-    messages = [m.model_dump(mode="json") for m in data.messages]
+    messages = unwrap_deferred_in_message_dicts([m.model_dump(mode="json") for m in data.messages])
     return {"messages": messages, "total": len(messages)}
 
 

--- a/backend/cubebox/api/routes/v1/shares.py
+++ b/backend/cubebox/api/routes/v1/shares.py
@@ -262,6 +262,8 @@ async def get_share(
     user: Annotated[User | None, Depends(optional_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> dict[str, Any]:
+    from cubebox.agents.stream import unwrap_deferred_in_message_dicts
+
     repo = ConversationShareRepository(session)
     share = await repo.get_active(share_id)
     if not share:
@@ -269,13 +271,19 @@ async def get_share(
 
     await _check_scope_access(share, user, session)
 
+    # Legacy snapshots (created before the build_snapshot fix) still hold the
+    # dispatcher form; unwrap on read so old share links don't render
+    # mismatched cards. Newer snapshots are already unwrapped — the helper
+    # is a no-op for them.
+    messages = unwrap_deferred_in_message_dicts(share.snapshot.get("messages", []))
+
     return {
         "id": share.id,
         "title": share.title,
         "creator_display_name": share.creator_display_name,
         "scope": share.scope.value,
         "created_at": utc_isoformat(share.created_at),
-        "messages": share.snapshot.get("messages", []),
+        "messages": messages,
         "artifacts": share.artifacts_snapshot,
     }
 

--- a/backend/cubebox/services/conversation_sharing.py
+++ b/backend/cubebox/services/conversation_sharing.py
@@ -51,11 +51,13 @@ def filter_messages_for_snapshot(
 
 async def build_snapshot(conversation_id: str) -> list[dict[str, Any]]:
     """Load messages from cubepi checkpointer, filter for public snapshot."""
+    from cubebox.agents.stream import unwrap_deferred_in_message_dicts
+
     async with init_checkpointer() as cp:
         data = await cp.load(conversation_id)
     if data is None:
         return []
-    raw = [m.model_dump(mode="json") for m in data.messages]
+    raw = unwrap_deferred_in_message_dicts([m.model_dump(mode="json") for m in data.messages])
     return filter_messages_for_snapshot(raw)
 
 

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1447,7 +1447,7 @@ class RunManager:
           - MCP tools (workspace-enabled HTTP MCP servers)
         """
         from cubebox.agents.checkpointer import init_checkpointer
-        from cubebox.agents.stream import convert_agent_event_to_sse
+        from cubebox.agents.stream import StreamConverter
         from cubebox.middleware.citations.counter import citation_counter_var
 
         # extra_ref late-binding: compaction, skills, and todo all need access
@@ -1513,6 +1513,10 @@ class RunManager:
 
             _user_msg_seen = 0
             auto_detach = _build_auto_detach_listener(agent)
+            # One per-run StreamConverter so progressive `deferred_tool_call`
+            # unwrap can stitch deltas across events; without persistent state
+            # we couldn't peel the wrapper JSON as it streams.
+            stream_converter = StreamConverter()
 
             def _on_event(evt: Any, _signal: Any = None) -> None:
                 # Runs on the same event loop as _run_cubepi_path, so
@@ -1527,7 +1531,7 @@ class RunManager:
                     _user_msg_seen += 1
                     if _user_msg_seen == 1:
                         return  # seed prompt — already shown optimistically
-                for d in convert_agent_event_to_sse(evt):
+                for d in stream_converter.convert_agent_event(evt):
                     sse_queue.put_nowait(d)
 
             agent.subscribe(_on_event)
@@ -1906,7 +1910,7 @@ class RunManager:
           meta row while our claim still owns it.
         """
         from cubebox.agents.checkpointer import init_checkpointer
-        from cubebox.agents.stream import convert_agent_event_to_sse
+        from cubebox.agents.stream import StreamConverter
         from cubebox.middleware.citations.counter import citation_counter_var
         from cubebox.streams.hitl_resume import (
             classify_terminal_status,
@@ -1954,13 +1958,17 @@ class RunManager:
             extra_ref_holder["extra"] = agent._extra
 
             auto_detach = _build_auto_detach_listener(agent)
+            # One per-run StreamConverter — see comment on the prompt path
+            # variant above; the deferred-call unwrap needs persistent state
+            # across deltas inside a single run.
+            stream_converter = StreamConverter()
 
             def _on_event(evt: Any, _signal: Any = None) -> None:
                 # auto_detach runs first so a follow-up HitlRequestEvent
                 # detaches the agent before SSE conversion; T6 reads
                 # `auto_detach.detached` in the terminal block below.
                 auto_detach(evt, _signal)
-                for d in convert_agent_event_to_sse(evt):
+                for d in stream_converter.convert_agent_event(evt):
                     sse_queue.put_nowait(d)
 
             agent.subscribe(_on_event)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -185,7 +185,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "a7bd529dbff6ec608f335bc83a8921e037650ee0" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "915783c4886293dc304e3da740b7786ba4031b3b" }
 
 [dependency-groups]
 dev = [

--- a/backend/tests/unit/test_stream_deferred.py
+++ b/backend/tests/unit/test_stream_deferred.py
@@ -1,0 +1,388 @@
+"""Streaming unwrap of cubepi's `deferred_tool_call` dispatcher.
+
+The dispatcher carries the real tool call inside its `arguments` envelope:
+
+    name=deferred_tool_call
+    arguments={"tool_name": "<real>", "arguments": {...}}
+
+cubepi rewrites the call via `resolve_tool_call` before execution, so the
+`tool_result` event uses the real tool name. Without unwrap here, the
+streamed `tool_call_delta` / `tool_call` events would carry
+`deferred_tool_call` plus a wrapper-JSON delta — the frontend would render
+an opaque dispatcher card and only learn the real name when the result
+arrives. `StreamConverter` peels the wrapper progressively so the title and
+args stream as if the model had called the real tool directly.
+"""
+
+from __future__ import annotations
+
+import json
+
+from cubepi.providers.base import (
+    AssistantMessage,
+    StreamEvent,
+    ToolCall,
+    Usage,
+)
+
+from cubebox.agents.stream import StreamConverter
+
+
+def _mk_assistant(tool_calls: list[ToolCall] | None = None) -> AssistantMessage:
+    content: list = list(tool_calls or [])
+    return AssistantMessage(content=content, usage=Usage())
+
+
+def _deferred_partial(call_id: str = "tc1") -> AssistantMessage:
+    """Partial message during streaming — ToolCall.arguments is still {} per the
+    Anthropic provider; raw JSON lives in the delta string and we accumulate it
+    in the converter's state."""
+    return _mk_assistant(tool_calls=[ToolCall(id=call_id, name="deferred_tool_call", arguments={})])
+
+
+def _feed(conv: StreamConverter, deltas: list[str]) -> list[list[dict]]:
+    """Feed a sequence of toolcall_delta events at content_index=0 with the
+    given delta chunks; return the converter's emitted dict lists per delta."""
+    out: list[list[dict]] = []
+    partial = _deferred_partial()
+    for chunk in deltas:
+        evt = StreamEvent(
+            type="toolcall_delta",
+            delta=chunk,
+            partial=partial,
+            content_index=0,
+        )
+        out.append(conv.convert(evt))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# toolcall_end (terminal) unwrap
+
+
+def test_deferred_toolcall_end_emits_unwrapped_real_tool_call() -> None:
+    """toolcall_end with name=deferred_tool_call and a parsed arguments dict
+    must emit a `tool_call` SSE event whose name = inner.tool_name and
+    arguments = inner.arguments. Without this the frontend card title stays
+    `deferred_tool_call` and the args are the wrapper dict, not the real
+    call's args."""
+    inner_args = {"path": "a.txt", "content": "hello"}
+    partial = _mk_assistant(
+        tool_calls=[
+            ToolCall(
+                id="tc1",
+                name="deferred_tool_call",
+                arguments={"tool_name": "file_write", "arguments": inner_args},
+            )
+        ]
+    )
+    evt = StreamEvent(type="toolcall_end", content_index=0, partial=partial)
+    out = StreamConverter().convert(evt)
+    assert len(out) == 1
+    assert out[0] == {
+        "type": "tool_call",
+        "id": "tc1",
+        "name": "file_write",
+        "arguments": inner_args,
+    }
+
+
+def test_non_deferred_toolcall_end_passes_through_unchanged() -> None:
+    """Non-deferred tool calls keep the existing translation (no unwrap)."""
+    partial = _mk_assistant(
+        tool_calls=[ToolCall(id="tc1", name="file_write", arguments={"path": "a.txt"})]
+    )
+    evt = StreamEvent(type="toolcall_end", content_index=0, partial=partial)
+    out = StreamConverter().convert(evt)
+    assert out == [
+        {
+            "type": "tool_call",
+            "id": "tc1",
+            "name": "file_write",
+            "arguments": {"path": "a.txt"},
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Streaming unwrap — tool_name then arguments (typical schema order)
+
+
+def test_streaming_emits_nothing_before_tool_name_known() -> None:
+    """Until the `tool_name` value's closing quote is in the buffer, nothing
+    streams — we don't know what title to attach to the card yet."""
+    conv = StreamConverter()
+    emits = _feed(conv, ['{"tool_n', 'ame": "fi'])
+    assert emits == [[], []]
+
+
+def test_streaming_starts_emitting_once_inner_args_opens() -> None:
+    """First emit carries the resolved real tool name and the chars seen so far
+    *inside* the inner arguments value — the wrapper prefix is dropped."""
+    conv = StreamConverter()
+    emits = _feed(
+        conv,
+        [
+            '{"tool_name": "file_write", "arg',
+            'uments": {"path":',
+            ' "a.txt"',
+        ],
+    )
+    # First two chunks: title not yet resolvable to "args started" — no emit
+    # until the inner '{' is in the buffer.
+    assert emits[0] == []
+    # Second chunk reaches `"arguments": {` — emit kicks in with the inner '{'.
+    assert len(emits[1]) == 1
+    first = emits[1][0]
+    assert first["type"] == "tool_call_delta"
+    assert first["index"] == 0
+    assert first["id"] == "tc1"
+    assert first["name"] == "file_write"
+    assert first["delta"] == '{"path":'
+    # Third chunk: append the rest of the inner value seen so far.
+    assert len(emits[2]) == 1
+    assert emits[2][0]["delta"] == ' "a.txt"'
+    assert emits[2][0]["name"] == "file_write"
+
+
+def test_streaming_stops_at_inner_args_close() -> None:
+    """When the closing `}` of inner arguments arrives — possibly followed by
+    the outer `}` — only the inner closing brace is emitted, never the wrapper
+    close."""
+    conv = StreamConverter()
+    emits = _feed(
+        conv,
+        [
+            '{"tool_name": "file_write", "arguments": {"path": "a.txt"',
+            "}}",
+        ],
+    )
+    # First chunk emits the inner-args prefix up to current end.
+    assert emits[0][0]["delta"] == '{"path": "a.txt"'
+    # Second chunk emits only the inner '}' — outer '}' is dropped.
+    assert len(emits[1]) == 1
+    assert emits[1][0]["delta"] == "}"
+
+
+# ---------------------------------------------------------------------------
+# Streaming unwrap — arguments first, then tool_name
+
+
+def test_streaming_buffers_when_arguments_appears_before_tool_name() -> None:
+    """Some models may emit `arguments` before `tool_name` (the JSON object key
+    order is not guaranteed). The converter must NOT emit args deltas with no
+    title — it buffers until tool_name is resolved, then emits the whole
+    inner-args block in one chunk with the resolved name."""
+    conv = StreamConverter()
+    emits = _feed(
+        conv,
+        [
+            '{"arguments": {"path": "a.txt"}, "tool_n',
+            'ame": "file_write"}',
+        ],
+    )
+    # First chunk: args fully seen but tool_name still unknown → no emit yet.
+    assert emits[0] == []
+    # Second chunk: tool_name resolves; the entire buffered inner-args block
+    # is emitted as one delta carrying the now-known name.
+    assert len(emits[1]) == 1
+    assert emits[1][0]["name"] == "file_write"
+    assert emits[1][0]["delta"] == '{"path": "a.txt"}'
+
+
+# ---------------------------------------------------------------------------
+# Streaming unwrap — single-shot full delta
+
+
+def test_streaming_full_payload_in_one_delta_unwraps_inner() -> None:
+    """If the provider hands us the whole JSON in one delta event, the emit
+    still strips the wrapper and shows real name + inner args."""
+    conv = StreamConverter()
+    emits = _feed(
+        conv,
+        ['{"tool_name": "file_write", "arguments": {"path": "a.txt"}}'],
+    )
+    assert len(emits[0]) == 1
+    assert emits[0][0]["name"] == "file_write"
+    assert emits[0][0]["delta"] == '{"path": "a.txt"}'
+
+
+def test_streaming_empty_inner_arguments() -> None:
+    """`"arguments": {}` produces a `{}` delta — distinguishes deliberate no-arg
+    calls from the wrapper-not-yet-opened case."""
+    conv = StreamConverter()
+    emits = _feed(conv, ['{"tool_name": "ping", "arguments": {}}'])
+    assert emits[0][0]["delta"] == "{}"
+    assert emits[0][0]["name"] == "ping"
+
+
+# ---------------------------------------------------------------------------
+# Non-deferred streaming — must pass through unchanged
+
+
+def test_non_deferred_streaming_delta_passes_through_with_identity() -> None:
+    """Non-deferred tool calls keep their original delta JSON and outer name."""
+    conv = StreamConverter()
+    partial = _mk_assistant(tool_calls=[ToolCall(id="tc1", name="file_write", arguments={})])
+    evt = StreamEvent(
+        type="toolcall_delta",
+        delta='{"path": "a.txt"',
+        partial=partial,
+        content_index=0,
+    )
+    out = conv.convert(evt)
+    assert out == [
+        {
+            "type": "tool_call_delta",
+            "delta": '{"path": "a.txt"',
+            "index": 0,
+            "id": "tc1",
+            "name": "file_write",
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Independent state per content_index — parallel deferred calls don't bleed
+
+
+def test_independent_state_per_content_index() -> None:
+    """Two deferred calls streamed in parallel (different content_index)
+    must not mix buffers — each gets its own scanning state."""
+    conv = StreamConverter()
+    p0 = _mk_assistant(
+        tool_calls=[
+            ToolCall(id="tc0", name="deferred_tool_call", arguments={}),
+            ToolCall(id="tc1", name="deferred_tool_call", arguments={}),
+        ]
+    )
+
+    def evt(idx: int, delta: str) -> StreamEvent:
+        return StreamEvent(
+            type="toolcall_delta",
+            delta=delta,
+            partial=p0,
+            content_index=idx,
+        )
+
+    # Interleave deltas for tc0 (file_write) and tc1 (file_read).
+    conv.convert(evt(0, '{"tool_name": "file_write", '))
+    conv.convert(evt(1, '{"tool_name": "file_read", '))
+    out0 = conv.convert(evt(0, '"arguments": {"path": "a.txt"}}'))
+    out1 = conv.convert(evt(1, '"arguments": {"path": "b.txt"}}'))
+    assert out0[0]["name"] == "file_write"
+    assert out0[0]["delta"] == '{"path": "a.txt"}'
+    assert out1[0]["name"] == "file_read"
+    assert out1[0]["delta"] == '{"path": "b.txt"}'
+
+
+# ---------------------------------------------------------------------------
+# State cleanup at toolcall_end — the deferred buffer must not accumulate
+
+
+def test_deferred_state_cleared_after_toolcall_end() -> None:
+    """toolcall_end must drop the per-content-index buffer so a long run with
+    many deferred calls doesn't grow the converter's working set unboundedly."""
+    conv = StreamConverter()
+    _feed(conv, ['{"tool_name": "file_write", "arguments": {"path": "a.txt"}}'])
+    assert 0 in conv._deferred  # streaming state is present mid-call
+    end_evt = StreamEvent(
+        type="toolcall_end",
+        content_index=0,
+        partial=_mk_assistant(
+            tool_calls=[
+                ToolCall(
+                    id="tc1",
+                    name="deferred_tool_call",
+                    arguments={"tool_name": "file_write", "arguments": {"path": "a.txt"}},
+                )
+            ]
+        ),
+    )
+    conv.convert(end_evt)
+    assert conv._deferred == {}
+
+
+def test_parallel_deferred_end_clears_only_finished_call() -> None:
+    """Ending one parallel deferred call must NOT wipe the in-flight sibling's
+    buffer — that would corrupt the still-streaming call's args."""
+    conv = StreamConverter()
+    partial = _mk_assistant(
+        tool_calls=[
+            ToolCall(id="tc0", name="deferred_tool_call", arguments={}),
+            ToolCall(id="tc1", name="deferred_tool_call", arguments={}),
+        ]
+    )
+
+    def delta_evt(idx: int, chunk: str) -> StreamEvent:
+        return StreamEvent(type="toolcall_delta", delta=chunk, partial=partial, content_index=idx)
+
+    conv.convert(delta_evt(0, '{"tool_name": "file_write", "arguments": {"path": "a.txt"}}'))
+    conv.convert(delta_evt(1, '{"tool_name": "file_read", "arguments": {"pa'))
+    assert 0 in conv._deferred and 1 in conv._deferred
+
+    end_evt0 = StreamEvent(
+        type="toolcall_end",
+        content_index=0,
+        partial=_mk_assistant(
+            tool_calls=[
+                ToolCall(
+                    id="tc0",
+                    name="deferred_tool_call",
+                    arguments={"tool_name": "file_write", "arguments": {"path": "a.txt"}},
+                ),
+                ToolCall(id="tc1", name="deferred_tool_call", arguments={}),
+            ]
+        ),
+    )
+    conv.convert(end_evt0)
+    assert 0 not in conv._deferred
+    assert 1 in conv._deferred  # sibling still streaming — buffer intact
+
+
+def test_non_deferred_end_clears_any_stale_state_at_index() -> None:
+    """If an earlier deferred call somehow left state at an index and a
+    non-deferred end fires there next, the stale buffer must be dropped — a
+    defense-in-depth guarantee that no idx is silently shared across calls."""
+    conv = StreamConverter()
+    # Plant stale state by partially streaming a deferred call at idx=0.
+    _feed(conv, ['{"tool_name": "x", "arguments": {"y": 1'])
+    assert 0 in conv._deferred
+    non_deferred_end = StreamEvent(
+        type="toolcall_end",
+        content_index=0,
+        partial=_mk_assistant(
+            tool_calls=[ToolCall(id="tc-other", name="file_write", arguments={"path": "a.txt"})]
+        ),
+    )
+    conv.convert(non_deferred_end)
+    assert conv._deferred == {}
+
+
+# ---------------------------------------------------------------------------
+# String escapes inside inner args must not confuse the brace scanner
+
+
+def test_streaming_handles_escaped_braces_in_inner_string_value() -> None:
+    """A `}` inside a string value must not close the inner-args object early.
+    Regression guard for the brace-depth scanner ignoring string contents."""
+    conv = StreamConverter()
+    emits = _feed(
+        conv,
+        [
+            '{"tool_name": "echo", "arguments": {"msg": "use }} braces"}}',
+        ],
+    )
+    body = json.loads(emits[0][0]["delta"])
+    assert body == {"msg": "use }} braces"}
+
+
+def test_streaming_handles_escaped_quote_in_string_value() -> None:
+    """An escaped `\\\"` inside a string must not be treated as a close-quote."""
+    conv = StreamConverter()
+    emits = _feed(
+        conv,
+        ['{"tool_name": "echo", "arguments": {"msg": "say \\"hi\\""}}'],
+    )
+    body = json.loads(emits[0][0]["delta"])
+    assert body == {"msg": 'say "hi"'}

--- a/backend/tests/unit/test_stream_deferred.py
+++ b/backend/tests/unit/test_stream_deferred.py
@@ -479,6 +479,111 @@ def test_unwrap_preserves_malformed_wrapper_so_error_chain_stays() -> None:
     assert out == malformed
 
 
+def test_unwrap_coerces_none_arguments_to_empty_dict() -> None:
+    """`"arguments": null` is cubepi's explicit no-arg path — resolver
+    coerces None to {} and dispatches normally. The display unwrap must
+    mirror that or live and history will diverge from execution."""
+    msg = {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_call",
+                "id": "tc1",
+                "name": "deferred_tool_call",
+                "arguments": {"tool_name": "ping", "arguments": None},
+            }
+        ],
+    }
+    out = unwrap_deferred_in_message_dicts([msg])
+    assert out[0]["content"][0]["name"] == "ping"
+    assert out[0]["content"][0]["arguments"] == {}
+
+
+def test_unwrap_coerces_missing_arguments_key_to_empty_dict() -> None:
+    """When the wrapper omits the `arguments` key entirely, treat it as the
+    same no-arg case cubepi handles via `wrapper.get('arguments')` → None →
+    {}."""
+    msg = {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_call",
+                "id": "tc1",
+                "name": "deferred_tool_call",
+                "arguments": {"tool_name": "ping"},
+            }
+        ],
+    }
+    out = unwrap_deferred_in_message_dicts([msg])
+    assert out[0]["content"][0]["name"] == "ping"
+    assert out[0]["content"][0]["arguments"] == {}
+
+
+def test_unwrap_preserves_dispatcher_block_when_inner_args_is_list() -> None:
+    """Non-dict non-None inner arguments makes cubepi's resolver return None,
+    so the dispatcher's _execute runs and yields an error. The UI must show
+    the dispatcher block (name + raw wrapper) — coercing to {} would surface
+    a real-name card with empty args, hiding what actually broke."""
+    block = {
+        "type": "tool_call",
+        "id": "tc1",
+        "name": "deferred_tool_call",
+        "arguments": {"tool_name": "file_write", "arguments": ["bad"]},
+    }
+    out = unwrap_deferred_in_message_dicts([{"role": "assistant", "content": [block]}])
+    assert out[0]["content"][0] == block
+
+
+def test_unwrap_preserves_dispatcher_block_when_inner_args_is_scalar() -> None:
+    """Same as the list case but for a scalar (number / string) — anything
+    non-dict-non-None must keep the dispatcher form so cubepi's error
+    fallback chain stays visible."""
+    block = {
+        "type": "tool_call",
+        "id": "tc1",
+        "name": "deferred_tool_call",
+        "arguments": {"tool_name": "file_write", "arguments": 42},
+    }
+    out = unwrap_deferred_in_message_dicts([{"role": "assistant", "content": [block]}])
+    assert out[0]["content"][0] == block
+
+
+# ---------------------------------------------------------------------------
+# SSE toolcall_end must honor the same coercion rules as the dict unwrap
+
+
+def test_toolcall_end_with_none_inner_arguments_emits_real_name_empty_dict() -> None:
+    """Same coercion semantics as the history dict path: inner arguments None
+    means real-name call with {} args, matching cubepi's resolver."""
+    partial = _mk_assistant(
+        tool_calls=[
+            ToolCall(
+                id="tc1",
+                name="deferred_tool_call",
+                arguments={"tool_name": "ping", "arguments": None},
+            )
+        ]
+    )
+    evt = StreamEvent(type="toolcall_end", content_index=0, partial=partial)
+    out = StreamConverter().convert(evt)
+    assert out[0]["name"] == "ping"
+    assert out[0]["arguments"] == {}
+
+
+def test_toolcall_end_with_list_inner_arguments_keeps_dispatcher_form() -> None:
+    """If the model produced non-dict non-None inner args, cubepi will run
+    the dispatcher's _execute and emit an error result — keep the dispatcher
+    block in the live SSE so the user sees the call name match the result."""
+    wrapper = {"tool_name": "file_write", "arguments": ["bad"]}
+    partial = _mk_assistant(
+        tool_calls=[ToolCall(id="tc1", name="deferred_tool_call", arguments=wrapper)]
+    )
+    evt = StreamEvent(type="toolcall_end", content_index=0, partial=partial)
+    out = StreamConverter().convert(evt)
+    assert out[0]["name"] == "deferred_tool_call"
+    assert out[0]["arguments"] == wrapper
+
+
 def test_unwrap_does_not_mutate_input_messages() -> None:
     """The helper runs on the model_dump'd output and must not mutate the
     caller's list — callers may still hold references to the dicts."""

--- a/backend/tests/unit/test_stream_deferred.py
+++ b/backend/tests/unit/test_stream_deferred.py
@@ -25,7 +25,7 @@ from cubepi.providers.base import (
     Usage,
 )
 
-from cubebox.agents.stream import StreamConverter
+from cubebox.agents.stream import StreamConverter, unwrap_deferred_in_message_dicts
 
 
 def _mk_assistant(tool_calls: list[ToolCall] | None = None) -> AssistantMessage:
@@ -386,3 +386,140 @@ def test_streaming_handles_escaped_quote_in_string_value() -> None:
     )
     body = json.loads(emits[0][0]["delta"])
     assert body == {"msg": 'say "hi"'}
+
+
+# ---------------------------------------------------------------------------
+# Persisted-message unwrap — /messages, /bootstrap, /shares display path
+#
+# cubepi's resolve_tool_call rewrites the ToolCall at execute time, but the
+# checkpointed AssistantMessage keeps the dispatcher block (cubepi never
+# mutates the persisted assistant message for prompt-cache reasons). Without
+# unwrap_deferred_in_message_dicts, reloads of completed conversations would
+# show `deferred_tool_call` cards while the live stream showed real names.
+
+
+def test_unwrap_rewrites_persisted_deferred_assistant_tool_call() -> None:
+    """The dispatcher block in a checkpointed assistant message is rewritten
+    to the resolved real tool name + inner args for display."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_call",
+                    "id": "tc1",
+                    "name": "deferred_tool_call",
+                    "arguments": {
+                        "tool_name": "file_write",
+                        "arguments": {"path": "a.txt"},
+                    },
+                }
+            ],
+        }
+    ]
+    out = unwrap_deferred_in_message_dicts(messages)
+    assert out[0]["content"][0] == {
+        "type": "tool_call",
+        "id": "tc1",
+        "name": "file_write",
+        "arguments": {"path": "a.txt"},
+    }
+
+
+def test_unwrap_leaves_non_deferred_tool_call_untouched() -> None:
+    """A persisted tool_call from a non-deferred path (e.g. a builtin or
+    subagent tool) passes through with name and arguments intact."""
+    block = {
+        "type": "tool_call",
+        "id": "tc1",
+        "name": "show_widget",
+        "arguments": {"kind": "panel"},
+    }
+    out = unwrap_deferred_in_message_dicts([{"role": "assistant", "content": [block]}])
+    assert out[0]["content"][0] == block
+
+
+def test_unwrap_passes_through_user_and_tool_result_messages() -> None:
+    """Only AssistantMessages can carry ToolCall blocks. User and tool_result
+    messages must not be mutated even if they happen to contain a key named
+    `name` or `arguments` somewhere in their payload."""
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        {
+            "role": "tool_result",
+            "tool_call_id": "tc1",
+            "tool_name": "file_write",
+            "content": [{"type": "text", "text": "ok"}],
+        },
+    ]
+    out = unwrap_deferred_in_message_dicts(messages)
+    assert out == messages
+
+
+def test_unwrap_preserves_malformed_wrapper_so_error_chain_stays() -> None:
+    """A wrapper whose inner `tool_name` is missing or non-string passes
+    through unchanged. cubepi's resolver falls through to the dispatcher's
+    `_execute`, which yields an is_error AgentToolResult ("Unknown deferred
+    tool: ..."); rewriting the assistant block here would hide that and
+    leave the user with an inscrutable error against an invented name."""
+    malformed = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_call",
+                    "id": "tc1",
+                    "name": "deferred_tool_call",
+                    "arguments": {"tool_name": None, "arguments": {"x": 1}},
+                }
+            ],
+        }
+    ]
+    out = unwrap_deferred_in_message_dicts(malformed)
+    assert out == malformed
+
+
+def test_unwrap_does_not_mutate_input_messages() -> None:
+    """The helper runs on the model_dump'd output and must not mutate the
+    caller's list — callers may still hold references to the dicts."""
+    block = {
+        "type": "tool_call",
+        "id": "tc1",
+        "name": "deferred_tool_call",
+        "arguments": {"tool_name": "file_write", "arguments": {"path": "a.txt"}},
+    }
+    msg = {"role": "assistant", "content": [block]}
+    input_messages = [msg]
+    unwrap_deferred_in_message_dicts(input_messages)
+    # Original list / dict / block references unchanged.
+    assert input_messages[0] is msg
+    assert msg["content"][0] is block
+    assert block["name"] == "deferred_tool_call"
+    assert block["arguments"] == {"tool_name": "file_write", "arguments": {"path": "a.txt"}}
+
+
+def test_unwrap_handles_mixed_assistant_content_blocks() -> None:
+    """An assistant message can mix text/thinking/tool_call blocks; unwrap
+    only touches the deferred tool_call block and leaves the rest alone."""
+    msg = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Calling file_write…"},
+            {"type": "thinking", "thinking": "I should write the file."},
+            {
+                "type": "tool_call",
+                "id": "tc1",
+                "name": "deferred_tool_call",
+                "arguments": {
+                    "tool_name": "file_write",
+                    "arguments": {"path": "a.txt"},
+                },
+            },
+        ],
+    }
+    out = unwrap_deferred_in_message_dicts([msg])
+    content = out[0]["content"]
+    assert content[0]["type"] == "text"
+    assert content[1]["type"] == "thinking"
+    assert content[2]["name"] == "file_write"
+    assert content[2]["arguments"] == {"path": "a.txt"}

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -968,7 +968,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=48.0.1" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=a7bd529dbff6ec608f335bc83a8921e037650ee0" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=915783c4886293dc304e3da740b7786ba4031b3b" },
     { name = "dingtalk-stream", specifier = ">=0.24.3" },
     { name = "discord-py", specifier = ">=2.7.1" },
     { name = "dynaconf", specifier = ">=3.2.11" },
@@ -1025,7 +1025,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.11.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=a7bd529dbff6ec608f335bc83a8921e037650ee0#a7bd529dbff6ec608f335bc83a8921e037650ee0" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=915783c4886293dc304e3da740b7786ba4031b3b#915783c4886293dc304e3da740b7786ba4031b3b" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },


### PR DESCRIPTION
## Summary

- **Live SSE streaming.** New per-run `StreamConverter` peels cubepi's
  `deferred_tool_call(tool_name, arguments)` wrapper from `tool_call_delta` /
  `tool_call` events as the LLM streams, so the frontend card title and args
  match the eventual `tool_result` (which already carries the resolver-rewritten
  real name). Handles both schema-order and reverse-order JSON, escaped quotes /
  braces, parallel deferred calls per `content_index`, and falls back to the raw
  dispatcher form on malformed wrappers so cubepi's "Unknown deferred tool"
  error chain stays visible.
- **History / share reload.** cubepi's `resolve_tool_call` only rewrites the
  call at execute time; the checkpointed `AssistantMessage` keeps the
  dispatcher block. Added `unwrap_deferred_in_message_dicts` (dict-level, post
  `model_dump`) and wired it into `_get_history_messages` (used by `/messages`
  and `/bootstrap`), `build_snapshot` (new shares), and `get_share` (legacy
  share snapshots). Model-replay path (cubepi's own load) is untouched.
- **cubepi pin bump (`915783c`).** Picks up a hint in the dispatcher's tool
  description nudging models to emit `tool_name` before `arguments` so the
  streaming unwrap usually skips the buffer-and-flush fallback. The
  `arguments`-first path remains tested.
- **Resolver-consistent malformed-args handling.** Shared
  `_resolve_deferred_wrapper` mirrors cubepi exactly: `arguments: None` →
  `{}`; any other non-dict value preserves the dispatcher block so the UI
  doesn't mask the failure with a real-name card.

## Test plan

- [x] `tests/unit/test_stream_deferred.py` — 27 tests covering streaming
      unwrap, state cleanup, parallel `content_index` isolation, history
      dict unwrap, immutability, coercion edge cases (`None` / missing /
      list / scalar).
- [x] `tests/unit/test_stream*.py` + `test_run_manager_cubepi_dict_to_event` +
      `test_snapshot_filter` + `test_replay_coalescer` + `test_artifact_event_pipeline` +
      `test_mcp_disclosure` — 111 regression tests pass.
- [x] `mypy` clean on `cubebox/agents/stream.py`,
      `cubebox/api/routes/v1/conversations.py`,
      `cubebox/api/routes/v1/shares.py`,
      `cubebox/services/conversation_sharing.py`,
      `cubebox/streams/run_manager.py`.
- [ ] Manual smoke against a real deferred MCP call: live card title shows
      the real tool name, args stream as inner JSON, reload preserves the
      same shape, share link shows the same shape.