### PR TITLE
feat(conversations): fork from a message

### DIFF
--- a/backend/cubebox/api/routes/v1/attachments.py
+++ b/backend/cubebox/api/routes/v1/attachments.py
@@ -126,7 +126,7 @@ async def get_attachment(
         org_id=ctx.org_id,
         workspace_id=ctx.workspace_id,
     )
-    row = await repo.get_in_conversation(
+    row = await repo.get_with_fork_fallback(
         conversation_id=conversation_id,
         attachment_id=attachment_id,
     )
@@ -156,7 +156,7 @@ async def download_attachment(
         org_id=ctx.org_id,
         workspace_id=ctx.workspace_id,
     )
-    row = await repo.get_in_conversation(
+    row = await repo.get_with_fork_fallback(
         conversation_id=conversation_id,
         attachment_id=attachment_id,
     )
@@ -191,7 +191,7 @@ async def thumbnail_attachment(
         org_id=ctx.org_id,
         workspace_id=ctx.workspace_id,
     )
-    row = await repo.get_in_conversation(
+    row = await repo.get_with_fork_fallback(
         conversation_id=conversation_id,
         attachment_id=attachment_id,
     )

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -36,6 +36,12 @@ from cubebox.repositories import (
     MembershipRepository,
     UserSandboxRepository,
 )
+from cubebox.repositories.conversation import (
+    ForkGroupChatError,
+    ForkNewThreadExistsError,
+    ForkRunNotCompletedError,
+    ForkSourceMissingError,
+)
 from cubebox.skills.cache import SkillCache
 from cubebox.streams.replay_coalescer import ReplayCoalescer
 from cubebox.streams.run_events import (
@@ -465,6 +471,70 @@ async def set_pin(
             detail=f"Conversation {conversation_id} not found",
         )
     return _serialize_conversation(conversation)
+
+
+class ForkConversationRequest(BaseModel):
+    """Request body for forking a conversation."""
+
+    after_run_id: str
+
+
+@router.post("/{conversation_id}/fork", status_code=status.HTTP_201_CREATED)
+async def fork_conversation(
+    conversation_id: str,
+    body: ForkConversationRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    ctx: Annotated[RequestContext, Depends(require_member)],
+) -> dict[str, object]:
+    """Fork a conversation after the given completed run.
+
+    Copies all messages through the end of ``after_run_id`` into a new
+    conversation owned by the caller, in the same workspace and topic as
+    the source. Group-chat sources are rejected.
+    """
+    if not body.after_run_id.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_after_run_id"},
+        )
+    repo = ConversationRepository(
+        session,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
+    src = await repo.get_by_id(conversation_id)
+    if not src:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Conversation {conversation_id} not found",
+        )
+    try:
+        new_conv = await repo.fork(src, after_run_id=body.after_run_id)
+    except ForkGroupChatError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "group_chat_not_supported"},
+        ) from exc
+    except ForkRunNotCompletedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "run_not_completed"},
+        ) from exc
+    except ForkSourceMissingError as exc:
+        # Source conversation exists in cubebox but has no cubepi thread —
+        # nothing to fork. Treat as a client error against the fork-point
+        # contract (you can't fork a conversation that has no messages).
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "source_has_no_messages"},
+        ) from exc
+    except ForkNewThreadExistsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "new_thread_exists"},
+        ) from exc
+    return _serialize_conversation(new_conv)
 
 
 @router.delete("/{conversation_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -534,6 +534,16 @@ async def fork_conversation(
             status_code=status.HTTP_409_CONFLICT,
             detail={"code": "new_thread_exists"},
         ) from exc
+    # Index the forked conversation so it shows up in conversation-search
+    # right away — without this, the fork is invisible to search until the
+    # caller sends another message. Best-effort; same shape as the
+    # post-send-message index trigger.
+    await _enqueue_search_index(
+        new_conv.id,
+        org_id=ctx.org_id,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user.id,
+    )
     return _serialize_conversation(new_conv)
 
 

--- a/backend/cubebox/repositories/attachment.py
+++ b/backend/cubebox/repositories/attachment.py
@@ -2,10 +2,15 @@
 
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 
 from cubebox.models import Attachment
 from cubebox.repositories.base import ScopedRepository
+
+# Max ancestor hops walked by ``get_with_fork_fallback``. A request that has
+# climbed past this many forks-of-forks is either pathological or someone
+# probing for an exfiltration loop — short-circuit with a 404.
+_FORK_WALK_MAX_HOPS = 8
 
 
 class AttachmentRepository(ScopedRepository[Attachment]):
@@ -25,6 +30,51 @@ class AttachmentRepository(ScopedRepository[Attachment]):
         )
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
+
+    async def get_with_fork_fallback(
+        self, *, conversation_id: str, attachment_id: str
+    ) -> Attachment | None:
+        """Resolve an attachment, walking up the fork chain on miss.
+
+        A forked conversation's cloned cubepi messages still reference the
+        SOURCE conversation's attachment ids (the messages were copied
+        verbatim, and Attachment rows are PK'd by id under a single
+        conversation_id — no per-fork clone, no row aliasing). Without
+        this fallback every image / file in a fork would 404 on first
+        render.
+
+        Walks ``cubepi_threads.parent_thread_id`` up to ``_FORK_WALK_MAX_HOPS``
+        ancestors, retrying the per-conversation lookup at each step. The
+        workspace scope from ``_scoped_select`` is preserved at every hop,
+        so this can never reach an attachment outside the caller's
+        workspace.
+        """
+        row = await self.get_in_conversation(
+            conversation_id=conversation_id, attachment_id=attachment_id
+        )
+        if row is not None:
+            return row
+        # Climb the fork chain.  Direct SQL against the cubepi-owned table
+        # (no SQLModel for it on the cubebox side) — kept to a single
+        # column SELECT so the coupling is minimal and obvious.
+        current = conversation_id
+        seen: set[str] = {current}
+        for _ in range(_FORK_WALK_MAX_HOPS):
+            result = await self.session.execute(
+                text("SELECT parent_thread_id FROM cubepi_threads WHERE thread_id = :tid"),
+                {"tid": current},
+            )
+            parent = result.scalar_one_or_none()
+            if not parent or parent in seen:
+                return None
+            seen.add(parent)
+            current = parent
+            row = await self.get_in_conversation(
+                conversation_id=current, attachment_id=attachment_id
+            )
+            if row is not None:
+                return row
+        return None
 
     async def list_by_conversation(
         self, *, conversation_id: str, status: str | None = None

--- a/backend/cubebox/repositories/conversation.py
+++ b/backend/cubebox/repositories/conversation.py
@@ -9,13 +9,37 @@ columns are still persisted via ``OrgScopedMixin``.
 from datetime import UTC, datetime
 from typing import Any, cast
 
+from cubepi.checkpointer.exceptions import (
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
+)
 from sqlalchemy import and_, case, desc, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from cubebox.agents.checkpointer import init_checkpointer
 from cubebox.models import Conversation
 from cubebox.models.conversation_participant import ConversationParticipant
+from cubebox.models.public_id import generate_public_id
 from cubebox.models.topic import Topic, TopicParticipant
 from cubebox.repositories.base import ScopedRepository
+from cubebox.utils.time import utc_isoformat
+
+
+class ForkGroupChatError(Exception):
+    """Source conversation is a group chat; fork is not supported."""
+
+
+class ForkRunNotCompletedError(Exception):
+    """The ``after_run_id`` is unknown or has not completed on the source."""
+
+
+class ForkNewThreadExistsError(Exception):
+    """The freshly-allocated destination id already exists in cubepi."""
+
+
+class ForkSourceMissingError(Exception):
+    """Source thread is absent from cubepi (drafted but never sent)."""
 
 
 class ConversationRepository(ScopedRepository[Conversation]):
@@ -263,6 +287,82 @@ class ConversationRepository(ScopedRepository[Conversation]):
         await self.session.commit()
         await self.session.refresh(conv)
         return conv
+
+    async def fork(
+        self,
+        src: Conversation,
+        *,
+        after_run_id: str,
+    ) -> Conversation:
+        """Fork a conversation after a completed run.
+
+        Delegates the message-history copy to cubepi's checkpointer
+        (``cp.fork`` handles the advisory lock, parent linkage, and the
+        bulk INSERT … SELECT). Then inserts a fresh ``conversations`` row
+        owned by ``self.user_id``, carrying over ``topic_id``, ``model_key``,
+        and ``thinking`` from the source.
+
+        Order matters: cubepi.fork() runs first so the destination
+        ``cubepi_threads`` row (and its messages) exists before we publish
+        a conversations row that points at it. If the row insert then
+        fails the orphan cubepi thread is bounded by request failure rate
+        and reapable by a future GC job — far better than the inverse
+        (a visible conversation pointing at zero messages).
+        """
+        if src.is_group_chat:
+            raise ForkGroupChatError(src.id)
+
+        new_id = generate_public_id("conv")
+        metadata: dict[str, Any] = {
+            "source_conversation_id": src.id,
+            "forked_by_user_id": self.user_id,
+            "forked_at": utc_isoformat(datetime.now(UTC)),
+        }
+        try:
+            async with init_checkpointer() as cp:
+                await cp.fork(
+                    src.id,
+                    new_id,
+                    after_run_id=after_run_id,
+                    metadata=metadata,
+                )
+        except RunNotCompletedError as exc:
+            raise ForkRunNotCompletedError(after_run_id) from exc
+        except ThreadNotFoundError as exc:
+            raise ForkSourceMissingError(src.id) from exc
+        except ThreadAlreadyExistsError as exc:
+            raise ForkNewThreadExistsError(new_id) from exc
+
+        # Title fits within the 255-char column; the suffix is 7 chars so we
+        # truncate the source title accordingly when needed.
+        suffix = " — fork"
+        max_title = 255 - len(suffix)
+        forked_title = f"{src.title[:max_title]}{suffix}"
+
+        # Fork is always a *personal* conversation owned by the caller. We do
+        # not inherit `topic_id` because:
+        #   (a) the caller may see the source only via B4 (conv-level invite,
+        #       not topic membership); copying topic_id would publish the
+        #       fork to every topic participant — a visibility leak, AND the
+        #       caller's own redirect would 404 (no B-rule covers them on
+        #       the new conv).
+        #   (b) "explore an alternate continuation" is the primary use case;
+        #       sharing the fork can come later via the existing
+        #       upgrade-to-topic / invite flow.
+        conv = Conversation(
+            id=new_id,
+            title=forked_title,
+            org_id=self.org_id,
+            workspace_id=self.workspace_id,
+            creator_user_id=self.user_id,
+            topic_id=None,
+            has_messages=True,
+            is_pinned=False,
+            is_group_chat=False,
+            model_key=src.model_key,
+            thinking=src.thinking,
+        )
+        return await self.add(conv)
 
     async def delete_conversation(self, conversation_id: str) -> bool:
         """Soft-delete: stamp ``deleted_at`` so the row stays as a FK target.

--- a/backend/tests/e2e/test_conversation_fork.py
+++ b/backend/tests/e2e/test_conversation_fork.py
@@ -1,0 +1,193 @@
+"""E2E: fork conversation endpoint.
+
+Covers the four contract guarantees the route promises (happy path,
+group-chat reject, cross-workspace 404, bogus run → 400). We seed
+cubepi state directly with ``claim_run`` + ``append`` + ``mark_run_complete``
+so the test does not need to call a real LLM — fork semantics are about
+state mechanics, not model behavior.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from cubepi.providers.base import AssistantMessage, TextContent, UserMessage
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from cubebox.agents.checkpointer import init_checkpointer
+from cubebox.db.engine import _build_database_url
+from cubebox.models import Conversation
+from tests.e2e.conftest import DEFAULT_WS_ID
+
+pytestmark = pytest.mark.e2e
+
+
+async def _seed_completed_run(
+    conversation_id: str,
+    *,
+    run_id: str,
+    user_text: str,
+    assistant_text: str,
+) -> None:
+    """Append a user/assistant turn under ``run_id`` and mark the run complete."""
+    async with init_checkpointer() as cp:
+        await cp.claim_run(conversation_id, run_id)
+        await cp.append(
+            conversation_id,
+            [
+                UserMessage(
+                    content=[TextContent(text=user_text)],
+                    timestamp=1.0,
+                    run_id=run_id,
+                ),
+                AssistantMessage(
+                    content=[TextContent(text=assistant_text)],
+                    timestamp=2.0,
+                    run_id=run_id,
+                ),
+            ],
+        )
+        await cp.mark_run_complete(conversation_id, run_id)
+
+
+async def _set_group_chat(conversation_id: str) -> None:
+    """Flip is_group_chat on a conversation row (bypass higher-level checks)."""
+    engine = create_async_engine(_build_database_url(), poolclass=NullPool)
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with maker() as session:
+            await session.execute(
+                update(Conversation)
+                .where(Conversation.id == conversation_id)  # type: ignore[arg-type]
+                .values(is_group_chat=True)
+            )
+            await session.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_fork_happy_path(memory_client: httpx.AsyncClient) -> None:
+    resp = await memory_client.post(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "src for fork"}
+    )
+    assert resp.status_code == 201, resp.text
+    src_id = resp.json()["id"]
+
+    await _seed_completed_run(
+        src_id, run_id="run-fork-1", user_text="ping", assistant_text="pong"
+    )
+
+    resp = await memory_client.post(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/fork",
+        json={"after_run_id": "run-fork-1"},
+    )
+    assert resp.status_code == 201, resp.text
+    new_conv = resp.json()
+    new_id = new_conv["id"]
+    assert new_id != src_id
+    assert new_conv["title"].endswith(" — fork")
+    assert new_conv["is_pinned"] is False
+    assert new_conv["is_group_chat"] is False
+
+    # Forked thread carries the same message bodies (by role+text) as the src.
+    src_msgs = (
+        await memory_client.get(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/messages"
+        )
+    ).json()["messages"]
+    new_msgs = (
+        await memory_client.get(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{new_id}/messages"
+        )
+    ).json()["messages"]
+
+    def _shape(msgs: list[dict[str, object]]) -> list[tuple[str, str]]:
+        out: list[tuple[str, str]] = []
+        for m in msgs:
+            content = m.get("content")
+            text = ""
+            if isinstance(content, list) and content:
+                first = content[0]
+                if isinstance(first, dict):
+                    text = str(first.get("text", ""))
+            out.append((str(m.get("role")), text))
+        return out
+
+    assert _shape(new_msgs) == _shape(src_msgs)
+
+
+@pytest.mark.asyncio
+async def test_fork_run_not_completed_returns_400(memory_client: httpx.AsyncClient) -> None:
+    resp = await memory_client.post(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "src bad run"}
+    )
+    src_id = resp.json()["id"]
+    await _seed_completed_run(
+        src_id, run_id="run-good", user_text="hi", assistant_text="hey"
+    )
+
+    resp = await memory_client.post(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/fork",
+        json={"after_run_id": "run-does-not-exist"},
+    )
+    # cubepi raises RunNotCompletedError for both "no row" and "row not done".
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"]["code"] == "run_not_completed"
+
+
+@pytest.mark.asyncio
+async def test_fork_group_chat_rejected(memory_client: httpx.AsyncClient) -> None:
+    resp = await memory_client.post(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "src group"}
+    )
+    src_id = resp.json()["id"]
+    await _seed_completed_run(
+        src_id, run_id="run-group", user_text="hi", assistant_text="hey"
+    )
+    await _set_group_chat(src_id)
+
+    resp = await memory_client.post(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/fork",
+        json={"after_run_id": "run-group"},
+    )
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"]["code"] == "group_chat_not_supported"
+
+
+@pytest.mark.asyncio
+async def test_fork_cross_workspace_returns_404(
+    memory_client: httpx.AsyncClient,
+    member_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """A user in WS A cannot fork a conversation that lives in WS B."""
+    other_client, other_ws = member_client
+
+    resp = await memory_client.post(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "src xws"}
+    )
+    src_id = resp.json()["id"]
+    await _seed_completed_run(
+        src_id, run_id="run-xws", user_text="hi", assistant_text="hey"
+    )
+
+    # Path-scope a request to the *other* workspace pointing at this src id.
+    # 404 — visibility is enforced by ConversationRepository, not 403.
+    resp = await other_client.post(
+        f"/api/v1/ws/{other_ws}/conversations/{src_id}/fork",
+        json={"after_run_id": "run-xws"},
+    )
+    assert resp.status_code == 404, resp.text
+
+    # Also confirm: that other user, in their own workspace, sees 404 even
+    # if they happen to use the matching workspace path for the src row.
+    resp2 = await other_client.post(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/fork",
+        json={"after_run_id": "run-xws"},
+    )
+    # require_member rejects access to a workspace they aren't a member of
+    # before the route logic runs. 403 or 404 both prove isolation; we
+    # accept either because both shapes mean "you can't see it."
+    assert resp2.status_code in (403, 404), resp2.text

--- a/backend/tests/e2e/test_conversation_fork.py
+++ b/backend/tests/e2e/test_conversation_fork.py
@@ -5,6 +5,11 @@ group-chat reject, cross-workspace 404, bogus run → 400). We seed
 cubepi state directly with ``claim_run`` + ``append`` + ``mark_run_complete``
 so the test does not need to call a real LLM — fork semantics are about
 state mechanics, not model behavior.
+
+Each test cleans up its source + fork rows AND the corresponding cubepi
+threads + messages + runs. The default workspace is shared across the
+suite; orphan rows accumulating here would flake any later test that
+list/counts conversations under it.
 """
 
 from __future__ import annotations
@@ -12,7 +17,7 @@ from __future__ import annotations
 import httpx
 import pytest
 from cubepi.providers.base import AssistantMessage, TextContent, UserMessage
-from sqlalchemy import update
+from sqlalchemy import text, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
@@ -68,93 +73,164 @@ async def _set_group_chat(conversation_id: str) -> None:
         await engine.dispose()
 
 
+async def _cleanup(conversation_ids: list[str]) -> None:
+    """Hard-delete the conv rows AND their cubepi state.
+
+    The route soft-deletes (sets ``deleted_at``); we want hard deletes so
+    counts/aggregates over the shared default workspace stay clean across
+    runs.
+
+    Iterate in REVERSE insertion order — tests append src then new_id, and
+    ``cubepi_threads.parent_thread_id`` is a self-FK from the fork back to
+    its source. Deleting the source first would orphan the FK; reversing
+    drops the child first.
+    """
+    if not conversation_ids:
+        return
+    engine = create_async_engine(_build_database_url(), poolclass=NullPool)
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with maker() as session:
+            for cid in reversed(conversation_ids):
+                # cubepi state — ``cubepi_runs`` has FK into ``cubepi_threads``,
+                # so messages + runs go before the thread row.
+                await session.execute(
+                    text("DELETE FROM cubepi_messages WHERE thread_id = :t"),
+                    {"t": cid},
+                )
+                await session.execute(
+                    text("DELETE FROM cubepi_runs WHERE thread_id = :t"),
+                    {"t": cid},
+                )
+                await session.execute(
+                    text("DELETE FROM cubepi_threads WHERE thread_id = :t"),
+                    {"t": cid},
+                )
+                # Dependent cubebox tables that the fork route creates rows in
+                # (search index enqueue → conversation_chunks + embedding_jobs).
+                # Drop these before the conversation row so its FK targets are
+                # free.
+                await session.execute(
+                    text("DELETE FROM conversation_chunks WHERE conversation_id = :id"),
+                    {"id": cid},
+                )
+                await session.execute(
+                    text("DELETE FROM embedding_jobs WHERE conversation_id = :id"),
+                    {"id": cid},
+                )
+                # cubebox conversation row.
+                await session.execute(
+                    text("DELETE FROM conversations WHERE id = :id"),
+                    {"id": cid},
+                )
+            await session.commit()
+    finally:
+        await engine.dispose()
+
+
 @pytest.mark.asyncio
 async def test_fork_happy_path(memory_client: httpx.AsyncClient) -> None:
-    resp = await memory_client.post(
-        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "src for fork"}
-    )
-    assert resp.status_code == 201, resp.text
-    src_id = resp.json()["id"]
-
-    await _seed_completed_run(
-        src_id, run_id="run-fork-1", user_text="ping", assistant_text="pong"
-    )
-
-    resp = await memory_client.post(
-        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/fork",
-        json={"after_run_id": "run-fork-1"},
-    )
-    assert resp.status_code == 201, resp.text
-    new_conv = resp.json()
-    new_id = new_conv["id"]
-    assert new_id != src_id
-    assert new_conv["title"].endswith(" — fork")
-    assert new_conv["is_pinned"] is False
-    assert new_conv["is_group_chat"] is False
-
-    # Forked thread carries the same message bodies (by role+text) as the src.
-    src_msgs = (
-        await memory_client.get(
-            f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/messages"
+    created: list[str] = []
+    try:
+        resp = await memory_client.post(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "src for fork"}
         )
-    ).json()["messages"]
-    new_msgs = (
-        await memory_client.get(
-            f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{new_id}/messages"
+        assert resp.status_code == 201, resp.text
+        src_id = resp.json()["id"]
+        created.append(src_id)
+
+        await _seed_completed_run(
+            src_id, run_id="run-fork-1", user_text="ping", assistant_text="pong"
         )
-    ).json()["messages"]
 
-    def _shape(msgs: list[dict[str, object]]) -> list[tuple[str, str]]:
-        out: list[tuple[str, str]] = []
-        for m in msgs:
-            content = m.get("content")
-            text = ""
-            if isinstance(content, list) and content:
-                first = content[0]
-                if isinstance(first, dict):
-                    text = str(first.get("text", ""))
-            out.append((str(m.get("role")), text))
-        return out
+        resp = await memory_client.post(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/fork",
+            json={"after_run_id": "run-fork-1"},
+        )
+        assert resp.status_code == 201, resp.text
+        new_conv = resp.json()
+        new_id = new_conv["id"]
+        created.append(new_id)
+        assert new_id != src_id
+        assert new_conv["title"].endswith(" — fork")
+        assert new_conv["is_pinned"] is False
+        assert new_conv["is_group_chat"] is False
 
-    assert _shape(new_msgs) == _shape(src_msgs)
+        # Forked thread carries the same message bodies (by role+text) as the src.
+        src_msgs = (
+            await memory_client.get(
+                f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/messages"
+            )
+        ).json()["messages"]
+        new_msgs = (
+            await memory_client.get(
+                f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{new_id}/messages"
+            )
+        ).json()["messages"]
+
+        def _shape(msgs: list[dict[str, object]]) -> list[tuple[str, str]]:
+            out: list[tuple[str, str]] = []
+            for m in msgs:
+                content = m.get("content")
+                msg_text = ""
+                if isinstance(content, list) and content:
+                    first = content[0]
+                    if isinstance(first, dict):
+                        msg_text = str(first.get("text", ""))
+                out.append((str(m.get("role")), msg_text))
+            return out
+
+        assert _shape(new_msgs) == _shape(src_msgs)
+    finally:
+        await _cleanup(created)
 
 
 @pytest.mark.asyncio
 async def test_fork_run_not_completed_returns_400(memory_client: httpx.AsyncClient) -> None:
-    resp = await memory_client.post(
-        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "src bad run"}
-    )
-    src_id = resp.json()["id"]
-    await _seed_completed_run(
-        src_id, run_id="run-good", user_text="hi", assistant_text="hey"
-    )
+    created: list[str] = []
+    try:
+        resp = await memory_client.post(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "src bad run"}
+        )
+        src_id = resp.json()["id"]
+        created.append(src_id)
+        await _seed_completed_run(
+            src_id, run_id="run-good", user_text="hi", assistant_text="hey"
+        )
 
-    resp = await memory_client.post(
-        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/fork",
-        json={"after_run_id": "run-does-not-exist"},
-    )
-    # cubepi raises RunNotCompletedError for both "no row" and "row not done".
-    assert resp.status_code == 400, resp.text
-    assert resp.json()["detail"]["code"] == "run_not_completed"
+        resp = await memory_client.post(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/fork",
+            json={"after_run_id": "run-does-not-exist"},
+        )
+        # cubepi raises RunNotCompletedError for both "no row" and "row not done".
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"]["code"] == "run_not_completed"
+    finally:
+        await _cleanup(created)
 
 
 @pytest.mark.asyncio
 async def test_fork_group_chat_rejected(memory_client: httpx.AsyncClient) -> None:
-    resp = await memory_client.post(
-        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "src group"}
-    )
-    src_id = resp.json()["id"]
-    await _seed_completed_run(
-        src_id, run_id="run-group", user_text="hi", assistant_text="hey"
-    )
-    await _set_group_chat(src_id)
+    created: list[str] = []
+    try:
+        resp = await memory_client.post(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "src group"}
+        )
+        src_id = resp.json()["id"]
+        created.append(src_id)
+        await _seed_completed_run(
+            src_id, run_id="run-group", user_text="hi", assistant_text="hey"
+        )
+        await _set_group_chat(src_id)
 
-    resp = await memory_client.post(
-        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/fork",
-        json={"after_run_id": "run-group"},
-    )
-    assert resp.status_code == 400, resp.text
-    assert resp.json()["detail"]["code"] == "group_chat_not_supported"
+        resp = await memory_client.post(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/fork",
+            json={"after_run_id": "run-group"},
+        )
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"]["code"] == "group_chat_not_supported"
+    finally:
+        await _cleanup(created)
 
 
 @pytest.mark.asyncio
@@ -164,30 +240,34 @@ async def test_fork_cross_workspace_returns_404(
 ) -> None:
     """A user in WS A cannot fork a conversation that lives in WS B."""
     other_client, other_ws = member_client
+    created: list[str] = []
+    try:
+        resp = await memory_client.post(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "src xws"}
+        )
+        src_id = resp.json()["id"]
+        created.append(src_id)
+        await _seed_completed_run(
+            src_id, run_id="run-xws", user_text="hi", assistant_text="hey"
+        )
 
-    resp = await memory_client.post(
-        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations", params={"title": "src xws"}
-    )
-    src_id = resp.json()["id"]
-    await _seed_completed_run(
-        src_id, run_id="run-xws", user_text="hi", assistant_text="hey"
-    )
+        # Path-scope a request to the *other* workspace pointing at this src id.
+        # 404 — visibility is enforced by ConversationRepository, not 403.
+        resp = await other_client.post(
+            f"/api/v1/ws/{other_ws}/conversations/{src_id}/fork",
+            json={"after_run_id": "run-xws"},
+        )
+        assert resp.status_code == 404, resp.text
 
-    # Path-scope a request to the *other* workspace pointing at this src id.
-    # 404 — visibility is enforced by ConversationRepository, not 403.
-    resp = await other_client.post(
-        f"/api/v1/ws/{other_ws}/conversations/{src_id}/fork",
-        json={"after_run_id": "run-xws"},
-    )
-    assert resp.status_code == 404, resp.text
-
-    # Also confirm: that other user, in their own workspace, sees 404 even
-    # if they happen to use the matching workspace path for the src row.
-    resp2 = await other_client.post(
-        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/fork",
-        json={"after_run_id": "run-xws"},
-    )
-    # require_member rejects access to a workspace they aren't a member of
-    # before the route logic runs. 403 or 404 both prove isolation; we
-    # accept either because both shapes mean "you can't see it."
-    assert resp2.status_code in (403, 404), resp2.text
+        # Also confirm: that other user, in their own workspace, sees 404 even
+        # if they happen to use the matching workspace path for the src row.
+        resp2 = await other_client.post(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{src_id}/fork",
+            json={"after_run_id": "run-xws"},
+        )
+        # require_member rejects access to a workspace they aren't a member of
+        # before the route logic runs. 403 or 404 both prove isolation; we
+        # accept either because both shapes mean "you can't see it."
+        assert resp2.status_code in (403, 404), resp2.text
+    finally:
+        await _cleanup(created)

--- a/docs/dev/plans/2026-06-23-fork-conversation.md
+++ b/docs/dev/plans/2026-06-23-fork-conversation.md
@@ -1,0 +1,197 @@
+# Plan: fork conversation from a message
+
+Spec: [../specs/2026-06-23-fork-conversation-design.md](../specs/2026-06-23-fork-conversation-design.md)
+
+Branch: `feat/2026-06-23-fork-conversation`
+Worktree: `.worktrees/feat/2026-06-23-fork-conversation/` (slot 78,
+ports 8078/3078, DB `cubebox_feat_2026_06_23_fork_conversation`)
+
+Single PR. The frontend touches one new affordance and three files; the
+backend adds one route + one repo method. Splitting would mean shipping
+a backend endpoint nothing calls — not worth the review overhead.
+
+## Step 1 — Backend: repository method
+
+File: `backend/cubebox/repositories/conversation.py`
+
+Add `ConversationRepository.fork(src: Conversation, *, after_run_id: str) -> Conversation`:
+
+1. Reject `src.is_group_chat` with `ValueError("group_chat_not_supported")`.
+2. Allocate the new id up front: `new_id = generate_public_id("conv")`
+   (so we can pass it to `cp.fork` *and* the row insert).
+3. `async with init_checkpointer() as cp: await cp.fork(src.id, new_id,
+   after_run_id=after_run_id, metadata={"source_conversation_id": src.id,
+   "forked_by_user_id": self.user_id, "forked_at": utc_isoformat(now())})`.
+4. Catch `cubepi.RunNotCompletedError` → re-raise as a typed cubebox
+   exception the route maps to 400. Same for `ThreadNotFoundError` and
+   `ThreadAlreadyExistsError`.
+5. Insert `Conversation(id=new_id, ...)` carrying over fields per spec.
+   `has_messages=True`. `creator_user_id=self.user_id`. `topic_id=src.topic_id`.
+   Title: `f"{src.title} — fork"` truncated to the 255-char column limit.
+
+Wrap the SQL transaction `await self.session.commit()`. If commit fails,
+re-raise; orphan cleanup is documented in the spec (out of scope here).
+
+Define module-local exception classes `ForkRunNotCompleted`,
+`ForkRunNotFound`, `ForkGroupChat`, `ForkNewThreadExists` in this file —
+no separate exceptions module yet; the codebase pattern is to raise
+HTTPException from the route layer and keep small typed errors next to
+the repo that produces them. Mirror what `conversation_title.py` does
+for `TitleGenerationError`.
+
+## Step 2 — Backend: route
+
+File: `backend/cubebox/api/routes/v1/conversations.py`
+
+Insert after the existing `PATCH /{id}/pin` block (so the file's
+ordering — list/create/get → mutations → message ops → run ops — stays
+intact):
+
+```py
+class ForkConversationRequest(BaseModel):
+    after_run_id: str = Field(min_length=1, max_length=64)
+
+@router.post("/{conversation_id}/fork")
+async def fork_conversation(
+    conversation_id: str,
+    body: ForkConversationRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    ctx: Annotated[RequestContext, Depends(require_member)],
+) -> ConversationResponse:
+    conv_repo = ConversationRepository(session, org_id=..., workspace_id=..., user_id=...)
+    src = await conv_repo.get_by_id(conversation_id)
+    if not src:
+        raise HTTPException(404, ...)
+    try:
+        new_conv = await conv_repo.fork(src, after_run_id=body.after_run_id)
+    except ForkGroupChat:
+        raise HTTPException(400, detail={"error": "group_chat_not_supported"})
+    except ForkRunNotCompleted:
+        raise HTTPException(400, detail={"error": "run_not_completed"})
+    except ForkRunNotFound:
+        raise HTTPException(400, detail={"error": "run_not_found"})
+    except ForkNewThreadExists:
+        raise HTTPException(409, detail={"error": "new_thread_exists"})
+    return serialize_conversation(new_conv)
+```
+
+## Step 3 — Backend e2e test
+
+File: `backend/tests/e2e/test_conversation_fork.py`
+
+Pattern: mirror `tests/e2e/test_conversation_flow.py` because we need
+real messages in cubepi before we can fork. The minimum useful test
+sends a message with the mocked-LLM helper, waits for the run to
+complete, then issues the fork. Cases:
+
+1. `test_fork_happy_path` — send a turn, get the assistant's `run_id`
+   from `GET /messages`, fork, assert: new conv id ≠ src id, response
+   carries title `"… — fork"`, `GET /{new}/messages` returns the same
+   message bodies as the source (compare by `(role, content)`, ignore
+   timestamps and the run_id which is preserved by `cp.fork`).
+2. `test_fork_run_not_completed` — kick off a send but cancel before
+   the run finishes (or fork against a fabricated run_id) → 400
+   `run_not_completed` / `run_not_found`.
+3. `test_fork_cross_workspace_returns_404` — create a conv in WS A,
+   call fork as a member of WS B → 404, not 403.
+4. `test_fork_group_chat_rejected` — set `is_group_chat=True` on the
+   source row, attempt fork → 400 `group_chat_not_supported`.
+
+Tag with `pytest.mark.e2e` (auto-applied by conftest under `tests/e2e/`).
+The happy path needs an LLM-completed run; use the existing test helper
+that fakes the provider (look for usage in `test_conversation_flow.py`).
+If no such helper exists, write a tiny one that uses cubepi's
+checkpointer directly to seed a completed run — simpler than running the
+real agent.
+
+Cleanup: each test creates its own conversation; delete both `src` and
+`fork` rows at the end so the shared workspace stays clean.
+
+## Step 4 — Frontend: API client
+
+File: `frontend/packages/core/src/api/conversations.ts`
+
+Add:
+
+```ts
+export async function forkConversation(
+  client: ApiClient,
+  conversationId: string,
+  afterRunId: string,
+): Promise<ConversationResponse> {
+  return client.post(
+    `/api/v1/conversations/${conversationId}/fork`,
+    { after_run_id: afterRunId },
+  );
+}
+```
+
+Re-export the function from `packages/core/src/api/index.ts` if needed
+(check the existing pattern; `listMessages` etc. are already exported
+through the barrel).
+
+## Step 5 — Frontend: per-message hover menu
+
+This is the only new affordance. The codebase has no
+`MessageActions`-style component yet, so introduce a tiny one:
+
+File: `frontend/packages/web/components/chat/MessageActions.tsx` (new)
+
+Props: `{ runId: string | null, conversationId: string, disabledReason?: string }`.
+Renders a small button group that becomes visible on hover of the parent
+message. Single button: `Fork conversation` (i18n key — see Step 6).
+
+Behavior:
+
+- If `runId == null` or `disabledReason != null`, render the button
+  disabled with a tooltip carrying the reason.
+- On click, call `forkConversation(client, conversationId, runId)`.
+- On success, `router.push(\`/w/${wsId}/conversations/${newConv.id}\`)`.
+  Use `useWsId()` from the existing hook.
+- On error, toast the error (`useToast`); for the `run_not_completed`
+  shape, surface a kinder string ("Wait for the response to finish").
+
+File: `frontend/packages/web/components/chat/UserMessage.tsx`
+File: `frontend/packages/web/components/chat/AssistantMessage.tsx`
+
+Add `runId` prop (read from the cubepi message dump — the field is named
+`run_id` on the wire; the frontend renames to `runId` at the message-list
+boundary). Render `<MessageActions ...>` positioned absolute-top-right
+inside a `group-hover:opacity-100` wrapper. Don't restyle the bubble.
+
+File: `frontend/packages/web/components/chat/MessageList.tsx`
+
+Pass `runId={m.run_id}` and `conversationId={conversationId}` through to
+the per-role components. Plumb `is_group_chat` from the conversation
+record to a `forkDisabled` prop so MessageActions can render the right
+tooltip on group chats.
+
+## Step 6 — i18n strings
+
+Add to whichever locale files the chat namespace lives in (likely
+`frontend/packages/web/locales/{en,zh-CN}/chat.json` — verify path
+before writing). Keys:
+
+- `chat.forkConversation` — button label ("Fork conversation" / "复刻对话")
+- `chat.forkDisabled.noRun` — "Cannot fork from this message"
+- `chat.forkDisabled.runStreaming` — "Wait for the response to finish"
+- `chat.forkDisabled.groupChat` — "Fork is not available in group chats"
+- `chat.forkSuccess` — "Forked to a new conversation"
+- `chat.forkError` — generic toast fallback
+
+## Step 7 — Verify
+
+```bash
+cd backend
+uv run mypy cubebox 2>&1 | tee tmp/mypy.log | tail -3
+uv run pytest tests/e2e/test_conversation_fork.py --no-cov 2>&1 | tee tmp/fork.log | tail -10
+
+cd ../frontend
+pnpm --filter @cubebox/core build 2>&1 | tee ../tmp/core-build.log | tail -3
+pnpm --filter @cubebox/web lint 2>&1 | tee ../tmp/lint.log | tail -5
+pnpm --filter @cubebox/web typecheck 2>&1 | tee ../tmp/tsc.log | tail -3
+```
+
+Manual smoke (optional, gated on time): start the dev server on this
+worktree's ports (8078/3078), send a message, hover, click Fork, confirm
+the URL changes and the history is identical.

--- a/docs/dev/specs/2026-06-23-fork-conversation-design.md
+++ b/docs/dev/specs/2026-06-23-fork-conversation-design.md
@@ -1,0 +1,171 @@
+# Fork conversation from a message
+
+Status: design
+Date: 2026-06-23
+Owner: xfgong
+
+## What this is
+
+Let a user pick any message in a conversation and create a new conversation
+that starts as an exact copy of the history up to (and including) that
+message's turn. The new conversation is independent — sending new messages
+in either side does not affect the other.
+
+## Why
+
+Two real workflows that today require copy-paste:
+
+1. **Explore an alternate continuation.** "I want to try a different
+   follow-up question from this point without losing the current thread."
+2. **Re-derive from a known-good state.** A long thread drifted off-topic;
+   the user wants a clean continuation from message N and the noise after
+   it gone.
+
+## Where the action lives
+
+Per-message hover menu on user and assistant messages in
+`components/chat/MessageList.tsx`. There is no per-message hover menu in
+the codebase today — this feature introduces it. Single action for now:
+**Fork conversation**.
+
+A new conversation opens at `/w/{wsId}/conversations/{newId}`. The user
+lands on the forked conversation, ready to type the next message.
+
+## Fork point — what "from this message" actually means
+
+cubepi's checkpointer (the source of truth for messages) only supports
+forking *after a completed run*. A "run" starts when a user sends a
+message and ends when the assistant finishes responding (or the run is
+cancelled and marked complete). All messages inside a run share the same
+`run_id`.
+
+Concretely: every `UserMessage`, `AssistantMessage`, and `ToolResultMessage`
+exposes `run_id: str | None` in the API payload (see
+`cubepi/providers/base.py:128`). Forking is implemented as
+`cp.fork(src_thread_id=src_conv_id, new_thread_id=new_conv_id, after_run_id=<run_id>, metadata=...)`.
+
+UX mapping:
+
+- **Click on an assistant message** → fork after this assistant's run.
+  Result: the new conversation contains every message through the end of
+  this turn.
+- **Click on a user message** → also forks after this user message's run
+  (same run as the assistant reply it produced). Result: same as above —
+  the new conversation contains the user message *and* its assistant
+  reply. We use the message's `run_id` directly; the user does not need
+  to think about "which side of the turn."
+- **Click on a tool-result message** → uses the same run_id; same
+  semantics.
+
+Edges where Fork is disabled (button greyed, tooltip explains):
+
+- Message has no `run_id` (e.g., synthetic system nudges, very old rows
+  pre-`060310ecfd8a` migration). Tooltip: "Cannot fork from this message."
+- The run is not yet completed (the assistant is still streaming, or
+  hit a HITL request and is paused). Tooltip: "Wait for the response to
+  finish."
+- The conversation is a group chat (`is_group_chat = True`). Forking a
+  multi-participant conversation into a personal copy raises participant
+  questions we do not want to decide in this PR. Tooltip: "Fork is not
+  available in group chats."
+
+## What carries over to the new conversation
+
+From the source `conversations` row:
+
+| Field | Behavior |
+|---|---|
+| `id` | fresh (`generate_public_id("conv")`) |
+| `org_id`, `workspace_id` | same as source |
+| `creator_user_id` | the caller (not the source's creator) |
+| `topic_id` | always `NULL` — fork is a personal conversation owned by the caller (see "Fork is always personal" below) |
+| `title` | `"{source_title}"` with an em-dash suffix `" — fork"`. Auto-title may overwrite later via the existing CAS path (`update_title_if_current`); manual rename always wins. |
+| `model_key` | same as source |
+| `thinking` | same as source |
+| `has_messages` | `True` (we just copied messages) |
+| `is_pinned` | `False` (fresh start; user can pin) |
+| `is_group_chat` | `False` (forks are personal by construction; group-source is rejected above) |
+| `deleted_at` | `NULL` |
+
+From cubepi (handled by `cp.fork()`):
+
+- All messages with `run_id IS NULL` or belonging to a completed run with
+  `completion_seq <= cutoff`, with `seq` preserved.
+- All completed runs satisfying the cutoff.
+- A new `cubepi_threads` row with `parent_thread_id = src_conv_id`,
+  `forked_at_seq = cutoff`, and `extra.fork = {source_conversation_id,
+  forked_by_user_id, forked_at}` so the lineage survives in storage.
+
+The `parent_thread_id` link is informational for now; we do not surface
+"this is a fork of X" in the UI in this PR. A follow-up can add a small
+"forked from …" header link.
+
+## API contract
+
+```
+POST /api/v1/ws/{workspace_id}/conversations/{conversation_id}/fork
+Body: { "after_run_id": "<run id>" }
+Auth: require_member
+```
+
+Response (200): the standard conversation serializer payload (same shape
+as `GET /{id}`).
+
+Errors:
+
+- 404 — source conversation not visible to caller (any of: doesn't exist,
+  cross-workspace, cross-org, soft-deleted, caller is not a member of the
+  topic/conv).
+- 400 `{detail: {code: "run_not_completed"}}` — `after_run_id` is either
+  unknown on this thread or not yet completed. cubepi raises the same
+  `RunNotCompletedError` for both cases; we surface a single code.
+- 400 `{detail: {code: "group_chat_not_supported"}}` — source
+  `is_group_chat = True`.
+- 400 `{detail: {code: "invalid_after_run_id"}}` — empty / whitespace body.
+- 400 `{detail: {code: "source_has_no_messages"}}` — source conversation
+  exists in cubebox but has no cubepi thread (drafted but never sent).
+- 409 `{detail: {code: "new_thread_exists"}}` — the freshly-minted
+  `new_id` already exists in cubepi (vanishingly rare given
+  `generate_public_id`; we surface it rather than silently retrying so
+  the operator sees the collision).
+
+The `detail.code` shape matches the frontend's `toApiError()` mapper so
+`ApiError.code` lights up the right toast on the client.
+
+The destination conversation row is inserted in a single SQLAlchemy
+transaction *after* `cp.fork()` succeeds. If the row insert fails, the
+cubepi thread is orphaned — a follow-up cleanup job can reap orphan
+threads whose `extra.fork.source_conversation_id` exists but whose
+`conversations.id = thread_id` row is missing. We accept this leak
+because (a) it's bounded by request failure rate, (b) cubepi storage is
+cheap, and (c) the simpler alternative (insert row first, then fork)
+leaves a conversation pointing at no messages on the inverse failure,
+which is much worse UX.
+
+## Visibility & RBAC — fork is always personal
+
+- Caller must pass `ConversationRepository.get_by_id(src_id)` (B1–B4
+  visibility rules) to see the source. Standard 404 on miss.
+- The fork is created as a **personal conversation** (`topic_id = NULL`)
+  owned by the caller. It is invisible to everyone else until the caller
+  explicitly invites them via the existing upgrade-to-topic / invite
+  flow.
+- We do not inherit `src.topic_id` because the source may be visible to
+  the caller only through B4 (a conv-level invite into a topic the
+  caller is *not* a member of). Copying `topic_id` in that case would
+  (a) publish the fork's content to every topic participant — a
+  visibility leak from a conversation that was scoped to the conv-level
+  invitee — and (b) leave the caller themselves without a B-rule that
+  covers the new conv, so the post-fork redirect would 404.
+- Going personal-only is also the right default for the primary use
+  case ("explore an alternate continuation"). Promoting a fork into a
+  topic is one extra click; recovering from a leaked fork is not.
+
+## Out of scope (named so we don't argue later)
+
+- "Fork into a different workspace/agent" — separate feature, separate PR.
+- A "Forked from …" header in the conversation view — easy follow-up.
+- Showing a tree of forks in the sidebar — explicit non-goal; the
+  `parent_thread_id` is recorded but not visualized.
+- Forking *before* a message ("redo this turn"). The cubepi API doesn't
+  expose that; we'd need to introduce a new fork-before primitive.

--- a/frontend/packages/core/src/api/conversations.ts
+++ b/frontend/packages/core/src/api/conversations.ts
@@ -69,6 +69,18 @@ export async function setPinConversation(
   return res.json() as Promise<Conversation>
 }
 
+export async function forkConversation(
+  client: ApiClient,
+  id: string,
+  afterRunId: string,
+): Promise<Conversation> {
+  const res = await client.post(`/api/v1/conversations/${id}/fork`, {
+    after_run_id: afterRunId,
+  })
+  if (!res.ok) throw await toApiError(res)
+  return res.json() as Promise<Conversation>
+}
+
 export async function generateConversationTitle(
   client: ApiClient,
   id: string,

--- a/frontend/packages/core/src/api/stream.ts
+++ b/frontend/packages/core/src/api/stream.ts
@@ -204,11 +204,24 @@ export async function* streamMessages(
     if (contentType.includes('text/event-stream')) {
       const reader = res.body?.getReader()
       if (!reader) return
+      // SSE branch: no JSON {run_id} envelope to pluck. Every payload
+      // ``run_manager._publish_event`` produces already carries ``run_id``
+      // at the top level, so fire ``onRunId`` on the first event that has
+      // one. Skipping the JSON-branch handshake here would leave
+      // ``currentRunId`` null for the whole turn — the fresh assistant +
+      // tool messages would stamp ``run_id: null`` and Fork would stay
+      // disabled on the just-finished turn until reload.
+      let runIdReported = false
       try {
         for await (const line of readLines(reader)) {
           if (line.startsWith('data: ')) {
             try {
-              yield JSON.parse(line.slice(6)) as AgentEvent
+              const event = JSON.parse(line.slice(6)) as AgentEvent
+              if (!runIdReported && event.run_id) {
+                options?.onRunId?.(event.run_id)
+                runIdReported = true
+              }
+              yield event
             } catch {
               // skip malformed lines
             }

--- a/frontend/packages/core/src/api/stream.ts
+++ b/frontend/packages/core/src/api/stream.ts
@@ -148,7 +148,20 @@ export async function* streamMessages(
   content: string,
   attachmentIds?: string[],
   signal?: AbortSignal,
-  options?: { model_key?: string | null; thinking?: ThinkingLevel },
+  options?: {
+    model_key?: string | null
+    thinking?: ThinkingLevel
+    /**
+     * Fires as soon as the POST returns a run id, BEFORE any event is
+     * yielded — only on the JSON-then-tail path (the production path
+     * through the Next.js SSE proxy). The direct-SSE path keeps it
+     * unset; callers fall back to `currentRunId` derived from later
+     * events. This is the only seam where the store can learn the run
+     * id for an in-flight send so optimistic messages can be stamped
+     * (e.g. for "fork from this message" to work without reload).
+     */
+    onRunId?: (runId: string) => void
+  },
 ): AsyncGenerator<AgentEvent> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -208,6 +221,7 @@ export async function* streamMessages(
     }
 
     const body = (await res.json()) as { run_id: string }
+    options?.onRunId?.(body.run_id)
     for await (const event of streamRun(client, conversationId, body.run_id, undefined, signal)) {
       yield event
     }

--- a/frontend/packages/core/src/stores/conversationStore.ts
+++ b/frontend/packages/core/src/stores/conversationStore.ts
@@ -8,6 +8,7 @@ import {
   renameConversation,
   setPinConversation,
   generateConversationTitle,
+  forkConversation,
   inviteToGroup,
   listConversationParticipants,
 } from '../api'
@@ -31,6 +32,7 @@ export interface ConversationStore {
   conversationParticipants: Record<string, ConversationParticipant[]>
   fetchList(client: ApiClient): Promise<void>
   create(client: ApiClient, title?: string, opts?: { draft?: boolean }): Promise<Conversation>
+  fork(client: ApiClient, sourceId: string, afterRunId: string): Promise<Conversation>
   remove(client: ApiClient, id: string): Promise<void>
   rename(client: ApiClient, id: string, title: string): Promise<void>
   setPin(client: ApiClient, id: string, isPinned: boolean): Promise<void>
@@ -74,6 +76,17 @@ export const useConversationStore = create<ConversationStore>((set, get) => ({
     } finally {
       set({ isLoading: false })
     }
+  },
+
+  async fork(client: ApiClient, sourceId: string, afterRunId: string) {
+    // Mirrors `create`: hit the API, prepend the new conv into local
+    // state, return it. Without the prepend the sidebar / header /
+    // upgrade-to-topic controls render stale until the next list
+    // fetch — the user lands on a conv that exists on the server but
+    // not in the store. Errors propagate (MessageActions toasts them).
+    const convo = await forkConversation(client, sourceId, afterRunId)
+    set((s) => ({ conversations: sortPinnedFirst([convo, ...s.conversations]) }))
+    return convo
   },
 
   async remove(client: ApiClient, id: string) {

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -318,6 +318,7 @@ function buildPendingUserMessage(runId: string, content: string): UserMessageTyp
     role: 'user',
     content: [{ type: 'text', text: content }],
     timestamp: Date.now() / 1000,
+    run_id: runId,
     metadata: {},
   }
 }
@@ -715,6 +716,7 @@ function buildTurnMessages(
   toolResultMap: MessageStore['toolResultMap'],
   turnUsage: import('../types').TurnUsage | null,
   stopReason: AssistantMessageType['stop_reason'] = 'stop',
+  runId: string | null = null,
 ): { assistantMessage: AssistantMessageType | null; toolMessages: ToolResultMessageType[] } {
   const mainStream = agents[MAIN_AGENT_KEY]
   if (!mainStream) return { assistantMessage: null, toolMessages: [] }
@@ -738,6 +740,7 @@ function buildTurnMessages(
         }
       : null,
     timestamp: Date.now() / 1000,
+    run_id: runId,
     metadata: {},
   }
 
@@ -768,6 +771,7 @@ function buildTurnMessages(
       tool_call_id: tcId,
       tool_name: tr.data.tool_name ?? '',
       timestamp: receivedAtMs / 1000,
+      run_id: runId,
       metadata: {},
     })
   }
@@ -783,6 +787,7 @@ function buildTurnMessages(
       tool_call_id: toolCallId,
       tool_name: 'subagent',
       timestamp: Date.now() / 1000,
+      run_id: runId,
       metadata: {
         subagent_events: {
           text: agentStream.text,
@@ -827,6 +832,7 @@ async function finalizeCompletedStream(
     get().toolResultMap,
     get().turnUsage[conversationId] ?? null,
     stopReason,
+    get().currentRunId,
   )
 
   if (!assistantMessage) {
@@ -896,6 +902,7 @@ async function finalizePausedStream(
     state0.toolResultMap,
     state0.turnUsage[conversationId] ?? null,
     'stop',
+    state0.currentRunId,
   )
 
   if (!assistantMessage) {
@@ -1373,6 +1380,28 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
     const controller = new AbortController()
     activeStreamController = controller
 
+    // onRunId is fired by streamMessages the moment the POST returns a
+    // run id (the JSON-then-tail path, which is the production path
+    // through the Next.js SSE proxy). We use it to:
+    //   - set `currentRunId` so `finalizeCompletedStream` can stamp
+    //     `run_id` onto the optimistic assistant / tool messages — without
+    //     this, "fork from this message" is disabled for a just-finished
+    //     turn until the next bootstrap/reload.
+    //   - backfill `run_id` on the optimistic user message we appended
+    //     above, so the user message is forkable too.
+    const handleRunId = (runId: string) => {
+      set((s) => ({
+        currentRunId: runId,
+        messages: {
+          ...s.messages,
+          [conversationId]: (s.messages[conversationId] ?? []).map((m) =>
+            m.id === userMessage.id ? { ...m, run_id: runId } : m,
+          ),
+        },
+      }))
+    }
+    const streamOptions = { ...(options ?? {}), onRunId: handleRunId }
+
     let retried = false
     let streamSource = streamMessages(
       client,
@@ -1380,7 +1409,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       content,
       attachmentIds,
       controller.signal,
-      options,
+      streamOptions,
     )
 
     let processed = 0
@@ -1417,7 +1446,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
                 content,
                 attachmentIds,
                 controller.signal,
-                options,
+                streamOptions,
               )
               continue outer
             }

--- a/frontend/packages/core/src/types/events.ts
+++ b/frontend/packages/core/src/types/events.ts
@@ -100,6 +100,11 @@ export interface AgentEvent {
   agent_id: string | null
   agent_name: string | null
   event_id?: string
+  // Set by the backend ``run_manager._publish_event`` on every payload it
+  // emits. The send/streamMessages path uses the first event that carries
+  // it to populate ``currentRunId`` on the direct-SSE branch (the JSON
+  // branch learns it from the POST response body instead).
+  run_id?: string | null
 }
 
 export interface TextDeltaEvent extends AgentEvent {

--- a/frontend/packages/core/src/types/message.ts
+++ b/frontend/packages/core/src/types/message.ts
@@ -57,6 +57,12 @@ interface MessageBase {
   // Synthesized client-side for React keys; never sent to the backend.
   id: string
   timestamp?: number | null // epoch seconds (cubepi convention)
+  // Identifies the agent run this message belongs to. User + assistant
+  // messages produced within the same turn share a run_id. Null on
+  // very-old rows (pre-cubepi v3) and on framework-injected synthetic
+  // messages that never enter a run. The forkConversation API uses this
+  // as ``after_run_id``.
+  run_id?: string | null
   metadata?: Record<string, unknown> & {
     attachments?: MessageAttachment[]
     memory_snapshot?: unknown

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -148,6 +148,12 @@ interface HistoryProps {
   conversationId?: string
   workspaceId?: string | null
   isGroupChat?: boolean
+  // Whether a turn is streaming somewhere in this conversation. If
+  // ``activeRunId === message.run_id`` the fork action greys out for
+  // this bubble (mid-turn fork is rejected by the backend with
+  // run_not_completed).
+  activeRunId?: string | null
+  isStreamingTurn?: boolean
   stream?: never
   isStreaming?: never
   statusPhase?: never
@@ -164,6 +170,8 @@ interface StreamingProps {
   conversationId?: string
   workspaceId?: string | null
   isGroupChat?: boolean
+  activeRunId?: string | null
+  isStreamingTurn?: boolean
   stream: AgentStream
   isStreaming: boolean
   statusPhase?: string | null
@@ -532,6 +540,8 @@ export function AssistantMessage({
   conversationId,
   workspaceId,
   isGroupChat,
+  activeRunId,
+  isStreamingTurn,
   pendingConfirmMap,
   onSandboxConfirm,
 }: AssistantMessageProps) {
@@ -652,6 +662,8 @@ export function AssistantMessage({
                   workspaceId={workspaceId ?? null}
                   runId={message.run_id}
                   isGroupChat={isGroupChat ?? false}
+                  activeRunId={activeRunId ?? null}
+                  isStreaming={isStreamingTurn ?? false}
                 />
               </div>
             )}

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -19,6 +19,7 @@ import { SubAgentCluster } from './SubAgentCluster'
 import { TaskProgressCard } from './TaskProgressCard'
 import { ToolCallGroup } from './ToolCallGroup'
 import { ToolCallItem } from './ToolCallItem'
+import { MessageActions } from './MessageActions'
 import { getWriteFileSummary } from '@/lib/writeFilePreview'
 import { extractWidgetCode, extractJsonStringPrefix } from '@/lib/partialJson'
 import { WidgetView } from '@/components/chat/widget/WidgetView'
@@ -145,6 +146,8 @@ interface HistoryProps {
   subagentDataMap?: Record<string, SubagentSummary>
   toolResultMap: Record<string, { content: string; receivedAt: number }>
   conversationId?: string
+  workspaceId?: string | null
+  isGroupChat?: boolean
   stream?: never
   isStreaming?: never
   statusPhase?: never
@@ -159,6 +162,8 @@ interface StreamingProps {
   subagentDataMap?: never
   toolResultMap: Record<string, { content: string; receivedAt: number }>
   conversationId?: string
+  workspaceId?: string | null
+  isGroupChat?: boolean
   stream: AgentStream
   isStreaming: boolean
   statusPhase?: string | null
@@ -525,6 +530,8 @@ export function AssistantMessage({
   toolResultMap,
   todos,
   conversationId,
+  workspaceId,
+  isGroupChat,
   pendingConfirmMap,
   onSandboxConfirm,
 }: AssistantMessageProps) {
@@ -600,7 +607,7 @@ export function AssistantMessage({
   }
 
   return (
-    <div data-role="assistant" className="space-y-2">
+    <div data-role="assistant" className="group space-y-2">
       {(grouped.length > 0 || totalSubagents >= 2 || showErrorBubble) && (
         <div className="flex justify-start gap-2.5">
           <div
@@ -633,6 +640,19 @@ export function AssistantMessage({
                     {errorMessage}
                   </pre>
                 </div>
+              </div>
+            )}
+            {message && conversationId && (
+              <div
+                className="opacity-0 transition-opacity group-hover:opacity-100
+                  focus-within:opacity-100"
+              >
+                <MessageActions
+                  conversationId={conversationId}
+                  workspaceId={workspaceId ?? null}
+                  runId={message.run_id}
+                  isGroupChat={isGroupChat ?? false}
+                />
               </div>
             )}
           </div>

--- a/frontend/packages/web/components/chat/MessageActions.tsx
+++ b/frontend/packages/web/components/chat/MessageActions.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useId, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import { toast } from 'sonner'
+import { GitBranch } from 'lucide-react'
+
+import { createApiClient, useConversationStore, ApiError } from '@cubebox/core'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+interface MessageActionsProps {
+  conversationId: string
+  workspaceId: string | null
+  runId: string | null | undefined
+  isGroupChat: boolean
+}
+
+/**
+ * Hover-revealed action bar attached to each message bubble. Exposes
+ * "Fork conversation" — copies the message history through the end of this
+ * message's run into a fresh conversation. Disabled (with a tooltip
+ * explanation) when the action can't be performed:
+ *  - no run_id on this message (synthetic / pre-cubepi-v3 row)
+ *  - the conversation is a group chat (server-side reject too)
+ *
+ * Parent positions this component (typically absolute, opacity-0 with
+ * group-hover:opacity-100). MessageActions does not place itself; it just
+ * renders the button + its disabled-state UI.
+ */
+export function MessageActions({
+  conversationId,
+  workspaceId,
+  runId,
+  isGroupChat,
+}: MessageActionsProps) {
+  const t = useTranslations('chat')
+  const router = useRouter()
+  const fork = useConversationStore((s) => s.fork)
+  const [busy, setBusy] = useState(false)
+  // Stable per-mount id for the disabled-state aria-describedby. Using
+  // useId avoids collisions when several disabled fork buttons coexist on
+  // a single page (every message without a run_id would otherwise share
+  // one DOM id, breaking screen-reader association).
+  const reactId = useId()
+  const reasonId = `fork-disabled-${reactId}`
+
+  const disabledReason = !runId
+    ? t('forkDisabled.noRun')
+    : isGroupChat
+      ? t('forkDisabled.groupChat')
+      : null
+
+  const handleFork = async () => {
+    if (!runId || !workspaceId || busy) return
+    setBusy(true)
+    try {
+      const client = createApiClient('')
+      client.setWorkspaceId(workspaceId)
+      const newConv = await fork(client, conversationId, runId)
+      toast.success(t('forkSuccess'))
+      router.push(`/w/${workspaceId}/conversations/${newConv.id}`)
+    } catch (err) {
+      const code = err instanceof ApiError ? err.code : null
+      if (code === 'run_not_completed') {
+        toast.error(t('forkDisabled.runStreaming'))
+      } else if (code === 'group_chat_not_supported') {
+        toast.error(t('forkDisabled.groupChat'))
+      } else {
+        toast.error(t('forkError'))
+      }
+      setBusy(false)
+    }
+  }
+
+  const buttonClass = cn(
+    'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs',
+    'text-muted-foreground hover:text-foreground hover:bg-muted/60',
+    'disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent',
+    'disabled:hover:text-muted-foreground transition-colors',
+  )
+
+  if (!disabledReason) {
+    return (
+      <button
+        type="button"
+        onClick={handleFork}
+        disabled={busy}
+        aria-label={t('forkConversation')}
+        className={buttonClass}
+      >
+        <GitBranch className="size-3.5" />
+        <span>{t('forkConversation')}</span>
+      </button>
+    )
+  }
+
+  // Disabled state: use aria-disabled (NOT the native `disabled` attribute)
+  // so the button stays in the tab order and the tooltip's hover/focus
+  // detection still fires. The onClick is no-op'd while disabled; the
+  // aria-describedby links the visible reason to the button for screen
+  // readers, so the reason is announced even if the tooltip itself never
+  // visually opens (e.g. mobile / no-pointer environments).
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        type="button"
+        aria-disabled="true"
+        aria-label={t('forkConversation')}
+        aria-describedby={reasonId}
+        onClick={(e) => e.preventDefault()}
+        className={cn(buttonClass, 'cursor-not-allowed opacity-60')}
+      >
+        <GitBranch className="size-3.5" />
+        <span>{t('forkConversation')}</span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span id={reasonId}>{disabledReason}</span>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/frontend/packages/web/components/chat/MessageActions.tsx
+++ b/frontend/packages/web/components/chat/MessageActions.tsx
@@ -15,6 +15,13 @@ interface MessageActionsProps {
   workspaceId: string | null
   runId: string | null | undefined
   isGroupChat: boolean
+  // Active-run guard: when this message belongs to the run that is still
+  // streaming (or paused on HITL), the backend's ``cp.fork`` will reject
+  // with ``run_not_completed`` because the run row's ``completion_seq``
+  // is still NULL. Disable the button up-front instead of round-tripping
+  // for a 400 toast.
+  activeRunId: string | null
+  isStreaming: boolean
 }
 
 /**
@@ -34,6 +41,8 @@ export function MessageActions({
   workspaceId,
   runId,
   isGroupChat,
+  activeRunId,
+  isStreaming,
 }: MessageActionsProps) {
   const t = useTranslations('chat')
   const router = useRouter()
@@ -46,11 +55,15 @@ export function MessageActions({
   const reactId = useId()
   const reasonId = `fork-disabled-${reactId}`
 
+  const runStillRunning =
+    runId != null && activeRunId === runId && isStreaming
   const disabledReason = !runId
     ? t('forkDisabled.noRun')
     : isGroupChat
       ? t('forkDisabled.groupChat')
-      : null
+      : runStillRunning
+        ? t('forkDisabled.runStreaming')
+        : null
 
   const handleFork = async () => {
     if (!runId || !workspaceId || busy) return

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -202,6 +202,11 @@ export function MessageList({ conversationId }: MessageListProps) {
   const pendingConfirmMap = useMessageStore((s) => s.pendingConfirmMap)
   const pendingAsk = useMessageStore((s) => s.pendingAsk)
   const streamingConversationId = useMessageStore((s) => s.streamingConversationId)
+  // Active run guard for the per-message Fork action — MessageActions
+  // greys the button when the clicked message is part of the still-running
+  // turn (cubepi rejects ``cp.fork`` with run_not_completed until the
+  // run's ``completion_seq`` is stamped).
+  const activeRunId = useMessageStore((s) => s.currentRunId)
   // `failoverEvents` is populated by the message store's SSE consumer
   // whenever a `model_failover` event arrives. The core slice's per-event
   // shape is structurally identical to the web `FailoverEvent` type, so
@@ -433,6 +438,8 @@ export function MessageList({ conversationId }: MessageListProps) {
                   workspaceId={workspaceId}
                   runId={msg.run_id}
                   isGroupChat={isGroupChat}
+                  activeRunId={activeRunId}
+                  isStreaming={isStreaming}
                 />
               </>
             )}
@@ -444,6 +451,8 @@ export function MessageList({ conversationId }: MessageListProps) {
                 conversationId={conversationId}
                 workspaceId={workspaceId}
                 isGroupChat={isGroupChat}
+                activeRunId={activeRunId}
+                isStreamingTurn={isStreaming}
                 pendingConfirmMap={pendingConfirmMap}
                 onSandboxConfirm={handleSandboxConfirm}
               />

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useCallback, useMemo } from 'react'
 import { useTranslations } from 'next-intl'
 import {
   useMessageStore,
+  useConversationStore,
   createApiClient,
   getTextContent,
   getToolResultPreviewContent,
@@ -211,6 +212,14 @@ export function MessageList({ conversationId }: MessageListProps) {
       (s.failoverEvents[conversationId] as FailoverEvent[] | undefined) ?? EMPTY_FAILOVER_EVENTS,
   )
   const { workspaceId } = useWorkspaceContext()
+  // Fork action needs to know whether this is a group chat (the backend
+  // rejects forks on group chats, and we render the disabled-state UI for
+  // it). Conversation row is loaded by the parent page; if it's not in the
+  // store yet (rare race), assume false — a fork attempt will still get a
+  // graceful 400 toast.
+  const isGroupChat = useConversationStore(
+    (s) => s.conversations.find((c) => c.id === conversationId)?.is_group_chat ?? false,
+  )
   // Hoisted: also drives status-row visibility below so an empty chip doesn't
   // leave a stray gutter-only line.
   const memoryCount = useMemoryCount(workspaceId, conversationId)
@@ -418,7 +427,13 @@ export function MessageList({ conversationId }: MessageListProps) {
                     conversationId={conversationId}
                   />
                 )}
-                <UserMessage content={getTextContent(msg)} />
+                <UserMessage
+                  content={getTextContent(msg)}
+                  conversationId={conversationId}
+                  workspaceId={workspaceId}
+                  runId={msg.run_id}
+                  isGroupChat={isGroupChat}
+                />
               </>
             )}
             {msg.role === 'assistant' && msg.id !== lastAssistantId && (
@@ -427,6 +442,8 @@ export function MessageList({ conversationId }: MessageListProps) {
                 subagentDataMap={subagentDataMap}
                 toolResultMap={messageScopedToolResults[msg.id] ?? historicalToolResults}
                 conversationId={conversationId}
+                workspaceId={workspaceId}
+                isGroupChat={isGroupChat}
                 pendingConfirmMap={pendingConfirmMap}
                 onSandboxConfirm={handleSandboxConfirm}
               />

--- a/frontend/packages/web/components/chat/UserMessage.tsx
+++ b/frontend/packages/web/components/chat/UserMessage.tsx
@@ -1,12 +1,35 @@
+import { MessageActions } from './MessageActions'
+
 interface UserMessageProps {
   content: string
+  conversationId: string
+  workspaceId: string | null
+  runId: string | null | undefined
+  isGroupChat: boolean
 }
 
-export function UserMessage({ content }: UserMessageProps) {
+export function UserMessage({
+  content,
+  conversationId,
+  workspaceId,
+  runId,
+  isGroupChat,
+}: UserMessageProps) {
   return (
-    <div data-role="user" className="flex justify-end">
+    <div data-role="user" className="group relative flex justify-end">
       <div className="max-w-[88%] md:max-w-[78%] rounded-lg rounded-br-xs border border-border bg-raised px-3.5 py-2.5 text-md leading-relaxed">
         {content}
+      </div>
+      <div
+        className="absolute -bottom-1 right-0 translate-y-full opacity-0
+          transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+      >
+        <MessageActions
+          conversationId={conversationId}
+          workspaceId={workspaceId}
+          runId={runId}
+          isGroupChat={isGroupChat}
+        />
       </div>
     </div>
   )

--- a/frontend/packages/web/components/chat/UserMessage.tsx
+++ b/frontend/packages/web/components/chat/UserMessage.tsx
@@ -6,6 +6,8 @@ interface UserMessageProps {
   workspaceId: string | null
   runId: string | null | undefined
   isGroupChat: boolean
+  activeRunId: string | null
+  isStreaming: boolean
 }
 
 export function UserMessage({
@@ -14,6 +16,8 @@ export function UserMessage({
   workspaceId,
   runId,
   isGroupChat,
+  activeRunId,
+  isStreaming,
 }: UserMessageProps) {
   return (
     <div data-role="user" className="group relative flex justify-end">
@@ -29,6 +33,8 @@ export function UserMessage({
           workspaceId={workspaceId}
           runId={runId}
           isGroupChat={isGroupChat}
+          activeRunId={activeRunId}
+          isStreaming={isStreaming}
         />
       </div>
     </div>

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -312,7 +312,15 @@
     "modelSectionLabel": "Model",
     "effortLabel": "Effort",
     "effortFaster": "Faster",
-    "effortSmarter": "Smarter"
+    "effortSmarter": "Smarter",
+    "forkConversation": "Fork conversation",
+    "forkSuccess": "Forked to a new conversation",
+    "forkError": "Couldn't fork this conversation",
+    "forkDisabled": {
+      "noRun": "Cannot fork from this message",
+      "runStreaming": "Wait for the response to finish",
+      "groupChat": "Fork is not available in group chats"
+    }
   },
   "subagent": {
     "cluster": "Agent cluster",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -312,7 +312,15 @@
     "modelSectionLabel": "模型",
     "effortLabel": "思考深度",
     "effortFaster": "更快",
-    "effortSmarter": "更聪明"
+    "effortSmarter": "更聪明",
+    "forkConversation": "复刻对话",
+    "forkSuccess": "已复刻到新对话",
+    "forkError": "无法复刻该对话",
+    "forkDisabled": {
+      "noRun": "此消息无法作为复刻起点",
+      "runStreaming": "请等待回复完成",
+      "groupChat": "群聊不支持复刻"
+    }
   },
   "subagent": {
     "cluster": "Agent 集群",


### PR DESCRIPTION
## Summary

- Per-message hover button on user + assistant bubbles that forks the
  conversation: a new personal conversation owned by the caller, with
  message history copied through the end of that message's run.
- Backend wraps cubepi's `cp.fork(src, new, after_run_id, metadata)` and
  inserts a fresh `conversations` row (`POST /ws/{ws}/conversations/{id}/fork`).
- Frontend stamps `run_id` onto optimistic user/assistant/tool messages
  via a new `onRunId` callback in `streamMessages`, so the just-finished
  turn is forkable without a reload.
- Fork is always **personal** (drops `topic_id`) — see spec for the
  visibility-leak / 404-after-redirect reasoning that drove the policy.

Spec: [`docs/dev/specs/2026-06-23-fork-conversation-design.md`](docs/dev/specs/2026-06-23-fork-conversation-design.md)
Plan: [`docs/dev/plans/2026-06-23-fork-conversation.md`](docs/dev/plans/2026-06-23-fork-conversation.md)

## What changed

**Backend**
- `repositories/conversation.py::ConversationRepository.fork()` — typed errors
  (`ForkGroupChatError`, `ForkRunNotCompletedError`, `ForkSourceMissingError`,
  `ForkNewThreadExistsError`) raised back to the route.
- `api/routes/v1/conversations.py::fork_conversation` — maps errors to
  `{detail: {code: "..."}}` (matches the frontend's `toApiError` mapper).
- `tests/e2e/test_conversation_fork.py` — 4 tests: happy path, run-not-completed,
  group-chat reject, cross-workspace 404.

**Frontend**
- `core/api/conversations.ts::forkConversation()` + `core/types/message.ts`
  `MessageBase.run_id`.
- `core/api/stream.ts::streamMessages` gained `options.onRunId` so the send
  path can capture the run id at POST time.
- `core/stores/conversationStore.ts::fork()` — wraps the API call and
  prepends the new conv into local state (mirrors `create()`).
- `core/stores/messageStore.ts` — `buildPendingUserMessage` and
  `buildTurnMessages` now stamp `run_id`; `send()` backfills it onto the
  optimistic user message via the new `onRunId` callback.
- `web/components/chat/MessageActions.tsx` (new) — hover button; disabled
  state uses `aria-disabled` + focusable `TooltipTrigger` + `useId()`
  `aria-describedby` so the reason is announced to screen readers.
- `MessageList`, `UserMessage`, `AssistantMessage` plumb `runId`,
  `conversationId`, `workspaceId`, `isGroupChat` to the action.
- i18n: `chat.forkConversation` + `chat.forkDisabled.*` in en + zh.

## Codex review rounds

Two local rounds completed before pushing. R1 returned M1/M2/L1/L2; R2
confirmed M1/L1/L2 resolved and caught that M2's first fix only stamped
`run_id` in the finalizer (still null) — final fix above plumbs it through
`streamMessages.onRunId` so the optimistic messages are forkable
immediately, and adds `useConversationStore.fork()` + `useId()` for R2's
two LOWs.

## Test plan

- [x] backend `mypy cubebox` clean (455 files)
- [x] backend `pytest tests/e2e/test_conversation_fork.py` — 4 passed
- [x] frontend `@cubebox/core` build clean
- [x] frontend `pnpm lint` clean
- [x] frontend `tsc --noEmit` clean
- [ ] manual smoke: send a turn → hover the assistant reply → click Fork →
      land on `/w/{ws}/conversations/{newId}` with full history present;
      send a follow-up in the fork — confirm the source is unaffected.
- [ ] manual: try forking from a streaming turn → button disabled with
      "Wait for the response to finish" tooltip after backend rejects.
- [ ] manual: group chat — confirm tooltip says "Fork is not available in
      group chats" before clicking.