### PR TITLE
fix(im/link): post-login redirect, error CTA, IM success notice

### DIFF
--- a/backend/cubebox/api/routes/v1/im_link.py
+++ b/backend/cubebox/api/routes/v1/im_link.py
@@ -6,6 +6,7 @@ token (not the URL path); the user comes from the auth cookie.
 
 from __future__ import annotations
 
+import json
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException
@@ -16,6 +17,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.auth.dependencies import current_active_user
+from cubebox.credentials.dependencies import (
+    build_credential_service,
+    get_encryption_backend,
+)
+from cubebox.credentials.encryption import EncryptionBackend
 from cubebox.db.session import get_session
 from cubebox.im.link import LinkClaims, verify_link_token
 from cubebox.models.im_connector import IMConnectorAccount, IMIdentityLink
@@ -106,6 +112,7 @@ async def confirm_im_link(
     body: Annotated[_ConfirmBody, Body()],
     user: Annotated[User, Depends(current_active_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    backend: Annotated[EncryptionBackend, Depends(get_encryption_backend)],
 ) -> _ConfirmResult:
     secret = _get_jwt_secret()
     try:
@@ -136,4 +143,77 @@ async def confirm_im_link(
         user.id,
         claims.account_id,
     )
+
+    # Best-effort: send a confirmation back to the originating chat so the
+    # user sees feedback in IM too. Failure here must not flip the API
+    # response — the link is already persisted.
+    if claims.platform == "feishu" and claims.chat_id:
+        try:
+            await _send_feishu_link_success_notice(
+                session=session,
+                backend=backend,
+                claims=claims,
+                display_name=user.display_name or user.email,
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                "[IM link] post-confirm notice failed for account={}",
+                claims.account_id,
+            )
+
     return _ConfirmResult(ok=True, platform=claims.platform, account_id=claims.account_id)
+
+
+async def _send_feishu_link_success_notice(
+    *,
+    session: AsyncSession,
+    backend: EncryptionBackend,
+    claims: LinkClaims,
+    display_name: str,
+) -> None:
+    """Post '绑定成功' back to the Feishu chat that issued the /link command."""
+    account = (
+        await session.execute(
+            select(IMConnectorAccount).where(
+                IMConnectorAccount.id == claims.account_id,  # type: ignore[arg-type]
+            )
+        )
+    ).scalar_one_or_none()
+    if account is None:
+        return
+
+    cred_service = build_credential_service(
+        session,
+        backend,
+        org_id=account.org_id,
+        actor_user_id=None,
+    )
+    secret_json = await cred_service.get_decrypted(
+        credential_id=account.credential_id, requesting_kind="im_bot"
+    )
+    secrets = json.loads(secret_json)
+
+    try:
+        import lark_oapi as _lark
+        from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
+    except ImportError:
+        logger.warning("[IM link] lark_oapi missing; skipping confirmation notice")
+        return
+
+    from cubebox.im.feishu.connector import FeishuConnector
+
+    domain = LARK_DOMAIN if str(secrets.get("domain", "feishu")) == "lark" else FEISHU_DOMAIN
+    client = (
+        _lark.Client.builder()
+        .app_id(str(secrets["app_id"]))
+        .app_secret(str(secrets["app_secret"]))
+        .domain(domain)
+        .log_level(_lark.LogLevel.WARNING)
+        .build()
+    )
+    connector = FeishuConnector(
+        bot_open_id=str(secrets.get("bot_open_id") or "") or None,
+        client=client,
+    )
+    text = f"✅ 绑定成功！已将此账号关联到 cubebox 用户 {display_name}。"
+    await connector.send_to_chat(claims.chat_id, None, text)

--- a/backend/cubebox/im/feishu/link_command.py
+++ b/backend/cubebox/im/feishu/link_command.py
@@ -63,6 +63,7 @@ async def handle_link_command(
             workspace_id=account.workspace_id,
             platform="feishu",
             secret=secret,
+            chat_id=event.channel_id or "",
         )
     except Exception:
         logger.opt(exception=True).warning("[Feishu] sign_link_token failed")

--- a/backend/cubebox/im/link.py
+++ b/backend/cubebox/im/link.py
@@ -23,6 +23,7 @@ class LinkClaims:
     account_id: str
     workspace_id: str
     platform: str
+    chat_id: str = ""
 
 
 def sign_link_token(
@@ -33,6 +34,7 @@ def sign_link_token(
     workspace_id: str,
     platform: str,
     secret: str,
+    chat_id: str = "",
 ) -> str:
     now = datetime.now(UTC)
     claims = {
@@ -41,6 +43,7 @@ def sign_link_token(
         "act": account_id,
         "ws": workspace_id,
         "plt": platform,
+        "cid": chat_id,
         "exp": int((now + _TTL).timestamp()),
         "iat": int(now.timestamp()),
         "iss": _ISS,
@@ -76,4 +79,5 @@ def verify_link_token(token: str, *, secret: str) -> LinkClaims:
         account_id=payload["act"],
         workspace_id=payload["ws"],
         platform=payload["plt"],
+        chat_id=str(payload.get("cid") or ""),
     )

--- a/backend/tests/unit/im/test_im_link_confirm.py
+++ b/backend/tests/unit/im/test_im_link_confirm.py
@@ -28,6 +28,14 @@ def _make_app(user: User | None = None) -> FastAPI:
 
         app.dependency_overrides[current_active_user] = lambda: user
 
+    # The confirm endpoint depends on EncryptionBackend so it can build a
+    # Feishu client for the post-confirm IM notice. These unit tests never
+    # exercise that path (platform="discord", chat_id=""), but FastAPI
+    # still resolves the dependency on every request — stub it.
+    from cubebox.credentials.dependencies import get_encryption_backend
+
+    app.dependency_overrides[get_encryption_backend] = lambda: None  # type: ignore[return-value]
+
     return app
 
 

--- a/frontend/packages/web/components/auth/ImLinkPage.tsx
+++ b/frontend/packages/web/components/auth/ImLinkPage.tsx
@@ -41,7 +41,10 @@ export function ImLinkPage() {
       .catch((err: unknown) => {
         if (err instanceof ApiError && err.status === 401) {
           const returnUrl = `/im-link?token=${encodeURIComponent(token)}`
-          router.replace(`/login?redirect=${encodeURIComponent(returnUrl)}`)
+          // LoginForm reads ``next``, not ``redirect`` — using the wrong param
+          // silently drops the return URL and the user lands on home with no
+          // binding feedback.
+          router.replace(`/login?next=${encodeURIComponent(returnUrl)}`)
           return
         }
         setStatus('error')
@@ -69,6 +72,9 @@ export function ImLinkPage() {
   return (
     <div className="text-center space-y-3">
       <p className="text-sm text-destructive">{errorMsg}</p>
+      <Link href="/" className="text-sm text-primary underline">
+        {t('goToApp')}
+      </Link>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Follow-up to #274 — three `/link` confirmation-flow gaps caught while testing an expired-token retry. All scoped to the Feishu identity-link path.

- **Login redirect after token expiry was a no-op.** `ImLinkPage` pushed `/login?redirect=<returnUrl>` on 401, but `LoginForm` reads `next`, not `redirect`. The param silently dropped, login landed on home, the user got zero feedback. Switch to `next=` so the user comes back to `/im-link` and sees the actual binding result.
- **Error states had no escape hatch.** Success showed a "Go to app" link; the error branch had only the red message. Mirror the success CTA so users on `email_mismatch` / `invalid_token` / `not_member` can navigate out without re-entering the URL.
- **Bind success was silent in IM.** Added a new `cid` claim to the link JWT (defaults to `""`, so pre-change tokens still verify). The Feishu `handle_link_command` now passes `event.channel_id` into the token, and the confirm endpoint best-effort posts `✅ 绑定成功！…` back to that chat using a fresh outbound lark client built from the bot's stored credentials. Failures here only log — they don't flip the API response (the identity link is already persisted).

Existing `test_im_link_confirm.py` needed a `get_encryption_backend` dependency override because confirm now takes that as a FastAPI dep; non-Feishu / no-`cid` tokens skip the IM notice path entirely. 11/11 in `tests/unit/im/test_im_link_confirm.py` + `test_feishu_link_intercept.py` pass.

## Test plan

- [x] `uv run pytest backend/tests/unit/im/test_feishu_link_intercept.py backend/tests/unit/im/test_im_link_confirm.py` — 11/11 passing
- [ ] In Feishu, `/link <email>` → open link logged in as that account → success page renders + IM chat gets `✅ 绑定成功！…`
- [ ] `/link <email>` with wrong-account session → page shows `emailMismatch` + visible "Go to app" link
- [ ] Token expired, open link → forwarded to `/login?next=/im-link?token=...` → after login, returns to `/im-link` and shows `invalidToken` + "Go to app" link
- [ ] `/link <email>` from a Feishu group → success notice posts to the same group