### PR TITLE
chore(im/feishu): card header polish, silence ws/lark debug logs, swallow unhandled IM events

### DIFF
--- a/backend/cubebox/im/feishu/card_renderer.py
+++ b/backend/cubebox/im/feishu/card_renderer.py
@@ -193,16 +193,15 @@ TOOL_DISPLAY: dict[str, ToolDisplay] = {
 def _header(state: CardState) -> dict[str, Any]:
     if state.error:
         template = "red"
-        subtitle = "运行失败"
+        title = "运行失败"
     elif state.finalized:
         template = "green"
-        subtitle = f"已完成 · {state.elapsed_ms / 1000:.1f}s" if state.elapsed_ms else "已完成"
+        title = f"已完成 · {state.elapsed_ms / 1000:.1f}s" if state.elapsed_ms else "已完成"
     else:
         template = "blue"
-        subtitle = "运行中…"
+        title = "运行中…"
     return {
-        "title": {"tag": "plain_text", "content": state.bot_name},
-        "subtitle": {"tag": "plain_text", "content": subtitle},
+        "title": {"tag": "plain_text", "content": title},
         "template": template,
     }
 

--- a/backend/cubebox/im/feishu/long_connection.py
+++ b/backend/cubebox/im/feishu/long_connection.py
@@ -255,10 +255,31 @@ def build_event_handler(
             logger.warning("[Feishu LC] card.action handler raised: {}", exc)
             return P2CardActionTriggerResponse()
 
+    # If the bot's Feishu app subscribes to additional IM events (reactions,
+    # recall, read receipts, chat membership churn) the SDK raises
+    # ``EventException: processor not found`` for every push we haven't
+    # registered. Register silent no-ops for the common ones so the log
+    # stays clean — promote any of these to a real handler when we add
+    # the corresponding feature.
+    def _noop(_: Any) -> None:
+        return None
+
     return (
         lark.EventDispatcherHandler.builder("", "")
         .register_p2_im_message_receive_v1(_on_message)
         .register_p2_card_action_trigger(_on_card_action)
+        .register_p2_im_message_reaction_created_v1(_noop)
+        .register_p2_im_message_reaction_deleted_v1(_noop)
+        .register_p2_im_message_recalled_v1(_noop)
+        .register_p2_im_message_message_read_v1(_noop)
+        .register_p2_im_chat_member_user_added_v1(_noop)
+        .register_p2_im_chat_member_user_deleted_v1(_noop)
+        .register_p2_im_chat_member_user_withdrawn_v1(_noop)
+        .register_p2_im_chat_member_bot_added_v1(_noop)
+        .register_p2_im_chat_member_bot_deleted_v1(_noop)
+        .register_p2_im_chat_updated_v1(_noop)
+        .register_p2_im_chat_disbanded_v1(_noop)
+        .register_p2_im_chat_access_event_bot_p2p_chat_entered_v1(_noop)
         .build()
     )
 

--- a/backend/cubebox/utils/log.py
+++ b/backend/cubebox/utils/log.py
@@ -94,6 +94,11 @@ _NOISY_THIRD_PARTY_LOGGERS = (
     "openai",
     "opensandbox",
     "mcp.client.streamable_http",
+    # lark_oapi's WebSocket transport (long-connection mode) and the
+    # underlying `websockets` library log every PING/PONG frame at DEBUG,
+    # which floods the log when running with debug on.
+    "websockets",
+    "lark_oapi",
 )
 
 

--- a/backend/tests/im/feishu/test_card_renderer_layout.py
+++ b/backend/tests/im/feishu/test_card_renderer_layout.py
@@ -189,6 +189,14 @@ def test_done_state_uses_green_header() -> None:
     assert card["header"]["template"] == "green"
 
 
+def test_header_does_not_carry_bot_name() -> None:
+    state = _empty_state()
+    state.bot_name = "cubebox"
+    card = render(state)
+    title = card["header"]["title"]["content"]
+    assert "cubebox" not in title.lower()
+
+
 def test_sub_agent_row_rendered_above_tool_steps() -> None:
     from cubebox.im.feishu.card_model import SubAgentRow
 


### PR DESCRIPTION
## Summary

Three small Feishu-side cleanups surfaced while running the bot against a real workspace:

- **Card header lost the bot name.** The bot_name title (`cubebox`) duplicated the IM-side bot name shown right above every card, eating vertical space for no signal. Drop the title slot, keep the colored template + status string (`运行中…` / `已完成 · 1.2s` / `运行失败`) — Feishu card v2 still renders a tight one-line pill. New `test_header_does_not_carry_bot_name` locks in the contract.
- **WebSocket frame-level DEBUG was flooding the log.** When debug is on, `lark_oapi`'s WebSocket transport plus the underlying `websockets` library log every PING/PONG frame (`> PING 72 39 73 ef [binary, 4 bytes]`). Add both to `_NOISY_THIRD_PARTY_LOGGERS` so the existing `logging.third_party_level` (default WARNING) caps them; opt back in via `logging.verbose_modules` when actually debugging the transport.
- **`processor not found` exceptions for unhandled IM event types.** lark_oapi's `EventDispatcherHandler` has no default handler — it raises `EventException` for every push whose `event_type` we didn't `register_p2_*`. Once the bot's Feishu app subscribes to reaction / recall / read-receipt / chat-membership events (a single console checkbox can subscribe to several at once), every such push hit the log as an ERROR. Register silent no-op processors for the IM-related events we don't currently act on. Promote any one of them to a real handler when the corresponding feature lands.

  Covered: `reaction.created/deleted_v1`, `recalled_v1`, `message_read_v1`, `chat.member.{user,bot}_{added,deleted}_v1`, `chat.member.user_withdrawn_v1`, `chat.updated_v1`, `chat.disbanded_v1`, `chat.access_event.bot_p2p_chat_entered_v1`.

## Test plan

- [x] `uv run pytest backend/tests/im/feishu/test_card_renderer_layout.py` — 15/15 passing
- [ ] Send a message to the Feishu bot → reply card renders with the new compact status header (no `cubebox` title)
- [ ] React to one of the bot's messages → no `EventException: processor not found` in the server log
- [ ] Tail the server log during normal traffic → no `> PING …` frame chatter even with debug on