### PR TITLE
docs(site): correct factual drift + author IM connector guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,22 @@ cubebox is a full-stack agent platform.
     task; reserve the full suite for the pre-PR sweep.
 12. **Plain language in docs/specs.** Don't invent abstract jargon. Say what
     literally happens + why, in concrete words.
+13. **Docs ship with the code.** Any change that adds, removes, or alters a
+    user-facing behavior — a route or its path, a header, an enum/option,
+    a default limit, a config key, a UI flow, a role/permission, a CLI/slash
+    command — MUST update the matching page under `docs/site/docs/` in the
+    **same PR**. A PR that changes documented behavior without touching the
+    doc is incomplete. New user-facing subsystems get a new doc page (this is
+    the one sanctioned exception to "don't create new docs"). When a screenshot
+    is needed but not yet captured, leave a placeholder, never a silent gap:
+    ```md
+    :::info 📸 Screenshot placeholder
+    **Capture:** <what to show, incl. the interaction/state>
+    **Asset:** `/img/<area>/<name>.png`
+    :::
+    ```
+    The mapping from code area to doc page lives in the docs-overhaul plan
+    ([docs/dev/plans/2026-06-23-docs-overhaul.md](docs/dev/plans/2026-06-23-docs-overhaul.md)).
 
 ---
 

--- a/docs/dev/notes/2026-06-23-docs-overhaul-review-report.md
+++ b/docs/dev/notes/2026-06-23-docs-overhaul-review-report.md
@@ -1,0 +1,122 @@
+# CubeBox Docs Overhaul — Review & Correction Report
+
+**Date:** 2026-06-23
+**Branch:** `feat/2026-06-23-docs-overhaul`
+**Method:** A `Workflow` fan-out (9 per-module reviewers + 1 synthesizer) verified
+every page of `docs/site/docs/` against the backend/frontend code and corrected
+drift in place. This note is the synthesizer's report plus the human-decision
+list. See the plan: [2026-06-23-docs-overhaul.md](../plans/2026-06-23-docs-overhaul.md).
+
+**Verification:** `pnpm build` in `docs/site` passes for both `en` and `zh-Hans`
+locales (config sets `onBrokenLinks: throw` / `onBrokenAnchors: throw`), so all
+internal links and anchors resolve. One MDX bug introduced during the pass
+(`{enabled}` brace-expression in a placeholder) was caught by the build and
+fixed.
+
+---
+
+## Overview
+
+This pass corrected factual drift across nine documentation modules and authored
+a brand-new IM Connectors surface. The dominant theme was **navigation and
+naming drift**: leaked Next.js route-group paths (`/(app)/w/{id}/...`) were
+replaced with real user-facing URLs, fabricated nav vocabulary
+(`Settings > Models`, `Workspace Settings > MCP`, `Organization Settings >`) was
+repointed to the actual Admin panel and top-level workspace sidebar pages, and
+UI labels were aligned to the real i18n strings (`Extra High`, `New task`,
+`Add to workspace`, `Re-authenticate`). Several **fabricated or invented
+mechanisms** were removed entirely — an email-invite member flow, a
+transfer-ownership action, a configurable missed-run policy, an org-level skill
+enable/disable toggle, workspace-level model restrictions, and CPU/memory
+resource limits — and replaced with what the code actually does. The IM module
+went from zero coverage to an overview plus a full Feishu setup guide, wired into
+the sidebar. Event Triggers (hand-fixed in step 1) needed no further corrections.
+
+## Highest-impact factual corrections
+
+| Module | Was wrong | Fix | Evidence |
+|---|---|---|---|
+| Getting Started | First self-hosted user "instantly creates org & becomes owner"; others wait for admin approval | One-time setup screen (name org + slug) → owner; later users join as members with personal workspace | `auth/users.py:86,230`; `auth.md:69-86`; `RegisterForm.tsx:31-34` |
+| Getting Started | Model setup at `Settings > Models` | `Admin > Models > Model Providers` (via avatar menu) | `app/admin/models`; `AdminSubNav.tsx:132-136` |
+| Conversations | Failover banner used hard-coded dated model IDs | Generic `<provider>/<model>` refs; exact text `Failover exhausted on …` | `FailoverBanner.tsx:26-28` |
+| Conversations | Artifacts created only by `save_artifact` | Both `save_artifact` and `generate_image` produce artifacts | `agents/stream.py:87` |
+| Skills | Trust tier "Unvetted"; "remote registry" as a stored source type | "Untrusted" (enum); source is `preinstalled\|uploaded`, remote stored as uploaded w/ registry ref | `skills/sources/base.py:26-29`; `models/skill.py:27,31-34` |
+| Skills (admin) | Org-level enable/disable toggle removing a skill from all workspaces | Org install/uninstall + auto-bind, plus per-workspace enable/disable bindings | `admin_skills.py:381-472,577-613` |
+| Memory | Workspace/org edits restricted to admins or item creator | Any member who can view an item can archive/update it | `repositories/memory.py:53-60`; `services/memory.py:48-54` |
+| Memory | Proactive saves default to workspace scope | Agent always saves **personal**; workspace/org only on explicit request | `prompts/memory.py:28-40` |
+| Memory | "Delete" permanently removes an item | Memory Center only archives; API delete is a soft-delete | `api/routes/v1/memory.py:139-153` |
+| MCP (admin) | Fabricated Auth tab with client ID/secret + redirect URI fields | DCR auto-registers; static clients need deploy-time env-var/seeder; tabs are Overview/Tools/Citations/Workspaces | `MCPAdminDetailPanel.tsx:312-382`; `template_seed.py:8-11` |
+| MCP | DCR-auto OAuth list omitted Atlassian | Added Atlassian | `template_seed.py:174` |
+| Scheduled Tasks | Configurable "missed-run policy" (Skip / Run latest) | No such field; only latest due occurrence catches up, older → Skipped (missed) | `schedules/compute.py:17-19`; `poller.py:53,160-211` |
+| Scheduled Tasks | "Three schedule kinds" incl. raw cron the user types | Visual builder: Daily/Weekly/Monthly/Every…/Once; cron is storage only | `ScheduleEditor.tsx:19-27` |
+| Admin (members) | Email-invite flow with sign-up link | "Add members" adds an existing CubeBox user by email; fails if no account | `admin_members.py:90-99` |
+| Admin (members) | "Transfer Ownership" action | No such endpoint; owner role unchangeable, owner unremovable | `admin_members.py:120,142` |
+| Admin (sandbox) | Fixed runtime language list | Languages depend on configured `default_image`; agent runs via shell `execute` | `prompts/artifacts.py:13`; `models/sandbox_policy.py:60` |
+| Admin (sandbox) | Resource limits control CPU/memory/duration | Real feature is Command rules (allow/deny/confirm HITL) + per-run timeout | `models/sandbox_policy.py:78-80` |
+| IM (new) | Zero IM coverage | New overview + Feishu setup guide | `im/feishu/signature.py:87-105`; `im_ingress.py:117` |
+
+---
+
+## Residual gaps — human decisions required
+
+### Cross-module: ratify the navigation vocabulary
+A single nav vocabulary was adopted and should be confirmed:
+- **Org-scoped** → `Admin > <Section>` via avatar menu → "Admin panel" → `/admin/...`
+- **Workspace features** → top-level sidebar pages by name (Skills, MCP, Scheduled Tasks, Triggers, Memory, Artifacts)
+- **Workspace Settings sub-views** → `Settings > <Tab>` (General / IM / Memory / Sandbox env / Members / Shares)
+- Banned: `Organization Settings >`, `Workspace Settings > Models/MCP/Skills/Automation`, bare `Settings > Models`.
+
+### Cross-module: i18n decision
+`zh-Hans` builds but has **no translations** (no `i18n/` dir) — Chinese users get
+the language switcher and English content. Also `SettingsTabs.tsx` has
+`navMemory` / `navModel` label keys whose tabs are **not rendered**. Decide:
+translate vs. drop the locale; and whether those keys are dead (remove) or
+pending features.
+
+### Per-module unverified claims
+
+**Resolved (owner confirmed 2026-06-24):**
+- **Skills — "Deprecate a skill"** → ✅ removed. No such feature exists; section deleted from `admin/skills-management.md`.
+- **Admin (sandbox) — "secrets are not logged"** → ✅ rewritten to the real mechanism. Secrets are injected as opaque `cbxref_…` **placeholders**, never the real value; the **egress proxy** substitutes the real secret at the network boundary, only for allowed hosts/headers (`sandbox_env/placeholder.py`, `services/egress_exchange.py`, `sandbox/manager.py`). So the secret never enters the sandbox or its logs. Section retitled "How secrets stay out of the sandbox" and now recommends secret-env entries for all credentials.
+- **Memory — confidence "self-rated by the agent"** → ✅ confirmed correct; wording stands (default 0.8).
+
+**Still open (left in place per honesty rule):**
+- **Getting Started** — could not confirm any workspace-level model allowlist UI; the restriction claim was removed. Verify in the model-presets service/repo.
+- **Skills** — version rollback documented as "install the version you want" (no dedicated rollback endpoint).
+- **Memory** — "personal memory wins on conflict" could not be verified; rewritten to verifiable behavior (org→workspace→personal render order + intra-scope `correction` priority).
+- **MCP** — the four catalog status labels are a simplification of `install_scope`/`auth_status`/`discovery_status`/`install_state`/`credential_availability`; exact on-screen strings need a frontend render check.
+- **Scheduled Tasks** — interval **resume** first-fire wording is approximate; misfire grace window left unstated (code default 300s but constructor-overridable).
+- **Event Triggers** — two overview/Tips wording issues outside the webhook facts: the "Rate limited" row omits the 429-vs-`202_drop` distinction; "excess events are queued and processed in order" is wrong (token-bucket rejects, no queue). Reword after a product decision.
+
+### IM Connectors — all five setup guides now authored
+Feishu, Slack, DingTalk, Teams, and Discord each have a dedicated page, wired into
+the sidebar; `overview.md` links them and its platform/command/identity claims were
+corrected against code. Authoring surfaced two **code-confirmed** facts that also
+fixed the overview:
+- `/new` / `/reset` only exist on **Feishu** (text) and **Discord** (native slash) —
+  **not** Slack, DingTalk, or Teams (`feishu/reset_command.py`, `discord/commands.py`;
+  absent elsewhere).
+- Email auto-resolution is wired on **Feishu, Slack, DingTalk** (`resolve_email` →
+  `identity_resolver` in each gateway); **Discord/Teams** use `/link`. The `绑定`
+  alias is Feishu-only; DingTalk has no Chinese alias.
+
+Remaining (screenshots + external-console strings, not code):
+- All per-platform screenshot placeholders are unfilled (Slack/Discord/Azure/DingTalk consoles).
+- Exact console strings — Slack scope names, Discord intents/OAuth scopes, DingTalk permission names, Azure blade/manifest fields, Feishu scope/event keys — are described by capability (they live in each vendor's console, not in code). Confirm during screenshot capture.
+- Channel-binding "shared" mode `sandbox_mode` values still not enumerated — verify in `api/schemas/im_channel_binding.py`.
+
+---
+
+## Screenshots to capture (28 placeholders added)
+
+Capture against a seeded demo workspace; store under `docs/site/static/img/`
+matching each page path. Grouped:
+
+- **Getting Started** — one-time org setup screen; `Admin > Models > Model Providers`.
+- **Conversations** — Effort slider (Off→Extra High); failover banner mid-stream.
+- **Skills** — Workspace Skills page with Source dropdown; skill artifact card "Add to workspace"; Add-registry form + `.zip` upload modal.
+- **Memory** — Memory Center four tabs; a memory card (badge/confidence/archive).
+- **MCP** — workspace MCP page "Connect with <provider>" state; admin detail Overview/Tools/Citations/Workspaces tabs; "+ Add custom connector" dialog.
+- **Scheduled Tasks** — schedule builder frequency pills; conversation-target section; run-history with six state badges.
+- **Admin** — Members "Add members" dialog + owner badge; Sandbox Environment + Command rules editor; cost dashboard (granularity/dimension/export).
+- **IM** — overview flow diagram + maturity table; Feishu app-create/bot-publish, binding form, event subscription.

--- a/docs/dev/plans/2026-06-23-docs-overhaul.md
+++ b/docs/dev/plans/2026-06-23-docs-overhaul.md
@@ -1,0 +1,163 @@
+# Docs Site Overhaul — Review & Correction Plan
+
+**Date:** 2026-06-23
+**Branch:** `feat/2026-06-23-docs-overhaul`
+**Scope:** `docs/site/docs/**` (the user-facing product documentation site)
+
+---
+
+## Goal
+
+Bring the user-facing docs site into factual agreement with the shipped
+product, close the major content gaps, fix rendering bugs, and establish a
+process so docs never silently drift from code again.
+
+This plan is a frozen snapshot. Rebase the content; don't rewrite history.
+
+---
+
+## How we got here
+
+The docs site (`docs/site/`, Docusaurus) was written as one batch and is
+broadly good — clear structure, consistent voice, useful per-page "Tips".
+Spot-checking against the codebase confirmed most product facts are accurate
+(`save_artifact` / `load_skill` tool names, the five thinking levels
+`off/low/medium/high/xhigh`, the 50 MB / 500 MB attachment limits all match).
+
+But a verification pass surfaced **factual drift** (docs describe behavior the
+code does not implement), **whole missing subsystems** (IM connectors), and a
+class of **rendering bugs** (`--` not rendering as an em-dash). This plan
+records every finding and drives a per-module correction workflow.
+
+---
+
+## Findings
+
+### Tier 1 — Factual errors (a user following the doc will fail)
+
+All in `guides/automation/event-triggers.md`. Verified against
+`backend/cubebox/triggers/ingest.py`, `triggers/signature.py`, and
+`api/routes/v1/trigger_ingest.py`.
+
+| # | Doc claims | Reality (code) |
+|---|---|---|
+| T1 | Signature header is `X-Webhook-Signature` | Default is `X-Signature` (`ingest.py:129`, configurable via `signature_header`) |
+| T2 | Webhook URL is `…/api/v1/webhooks/trg_abc123` | Route is `POST /api/v1/ws/{workspace_id}/triggers/{trigger_id}/ingest` (`trigger_ingest.py:17,20`) |
+| T3 | "compute the HMAC-SHA256 of the raw request body" | Signed message is `"{timestamp}." + raw_body` — timestamp is part of the signature (`signature.py:sign`) |
+| T4 | Only a signature header is needed | `X-Timestamp` is **also required** (missing → 404). `X-Event-Id` is optional (dedup). All configurable. |
+| T5 | Invalid signature → `401` | Every failure path returns **404** `{"error":"not_found"}` — deliberately opaque (`_flat_404()`) |
+| T6 | Event-log "Rejected" status = signature failed | Signature failures return 404 **before** any `trigger_events` row is inserted, so they never appear in the event log at all |
+| T7 | Implied 5xx for stale requests not mentioned | Timestamp freshness window is **300 s** (`timestamp_fresh`, `signature.py`); stale → 404 |
+| T8 | "GitHub, Stripe… paste the HMAC secret and CubeBox validates `X-Hub-Signature-256` automatically" | **False.** The generic webhook expects CubeBox's own scheme (`X-Signature` over `timestamp.body` + required `X-Timestamp`). GitHub sends no `X-Timestamp` and signs body-only with a different header → always 404. The sender must implement CubeBox's scheme (or sit behind a relay). |
+
+> **T8 is the most damaging** — both worked examples ("GitHub issue triage",
+> "Slack alert escalation") are written as drop-in integrations that cannot
+> work as described. The honest framing: the generic webhook is a
+> *bring-your-own-signer* endpoint; the `curl` recipe is the reference.
+
+### Tier 2 — Missing subsystems / content gaps
+
+| # | Gap |
+|---|---|
+| G1 | **IM connectors have zero docs.** Code ships Feishu, DingTalk, Discord, Slack, Teams (`backend/cubebox/im/`). This is a flagship surface (recent commits are IM-heavy) with no "connect a bot" guide. |
+| G2 | **i18n is a shell.** `docusaurus.config.ts` declares the `zh-Hans` locale + a language dropdown, but there is no `i18n/` directory — Chinese users get the switcher and untranslated/fallback pages. Either translate or drop the locale until ready. |
+| G3 | **No API-keys doc** (programmatic access exists in flight). |
+| G4 | **No group-chat / conversation-participants doc** (recent plans). |
+| G5 | **No "Limits & Quotas" reference page.** Limits are scattered; e.g. `max_per_message = 10` attachments/message (`conversations.py:1329`) is undocumented. |
+| G6 | **No Troubleshooting/FAQ landing page and no glossary** (preset, grant, template, install are unglossed jargon on first use). |
+
+### Tier 3 — Rendering & consistency
+
+| # | Issue |
+|---|---|
+| R1 | **`--` used as an em-dash** in `basics.md`, `memory/*`, `automation/*`. Docusaurus renders it as two literal hyphens. Other files correctly use `—`. Normalize all to `—`. |
+| R2 | **Internal route groups leak into user docs.** `managing-memory.md` shows `/(app)/w/{workspaceId}/memory` — `(app)` is a Next route group, never in a real URL. `discover-and-install.md` shows `/<workspace>/skills`. Replace with the real user-facing path or describe navigation, not URLs. |
+| R3 | **Inconsistent navigation nomenclature** — "Settings > Models" vs "Organization Settings > Models" vs "Admin > Models" for the same destination. Pick one vocabulary and apply globally. |
+| R4 | **Hard-coded dated model IDs** in `model-selection.md` failover banner (`claude-sonnet-4-20250514`, …) will age and clash with the "friendly preset names" model used elsewhere. |
+
+### Tier 4 — Structural
+
+| # | Item |
+|---|---|
+| S1 | **Zero screenshots.** Acceptable pre-launch, but the artifact panel, preset picker, and Memory Center can't be explained in prose alone. This plan introduces screenshot placeholders everywhere a visual is needed. |
+| S2 | Consider a top-level **"Concepts" vs "How-to" vs "Reference"** split (Diátaxis) as the doc set grows; out of scope for this pass, noted for later. |
+
+---
+
+## Screenshot placeholder convention
+
+Until we capture real interaction screenshots, every spot that needs a visual
+gets a **visible** placeholder so reviewers see the gap and the future
+photographer knows exactly what to capture and where the asset lands:
+
+```md
+:::info 📸 Screenshot placeholder
+**Capture:** <what to show, including the interaction/state to demonstrate>
+**Asset:** `/img/<area>/<name>.png`
+:::
+```
+
+- Placeholders render as a visible admonition (obvious during review).
+- `**Asset:**` reserves the final path under `docs/site/static/img/<area>/`.
+- Replace each block with `![alt](/img/<area>/<name>.png)` once the real
+  screenshot (with interaction visible) is added. Real screenshots land in a
+  follow-up pass.
+
+---
+
+## Execution
+
+### Step 1 (done in this PR) — fix the Tier-1 webhook errors
+
+Rewrite the webhook sections of `event-triggers.md` with the verified facts
+(T1–T8), correct both worked examples, and add screenshot placeholders. This
+is the demonstrated first revision; the rest is driven by the workflow below.
+
+### Step 2 — per-module review-and-correct workflow
+
+A workflow (`Workflow` tool) fans out one agent per subsystem. Each agent:
+
+1. Reads its doc file(s).
+2. Greps the corresponding backend/frontend code for the facts the doc asserts
+   (routes, headers, limits, tool names, state machines, enums).
+3. Applies corrections **in place** (Edit/Write).
+4. Inserts screenshot placeholders per the convention above.
+5. Returns a structured change report (what was wrong, what changed, residual
+   gaps it could not resolve).
+
+A final synthesis agent compiles a master report and the open-gaps list (IM
+docs to author, i18n decision, etc.).
+
+**Module → code map:**
+
+| Module (docs) | Code to verify against |
+|---|---|
+| getting-started/* | cross-cutting: auth, bootstrap, workspaces |
+| conversations/* | `agents/`, `attachments.py`, frontend `components/chat/` |
+| skills/* + admin/skills-management | `skills/`, frontend skills pages |
+| memory/* | `memory/` |
+| mcp/* + admin/mcp-connectors | `mcp/`, `triggers` (citations) |
+| automation/scheduled-tasks | `schedules/` |
+| automation/event-triggers | `triggers/` (already fixed in Step 1; agent verifies only) |
+| admin/{models,members,sandbox,cost} | `api/routes/v1/admin*`, sandbox, cost |
+| **NEW** im-connectors/* | `backend/cubebox/im/{feishu,dingtalk,slack,teams,discord}` |
+
+### Step 3 — process guardrail
+
+Add a non-negotiable rule to `CLAUDE.md`: any feature add/change must update
+`docs/site/docs` in the **same PR**, and code touching a documented
+route/limit/enum must update the doc that asserts it. Include the
+screenshot-placeholder convention so new visuals are stubbed, not skipped.
+
+### Step 4 (follow-up, not this PR) — real screenshots + i18n decision
+
+Capture the interaction screenshots that replace the placeholders, and decide
+whether to translate `zh-Hans` or remove the locale.
+
+---
+
+## Out of scope
+
+- Real screenshot capture (placeholders only this pass).
+- Actually translating the docs.
+- Diátaxis restructure (S2).

--- a/docs/dev/plans/docs-review-workflow.js
+++ b/docs/dev/plans/docs-review-workflow.js
@@ -1,0 +1,238 @@
+export const meta = {
+  name: 'docs-module-review',
+  description: 'Per-module review + in-place correction of the CubeBox docs site against the code',
+  phases: [
+    { title: 'Review & correct' },
+    { title: 'Synthesize' },
+  ],
+}
+
+// All agents operate inside this worktree. Absolute paths only — subagents do
+// not inherit cwd.
+const WT = '/home/chris/cubebox/.worktrees/feat/2026-06-23-docs-overhaul'
+const DOCS = `${WT}/docs/site/docs`
+const CODE = `${WT}/backend/cubebox`
+const FE = `${WT}/frontend/packages/web`
+
+const PLACEHOLDER = [
+  'Screenshot placeholder convention — insert where a visual is genuinely needed',
+  '(key UI surface that prose cannot fully convey: panels, pickers, dashboards,',
+  'state transitions). Do NOT spam them. Use this exact Docusaurus admonition:',
+  '',
+  ':::info 📸 Screenshot placeholder',
+  '**Capture:** <what to show, including the interaction/state to demonstrate>',
+  '**Asset:** `/img/<area>/<name>.png`',
+  ':::',
+].join('\n')
+
+const RULES = `
+You are correcting ONE module of the CubeBox user-facing docs site (Docusaurus).
+Worktree root: ${WT}
+Docs root:     ${DOCS}
+Backend code:  ${CODE}
+Frontend code: ${FE}
+
+Your job, in order:
+1. READ every assigned doc file in full.
+2. VERIFY each concrete claim against the code by grepping/reading the mapped
+   source dirs: routes & path prefixes, HTTP methods, header names, enum values,
+   default limits, tool names, state-machine states, role/permission tables,
+   config keys. Treat the code as ground truth.
+3. CORRECT the docs IN PLACE with the Edit/Write tools. Fix factual drift, wrong
+   routes, wrong enums, wrong limits. Preserve the existing voice, structure,
+   and the "Tips" sections — surgical edits, not rewrites, unless a section is
+   wholesale wrong.
+4. NORMALIZE typography: ' -- ' used as an em-dash must become ' — ' (an actual
+   em-dash). Do NOT touch '--' inside code blocks, CLI flags, or inline code.
+5. DE-LEAK internal paths: Next.js route groups like '/(app)/...' and pseudo
+   patterns like '/<workspace>/...' must never appear in user docs. Replace with
+   the real user-facing URL (verify it) or describe the navigation instead.
+6. SCREENSHOTS: ${PLACEHOLDER}
+7. HONESTY: if you cannot verify a claim in the code, DO NOT invent a fact and
+   DO NOT delete the claim silently — leave it, and record it under
+   residual_gaps with the exact file:line and what you'd need to confirm it.
+
+Only edit the files assigned to you. Do not run servers, migrations, or tests.
+After editing, return ONLY the structured report object.
+`
+
+const REPORT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['module', 'files_touched', 'corrections', 'placeholders_added', 'residual_gaps'],
+  properties: {
+    module: { type: 'string' },
+    files_touched: { type: 'array', items: { type: 'string' } },
+    corrections: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['file', 'was_wrong', 'fix', 'evidence'],
+        properties: {
+          file: { type: 'string' },
+          was_wrong: { type: 'string' },
+          fix: { type: 'string' },
+          evidence: { type: 'string', description: 'code path:line proving the fix' },
+        },
+      },
+    },
+    placeholders_added: { type: 'integer' },
+    residual_gaps: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const MODULES = [
+  {
+    key: 'getting-started',
+    prompt: `Module: Getting Started.
+Files: ${DOCS}/intro.mdx, ${DOCS}/getting-started/quick-start.md,
+${DOCS}/getting-started/core-concepts.md, ${DOCS}/getting-started/workspace-setup.md
+Verify against: ${CODE}/auth, ${CODE}/api/routes/v1 (registration, workspaces, members),
+${CODE}/models, and ${WT}/backend/docs/auth.md.
+Focus: org/workspace role tables and capabilities; single_tenant vs multi_tenant
+bootstrap (first-user-becomes-owner); the real post-register landing URL; and
+NAVIGATION NOMENCLATURE — the docs mix "Settings > Models", "Organization
+Settings > Models", and "Admin > Models" for the same destination. Pick the one
+that matches the actual UI/route and make it consistent across THIS module
+(note the chosen vocabulary in residual_gaps so other modules can align).`,
+  },
+  {
+    key: 'conversations',
+    prompt: `Module: Conversations.
+Files: ${DOCS}/guides/conversations/basics.md, .../attachments.md,
+.../artifacts.md, .../model-selection.md
+Verify against: ${CODE}/agents, ${CODE}/services/attachments.py,
+${CODE}/api/routes/v1/conversations.py, ${FE}/components/chat.
+Focus: thinking levels (off/low/medium/high/xhigh — confirm the displayed label
+for 'xhigh'); attachment limits (max_file_bytes, max_per_conversation_bytes, AND
+the per-message cap attachments.max_per_message — currently UNDOCUMENTED, add
+it); artifact types and the save_artifact/generate_image tools; the failover
+banner text and whether hard-coded dated model IDs should be replaced with
+generic placeholders; preset stickiness behavior.`,
+  },
+  {
+    key: 'skills',
+    prompt: `Module: Skills.
+Files: ${DOCS}/guides/skills/overview.md, .../discover-and-install.md,
+.../managing-skills.md, ${DOCS}/admin/skills-management.md
+Verify against: ${CODE}/skills, ${FE} skills pages.
+Focus: skill states/source enums; the in-sandbox mount path
+('/.skills/<name>/<version>/' — confirm exact); load_skill tool; remote registry
+flow and trust tiers; org-wide vs workspace-private install semantics; and the
+'/<workspace>/skills' pseudo-URL leak in discover-and-install.md.`,
+  },
+  {
+    key: 'memory',
+    prompt: `Module: Memory.
+Files: ${DOCS}/guides/memory/overview.md, .../using-memory.md, .../managing-memory.md
+Verify against: ${CODE}/memory.
+Focus: the three tiers and precedence; the six memory types (confirm the exact
+enum strings); confidence range; Active/Archived status; the
+'/(app)/w/{workspaceId}/memory' route-group LEAK in managing-memory.md (replace
+with the real user URL); and the who-can-view/edit permission table.`,
+  },
+  {
+    key: 'mcp',
+    prompt: `Module: MCP Tools.
+Files: ${DOCS}/guides/mcp/overview.md, .../installing-connectors.md,
+.../using-tools.md, ${DOCS}/admin/mcp-connectors.md
+Verify against: ${CODE}/mcp and ${WT}/backend/docs/mcp_catalog_oauth.md.
+Focus: the Template→Install→Grant→Active lifecycle; the listed connector catalog
+(does it match what ships?); auth modes (API key / OAuth / bearer); PKCE + DCR
+claims and which providers need pre-registered OAuth apps; progressive
+disclosure; tool citations; admin route paths.`,
+  },
+  {
+    key: 'automation-schedules',
+    prompt: `Module: Scheduled Tasks.
+Files: ${DOCS}/guides/automation/scheduled-tasks.md
+Verify against: ${CODE}/schedules (and any trigger/destination code).
+Focus: schedule kinds (cron / fixed interval / one-shot); missed-run policy
+options (Skip / Run latest — confirm exact set and names); conversation options
+(fixed vs new-per-fire); run-history fields; first-fire timing for intervals.`,
+  },
+  {
+    key: 'automation-triggers',
+    prompt: `Module: Event Triggers — VERIFY-ONLY + typography.
+File: ${DOCS}/guides/automation/event-triggers.md
+This file was just hand-corrected against ${CODE}/triggers (ingest.py,
+signature.py, ${CODE}/api/routes/v1/trigger_ingest.py). DO NOT re-rewrite the
+webhook facts. Your ONLY edits: normalize remaining ' -- ' to ' — ' outside code
+blocks. Then verify the corrected facts still match the code and report any
+discrepancy you find under residual_gaps. Keep placeholders_added at the count
+you actually add (likely 0).`,
+  },
+  {
+    key: 'admin',
+    prompt: `Module: Administration.
+Files: ${DOCS}/admin/models.md, ${DOCS}/admin/members.md, ${DOCS}/admin/sandbox.md,
+${DOCS}/admin/cost-tracking.md
+Verify against: ${CODE}/api/routes/v1 (admin_*.py), ${CODE}/sandbox, ${CODE}/credentials,
+and cost/usage code.
+Focus: admin route paths (/admin/...); sandbox supported languages list (confirm
+against OpenSandbox integration); env-var scope precedence (User>Workspace>Org);
+secret handling claims; org role table and Transfer Ownership; cost-tracking
+inputs (input/output tokens, per-model rates).`,
+  },
+  {
+    key: 'im-connectors',
+    isAuthoring: true,
+    prompt: `Module: IM Connectors — AUTHORING (this surface has ZERO docs today).
+Code: ${CODE}/im (feishu, dingtalk, slack, teams, discord), ${CODE}/api/routes/v1/im_ingress.py,
+admin_im.py, and ${WT}/backend/cubebox/im/feishu/*.
+Task:
+1. CREATE ${DOCS}/im/overview.md — what IM connectors are, the supported
+   platforms (state honestly which are mature vs early, based on the code), the
+   general model (bind a bot → inbound webhook → agent run → reply), identity
+   linking, and the /new and /reset commands if present in code.
+2. CREATE ${DOCS}/im/feishu.md — a concrete setup guide for Feishu/Lark (the most
+   developed platform per the code): create the bot, configure the event/webhook
+   URL and encrypt/verification-token, the signature scheme (verify against
+   ${CODE}/im/feishu/signature.py), and how a workspace user links their account.
+   Use screenshot placeholders for every external-console step.
+3. Register both pages in ${WT}/docs/site/sidebars.ts under a new
+   "IM Connectors" category (place it after Automation). Keep the file valid TS.
+4. For dingtalk/slack/teams/discord, do NOT fabricate full guides — add a short
+   "Other platforms" section in overview.md listing them with a one-line status
+   and a residual_gap noting each needs its own page.
+Accuracy over completeness: only state what the code supports. Everything
+unconfirmed goes in residual_gaps.`,
+  },
+]
+
+phase('Review & correct')
+const reports = await parallel(
+  MODULES.map((m) => () =>
+    agent(`${RULES}\n\n${m.prompt}`, {
+      label: `doc:${m.key}`,
+      phase: 'Review & correct',
+      agentType: 'claude',
+      schema: REPORT_SCHEMA,
+    }),
+  ),
+)
+
+const clean = reports.filter(Boolean)
+
+phase('Synthesize')
+const summary = await agent(
+  `You are the docs-overhaul synthesizer. Below are JSON change reports from
+per-module doc-correction agents for the CubeBox docs site.
+
+${JSON.stringify(clean, null, 2)}
+
+Produce a concise Markdown report for the human reviewer with:
+- A one-paragraph overview of what changed across the site.
+- A table of the highest-impact factual corrections (module | was wrong | fix | evidence).
+- The consolidated list of residual gaps / unverified claims, grouped by module,
+  that a human must confirm or that need follow-up (call out the i18n decision,
+  the remaining IM platform pages, and any nav-nomenclature conflicts between
+  modules).
+- A short "screenshots to capture" checklist aggregated from every placeholder
+  added (asset path + what to capture).
+Return the Markdown only.`,
+  { label: 'synthesize', phase: 'Synthesize' },
+)
+
+return { reports: clean, summary }

--- a/docs/site/docs/admin/cost-tracking.md
+++ b/docs/site/docs/admin/cost-tracking.md
@@ -13,10 +13,13 @@ Every LLM call made through CubeBox records:
 
 - **Input tokens** — the number of tokens sent to the model (prompt, system instructions, tool results, etc.).
 - **Output tokens** — the number of tokens the model generated in its response.
-- **Model** — which model was used.
-- **Timestamp** — when the call was made.
+- **Cache read / cache write tokens** — tokens served from or written to the prompt cache, billed at their own rates (often much cheaper than fresh input tokens).
+- **Provider and model** — which provider and model handled the call.
+- **Timestamps** — when the call started and ended.
 
-CubeBox multiplies token counts by the per-model cost rates you configured in [Model Management](./models.md) to calculate dollar amounts.
+Each call also records the per-model price rates (input, output, cache read, and cache write) **as a snapshot at the time of the call**, so historical costs stay accurate even after you later change a model's rates in [Model Management](./models.md).
+
+Cost tracking also records **sandbox compute** events, so the totals reflect more than just LLM token spend.
 
 ## Usage dashboard
 
@@ -24,11 +27,27 @@ The dashboard gives you a high-level view of your organization's AI spending.
 
 ### Spend over time
 
-A time-series chart showing daily or weekly spend. Use this to spot trends — increasing usage after onboarding new team members, spikes from large batch tasks, or the impact of switching to a cheaper model.
+A time-series chart of spend, viewable at **daily** or **weekly** granularity. You can break the series down by **workspace**, **model**, or **user**. Use this to spot trends — increasing usage after onboarding new team members, spikes from large batch tasks, or the impact of switching to a cheaper model.
 
-### Per-model breakdown
+### Breakdowns
 
-A breakdown table showing token consumption and cost for each model. This helps you understand which models drive the most spend and whether cheaper alternatives might work for certain use cases.
+Alongside the org-wide totals, the dashboard breaks spend down several ways for the selected period:
+
+- **By model** — which models drive the most spend, and whether cheaper alternatives might work for certain use cases.
+- **By workspace** — which teams or projects are spending the most.
+- **By user** — per-person usage.
+- **By day** — daily totals across the period.
+
+Each row shows input/output and cache token counts, the call count, and the cost.
+
+### Export
+
+You can export the raw cost data as CSV — for the whole organization or for a single workspace — to analyze it in a spreadsheet or feed it into your own reporting.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Admin > Cost dashboard showing the spend-over-time chart at the top (with the workspace/model/user dimension toggle) and a breakdown table below it.
+**Asset:** `/img/admin/cost-dashboard.png`
+:::
 
 ## Tips for managing costs
 

--- a/docs/site/docs/admin/mcp-connectors.md
+++ b/docs/site/docs/admin/mcp-connectors.md
@@ -7,56 +7,59 @@ title: MCP Connector Management
 
 MCP (Model Context Protocol) connectors let the agent call external APIs — databases, SaaS products, internal services, and more. As an admin, you manage the connector catalog, configure authentication, and control which workspaces have access.
 
-Connector management happens at **Admin > MCP** (`/admin/mcp`).
+Connector management happens at **Admin > MCP Connectors** (`/admin/mcp`).
 
 ## Key concepts
 
 | Concept | Description |
 |---|---|
-| **Template** | A connector definition that describes what the connector does, its tools, and how it authenticates. Think of it as the "app" in an app store. |
-| **Auth config** | The credentials and OAuth settings attached to a template. |
-| **Installed instance** | A template that has been activated for a specific org or workspace, with credentials configured. |
-| **Grant** | Permission for a workspace (and its members) to use an installed connector. |
+| **Template** | A catalog connector definition that describes a service, its server URL, transport, and which authentication methods it supports. Think of it as the "app" in an app store. Templates are seeded from CubeBox's built-in catalog; they carry no tenant credentials and no tool list. |
+| **Install** | A template activated for a specific org or workspace. Installing creates a concrete connector instance and triggers tool discovery against the server. |
+| **Credential** | The secret attached to an install — an API token, bearer token, or OAuth grant — stored encrypted in the credential vault. |
+| **Grant / workspace access** | Which workspaces (and their members) can use an org-wide install. Managed per-workspace on the install's **Workspaces** tab. |
 
 ## Manage the connector catalog
 
-The catalog contains all connector templates available to your organization.
+The catalog contains the connector templates available to your organization. The built-in templates (GitHub, Notion, Slack, Tavily, and the rest) ship with CubeBox and are loaded by the catalog seeder during deployment — you do not create or edit those by hand.
 
-### Add a connector template
+### Add a custom MCP server
 
-1. Go to **Admin > MCP**.
-2. Click **Add Connector**.
-3. Fill in the template definition: name, description, server URL, and available tools.
-4. Click **Save**.
+For an MCP server that is not in the built-in catalog (for example, an internal service), register it directly:
 
-### Remove a connector template
+1. Go to **Admin > MCP Connectors** (`/admin/mcp`).
+2. Click **+ Add custom connector**.
+3. Fill in the **Add custom MCP server** form:
+   - **Name** and **Server URL**.
+   - **Transport** (`streamable_http` or `sse`).
+   - **Auth method** (OAuth, API token, or no auth) and **Credential scope** (organization-shared, per user, or none).
+   - The **Credential** itself, when the auth method requires one.
+4. Optionally click **Test connection** to confirm the server reachable and see the tool count.
+5. Click **Create server**.
 
-Removing a template also removes all of its installed instances across workspaces. Confirm before proceeding.
+CubeBox does not ask you to list the server's tools — it discovers them automatically by calling the server after the install is created.
 
-## Configure authentication
+### Remove a connector
 
-Connectors authenticate with external services in different ways. You configure auth at the template level.
+Uninstalling a connector removes that install and its credentials. Built-in catalog templates cannot be deleted from the UI; if a template is dropped from the built-in catalog it is marked deprecated by the seeder so existing installs keep working while new installs are blocked.
+
+## Authentication
+
+Connectors authenticate with external services in different ways. The auth method is fixed by the template; you supply the credential when you install.
 
 ### OAuth connectors
 
-For connectors that use OAuth (e.g., GitHub, Slack, Google):
+Most OAuth connectors support **Dynamic Client Registration (DCR)** — Notion, Linear, Atlassian, Asana, Sentry, Intercom, and Cloudflare. For these, no setup is required: CubeBox registers its own OAuth client with the service automatically the first time the connector is installed, then walks the installer through the vendor's consent screen.
 
-1. Select the connector in the catalog.
-2. Open the **Auth** tab.
-3. Enter the OAuth client ID and client secret from the external service's developer console.
-4. Configure the redirect URI (CubeBox provides the expected URI).
-5. Save the configuration.
+A few OAuth connectors do **not** support DCR — **GitHub, Slack, and Google Workspace**. These require a pre-registered OAuth app:
 
-When a user installs this connector, they are guided through the OAuth authorization flow (DRC — Dynamic Registration and Consent) to grant CubeBox access.
+1. An operator registers an OAuth app in the vendor's developer console, using redirect URI `${CUBEBOX_PUBLIC_BASE_URL}/api/v1/oauth/mcp/callback`.
+2. The app's client ID and secret are placed in environment variables (`CUBEBOX_MCP_OAUTH__<SLUG>__CLIENT_ID` / `…__CLIENT_SECRET`) and loaded by the catalog seeder.
 
-### Manual token entry
+This is a deploy-time step, not something you enter in the admin UI. Until those credentials are loaded, the connector's OAuth flow cannot complete. See the operator runbook in `backend/docs/mcp_catalog_oauth.md` for details.
 
-For connectors that use API keys or bearer tokens:
+### API key / bearer token connectors
 
-1. Select the connector in the catalog.
-2. Open the **Auth** tab.
-3. Choose the auth type (API key or Bearer token).
-4. The token will be requested when the connector is installed.
+For connectors that authenticate with a static API token or bearer token (for example, the search connectors Tavily, Exa, and Jina AI), the token is requested in the install form. CubeBox encrypts it into the credential vault.
 
 ## Install connectors
 
@@ -64,29 +67,33 @@ Connectors can be installed at the **organization level** (available to all work
 
 ### Install at the org level
 
-1. Go to **Admin > MCP**.
+1. Go to **Admin > MCP Connectors** (`/admin/mcp`).
 2. Select a template from the catalog.
-3. Click **Install** and choose **Organization-wide**.
-4. Complete the auth flow if required (OAuth redirect or token entry).
-5. The connector is now available to grant to workspaces.
+3. Click **Install**. Choose the **Workspace rollout**:
+   - **Each workspace enables manually** — installs at the org level only; every workspace sees the connector but it stays disabled until each workspace turns it on.
+   - **Enable for all workspaces** — installs and enables it for every existing workspace, and auto-enables it for new workspaces created later.
+4. Complete the auth flow if required (OAuth consent or token entry).
+5. The connector is now installed org-wide; control per-workspace access on its **Workspaces** tab.
 
 ### Install at the workspace level
 
-1. Navigate to the target workspace's settings.
-2. Go to the **MCP Tools** section.
-3. Select a connector from the catalog and click **Install**.
-4. Complete the auth flow.
+Workspace-scoped installs are made by a workspace admin from the workspace **MCP** page (sidebar **MCP** item), not from the org admin area. Select a connector in the **Available** section, click **Connect**, and complete the auth flow. The install is private to that workspace.
 
 ## Grant workspace access
 
 After installing a connector at the org level, you control which workspaces can use it.
 
-1. Go to **Admin > MCP** and select the installed connector.
-2. Open the **Workspace Access** tab.
-3. Toggle access on or off for each workspace.
+1. Go to **Admin > MCP Connectors** (`/admin/mcp`) and select the installed connector.
+2. Open the **Workspaces** tab. It shows a per-workspace **Enabled / Disabled** toggle and a summary (e.g. "3 of 8 workspaces enabled").
+3. Toggle each workspace on or off.
 
-Only members of granted workspaces will see the connector's tools in their conversations.
+Only members of enabled workspaces will see the connector's tools in their conversations.
+
+:::info 📸 Screenshot placeholder
+**Capture:** An org-wide connector's detail panel with the **Workspaces** tab open, showing several workspaces with Enabled/Disabled toggles and the `<enabled> of <total> workspaces enabled` summary.
+**Asset:** `/img/mcp/admin-workspaces-tab.png`
+:::
 
 ## Revoke access
 
-To remove a workspace's access to a connector, toggle it off in the **Workspace Access** tab. Active conversations that were using the connector will no longer be able to call its tools in subsequent turns.
+To remove a workspace's access to a connector, toggle it off on the **Workspaces** tab. Conversations that were using the connector will no longer be able to call its tools in subsequent turns.

--- a/docs/site/docs/admin/members.md
+++ b/docs/site/docs/admin/members.md
@@ -9,25 +9,30 @@ CubeBox uses a two-level role system: **organization roles** control access to a
 
 Org-level member management happens at **Admin > Members** (`/admin/members`). Workspace-level roles are managed within each workspace's settings.
 
+:::info 📸 Screenshot placeholder
+**Capture:** The Admin > Members table with several members listed — show the owner row carrying an **Owner** badge (no role dropdown, no Remove button) alongside other rows that have an admin/member role dropdown and a Remove action.
+**Asset:** `/img/admin/members-table.png`
+:::
+
 ## Organization roles
 
 | Role | Capabilities |
 |---|---|
-| **Owner** | Full control. Manage providers, models, members, billing, org settings. Transfer ownership. Only one owner per org. |
-| **Admin** | Same as owner except cannot transfer ownership or remove the owner. |
+| **Owner** | Full control. Manage providers, models, members, cost tracking, and org settings. Only one owner per org. The owner's role cannot be changed and the owner cannot be removed. |
+| **Admin** | Manage providers, models, members, and other admin settings. Cannot change the owner's role or remove the owner. |
 | **Member** | Use assigned workspaces. No access to admin settings. |
 
 The role hierarchy is: **Owner > Admin > Member**. Higher roles inherit all permissions of lower roles.
 
-## Invite members
+## Add members
 
 1. Go to **Admin > Members**.
-2. Click **Invite Member**.
+2. Click **Add Member**.
 3. Enter the person's email address.
 4. Select an organization role (Admin or Member).
-5. Click **Send Invite**.
+5. Click **Add**.
 
-The invitee receives an email with a link to join your organization. If they do not already have a CubeBox account, they will create one during the sign-up flow.
+The person must already have a CubeBox account — the email is matched against existing accounts, and adding fails if no account with that email exists. Ask new teammates to sign up first, then add them to your organization. Once added, they immediately gain the access their org role grants.
 
 ## Change a member's org role
 
@@ -37,7 +42,7 @@ The invitee receives an email with a link to join your organization. If they do 
 4. Select the new role.
 
 :::note
-You cannot change the owner's role directly. To transfer ownership, the current owner must use the **Transfer Ownership** action.
+The owner's role cannot be changed from the members list — the owner appears with an **Owner** badge instead of a role dropdown, and has no **Remove** action. Each organization has exactly one owner.
 :::
 
 ## Remove a member
@@ -63,7 +68,7 @@ Workspace roles are managed from the workspace's own settings page, not the org-
 
 ### Grant someone admin access without making them org owner
 
-Assign the **Admin** org role. They gain access to all admin settings (models, members, connectors, etc.) but cannot transfer ownership.
+Assign the **Admin** org role. They gain access to all admin settings (models, members, connectors, etc.) but cannot change or remove the owner.
 
 ### Limit a member to specific workspaces
 

--- a/docs/site/docs/admin/models.md
+++ b/docs/site/docs/admin/models.md
@@ -9,6 +9,11 @@ CubeBox connects to LLM providers through API keys you configure at the organiza
 
 All model management happens at **Admin > Models** (`/admin/models`).
 
+:::info 📸 Screenshot placeholder
+**Capture:** The Admin > Models page showing the list of configured providers with their logos and connection/test status, and the models each provider exposes.
+**Asset:** `/img/admin/models-providers.png`
+:::
+
 ## Providers
 
 A provider represents an LLM API endpoint. Each provider has:
@@ -55,7 +60,7 @@ You can configure the following for each model:
 |---|---|
 | **Reasoning mode** | How the model handles extended thinking. Options vary by model: binary on/off, budget (token budget), effort level, or enum selection. |
 | **Modalities** | Input/output capabilities — text, vision, tool use, etc. |
-| **Cost rates** | Input and output token costs, used for the [Cost Tracking](./cost-tracking.md) dashboard. |
+| **Cost rates** | Per-token costs — input, output, and (where applicable) cache read / cache write — used for the [Cost Tracking](./cost-tracking.md) dashboard. |
 
 ### How models reach workspaces
 

--- a/docs/site/docs/admin/sandbox.md
+++ b/docs/site/docs/admin/sandbox.md
@@ -9,16 +9,11 @@ CubeBox executes agent-generated code in an isolated sandbox powered by OpenSand
 
 Sandbox configuration is split across two admin pages: **Admin > Sandbox** (`/admin/sandbox`) for policies and **Admin > Sandbox Environment** (`/admin/sandbox-env`) for environment variables and secrets.
 
-## Supported languages
+## What the sandbox can run
 
-The sandbox supports multiple runtimes out of the box:
+The agent runs code in the sandbox through a single shell-based `execute` tool — it issues shell commands, writes files via heredocs, and runs scripts (for example, `python script.py`). It is not tied to a fixed list of languages.
 
-- Python
-- JavaScript / TypeScript (Node.js)
-- Java
-- C# (.NET)
-- Go
-- Shell scripts (Bash)
+Which languages and tools are actually available depends on the **sandbox image** configured for your organization (the `default_image` in the sandbox policy). Whatever is installed in that image — Python, Node.js, and any other runtimes or CLI tools — is what the agent can use. To support an additional language or library, configure a sandbox image that includes it.
 
 ## Sandbox policies
 
@@ -46,9 +41,24 @@ Set the default action to **Deny**, then add allow rules for only the hosts the 
 
 This ensures the agent can install packages and call your internal API, but cannot reach anything else.
 
-### Resource limits
+:::info 📸 Screenshot placeholder
+**Capture:** The Admin > Sandbox network policy editor with the default action set to **Deny** and a few allow rules added (e.g. `pypi.org`, `registry.npmjs.org`), showing the per-rule action/target controls.
+**Asset:** `/img/admin/sandbox-network-policy.png`
+:::
 
-Sandbox policies also control resource limits such as CPU time, memory, and execution duration. These prevent runaway processes from consuming excessive resources.
+### Command rules
+
+In addition to network rules, sandbox policies can match shell commands the agent tries to run and apply one of three actions:
+
+- **Allow** — permit commands matching the pattern.
+- **Deny** — block commands matching the pattern.
+- **Confirm** — pause the agent and require a human to approve or deny the command before it runs.
+
+Use **Confirm** for sensitive operations you want a person to sign off on, and **Deny** for commands that should never run.
+
+:::note
+Each sandbox run also has an execution timeout: long-running commands are cut off automatically so a stuck process cannot hold a sandbox open indefinitely.
+:::
 
 ## Environment variables and secrets
 
@@ -58,28 +68,39 @@ You can inject environment variables and secrets into the sandbox at runtime. Th
 
 Environment variables can be scoped to three levels:
 
-| Scope | Visibility | Managed by |
+| Scope | Visibility | Managed from |
 |---|---|---|
-| **Organization** | All workspaces, all users | Org admin |
-| **Workspace** | All users within that workspace | Workspace admin |
-| **User** | Only the individual user's sandbox sessions | The user themselves |
+| **Organization** | All workspaces, all users | **Admin > Sandbox Environment** |
+| **Workspace** | All users within that workspace | The workspace's own settings |
+| **User** | Only that user's sandbox sessions within a workspace | The workspace's own settings |
 
 When the same variable name exists at multiple scopes, the narrower scope wins: User overrides Workspace, which overrides Organization.
 
-### Add an environment variable
+The **Admin > Sandbox Environment** page manages **Organization**-scope variables only — these are injected into every workspace sandbox. Workspace- and user-scope variables are added from within each workspace, not from this admin page.
+
+### Add an organization environment variable
 
 1. Go to **Admin > Sandbox Environment**.
 2. Click **Add Variable**.
 3. Enter the variable name and value.
-4. Choose the scope (Organization or Workspace).
-5. Optionally mark it as a **secret** (the value will be masked in the UI after saving).
-6. Click **Save**.
+4. To store a credential, mark it as a **secret**. Secrets are handled very differently from plain values (see [How secrets stay out of the sandbox](#how-secrets-stay-out-of-the-sandbox)) — you also specify the **allowed hosts** the secret may be sent to, and optionally which request **header names** it applies to.
+5. Click **Save**. A secret's value is encrypted and is not shown again after saving.
 
-### Security
+### How secrets stay out of the sandbox
 
-- **Secrets are encrypted at rest.** Values marked as secrets are stored encrypted in the database and are only decrypted when injected into a sandbox session.
-- **Secrets are not logged.** Sandbox execution logs redact secret values.
-- **Secrets are injected at runtime.** They exist in the sandbox process's environment only for the duration of the execution.
+For anything sensitive — API keys, tokens, database passwords — **use a secret entry**, not a plain variable. CubeBox is designed so the real secret value never lives inside the sandbox, where agent-written code (or its logs) could leak it. The two entry kinds behave differently:
+
+- **Plain variables** (not marked secret) are injected into the sandbox environment as their literal value. Use them for non-sensitive config (base URLs, region names, feature flags). Code reads them directly, and they can appear in output and logs.
+- **Secrets** are **never** injected as their real value. The sandbox instead receives an opaque **placeholder** token (e.g. `cbxref_…`). Your code uses the placeholder exactly as it would the real key — for example, putting it in an `Authorization` header. When the sandbox makes an outbound request, CubeBox's **egress proxy** substitutes the placeholder for the real secret **at the network boundary**, and only when both:
+  - the destination **host** is one you allowed for that secret, and
+  - the placeholder appears in one of the allowed **header names** (when you configured them).
+
+Consequences of this design:
+
+- **The real secret never exists inside the sandbox.** Code, files, and execution logs only ever see the placeholder — so secrets cannot end up in the agent's output or run logs.
+- **Substitution happens outside the sandbox**, inside the egress proxy, so the secret is never written to any sandbox process or log.
+- **Encrypted at rest.** The value lives in the credential vault and is only decrypted by the proxy at request time, for the verified sandbox, for an allowed host.
+- **A leaked placeholder is useless.** It resolves only for its own sandbox and its allowed hosts, and is revoked when the run ends.
 
 ### Common use cases
 

--- a/docs/site/docs/admin/skills-management.md
+++ b/docs/site/docs/admin/skills-management.md
@@ -19,24 +19,23 @@ Every skill has the following attributes:
 | **Description** | What the skill does, shown during discovery and install. |
 | **Keywords** | Tags used for search and categorization. |
 | **Version** | Semantic version string. |
-| **Source type** | Where the skill comes from: preinstalled, uploaded, or remote registry. |
+| **Source type** | Where the skill comes from: `preinstalled` or `uploaded`. Skills imported from a remote registry are stored as `uploaded` and additionally record which registry they came from. |
 
 ## Skill sources
 
-CubeBox supports three sources of skills:
+A skill's stored source is one of two values, `preinstalled` or `uploaded`:
 
-- **Preinstalled** — skills that ship with CubeBox. These are always available and cannot be removed.
-- **Uploaded** — custom skills your organization creates and uploads directly.
-- **Remote registry** — skills fetched from an external registry URL (e.g., [skills.sh](https://skills.sh)).
+- **Preinstalled** — skills that ship with CubeBox. These are available by default. An admin can uninstall a preinstalled skill for the org; CubeBox records that decision so it is not restored on the next system update.
+- **Uploaded** — custom skills your organization creates and uploads directly. Skills imported from a remote registry (e.g., [skills.sh](https://skills.sh)) are also stored as `uploaded`, with a reference back to the registry they were imported from.
 
 ## Upload a custom skill
 
 1. Go to **Admin > Skills**.
 2. Click **Upload Skill**.
-3. Provide the skill package (name, description, keywords, and skill content).
-4. Click **Save**.
+3. Select a `.zip` bundle. It must contain a `SKILL.md` at the root whose frontmatter includes `name`, `version`, and `description`. (Each file may be at most 10 MB, and the whole bundle at most 50 MB.) The skill's name, description, and keywords are read from that frontmatter.
+4. Upload it. CubeBox validates the bundle and publishes it.
 
-The skill becomes available to all workspaces in your organization. Workspace admins and members can then install it from the skill discovery interface.
+The skill is added to your organization's catalog. To make it available in every workspace, install it org-wide (see "Install and control availability" below). Workspace owners and members can also install catalog skills themselves from the skill discovery interface.
 
 ## Connect a skill registry
 
@@ -44,29 +43,31 @@ Skill registries are external servers that host collections of skills. Connectin
 
 1. Go to **Admin > Skill Registries**.
 2. Click **Add Registry**.
-3. Enter the registry URL (e.g., `https://skills.sh`).
-4. Click **Save**.
+3. Choose the **Kind**: a built-in provider (skills.sh or ClawHub) or a generic **remote** registry. For a generic remote registry, also enter its **URL** (e.g., `https://registry.example.com`); built-in providers use their known base URL automatically.
+4. Give the registry a **Name**.
+5. Set the **Trust tier** — `official`, `community`, or `untrusted`. This is the default trust level applied to skills discovered through this registry. (For skills.sh, individual skills from recognized official upstreams are promoted to `official` regardless of this default.)
+6. Click **Save**.
 
-CubeBox periodically syncs the registry to keep the skill catalog up to date.
+Once a registry is connected (and enabled), its skills surface in the discovery interface when users search. You can enable, disable, or change the trust tier of a registry later from its detail panel.
 
-## Enable and disable skills
+:::info 📸 Screenshot placeholder
+**Capture:** The Add Registry form with the Kind selector (skills.sh / ClawHub / remote), the conditional URL field shown for the remote kind, and the Trust tier picker.
+**Asset:** `/img/admin/add-skill-registry.png`
+:::
 
-You can enable or disable any non-preinstalled skill at the org level:
+## Install and control availability
 
-1. Go to **Admin > Skills**.
-2. Find the skill in the list.
-3. Toggle it **on** or **off**.
+From **Admin > Skills** you control which skills exist in your organization and how they reach workspaces:
 
-Disabling a skill removes it from the discovery interface across all workspaces. Conversations that previously used the skill will still show its historical output, but the agent will no longer invoke it.
+- **Install** a skill org-wide so it becomes available to every workspace. Each org-wide install carries an **auto-bind** setting: when on, the skill is automatically enabled in workspaces; when off, a workspace owner must turn it on per workspace. Preinstalled skills default to auto-bind on; uploaded skills default to off.
+- **Uninstall** a skill to remove it from the org. This also removes its per-workspace bindings. Uninstalling a *preinstalled* skill records a tombstone so CubeBox does not restore it on the next system update.
+
+Whether a specific workspace can use an org-installed skill is then a per-workspace toggle (managed by the workspace owner from the workspace **Skills** page, or by an admin from the skill's workspace-bindings view). Disabling a skill for a workspace hides it from the agent there; historical conversation output is unaffected.
 
 ## Manage skill versions
 
-When a new version of a skill is available (from an upload or a registry sync), you can update or roll back:
+Each upload or registry import appends a new immutable version; older versions are never modified. When a newer version exists than the one your org installed, the skill shows **update available**.
 
 1. Go to **Admin > Skills** and select the skill.
-2. View available versions.
-3. Select the version you want active.
-
-### Deprecate a skill
-
-If a skill is no longer recommended, you can mark it as deprecated. Deprecated skills remain functional for existing installs but are hidden from discovery. This gives workspace users time to migrate before you fully disable it.
+2. Review the available versions in the detail panel.
+3. Install the version you want your org to use. Installing the latest picks up the update; installing an earlier version pins the org to it.

--- a/docs/site/docs/getting-started/core-concepts.md
+++ b/docs/site/docs/getting-started/core-concepts.md
@@ -43,7 +43,7 @@ Skills are packaged capabilities you install to extend what the agent can do. Th
 - **Org-uploaded** — your organization creates and shares custom skills.
 - **Remote registries** — community skills hosted on registries like [skills.sh](https://skills.sh).
 
-You discover and install skills from within a conversation or from the workspace settings page. Once installed, the agent can use a skill whenever it is relevant to the conversation.
+You discover and install skills from within a conversation or from the **Skills** page in the workspace sidebar. Once installed, the agent can use a skill whenever it is relevant to the conversation.
 
 See the [Skills guide](../guides/skills/overview.md) for details.
 
@@ -83,9 +83,9 @@ Model Context Protocol (MCP) connectors let the agent call external APIs — dat
 
 **Authentication modes:**
 
-- **API key** — you provide a static key.
+- **Static credential** — you provide a fixed secret (an API key or bearer token), sent as an `Authorization` header, a custom header, or a query parameter depending on the connector.
 - **OAuth** — the connector walks you through an OAuth flow.
-- **Bearer token** — a pre-issued token.
+- **None** — the connector needs no credential.
 
 See the [MCP Tools guide](../guides/mcp/overview.md) for details.
 

--- a/docs/site/docs/getting-started/quick-start.md
+++ b/docs/site/docs/getting-started/quick-start.md
@@ -23,8 +23,8 @@ Get from zero to your first AI conversation in a few minutes.
 <TabItem value="self-hosted" label="Self-hosted">
 
 1. Open the CubeBox URL your administrator provided.
-2. If you are the **first user**, you will create the organization and become its owner.
-3. Otherwise, register with an invite link or sign up and wait for an admin to approve your membership.
+2. If you are the **first user**, registration takes you to a one-time **setup** screen where you name the organization and choose a slug. You become its owner.
+3. Otherwise, register normally — you join the existing organization as a member and land in your own personal workspace.
 
 </TabItem>
 </Tabs>
@@ -33,7 +33,7 @@ Get from zero to your first AI conversation in a few minutes.
 
 Before chatting, make sure at least one AI model is available.
 
-- **Org owners/admins**: Go to **Settings > Models** and add a provider (e.g., Anthropic, OpenAI) with your API key. Then enable the models you want your team to use.
+- **Org owners/admins**: Open the **Admin** area and go to **Models > Model Providers**. Add a provider (e.g., Anthropic, OpenAI) with your API key, then enable the models you want your team to use.
 - **Members**: You will see whichever models your admin has enabled. No setup needed.
 
 ## 3. Start a conversation
@@ -43,6 +43,11 @@ Before chatting, make sure at least one AI model is available.
 3. Type a message and press **Send**.
 
 The agent responds with text, and may also produce tool calls, code execution results, or artifacts depending on the model and available tools.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The chat view mid-conversation — show the model selector on the chat input, the attachment icon, and a streaming agent response.
+**Asset:** `/img/getting-started/first-conversation.png`
+:::
 
 ### Try attaching a file
 

--- a/docs/site/docs/getting-started/workspace-setup.md
+++ b/docs/site/docs/getting-started/workspace-setup.md
@@ -17,16 +17,14 @@ A workspace is where your team collaborates with AI. This guide walks you throug
 
 ## Create a workspace
 
-1. Open the **organization settings** from the sidebar menu.
-2. Go to the **Workspaces** tab.
-3. Click **Create workspace**.
-4. Enter a name and optional description, then confirm.
+1. Open the **workspace switcher** at the top of the sidebar and click **New workspace** (this opens the **Workspaces** page).
+2. Fill in the **Create workspace** form with a name and confirm.
 
 You are automatically assigned the **workspace admin** role in the new workspace.
 
 ## Invite members
 
-1. Navigate to your workspace, then open **Workspace Settings > Members**.
+1. Navigate to your workspace, open **Settings** in the sidebar, then select the **Members** tab.
 2. Click **Invite member**.
 3. Enter the user's email address and choose a role:
    - **Admin** — can manage workspace settings, tools, skills, and members.
@@ -52,19 +50,24 @@ Click the invite link, or ask your admin to add you directly from the workspace 
 
 Before your team can chat, at least one AI model must be enabled at the organization level.
 
-1. Go to **Organization Settings > Models**.
+1. Open the **Admin** area from the avatar menu (**Admin panel**), then go to **Models > Model Providers**.
 2. Add a provider (Anthropic, OpenAI, or a custom endpoint) and enter your API key.
 3. Enable the specific models you want available.
 
-Models enabled at the org level are available across all workspaces. Workspace admins can further restrict which models appear in their workspace from **Workspace Settings > Models**.
+Models enabled at the org level are available across all workspaces.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Admin **Models > Model Providers** page with a provider being added — show the provider type selector, the API-key field, and the per-model enable toggles.
+**Asset:** `/img/admin/model-providers.png`
+:::
 
 ## Install MCP tools
 
 MCP connectors let the agent interact with external services.
 
-1. Go to **Workspace Settings > MCP Tools**.
+1. Open the **MCP** page from the workspace sidebar.
 2. Browse the connector catalog and click **Install** on the one you want.
-3. Provide authentication credentials (API key, OAuth, or bearer token depending on the connector).
+3. Provide authentication credentials (a static credential, OAuth, or none, depending on the connector).
 4. Choose which workspace members should have access via **Grants**.
 
 Once installed and granted, the tools are available to the agent in conversations. See the [MCP Tools guide](../guides/mcp/overview.md) for a full walkthrough.
@@ -73,7 +76,7 @@ Once installed and granted, the tools are available to the agent in conversation
 
 Skills extend what the agent can do. To add skills to your workspace:
 
-1. Go to **Workspace Settings > Skills**, or use the `/` command inside a conversation to discover skills.
+1. Open the **Skills** page from the workspace sidebar, or use the `/` command inside a conversation to discover skills.
 2. Browse built-in skills, org-uploaded skills, or remote registries.
 3. Click **Install** to make a skill available in the workspace.
 
@@ -83,8 +86,8 @@ See the [Skills guide](../guides/skills/overview.md) for details.
 
 If you want the agent to run tasks on a schedule or in response to events:
 
-1. Go to **Workspace Settings > Automation**.
-2. Create a **scheduled task** (cron, interval, or one-shot) or an **event trigger** (webhook URL that starts an agent run).
+1. Open the **Scheduled Tasks** page (for cron, interval, or one-shot runs) or the **Triggers** page (for webhook URLs that start an agent run) from the workspace sidebar.
+2. Create a scheduled task or an event trigger.
 3. Configure the prompt, model, and any tools the automated run should use.
 
 See the [Automation guides](../guides/automation/scheduled-tasks.md) for details.

--- a/docs/site/docs/guides/automation/event-triggers.md
+++ b/docs/site/docs/guides/automation/event-triggers.md
@@ -5,14 +5,18 @@ title: Event Triggers
 
 # Event Triggers
 
-Event triggers start agent runs when external events occur. You create a trigger, CubeBox gives you a webhook URL, and any service that can send HTTP webhooks (GitHub, Slack, Stripe, your own backend) can fire it.
+Event triggers start agent runs when external events occur. You create a trigger, CubeBox gives you a webhook URL and a signing secret, and any service that can send an HMAC-signed HTTP POST can fire it.
+
+:::caution The generic webhook uses CubeBox's own signing scheme
+CubeBox does **not** natively accept a third-party provider's signature format (such as GitHub's `X-Hub-Signature-256` or a Stripe `Stripe-Signature`). The inbound request must be signed the way CubeBox expects: an `X-Signature` header over `"{timestamp}." + body`, plus an `X-Timestamp` header (see [Webhook URL and signing](#webhook-url-and-signing)). In practice the sender is **your own backend** or a small relay you control that re-signs the payload. A service whose signature format you can't change (raw GitHub, raw Stripe) cannot fire the trigger directly today.
+:::
 
 ## How it works
 
 1. You create a trigger in CubeBox and define what should happen when an event arrives.
-2. CubeBox generates a **webhook URL** and an **HMAC secret**.
-3. You configure the external service to send webhooks to that URL, using the HMAC secret for signature verification.
-4. When an event hits the webhook, CubeBox verifies the signature, applies your filter conditions, and starts an agent run with the event payload as context.
+2. CubeBox generates a **webhook URL** and an **HMAC signing secret**.
+3. Your sender signs each request with that secret using CubeBox's scheme and POSTs it to the URL.
+4. When a request arrives, CubeBox verifies the signature and timestamp, applies your filter conditions, and starts an agent run with the event payload as context.
 
 ## Creating a trigger
 
@@ -27,19 +31,47 @@ Navigate to your workspace, open **Triggers** from the sidebar, and click **New 
 | **Target conversation** | Where the agent run happens. Same options as [scheduled tasks](./scheduled-tasks.md#conversation-options): fixed conversation or new conversation per event. |
 | **Run identity** | Which user the agent run executes as. This controls the agent's permissions and tool access. |
 
-After saving, CubeBox displays the **webhook URL** and **HMAC secret**. Copy both -- you will need them when configuring the external service.
+After saving, CubeBox displays the **webhook URL** and the **signing secret**. Copy both — you will need them when configuring your sender.
 
-## Webhook URL and HMAC verification
+:::info 📸 Screenshot placeholder
+**Capture:** The trigger detail panel right after creation, showing the generated webhook URL and the (revealed) signing secret with their copy buttons.
+**Asset:** `/img/automation/trigger-webhook-url-secret.png`
+:::
 
-The webhook URL is a public endpoint (no authentication token in the URL), but every request must include an HMAC signature computed from the request body and the shared secret.
+## Webhook URL and signing
 
-CubeBox verifies the signature on every inbound request. If the signature is missing or invalid, the request is rejected with a `401` response. This ensures that only the service holding your HMAC secret can trigger agent runs.
+The webhook URL is workspace- and trigger-scoped:
 
-**How to configure your external service:**
+```
+POST https://<your-cubebox-host>/api/v1/ws/<workspace_id>/triggers/<trigger_id>/ingest
+```
 
-Most webhook-capable services (GitHub, Stripe, etc.) have a "secret" field in their webhook settings. Paste the HMAC secret there. The service will include the signature in a header (e.g., `X-Hub-Signature-256` for GitHub), and CubeBox validates it automatically.
+Copy the exact URL CubeBox shows you — it already contains the right workspace and trigger IDs.
 
-For custom integrations, compute the HMAC-SHA256 of the raw request body using the secret, and send it in the `X-Webhook-Signature` header.
+### Required headers
+
+Every request must carry these headers (names are the defaults; a trigger's source config can override them):
+
+| Header | Required | Value |
+|---|---|---|
+| `X-Signature` | Yes | Hex HMAC-SHA256 of the signed message (below), keyed by the signing secret. |
+| `X-Timestamp` | Yes | The Unix epoch **seconds** used in the signature. Must be within **5 minutes** of server time, or the request is rejected. |
+| `X-Event-Id` | No | A stable per-event ID used for deduplication. If your sender retries, send the same value so CubeBox processes the event once. |
+
+### How to sign
+
+The signed message is the timestamp and the raw body joined by a literal dot:
+
+```
+message   = "<timestamp>." + <raw request body bytes>
+signature = hex( HMAC_SHA256(signing_secret, message) )
+```
+
+Send `signature` in `X-Signature` and the same `<timestamp>` in `X-Timestamp`.
+
+### What gets rejected
+
+CubeBox returns an opaque **`404 {"error":"not_found"}`** for *every* rejection — unknown workspace/trigger, missing `X-Signature` or `X-Timestamp`, bad signature, a timestamp outside the 5-minute window, or an oversized body (2 MiB cap). The 404 is deliberate: it does not reveal whether the trigger exists. A rejected request never reaches the [event log](#event-log) because rejection happens before any event row is created. A successful request returns `202 {"status":"accepted","event_id":"..."}`.
 
 ## Filtering events
 
@@ -53,7 +85,7 @@ Not every webhook delivery should trigger an agent run. Filter conditions let yo
 | `event.repository.full_name == "acme/api"` | Only fire for events from a specific repository. |
 | `event.pull_request.draft == false` | Ignore draft pull requests. |
 
-You can combine multiple conditions -- all conditions must match for the trigger to fire (AND logic).
+You can combine multiple conditions — all conditions must match for the trigger to fire (AND logic).
 
 If no filter conditions are set, every valid webhook delivery fires the trigger.
 
@@ -61,26 +93,36 @@ If no filter conditions are set, every valid webhook delivery fires the trigger.
 
 CubeBox protects against accidental floods and duplicate deliveries:
 
-- **Rate limiting** -- if a trigger receives events faster than the agent can process them, excess events are queued and processed in order. Sustained excessive volume is throttled.
-- **Deduplication** -- if the same event is delivered multiple times (common with webhook retry mechanisms), CubeBox detects the duplicate and processes it only once.
-- **Retry with backoff** -- if an agent run fails (e.g., transient model error), CubeBox retries the run with exponential backoff before marking it as failed.
+- **Rate limiting** — if a trigger receives events faster than the agent can process them, excess events are queued and processed in order. Sustained excessive volume is throttled.
+- **Deduplication** — if the same event is delivered multiple times (common with webhook retry mechanisms), CubeBox detects the duplicate and processes it only once.
+- **Retry with backoff** — if an agent run fails (e.g., transient model error), CubeBox retries the run with exponential backoff before marking it as failed.
 
 ## Event log
 
-Each trigger has an event log that shows all received webhook deliveries and their processing status:
+Each trigger has an event log that shows every delivery that **passed signature and timestamp verification**, along with its outcome:
 
-| Status | Meaning |
+| Outcome | Meaning |
 |---|---|
-| **Processed** | Event matched filters, agent run completed successfully. |
-| **Filtered** | Event was received but did not match filter conditions. No agent run started. |
-| **Failed** | Agent run started but failed. Check the linked conversation for details. |
-| **Rejected** | Signature verification failed. The request was not processed. |
+| **Accepted / processed** | Event matched filters and an agent run was started. |
+| **Filtered out** | Event was received but did not match filter conditions. No agent run started. |
+| **Duplicate** | The event's `X-Event-Id` (or body hash) was already seen. Processed once; the retry was dropped. |
+| **Rate limited** | The trigger exceeded its per-minute rate; the event was dropped. |
+| **Failed** | An agent run started but failed. Check the linked conversation for details. |
+
+:::note Signature failures are not logged
+Requests with a missing/invalid signature or a stale timestamp are rejected with a `404` **before** any event row is created, so they never appear in the event log. If you expect a delivery and see nothing here, suspect the signature or timestamp — not a filter.
+:::
 
 Use the event log to verify that your webhook integration is working, debug filter conditions, and monitor trigger health.
 
+:::info 📸 Screenshot placeholder
+**Capture:** A trigger's event log with a mix of outcomes (one accepted, one filtered out, one duplicate), each row expandable to show the payload.
+**Asset:** `/img/automation/trigger-event-log.png`
+:::
+
 ## Example: GitHub issue triage
 
-**Goal:** When a new issue is opened in your repository, the agent automatically triages it -- adds labels, assigns a priority, and posts a summary comment.
+**Goal:** When a new issue is opened in your repository, the agent automatically triages it — adds labels, assigns a priority, and posts a summary comment.
 
 1. Go to **Triggers** and click **New Trigger**.
 2. Name it "GitHub issue triage".
@@ -89,13 +131,13 @@ Use the event log to verify that your webhook integration is working, debug filt
 5. Set the prompt:
    > A new GitHub issue was just opened. Read the issue title and body from the event payload. Based on the content, assign appropriate labels (bug, feature, docs, etc.), estimate priority (P0-P3), and post a triage comment on the issue summarizing your assessment and suggested next steps.
 6. Choose **new conversation per event** so each issue gets its own clean context.
-7. Save and copy the webhook URL and HMAC secret.
-8. In your GitHub repository, go to **Settings > Webhooks > Add webhook**:
-   - Paste the webhook URL.
-   - Set content type to `application/json`.
-   - Paste the HMAC secret.
-   - Select "Issues" under events.
-9. Save the webhook. The next time someone opens an issue, CubeBox receives the event and the agent triages it.
+7. Save and copy the webhook URL and signing secret.
+8. Stand up a small **relay** that GitHub can call and that re-signs for CubeBox (GitHub's own signature is not accepted directly — see the caution at the top):
+   - Point a GitHub webhook (**Settings > Webhooks**, content type `application/json`, events: "Issues") at your relay.
+   - In the relay, verify GitHub's `X-Hub-Signature-256` if you wish, then forward the JSON body to the CubeBox webhook URL, signing it with CubeBox's scheme: set `X-Timestamp` to the current epoch seconds and `X-Signature` to the HMAC of `"<timestamp>." + body`.
+9. Now when someone opens an issue, GitHub calls your relay, the relay forwards a properly signed request to CubeBox, and the agent triages the issue.
+
+> **No relay yet?** Use the [`curl` recipe](#tips) below to fire the trigger by hand with a sample issue payload and confirm the prompt behaves before wiring up delivery.
 
 ## Example: Slack alert escalation
 
@@ -106,18 +148,24 @@ Use the event log to verify that your webhook integration is working, debug filt
 3. Set the prompt:
    > A critical alert was triggered. Investigate the alert details from the event payload, check relevant logs and metrics if tools are available, and provide a preliminary root cause analysis with recommended next steps.
 4. Choose a **fixed conversation** so the agent can correlate across multiple alerts.
-5. Configure your monitoring system to send webhooks to the trigger URL when critical alerts fire.
+5. Configure your monitoring system (or a relay in front of it) to POST the alert payload to the trigger URL, signed with CubeBox's scheme (`X-Timestamp` + `X-Signature` over `"<timestamp>." + body`). Many alerting tools let you set custom headers and a signing secret on outbound webhooks; if yours signs with a fixed scheme you can't change, put a small relay in between.
 
 ## Tips
 
-- **Keep the HMAC secret secure.** Treat it like a password. If compromised, delete the trigger and create a new one.
+- **Keep the signing secret secure.** Treat it like a password. If compromised, rotate it (or delete the trigger and create a new one).
 - **Use filters to reduce noise.** Broad triggers (no filters) on high-volume webhooks will generate many agent runs and consume model tokens quickly.
-- **Test with a manual webhook.** Before connecting a live service, send a test payload with `curl` to verify your trigger and filters work:
+- **Test with a manual webhook.** Before wiring up a live sender, fire the trigger with `curl` to verify your prompt and filters. Sign `"<timestamp>." + body` and send both headers — note the signed body must be byte-for-byte the body you POST:
   ```bash
-  curl -X POST https://your-cubebox-instance/api/v1/webhooks/trg_abc123 \
+  TS=$(date +%s)
+  BODY='{"event_type":"test","action":"opened"}'
+  SIG=$(printf '%s.%s' "$TS" "$BODY" \
+    | openssl dgst -sha256 -hmac 'your-signing-secret' | sed 's/^.* //')
+  curl -X POST "https://<your-cubebox-host>/api/v1/ws/<workspace_id>/triggers/<trigger_id>/ingest" \
     -H "Content-Type: application/json" \
-    -H "X-Webhook-Signature: $(echo -n '{"test": true}' | openssl dgst -sha256 -hmac 'your-secret' | cut -d' ' -f2)" \
-    -d '{"test": true}'
+    -H "X-Timestamp: $TS" \
+    -H "X-Signature: $SIG" \
+    -d "$BODY"
   ```
+  A valid request returns `202` with an `event_id`; any signing or timestamp mistake returns `404`.
 - **Monitor the event log.** Check the event log after connecting a new service to verify events are arriving and being processed as expected.
 - **Choose the right conversation strategy.** Use new conversations for independent events (issue triage). Use a fixed conversation when correlation across events matters (alert investigation).

--- a/docs/site/docs/guides/automation/scheduled-tasks.md
+++ b/docs/site/docs/guides/automation/scheduled-tasks.md
@@ -5,104 +5,126 @@ title: Scheduled Tasks
 
 # Scheduled Tasks
 
-Scheduled tasks let you run agent prompts automatically on a recurring or one-time basis -- no manual interaction needed. Each fire creates a normal agent run in the target conversation, attributed to the task owner.
+Scheduled tasks let you run agent prompts automatically on a recurring or one-time basis — no manual interaction needed. Each fire creates a normal agent run in the target conversation, attributed to the task owner.
 
 ## Creating a scheduled task
 
-Navigate to your workspace and open **Scheduled Tasks** from the sidebar. Click **New Task** and fill in:
+Open your workspace and go to **Scheduled Tasks** from the sidebar. Click **New task** and fill in:
 
 | Field | Description |
 |---|---|
-| **Name** | A descriptive label (e.g., "Weekly issue digest"). |
-| **Schedule** | When the task fires. See [schedule types](#schedule-types) below. |
+| **Name** | A descriptive label (e.g., "Daily digest"). |
 | **Prompt** | The message sent to the agent on each fire (e.g., "Summarize all GitHub issues opened this week"). |
-| **Conversation** | Which conversation to run in. See [conversation options](#conversation-options) below. |
+| **Schedule** | How often the task fires. See [schedule types](#schedule-types) below. |
+| **Conversation target** | Which conversation each fire runs in. See [conversation options](#conversation-options) below. |
+
+:::info 📸 Screenshot placeholder
+**Capture:** The "New scheduled task" dialog with name, prompt, the frequency pills (Daily / Weekly / Monthly / Every… / Once), and the conversation target radio group all visible.
+**Asset:** `/img/scheduled-tasks/new-task-dialog.png`
+:::
 
 ## Schedule types
 
-CubeBox supports three schedule kinds:
+The schedule editor is a visual builder. Pick a **frequency**, then fill in the matching details:
 
-### Cron expression
+### Daily, weekly, monthly
 
-Standard five-field cron syntax. Use this for precise recurring schedules.
+Run at a fixed time of day, on a recurring calendar pattern:
 
-| Expression | Meaning |
-|---|---|
-| `0 9 * * 1-5` | Every weekday at 9:00 AM |
-| `0 0 1 * *` | First day of each month at midnight |
-| `*/15 * * * *` | Every 15 minutes |
-| `0 18 * * 5` | Every Friday at 6:00 PM |
+- **Daily** — every day at a chosen time (e.g., 09:00).
+- **Weekly** — at a chosen time on one or more selected weekdays.
+- **Monthly** — at a chosen time on a specific day of the month. Days 1–28 are offered to avoid skipping short months, plus a **Last day of month** option that adapts to each month's length.
 
-### Fixed interval
+Each of these sets a **Run time** and a **timezone** (defaulted to your browser's timezone, editable). Internally these are stored as cron expressions, but you configure them through the visual controls — you never have to write cron by hand.
 
-Run every N minutes or hours. Simpler than cron when you just need a regular cadence.
+### Every… (fixed interval)
+
+Run every N minutes, hours, or days. Simpler than a calendar pattern when you just need a regular cadence.
 
 **Examples:** every 30 minutes, every 2 hours, every 6 hours.
 
-The first fire happens one interval after you create (or resume) the task.
+The minimum interval is 60 seconds. The first fire happens one interval after you create (or resume) the task.
 
-### One-shot
+### Once
 
-Run once at a specific future date and time. The task moves to a completed state after it fires.
+Run a single time at a specific future date and time. After it fires, the task has no upcoming run.
 
-**Example:** "Run at 2025-03-15 14:00 UTC" to generate a quarterly report on a specific date.
+**Example:** "Run on 2025-03-15 at 14:00" to generate a quarterly report on a specific date.
+
+### End date
+
+For recurring schedules (everything except **Once**), you can set an optional **End date** after which the task stops firing automatically. If unset, the task runs indefinitely.
 
 ## Conversation options
 
-You control where each fire's agent run happens:
+You control where each fire's agent run happens with the **Conversation target**:
 
-- **Fixed conversation** -- every fire runs in the same conversation. Context accumulates across fires, so the agent can reference previous runs. Good for rolling summaries or monitoring tasks.
-- **New conversation per fire** -- each fire creates a fresh conversation. The agent starts with no prior context. Good for independent tasks like one-off reports.
+- **New conversation each run** — each fire creates a fresh conversation. The agent starts with no prior context. Good for independent tasks like one-off reports. You can optionally pick a **Topic** to group these conversations together; new conversations inherit the topic's members and sandbox.
+- **This conversation (fixed)** — every fire runs in one existing conversation you own. Context accumulates across fires, so the agent can reference previous runs. Good for rolling summaries or monitoring tasks.
+
+A third mode, **IM channel**, posts results into a chat on a linked IM platform. This mode can't be selected here — it's created only from IM, by using a slash command inside the chat. See the IM integration guide for details.
+
+The conversation target is fixed at creation time. You can still edit the name, prompt, and schedule afterward, but to change the destination you delete and recreate the task.
 
 ## Pause, resume, and missed runs
 
-You can **pause** a task at any time. While paused, no fires occur. Click **Resume** to reactivate it.
+You can **pause** a task at any time from its detail panel or card menu. While paused, no fires occur and the status shows **Paused**. Click **Resume** to reactivate it.
 
-When a task is paused (or the system is temporarily unavailable) and one or more scheduled fires are missed, the **missed-run policy** determines what happens on resume:
+When a task can't fire on time — because it was paused, or the scheduler was temporarily unavailable — missed occurrences are handled automatically; there is no per-task policy to configure:
 
-| Policy | Behavior |
-|---|---|
-| **Skip** | Discard all missed fires. The next fire happens at the next scheduled time. |
-| **Run latest** | Execute the most recent missed fire immediately, then resume the normal schedule. Earlier missed fires are discarded. |
+- **Only the latest missed occurrence catches up.** On resume (or when the scheduler recovers), the task runs the most recent occurrence that was due, then continues on its normal schedule. Any earlier missed occurrences are recorded as **Skipped (missed)** rather than replayed, so a task that was down for a week doesn't suddenly fire seven backlogged runs.
+- **Stale occurrences are skipped entirely.** If even the latest due occurrence is older than a short grace window, it is also recorded as **Skipped (missed)** and not run. This prevents a long-paused task from firing a run that is no longer timely.
 
 ## Run history
 
-Every fire is recorded in the task's run history. Each entry shows:
+Every occurrence is recorded in the task's run history, shown in the task detail panel. Each entry shows:
 
-- **Scheduled time** -- when the fire was supposed to happen.
-- **Actual time** -- when the fire actually started.
-- **Run ID** -- links to the agent run in the target conversation.
-- **Outcome** -- success, failure, or skipped.
+- **Scheduled time** — when the occurrence was due to fire.
+- **State** — one of:
+  - **Claimed** — the occurrence was picked up and is about to start.
+  - **Running** — the agent run is in progress.
+  - **Succeeded** — the run completed.
+  - **Failed** — the run errored.
+  - **Skipped (missed)** — the occurrence was missed and not run (see [missed runs](#pause-resume-and-missed-runs)).
+  - **Skipped (busy)** — the conversation was busy and the occurrence exhausted its retries.
+- **Retry info** — if the occurrence was retried, the retry count and the next retry time.
+- **View conversation** — a link to the agent run's conversation, when one was created.
 
-Use run history to audit what the agent did and when, or to debug tasks that are not behaving as expected.
+The panel refreshes automatically every few seconds, and a **Refresh** button forces an immediate reload. Use run history to audit what the agent did and when, or to debug tasks that are not behaving as expected.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The task detail panel showing the schedule summary, next-run line, Pause/Resume controls, and the run-history list with a mix of Succeeded and Skipped (missed) state badges.
+**Asset:** `/img/scheduled-tasks/run-history.png`
+:::
 
 ## Example: weekly issue digest
 
-**Goal:** Every Monday at 9 AM, summarize last week's GitHub issues in the #engineering workspace.
+**Goal:** Every Monday at 9 AM, summarize last week's GitHub issues.
 
-1. Go to **Scheduled Tasks** and click **New Task**.
+1. Go to **Scheduled Tasks** and click **New task**.
 2. Name it "Weekly GitHub issue digest".
-3. Set the schedule to **Cron expression**: `0 9 * * 1`.
-4. Set the prompt:
+3. Set the prompt:
    > Summarize all GitHub issues opened in the last 7 days. Group by repository, highlight any critical or blocking issues, and note issues that have been open for more than 3 days without a response.
-5. Choose a **fixed conversation** so the agent can reference previous weeks' summaries.
-6. Set missed-run policy to **Run latest** so you still get a summary if Monday is a holiday.
-7. Save and the task starts on the next Monday at 9 AM.
+4. Set the frequency to **Weekly**, select **Mon**, and set the run time to **09:00** in your timezone.
+5. Choose **This conversation** so the agent can reference previous weeks' summaries.
+6. Click **Create task**. The task starts on the next Monday at 9 AM.
 
-## Example: daily database health check
+## Example: database health check
 
 **Goal:** Every 6 hours, run a health check on your production database.
 
 1. Create a new task named "DB health check".
-2. Set the schedule to **Fixed interval**: every 6 hours.
-3. Set the prompt:
+2. Set the prompt:
    > Check the database connection pool usage, slow query log from the last 6 hours, and table sizes. Flag anything unusual.
-4. Choose a **fixed conversation** so trends are visible across runs.
-5. Set missed-run policy to **Skip** -- if a check is missed, the next one will catch any issues.
+3. Set the frequency to **Every…** and choose **6 hours**.
+4. Choose **This conversation** so trends are visible across runs.
+5. Click **Create task**.
+
+If a check is ever missed, the task automatically picks up at the next due interval — only the most recent missed occurrence catches up, so you won't get a burst of stale checks.
 
 ## Tips
 
 - **Keep prompts specific.** The agent has no memory of why the task exists beyond what you write in the prompt. Include context about what to check, where to report, and what format to use.
-- **Use fixed conversations for continuity.** When the agent can see its own previous runs, it can track trends and flag changes ("disk usage grew 12% since last check").
-- **Use new conversations for isolation.** When each run is independent and you do not want accumulated context to influence the agent's behavior.
+- **Use a fixed conversation for continuity.** When the agent can see its own previous runs, it can track trends and flag changes ("disk usage grew 12% since last check").
+- **Use new conversations for isolation.** When each run is independent and you do not want accumulated context to influence the agent's behavior. Add a topic to keep those conversations grouped.
 - **Start with a manual test.** Before scheduling, paste your prompt into a regular conversation to verify the agent produces the output you expect.

--- a/docs/site/docs/guides/conversations/artifacts.md
+++ b/docs/site/docs/guides/conversations/artifacts.md
@@ -5,18 +5,24 @@ title: Artifacts
 
 # Artifacts
 
-Artifacts are deliverables the agent produces during a conversation -- files, websites, images, code, data, and more. Unlike plain-text responses, artifacts are versioned, previewable, and downloadable.
+Artifacts are deliverables the agent produces during a conversation — files, websites, images, code, data, and more. Unlike plain-text responses, artifacts are versioned, previewable, and downloadable.
 
 ## How artifacts are created
 
-You do not create artifacts directly. The agent creates them by calling the `save_artifact` tool after producing a file or set of files. This happens naturally when you ask the agent to build something concrete:
+You do not create artifacts directly. The agent creates them by calling one of two tools:
+
+- **`save_artifact`** — registers a file or set of files the agent wrote (a website, document, code project, data file, or skill bundle) as an artifact.
+- **`generate_image`** — produces an image artifact directly from a prompt.
+
+This happens naturally when you ask the agent to build something concrete:
 
 - "Build me a landing page"
 - "Generate a bar chart from this CSV"
 - "Write a Python script that processes these logs"
 - "Create a project proposal document"
+- "Draw an illustration of a mountain at sunset"
 
-The agent writes the files (using code execution in the sandbox), then registers them as an artifact so they appear in your conversation.
+For `save_artifact`, the agent writes the files (using code execution in the sandbox), then registers them as an artifact so they appear in your conversation.
 
 ## Artifact types
 
@@ -39,7 +45,12 @@ When the agent creates an artifact, an **artifact card** appears inline in the c
 - A version badge (for artifacts with multiple versions).
 - **Preview** (eye icon) and **Download** buttons.
 
-Clicking the card (or the preview button) opens the **artifact panel** on the right side of the screen. The panel renders a live preview based on the artifact type -- websites run in a sandboxed iframe, images display at full resolution, code gets syntax highlighting, and so on.
+Clicking the card (or the preview button) opens the **artifact panel** on the right side of the screen. The panel renders a live preview based on the artifact type — websites run in a sandboxed iframe, images display at full resolution, code gets syntax highlighting, and so on.
+
+:::info 📸 Screenshot placeholder
+**Capture:** An artifact card inline in the chat with the artifact panel open on the right, showing a live website preview and the version badge expanded into the version dropdown.
+**Asset:** `/img/conversations/artifact-panel.png`
+:::
 
 ### Artifact gallery
 
@@ -62,7 +73,7 @@ For multi-file artifacts (like a website with HTML, CSS, and JS files), the down
 
 ## Skill artifacts
 
-When the agent creates a skill (via the skill-creator workflow), the artifact type is **skill**. Skill artifacts have a special action: **Add to Workspace**. Clicking this publishes the skill to your workspace so it becomes available in future conversations.
+When the agent creates a skill (via the skill-creator workflow), the artifact type is **skill**. Skill artifacts have a special action: **Add to workspace**. Clicking this publishes the skill to your workspace so it becomes available in future conversations (the agent can load it via `load_skill`). The version comes from the `version` field in the skill's `SKILL.md` frontmatter; to update a published skill, bump that version and add it again.
 
 ## Tips
 

--- a/docs/site/docs/guides/conversations/attachments.md
+++ b/docs/site/docs/guides/conversations/attachments.md
@@ -28,7 +28,7 @@ The exact set of allowed MIME types is configured by your org admin. If you try 
 3. The files appear as chips above the input area while they upload.
 4. Type your message (optional) and press **Enter** to send.
 
-You can attach multiple files to a single message.
+You can attach multiple files to a single message, up to the per-message cap (see [Size and quota limits](#size-and-quota-limits)).
 
 ### Drag and drop
 
@@ -60,9 +60,10 @@ Sent attachments appear above the message bubble:
 | Limit | Default |
 |---|---|
 | **Max file size** | 50 MB per file |
+| **Max files per message** | 10 attachments referenced in a single message |
 | **Max per conversation** | 500 MB total across all attachments |
 
-These limits are configurable by the org admin. If you exceed the per-file limit, the upload is rejected. If you exceed the per-conversation quota, you need to start a new conversation or ask an admin to adjust the limit.
+These limits are configurable by the org admin. If you exceed the per-file limit, the upload is rejected. If you attach more than the per-message cap, sending the message is rejected — split the files across multiple messages. If you exceed the per-conversation quota, you need to start a new conversation or ask an admin to adjust the limit.
 
 ## Tips
 

--- a/docs/site/docs/guides/conversations/basics.md
+++ b/docs/site/docs/guides/conversations/basics.md
@@ -17,35 +17,40 @@ You can also click **New Chat** in the sidebar to start fresh at any time.
 
 The layout has three main areas:
 
-- **Sidebar** (left) -- lists your recent conversations, workspace navigation (skills, tools, memory, settings), and workspace switcher.
-- **Chat area** (center) -- the message thread and input bar.
-- **Side panel** (right, opens on demand) -- previews artifacts, attachment images, tool call details, or the sandbox browser.
+- **Sidebar** (left) — lists your recent conversations, workspace navigation (skills, tools, memory, settings), and workspace switcher.
+- **Chat area** (center) — the message thread and input bar.
+- **Side panel** (right, opens on demand) — previews artifacts, attachment images, tool call details, or the sandbox browser.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The full conversation view with the three areas labeled — sidebar (left), chat thread (center), and the side panel open on the right showing an artifact preview.
+**Asset:** `/img/conversations/conversation-layout.png`
+:::
 
 The input bar sits at the bottom. It includes:
 
-- **Model preset picker** -- choose which model to use for this message.
-- **Thinking control** -- set the reasoning depth (off, low, medium, high, extra-high).
-- **Attach button** (paperclip icon) -- add files to your message.
-- **Text area** -- type your message. Press **Enter** to send, **Shift+Enter** for a new line.
-- **Send / Stop button** -- sends the message, or stops a running response.
+- **Model preset picker** — choose which model to use for this message.
+- **Thinking control** — set the reasoning depth (Off, Low, Medium, High, Extra High).
+- **Attach button** (paperclip icon) — add files to your message.
+- **Text area** — type your message. Press **Enter** to send, **Shift+Enter** for a new line.
+- **Send / Stop button** — sends the message, or stops a running response.
 
 ## What the agent can do
 
 During a conversation, the agent can:
 
-- **Respond with text** -- standard conversational replies with markdown formatting.
-- **Think** -- show its reasoning process in a collapsible "thinking" block (when thinking is enabled).
-- **Call tools** -- invoke MCP connectors to reach external services (databases, APIs, SaaS products).
-- **Execute code** -- run commands in a sandboxed environment.
-- **Generate artifacts** -- produce downloadable files, live website previews, images, data files, and more. See [Artifacts](./artifacts.md).
-- **Save memories** -- store facts, preferences, or decisions for future conversations. See [Memory overview](../memory/overview.md).
+- **Respond with text** — standard conversational replies with markdown formatting.
+- **Think** — show its reasoning process in a collapsible "thinking" block (when thinking is enabled).
+- **Call tools** — invoke MCP connectors to reach external services (databases, APIs, SaaS products).
+- **Execute code** — run commands in a sandboxed environment.
+- **Generate artifacts** — produce downloadable files, live website previews, images, data files, and more. See [Artifacts](./artifacts.md).
+- **Save memories** — store facts, preferences, or decisions for future conversations. See [Memory overview](../memory/overview.md).
 
 ## Steering and stopping
 
 While the agent is responding, you can:
 
-- **Stop the response** -- click the stop button (square icon) to cancel the current response.
-- **Steer mid-stream** -- type a message while the agent is still responding and press Enter. This sends a "steer" instruction that redirects the agent without waiting for it to finish.
+- **Stop the response** — click the stop button (square icon) to cancel the current response.
+- **Steer mid-stream** — type a message while the agent is still responding and press Enter. This sends a "steer" instruction that redirects the agent without waiting for it to finish.
 
 When the agent needs your input (e.g., a confirmation before proceeding), the input bar locks until you respond to the prompt card that appears in the chat.
 
@@ -53,10 +58,10 @@ When the agent needs your input (e.g., a confirmation before proceeding), the in
 
 Right-click (or click the three-dot menu) on any conversation in the sidebar to access these actions:
 
-- **Rename** -- give the conversation a descriptive title. By default, CubeBox auto-generates a title from your first message.
-- **Pin** -- pinned conversations stick to the top of the sidebar list so you can find them quickly.
-- **Unpin** -- remove a conversation from the pinned section.
-- **Delete** -- soft-deletes the conversation. It disappears from the sidebar but its data (messages, artifacts, cost records) is preserved internally.
+- **Rename** — give the conversation a descriptive title. By default, CubeBox auto-generates a title from your first message.
+- **Pin** — pinned conversations stick to the top of the sidebar list so you can find them quickly.
+- **Unpin** — remove a conversation from the pinned section.
+- **Delete** — soft-deletes the conversation. It disappears from the sidebar but its data (messages, artifacts, cost records) is preserved internally.
 
 ## Auto-generated titles
 

--- a/docs/site/docs/guides/conversations/model-selection.md
+++ b/docs/site/docs/guides/conversations/model-selection.md
@@ -5,7 +5,7 @@ title: Model Selection
 
 # Model Selection
 
-CubeBox lets you choose which AI model powers each message. Different models have different strengths -- cost, speed, reasoning depth, vision support, and more. You pick the model from the input bar before sending a message.
+CubeBox lets you choose which AI model powers each message. Different models have different strengths — cost, speed, reasoning depth, vision support, and more. You pick the model from the input bar before sending a message.
 
 ## Presets
 
@@ -19,7 +19,7 @@ Each workspace has a **default preset** that is automatically selected when you 
 2. Click the dropdown and choose a different preset.
 3. Your next message (and all subsequent messages in this conversation) will use the new preset, until you switch again.
 
-The preset choice is **sticky per workspace** -- if you switch to "Claude Opus," it stays selected for your next conversation in that workspace too, until you change it.
+The preset choice is **sticky per workspace** — if you switch to "Claude Opus," it stays selected for your next conversation in that workspace too, until you change it. Each workspace remembers its own choice independently in your browser, so switching workspaces does not carry the selection over.
 
 ### Default badge
 
@@ -27,7 +27,7 @@ The preset marked as the workspace default shows a small "Default" badge in the 
 
 ## Thinking (extended reasoning)
 
-Some models support **extended thinking** -- a mode where the agent reasons step-by-step before producing its final answer. CubeBox exposes this as a separate control next to the preset picker.
+Some models support **extended thinking** — a mode where the agent reasons step-by-step before producing its final answer. CubeBox exposes this as a separate **Effort** control (a "Faster → Smarter" slider) next to the preset picker.
 
 ### Thinking levels
 
@@ -37,7 +37,7 @@ Some models support **extended thinking** -- a mode where the agent reasons step
 | **Low** | Brief internal reasoning. Fast, low cost. |
 | **Medium** | Moderate reasoning depth. Good default for most tasks. |
 | **High** | Deep reasoning. Better for complex analytical or coding tasks. |
-| **Extra-high** | Maximum reasoning depth. Use for the hardest problems. |
+| **Extra High** | Maximum reasoning depth. Use for the hardest problems. |
 
 Higher thinking levels consume more tokens and take longer, but produce more thorough analysis for complex questions. For simple questions ("What is the capital of France?"), thinking adds cost without benefit.
 
@@ -53,13 +53,13 @@ When thinking is enabled, the agent's response includes a collapsible **Thinking
 
 ## Model failover
 
-If the selected model is temporarily unavailable (provider outage, rate limit, network issue), CubeBox can automatically fail over to a backup model in the same preset's fallback chain. When this happens, a small banner appears in the chat:
+If the selected model is temporarily unavailable (provider outage, rate limit, network issue), CubeBox can automatically fail over to a backup model in the same preset's fallback chain. When this happens, a small banner appears in the chat naming the model it switched from and the one it switched to:
 
-> Switched from claude-sonnet-4-20250514 to claude-haiku-4-20250414
+> Switched from `<provider>/<model>` to `<fallback-provider>/<fallback-model>`
 
-Expand the banner to see the reason for the failover. The conversation continues on the backup model until the next message, at which point CubeBox tries the primary model again.
+Click the banner to expand it and see the reason for the failover. The conversation continues on the backup model until the next message, at which point CubeBox tries the primary model again.
 
-If the entire fallback chain is exhausted (all models in the preset are unavailable), you see a "Failover exhausted" message and the run stops. Wait and try again, or switch to a different preset.
+If the entire fallback chain is exhausted (all models in the preset are unavailable), the banner instead reads **"Failover exhausted on `<provider>/<model>`"** and the run stops. Wait and try again, or switch to a different preset.
 
 ## Which model to choose
 
@@ -69,7 +69,7 @@ There is no single best model. Here are practical guidelines:
 |---|---|
 | Quick questions, summarization, formatting | A fast, cost-efficient model (e.g., Haiku, GPT-4o-mini). Thinking off. |
 | Coding, debugging, code review | A capable model with thinking on medium or high. |
-| Complex analysis, multi-step reasoning | A top-tier model with thinking on high or extra-high. |
+| Complex analysis, multi-step reasoning | A top-tier model with thinking on high or extra high. |
 | Image understanding, screenshot analysis | A model with **vision** support. Check with your admin which presets support vision. |
 | Long documents, large context | A model with a large context window. |
 

--- a/docs/site/docs/guides/conversations/topics.md
+++ b/docs/site/docs/guides/conversations/topics.md
@@ -1,0 +1,108 @@
+---
+sidebar_position: 5
+title: Topics (group conversations)
+---
+
+# Topics
+
+A **topic** turns the agent into a shared, multi-person workspace. Where a normal conversation is just you and the agent, a topic has a **roster of participants** and can hold **several conversations** under one umbrella — everyone in the topic can see and join every conversation inside it.
+
+Use a topic when more than one person needs to work with the same agent on the same thing: a project channel, a team investigation, an on-call room, or a group chat driven from an IM platform.
+
+## Topic vs. conversation
+
+| | Conversation | Topic |
+|---|---|---|
+| Participants | Just you | Many (you + invited members) |
+| Contains | One message thread | One or more conversations |
+| Sidebar | A standalone row | A group node with its conversations nested under it |
+| Sandbox | Your personal sandbox | A shared sandbox (see [The shared sandbox](#the-shared-sandbox)) |
+
+A topic with only one participant behaves like a normal 1:1 chat until you add someone.
+
+## Creating a topic
+
+There are three ways a topic comes into being. However it is created, the creator becomes its **owner**.
+
+### New Topic
+
+Click **New Topic** in the sidebar. In the dialog, give it a title, invite workspace members, and choose the [sandbox mode](#the-shared-sandbox). CubeBox creates the topic with a first conversation and drops you into it.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The "New Topic" dialog with a title entered, two members selected, and the sandbox-mode choice visible.
+**Asset:** `/img/conversations/topic-create-dialog.png`
+:::
+
+### Upgrade an existing conversation
+
+Already deep in a 1:1 conversation that should become a group effort? Use **Upgrade to topic** from the conversation header. The existing conversation becomes the first conversation under a new topic, and you become its owner.
+
+You cannot upgrade a conversation that is already part of a topic, or one that is wired to an IM bot, a scheduled task, or an event trigger — detach those first.
+
+### From an IM bot
+
+When a bot is bound to a group chat in **topic** or **shared** routing mode, CubeBox creates a topic automatically the first time a message arrives in that chat. These IM-created topics carry the originating platform and channel as metadata. See [IM Connectors](../im/overview.md).
+
+:::note Web topics and IM topics don't cross over (current limitation)
+The IM runner only drives topics that originated from IM. A topic you create in the web app cannot currently be answered from an IM channel.
+:::
+
+## Participants and roles
+
+Every participant has one of two roles:
+
+- **Owner** — the creator. Manages the roster, the title, and the topic's lifecycle.
+- **Member** — can read and post in every conversation under the topic, and start new conversations in it.
+
+| Action | Who can do it |
+|---|---|
+| Invite participants | Owner only |
+| Leave the topic | Any participant (yourself) |
+| Remove another participant | Owner only |
+| Transfer ownership / change a role | Owner only |
+| Rename the topic | Owner only |
+| Pin / unpin the topic | Any participant |
+| Archive the topic | Owner only |
+| Start a new conversation in the topic | Any participant |
+
+Invited people must already be members of the workspace — inviting them to a topic does not add them to the workspace or create an account. A topic is only visible to its participants; everyone else in the workspace cannot see it.
+
+If an owner leaves or is removed, ownership automatically passes to the earliest-joined remaining participant, so a topic is never left ownerless.
+
+**Participant limit:** a topic holds up to **20** participants by default. Topics created from a shared IM channel allow up to **100**.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The topic members panel showing the participant list with the owner badge, the Invite button (owner view), and the Leave action.
+**Asset:** `/img/conversations/topic-members-panel.png`
+:::
+
+## The shared sandbox
+
+Because a topic is shared, its [code-execution sandbox](../../admin/sandbox.md) is shared too. You pick how that works when you create the topic, and **it cannot be changed afterward** — choose deliberately:
+
+- **Dedicated topic sandbox** — CubeBox spins up a **fresh sandbox that belongs to the topic**. It is isolated from anyone's personal sandbox, and files from the conversation you started in are **not** carried over. This is the default for **New Topic** and the safer choice for a group.
+- **Reuse the creator's sandbox** — the topic runs in the **owner's personal sandbox**. Files and environment carry over, which is convenient when you're upgrading your own conversation and want to keep its working files. The trade-off: **every participant's code runs in the owner's environment**, with access to whatever is in it. This is the default when you **upgrade** an existing conversation.
+
+:::caution
+In "reuse the creator's sandbox" mode, other members' actions execute inside your personal sandbox. Only use it with people you'd trust with your own environment.
+:::
+
+## Conversations inside a topic
+
+A topic starts with one conversation, but any participant can open more — for example, one conversation per sub-task. All of them are visible to every participant and appear nested under the topic in the sidebar. There is no separate "topic page"; you work inside the topic's conversations just like any other chat.
+
+## Ordering, pinning, and archiving
+
+- **Ordering.** Topics and standalone conversations share one sidebar list, ordered by most recent activity. A topic floats up whenever any conversation inside it gets a new message.
+- **Pinning.** Any participant can pin a topic to keep it at the top. Pinning is shared — it affects the topic's position for everyone. (Pinning an individual conversation lifts just that conversation to the top, even out of its topic.)
+- **Archiving.** An owner can archive a topic from its sidebar menu. Archived topics disappear from the sidebar for all participants. Individual members who just want out can **leave** the topic from the members panel instead.
+
+## Topics as automation destinations
+
+A scheduled task can target a topic, so a recurring run posts into a shared group instead of a private conversation. See [Scheduled Tasks](../automation/scheduled-tasks.md).
+
+## Tips
+
+- **Pick the sandbox mode on purpose.** It is the one topic setting you can't change later. Default to a dedicated sandbox unless you specifically need the creator's files.
+- **Upgrade, don't recreate.** If a 1:1 chat grows into team work, upgrade it — you keep the history and (optionally) the working files.
+- **Use separate conversations for separate threads.** One topic, many conversations keeps a group's parallel workstreams readable instead of interleaved in a single thread.

--- a/docs/site/docs/guides/im/dingtalk.md
+++ b/docs/site/docs/guides/im/dingtalk.md
@@ -1,0 +1,104 @@
+---
+sidebar_position: 4
+title: DingTalk Setup
+---
+
+# DingTalk setup
+
+DingTalk binds an enterprise bot to your CubeBox workspace over a **Stream** connection: CubeBox opens an outbound socket to DingTalk and receives messages over it, so nothing on your CubeBox host needs to be reachable from the internet. This guide walks you through creating an internal app in the DingTalk Open Platform console, giving its bot a Stream-mode robot, granting the permissions the connector needs, binding it to CubeBox with your app key and app secret, and linking your account so the bot answers you.
+
+## Before you start
+
+You need:
+
+- A **workspace admin** or member account in CubeBox (a plain member can bind a bot that runs as themselves; impersonating another user requires workspace admin).
+- Permission to create an **internal app** in your organization's DingTalk Open Platform console (`open-dev.dingtalk.com`).
+
+## Step 1 — Create an internal app
+
+In the DingTalk **Open Platform** console (`open-dev.dingtalk.com`), create a new **internal enterprise app**. Once it exists, open its **Credentials & Basic Info** page and note the **AppKey** and **AppSecret** — you'll need both when binding to CubeBox.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The DingTalk Open Platform "create internal app" dialog, and the app's Credentials & Basic Info page showing where AppKey and AppSecret appear.
+**Asset:** `/img/im/dingtalk-app-credentials.png`
+:::
+
+## Step 2 — Add the bot (robot) capability
+
+Under the app's capabilities, add the **Bot** (robot) capability so the app can receive and send chat messages. Give the bot a name and icon — this is the identity users see in DingTalk.
+
+CubeBox identifies the bot by your **AppKey** (it doubles as the bot's robot code), so there is no separate bot ID to copy here — but the robot capability must be added, or the bot never receives messages.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The app's capability/feature page with the Bot (robot) capability added and the bot name/icon filled in.
+**Asset:** `/img/im/dingtalk-bot-capability.png`
+:::
+
+## Step 3 — Enable Stream mode
+
+In the bot's message-receiving settings, choose **Stream mode** (the persistent-connection delivery option) rather than a webhook/HTTP callback URL. In Stream mode DingTalk pushes each inbound message down the socket CubeBox holds open, so you don't configure any public callback URL.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The bot's message-receiving configuration with the Stream-mode (persistent connection) option selected instead of the HTTP-callback option.
+**Asset:** `/img/im/dingtalk-stream-mode.png`
+:::
+
+## Step 4 — Grant the permissions the connector needs
+
+In the app's **Permissions** section, grant the scopes the connector uses:
+
+- **Send and receive bot messages** — required, so the bot can read messages addressed to it and reply with cards. Without this the bot sees nothing.
+- **Read a user's profile (to resolve email)** — optional but recommended. CubeBox can look up a sender's email from their DingTalk staff ID and match it to a CubeBox account, so users don't have to run `link` manually (see Step 6). This needs the user-profile read permission that exposes the user's email.
+
+:::note
+The exact permission names in the DingTalk console change between console versions and editions, so the labels above are described by capability rather than quoted verbatim. Grant the permission that lets the app **send/receive bot messages** and, for email auto-resolution, the one that lets it **read a user's profile including email**. If your console wording differs, match by capability.
+:::
+
+:::info 📸 Screenshot placeholder
+**Capture:** The app Permissions page with the bot-message send/receive permission and the user-profile (email) read permission granted.
+**Asset:** `/img/im/dingtalk-permissions.png`
+:::
+
+## Step 5 — Bind the bot in CubeBox
+
+In your CubeBox workspace, open the **IM connectors** settings and connect a new DingTalk account. Provide:
+
+| Field | Required | Notes |
+|---|---|---|
+| **AppKey** | Yes | From Step 1. Also serves as the account's external identifier and the bot's robot code. |
+| **AppSecret** | Yes | From Step 1. CubeBox uses it to obtain an access token and to call DingTalk. |
+| **Run identity** | Yes | `self` (the bot runs as you) by default. Binding it to run as another user requires the **workspace admin** role. |
+
+The delivery mode is fixed to **Stream** — there is nothing to choose. On binding, CubeBox validates the AppKey + AppSecret by exchanging them for a DingTalk access token; if the credentials are wrong the token exchange fails and binding is rejected. Fix them in the console and retry. Valid credentials are stored encrypted.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The CubeBox "Connect DingTalk account" form with the AppKey, AppSecret, and Run identity fields.
+**Asset:** `/img/im/dingtalk-cubebox-connect-form.png`
+:::
+
+Once bound, CubeBox opens the Stream connection automatically. (Note: re-enabling a disabled Stream account currently requires an API restart to re-establish the socket — see the [Overview](./overview.md#delivery-modes).)
+
+## Step 6 — Test it
+
+Add the bot to a chat (or DM it directly) and @-mention it in a group, or just message it in a DM. The first time, CubeBox needs to know who you are:
+
+- If you granted the user-profile (email) permission in Step 4, CubeBox resolves your DingTalk email automatically and — if that email matches a CubeBox account in this workspace — runs your message immediately.
+- Otherwise, the bot asks you to link. Send it `link your@email.com` (the `/link your@email.com` form also works), open the link the bot replies with **while logged in to CubeBox**, and confirm. See [Identity linking](./overview.md#identity-linking).
+
+Once linked, the bot replies with a live-updating interactive card as the agent streams its response.
+
+## Conversation commands
+
+The DingTalk bot recognizes the link command in any chat it's in:
+
+| Command | Aliases | Effect |
+|---|---|---|
+| `link <email>` | `/link <email>` | Link your DingTalk identity to your CubeBox account (see [Identity linking](./overview.md#identity-linking)). |
+
+:::note
+The `/new` and `/reset` "start a fresh conversation" commands are **not** wired up on the DingTalk connector today — they work on Feishu/Lark and Discord but are silently ignored on DingTalk. To start over, message the bot fresh; per-channel conversation behavior follows the [channel binding mode](./overview.md#channel-binding-modes).
+:::
+
+## Rotating credentials
+
+There is no in-place secret edit. To rotate an AppSecret, **delete** the account in CubeBox and bind it again with the new AppKey + AppSecret.

--- a/docs/site/docs/guides/im/discord.md
+++ b/docs/site/docs/guides/im/discord.md
@@ -1,0 +1,117 @@
+---
+sidebar_position: 6
+title: Discord Setup
+---
+
+# Discord setup
+
+Discord runs as a gateway bot: CubeBox opens a persistent outbound socket to Discord and receives messages over it, so nothing on your CubeBox host needs to be reachable from the internet. Its distinguishing feature is **native slash commands** — CubeBox registers `/new`, `/reset`, and `/link` directly on your Discord application, so they show up in Discord's command picker.
+
+This guide walks you through creating the Discord application, adding a bot and copying its credentials, enabling the privileged intent the bot needs, inviting the bot to your server, binding it to your CubeBox workspace, and linking your account.
+
+:::note No email resolution on Discord
+Discord exposes no email for a sender, so CubeBox can't auto-match you to your account the way it can on Feishu. On Discord, **`/link <email>` is the only way to connect your chat identity to your CubeBox account** — every user runs it once. See [Identity linking](./overview.md#identity-linking).
+:::
+
+## Before you start
+
+You need:
+
+- A **workspace admin** or member account in CubeBox (a plain member can bind a bot that runs as themselves; impersonating another user requires workspace admin).
+- A Discord account with permission to create an application in the [Discord Developer Portal](https://discord.com/developers/applications), and **Manage Server** permission on the Discord server you want the bot to join.
+
+## Step 1 — Create a Discord application
+
+In the **Discord Developer Portal**, create a new application. This is the container for your bot and is what owns the slash commands CubeBox will register.
+
+On the application's **General Information** page, copy the **Application ID** — you'll need it when binding to CubeBox (it's also the value CubeBox uses as this account's external identifier).
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Discord Developer Portal "Create an application" dialog, and the application's General Information page with the Application ID field highlighted.
+**Asset:** `/img/im/discord-create-application.png`
+:::
+
+## Step 2 — Add a bot and copy its token
+
+Open the application's **Bot** section and add a bot. Then **Reset Token** (or **Copy**) to reveal the **bot token** — Discord shows the full token only once, so copy it now and keep it secret. You'll supply this token when binding to CubeBox.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The application's Bot page showing the bot username, avatar, and the token reveal/reset control (token value itself redacted).
+**Asset:** `/img/im/discord-bot-token.png`
+:::
+
+## Step 3 — Enable the Message Content intent
+
+CubeBox's gateway connection requests the **Message Content** privileged intent so the bot can read the text of messages people send it. Message Content is a *privileged* intent on Discord and must be toggled on in the portal — without it, the bot connects but sees empty message bodies.
+
+On the **Bot** page, enable the **Message Content Intent** under privileged gateway intents.
+
+The connector also subscribes to guild messages, direct messages, and reactions, which are part of the default (non-privileged) intent set and need no separate toggle. Message Content is the only intent you have to enable by hand.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Bot page's "Privileged Gateway Intents" section with Message Content Intent turned on.
+**Asset:** `/img/im/discord-message-content-intent.png`
+:::
+
+## Step 4 — Invite the bot to your server
+
+Generate an OAuth2 invite URL for the bot and use it to add the bot to your Discord server. The invite needs two OAuth2 scopes:
+
+- **`bot`** — adds the bot as a member of the server.
+- **`applications.commands`** — lets CubeBox register the `/new`, `/reset`, and `/link` slash commands so they appear in the server's command picker.
+
+Most servers grant the bot a baseline set of channel permissions (reading and sending messages in the channels you want it to operate in). Open the generated URL, choose the target server, and authorize.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The OAuth2 URL Generator with the `bot` and `applications.commands` scopes checked, and the resulting "Add to Server" authorization screen.
+**Asset:** `/img/im/discord-oauth-invite.png`
+:::
+
+## Step 5 — Bind the bot in CubeBox
+
+In your CubeBox workspace, open the **IM connectors** settings and connect a new Discord account. Provide:
+
+| Field | Required | Notes |
+|---|---|---|
+| **Bot token** | Yes | From Step 2. CubeBox uses it to open the gateway socket and to call Discord. |
+| **Application ID** | Yes | From Step 1. Also serves as this account's external identifier. |
+| **Run identity** | Yes | `self` (the bot runs as you) by default. Binding it to run as another user requires the **workspace admin** role. |
+
+On binding, CubeBox validates the bot token by calling Discord's `GET /users/@me` (this also fetches the bot's username and avatar) and stores the credentials encrypted. If the token is wrong, binding fails — fix it in the portal and retry. The delivery mode is always **gateway** for Discord; there is no webhook option.
+
+Once bound, CubeBox connects over the gateway and **syncs the `/new`, `/reset`, and `/link` slash commands** to the servers the bot is in, so they become available in Discord's command picker.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The CubeBox "Connect Discord account" form with the Bot token, Application ID, and Run identity fields.
+**Asset:** `/img/im/discord-cubebox-connect-form.png`
+:::
+
+:::caution Re-enabling needs an API restart
+Disabling or deleting a Discord account tears down its gateway connection immediately. Re-enabling it rebinds lazily — the current version needs the API process restarted to fully re-establish the socket. See the [overview](./overview.md#delivery-modes).
+:::
+
+## Step 6 — Link your account and test
+
+DM the bot or @-mention it in a channel it can see. Because Discord has no email API, the first time you'll need to link:
+
+- Run the **`/link`** slash command with your CubeBox email (e.g. `/link you@example.com`). You can also type `/link you@example.com` as a plain message.
+- The bot replies (privately) with a confirmation URL of the form `https://<your-cubebox-host>/im-link?token=...`. Open it **while logged in to CubeBox** and confirm.
+- The email you link must belong to an existing CubeBox account that is already a member of this workspace. Linking connects an existing account — it doesn't create one or grant membership.
+
+After linking, your messages run as your CubeBox user without re-linking, and the bot replies in the chat as the agent responds. See [Identity linking](./overview.md#identity-linking) for the full flow.
+
+## Conversation commands
+
+On Discord these are registered as **native slash commands** (they appear in the command picker) and also work as plain typed messages:
+
+| Command | Effect |
+|---|---|
+| `/new` | Start a fresh conversation; your next message begins a new one. |
+| `/reset` | Same as `/new` — drops the current conversation binding for this chat scope. |
+| `/link <email>` | Link your Discord identity to your CubeBox account (see [Identity linking](./overview.md#identity-linking)). |
+
+`/new` and `/reset` are equivalent. Slash command responses are sent privately (ephemeral) to the person who ran them.
+
+## Rotating credentials
+
+There is no in-place secret edit. To rotate a bot token, **delete** the account in CubeBox and bind it again with the new token.

--- a/docs/site/docs/guides/im/feishu.md
+++ b/docs/site/docs/guides/im/feishu.md
@@ -1,0 +1,167 @@
+---
+sidebar_position: 2
+title: Feishu / Lark Setup
+---
+
+# Feishu / Lark setup
+
+Feishu (and its international edition, Lark) is the most developed IM connector. This guide walks you through creating the bot in the Feishu/Lark developer console, binding it to your CubeBox workspace, and linking your account so the bot answers you.
+
+CubeBox supports both editions from the same connector — choose **Feishu** (`feishu.cn`) or **Lark** (`larksuite.com`) when you bind. The setup steps are identical; only the console domain differs.
+
+## Before you start
+
+You need:
+
+- A **workspace admin** or member account in CubeBox (a plain member can bind a bot that runs as themselves; impersonating another user requires workspace admin).
+- Permission to create a **custom app** in your Feishu/Lark organization's developer console.
+
+## Step 1 — Create a custom app
+
+In the Feishu/Lark **Developer Console** (`open.feishu.cn` for Feishu, `open.larksuite.com` for Lark), create a new **custom app**. Note its **App ID** and **App Secret** — you'll need both when binding to CubeBox.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Feishu/Lark developer console "Create custom app" dialog, and the app's credentials page showing where App ID and App Secret appear.
+**Asset:** `/img/im/feishu/console-app-credentials.png`
+:::
+
+## Step 2 — Enable the bot capability
+
+Under the app's **Features**, add the **Bot** capability and publish the bot identity. CubeBox reads the bot's identity (its open ID) automatically from the App ID + App Secret when you bind — but the bot must be **published** first, or binding fails with a "could not hydrate bot" error.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The app Features page with the Bot capability enabled.
+**Asset:** `/img/im/feishu/console-bot-capability.png`
+:::
+
+## Step 3 — Grant message permissions
+
+Under **Permissions & Scopes**, grant the scopes the bot needs to read mentions and send messages. To let CubeBox auto-resolve a sender's email (so users don't have to run `/link` manually), also grant the contact/read-email scope.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The app Permissions & Scopes page with the message read/send and contact email scopes selected.
+**Asset:** `/img/im/feishu/console-permissions.png`
+:::
+
+## Step 4 — Choose how events reach CubeBox
+
+Feishu can deliver events two ways. Pick one — it controls what you configure next and which `delivery_mode` you choose when binding.
+
+### Option A — Long-connection (default, recommended)
+
+CubeBox opens an outbound socket to Feishu and receives events over it. Nothing on your CubeBox host needs to be reachable from the internet, so this works behind a firewall. In the Feishu console, set the app's event delivery to **"Use long connection to receive events."** No public URL or signature is involved.
+
+This is the default. When you bind in CubeBox, leave `delivery_mode` as `long_connection`.
+
+### Option B — Webhook
+
+Feishu POSTs each event to a public URL on your CubeBox host. Use this only if your host is internet-reachable and you prefer webhooks.
+
+In the console's **Event Subscriptions**, set the **Request URL** to:
+
+```
+https://<your-cubebox-host>/api/v1/im/feishu/events
+```
+
+Feishu sends a one-time `url_verification` challenge to that URL; CubeBox echoes the challenge back automatically once the account is bound and the verification token matches, so bind the account in CubeBox (Step 5) **before** you ask Feishu to verify the URL.
+
+When you bind in CubeBox, set `delivery_mode` to `webhook`.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Feishu console Event Subscriptions page showing the long-connection toggle vs. the Request URL field.
+**Asset:** `/img/im/feishu/console-event-delivery.png`
+:::
+
+## Step 5 — Configure the verification token and encryption (optional but recommended)
+
+In the Feishu console's **Event Subscriptions** section, Feishu shows two security values:
+
+- **Verification Token** — a static token Feishu includes in every event. CubeBox compares it in constant time and rejects events whose token doesn't match. Supply it when you bind.
+- **Encrypt Key** — enabling **Event Encryption** makes Feishu encrypt the whole event body. CubeBox decrypts it and also verifies the request signature. Strongly recommended for the webhook path.
+
+Both are optional fields when binding. If you set an Encrypt Key, Feishu signs each webhook request and CubeBox verifies the signature (see [Signature scheme](#signature-scheme)).
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Event Subscriptions security panel showing the Verification Token and Encrypt Key / Event Encryption toggle.
+**Asset:** `/img/im/feishu/console-token-encrypt.png`
+:::
+
+### Subscribe to the message event
+
+Still under Event Subscriptions, add the bot-message-received event so Feishu forwards messages to CubeBox. Without this subscription the bot never sees any messages.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The "Add events" dialog with the receive-message event subscribed.
+**Asset:** `/img/im/feishu/console-subscribe-message.png`
+:::
+
+## Step 6 — Bind the bot in CubeBox
+
+In your CubeBox workspace, open the **IM connectors** settings and connect a new Feishu account. Provide:
+
+| Field | Required | Notes |
+|---|---|---|
+| **App ID** | Yes | From Step 1. Also serves as the account's external identifier. |
+| **App Secret** | Yes | From Step 1. CubeBox uses it to read the bot identity and to call Feishu. |
+| **Encrypt Key** | No | Only if you enabled Event Encryption (Step 5). |
+| **Verification Token** | No | The token from Step 5. |
+| **Domain** | Yes | `feishu` or `lark` — pick the edition your app lives in. Defaults to `feishu`. |
+| **Delivery mode** | Yes | `long_connection` (default) or `webhook`, matching Step 4. |
+| **Run identity** | Yes | `self` (the bot runs as you) by default. Binding it to run as another user requires the **workspace admin** role. |
+
+On binding, CubeBox reads the bot's identity from Feishu using your App ID + App Secret and stores the credentials encrypted. If the App Secret is wrong or the bot isn't published, binding fails — fix the console side and retry.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The CubeBox "Connect Feishu account" form with the App ID, App Secret, Encrypt Key, Verification Token, Domain (Feishu/Lark), and Delivery mode fields.
+**Asset:** `/img/im/feishu/cubebox-connect-form.png`
+:::
+
+If you chose the **webhook** path, go back to the Feishu console now and trigger the Request URL verification — CubeBox will answer the challenge.
+
+## Step 7 — Test it
+
+Add the bot to a chat (or DM it directly) and @-mention it. The first time, CubeBox needs to know who you are:
+
+- If you granted the contact/email scope (Step 3), CubeBox resolves your Feishu email automatically and — if that email matches a CubeBox account in this workspace — runs your message immediately.
+- Otherwise, the bot asks you to link. Send it `/link your@email.com` (or `绑定 your@email.com`), open the link the bot replies with **while logged in to CubeBox**, and confirm. See [Identity linking](./overview.md#identity-linking).
+
+Once linked, the bot replies with a live-updating interactive card as the agent streams its response.
+
+## Signature scheme
+
+When you enable **Event Encryption** (Encrypt Key set), Feishu signs each webhook request and CubeBox verifies it. This applies to the webhook delivery path; the long-connection path is authenticated by the socket itself.
+
+CubeBox computes the signature exactly as Feishu specifies:
+
+```
+signature = SHA256( timestamp + nonce + encrypt_key + raw_request_body )
+```
+
+The three inputs other than the body and key arrive as request headers:
+
+| Header | Meaning |
+|---|---|
+| `x-lark-request-timestamp` | The timestamp included in the signed string. |
+| `x-lark-request-nonce` | The per-request nonce included in the signed string. |
+| `x-lark-signature` | The hex SHA-256 digest CubeBox compares against (constant-time). |
+
+The signature is computed over the **outer** request body. When Event Encryption is on, that body is `{"encrypt": "<base64 ciphertext>"}`; CubeBox decrypts it (AES-256-CBC, key = `SHA256(encrypt_key)`, IV = first 16 bytes of the ciphertext, PKCS#7 padding) before processing the event.
+
+In addition to (or instead of) the signature, CubeBox checks the **verification token** carried in the event payload's `header.token` (or top-level `token` on legacy events). The verification-token check runs **before** the `url_verification` challenge is echoed, so an attacker can't prove control of your endpoint by getting a challenge bounced back.
+
+:::tip Plain mode
+If you don't set an Encrypt Key, Feishu doesn't send the `x-lark-signature` header and CubeBox skips signature verification — the **verification token** is then the only safeguard. For internet-facing webhook deployments, enabling Event Encryption is strongly recommended.
+:::
+
+## Conversation commands
+
+The bot understands these in any chat it's in:
+
+| Command | Aliases | Effect |
+|---|---|---|
+| `/link <email>` | `绑定 <email>` | Link your Feishu identity to your CubeBox account. |
+| `/new` | `/reset`, `新对话` | Start a fresh conversation; your next message begins a new one. |
+
+## Rotating credentials
+
+There is no in-place secret edit. To rotate an App Secret, Encrypt Key, or Verification Token, **delete** the account in CubeBox and bind it again with the new values.

--- a/docs/site/docs/guides/im/overview.md
+++ b/docs/site/docs/guides/im/overview.md
@@ -1,0 +1,109 @@
+---
+sidebar_position: 1
+title: IM Connectors Overview
+---
+
+# IM Connectors
+
+IM connectors let your workspace's agent answer messages inside a chat platform — Feishu/Lark, DingTalk, Slack, Microsoft Teams, or Discord. You bind a bot once, and from then on anyone in the chat (who is also a member of your workspace) can @-mention the bot or DM it and get the same agent that runs in the CubeBox web app, with the same skills, memory, and tools.
+
+## The general model
+
+Every platform follows the same four-step flow:
+
+1. **Bind a bot.** A workspace member registers the bot's credentials (app ID, secrets, tokens) against the workspace. CubeBox stores them encrypted and creates an **IM connector account**.
+2. **Inbound message arrives.** The platform delivers each message to CubeBox — either by pushing it to a webhook URL you configure in the platform's console, or over a persistent socket CubeBox opens to the platform (see [Delivery modes](#delivery-modes)).
+3. **Identity gate + agent run.** CubeBox figures out *which CubeBox user* the sender is (see [Identity linking](#identity-linking)), confirms they belong to the workspace, then starts an agent run on their behalf.
+4. **Reply.** The agent's response streams back into the chat. On Feishu it renders as a live-updating interactive card; on other platforms it posts as a message (and edits in place where the platform allows).
+
+The bot runs each message as a real CubeBox user, so permissions, model access, and tool access are exactly what that user would have in the web app. If a sender can't be matched to a workspace member, the bot replies that it can't help and the run never starts.
+
+## Supported platforms
+
+CubeBox ships connector code for five platforms. They are **not** equally mature — Feishu/Lark is the reference implementation — but each has its own setup guide.
+
+| Platform | Maturity | Delivery mode | Setup guide |
+|---|---|---|---|
+| **Feishu / Lark** | Most developed — interactive streaming cards, message encryption, signature verification, in-place card edits, human-in-the-loop button actions. | Long-connection (default) or webhook | [Feishu / Lark](./feishu.md) |
+| **Slack** | Working connector — in-place message edits, automatic email-based identity resolution, native `/link` slash command. | Gateway (Socket Mode) | [Slack](./slack.md) |
+| **DingTalk** | Working connector — automatic email-based identity resolution. | Stream | [DingTalk](./dingtalk.md) |
+| **Microsoft Teams** | Working connector — validates the Azure Bot Framework JWT on each inbound activity; requires a publicly reachable host. | Webhook | [Microsoft Teams](./teams.md) |
+| **Discord** | Working connector — native `/new`, `/reset`, `/link` slash commands. | Gateway | [Discord](./discord.md) |
+
+Command support varies by platform — see [Conversation commands](#conversation-commands).
+
+### Delivery modes
+
+How a platform's messages reach CubeBox depends on the platform:
+
+- **Long-connection / gateway / stream** — CubeBox opens a persistent outbound socket to the platform and receives events over it. Nothing needs to be reachable from the internet, so this works behind a firewall. Feishu (default), Slack, Discord, and DingTalk use this style.
+- **Webhook** — the platform POSTs each event to a public URL on your CubeBox host. The host must be reachable from the platform's servers. Feishu (optional) and Teams use this style.
+
+:::caution Re-enabling a long-connection account needs an API restart
+Disabling or deleting an account tears down its live connection immediately. **Re-enabling** a long-connection account from the admin API rebinds it lazily — the current version requires restarting the API process to fully re-establish the socket. Webhook accounts pick up again immediately because the inbound route re-checks the enabled flag on every request.
+:::
+
+## Identity linking
+
+A message in a chat app carries a platform user ID, not a CubeBox identity. Before running anything, CubeBox maps the sender to a CubeBox user and checks they're a member of the bot's workspace. Membership is **re-checked on every message**, even after the mapping is cached — a user removed from the workspace stops getting answers immediately.
+
+Resolution happens in this order:
+
+1. **Cached link.** If the sender was matched before, CubeBox reuses the stored mapping (after re-confirming workspace membership).
+2. **Email resolution.** On platforms with a contact API — **Feishu, Slack, and DingTalk** — CubeBox looks up the sender's email and matches it to a CubeBox user with that email.
+3. **`/link` command fallback.** On platforms without an email API (**Discord**, **Teams**), or whenever email resolution fails, the sender links manually.
+
+### Linking with `/link`
+
+The sender sends the bot:
+
+```
+/link you@example.com
+```
+
+(The Chinese alias `绑定 you@example.com` also works.) The bot replies with a confirmation URL of the form `https://<your-cubebox-host>/im-link?token=...`. The link carries a short-lived signed token (valid 10 minutes) encoding the claimed email and the target workspace.
+
+The sender opens that link **while logged in to CubeBox**. CubeBox confirms that the logged-in user's email matches the claimed email and that they belong to the workspace, then permanently links the chat identity to the CubeBox account. After that, the sender's messages run as that user without re-linking.
+
+:::tip
+The email you `/link` must be the email of an existing CubeBox account that is already a member of the bot's workspace. Linking does not create accounts or grant membership — it only connects an existing one.
+:::
+
+## Conversation commands
+
+Command support differs by platform — not every command exists everywhere.
+
+| Command | Effect | Available on |
+|---|---|---|
+| `/link <email>` | Links your chat identity to your CubeBox account (see [Identity linking](#identity-linking)). | All platforms. Native slash command on Slack and Discord; a text message on Feishu, DingTalk, and Teams. The Chinese alias `绑定 <email>` works on Feishu only. |
+| `/new` (alias `/reset`, `新对话`) | Starts a fresh conversation — drops the current conversation binding for the chat scope you're in, so the bot starts clean on your next message. | **Feishu** (text command) and **Discord** (native slash command) only. Not yet wired up on Slack, DingTalk, or Teams. |
+
+See each platform's setup guide for the exact command form.
+
+## Channel binding modes
+
+In a group chat, you can choose whether everyone shares one conversation or each person gets their own:
+
+- **Isolated** (default) — each sender in a group gets their own private conversation with the bot. This is the default for any channel without an explicit binding.
+- **Shared** — everyone in the channel talks to one shared conversation. Shared mode requires choosing a sandbox mode for the channel.
+
+Bindings are managed per account from the workspace IM settings.
+
+## Managing connectors
+
+IM connector accounts are created and managed from your workspace settings. Workspace members can connect a bot that runs **as themselves**; binding a bot that runs as *another* user (impersonation) requires the **workspace admin** role. Disabling, deleting, and channel-binding management are available from the same settings area.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The workspace IM connectors settings page showing the list of bound accounts (platform icon, bot name, enabled toggle) and the "Connect" entry point.
+**Asset:** `/img/im/connectors-list.png`
+:::
+
+## Per-platform setup guides
+
+Every platform binds through the same workspace IM settings and follows the same inbound → identity gate → agent run → reply model described above. The credentials and console steps differ — follow the guide for your platform:
+
+- **[Feishu / Lark](./feishu.md)** — app ID + app secret (+ optional encrypt key / verification token). Long-connection (default) or webhook.
+- **[Slack](./slack.md)** — bot token + app-level token (Socket Mode). Gateway.
+- **[DingTalk](./dingtalk.md)** — app key + app secret. Stream.
+- **[Microsoft Teams](./teams.md)** — app (bot) ID + app secret + tenant ID. Webhook (needs a publicly reachable host).
+- **[Discord](./discord.md)** — bot token + application ID. Gateway; native `/new`, `/reset`, `/link` slash commands.

--- a/docs/site/docs/guides/im/slack.md
+++ b/docs/site/docs/guides/im/slack.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 3
+title: Slack Setup
+---
+
+# Slack setup
+
+Slack runs over **Socket Mode** — CubeBox opens a persistent outbound socket to Slack and receives events over it, so nothing on your CubeBox host needs to be reachable from the internet. This guide walks you through creating the Slack app, enabling Socket Mode, granting the bot the scopes and event subscriptions the connector needs, installing the app to your Slack workspace, and binding it to your CubeBox workspace.
+
+Binding takes **two tokens**: a **bot token** (`xoxb-…`) and an **app-level token** (`xapp-…`). The bot token authenticates API calls; the app-level token opens the Socket Mode connection.
+
+## Before you start
+
+You need:
+
+- A **workspace admin** or member account in CubeBox (a plain member can bind a bot that runs as themselves; impersonating another user requires the workspace admin role).
+- Permission to create and install a Slack app in your Slack workspace (workspace owners/admins, or a workspace that allows member app installs).
+
+## Step 1 — Create a Slack app
+
+Go to the [Slack API apps page](https://api.slack.com/apps) and create a new app **from scratch**. Give it a name and pick the Slack workspace you want to install it into.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The "Create an app" dialog with "From scratch" selected, showing the app-name field and the target-workspace picker.
+**Asset:** `/img/im/slack-create-app.png`
+:::
+
+## Step 2 — Enable Socket Mode
+
+In the app settings, open **Socket Mode** and turn it on. Socket Mode is what lets CubeBox receive events over an outbound socket instead of a public webhook URL — it is the only delivery mode the Slack connector supports.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Socket Mode settings page with the "Enable Socket Mode" toggle switched on.
+**Asset:** `/img/im/slack-socket-mode.png`
+:::
+
+## Step 3 — Generate the app-level token
+
+Enabling Socket Mode prompts you to create an **app-level token**. Generate one (Slack calls this an "App-Level Token") and grant it the connections scope that Socket Mode requires. Copy the token — it starts with `xapp-`. You'll paste it into CubeBox in Step 7.
+
+:::tip
+App-level tokens are shown **once**. If you lose it, generate a new one — you can't reveal an existing token after leaving the page.
+:::
+
+:::info 📸 Screenshot placeholder
+**Capture:** The app-level token generation dialog with the connections scope attached, showing the generated `xapp-…` token.
+**Asset:** `/img/im/slack-app-token.png`
+:::
+
+## Step 4 — Add bot token scopes
+
+Open **OAuth & Permissions** and add the **Bot Token Scopes** the connector needs. The bot must be able to:
+
+- Read messages where it's mentioned and read direct messages sent to it.
+- Post and edit messages in channels and DMs (replies stream in as live-updating messages).
+- Add and remove emoji reactions (the bot reacts to acknowledge a message it's working on).
+- Look up a user's profile to read their email — this is how CubeBox auto-resolves a sender's CubeBox identity without a manual `/link` (see [Step 8](#step-8--link-your-identity)).
+
+:::caution Confirm the exact scope strings in Slack's console
+The capabilities above are confirmed from the connector code (it calls `auth.test`, `users.info`, `chat.postMessage`, `chat.update`, and the reactions API, and listens for `app_mention` + `message` events). The exact Slack scope **names** that grant each capability are defined by Slack, not CubeBox, and Slack occasionally renames or splits them — add the scopes Slack's OAuth & Permissions page lists for "read mentions," "read DMs," "post/edit messages," "manage reactions," and "read user email," and verify against Slack's current scope reference rather than copying a fixed list here.
+:::
+
+:::info 📸 Screenshot placeholder
+**Capture:** The OAuth & Permissions → Bot Token Scopes section with the message-read, message-write, reactions, and read-email scopes added.
+**Asset:** `/img/im/slack-bot-scopes.png`
+:::
+
+## Step 5 — Subscribe to message events
+
+Open **Event Subscriptions** and turn it on (with Socket Mode enabled, Slack delivers these events over the socket — no Request URL is needed). Under **Subscribe to bot events**, add the two events the connector listens for:
+
+- **`app_mention`** — fires when the bot is @-mentioned in a channel.
+- **`message.im`** — fires on direct messages to the bot.
+
+Without these subscriptions the bot never sees any messages. After adding events, Slack will prompt you to reinstall the app (Step 6) so the new scopes and subscriptions take effect.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Event Subscriptions page with "Subscribe to bot events" expanded, showing `app_mention` and `message.im` added.
+**Asset:** `/img/im/slack-event-subscriptions.png`
+:::
+
+## Step 6 — Install the app and grab the bot token
+
+Back on **OAuth & Permissions** (or **Install App**), click **Install to Workspace** and approve the requested scopes. After installing, Slack shows the **Bot User OAuth Token** — it starts with `xoxb-`. Copy it; this is the bot token you'll paste into CubeBox.
+
+If you change scopes or event subscriptions later, **reinstall** the app so the changes take effect, and grab the bot token again if Slack rotates it.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Install App / OAuth & Permissions page after install, showing the "Bot User OAuth Token" (`xoxb-…`) and the copy button.
+**Asset:** `/img/im/slack-install-token.png`
+:::
+
+## Step 7 — Bind the bot in CubeBox
+
+In your CubeBox workspace, open the **IM connectors** settings and connect a new Slack account. Provide:
+
+| Field | Required | Notes |
+|---|---|---|
+| **Bot token** | Yes | The `xoxb-…` token from Step 6. CubeBox uses it to call Slack and to read the bot's identity. |
+| **App-level token** | Yes | The `xapp-…` token from Step 3. Opens the Socket Mode connection. |
+| **Run identity** | Yes | `self` (the bot runs as you) by default. Binding it to run as another user requires the **workspace admin** role. |
+
+On binding, CubeBox validates the bot token against Slack (`auth.test`) and reads the bot's identity and the Slack team it belongs to; the Slack **team ID** becomes the account's external identifier, so you can only bind one CubeBox account per Slack team. Both tokens are stored encrypted. If the bot token is invalid, binding fails — fix it in the Slack console and retry. Delivery mode is fixed to **gateway** (Socket Mode); there is no webhook option for Slack.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The CubeBox "Connect Slack account" form with the Bot token and App-level token fields and the Run identity selector.
+**Asset:** `/img/im/slack-cubebox-connect-form.png`
+:::
+
+## Step 8 — Link your identity
+
+Add the bot to a channel (or DM it directly) and @-mention it. The first time, CubeBox needs to know which CubeBox user you are:
+
+- If you granted the read-email scope (Step 4), CubeBox resolves your Slack email via `users.info` and — if that email matches a CubeBox account in this workspace — runs your message immediately, no manual linking needed.
+- Otherwise (no email scope, or your Slack email doesn't match a CubeBox account), link manually. Run the `/link` slash command:
+
+  ```
+  /link your-cubebox-email@example.com
+  ```
+
+  The bot replies (privately, only you see it) with a confirmation URL of the form `https://<your-cubebox-host>/im-link?token=…`. Open it **while logged in to CubeBox** and confirm. The email must belong to an existing CubeBox account that is already a member of this workspace — linking connects an existing account, it doesn't create one or grant membership. See [Identity linking](./overview.md#identity-linking).
+
+Once linked (or auto-resolved), the bot replies in-channel and edits its message in place as the agent streams its response.
+
+## Conversation commands
+
+Slack registers **one** native slash command:
+
+| Command | Effect |
+|---|---|
+| `/link <email>` | Link your Slack identity to your CubeBox account (see [Step 8](#step-8--link-your-identity)). Replies privately. |
+
+:::note `/new` and `/reset` are not wired on Slack
+The shared conversation model documents `/new` and `/reset` for starting a fresh conversation, and Feishu and Discord support them. The Slack connector does **not** register or parse `/new` / `/reset` today — only `/link` is wired. To start a clean conversation on Slack, use a new DM or thread, or manage channel bindings from the workspace IM settings.
+:::
+
+## Rotating credentials
+
+There is no in-place secret edit. To rotate the bot token or app-level token, **delete** the Slack account in CubeBox and bind it again with the new values. If you regenerate the app-level token or reinstall the app in Slack (which can rotate the bot token), update CubeBox by re-binding.

--- a/docs/site/docs/guides/im/teams.md
+++ b/docs/site/docs/guides/im/teams.md
@@ -1,0 +1,146 @@
+---
+sidebar_position: 5
+title: Microsoft Teams Setup
+---
+
+# Microsoft Teams setup
+
+The Microsoft Teams connector lets your workspace's agent answer messages inside Teams. This guide walks you through registering a bot in Azure, pointing it at your CubeBox host, making it installable in Teams, binding it to your CubeBox workspace, and linking your account so the bot answers you.
+
+Teams is the **one platform that requires a publicly reachable CubeBox host.** Unlike Feishu's long connection or the Slack / Discord / DingTalk gateway connectors — where CubeBox opens an outbound socket and nothing on your side needs to be exposed — Teams delivers messages by **webhook**: Microsoft's Bot Framework service POSTs each activity to a URL on your host. That URL must be reachable from Microsoft's servers over HTTPS. If your CubeBox host is behind a firewall with no inbound access, this connector will not work.
+
+CubeBox validates the **Azure Bot Framework JWT** on every inbound activity, so only Microsoft's signed requests are accepted.
+
+## Before you start
+
+You need:
+
+- A **workspace admin** or member account in CubeBox (a plain member can bind a bot that runs as themselves; impersonating another user requires workspace admin).
+- An **Azure account** with permission to register an Azure Bot resource and a Microsoft Entra (Azure AD) application in your tenant.
+- A **publicly reachable HTTPS URL** for your CubeBox host (see the note above).
+
+:::caution The Azure / Teams console changes often
+The screen names, blade labels, and manifest editor in Azure and the Teams Developer Portal change frequently and differ across tenants. This guide describes each step by **what you are configuring** (register a bot, get an app ID + secret + tenant ID, set the messaging endpoint, enable the Teams channel, build a manifest). Where an exact Azure UI label is given it may have moved or been renamed — follow the capability, not the literal string. The values CubeBox actually consumes — the app ID, app secret, tenant ID, and messaging endpoint path — are the only ones this guide can state with certainty, because they come from CubeBox's own code.
+:::
+
+## Step 1 — Register an Azure Bot
+
+In the **Azure portal**, create an **Azure Bot** resource. During creation Azure provisions (or lets you supply) a **Microsoft App** — an Entra / Azure AD application identity for the bot. This is what gives you the credentials CubeBox needs.
+
+Record three values as you go:
+
+- **App ID** (the Microsoft App ID / client ID) — this is the bot's identity. CubeBox stores it as the account's external identifier, and it is the `recipient.id` Microsoft puts on every inbound activity, so it must match exactly.
+- **App secret** (a client secret you generate for the app) — CubeBox uses it to obtain a Bot Framework token. Generate the secret and copy it immediately; Azure shows the secret value only once.
+- **Tenant ID** — the Entra directory (tenant) ID the app lives in.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Azure portal "Create an Azure Bot" form, and the resulting resource's identity page showing where the Microsoft App ID and the option to create a client secret appear.
+**Asset:** `/img/im/teams-azure-bot-create.png`
+:::
+
+:::info 📸 Screenshot placeholder
+**Capture:** The app's "Certificates & secrets" view at the moment a new client secret is created, with the one-time secret value visible (redact before publishing).
+**Asset:** `/img/im/teams-app-secret.png`
+:::
+
+## Step 2 — Set the messaging endpoint
+
+In the Azure Bot resource's **configuration**, set the **messaging endpoint** to the inbound webhook on your CubeBox host:
+
+```
+https://<your-cubebox-host>/api/v1/im/teams/messages
+```
+
+This is the exact path CubeBox listens on. Microsoft's Bot Framework service POSTs each Teams activity to this URL. The host must be internet-reachable over HTTPS (see the intro note) — Microsoft will not deliver to an unreachable or plain-HTTP endpoint.
+
+You can set this endpoint before or after you bind in CubeBox, but the bot won't get any answers until both sides are in place: the endpoint must point here **and** the account must be bound and enabled in CubeBox (Step 5). CubeBox rejects activities for an unknown or disabled bot.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Azure Bot resource configuration page with the messaging endpoint field set to `https://<your-cubebox-host>/api/v1/im/teams/messages`.
+**Asset:** `/img/im/teams-messaging-endpoint.png`
+:::
+
+## Step 3 — Enable the Teams channel
+
+A freshly registered Azure Bot isn't reachable from Teams until you add the **Microsoft Teams channel** to it. In the Azure Bot resource's **Channels** area, add and enable the Teams channel.
+
+Without this, the bot exists but no Teams message ever reaches it.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Azure Bot "Channels" page with the Microsoft Teams channel added and showing as enabled / running.
+**Asset:** `/img/im/teams-channel-enable.png`
+:::
+
+## Step 4 — Build and upload the Teams app manifest
+
+To make the bot installable for users, package it as a **Teams app**. A Teams app is described by a **manifest** (a small JSON document plus icons) that declares, among other things, the **bot ID** — which must be the **App ID from Step 1** — so Teams knows which bot the app installs.
+
+You can author the manifest in the **Teams Developer Portal** (or hand-write the manifest JSON and zip it with the icons). Set the bot in the manifest to your App ID, fill in the app name and icons, then upload / install the resulting app into Teams — either by sideloading it for yourself for testing, or publishing it to your organization's app catalog so others can install it.
+
+:::caution Manifest field names are not verifiable from CubeBox
+The exact manifest schema keys and the Developer Portal's field labels live on Microsoft's side and change between schema versions, so this guide can't state them as fixed strings. The one value CubeBox depends on is that the manifest's bot ID equals the **App ID** you bind in CubeBox (Step 5). Get that wrong and inbound activities arrive under a `recipient.id` CubeBox has no account for, and they are silently dropped.
+:::
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Teams Developer Portal manifest editor (or the manifest JSON) showing the bot configured with the App ID, plus the upload / install action.
+**Asset:** `/img/im/teams-manifest.png`
+:::
+
+## Step 5 — Bind the bot in CubeBox
+
+In your CubeBox workspace, open the **IM connectors** settings and connect a new Teams account. Provide:
+
+| Field | Required | Notes |
+|---|---|---|
+| **App ID** | Yes | The Microsoft App ID from Step 1. Also serves as the account's external identifier and must match the `recipient.id` on inbound activities. |
+| **App secret** | Yes | The client secret from Step 1. CubeBox uses it to obtain a Bot Framework token. |
+| **Tenant ID** | Yes | The Entra directory (tenant) ID from Step 1. |
+| **Run identity** | Yes | `self` (the bot runs as you) by default. Binding it to run as another user requires the **workspace admin** role. |
+
+The delivery mode for Teams is always **webhook** — there is no choice to make; CubeBox sets it for you.
+
+On binding, CubeBox validates the credentials by requesting a client-credentials token from Microsoft (`https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token`). If the App ID, secret, or tenant ID is wrong, the token request fails and binding is rejected with a "could not validate Teams bot credentials" error — fix the values in Azure and retry. The credentials are stored encrypted.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The CubeBox "Connect Teams account" form with the App ID, App secret, and Tenant ID fields, and the run-identity selector.
+**Asset:** `/img/im/teams-cubebox-connect-form.png`
+:::
+
+## Step 6 — Test it
+
+Install the bot in Teams (Step 4) and message it — DM it directly or @-mention it in a channel where it's installed. The first time, CubeBox needs to know who you are.
+
+Teams has no email-resolution path, so you link manually. Send the bot:
+
+```
+/link your@email.com
+```
+
+The bot replies with a confirmation URL of the form `https://<your-cubebox-host>/im-link?token=...`. Open that link **while logged in to CubeBox**, and confirm. CubeBox checks that your logged-in email matches the claimed email and that you belong to the bot's workspace, then permanently links your Teams identity to your CubeBox account. See [Identity linking](./overview.md#identity-linking).
+
+The linked email must already belong to a CubeBox account that is a member of the bot's workspace — linking connects an existing account, it doesn't create one or grant membership.
+
+Once linked, your messages run as that user, with the same skills, memory, and tools you have in the web app, and the agent's reply posts back into the chat.
+
+## Conversation commands
+
+| Command | Effect |
+|---|---|
+| `/link <email>` | Link your Teams identity to your CubeBox account. |
+| `/new` | Start a fresh conversation; your next message begins a new one. |
+
+`/reset` is an alias for `/new`. (The Chinese `绑定` / `新对话` aliases documented for Feishu are not part of the Teams reply flow.)
+
+## How inbound messages are authenticated
+
+Every Teams activity arrives at `POST /api/v1/im/teams/messages`. Before CubeBox does any work it:
+
+1. Reads the bot ID from the activity's `recipient.id` and finds the matching bound account. An unknown bot ID is dropped.
+2. Validates the **Azure Bot Framework JWT** carried in the request's `Authorization: Bearer …` header against the bot's token validator, including the activity's `serviceUrl`. A missing, malformed, or invalid token is rejected with `401`. This is what guarantees the request genuinely came from Microsoft's Bot Framework and not from anyone who guessed your endpoint URL.
+3. Confirms the account is enabled, then resolves identity and runs the agent.
+
+Because the endpoint is public, this JWT check is the security boundary for the Teams connector — there is no separate signing secret you configure, unlike Feishu's encrypt key.
+
+## Rotating credentials
+
+There is no in-place secret edit. To rotate the App secret (or change the App ID or tenant ID), **delete** the account in CubeBox and bind it again with the new values.

--- a/docs/site/docs/guides/mcp/installing-connectors.md
+++ b/docs/site/docs/guides/mcp/installing-connectors.md
@@ -9,8 +9,8 @@ This guide walks you through adding MCP connectors to your workspace. You need *
 
 ## Browse the catalog
 
-1. Go to **Settings > MCP Connectors** (for workspace-level installs) or **Admin > MCP** (for org-wide installs).
-2. You will see the connector catalog — a list of available templates with their names, descriptions, and authentication requirements.
+1. Open the **MCP** page from your workspace sidebar (for workspace-level installs). Org admins install org-wide connectors from **Admin > MCP Connectors** (`/admin/mcp`).
+2. You will see the connector catalog. The page splits into an **Installed** section (connectors already set up for your workspace) and an **Available** section (connectors you can add), each showing names, descriptions, and authentication requirements.
 
 Each catalog entry shows its current status for your workspace:
 
@@ -40,11 +40,16 @@ For connectors that use OAuth (like GitHub, Notion, Slack, or Linear):
 
 1. Click the connector in the catalog.
 2. Select **OAuth** as the authentication method.
-3. Click **Authorize**. You will be redirected to the service's consent screen.
+3. Click **Connect with &lt;provider&gt;**. A new window opens with the service's consent screen.
 4. Grant the requested permissions.
-5. You are redirected back to CubeBox. The connector is now installed and active.
+5. The window returns you to CubeBox. The connector is now connected and active.
 
-**What happens behind the scenes:** CubeBox uses PKCE (Proof Key for Code Exchange) for all OAuth flows. For services that support Dynamic Client Registration (Notion, Linear, Asana, Sentry, Intercom, Cloudflare), no pre-configuration is needed. For services that require a pre-registered OAuth app (GitHub, Slack, Google Workspace), your system administrator must configure the OAuth client credentials before the connector appears in the catalog.
+**What happens behind the scenes:** CubeBox uses PKCE (Proof Key for Code Exchange) for all OAuth flows. For services that support Dynamic Client Registration — DCR (Notion, Linear, Atlassian, Asana, Sentry, Intercom, Cloudflare), no pre-configuration is needed: CubeBox registers its own OAuth client with the service automatically the first time someone installs the connector. For services that do not support DCR (GitHub, Slack, Google Workspace), your system administrator must register an OAuth app in the vendor's developer console and load its client credentials into CubeBox (via environment variables and the catalog seeder) before the connector can complete an OAuth flow.
+
+:::info 📸 Screenshot placeholder
+**Capture:** A connector card mid-OAuth, showing the **Connect with &lt;provider&gt;** button and the "Waiting for authorization in the new window…" state.
+**Asset:** `/img/mcp/oauth-connect.png`
+:::
 
 ### User-scoped OAuth
 
@@ -52,22 +57,22 @@ Some connectors may be configured so that each user authorizes their own account
 
 ### Reconnecting expired tokens
 
-OAuth tokens can expire. If a connector loses its authorization, you will see a **Reconnect** prompt the next time the agent tries to use that connector. Click it to re-authorize.
+OAuth tokens can expire. If a connector loses its authorization, its card on the **MCP** page shows a **Needs your credential** state with a **Re-authenticate** action. Click it to re-run the OAuth flow and restore access.
 
 ## Org-wide vs. workspace installs
 
 | Scope | Who can install | Visible in |
 |---|---|---|
-| **Org-wide** | Org admin (via **Admin > MCP**) | All workspaces in the organization |
-| **Workspace** | Workspace admin (via workspace **Settings > MCP Connectors**) | That workspace only |
+| **Org-wide** | Org admin (via **Admin > MCP Connectors**) | All workspaces in the organization |
+| **Workspace** | Workspace admin (via the workspace **MCP** page) | That workspace only |
 
 - Org-wide installs are useful for connectors the whole team needs (e.g., a shared GitHub integration).
 - Workspace installs are useful for project-specific tools or when different workspaces need different credentials.
 
 ## Disable or remove a connector
 
-- **Disable an org-wide connector** for your workspace: go to workspace **Settings > MCP Connectors**, find the connector, and toggle it off. The connector remains installed org-wide but is hidden from your workspace.
-- **Remove a workspace connector**: go to workspace **Settings > MCP Connectors**, find the connector, and click **Remove**. This deletes the install and its credentials.
+- **Disable an org-wide connector** for your workspace: open the workspace **MCP** page, find the connector, and turn it off. The connector remains installed org-wide but is hidden from your workspace.
+- **Remove a workspace connector**: open the workspace **MCP** page, find the connector, and choose **Uninstall**. This deletes the install and its credentials.
 
 ## Verifying the install
 

--- a/docs/site/docs/guides/mcp/overview.md
+++ b/docs/site/docs/guides/mcp/overview.md
@@ -29,13 +29,18 @@ CubeBox ships with templates for a growing list of services:
 | **Infrastructure** | Cloudflare (API, Workers, Observability, Logs, Radar) |
 | **Knowledge** | Microsoft Learn |
 
-Your admin may have additional connectors available. Check the connector catalog in your workspace to see what is installed.
+Your admin may have additional connectors available. Open the **MCP** page in your workspace sidebar to see what is installed and what is available to add.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The workspace **MCP** page showing the **Installed** and **Available** connector sections, with at least one connector in each (one ready, one showing a "Connect" action).
+**Asset:** `/img/mcp/workspace-mcp-page.png`
+:::
 
 ## Authentication modes
 
 Different connectors use different authentication methods:
 
-- **OAuth** — You authorize CubeBox to access the service on your behalf. The connector walks you through the vendor's consent screen. Some connectors (Notion, Linear, Asana, Sentry, Intercom, Cloudflare) handle this automatically; others (GitHub, Slack, Google Workspace) require admin pre-configuration.
+- **OAuth** — You authorize CubeBox to access the service on your behalf. The connector walks you through the vendor's consent screen. Most connectors (Notion, Linear, Atlassian, Asana, Sentry, Intercom, Cloudflare) handle this automatically; a few (GitHub, Slack, Google Workspace) require your administrator to pre-register an OAuth app first.
 - **API key** — You or your admin provides a static API key. Common for search connectors like Tavily and Exa.
 - **Bearer token** — A pre-issued token, similar to an API key. Used by connectors that issue long-lived access tokens.
 

--- a/docs/site/docs/guides/mcp/using-tools.md
+++ b/docs/site/docs/guides/mcp/using-tools.md
@@ -39,13 +39,13 @@ The agent may call both the GitHub and Linear connectors, then synthesize the re
 
 ## Progressive disclosure
 
-When your workspace has many connectors installed, CubeBox uses **progressive disclosure** to keep the agent efficient. Instead of loading every tool into the agent's context at once, the system:
+When your workspace has many connectors installed, CubeBox uses **progressive disclosure** to keep the agent efficient. When the combined tool definitions would take up too much of the model's context window, the system stops loading every tool upfront and instead:
 
-1. Loads the most commonly used tools upfront.
-2. Defers less-used tools into named groups.
-3. Activates deferred tools on demand when the agent determines they are relevant.
+1. Groups each connector's tools into a named, deferred group rather than loading them all into the agent's context.
+2. Shows the agent a lightweight summary of what each group can do.
+3. Loads a group's full tools on demand, only when the agent decides that connector is relevant to your request.
 
-This happens transparently. You do not need to configure anything — it is an automatic optimization that keeps responses fast even when dozens of connectors are installed.
+This kicks in automatically once enough connectors are installed (it needs at least two before it activates) and the tools grow large relative to the context window. You do not need to configure anything — it is an automatic optimization that keeps responses fast even when dozens of connectors are installed.
 
 ## What you can ask the agent to do
 
@@ -79,7 +79,7 @@ Here are common patterns for each connector category:
 
 **The agent does not use a tool I expected:**
 
-- Confirm the connector is installed: check workspace **Settings > MCP Connectors**.
+- Confirm the connector is installed: open the workspace **MCP** page.
 - Make sure the connector is not disabled for your workspace.
 - Try being more explicit in your request (e.g., "Use the GitHub connector to...").
 
@@ -91,7 +91,7 @@ Here are common patterns for each connector category:
 
 **I do not see any tool calls:**
 
-- Your workspace may not have any connectors installed. Ask your workspace admin to set up connectors from the catalog.
+- Your workspace may not have any connectors installed. Open the workspace **MCP** page to check, or ask your workspace admin to set up connectors from the catalog.
 - The model you selected may not support tool use. Switch to a model that does (most modern models support tools).
 
 ## Next steps

--- a/docs/site/docs/guides/memory/managing-memory.md
+++ b/docs/site/docs/guides/memory/managing-memory.md
@@ -5,76 +5,75 @@ title: Managing Memory
 
 # Managing Memory
 
-The Memory Center gives you full control over what the agent remembers. You can view, filter, edit, and archive memory items for any scope you have access to.
+The Memory Center is where you review what the agent remembers and retire items that are no longer accurate. You can browse memory for every scope you have access to, and archive any active item.
 
 ## Opening the Memory Center
 
-Navigate to your workspace, then click **Memory** in the sidebar. This opens the Memory Center at the path `/(app)/w/{workspaceId}/memory`.
+Go to your workspace and open **Memory**. The Memory Center lives at `/w/{workspaceId}/memory`, where `{workspaceId}` is your current workspace. You can also reach it from a conversation: when the agent saves or updates a memory, the chip it shows links straight into the Memory Center, pre-filtered to that conversation.
+
+:::info 📸 Screenshot placeholder
+**Capture:** The Memory Center with the Personal / Workspace / Organization / Archived tabs visible, showing a few memory cards (type badge, confidence percentage, content, and the hover Archive button).
+**Asset:** `/img/memory/memory-center.png`
+:::
 
 ## Browsing memory items
 
-The Memory Center shows a list of all memory items you can access. Each item displays:
+The Memory Center is organized into four tabs:
 
-- **Content** -- The stored information.
-- **Scope** -- A badge showing Personal, Workspace, or Organization.
-- **Type** -- The memory type (preference, project_fact, procedure, correction, decision, or org_policy).
-- **Source** -- A link to the conversation that created the memory item.
-- **Confidence** -- The agent's self-rated confidence score (0.0 to 1.0).
-- **Status** -- Active or Archived.
+- **Personal** — Active memories scoped to you.
+- **Workspace** — Active memories shared across this workspace.
+- **Organization** — Active memories shared across your whole organization.
+- **Archived** — Items you've retired, across all scopes.
 
-## Filtering
+Each card displays:
 
-Use the filter controls at the top of the Memory Center to narrow the list:
+- **Content** — The stored information.
+- **Type** — A colored badge: Preference, Fact, Procedure, Correction, Decision, or Org Policy.
+- **Confidence** — The agent's self-rated confidence, shown as a percentage (the underlying score ranges from 0.0 to 1.0).
+- **Updated** — When the item last changed, shown as a relative time ("Today", "3d ago").
+- **Source hint** — A "from conversation" marker on items the agent created during a chat.
+- **Status** — Archived items carry an "Archived" badge; active items do not.
 
-- **By scope** -- Show only Personal, Workspace, or Organization items.
-- **By type** -- Show only a specific memory type (e.g., show only corrections, or only procedures).
+## Filtering to a single conversation
 
-Filters combine: selecting "Workspace" scope and "project_fact" type shows only workspace-level project facts.
+When you open the Memory Center from a conversation's memory chip, it filters to just the items tied to that conversation, with a banner at the top. Click **Clear** in the banner to return to the full list.
 
-## Editing a memory item
+## Editing memory
 
-Click on any memory item to open it for editing. You can change:
+The Memory Center is read-and-archive only. To change the *content* of a memory item, ask the agent in conversation — for example, "update the memory about our API base URL to `api.example.com`." The agent edits the existing item in place rather than creating a duplicate. The same applies to changing an item's type or confidence: those updates happen through the agent, not the Memory Center UI.
 
-- **Content** -- Update the stored information. For example, if your API base URL changed, edit the project_fact directly rather than waiting for the agent to learn the new one.
-- **Status** -- Switch between Active and Archived. Archived items are excluded from the agent's recall but remain in the system for reference.
+## Archiving
 
-Changes take effect immediately. The next time the agent recalls memory, it will use the updated content.
+To archive an active memory, hover over its card and click the archive button in the top-right corner. Archiving sets the item's status to Archived: it is excluded from the agent's recall but kept in the system, and it moves to the **Archived** tab.
 
-## Archiving vs. deleting
-
-CubeBox supports two ways to remove a memory item from active recall:
-
-- **Archive** -- Sets the status to Archived. The item stays in the Memory Center and can be restored to Active later. Use this when information is outdated but might be useful for historical reference.
-- **Delete** -- Permanently removes the memory item. Use this for items that were created by mistake or contain incorrect information you do not want to keep.
-
-When in doubt, archive rather than delete. You can always delete an archived item later.
+There is no permanent-delete button in the Memory Center — archiving is the way to take an item out of active use. If you no longer want an item recalled, archive it. (Behind the scenes, even the delete action in the API is a soft-delete that archives the item rather than erasing it.)
 
 ## Practical workflows
 
 ### Cleaning up after a project pivot
 
-If your team changes tech stacks or renames a project, some workspace memories will be outdated. Filter by scope "Workspace" and type "project_fact", then archive or update items that no longer apply.
+If your team changes tech stacks or renames a project, some workspace memories will be outdated. Open the **Workspace** tab, scan for project facts that no longer apply, and archive them. To replace one with corrected content, ask the agent to update it in conversation.
 
 ### Reviewing agent corrections
 
-Filter by type "correction" to see every time someone corrected the agent. This is useful for spotting patterns -- if the same correction keeps appearing, consider adding a clearer project_fact or procedure to prevent the misunderstanding in the first place.
+Open the **Workspace** tab and look at the Correction badges to see where the agent has been corrected. This is useful for spotting patterns — if the same correction keeps appearing, consider asking the agent to save a clearer fact or procedure to prevent the misunderstanding in the first place.
 
 ### Onboarding a new team member
 
-New members automatically benefit from workspace and organization memory. They do not need to do anything. If you want to review what the agent will tell them, filter by "Workspace" scope to see all shared knowledge.
+New members automatically benefit from workspace and organization memory. They do not need to do anything. If you want to review what the agent will tell them, open the **Workspace** and **Organization** tabs to see all shared knowledge.
 
 ## Who can manage which memories
 
-Access depends on the memory scope and your role:
+Access depends on the memory scope. Within a scope, anyone who can see an item can also archive or update it — there is no separate "creator only" or "admin only" restriction on memory:
 
-| Memory scope | Who can view | Who can edit/archive/delete |
+| Memory scope | Who can view | Who can archive/update |
 |---|---|---|
 | Personal | Only you | Only you |
-| Workspace | All workspace members | Workspace admins and the item creator |
-| Organization | All org members | Org admins and the item creator |
+| Workspace | All members of that workspace | All members of that workspace |
+| Organization | All members of that organization | All members of that organization |
 
 ## Tips
 
-- **Review periodically.** Memory items created months ago may no longer be accurate. A quick scan of workspace memories once a month keeps the agent sharp.
-- **Use archive over delete.** Archived items serve as an audit trail of what the agent used to know.
-- **Edit rather than duplicate.** If a fact changes, update the existing memory item instead of creating a new one. Duplicates can cause the agent to recall conflicting information.
+- **Review periodically.** Memory items created months ago may no longer be accurate. A quick scan of the Workspace tab once a month keeps the agent sharp.
+- **Archive is the audit trail.** Archived items stay in the Archived tab as a record of what the agent used to know, even though they no longer affect recall.
+- **Ask the agent to update, not duplicate.** If a fact changes, tell the agent to update the existing memory rather than saving a fresh one. The agent edits in place; duplicates can cause it to recall conflicting information.

--- a/docs/site/docs/guides/memory/overview.md
+++ b/docs/site/docs/guides/memory/overview.md
@@ -17,26 +17,26 @@ CubeBox organizes memory into three scopes. Each scope controls who can see and 
 | **Workspace** | All members of the workspace | Project facts, team procedures, codebase conventions |
 | **Organization** | Everyone across all workspaces | Company-wide policies, brand guidelines, shared decisions |
 
-When the agent processes your conversation, it pulls in relevant items from all three tiers. Personal memory takes precedence when it conflicts with broader scopes -- for example, if workspace memory says "use tabs" but your personal memory says "I prefer spaces," the agent follows your personal preference when working with you.
+When the agent processes your conversation, it pulls in relevant items from all three tiers. The memory block presented to the agent groups items by scope (organization, then workspace, then personal) and labels workspace and organization items as user-contributed, so the agent can weigh them appropriately. Within any single scope, `correction` items take priority over ordinary memory of the same topic.
 
 ## Memory types
 
 Each memory item is classified by type, which helps the agent understand how to apply it:
 
-- **preference** -- How you or your team likes things done. *"I prefer TypeScript over JavaScript."*
-- **project_fact** -- A concrete fact about a project, codebase, or domain. *"Our API uses snake_case for all JSON keys."*
-- **procedure** -- A step-by-step process to follow. *"To deploy, run `make build` then `make deploy-staging` before pushing to production."*
-- **correction** -- Something the agent got wrong that you corrected. *"PostgreSQL, not MySQL -- we migrated last year."*
-- **decision** -- An agreed-upon decision that should be respected going forward. *"We chose Tailwind over CSS modules for the new dashboard."*
-- **org_policy** -- An organization-wide rule or standard. *"All public APIs must include rate limiting."*
+- **preference** — How you or your team likes things done. *"I prefer TypeScript over JavaScript."*
+- **project_fact** — A concrete fact about a project, codebase, or domain. *"Our API uses snake_case for all JSON keys."*
+- **procedure** — A step-by-step process to follow. *"To deploy, run `make build` then `make deploy-staging` before pushing to production."*
+- **correction** — Something the agent got wrong that you corrected. *"PostgreSQL, not MySQL — we migrated last year."*
+- **decision** — An agreed-upon decision that should be respected going forward. *"We chose Tailwind over CSS modules for the new dashboard."*
+- **org_policy** — An organization-wide rule or standard. *"All public APIs must include rate limiting."*
 
 ## How memory works
 
 The agent handles memory automatically in two directions:
 
-**Recall** -- At the start of each conversation turn, the agent retrieves memory items relevant to the current context. You do not need to ask it to "check memory" -- it does this on its own.
+**Recall** — At the start of each conversation turn, the agent retrieves memory items relevant to the current context. You do not need to ask it to "check memory" — it does this on its own.
 
-**Storage** -- When you share important information during a conversation, the agent may save it as a memory item. This happens when:
+**Storage** — When you share important information during a conversation, the agent may save it as a memory item. This happens when:
 
 - You explicitly ask: *"Remember that our staging URL is staging.example.com."*
 - You correct the agent: *"No, we use Poetry, not pip."*
@@ -44,14 +44,14 @@ The agent handles memory automatically in two directions:
 
 Each stored memory item includes:
 
-- **Content** -- The actual information.
-- **Scope** -- Personal, workspace, or organization.
-- **Type** -- One of the six types listed above.
-- **Source** -- A link back to the conversation or artifact that created it.
-- **Confidence** -- A score from 0.0 to 1.0, self-rated by the agent, indicating how confident it is in the memory's accuracy.
-- **Status** -- Active (used in recall) or archived (hidden from recall but not deleted).
+- **Content** — The actual information.
+- **Scope** — Personal, workspace, or organization.
+- **Type** — One of the six types listed above.
+- **Source** — A reference back to the conversation, run, or artifact that created it.
+- **Confidence** — A score from 0.0 to 1.0, self-rated by the agent, indicating how confident it is in the memory's accuracy. New items default to 0.8.
+- **Status** — Active (used in recall) or archived (hidden from recall but not deleted).
 
 ## Next steps
 
-- [Using Memory](./using-memory.md) -- Learn how to teach the agent and shape what it remembers.
-- [Managing Memory](./managing-memory.md) -- Edit, archive, and organize memory items from the Memory Center.
+- [Using Memory](./using-memory.md) — Learn how to teach the agent and shape what it remembers.
+- [Managing Memory](./managing-memory.md) — Review and archive memory items from the Memory Center.

--- a/docs/site/docs/guides/memory/using-memory.md
+++ b/docs/site/docs/guides/memory/using-memory.md
@@ -11,19 +11,23 @@ You do not need to configure anything to start using memory. The agent automatic
 
 The most direct way to create a memory is to tell the agent to remember something:
 
-> "Remember that our API uses snake_case for all response fields."
-
-The agent saves this as a **project_fact** in workspace memory, so every workspace member benefits from it in future conversations.
-
 > "Remember that I like concise answers with code examples."
 
 This becomes a **preference** in your personal memory, applying across all your workspaces.
 
-You can also be explicit about scope:
+By default, the agent saves to **personal** scope. This keeps your memory private to you unless you decide otherwise. So even a project fact saved without further instruction lands in your personal memory:
+
+> "Remember that our API uses snake_case for all response fields."
+
+The agent saves this as a **project_fact** in your personal memory.
+
+To share a memory with your whole team or organization, ask explicitly. The agent only writes workspace or organization scope when you say so:
+
+> "Save this for the whole workspace: our API uses snake_case for all response fields."
 
 > "Save this as an org-wide policy: all customer-facing text must be reviewed by the content team before launch."
 
-The agent stores this as an **org_policy** in organization memory.
+The first becomes a workspace **project_fact**; the second an **org_policy** in organization memory.
 
 ## Correcting the agent
 
@@ -33,19 +37,19 @@ When the agent gets something wrong, correct it directly:
 >
 > **You:** "We use pnpm, not npm."
 
-The agent saves a **correction** to workspace memory. In future conversations, it will use pnpm without being told again.
+The agent saves a **correction** to your personal memory. In future conversations, it will use pnpm without being told again. If you want the whole team to inherit the fix, tell the agent to share it ("save that for the workspace").
 
-Corrections work at any scope. If the agent keeps misunderstanding your personal preference, a correction to personal memory fixes it across all workspaces:
+Corrections work at any scope, and a personal correction follows you across all your workspaces:
 
-> "That's wrong -- I prefer dark mode code blocks, not light."
+> "That's wrong — I prefer dark mode code blocks, not light."
 
 ## What the agent remembers automatically
 
 Beyond explicit instructions, the agent may store memory items when it identifies reusable information during a conversation. For example:
 
-- You describe a deployment process step by step -- the agent may save it as a **procedure**.
-- You and the agent agree on an approach -- it may store the outcome as a **decision**.
-- You share a fact the agent did not know -- it may record it as a **project_fact**.
+- You describe a deployment process step by step — the agent may save it as a **procedure**.
+- You and the agent agree on an approach — it may store the outcome as a **decision**.
+- You share a fact the agent did not know — it may record it as a **project_fact**.
 
 Each automatically created memory includes a confidence score. Items from explicit instructions ("remember that...") typically get higher confidence than items the agent infers from context.
 
@@ -53,28 +57,29 @@ Each automatically created memory includes a confidence score. Items from explic
 
 Here is a practical example of how memory accumulates and helps over time:
 
-1. **Day 1** -- You tell the agent: *"Our backend is FastAPI with PostgreSQL, deployed on AWS ECS."* The agent saves a workspace-scoped project_fact.
+1. **Day 1** — You tell the agent: *"Save this for the workspace: our backend is FastAPI with PostgreSQL, deployed on AWS ECS."* The agent saves a workspace-scoped project_fact so the whole team inherits it.
 
-2. **Day 2** -- A teammate asks the agent to help write a database migration. The agent already knows the stack is PostgreSQL and uses the correct syntax without asking.
+2. **Day 2** — A teammate asks the agent to help write a database migration. The agent already knows the stack is PostgreSQL and uses the correct syntax without asking.
 
-3. **Day 3** -- You correct the agent: *"We use Alembic for migrations, not raw SQL."* The agent saves a correction to workspace memory.
+3. **Day 3** — You correct the agent: *"We use Alembic for migrations, not raw SQL — save that for the workspace too."* The agent saves a correction to workspace memory.
 
-4. **Day 4** -- Another teammate asks for help with a new migration. The agent recalls both the PostgreSQL fact and the Alembic correction, and produces an Alembic migration file.
+4. **Day 4** — Another teammate asks for help with a new migration. The agent recalls both the PostgreSQL fact and the Alembic correction, and produces an Alembic migration file.
 
 ## Scope selection
 
-The agent chooses the scope for new memories based on the content:
+The agent always defaults new memories to **personal** scope, and infers the *type* from the content. It only writes workspace or organization scope when you explicitly ask it to share:
 
-| Content pattern | Typical scope | Typical type |
+| Content pattern | Default scope | Typical type |
 |---|---|---|
 | "I prefer..." / "I like..." | Personal | preference |
-| "Our project uses..." / "The codebase..." | Workspace | project_fact |
-| "Company policy is..." / "Org-wide, we..." | Organization | org_policy |
-| Correcting a mistake | Same scope as the corrected topic | correction |
-| Agreeing on an approach | Workspace | decision |
-| Describing a step-by-step process | Workspace | procedure |
+| "Our project uses..." / "The codebase..." | Personal | project_fact |
+| Correcting a mistake | Personal | correction |
+| Agreeing on an approach | Personal | decision |
+| Describing a step-by-step process | Personal | procedure |
+| "Save this for the workspace: ..." | Workspace | project_fact / procedure / decision |
+| "Save this as an org-wide policy: ..." | Organization | org_policy |
 
-If the agent picks the wrong scope, you can correct it in conversation ("make that a personal preference, not workspace") or edit it later in the Memory Center.
+To promote a memory beyond yourself, say so when you ask the agent to remember it ("save that for the whole workspace"). You cannot change the scope of an existing item from the Memory Center, so be explicit up front.
 
 ## Tips
 
@@ -84,4 +89,4 @@ If the agent picks the wrong scope, you can correct it in conversation ("make th
 
 ## Next steps
 
-- [Managing Memory](./managing-memory.md) -- View, edit, and archive memory items from the Memory Center.
+- [Managing Memory](./managing-memory.md) — Review and archive memory items from the Memory Center.

--- a/docs/site/docs/guides/skills/discover-and-install.md
+++ b/docs/site/docs/guides/skills/discover-and-install.md
@@ -41,11 +41,12 @@ Local catalog skills (built-in and uploaded) take priority over remote duplicate
 
 ## Using the Skills marketplace
 
-For a more visual browsing experience, open the **Skills** page from the workspace sidebar. The URL pattern is:
+For a more visual browsing experience, open the **Skills** page from the workspace sidebar. It lives under your workspace at `/w/<workspace-id>/skills`, where `<workspace-id>` is your current workspace.
 
-```
-/<workspace>/skills
-```
+:::info 📸 Screenshot placeholder
+**Capture:** The workspace Skills marketplace page showing the System Catalog list on the left, a remote search query producing External Sources results below it, and a skill detail panel open on the right.
+**Asset:** `/img/skills/marketplace.png`
+:::
 
 The marketplace shows two sections:
 
@@ -55,7 +56,7 @@ The marketplace shows two sections:
 ### Browsing and searching
 
 - Use the **search bar** in the toolbar to filter by name or keyword. When remote registries are connected, the search also queries them.
-- Toggle **External only** to show only results from remote registries, hiding the local catalog.
+- Use the **Source** dropdown in the toolbar to narrow the list. It offers **All**, **Preinstalled**, **Uploaded**, and **External** — choosing **External** shows only results from remote registries and hides the local catalog.
 - Click any skill card to open its detail panel on the right, which shows the full description, keywords, version, download count (for remote skills), trust tier, and a rendered preview of the skill's `SKILL.md` content.
 
 ### Installing from the marketplace

--- a/docs/site/docs/guides/skills/managing-skills.md
+++ b/docs/site/docs/guides/skills/managing-skills.md
@@ -9,7 +9,7 @@ Once skills are installed, you can manage them from the workspace settings or th
 
 ## Viewing your workspace skills
 
-Open **Workspace Settings > Skills** to see every skill available in your workspace. Each skill card shows:
+Open the **Skills** page from the workspace sidebar to see every skill available in your workspace. Each skill card shows:
 
 - **Name** and short description.
 - **Source** — whether the skill is built-in (preinstalled) or uploaded.
@@ -29,6 +29,11 @@ A skill in your workspace can be in one of four states:
 | **Workspace-private** | Installed directly into this workspace (not org-wide). Always enabled. |
 | **Available** | Visible in the catalog but not installed in this workspace. You can install it from the detail panel. |
 
+:::info 📸 Screenshot placeholder
+**Capture:** The workspace **Skills** page showing skill cards with their state badges (org-enabled, org-disabled, workspace-private, available) and the source/state filter controls in the toolbar.
+**Asset:** `/img/skills/workspace-skills-page.png`
+:::
+
 ## Enabling and disabling skills
 
 For **org-wide skills**, a workspace owner or admin can toggle individual skills on or off for the workspace. Disabling a skill does not uninstall it — it just hides it from the agent in that workspace. Re-enable it at any time from the same panel.
@@ -39,7 +44,7 @@ For **org-wide skills**, a workspace owner or admin can toggle individual skills
 
 You can upload a skill directly to your workspace:
 
-1. On the Skills page or in Workspace Settings > Skills, click the **Add** button (or the upload action in the toolbar).
+1. On the workspace **Skills** page, click the **Add** button (or the upload action in the toolbar).
 2. Select a `.zip` file containing your skill. The zip must include a `SKILL.md` at the root with valid frontmatter (name, version, description).
 3. CubeBox validates the bundle and publishes it. The skill appears immediately in your workspace.
 
@@ -49,7 +54,7 @@ Custom skills uploaded at the workspace level are workspace-private. To make a s
 
 - The zip must contain a `SKILL.md` file at the root.
 - `SKILL.md` frontmatter must include `name`, `version`, and `description`.
-- Individual files in the bundle have a size limit enforced by the server.
+- Each file in the bundle may be at most 10 MB, and the whole bundle at most 50 MB.
 - The skill name must be unique within your organization's catalog.
 
 ## Updating skills

--- a/docs/site/docs/guides/skills/overview.md
+++ b/docs/site/docs/guides/skills/overview.md
@@ -32,7 +32,7 @@ Skills from remote registries carry a trust indicator so you know what you are i
 |---|---|
 | **Official** | Vetted by the registry maintainer or a known publisher. |
 | **Community** | Published by community contributors; not formally vetted. |
-| **Unvetted** | No review has been performed. Inspect the skill content before installing. |
+| **Untrusted** | No review has been performed. Inspect the skill content before installing. |
 
 Built-in and uploaded skills are inherently trusted because they come from CubeBox or your own organization.
 
@@ -51,7 +51,7 @@ Every skill contains at least a `SKILL.md` file — a markdown document with fro
 - **Templates** — Starter files, boilerplate, or reference material.
 - **Configuration** — Settings that control the skill's behavior.
 
-When a skill is loaded, its files are mounted at `/.skills/<name>/<version>/` inside the sandbox so the agent can reference them.
+When a skill is loaded, its files are mounted at `/.skills/<name>/<version>/` inside the sandbox so the agent can reference them. The agent reads a skill's instructions by calling the built-in `load_skill` tool with the skill's exact name.
 
 ## Next steps
 

--- a/docs/site/docs/intro.mdx
+++ b/docs/site/docs/intro.mdx
@@ -30,7 +30,7 @@ Sign up at [cubebox.ai](https://cubebox.ai). An organization is created automati
 </TabItem>
 <TabItem value="self-hosted" label="Self-hosted">
 
-Deploy CubeBox on your own infrastructure. The first user to register creates the organization and becomes its owner. Subsequent users join that organization.
+Deploy CubeBox on your own infrastructure. The first user to register is taken to a one-time setup screen to name the organization and becomes its owner. Subsequent users join that organization as members, each with their own personal workspace.
 
 </TabItem>
 </Tabs>

--- a/docs/site/sidebars.ts
+++ b/docs/site/sidebars.ts
@@ -25,6 +25,7 @@ const sidebars: SidebarsConfig = {
             'guides/conversations/attachments',
             'guides/conversations/artifacts',
             'guides/conversations/model-selection',
+            'guides/conversations/topics',
           ],
         },
         {
@@ -60,6 +61,18 @@ const sidebars: SidebarsConfig = {
           items: [
             'guides/automation/scheduled-tasks',
             'guides/automation/event-triggers',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'IM Connectors',
+          items: [
+            'guides/im/overview',
+            'guides/im/feishu',
+            'guides/im/slack',
+            'guides/im/dingtalk',
+            'guides/im/teams',
+            'guides/im/discord',
           ],
         },
       ],


### PR DESCRIPTION
## What

A full review-and-correction pass over the user-facing docs site (`docs/site/`), verifying every page against the backend/frontend code, plus the missing **IM Connectors** documentation.

## Why

The docs were written as one batch and had drifted from the shipped product — wrong routes/headers, fabricated UI flows, leaked internal URLs, and whole subsystems (IM bots) undocumented.

## Highlights

- **Event Triggers webhook** rewritten end-to-end against `triggers/ingest.py`: real route `…/ws/{ws}/triggers/{trg}/ingest`, HMAC over `"{timestamp}."+body`, required `X-Signature`+`X-Timestamp`, 404 (not 401) rejections, and the GitHub/Stripe-need-a-relay caveat. `curl` recipe + both examples fixed.
- **Removed invented mechanisms** the product never had: email-invite member flow, transfer-ownership, configurable missed-run policy, org-level skill toggle, workspace model restrictions, sandbox CPU/memory limits.
- **Navigation + labels**: killed leaked `/(app)/…` route-group URLs, standardized nav vocabulary (`Admin > X` / workspace sidebar pages / `Settings > Tab`), aligned UI strings/enums, normalized `--` → `—` site-wide.
- **New IM Connectors section**: overview + setup guides for **Feishu, Slack, DingTalk, Teams, Discord**, wired into the sidebar. Command/identity claims verified against code (`/new`+`/reset` only on Feishu+Discord; email auto-resolves on Feishu/Slack/DingTalk).
- **Screenshot placeholders** added wherever a visual is needed — real captures (with interaction) are a deliberate follow-up.
- **AGENTS.md rule 13**: docs ship with the code (same-PR doc updates for any user-facing behavior change) + the placeholder convention.

## How it was done

Largely via a `Workflow` fan-out (9 per-module reviewers + synthesizer) plus parallel authoring agents for the IM pages; every correction is code-cited. Plan and full review report live under `docs/dev/`.

## Verification

`pnpm build` passes for **en + zh-Hans** (`onBrokenLinks`/`onBrokenAnchors` are set to `throw`, so all internal links and anchors resolve). One MDX bug introduced mid-pass (`{enabled}` brace expression) was caught by the build and fixed.

## Follow-ups (tracked in `docs/dev/notes/2026-06-23-docs-overhaul-review-report.md`)

- Capture the real interaction screenshots (28 placeholders).
- Translate `zh-Hans` (builds today but content is English) or drop the locale.
- A handful of unverifiable claims left in place per the honesty rule (e.g. skill deprecate UI, sandbox log redaction) — listed for human confirmation.