### PR TITLE
feat(frontend): unified file preview with syntax highlighting, media, and zoom

### DIFF
--- a/frontend/packages/web/components/panel/artifact/CodePreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/CodePreview.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import type { Artifact } from '@cubebox/core'
 import { PreviewLoading } from './PreviewLoading'
 import { buildPreviewUrl } from './previewUtils'
+import { CodeHighlight } from '@/components/shared/previews'
 
 interface CodePreviewProps {
   artifact: Artifact
@@ -36,14 +37,5 @@ export function CodePreview({ artifact, version, workspaceId }: CodePreviewProps
     return <PreviewLoading />
   }
 
-  return (
-    <div className="h-full overflow-auto">
-      <pre
-        className="p-4 text-xs leading-relaxed font-mono text-foreground whitespace-pre-wrap
-        break-words"
-      >
-        {code}
-      </pre>
-    </div>
-  )
+  return <CodeHighlight code={code} filename={filename} />
 }

--- a/frontend/packages/web/components/panel/artifact/DataPreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/DataPreview.tsx
@@ -4,21 +4,12 @@ import { useState, useEffect, useMemo } from 'react'
 import type { Artifact } from '@cubebox/core'
 import { PreviewLoading } from './PreviewLoading'
 import { buildPreviewUrl } from './previewUtils'
+import { CsvTable } from '@/components/shared/previews'
 
 interface DataPreviewProps {
   artifact: Artifact
   version: number | null
   workspaceId: string
-}
-
-function parseCsv(text: string): { headers: string[]; rows: string[][] } {
-  const lines = text.trim().split('\n')
-  if (lines.length === 0) return { headers: [], rows: [] }
-  const headers = lines[0].split(',').map((h) => h.trim().replace(/^"|"$/g, ''))
-  const rows = lines
-    .slice(1)
-    .map((line) => line.split(',').map((cell) => cell.trim().replace(/^"|"$/g, '')))
-  return { headers, rows }
 }
 
 function JsonTable({ data }: { data: unknown }) {
@@ -78,7 +69,7 @@ export function DataPreview({ artifact, version, workspaceId }: DataPreviewProps
 
   const parsed = useMemo(() => {
     if (!content) return null
-    if (isCsv) return { type: 'csv' as const, data: parseCsv(content) }
+    if (isCsv) return { type: 'csv' as const }
     try {
       return { type: 'json' as const, data: JSON.parse(content) }
     } catch {
@@ -90,38 +81,12 @@ export function DataPreview({ artifact, version, workspaceId }: DataPreviewProps
     return <div className="p-4 text-sm text-destructive">Failed to load data: {error}</div>
   }
 
-  if (!parsed) {
+  if (!parsed || !content) {
     return <PreviewLoading />
   }
 
   if (parsed.type === 'csv') {
-    const { headers, rows } = parsed.data
-    return (
-      <div className="overflow-auto h-full">
-        <table className="w-full text-xs border-collapse">
-          <thead>
-            <tr className="border-b border-border bg-muted/50 sticky top-0">
-              {headers.map((h) => (
-                <th key={h} className="text-left p-2 font-medium text-muted-foreground">
-                  {h}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row, i) => (
-              <tr key={i} className="border-b border-border/50 hover:bg-muted/30">
-                {row.map((cell, j) => (
-                  <td key={j} className="p-2 text-foreground">
-                    {cell}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    )
+    return <CsvTable content={content} />
   }
 
   if (parsed.type === 'json') {

--- a/frontend/packages/web/components/panel/artifact/ImagePreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/ImagePreview.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { useState } from 'react'
 import type { Artifact } from '@cubebox/core'
-import { PreviewLoading } from './PreviewLoading'
 import { buildPreviewUrl } from './previewUtils'
+import { ImageViewer } from '@/components/shared/previews'
 
 interface ImagePreviewProps {
   artifact: Artifact
@@ -12,25 +11,8 @@ interface ImagePreviewProps {
 }
 
 export function ImagePreview({ artifact, version, workspaceId }: ImagePreviewProps) {
-  const [loading, setLoading] = useState(true)
   const filename = artifact.path.split('/').pop() || 'image'
   const previewUrl = buildPreviewUrl(artifact, filename, version, workspaceId)
 
-  return (
-    <div className="flex items-center justify-center h-full p-4 bg-muted/20">
-      {loading && (
-        <div className="absolute inset-0">
-          <PreviewLoading />
-        </div>
-      )}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        key={`${artifact.id}-${version}`}
-        src={previewUrl}
-        alt={artifact.name}
-        className="max-w-full max-h-full object-contain rounded-md"
-        onLoad={() => setLoading(false)}
-      />
-    </div>
-  )
+  return <ImageViewer url={previewUrl} alt={artifact.name} />
 }

--- a/frontend/packages/web/components/panel/sandbox/SandboxFilePreview.tsx
+++ b/frontend/packages/web/components/panel/sandbox/SandboxFilePreview.tsx
@@ -1,72 +1,59 @@
 'use client'
 
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
+import dynamic from 'next/dynamic'
 import { Download, FileText } from 'lucide-react'
 import { csrfHeaders } from '@/lib/csrf'
 import { useSandboxFileContent } from '@/hooks/useSandboxFileContent'
 import type { SandboxFileEntry } from '@/hooks/useSandboxFiles'
 import { PreviewLoading } from '@/components/panel/artifact/PreviewLoading'
 import { MarkdownWithCitations } from '@/components/shared/MarkdownWithCitations'
+import { CodeHighlight, ImageViewer, MediaPlayer, CsvTable } from '@/components/shared/previews'
+
+const PdfPreview = dynamic(
+  () => import('@/components/panel/artifact/PdfPreview').then((m) => m.PdfPreview),
+  { ssr: false, loading: () => <PreviewLoading /> },
+)
 
 const OFFICE_EXTENSIONS = new Set(['.docx', '.xlsx', '.pptx'])
-const TEXT_EXTENSIONS = new Set([
-  '.txt',
-  '.md',
-  '.py',
-  '.js',
-  '.ts',
-  '.tsx',
-  '.jsx',
-  '.json',
-  '.yaml',
-  '.yml',
-  '.toml',
-  '.cfg',
-  '.ini',
-  '.sh',
-  '.bash',
-  '.zsh',
-  '.css',
-  '.scss',
-  '.less',
-  '.sql',
-  '.rs',
-  '.go',
-  '.java',
-  '.c',
-  '.cpp',
-  '.h',
-  '.rb',
-  '.php',
-  '.swift',
-  '.kt',
-  '.r',
-  '.lua',
-  '.pl',
-  '.ex',
-  '.exs',
-  '.vue',
-  '.svelte',
-  '.xml',
-  '.csv',
-  '.log',
-  '.env',
-  '.gitignore',
-  '.dockerfile',
-  '.makefile',
+
+const IMAGE_EXTENSIONS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.bmp', '.ico', '.tiff', '.avif',
 ])
+
+const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.mov', '.avi', '.mkv', '.ogv'])
+
+const AUDIO_EXTENSIONS = new Set(['.mp3', '.wav', '.ogg', '.flac', '.aac', '.m4a', '.wma'])
+
+const CODE_EXTENSIONS = new Set([
+  '.py', '.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs',
+  '.json', '.yaml', '.yml', '.toml', '.cfg', '.ini',
+  '.sh', '.bash', '.zsh',
+  '.css', '.scss', '.less', '.sql',
+  '.rs', '.go', '.java', '.c', '.cpp', '.h', '.hpp',
+  '.rb', '.php', '.swift', '.kt', '.cs',
+  '.r', '.lua', '.pl', '.ex', '.exs',
+  '.vue', '.svelte', '.xml',
+  '.dockerfile', '.makefile',
+])
+
+const PLAIN_TEXT_EXTENSIONS = new Set(['.txt', '.log', '.env', '.gitignore'])
 
 function getExtension(name: string): string {
   const dot = name.lastIndexOf('.')
   return dot >= 0 ? name.slice(dot).toLowerCase() : ''
 }
 
-function isTextFile(name: string): boolean {
-  const ext = getExtension(name)
-  if (TEXT_EXTENSIONS.has(ext)) return true
-  if (ext === '.html') return false // HTML gets iframe preview
-  if (!ext) return true // extensionless files assumed text
-  return false
+function buildDownloadUrl(
+  workspaceId: string,
+  path: string,
+  conversationId?: string | null,
+): string {
+  const convQs = conversationId ? `&conversation_id=${encodeURIComponent(conversationId)}` : ''
+  return (
+    `/api/v1/ws/${workspaceId}/sandbox/files/download` +
+    `?path=${encodeURIComponent(path)}${convQs}`
+  )
 }
 
 interface SandboxFilePreviewProps {
@@ -83,18 +70,55 @@ export function SandboxFilePreview({
   onNavigate,
 }: SandboxFilePreviewProps) {
   const ext = getExtension(entry.name)
+  const downloadUrl = buildDownloadUrl(workspaceId, entry.path, conversationId)
+
+  if (IMAGE_EXTENSIONS.has(ext)) {
+    return <ImageViewer url={downloadUrl} alt={entry.name} />
+  }
+
+  if (ext === '.pdf') {
+    return <PdfPreview fileUrl={downloadUrl} />
+  }
+
+  if (VIDEO_EXTENSIONS.has(ext)) {
+    return <MediaPlayer url={downloadUrl} type="video" filename={entry.name} />
+  }
+
+  if (AUDIO_EXTENSIONS.has(ext)) {
+    return <MediaPlayer url={downloadUrl} type="audio" filename={entry.name} />
+  }
 
   if (OFFICE_EXTENSIONS.has(ext)) {
     return (
-      <OfficeFilePreview entry={entry} workspaceId={workspaceId} conversationId={conversationId} />
+      <OfficeFilePreview
+        entry={entry}
+        workspaceId={workspaceId}
+        conversationId={conversationId}
+      />
     )
   }
+
   if (ext === '.html') {
     return (
-      <HtmlFilePreview entry={entry} workspaceId={workspaceId} conversationId={conversationId} />
+      <HtmlFilePreview
+        entry={entry}
+        workspaceId={workspaceId}
+        conversationId={conversationId}
+      />
     )
   }
-  if (ext === '.md' && onNavigate) {
+
+  if (ext === '.csv') {
+    return (
+      <CsvFilePreview
+        entry={entry}
+        workspaceId={workspaceId}
+        conversationId={conversationId}
+      />
+    )
+  }
+
+  if (ext === '.md') {
     return (
       <MarkdownFilePreview
         entry={entry}
@@ -104,12 +128,90 @@ export function SandboxFilePreview({
       />
     )
   }
-  if (isTextFile(entry.name)) {
+
+  if (CODE_EXTENSIONS.has(ext)) {
     return (
-      <TextFilePreview entry={entry} workspaceId={workspaceId} conversationId={conversationId} />
+      <CodeFilePreview
+        entry={entry}
+        workspaceId={workspaceId}
+        conversationId={conversationId}
+      />
     )
   }
-  return <FallbackPreview entry={entry} workspaceId={workspaceId} conversationId={conversationId} />
+
+  if (PLAIN_TEXT_EXTENSIONS.has(ext) || !ext) {
+    return (
+      <TextFilePreview
+        entry={entry}
+        workspaceId={workspaceId}
+        conversationId={conversationId}
+      />
+    )
+  }
+
+  return (
+    <FallbackPreview
+      entry={entry}
+      workspaceId={workspaceId}
+      conversationId={conversationId}
+    />
+  )
+}
+
+// ── Text content previews (fetch via useSandboxFileContent) ───────
+
+function CodeFilePreview({
+  entry,
+  workspaceId,
+  conversationId,
+}: {
+  entry: SandboxFileEntry
+  workspaceId: string
+  conversationId?: string | null
+}) {
+  const { content, error, loading } = useSandboxFileContent(
+    workspaceId, entry.path, conversationId,
+  )
+
+  if (loading) return <PreviewLoading />
+  if (error?.message === 'FILE_TOO_LARGE') {
+    return (
+      <FallbackPreview entry={entry} workspaceId={workspaceId} conversationId={conversationId} />
+    )
+  }
+  if (error) {
+    return <div className="p-4 text-sm text-destructive">Failed to load: {error.message}</div>
+  }
+  if (content == null) return null
+
+  return <CodeHighlight code={content} filename={entry.name} />
+}
+
+function CsvFilePreview({
+  entry,
+  workspaceId,
+  conversationId,
+}: {
+  entry: SandboxFileEntry
+  workspaceId: string
+  conversationId?: string | null
+}) {
+  const { content, error, loading } = useSandboxFileContent(
+    workspaceId, entry.path, conversationId,
+  )
+
+  if (loading) return <PreviewLoading />
+  if (error?.message === 'FILE_TOO_LARGE') {
+    return (
+      <FallbackPreview entry={entry} workspaceId={workspaceId} conversationId={conversationId} />
+    )
+  }
+  if (error) {
+    return <div className="p-4 text-sm text-destructive">Failed to load: {error.message}</div>
+  }
+  if (content == null) return null
+
+  return <CsvTable content={content} />
 }
 
 function MarkdownFilePreview({
@@ -121,19 +223,14 @@ function MarkdownFilePreview({
   entry: SandboxFileEntry
   workspaceId: string
   conversationId?: string | null
-  onNavigate: (path: string) => void
+  onNavigate?: (path: string) => void
 }) {
-  const { content, error, loading } = useSandboxFileContent(workspaceId, entry.path, conversationId)
+  const { content, error, loading } = useSandboxFileContent(
+    workspaceId, entry.path, conversationId,
+  )
 
   const resolveAssetUrl = useCallback(
-    (path: string) => {
-      const convQs = conversationId ? `&conversation_id=${encodeURIComponent(conversationId)}` : ''
-      return (
-        `/api/v1/ws/${workspaceId}` +
-        `/sandbox/files/download` +
-        `?path=${encodeURIComponent(path)}${convQs}`
-      )
-    },
+    (path: string) => buildDownloadUrl(workspaceId, path, conversationId),
     [workspaceId, conversationId],
   )
 
@@ -154,7 +251,7 @@ function MarkdownFilePreview({
         className="prose prose-sm dark:prose-invert max-w-none p-4"
         sandbox={{
           filePath: entry.path,
-          onNavigate,
+          onNavigate: onNavigate ?? (() => {}),
           resolveAssetUrl,
         }}
       >
@@ -173,7 +270,9 @@ function TextFilePreview({
   workspaceId: string
   conversationId?: string | null
 }) {
-  const { content, error, loading } = useSandboxFileContent(workspaceId, entry.path, conversationId)
+  const { content, error, loading } = useSandboxFileContent(
+    workspaceId, entry.path, conversationId,
+  )
 
   if (loading) return <PreviewLoading />
   if (error?.message === 'FILE_TOO_LARGE') {
@@ -199,6 +298,8 @@ function TextFilePreview({
   )
 }
 
+// ── HTML blob-URL iframe ──────────────────────────────────────────
+
 function HtmlFilePreview({
   entry,
   workspaceId,
@@ -208,7 +309,9 @@ function HtmlFilePreview({
   workspaceId: string
   conversationId?: string | null
 }) {
-  const { content, error, loading } = useSandboxFileContent(workspaceId, entry.path, conversationId)
+  const { content, error, loading } = useSandboxFileContent(
+    workspaceId, entry.path, conversationId,
+  )
   const blobUrl = useMemo(() => {
     if (!content) return null
     const blob = new Blob([content], { type: 'text/html' })
@@ -237,6 +340,8 @@ function HtmlFilePreview({
   )
 }
 
+// ── Office Online Viewer ──────────────────────────────────────────
+
 const OFFICE_LOAD_TIMEOUT_MS = 15_000
 
 function OfficeFilePreview({
@@ -251,6 +356,7 @@ function OfficeFilePreview({
   const [viewerUrl, setViewerUrl] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [timedOut, setTimedOut] = useState(false)
+  const [retrySeq, setRetrySeq] = useState(0)
   const loadCountRef = useRef(0)
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
@@ -281,7 +387,7 @@ function OfficeFilePreview({
     return () => {
       cancelled = true
     }
-  }, [workspaceId, conversationId, entry.path])
+  }, [workspaceId, conversationId, entry.path, retrySeq])
 
   useEffect(() => {
     if (!viewerUrl) return
@@ -301,30 +407,48 @@ function OfficeFilePreview({
     setTimedOut(false)
     setViewerUrl(null)
     setError(null)
+    setRetrySeq((n) => n + 1)
   }, [])
 
-  if (error) {
-    return <FallbackPreview entry={entry} workspaceId={workspaceId} />
-  }
-  if (!viewerUrl) return <PreviewLoading />
-
-  if (timedOut) {
+  if (error || timedOut) {
+    const downloadUrl = buildDownloadUrl(workspaceId, entry.path, conversationId)
     return (
       <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
-        <p className="text-sm text-muted-foreground">Office preview timed out.</p>
-        <button
-          onClick={handleRetry}
-          className={
-            'rounded-md bg-primary px-4 py-2 text-sm' +
-            ' font-medium text-primary-foreground' +
-            ' hover:bg-primary/90'
-          }
-        >
-          Retry
-        </button>
+        <div className="flex size-16 items-center justify-center rounded-xl bg-muted">
+          <FileText className="size-8 text-muted-foreground" />
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-foreground">{entry.name}</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {timedOut ? 'Office preview timed out.' : 'Failed to load preview.'}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleRetry}
+            className={
+              'rounded-md border border-border px-4 py-2 text-sm' +
+              ' font-medium text-foreground hover:bg-muted transition-colors'
+            }
+          >
+            Retry
+          </button>
+          <a
+            href={downloadUrl}
+            className={
+              'inline-flex items-center gap-2 rounded-md' +
+              ' bg-primary px-4 py-2 text-sm font-medium' +
+              ' text-primary-foreground hover:bg-primary/90 transition-colors'
+            }
+          >
+            <Download className="size-4" />
+            Download
+          </a>
+        </div>
       </div>
     )
   }
+  if (!viewerUrl) return <PreviewLoading />
 
   return (
     <iframe
@@ -336,6 +460,8 @@ function OfficeFilePreview({
   )
 }
 
+// ── Fallback download ─────────────────────────────────────────────
+
 function FallbackPreview({
   entry,
   workspaceId,
@@ -345,11 +471,7 @@ function FallbackPreview({
   workspaceId: string
   conversationId?: string | null
 }) {
-  const convQs = conversationId ? `&conversation_id=${encodeURIComponent(conversationId)}` : ''
-  const downloadUrl =
-    `/api/v1/ws/${workspaceId}` +
-    `/sandbox/files/download` +
-    `?path=${encodeURIComponent(entry.path)}${convQs}`
+  const downloadUrl = buildDownloadUrl(workspaceId, entry.path, conversationId)
   const sizeLabel =
     entry.size < 1024
       ? `${entry.size} B`

--- a/frontend/packages/web/components/shared/previews/CodeHighlight.tsx
+++ b/frontend/packages/web/components/shared/previews/CodeHighlight.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+const EXT_TO_LANG: Record<string, string> = {
+  py: 'python',
+  js: 'javascript',
+  ts: 'typescript',
+  tsx: 'typescript',
+  jsx: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  rb: 'ruby',
+  go: 'go',
+  rs: 'rust',
+  java: 'java',
+  kt: 'kotlin',
+  c: 'c',
+  cpp: 'cpp',
+  h: 'c',
+  hpp: 'cpp',
+  cs: 'csharp',
+  swift: 'swift',
+  sh: 'bash',
+  bash: 'bash',
+  zsh: 'bash',
+  html: 'xml',
+  css: 'css',
+  scss: 'scss',
+  less: 'less',
+  sql: 'sql',
+  json: 'json',
+  yaml: 'yaml',
+  yml: 'yaml',
+  toml: 'ini',
+  xml: 'xml',
+  vue: 'xml',
+  svelte: 'xml',
+  php: 'php',
+  r: 'r',
+  lua: 'lua',
+  pl: 'perl',
+  ex: 'elixir',
+  exs: 'elixir',
+  dockerfile: 'dockerfile',
+  makefile: 'makefile',
+}
+
+function getLang(filename: string): string | undefined {
+  const dot = filename.lastIndexOf('.')
+  if (dot < 0) return undefined
+  return EXT_TO_LANG[filename.slice(dot + 1).toLowerCase()]
+}
+
+interface CodeHighlightProps {
+  code: string
+  filename: string
+}
+
+export function CodeHighlight({ code, filename }: CodeHighlightProps) {
+  const [html, setHtml] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const lang = getLang(filename)
+    import('highlight.js/lib/common')
+      .then((mod) => {
+        if (cancelled) return
+        const hljs = mod.default
+        let result: { value: string }
+        if (lang) {
+          try {
+            result = hljs.highlight(code, { language: lang })
+          } catch {
+            result = hljs.highlightAuto(code)
+          }
+        } else {
+          result = hljs.highlightAuto(code)
+        }
+        setHtml(result.value)
+      })
+      .catch(() => {
+        // highlight.js failed to load — plain text fallback stays visible
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [code, filename])
+
+  const sourceLines = code.split('\n')
+  const displayLines = html !== null ? html.split('\n') : sourceLines
+  const gutterWidth = String(sourceLines.length).length
+
+  return (
+    <div className="h-full overflow-auto py-2">
+      <table className="w-full border-collapse text-xs font-mono leading-relaxed">
+        <tbody>
+          {displayLines.map((line, i) => (
+            <tr key={i} className="hover:bg-muted/30">
+              <td
+                className="select-none pr-4 text-right text-muted-foreground/50 align-top
+                  sticky left-0 bg-background"
+                style={{
+                  width: `${gutterWidth + 2}ch`,
+                  minWidth: `${gutterWidth + 2}ch`,
+                  paddingLeft: '0.75rem',
+                }}
+              >
+                {i + 1}
+              </td>
+              {html !== null ? (
+                <td
+                  className="whitespace-pre-wrap break-words pl-2 pr-4"
+                  dangerouslySetInnerHTML={{ __html: line || '&nbsp;' }}
+                />
+              ) : (
+                <td className="whitespace-pre-wrap break-words text-foreground pl-2 pr-4">
+                  {line || ' '}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/packages/web/components/shared/previews/CsvTable.tsx
+++ b/frontend/packages/web/components/shared/previews/CsvTable.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useMemo } from 'react'
+
+interface CsvTableProps {
+  content: string
+}
+
+function parseCsv(text: string): { headers: string[]; rows: string[][] } {
+  const lines = text.trim().split('\n')
+  if (lines.length === 0) return { headers: [], rows: [] }
+  const parse = (line: string): string[] =>
+    line.split(',').map((c) => c.trim().replace(/^"|"$/g, ''))
+  return { headers: parse(lines[0]), rows: lines.slice(1).map(parse) }
+}
+
+export function CsvTable({ content }: CsvTableProps) {
+  const { headers, rows } = useMemo(() => parseCsv(content), [content])
+
+  if (headers.length === 0) {
+    return <div className="p-4 text-sm text-muted-foreground">Empty CSV</div>
+  }
+
+  return (
+    <div className="overflow-auto h-full">
+      <table className="w-full text-xs border-collapse">
+        <thead>
+          <tr className="border-b border-border bg-muted/50 sticky top-0">
+            {headers.map((h, i) => (
+              <th key={i} className="text-left p-2 font-medium text-muted-foreground">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i} className="border-b border-border/50 hover:bg-muted/30">
+              {row.map((cell, j) => (
+                <td key={j} className="p-2 text-foreground whitespace-nowrap">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/packages/web/components/shared/previews/ImageViewer.tsx
+++ b/frontend/packages/web/components/shared/previews/ImageViewer.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { ZoomIn, ZoomOut, RotateCcw } from 'lucide-react'
+import { PreviewLoading } from '@/components/panel/artifact/PreviewLoading'
+
+interface ImageViewerProps {
+  url: string
+  alt?: string
+}
+
+export function ImageViewer({ url, alt = 'preview' }: ImageViewerProps) {
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [scale, setScale] = useState(1)
+  const [naturalSize, setNaturalSize] = useState<{ w: number; h: number } | null>(null)
+
+  const handleLoad = useCallback((e: React.SyntheticEvent<HTMLImageElement>) => {
+    const img = e.currentTarget
+    setNaturalSize({ w: img.naturalWidth, h: img.naturalHeight })
+    setLoading(false)
+  }, [])
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    if (!e.ctrlKey && !e.metaKey) return
+    e.preventDefault()
+    setScale((s) => {
+      const delta = e.deltaY > 0 ? -0.1 : 0.1
+      return Math.max(0.25, Math.min(4, +(s + delta).toFixed(2)))
+    })
+  }, [])
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-sm text-destructive">
+        Failed to load image
+      </div>
+    )
+  }
+
+  const zoomed = scale !== 1
+
+  return (
+    <div className="flex h-full flex-col">
+      {zoomed && (
+        <div
+          className="flex items-center justify-end gap-1 px-3 py-1.5 border-b
+            border-border bg-muted/30 shrink-0"
+        >
+          <button
+            onClick={() => setScale((s) => Math.max(0.25, +(s - 0.25).toFixed(2)))}
+            disabled={scale <= 0.25}
+            className="p-1 rounded hover:bg-muted disabled:opacity-30 transition-colors"
+          >
+            <ZoomOut className="size-4 text-foreground" />
+          </button>
+          <span className="text-xs text-muted-foreground tabular-nums min-w-[3rem] text-center">
+            {Math.round(scale * 100)}%
+          </span>
+          <button
+            onClick={() => setScale((s) => Math.min(4, +(s + 0.25).toFixed(2)))}
+            disabled={scale >= 4}
+            className="p-1 rounded hover:bg-muted disabled:opacity-30 transition-colors"
+          >
+            <ZoomIn className="size-4 text-foreground" />
+          </button>
+          <button
+            onClick={() => setScale(1)}
+            className="p-1 rounded hover:bg-muted transition-colors"
+          >
+            <RotateCcw className="size-3.5 text-foreground" />
+          </button>
+        </div>
+      )}
+      <div
+        className={
+          'relative flex-1 overflow-auto p-4 bg-muted/20' +
+          (zoomed ? '' : ' flex items-center justify-center')
+        }
+        onWheel={handleWheel}
+      >
+        {loading && (
+          <div className="absolute inset-0 z-10">
+            <PreviewLoading />
+          </div>
+        )}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={url}
+          alt={alt}
+          className="object-contain rounded-md"
+          style={
+            zoomed && naturalSize
+              ? { width: naturalSize.w * scale, height: naturalSize.h * scale }
+              : { maxWidth: '100%', maxHeight: '100%' }
+          }
+          onLoad={handleLoad}
+          onError={() => {
+            setLoading(false)
+            setError(true)
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/packages/web/components/shared/previews/MediaPlayer.tsx
+++ b/frontend/packages/web/components/shared/previews/MediaPlayer.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { FileAudio } from 'lucide-react'
+
+interface MediaPlayerProps {
+  url: string
+  type: 'audio' | 'video'
+  filename: string
+}
+
+export function MediaPlayer({ url, type, filename }: MediaPlayerProps) {
+  if (type === 'audio') {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-6 p-8">
+        <div className="flex size-20 items-center justify-center rounded-2xl bg-muted">
+          <FileAudio className="size-10 text-muted-foreground" />
+        </div>
+        <p className="text-sm font-medium text-foreground">{filename}</p>
+        <audio controls preload="metadata" className="w-full max-w-md">
+          <source src={url} />
+        </audio>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full items-center justify-center bg-black/95 p-2">
+      <video
+        controls
+        preload="metadata"
+        className="max-w-full max-h-full rounded"
+      >
+        <source src={url} />
+      </video>
+    </div>
+  )
+}

--- a/frontend/packages/web/components/shared/previews/index.ts
+++ b/frontend/packages/web/components/shared/previews/index.ts
@@ -1,0 +1,4 @@
+export { CodeHighlight } from './CodeHighlight'
+export { ImageViewer } from './ImageViewer'
+export { MediaPlayer } from './MediaPlayer'
+export { CsvTable } from './CsvTable'

--- a/frontend/packages/web/package.json
+++ b/frontend/packages/web/package.json
@@ -22,6 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "geist": "^1.7.2",
+    "highlight.js": "^11.11.1",
     "katex": "^0.16.45",
     "lucide-react": "^1.6.0",
     "next": "16.2.9",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       geist:
         specifier: ^1.7.2
         version: 1.7.2(next@16.2.9(@babel/core@7.29.7)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       katex:
         specifier: ^0.16.45
         version: 0.16.47


### PR DESCRIPTION
## Summary

- **Extract shared preview components** — `CodeHighlight`, `ImageViewer`, `MediaPlayer`, `CsvTable` into `components/shared/previews/` so both sandbox and artifact panels reuse identical rendering logic
- **Sandbox file preview gains full media support** — image (with Ctrl+wheel zoom), PDF (react-pdf with TOC/page nav), video, audio, CSV table previews that were previously missing
- **Syntax highlighting everywhere** — highlight.js with line numbers, 40+ language mappings, dynamic import for code splitting
- **Fix Office preview retry bug** — the Retry button previously did nothing (effect deps weren't changing); now uses a retry counter to re-trigger the fetch, and unifies error/timeout into a single view with Retry + Download buttons

## Test plan

- [ ] Open a sandbox with image files → verify zoom (Ctrl+wheel), zoom toolbar, scroll works when zoomed in
- [ ] Open PDF in sandbox → verify page navigation, TOC sidebar
- [ ] Open code files (.py, .ts, .json, etc.) in sandbox → verify syntax highlighting with line numbers
- [ ] Open code files in artifact panel → verify same highlighting
- [ ] Open CSV in sandbox → verify table with sticky header
- [ ] Open video/audio files in sandbox → verify native player controls
- [ ] Open .docx/.xlsx/.pptx → verify Office preview loads; test Retry button after timeout
- [ ] Open markdown with images in sandbox → verify images resolve correctly
- [ ] Verify artifact image preview still works (uses shared ImageViewer)
- [ ] Verify artifact CSV preview still works (uses shared CsvTable)