### PR TITLE
fix(im/link): Feishu autolink, post-login redirect, error CTA, IM success notice

### DIFF
--- a/backend/cubebox/im/feishu/link_command.py
+++ b/backend/cubebox/im/feishu/link_command.py
@@ -20,10 +20,20 @@ _LINK_RE = _re.compile(
     _re.IGNORECASE,
 )
 
+# Feishu auto-renders email-like input as `[user@host](mailto:user@host)`.
+# Unwrap before regex so the user-typed bare email and the auto-linked
+# form both match. Also covers angle-bracketed RFC 5322 form `<email>`.
+_MAILTO_AUTOLINK_RE = _re.compile(r"\[[^\]]+\]\(mailto:([^)]+)\)", _re.IGNORECASE)
+
+
+def _unwrap_email_autolinks(text: str) -> str:
+    text = _MAILTO_AUTOLINK_RE.sub(r"\1", text)
+    return text.replace("<", "").replace(">", "")
+
 
 def parse_link_command(text: str) -> str | None:
     """Extract email from a /link or 绑定 command. Returns None if not a match."""
-    m = _LINK_RE.match(text)
+    m = _LINK_RE.match(_unwrap_email_autolinks(text))
     return m.group(1).strip().lower() if m else None
 
 

--- a/backend/cubebox/plugins/defaults/auth.py
+++ b/backend/cubebox/plugins/defaults/auth.py
@@ -67,9 +67,7 @@ class DefaultAuthProvider:
 
     async def _authenticate_bearer(self, request: Request) -> User | None:
         """If a Bearer token resolves to a known API key, return its owner."""
-        auth_header = request.headers.get("authorization") or request.headers.get(
-            "Authorization"
-        )
+        auth_header = request.headers.get("authorization") or request.headers.get("Authorization")
         if not auth_header:
             return None
         scheme, _, token = auth_header.partition(" ")

--- a/backend/cubebox/repositories/api_key.py
+++ b/backend/cubebox/repositories/api_key.py
@@ -37,8 +37,12 @@ class ApiKeyRepository:
         return list((await self.session.execute(stmt)).scalars().all())
 
     async def count_by_user(self, user_id: str) -> int:
-        stmt = select(func.count()).select_from(ApiKey).where(
-            ApiKey.user_id == user_id  # type: ignore[arg-type]
+        stmt = (
+            select(func.count())
+            .select_from(ApiKey)
+            .where(
+                ApiKey.user_id == user_id  # type: ignore[arg-type]
+            )
         )
         return int((await self.session.execute(stmt)).scalar_one())
 

--- a/backend/tests/unit/im/test_feishu_link_intercept.py
+++ b/backend/tests/unit/im/test_feishu_link_intercept.py
@@ -26,3 +26,12 @@ class TestParseLinkCommand:
 
     def test_invalid_email_rejected(self) -> None:
         assert parse_link_command("/link notanemail") is None
+
+    def test_feishu_mailto_autolink_unwrapped(self) -> None:
+        # Feishu client auto-renders bare emails as markdown autolinks.
+        result = parse_link_command("/link [gxf.beta@gmail.com](mailto:gxf.beta@gmail.com)")
+        assert result == "gxf.beta@gmail.com"
+
+    def test_angle_bracketed_email_unwrapped(self) -> None:
+        result = parse_link_command("/link <chris@example.com>")
+        assert result == "chris@example.com"

--- a/frontend/packages/web/components/profile/ApiKeysSection.tsx
+++ b/frontend/packages/web/components/profile/ApiKeysSection.tsx
@@ -265,7 +265,9 @@ function CreateApiKeyDialog({
                 {t('oneTimeWarning')}
               </p>
               <div className="mt-3 flex items-center gap-2 rounded-md border border-border bg-muted px-3 py-2">
-                <code className="min-w-0 flex-1 truncate font-mono text-xs">{createdKey.token}</code>
+                <code className="min-w-0 flex-1 truncate font-mono text-xs">
+                  {createdKey.token}
+                </code>
                 <Button
                   type="button"
                   size="sm"


### PR DESCRIPTION
## Summary

Follow-up to #272 — three real-world `/link` flow bugs surfaced while testing the freshly-merged Feishu binding, plus one blocking drive-by.

- **Feishu rendered the typed email as a markdown autolink.** Sending `/link gxf.beta@gmail.com` produced `/link [gxf.beta@gmail.com](mailto:gxf.beta@gmail.com)`. The existing `\S+@\S+\.\S+` group ate the whole bracketed block, so `claims.email` in the signed token was the wrapped string and confirm always returned `email_mismatch`. Strip `[..](mailto:..)` and `<..>` wrappers before regex match. Bare and auto-linked input now both yield the clean lowercase email.
- **Login redirect after token expiry was a no-op.** ImLinkPage pushed `/login?redirect=<returnUrl>` on 401, but `LoginForm` reads `next`, not `redirect`. The param silently dropped, login landed on home, the user got zero feedback. Switch to `next=` so the user comes back to `/im-link` and sees the actual binding result.
- **Error states had no escape hatch.** Success showed a "Go to app" link; the error branch had only the red message. Mirror the success CTA so users on `email_mismatch` / `invalid_token` / `not_member` can navigate out without re-entering the URL.
- **Bind success was silent in IM.** Added a new `cid` claim to the link JWT (defaults to `""`, so pre-change tokens still verify). The Feishu `handle_link_command` now passes `event.channel_id` into the token, and the confirm endpoint best-effort posts `✅ 绑定成功！…` back to that chat using a fresh outbound lark client built from the bot's stored credentials. Failures here only log — they don't flip the API response (the identity link is already persisted).

### Drive-by

`chore(frontend): prettier format ApiKeysSection.tsx` also reformats two backend files (`plugins/defaults/auth.py`, `repositories/api_key.py`). Pre-push format checks were failing on all three after the api-key feature merged — three trivial reformat-only diffs to unblock the push.

## Test plan

- [x] `uv run pytest backend/tests/unit/im/test_feishu_link_intercept.py backend/tests/unit/im/test_im_link_confirm.py` — 11/11 passing
- [ ] In Feishu, `/link <email>` → bot replies with link → open link logged-in as the right user → success page renders + IM chat gets `✅ 绑定成功！…`
- [ ] `/link <email>` with wrong-account session → page shows `emailMismatch` + visible "Go to app" link
- [ ] Token expired, open link → forwarded to `/login?next=/im-link?token=...` → after login, returns to `/im-link` and shows `invalidToken` + "Go to app" link
- [ ] `/link <email>` from a Feishu group → success notice posts to the same group