### PR TITLE
feat(tests): auto-load backend/.test.env for per-dev test overrides

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,4 +1,5 @@
 .env
+.test.env
 .coverage
 coverage.xml
 scripts/dev

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,8 +1,19 @@
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv as _load_dotenv
+
 # Set environment BEFORE any imports
 os.environ.setdefault("ENV_FOR_DYNACONF", "test")
+
+# Per-developer test-only overrides (gitignored). Use this for machine-specific
+# values that shouldn't bleed into the dev server's `.env` — e.g. when local
+# rustfs isn't on the default port:
+#   CUBEBOX_OBJECTSTORE__ENDPOINT=http://127.0.0.1:9010
+# override=False so explicit shell exports still win.
+_test_env_path = Path(__file__).resolve().parents[1] / ".test.env"
+if _test_env_path.exists():
+    _load_dotenv(dotenv_path=_test_env_path, override=False)
 os.environ.setdefault(
     "CUBEBOX_AUTH__VAULT_KEY",
     "Nmu-K8QhP_uhdjmwbaiNmgxVQHbGeCkMOCz8RKp1LMM=",


### PR DESCRIPTION
## Summary

- conftest.py loads `backend/.test.env` (gitignored) before any imports, with `override=False` so explicit shell exports still win
- Adds `.test.env` to `backend/.gitignore`

## Motivation

Test-only env overrides currently have nowhere to live:

- `backend/.env` is loaded for both the dev server and the test suite, so test-only values (e.g. a local rustfs that listens on `:9010` because `:9000` is occupied by clickhouse) would also point the dev server at the wrong place.
- Shell exports don't survive new terminals.

`.test.env` fills the gap. Default behavior is unchanged for anyone without the file.

## Example

```bash
# backend/.test.env
CUBEBOX_OBJECTSTORE__ENDPOINT=http://127.0.0.1:9010
```

## Test plan

- [x] Verified locally: `uv run pytest tests/e2e/test_attachments_api.py::test_upload_png_returns_metadata` previously failed with a 400 against `:9000`, now passes against `:9010` after adding the `.test.env` override.
- [ ] CI green (no `.test.env` present → loader is a no-op, all suites behave as before).