### PR TITLE
feat(im): bot settings UI + route (PR2)

### DIFF
--- a/backend/cubebox/api/routes/v1/ws_im.py
+++ b/backend/cubebox/api/routes/v1/ws_im.py
@@ -475,6 +475,17 @@ async def update_bot_settings(
             detail="sandbox_mode is required when routing_mode is shared",
         )
     svc = _service(session, backend, ctx)
+    account = await svc.get(account_id=account_id, workspace_id=ctx.workspace_id)
+    if account is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="account not found")
+    # Teams' connector only emits per-sender scopes, so shared routing would
+    # silently make one group conversation per sender. Reject it on the API
+    # too, not just in the UI.
+    if body.routing_mode == "shared" and account.platform == "teams":
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="shared routing is not supported for this platform",
+        )
     updated = await svc.update_bot_settings(
         account_id=account_id, settings=body, workspace_id=ctx.workspace_id
     )

--- a/backend/cubebox/api/routes/v1/ws_im.py
+++ b/backend/cubebox/api/routes/v1/ws_im.py
@@ -31,6 +31,7 @@ from cubebox.credentials.dependencies import (
 )
 from cubebox.credentials.encryption import EncryptionBackend
 from cubebox.db.session import get_session
+from cubebox.im.bot_settings import IMBotSettings, load_bot_settings
 from cubebox.models.im_connector import IMConnectorAccount, IMIdentityLink
 from cubebox.models.membership import Role
 from cubebox.models.user import User
@@ -423,6 +424,63 @@ async def enable_workspace_account(
                     account_id,
                 )
     return _to_out(updated)
+
+
+# ---------------------------------------------------------------------------
+# Account-level bot settings (routing + topic mode)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/accounts/{account_id}/settings", response_model=IMBotSettings)
+async def get_bot_settings(
+    workspace_id: str,
+    account_id: str,
+    ctx: Annotated[RequestContext, Depends(require_member)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    backend: Annotated[EncryptionBackend, Depends(get_encryption_backend)],
+) -> IMBotSettings:
+    """Read the bot's account-level routing/topic settings (defaults if unset)."""
+    if workspace_id != ctx.workspace_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="workspace mismatch")
+    svc = _service(session, backend, ctx)
+    account = await svc.get(account_id=account_id, workspace_id=ctx.workspace_id)
+    if account is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="account not found")
+    return load_bot_settings(account.config)
+
+
+@router.put("/accounts/{account_id}/settings", response_model=IMBotSettings)
+async def update_bot_settings(
+    workspace_id: str,
+    account_id: str,
+    body: IMBotSettings,
+    ctx: Annotated[RequestContext, Depends(require_member)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    backend: Annotated[EncryptionBackend, Depends(get_encryption_backend)],
+) -> IMBotSettings:
+    """Update the bot's routing/topic settings. Admin-only (mutates behavior)."""
+    if workspace_id != ctx.workspace_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="workspace mismatch")
+    role = await MembershipRepository(session).get_role(
+        user_id=ctx.user.id, workspace_id=ctx.workspace_id
+    )
+    if role != Role.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="workspace admin required",
+        )
+    if body.routing_mode == "shared" and body.sandbox_mode is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="sandbox_mode is required when routing_mode is shared",
+        )
+    svc = _service(session, backend, ctx)
+    updated = await svc.update_bot_settings(
+        account_id=account_id, settings=body, workspace_id=ctx.workspace_id
+    )
+    if updated is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="account not found")
+    return load_bot_settings(updated.config)
 
 
 @router.get(

--- a/backend/cubebox/im/bot_settings.py
+++ b/backend/cubebox/im/bot_settings.py
@@ -28,13 +28,15 @@ class IMBotSettings(BaseModel):
     - ``topic_mode``: ``topic`` (roll each conversation up under a cubebox
       Topic) vs ``flat`` (standalone personal conversations, no Topic).
       ``shared`` always implies a Topic regardless of this knob.
-    - ``sandbox_mode``: sandbox the bot's runs use; defaulted to
-      ``dedicated`` for shared/topic runs at Topic-creation time.
+    - ``sandbox_mode``: sandbox the bot's runs use (``dedicated`` | ``creator``,
+      matching the native Topic schema); defaulted to ``dedicated`` for
+      shared/topic runs at Topic-creation time. An invalid stored value makes
+      ``load_bot_settings`` fall back to defaults rather than raising.
     """
 
     routing_mode: RoutingMode = "isolated"
     topic_mode: TopicMode = "topic"
-    sandbox_mode: str | None = Field(default=None)
+    sandbox_mode: str | None = Field(default=None, pattern=r"^(dedicated|creator)$")
 
 
 def load_bot_settings(config: dict[str, Any] | None) -> IMBotSettings:

--- a/backend/cubebox/im/conversation_resolver.py
+++ b/backend/cubebox/im/conversation_resolver.py
@@ -91,15 +91,18 @@ async def resolve_im_conversation(
     # Source metadata stamped on both the Topic and the Conversation. Its
     # presence under "im" is the IM-origin marker read by worker/resume.
     bot_name = bot_display_name(account.config)
-    # PR1: channel_name is not yet fetched from the platform — group topics
-    # fall back to the channel id. Lazy fetch is a follow-up (see spec).
+    # The bot avatar is hydrated into account.config at connect time; the
+    # sidebar renders it as the Topic avatar via attributes.im.
+    bot_avatar_url = (account.config or {}).get("bot_avatar_url")
+    # channel_name is not yet fetched from the platform — group topics fall
+    # back to the channel id. Lazy fetch is a follow-up (see spec).
     channel_name = None if scope_kind == "dm" else channel_id
     im_attrs = build_im_attributes(
         platform=account.platform,
         account_id=account.id,
         scope_kind=scope_kind,
         bot_name=bot_name,
-        bot_avatar_url=None,
+        bot_avatar_url=bot_avatar_url,
         channel_id=channel_id,
         channel_name=channel_name,
     )

--- a/backend/cubebox/im/inbound.py
+++ b/backend/cubebox/im/inbound.py
@@ -148,14 +148,14 @@ async def ingest_inbound_event(
         # a settings change. Reload it at this boundary — every transport
         # funnels through here — so saved routing/topic settings take effect
         # without a reconnect. (The webhook path already loads fresh; this is
-        # a cheap PK re-read.)
-        fresh_account = await session.get(IMConnectorAccount, account.id)
-        if fresh_account is not None:
-            account = fresh_account
-
+        # a cheap PK re-read.) Use the fresh copy ONLY for resolve — don't
+        # reassign ``account``: the thread-link retry below rolls back this
+        # session, which would expire a session-bound instance, and the
+        # recursive retry must read the caller's stable scalars (id/org/ws).
+        resolve_account = await session.get(IMConnectorAccount, account.id) or account
         resolved = await resolve_im_conversation(
             session,
-            account,
+            resolve_account,
             channel_id=event.channel_id,
             scope_key=event.scope_key,
             scope_kind=event.scope_kind,

--- a/backend/cubebox/im/inbound.py
+++ b/backend/cubebox/im/inbound.py
@@ -143,6 +143,16 @@ async def ingest_inbound_event(
                 return IngestResult(outcome="rejected", conversation_id=None)
             effective_user_id = resolved_user_id
 
+        # Live settings: the long-connection / gateway transports captured
+        # this account at startup, so its ``config`` can be stale relative to
+        # a settings change. Reload it at this boundary — every transport
+        # funnels through here — so saved routing/topic settings take effect
+        # without a reconnect. (The webhook path already loads fresh; this is
+        # a cheap PK re-read.)
+        fresh_account = await session.get(IMConnectorAccount, account.id)
+        if fresh_account is not None:
+            account = fresh_account
+
         resolved = await resolve_im_conversation(
             session,
             account,

--- a/backend/cubebox/services/im_connector.py
+++ b/backend/cubebox/services/im_connector.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from cubebox.im.bot_settings import IMBotSettings
 
 from loguru import logger
 from sqlalchemy import select
@@ -735,6 +738,29 @@ class IMConnectorService:
         if account is None:
             return None
         account.enabled = enabled
+        self._session.add(account)
+        await self._session.commit()
+        await self._session.refresh(account)
+        return account
+
+    async def update_bot_settings(
+        self,
+        *,
+        account_id: str,
+        settings: IMBotSettings,
+        workspace_id: str | None = None,
+    ) -> IMConnectorAccount | None:
+        """Merge account-level bot settings into ``config`` and persist.
+
+        Reassigns ``config`` (not in-place mutation) so SQLAlchemy detects the
+        JSON change. Returns None if the account is absent / out of scope.
+        """
+        from cubebox.im.bot_settings import store_bot_settings
+
+        account = await self.get(account_id=account_id, workspace_id=workspace_id)
+        if account is None:
+            return None
+        account.config = store_bot_settings(account.config, settings)
         self._session.add(account)
         await self._session.commit()
         await self._session.refresh(account)

--- a/backend/tests/e2e/test_im_bot_settings_routes.py
+++ b/backend/tests/e2e/test_im_bot_settings_routes.py
@@ -109,6 +109,12 @@ async def test_put_shared_requires_sandbox_mode(
             base, json={"routing_mode": "shared", "topic_mode": "topic"}
         )
         assert resp.status_code == 422, resp.text
+        # A non-enum sandbox value is also rejected (only dedicated|creator).
+        bad = await async_client.put(
+            base,
+            json={"routing_mode": "shared", "topic_mode": "topic", "sandbox_mode": "nope"},
+        )
+        assert bad.status_code == 422, bad.text
         # And the account's settings stay at the defaults (no partial write).
         assert (await async_client.get(base)).json()["routing_mode"] == "isolated"
     finally:
@@ -154,9 +160,10 @@ async def test_put_requires_admin(
     try:
         # Member CAN read.
         assert ws_member_client.get(base).status_code == 200
-        # Member CANNOT write.
+        # Member CANNOT write (valid body, so we hit the admin gate, not 422).
         put = ws_member_client.put(
-            base, json={"routing_mode": "shared", "topic_mode": "topic", "sandbox_mode": "x"}
+            base,
+            json={"routing_mode": "shared", "topic_mode": "topic", "sandbox_mode": "dedicated"},
         )
         assert put.status_code == 403, put.text
     finally:

--- a/backend/tests/e2e/test_im_bot_settings_routes.py
+++ b/backend/tests/e2e/test_im_bot_settings_routes.py
@@ -1,0 +1,163 @@
+"""E2E for the account-level IM bot settings routes (PR2).
+
+Covers the GET/PUT contract on
+``/api/v1/ws/{ws}/im/accounts/{id}/settings``: defaults, round-trip
+persistence, shared-mode validation, workspace isolation, and the admin gate
+on PUT.
+"""
+
+from __future__ import annotations
+
+import secrets as _secrets
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _app_id(tag: str) -> str:
+    return f"cli_{tag}_{_secrets.token_hex(4)}"
+
+
+async def _create_account(client: httpx.AsyncClient, ws_id: str, tag: str) -> str:
+    resp = await client.post(
+        f"/api/v1/ws/{ws_id}/im/accounts",
+        json={
+            "platform": "feishu",
+            "app_id": _app_id(tag),
+            "app_secret": "secret",
+            "encrypt_key": "ek",
+            "verification_token": "vt",
+            "domain": "feishu",
+            "delivery_mode": "long_connection",
+            "acting_user_id": "self",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return str(resp.json()["id"])
+
+
+@patch("cubebox.services.im_connector.IMConnectorService._hydrate_bot_info")
+async def test_get_defaults_then_put_roundtrip(
+    mock_hydrate: Any,
+    async_client: httpx.AsyncClient,
+) -> None:
+    """Defaults on first read; PUT persists and is reflected by GET."""
+
+    async def _fake(app_id: str, app_secret: str, domain: str) -> tuple[str, str, str]:
+        return "ou_bot", "", ""
+
+    mock_hydrate.side_effect = _fake
+    from tests.e2e.conftest import DEFAULT_WS_ID
+
+    account_id = await _create_account(async_client, DEFAULT_WS_ID, "settings")
+    base = f"/api/v1/ws/{DEFAULT_WS_ID}/im/accounts/{account_id}/settings"
+    try:
+        # Unset → defaults.
+        got = await async_client.get(base)
+        assert got.status_code == 200, got.text
+        assert got.json() == {
+            "routing_mode": "isolated",
+            "topic_mode": "topic",
+            "sandbox_mode": None,
+        }
+
+        # Update to shared + sandbox; response echoes the stored settings.
+        put = await async_client.put(
+            base,
+            json={
+                "routing_mode": "shared",
+                "topic_mode": "flat",
+                "sandbox_mode": "dedicated",
+            },
+        )
+        assert put.status_code == 200, put.text
+        assert put.json() == {
+            "routing_mode": "shared",
+            "topic_mode": "flat",
+            "sandbox_mode": "dedicated",
+        }
+
+        # Persisted across a fresh read.
+        got2 = await async_client.get(base)
+        assert got2.json()["routing_mode"] == "shared"
+        assert got2.json()["sandbox_mode"] == "dedicated"
+    finally:
+        await async_client.delete(f"/api/v1/ws/{DEFAULT_WS_ID}/im/accounts/{account_id}")
+
+
+@patch("cubebox.services.im_connector.IMConnectorService._hydrate_bot_info")
+async def test_put_shared_requires_sandbox_mode(
+    mock_hydrate: Any,
+    async_client: httpx.AsyncClient,
+) -> None:
+    """shared routing without a sandbox_mode is rejected (422)."""
+
+    async def _fake(app_id: str, app_secret: str, domain: str) -> tuple[str, str, str]:
+        return "ou_bot", "", ""
+
+    mock_hydrate.side_effect = _fake
+    from tests.e2e.conftest import DEFAULT_WS_ID
+
+    account_id = await _create_account(async_client, DEFAULT_WS_ID, "sandbox")
+    base = f"/api/v1/ws/{DEFAULT_WS_ID}/im/accounts/{account_id}/settings"
+    try:
+        resp = await async_client.put(
+            base, json={"routing_mode": "shared", "topic_mode": "topic"}
+        )
+        assert resp.status_code == 422, resp.text
+        # And the account's settings stay at the defaults (no partial write).
+        assert (await async_client.get(base)).json()["routing_mode"] == "isolated"
+    finally:
+        await async_client.delete(f"/api/v1/ws/{DEFAULT_WS_ID}/im/accounts/{account_id}")
+
+
+async def test_get_unknown_account_404(async_client: httpx.AsyncClient) -> None:
+    from tests.e2e.conftest import DEFAULT_WS_ID
+
+    resp = await async_client.get(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/im/accounts/imac-does-not-exist/settings"
+    )
+    assert resp.status_code == 404
+
+
+async def test_put_foreign_workspace_404(async_client: httpx.AsyncClient) -> None:
+    """A workspace the caller isn't a member of is rejected by require_member
+    with a 404 (scope isolation: don't leak that the workspace exists)."""
+    resp = await async_client.put(
+        "/api/v1/ws/ws-not-mine/im/accounts/imac-x/settings",
+        json={"routing_mode": "isolated", "topic_mode": "topic"},
+    )
+    assert resp.status_code == 404
+
+
+@patch("cubebox.services.im_connector.IMConnectorService._hydrate_bot_info")
+async def test_put_requires_admin(
+    mock_hydrate: Any,
+    async_client: httpx.AsyncClient,
+    ws_member_client: Any,
+) -> None:
+    """A plain workspace member cannot change bot settings (admin-only PUT);
+    GET is allowed for members."""
+
+    async def _fake(app_id: str, app_secret: str, domain: str) -> tuple[str, str, str]:
+        return "ou_bot", "", ""
+
+    mock_hydrate.side_effect = _fake
+    from tests.e2e.conftest import DEFAULT_WS_ID
+
+    account_id = await _create_account(async_client, DEFAULT_WS_ID, "rbac")
+    base = f"/api/v1/ws/{DEFAULT_WS_ID}/im/accounts/{account_id}/settings"
+    try:
+        # Member CAN read.
+        assert ws_member_client.get(base).status_code == 200
+        # Member CANNOT write.
+        put = ws_member_client.put(
+            base, json={"routing_mode": "shared", "topic_mode": "topic", "sandbox_mode": "x"}
+        )
+        assert put.status_code == 403, put.text
+    finally:
+        await async_client.delete(f"/api/v1/ws/{DEFAULT_WS_ID}/im/accounts/{account_id}")

--- a/backend/tests/e2e/test_im_bot_settings_routes.py
+++ b/backend/tests/e2e/test_im_bot_settings_routes.py
@@ -121,6 +121,44 @@ async def test_put_shared_requires_sandbox_mode(
         await async_client.delete(f"/api/v1/ws/{DEFAULT_WS_ID}/im/accounts/{account_id}")
 
 
+@patch("cubebox.services.im_connector.IMConnectorService._hydrate_bot_info")
+async def test_put_rejects_shared_for_teams(
+    mock_hydrate: Any,
+    async_client: httpx.AsyncClient,
+) -> None:
+    """Teams can't do channel-shared scope, so shared routing is rejected on
+    the API too (not just disabled in the UI)."""
+
+    async def _fake(app_id: str, app_secret: str, domain: str) -> tuple[str, str, str]:
+        return "ou_bot", "", ""
+
+    mock_hydrate.side_effect = _fake
+    from cubebox.db.engine import async_session_maker
+    from cubebox.models.im_connector import IMConnectorAccount
+    from tests.e2e.conftest import DEFAULT_WS_ID
+
+    account_id = await _create_account(async_client, DEFAULT_WS_ID, "teams")
+    base = f"/api/v1/ws/{DEFAULT_WS_ID}/im/accounts/{account_id}/settings"
+    try:
+        async with async_session_maker() as s:
+            acct = await s.get(IMConnectorAccount, account_id)
+            assert acct is not None
+            acct.platform = "teams"
+            await s.commit()
+        resp = await async_client.put(
+            base,
+            json={"routing_mode": "shared", "topic_mode": "topic", "sandbox_mode": "dedicated"},
+        )
+        assert resp.status_code == 422, resp.text
+        # Isolated still works for Teams.
+        ok = await async_client.put(
+            base, json={"routing_mode": "isolated", "topic_mode": "topic"}
+        )
+        assert ok.status_code == 200, ok.text
+    finally:
+        await async_client.delete(f"/api/v1/ws/{DEFAULT_WS_ID}/im/accounts/{account_id}")
+
+
 async def test_get_unknown_account_404(async_client: httpx.AsyncClient) -> None:
     from tests.e2e.conftest import DEFAULT_WS_ID
 

--- a/backend/tests/e2e/test_im_shared_mode_ingest.py
+++ b/backend/tests/e2e/test_im_shared_mode_ingest.py
@@ -44,9 +44,19 @@ _CHANNEL = "oc_shared_ch1"
 _EXT_ACCT = "cli_icb_ingest"
 
 
-def _set(account: IMConnectorAccount, settings: IMBotSettings) -> None:
-    """Apply account-level settings in-memory; ingest reads account.config."""
+async def _set(
+    maker: async_sessionmaker[AsyncSession],
+    account: IMConnectorAccount,
+    settings: IMBotSettings,
+) -> None:
+    """Persist account-level settings to the DB. ingest reloads the account at
+    its boundary, so settings must live in the row, not just in memory."""
     account.config = store_bot_settings(account.config, settings)
+    async with maker() as session:
+        row = await session.get(IMConnectorAccount, account.id)
+        assert row is not None
+        row.config = account.config
+        await session.commit()
 
 
 @pytest_asyncio.fixture
@@ -156,7 +166,7 @@ async def test_first_shared_message_creates_topic(
 ) -> None:
     """First @bot in shared mode creates Topic + owner participant + group conv."""
     maker, account = _seeded
-    _set(account, IMBotSettings(routing_mode="shared"))
+    await _set(maker, account, IMBotSettings(routing_mode="shared"))
 
     res = await ingest_inbound_event(_event(), account=account, session_maker=maker)
     assert res.outcome == "enqueued"
@@ -195,7 +205,7 @@ async def test_subsequent_shared_reuses_topic(
 ) -> None:
     """Second message in shared mode reuses the same conversation + topic."""
     maker, account = _seeded
-    _set(account, IMBotSettings(routing_mode="shared"))
+    await _set(maker, account, IMBotSettings(routing_mode="shared"))
 
     r1 = await ingest_inbound_event(
         _event(event_id="ev-sub-1"), account=account, session_maker=maker
@@ -252,12 +262,39 @@ async def test_default_isolated_creates_per_sender_topic(
         assert "im" in topic.attributes
 
 
+async def test_ingest_reloads_stale_account_settings(
+    _seeded: tuple[async_sessionmaker[AsyncSession], IMConnectorAccount],
+) -> None:
+    """A long-connection transport holds the account captured at startup. When
+    settings change in the DB, ingest must reload and honor them — without a
+    reconnect. Here the passed account object stays stale (empty config) while
+    the DB row is switched to shared."""
+    maker, account = _seeded
+    async with maker() as s:
+        row = await s.get(IMConnectorAccount, account.id)
+        assert row is not None
+        row.config = store_bot_settings(row.config, IMBotSettings(routing_mode="shared"))
+        await s.commit()
+    # The in-memory transport object is deliberately NOT updated.
+    assert (account.config or {}).get("bot_settings") is None
+
+    res = await ingest_inbound_event(_event(event_id="ev-stale-1"), account=account, session_maker=maker)
+    assert res.outcome == "enqueued"
+    async with maker() as s:
+        conv = (
+            await s.execute(select(Conversation).where(Conversation.id == res.conversation_id))
+        ).scalar_one()
+        # Reloaded config took effect: shared routing → group chat + topic.
+        assert conv.is_group_chat is True
+        assert conv.topic_id is not None
+
+
 async def test_flat_mode_no_topic(
     _seeded: tuple[async_sessionmaker[AsyncSession], IMConnectorAccount],
 ) -> None:
     """Isolated + flat: no Topic; conversation.topic_id is None."""
     maker, account = _seeded
-    _set(account, IMBotSettings(routing_mode="isolated", topic_mode="flat"))
+    await _set(maker, account, IMBotSettings(routing_mode="isolated", topic_mode="flat"))
 
     res = await ingest_inbound_event(
         _event(event_id="ev-flat-1", scope_key="u:on_senderA", scope_kind="participant"),

--- a/backend/tests/e2e/test_resolve_im_conversation.py
+++ b/backend/tests/e2e/test_resolve_im_conversation.py
@@ -146,6 +146,8 @@ async def test_shared_creates_topic_and_link(
     (owned by the bot's acting user) stamped with attributes.im."""
     maker, account = _seeded
     _with_settings(account, IMBotSettings(routing_mode="shared"))
+    # Avatar is hydrated into config at connect time → surfaces on the topic.
+    account.config = {**account.config, "bot_avatar_url": "https://x/avatar.png"}
 
     async with maker() as session:
         resolved = await resolve_im_conversation(
@@ -181,6 +183,7 @@ async def test_shared_creates_topic_and_link(
         assert topic.creator_user_id == _USER  # acting user owns shared topics
         assert topic.attributes.get("im", {}).get("account_id") == _ACCOUNT
         assert topic.attributes["im"]["scope_kind"] == "channel"
+        assert topic.attributes["im"]["bot_avatar_url"] == "https://x/avatar.png"
 
         owner_tp = (
             await session.execute(

--- a/frontend/packages/core/src/api/im.ts
+++ b/frontend/packages/core/src/api/im.ts
@@ -124,6 +124,38 @@ export async function wsEnableImAccount(
   return (await res.json()) as ImAccount
 }
 
+// ── Bot settings (account-level routing + topic mode) ────────────────────────
+
+export type ImRoutingMode = 'isolated' | 'shared'
+export type ImTopicMode = 'topic' | 'flat'
+
+export interface ImBotSettings {
+  routing_mode: ImRoutingMode
+  topic_mode: ImTopicMode
+  sandbox_mode: string | null
+}
+
+export async function wsGetImBotSettings(
+  client: ApiClient,
+  wsId: string,
+  accountId: string,
+): Promise<ImBotSettings> {
+  const res = await client.get(`/api/v1/ws/${wsId}/im/accounts/${accountId}/settings`)
+  if (!res.ok) throw await toApiError(res)
+  return (await res.json()) as ImBotSettings
+}
+
+export async function wsUpdateImBotSettings(
+  client: ApiClient,
+  wsId: string,
+  accountId: string,
+  body: ImBotSettings,
+): Promise<ImBotSettings> {
+  const res = await client.put(`/api/v1/ws/${wsId}/im/accounts/${accountId}/settings`, body)
+  if (!res.ok) throw await toApiError(res)
+  return (await res.json()) as ImBotSettings
+}
+
 // ── Admin scope ──────────────────────────────────────────────────────────────
 
 export async function adminListImAccounts(client: ApiClient): Promise<ImAccountListOut> {

--- a/frontend/packages/web/components/im/ImAccountDetailPanel.tsx
+++ b/frontend/packages/web/components/im/ImAccountDetailPanel.tsx
@@ -11,7 +11,6 @@ import {
   wsUpdateImBotSettings,
 } from '@cubebox/core'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
   Select,
@@ -62,21 +61,39 @@ export function ImAccountDetailPanel({
     }
   }, [client, account.workspace_id, account.id])
 
-  const loadSettings = useCallback(async () => {
-    try {
-      const res = await wsGetImBotSettings(client, account.workspace_id, account.id)
-      setSettings(res)
-      setSavedSettings(res)
-    } catch {
-      // non-critical; the section just stays in its loading state
-    }
-  }, [client, account.workspace_id, account.id])
-
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- load-on-mount
     void loadLinks()
-    void loadSettings()
-  }, [loadLinks, loadSettings])
+  }, [loadLinks])
+
+  // Bot settings are workspace-scoped (the GET route is guarded by
+  // require_member). The admin page can surface accounts from other
+  // workspaces, where this caller would 403 — so only load + render the
+  // section in workspace scope. On account switch, clear state and ignore a
+  // late response so account B never shows / saves account A's form.
+  const settingsScoped = scope === 'workspace'
+  useEffect(() => {
+    if (!settingsScoped) return
+    let active = true
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset on account switch
+    setSettings(null)
+    setSavedSettings(null)
+    setSettingsError(null)
+    void (async () => {
+      try {
+        const res = await wsGetImBotSettings(client, account.workspace_id, account.id)
+        if (active) {
+          setSettings(res)
+          setSavedSettings(res)
+        }
+      } catch {
+        // non-critical; the section stays in its loading state
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [client, account.workspace_id, account.id, settingsScoped])
 
   const botName = account.bot_app_name || 'cubebox'
   const settingsDirty =
@@ -93,11 +110,11 @@ export function ImAccountDetailPanel({
     try {
       const payload: ImBotSettings = {
         ...settings,
-        // Backend requires a sandbox_mode for shared routing; default it.
+        // Shared requires a sandbox_mode (default it); outside shared the
+        // field is hidden, so clear it — otherwise a stale value would still
+        // apply to isolated topics.
         sandbox_mode:
-          settings.routing_mode === 'shared'
-            ? settings.sandbox_mode || 'dedicated'
-            : settings.sandbox_mode,
+          settings.routing_mode === 'shared' ? settings.sandbox_mode || 'dedicated' : null,
       }
       const res = await wsUpdateImBotSettings(client, account.workspace_id, account.id, payload)
       setSettings(res)
@@ -117,7 +134,7 @@ export function ImAccountDetailPanel({
         : 'Each person gets their own conversation.'
     const topic =
       settings.topic_mode === 'topic' || settings.routing_mode === 'shared'
-        ? `Grouped under a topic — DM topics are titled “${botName}”, group topics use the chat name.`
+        ? `Grouped under a topic — DM topics are titled “${botName}”; group chats get one topic per channel.`
         : 'Standalone conversations, no topic grouping.'
     return `${routing} ${topic}`
   }, [settings, botName])
@@ -178,71 +195,89 @@ export function ImAccountDetailPanel({
           </dl>
         </section>
 
-        <Separator />
+        {settingsScoped && (
+          <>
+            <Separator />
 
-        <section>
-          <h3 className="mb-2 text-xs uppercase text-muted-foreground">Behavior</h3>
-          {settings === null ? (
-            <p className="text-xs text-muted-foreground">Loading…</p>
-          ) : (
-            <div className="flex flex-col gap-3">
-              <div className="grid grid-cols-[7rem_1fr] items-center gap-x-4 gap-y-3">
-                <Label htmlFor="im-routing-mode">Routing</Label>
-                <Select
-                  value={settings.routing_mode}
-                  onValueChange={(v) =>
-                    setSettings({ ...settings, routing_mode: v as ImBotSettings['routing_mode'] })
-                  }
-                >
-                  <SelectTrigger id="im-routing-mode" size="sm">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="isolated">Isolated (per person)</SelectItem>
-                    <SelectItem value="shared">Shared (per channel)</SelectItem>
-                  </SelectContent>
-                </Select>
+            <section>
+              <h3 className="mb-2 text-xs uppercase text-muted-foreground">Behavior</h3>
+              {settings === null ? (
+                <p className="text-xs text-muted-foreground">Loading…</p>
+              ) : (
+                <div className="flex flex-col gap-3">
+                  <div className="grid grid-cols-[7rem_1fr] items-center gap-x-4 gap-y-3">
+                    <Label htmlFor="im-routing-mode">Routing</Label>
+                    <Select
+                      value={settings.routing_mode}
+                      onValueChange={(v) => {
+                        const routing_mode = v as ImBotSettings['routing_mode']
+                        setSettings({
+                          ...settings,
+                          routing_mode,
+                          // Give shared a valid sandbox up front; clear it
+                          // when leaving shared (the field is hidden).
+                          sandbox_mode:
+                            routing_mode === 'shared' ? settings.sandbox_mode || 'dedicated' : null,
+                        })
+                      }}
+                    >
+                      <SelectTrigger id="im-routing-mode" size="sm">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="isolated">Isolated (per person)</SelectItem>
+                        <SelectItem value="shared">Shared (per channel)</SelectItem>
+                      </SelectContent>
+                    </Select>
 
-                <Label htmlFor="im-topic-mode">Topic grouping</Label>
-                <Select
-                  value={settings.topic_mode}
-                  onValueChange={(v) =>
-                    setSettings({ ...settings, topic_mode: v as ImBotSettings['topic_mode'] })
-                  }
-                >
-                  <SelectTrigger id="im-topic-mode" size="sm">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="topic">Group under a topic</SelectItem>
-                    <SelectItem value="flat">Standalone conversations</SelectItem>
-                  </SelectContent>
-                </Select>
+                    <Label htmlFor="im-topic-mode">Topic grouping</Label>
+                    <Select
+                      value={settings.topic_mode}
+                      onValueChange={(v) =>
+                        setSettings({ ...settings, topic_mode: v as ImBotSettings['topic_mode'] })
+                      }
+                    >
+                      <SelectTrigger id="im-topic-mode" size="sm">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="topic">Group under a topic</SelectItem>
+                        <SelectItem value="flat">Standalone conversations</SelectItem>
+                      </SelectContent>
+                    </Select>
 
-                {settings.routing_mode === 'shared' && (
-                  <>
-                    <Label htmlFor="im-sandbox-mode">Sandbox</Label>
-                    <Input
-                      id="im-sandbox-mode"
-                      value={settings.sandbox_mode ?? ''}
-                      placeholder="dedicated"
-                      onChange={(e) => setSettings({ ...settings, sandbox_mode: e.target.value })}
-                    />
-                  </>
-                )}
-              </div>
+                    {settings.routing_mode === 'shared' && (
+                      <>
+                        <Label htmlFor="im-sandbox-mode">Sandbox</Label>
+                        <Select
+                          value={settings.sandbox_mode ?? 'dedicated'}
+                          onValueChange={(v) => setSettings({ ...settings, sandbox_mode: v })}
+                        >
+                          <SelectTrigger id="im-sandbox-mode" size="sm">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="dedicated">Dedicated (topic-owned)</SelectItem>
+                            <SelectItem value="creator">Creator&apos;s sandbox</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </>
+                    )}
+                  </div>
 
-              <p className="text-xs text-muted-foreground">{behaviorSummary}</p>
-              {settingsError && <p className="text-xs text-destructive">{settingsError}</p>}
+                  <p className="text-xs text-muted-foreground">{behaviorSummary}</p>
+                  {settingsError && <p className="text-xs text-destructive">{settingsError}</p>}
 
-              <div>
-                <Button size="sm" disabled={!settingsDirty || saving} onClick={saveSettings}>
-                  {saving ? 'Saving…' : 'Save'}
-                </Button>
-              </div>
-            </div>
-          )}
-        </section>
+                  <div>
+                    <Button size="sm" disabled={!settingsDirty || saving} onClick={saveSettings}>
+                      {saving ? 'Saving…' : 'Save'}
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </section>
+          </>
+        )}
 
         <Separator />
 

--- a/frontend/packages/web/components/im/ImAccountDetailPanel.tsx
+++ b/frontend/packages/web/components/im/ImAccountDetailPanel.tsx
@@ -86,6 +86,10 @@ export function ImAccountDetailPanel({
     setSettings(null)
     setSavedSettings(null)
     setSettingsError(null)
+    // Clear any in-flight save state too: a save started for the previous
+    // account skips its own setSaving(false) once the id changes, which would
+    // otherwise leave the new account's Save button stuck disabled.
+    setSaving(false)
     void (async () => {
       try {
         const res = await wsGetImBotSettings(client, account.workspace_id, account.id)

--- a/frontend/packages/web/components/im/ImAccountDetailPanel.tsx
+++ b/frontend/packages/web/components/im/ImAccountDetailPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 
 import type { ImAccount, ImBotSettings, ImIdentityLink } from '@cubebox/core'
@@ -72,6 +72,13 @@ export function ImAccountDetailPanel({
   // section in workspace scope. On account switch, clear state and ignore a
   // late response so account B never shows / saves account A's form.
   const settingsScoped = scope === 'workspace'
+  // The latest account this panel instance is showing. Both the load effect
+  // and the save handler check it so a response for account A never lands on
+  // account B after the panel is reused.
+  const currentAccountId = useRef(account.id)
+  useEffect(() => {
+    currentAccountId.current = account.id
+  }, [account.id])
   useEffect(() => {
     if (!settingsScoped) return
     let active = true
@@ -96,6 +103,10 @@ export function ImAccountDetailPanel({
   }, [client, account.workspace_id, account.id, settingsScoped])
 
   const botName = account.bot_app_name || 'cubebox'
+  // Shared routing needs a channel-wide scope. The Teams connector only emits
+  // per-sender scopes, so shared would silently produce one group conversation
+  // per sender — disable it there.
+  const sharedSupported = account.platform !== 'teams'
   const settingsDirty =
     settings !== null &&
     savedSettings !== null &&
@@ -105,6 +116,7 @@ export function ImAccountDetailPanel({
 
   const saveSettings = useCallback(async () => {
     if (settings === null) return
+    const savingAccountId = account.id
     setSaving(true)
     setSettingsError(null)
     try {
@@ -117,25 +129,34 @@ export function ImAccountDetailPanel({
           settings.routing_mode === 'shared' ? settings.sandbox_mode || 'dedicated' : null,
       }
       const res = await wsUpdateImBotSettings(client, account.workspace_id, account.id, payload)
+      // Drop the response if the panel has since switched accounts.
+      if (currentAccountId.current !== savingAccountId) return
       setSettings(res)
       setSavedSettings(res)
     } catch (err) {
+      if (currentAccountId.current !== savingAccountId) return
       setSettingsError(err instanceof Error ? err.message : 'Failed to save settings')
     } finally {
-      setSaving(false)
+      if (currentAccountId.current === savingAccountId) setSaving(false)
     }
   }, [client, account.workspace_id, account.id, settings])
 
   const behaviorSummary = useMemo(() => {
     if (settings === null) return ''
-    const routing =
-      settings.routing_mode === 'shared'
-        ? 'Everyone in a channel shares one conversation.'
-        : 'Each person gets their own conversation.'
-    const topic =
-      settings.topic_mode === 'topic' || settings.routing_mode === 'shared'
-        ? `Grouped under a topic — DM topics are titled “${botName}”; group chats get one topic per channel.`
-        : 'Standalone conversations, no topic grouping.'
+    const shared = settings.routing_mode === 'shared'
+    const routing = shared
+      ? 'Everyone in a channel shares one conversation.'
+      : 'Each person gets their own conversation.'
+    let topic: string
+    if (!shared && settings.topic_mode === 'flat') {
+      topic = 'Standalone conversations, no topic grouping.'
+    } else if (shared) {
+      // Shared groups the whole channel under one topic; DMs stay per-sender.
+      topic = `Grouped under a topic — one per channel; DMs are titled “${botName}”.`
+    } else {
+      // Isolated keeps the sender scope, so topics are per person, not per channel.
+      topic = `Grouped under a topic — one per person (DMs titled “${botName}”).`
+    }
     return `${routing} ${topic}`
   }, [settings, botName])
 
@@ -226,9 +247,20 @@ export function ImAccountDetailPanel({
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="isolated">Isolated (per person)</SelectItem>
-                        <SelectItem value="shared">Shared (per channel)</SelectItem>
+                        <SelectItem value="shared" disabled={!sharedSupported}>
+                          Shared (per channel)
+                          {!sharedSupported && ' — not supported'}
+                        </SelectItem>
                       </SelectContent>
                     </Select>
+                    {!sharedSupported && (
+                      <>
+                        <span />
+                        <p className="text-xs text-muted-foreground">
+                          This platform only supports per-person routing.
+                        </p>
+                      </>
+                    )}
 
                     <Label htmlFor="im-topic-mode">Topic grouping</Label>
                     <Select

--- a/frontend/packages/web/components/im/ImAccountDetailPanel.tsx
+++ b/frontend/packages/web/components/im/ImAccountDetailPanel.tsx
@@ -3,9 +3,23 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslations } from 'next-intl'
 
-import type { ImAccount, ImIdentityLink } from '@cubebox/core'
-import { createApiClient, wsListIdentityLinks } from '@cubebox/core'
+import type { ImAccount, ImBotSettings, ImIdentityLink } from '@cubebox/core'
+import {
+  createApiClient,
+  wsGetImBotSettings,
+  wsListIdentityLinks,
+  wsUpdateImBotSettings,
+} from '@cubebox/core'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Separator } from '@/components/ui/separator'
 import { DetailPanel } from '@/components/shared/DetailPanel'
 
@@ -34,6 +48,10 @@ export function ImAccountDetailPanel({
   const t = useTranslations('im')
   const client = useMemo(() => createApiClient(''), [])
   const [links, setLinks] = useState<ImIdentityLink[]>([])
+  const [settings, setSettings] = useState<ImBotSettings | null>(null)
+  const [savedSettings, setSavedSettings] = useState<ImBotSettings | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [settingsError, setSettingsError] = useState<string | null>(null)
 
   const loadLinks = useCallback(async () => {
     try {
@@ -44,10 +62,65 @@ export function ImAccountDetailPanel({
     }
   }, [client, account.workspace_id, account.id])
 
+  const loadSettings = useCallback(async () => {
+    try {
+      const res = await wsGetImBotSettings(client, account.workspace_id, account.id)
+      setSettings(res)
+      setSavedSettings(res)
+    } catch {
+      // non-critical; the section just stays in its loading state
+    }
+  }, [client, account.workspace_id, account.id])
+
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- load-on-mount
     void loadLinks()
-  }, [loadLinks])
+    void loadSettings()
+  }, [loadLinks, loadSettings])
+
+  const botName = account.bot_app_name || 'cubebox'
+  const settingsDirty =
+    settings !== null &&
+    savedSettings !== null &&
+    (settings.routing_mode !== savedSettings.routing_mode ||
+      settings.topic_mode !== savedSettings.topic_mode ||
+      (settings.sandbox_mode ?? '') !== (savedSettings.sandbox_mode ?? ''))
+
+  const saveSettings = useCallback(async () => {
+    if (settings === null) return
+    setSaving(true)
+    setSettingsError(null)
+    try {
+      const payload: ImBotSettings = {
+        ...settings,
+        // Backend requires a sandbox_mode for shared routing; default it.
+        sandbox_mode:
+          settings.routing_mode === 'shared'
+            ? settings.sandbox_mode || 'dedicated'
+            : settings.sandbox_mode,
+      }
+      const res = await wsUpdateImBotSettings(client, account.workspace_id, account.id, payload)
+      setSettings(res)
+      setSavedSettings(res)
+    } catch (err) {
+      setSettingsError(err instanceof Error ? err.message : 'Failed to save settings')
+    } finally {
+      setSaving(false)
+    }
+  }, [client, account.workspace_id, account.id, settings])
+
+  const behaviorSummary = useMemo(() => {
+    if (settings === null) return ''
+    const routing =
+      settings.routing_mode === 'shared'
+        ? 'Everyone in a channel shares one conversation.'
+        : 'Each person gets their own conversation.'
+    const topic =
+      settings.topic_mode === 'topic' || settings.routing_mode === 'shared'
+        ? `Grouped under a topic — DM topics are titled “${botName}”, group topics use the chat name.`
+        : 'Standalone conversations, no topic grouping.'
+    return `${routing} ${topic}`
+  }, [settings, botName])
 
   return (
     <DetailPanel
@@ -103,6 +176,72 @@ export function ImAccountDetailPanel({
             <dt className="text-muted-foreground">Mode</dt>
             <dd>{account.delivery_mode}</dd>
           </dl>
+        </section>
+
+        <Separator />
+
+        <section>
+          <h3 className="mb-2 text-xs uppercase text-muted-foreground">Behavior</h3>
+          {settings === null ? (
+            <p className="text-xs text-muted-foreground">Loading…</p>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <div className="grid grid-cols-[7rem_1fr] items-center gap-x-4 gap-y-3">
+                <Label htmlFor="im-routing-mode">Routing</Label>
+                <Select
+                  value={settings.routing_mode}
+                  onValueChange={(v) =>
+                    setSettings({ ...settings, routing_mode: v as ImBotSettings['routing_mode'] })
+                  }
+                >
+                  <SelectTrigger id="im-routing-mode" size="sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="isolated">Isolated (per person)</SelectItem>
+                    <SelectItem value="shared">Shared (per channel)</SelectItem>
+                  </SelectContent>
+                </Select>
+
+                <Label htmlFor="im-topic-mode">Topic grouping</Label>
+                <Select
+                  value={settings.topic_mode}
+                  onValueChange={(v) =>
+                    setSettings({ ...settings, topic_mode: v as ImBotSettings['topic_mode'] })
+                  }
+                >
+                  <SelectTrigger id="im-topic-mode" size="sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="topic">Group under a topic</SelectItem>
+                    <SelectItem value="flat">Standalone conversations</SelectItem>
+                  </SelectContent>
+                </Select>
+
+                {settings.routing_mode === 'shared' && (
+                  <>
+                    <Label htmlFor="im-sandbox-mode">Sandbox</Label>
+                    <Input
+                      id="im-sandbox-mode"
+                      value={settings.sandbox_mode ?? ''}
+                      placeholder="dedicated"
+                      onChange={(e) => setSettings({ ...settings, sandbox_mode: e.target.value })}
+                    />
+                  </>
+                )}
+              </div>
+
+              <p className="text-xs text-muted-foreground">{behaviorSummary}</p>
+              {settingsError && <p className="text-xs text-destructive">{settingsError}</p>}
+
+              <div>
+                <Button size="sm" disabled={!settingsDirty || saving} onClick={saveSettings}>
+                  {saving ? 'Saving…' : 'Save'}
+                </Button>
+              </div>
+            </div>
+          )}
         </section>
 
         <Separator />


### PR DESCRIPTION
## What

**PR2** of the IM bot settings feature — the settings API + UI on top of [PR1 #278](https://github.com/xfgong/cubebox/pull/278). **Stacked on `feat/2026-06-23-im-bot-settings`** (retarget to `main` once PR1 merges).

## Changes

- **Backend route** (`ws_im.py`): workspace-scoped `GET/PUT /im/accounts/{id}/settings` reading/writing `account.config.bot_settings` via `IMConnectorService.update_bot_settings` (reassigns `config` so the JSON change is detected). GET is member-readable; PUT is **admin-only** and rejects shared routing without a `sandbox_mode`. Reuses the `IMBotSettings` pydantic model as the request/response schema.
- **Frontend** (`@cubebox/core` + `ImAccountDetailPanel`): `ImBotSettings` type + `wsGetImBotSettings`/`wsUpdateImBotSettings`; a **"Behavior" section** with routing_mode + topic_mode selects, a sandbox_mode input shown only for shared routing, a plain-language summary of the resulting behavior/topic title, and a dirty-gated Save (defaults sandbox to `dedicated` for shared; surfaces the admin-only 403).
- **Bot avatar on topics**: the avatar is already hydrated into `account.config` at connect time — read it into `attributes.im.bot_avatar_url` so the sidebar renders it as the Topic avatar (the "bot 头像 + 名称" identity). Group channel-name fetch remains a follow-up.

## Testing

- Backend **mypy clean (453)**, **ruff clean**; web **type-check + eslint clean**, prettier-formatted.
- **19 e2e pass**: settings routes (defaults, round-trip, shared-without-sandbox 422, unknown-account 404, foreign-workspace 404, member-cannot-PUT 403) + resolver (incl. avatar-on-topic) + shared ingest + im_routes.

> Frontend Playwright flow for the panel's load→edit→save state machine is deferred — the backend contract is covered by e2e and the panel is admin config.

@codex review