### PR TITLE
fix(objectstore): use virtual-hosted addressing for OSS

### DIFF
--- a/backend/cubebox/objectstore/client.py
+++ b/backend/cubebox/objectstore/client.py
@@ -31,10 +31,16 @@ class ObjectStoreClient:
         self._access_secret: str = config.get("objectstore.access_secret", "")
         self._session: aioboto3.Session = aioboto3.Session()
 
-        # OSS does not support aws-chunked transfer encoding.
+        # OSS does not support aws-chunked transfer encoding, and only accepts
+        # virtual-hosted style addressing (bucket as subdomain). With a custom
+        # endpoint_url botocore defaults to path style, which OSS rejects with
+        # SecondLevelDomainForbidden.
         if provider == "oss":
             self._boto_config = BotoConfig(
-                s3={"payload_signing_enabled": True},
+                s3={
+                    "addressing_style": "virtual",
+                    "payload_signing_enabled": True,
+                },
                 request_checksum_calculation="when_required",
             )
         else:


### PR DESCRIPTION
## Problem

Aliyun OSS rejects path-style `ListObjectsV2` with:

```
ClientError (SecondLevelDomainForbidden): Please use virtual hosted style to access.
```

botocore defaults to **path-style** addressing when a custom `endpoint_url` is set, but OSS only accepts **virtual-hosted style** (bucket as subdomain). This breaks:
- lazy sandbox skill sync (`_sync_skills` → `list_objects`)
- startup preinstalled-skill seeding (`lifespan` → `Failed to seed preinstalled skills`)

Both observed repeatedly in today's logs against `oss-cn-zhangjiakou.aliyuncs.com` / bucket `cubebox-dev`.

## Fix

Set `addressing_style: "virtual"` in the OSS `BotoConfig` branch.

## Test

S3 path (rustfs/minio, path-style) unaffected — change is scoped to the `provider == "oss"` branch only.