### PR TITLE
fix(attachments): hydrate uploads into sandbox before run

### DIFF
--- a/backend/cubebox/agents/hydrator.py
+++ b/backend/cubebox/agents/hydrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -49,8 +50,14 @@ class AttachmentHydrator:
             if row is None:
                 raise AttachmentHydrationError(file_id=fid, cause="row not found")
 
+            # shlex.quote prevents shell metacharacters in the user-supplied
+            # filename (e.g. ``$(whoami).xlsx``, backticks, ``;``) from being
+            # evaluated by the sandbox shell. _safe_basename allows these
+            # characters through, so the only safe form is single-quoting via
+            # shlex — bash double-quotes still expand $() and backticks.
+            quoted_path = shlex.quote(row.sandbox_path)
             check = await self.sandbox.execute(
-                f'test -f "{row.sandbox_path}" && echo EXISTS || echo MISSING'
+                f"test -f {quoted_path} && echo EXISTS || echo MISSING"
             )
             if (check.output or "").strip() == "EXISTS":
                 result[fid] = row.sandbox_path

--- a/backend/cubebox/middleware/sandbox.py
+++ b/backend/cubebox/middleware/sandbox.py
@@ -335,13 +335,47 @@ def _make_file_read_tool(
     ) -> AgentToolResult:
         import json
 
+        from cubebox.parsers.schema import ErrorOutput
+        from cubebox.sandbox.base import SandboxError
+
         del tool_call_id, signal, on_update
 
-        result = await sandbox.file_read(
-            args.path,
-            options=ParseOptions(page_range=args.page_range, line_range=args.line_range),
-            conversation_id=conversation_id,
-        )
+        # Surface FileNotFoundError / SandboxError as a structured ErrorOutput
+        # instead of letting them bubble into cubepi's generic tool-error
+        # wrapper — that wrapper writes ``str(exc)`` into the tool result, and
+        # ``str(FileNotFoundError(path))`` is literally the path, which the
+        # model reads as "the file content is its own path".
+        try:
+            result: Any = await sandbox.file_read(
+                args.path,
+                options=ParseOptions(page_range=args.page_range, line_range=args.line_range),
+                conversation_id=conversation_id,
+            )
+        except FileNotFoundError:
+            result = ErrorOutput(
+                path=args.path,
+                error=f"file not found: {args.path}",
+                retryable=False,
+            )
+        except SandboxError as exc:
+            result = ErrorOutput(
+                path=args.path,
+                error=f"sandbox error reading {args.path}: {exc}",
+                retryable=False,
+            )
+        except Exception as exc:  # noqa: BLE001 — last-resort wrapper
+            # Catch-all for transport errors (httpx.TransportError, timeouts)
+            # and anything else the download / sniff / dedup layers can raise
+            # outside the parser-registry's own try/except. Without this,
+            # cubepi's generic tool-error wrapper writes str(exc) into the
+            # ToolResult content — the same trap that FileNotFoundError fell
+            # into. asyncio.CancelledError is BaseException, not Exception,
+            # so user-cancel still propagates.
+            result = ErrorOutput(
+                path=args.path,
+                error=f"failed to read {args.path}: {exc}",
+                retryable=True,
+            )
         return AgentToolResult(content=[TextContent(text=json.dumps(result.model_dump()))])
 
     return AgentTool(

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -459,18 +459,72 @@ def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent 
     return None
 
 
+async def _hydrate_attachments_into_sandbox(
+    *,
+    org_id: str,
+    workspace_id: str,
+    conversation_id: str,
+    attachment_ids: list[str],
+    sandbox: Any,
+) -> None:
+    """Materialize attachment objects from ObjectStore onto the sandbox FS.
+
+    AttachmentService stamps every row with a promised path
+    (``/workspace/uploads/<conv>/<atch>/<filename>``) and the system prompt
+    tells the LLM to ``file_read`` that path — but the bytes live in
+    ObjectStore until something stages them in. This function is the
+    something. Idempotent (the hydrator checks for an existing file first).
+    Failures are logged and swallowed: the agent will see "file not found"
+    and surface it to the user, which is better than aborting the run.
+    """
+    if not attachment_ids or sandbox is None:
+        return
+
+    from cubebox.agents.hydrator import AttachmentHydrator
+    from cubebox.db.engine import async_session_maker
+    from cubebox.objectstore import get_objectstore_client
+    from cubebox.repositories import AttachmentRepository
+
+    try:
+        async with async_session_maker() as session:
+            repo = AttachmentRepository(
+                session,
+                org_id=org_id,
+                workspace_id=workspace_id,
+            )
+            hydrator = AttachmentHydrator(
+                repo=repo,
+                sandbox=sandbox,
+                objectstore=get_objectstore_client(),
+            )
+            await hydrator.hydrate(
+                conversation_id=conversation_id,
+                file_ids=attachment_ids,
+            )
+    except Exception as exc:  # noqa: BLE001 — non-fatal by design
+        logger.warning("Failed to hydrate attachments into sandbox: {}", exc)
+
+
 async def _build_attachment_content_blocks(
     *,
     org_id: str,
     workspace_id: str,
     conversation_id: str,
     attachment_ids: list[str],
+    sandbox_available: bool = True,
 ) -> list[dict[str, Any]]:
     """Return file_attachment content blocks for the given file_ids.
 
     Reads metadata via a short-lived session. Rows are expected to exist
     (validated at the API layer); missing rows are silently skipped here
     since hydration would have already failed for them.
+
+    When ``sandbox_available`` is False, document/other attachments are
+    dropped: their hint tells the model to ``file_read`` a sandbox path,
+    but ``file_read`` is only registered when SandboxMiddleware loads, and
+    hydration could not have placed bytes there either. Image attachments
+    are kept because ``view_images`` reads bytes from ObjectStore directly
+    and is registered regardless of sandbox availability.
     """
     if not attachment_ids:
         return []
@@ -491,6 +545,14 @@ async def _build_attachment_content_blocks(
                 attachment_id=fid,
             )
             if row is None:
+                continue
+            if not sandbox_available and row.kind != "image":
+                logger.warning(
+                    "Skipping non-image attachment {} ({}) — sandbox unavailable, "
+                    "file_read tool is not registered",
+                    row.id,
+                    row.kind,
+                )
                 continue
             blocks.append(
                 {
@@ -1567,12 +1629,21 @@ class RunManager:
             # Build attachment metadata blocks and inject into user message so
             # AttachmentHintMiddleware can render the [Attachments] hint.
             if attachments:
+                await _hydrate_attachments_into_sandbox(
+                    org_id=ctx.org_id,
+                    workspace_id=ctx.workspace_id,
+                    conversation_id=conversation_id,
+                    attachment_ids=attachments,
+                    sandbox=sandbox,
+                )
+
                 try:
                     _att_blocks = await _build_attachment_content_blocks(
                         org_id=ctx.org_id,
                         workspace_id=ctx.workspace_id,
                         conversation_id=conversation_id,
                         attachment_ids=attachments,
+                        sandbox_available=sandbox is not None,
                     )
                     if _att_blocks:
                         _user_msg_metadata["attachments"] = _att_blocks

--- a/backend/tests/test_hydrator.py
+++ b/backend/tests/test_hydrator.py
@@ -80,6 +80,34 @@ async def test_hydrate_raises_when_attachment_not_found() -> None:
 
 
 @pytest.mark.asyncio
+async def test_hydrate_quotes_shell_metacharacters_in_path() -> None:
+    """Filename shell metacharacters (``$()``, backticks, ``;``) must not run
+    as commands when the hydrator probes for the file via ``sandbox.execute``.
+
+    _safe_basename in AttachmentService preserves ``$``, backticks, ``(``,
+    ``)`` etc., so the only safe form here is shlex.quote — bash double-quotes
+    still expand $() and backticks.
+    """
+    evil_path = "/workspace/uploads/conv1/fid1/$(touch /tmp/pwned)`whoami`.xlsx"
+    sandbox = MagicMock()
+    sandbox.execute = AsyncMock(return_value=MagicMock(output="EXISTS", exit_code=0))
+    sandbox.upload = AsyncMock()
+    objectstore = MagicMock()
+    repo = MagicMock()
+    repo.get_in_conversation = AsyncMock(return_value=_att(sandbox_path=evil_path))
+
+    h = AttachmentHydrator(repo=repo, sandbox=sandbox, objectstore=objectstore)
+    await h.hydrate(conversation_id="conv1", file_ids=["fid1"])
+
+    (cmd,), _ = sandbox.execute.call_args
+    # The dangerous tokens must appear inside a single-quoted argument, which
+    # bash treats as a literal — never inside double quotes (which would still
+    # expand $() and backticks).
+    assert "'/workspace/uploads/conv1/fid1/$(touch /tmp/pwned)`whoami`.xlsx'" in cmd
+    assert '"' not in cmd.split("&&")[0]  # the test -f arg never sees a double quote
+
+
+@pytest.mark.asyncio
 async def test_hydrate_raises_on_objectstore_error() -> None:
     sandbox = MagicMock()
     sandbox.execute = AsyncMock(return_value=MagicMock(output="MISSING", exit_code=0))

--- a/backend/tests/unit/test_run_manager_hydrate_attachments.py
+++ b/backend/tests/unit/test_run_manager_hydrate_attachments.py
@@ -1,0 +1,213 @@
+"""Wire-up tests for ``_hydrate_attachments_into_sandbox`` in run_manager.
+
+The hydrator class itself is covered by ``backend/tests/test_hydrator.py``.
+These tests pin the contract that the run path actually invokes the hydrator
+with the right arguments and never raises on failure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cubebox.streams.run_manager import (
+    _build_attachment_content_blocks,
+    _hydrate_attachments_into_sandbox,
+)
+
+
+@asynccontextmanager
+async def _stub_session() -> AsyncGenerator[MagicMock, None]:
+    yield MagicMock()
+
+
+def _patches(hydrator_cls: MagicMock) -> Any:
+    """Patch the four lazy imports inside _hydrate_attachments_into_sandbox."""
+    return (
+        patch("cubebox.agents.hydrator.AttachmentHydrator", hydrator_cls),
+        patch("cubebox.db.engine.async_session_maker", _stub_session),
+        patch("cubebox.objectstore.get_objectstore_client", MagicMock()),
+        patch("cubebox.repositories.AttachmentRepository", MagicMock()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_skips_when_no_attachments() -> None:
+    hydrator_cls = MagicMock()
+    patches = _patches(hydrator_cls)
+    for p in patches:
+        p.start()
+    try:
+        await _hydrate_attachments_into_sandbox(
+            org_id="o1",
+            workspace_id="w1",
+            conversation_id="c1",
+            attachment_ids=[],
+            sandbox=MagicMock(),
+        )
+    finally:
+        for p in patches:
+            p.stop()
+    hydrator_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_sandbox_is_none() -> None:
+    hydrator_cls = MagicMock()
+    patches = _patches(hydrator_cls)
+    for p in patches:
+        p.start()
+    try:
+        await _hydrate_attachments_into_sandbox(
+            org_id="o1",
+            workspace_id="w1",
+            conversation_id="c1",
+            attachment_ids=["fid1"],
+            sandbox=None,
+        )
+    finally:
+        for p in patches:
+            p.stop()
+    hydrator_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_calls_hydrator_with_attachment_ids() -> None:
+    hydrate = AsyncMock()
+    instance = MagicMock()
+    instance.hydrate = hydrate
+    hydrator_cls = MagicMock(return_value=instance)
+    patches = _patches(hydrator_cls)
+    for p in patches:
+        p.start()
+    try:
+        await _hydrate_attachments_into_sandbox(
+            org_id="o1",
+            workspace_id="w1",
+            conversation_id="c1",
+            attachment_ids=["fid1", "fid2"],
+            sandbox=MagicMock(),
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    hydrator_cls.assert_called_once()
+    hydrate.assert_awaited_once_with(conversation_id="c1", file_ids=["fid1", "fid2"])
+
+
+def _att_row(*, fid: str, kind: str, filename: str = "f") -> MagicMock:
+    row = MagicMock()
+    row.id = fid
+    row.kind = kind
+    row.filename = filename
+    row.sandbox_path = f"/workspace/uploads/c1/{fid}/{filename}"
+    row.size_bytes = 10
+    row.width = None
+    row.height = None
+    return row
+
+
+@pytest.mark.asyncio
+async def test_build_blocks_drops_documents_when_sandbox_unavailable() -> None:
+    """When sandbox is None, the file_read tool is not registered. Hint
+    metadata for documents would tell the model to call a tool it can't see
+    — drop those rows but keep image rows (view_images works without
+    sandbox via direct ObjectStore reads).
+    """
+    rows = {
+        "img1": _att_row(fid="img1", kind="image", filename="a.png"),
+        "doc1": _att_row(fid="doc1", kind="document", filename="b.pdf"),
+        "other1": _att_row(fid="other1", kind="other", filename="c.bin"),
+    }
+    repo = MagicMock()
+
+    async def _get(*, conversation_id: str, attachment_id: str) -> MagicMock:
+        del conversation_id
+        return rows[attachment_id]
+
+    repo.get_in_conversation = _get
+    repo_cls = MagicMock(return_value=repo)
+
+    @asynccontextmanager
+    async def _ses() -> AsyncGenerator[MagicMock, None]:
+        yield MagicMock()
+
+    with (
+        patch("cubebox.db.engine.async_session_maker", _ses),
+        patch("cubebox.repositories.AttachmentRepository", repo_cls),
+    ):
+        blocks = await _build_attachment_content_blocks(
+            org_id="o1",
+            workspace_id="w1",
+            conversation_id="c1",
+            attachment_ids=["img1", "doc1", "other1"],
+            sandbox_available=False,
+        )
+
+    kinds = [b["kind"] for b in blocks]
+    assert kinds == ["image"]
+
+
+@pytest.mark.asyncio
+async def test_build_blocks_keeps_everything_when_sandbox_available() -> None:
+    rows = {
+        "img1": _att_row(fid="img1", kind="image", filename="a.png"),
+        "doc1": _att_row(fid="doc1", kind="document", filename="b.pdf"),
+    }
+    repo = MagicMock()
+
+    async def _get(*, conversation_id: str, attachment_id: str) -> MagicMock:
+        del conversation_id
+        return rows[attachment_id]
+
+    repo.get_in_conversation = _get
+    repo_cls = MagicMock(return_value=repo)
+
+    @asynccontextmanager
+    async def _ses() -> AsyncGenerator[MagicMock, None]:
+        yield MagicMock()
+
+    with (
+        patch("cubebox.db.engine.async_session_maker", _ses),
+        patch("cubebox.repositories.AttachmentRepository", repo_cls),
+    ):
+        blocks = await _build_attachment_content_blocks(
+            org_id="o1",
+            workspace_id="w1",
+            conversation_id="c1",
+            attachment_ids=["img1", "doc1"],
+            sandbox_available=True,
+        )
+
+    kinds = sorted(b["kind"] for b in blocks)
+    assert kinds == ["document", "image"]
+
+
+@pytest.mark.asyncio
+async def test_swallows_hydrate_failure() -> None:
+    """A hydration failure must not abort the run — the LLM tells the user."""
+    hydrate = AsyncMock(side_effect=RuntimeError("objectstore down"))
+    instance = MagicMock()
+    instance.hydrate = hydrate
+    hydrator_cls = MagicMock(return_value=instance)
+    patches = _patches(hydrator_cls)
+    for p in patches:
+        p.start()
+    try:
+        await _hydrate_attachments_into_sandbox(
+            org_id="o1",
+            workspace_id="w1",
+            conversation_id="c1",
+            attachment_ids=["fid1"],
+            sandbox=MagicMock(),
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    hydrate.assert_awaited_once()

--- a/backend/tests/unit/test_sandbox.py
+++ b/backend/tests/unit/test_sandbox.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -327,6 +328,78 @@ async def test_file_read_delegates_to_sandbox() -> None:
     payload = json.loads(_text(result))
     assert payload["kind"] == "text"
     assert payload["content"] == "file contents here"
+
+
+@pytest.mark.asyncio
+async def test_file_read_returns_error_kind_when_file_missing() -> None:
+    """FileNotFoundError must surface as ErrorOutput, not cubepi's generic
+    str(exc) wrapper (which would leak the bare path as 'file contents').
+    """
+    sandbox = _make_sandbox()
+    sandbox.file_read = AsyncMock(side_effect=FileNotFoundError("/work/missing.xlsx"))
+
+    tool = _make_file_read_tool(sandbox, conversation_id="conv-1")
+    args = _FileReadArgs(path="/work/missing.xlsx")
+    result = await tool.execute("tc-1", args)
+
+    payload = json.loads(_text(result))
+    assert payload["kind"] == "error"
+    assert payload["path"] == "/work/missing.xlsx"
+    assert "file not found" in payload["error"]
+    assert payload["retryable"] is False
+
+
+@pytest.mark.asyncio
+async def test_file_read_returns_error_kind_on_sandbox_error() -> None:
+    """SandboxError (provider down etc.) also surfaces as ErrorOutput."""
+    from cubebox.sandbox.base import SandboxError
+
+    sandbox = _make_sandbox()
+    sandbox.file_read = AsyncMock(side_effect=SandboxError("provider unreachable"))
+
+    tool = _make_file_read_tool(sandbox, conversation_id="conv-1")
+    args = _FileReadArgs(path="/work/data.csv")
+    result = await tool.execute("tc-1", args)
+
+    payload = json.loads(_text(result))
+    assert payload["kind"] == "error"
+    assert payload["path"] == "/work/data.csv"
+    assert "sandbox error" in payload["error"]
+    assert "provider unreachable" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_file_read_returns_error_kind_on_transport_error() -> None:
+    """Transient transport errors (httpx etc.) must also surface as ErrorOutput
+    with retryable=True — otherwise cubepi's str(exc) wrapper leaks raw error
+    text as tool content, the same trap as the bare FileNotFoundError case.
+    """
+    sandbox = _make_sandbox()
+    sandbox.file_read = AsyncMock(side_effect=ConnectionError("rustfs timed out"))
+
+    tool = _make_file_read_tool(sandbox, conversation_id="conv-1")
+    args = _FileReadArgs(path="/work/large.pdf")
+    result = await tool.execute("tc-1", args)
+
+    payload = json.loads(_text(result))
+    assert payload["kind"] == "error"
+    assert payload["retryable"] is True
+    assert "rustfs timed out" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_file_read_does_not_swallow_cancelled() -> None:
+    """The catch-all must let asyncio.CancelledError propagate so user steer /
+    abort works. CancelledError is BaseException, not Exception, so the
+    ``except Exception`` does not catch it — pin that contract.
+    """
+    sandbox = _make_sandbox()
+    sandbox.file_read = AsyncMock(side_effect=asyncio.CancelledError())
+
+    tool = _make_file_read_tool(sandbox, conversation_id="conv-1")
+    args = _FileReadArgs(path="/work/data.csv")
+    with pytest.raises(asyncio.CancelledError):
+        await tool.execute("tc-1", args)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- User uploads landed in ObjectStore and the DB row stamped a "promised" sandbox path (`/workspace/uploads/<conv>/<atch>/<filename>`), but `AttachmentHydrator` (added in M7) was never wired into the run path — `file_read` landed on a missing path and the agent fell back to "the file isn't in the sandbox" apologies. **Now hydrated from `run_manager._call_cubepi_for_turn` before the `[Attachments]` hint goes out.** Hydration failure is non-fatal: the run continues and the agent surfaces a "file not found" rather than aborting.
- `file_read` tool wrapped its `sandbox.file_read` call with no try/except, so `FileNotFoundError(path)` bubbled to cubepi's generic tool-error layer — which writes `str(exc)` as content. `str(FileNotFoundError(path))` is the path itself, so the LLM read "file content = its own path". Now caught + returned as structured `ErrorOutput`. `asyncio.CancelledError` still propagates.
- `AttachmentHydrator.hydrate` probed for the file with `sandbox.execute(f'test -f "{row.sandbox_path}"...')`. `_safe_basename` does **not** strip `$()`, backticks, or parentheses, and bash double-quotes still expand `$()` / backticks — a filename like `` `whoami`.xlsx `` would execute in the sandbox shell. Fixed with `shlex.quote` + regression test. (HIGH, flagged by local codex review.)
- When `sandbox is None` (`sandbox.enabled=false`), drop non-image attachment metadata — `file_read` isn't registered without `SandboxMiddleware`, so the hint was telling the model to call an absent tool. `view_images` works ObjectStore-direct, so image attachments stay.

## Test plan

- [x] `tests/test_hydrator.py` — 5 unit (added `test_hydrate_quotes_shell_metacharacters_in_path` for RCE regression)
- [x] `tests/unit/test_sandbox.py` — added `file_read` error-path tests (FileNotFoundError, SandboxError, transient transport error, CancelledError propagation)
- [x] `tests/unit/test_run_manager_hydrate_attachments.py` — new file, 6 cases: empty list, sandbox=None, hydrator called with right ids, hydrate failure swallowed, `_build_attachment_content_blocks` gating in both directions
- [x] `tests/e2e/test_send_with_attachments.py` (3/3) — regression-checked
- [x] `tests/e2e/test_attachments_api.py` (12/12) — regression-checked
- [x] mypy strict on all touched files
- [x] 3 rounds of local codex review (1 HIGH RCE + 2 MEDIUM fixed → CLEAN)