### PR TITLE
fix(streams): exclude skills_cache from reload + recover stranded runs at startup

### DIFF
--- a/backend/cubebox/api/app.py
+++ b/backend/cubebox/api/app.py
@@ -368,6 +368,10 @@ async def lifespan(_app: FastAPI):  # type: ignore
 
     await start_search_subsystem(_app)
 
+    from cubebox.streams.recovery import recover_stranded_runs
+
+    await recover_stranded_runs(redis_client, prefix=_app.state.redis_key_prefix)
+
     yield
 
     # ==================== Shutdown ====================

--- a/backend/cubebox/streams/recovery.py
+++ b/backend/cubebox/streams/recovery.py
@@ -1,0 +1,103 @@
+"""Startup recovery for runs stranded by a crashed / killed process.
+
+Called once during app lifespan, after Redis and DB are ready but before
+the app begins serving requests (before ``yield``).
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+from redis.asyncio import Redis
+
+from cubebox.streams.run_events import get_run_meta, mark_run_stale
+
+
+async def recover_stranded_runs(redis: Redis, *, prefix: str) -> int:
+    """Scan Redis for stranded active-run keys and clean them up.
+
+    Returns the number of stranded runs recovered.
+    """
+    pattern = f"{prefix}:conversation_active_run:*"
+    prefix_len = len(f"{prefix}:conversation_active_run:")
+    recovered: list[tuple[str, str]] = []
+
+    async for key in redis.scan_iter(match=pattern, count=200):
+        run_id = await redis.get(key)
+        if run_id is None:
+            continue
+        meta = await get_run_meta(redis, prefix=prefix, run_id=run_id)
+        if meta is None or meta.status != "running":
+            continue
+        conversation_id = key[prefix_len:]
+        await mark_run_stale(
+            redis,
+            prefix=prefix,
+            run_id=run_id,
+            conversation_id=conversation_id,
+        )
+        recovered.append((conversation_id, run_id))
+        logger.info(
+            "Recovered stranded run {} on conversation {}",
+            run_id,
+            conversation_id,
+        )
+
+    if not recovered:
+        return 0
+
+    await _stamp_cubepi_runs(recovered)
+    await _fail_stranded_scheduled_runs([rid for _, rid in recovered])
+    await _repair_stranded_threads([cid for cid, _ in recovered])
+
+    logger.info("Startup recovery: {} stranded run(s) cleaned up", len(recovered))
+    return len(recovered)
+
+
+async def _stamp_cubepi_runs(pairs: list[tuple[str, str]]) -> None:
+    """Mark stranded cubepi_runs rows as completed so history is consistent."""
+    from cubebox.agents.checkpointer import init_checkpointer
+
+    try:
+        async with init_checkpointer() as cp:
+            for thread_id, run_id in pairs:
+                try:
+                    await cp.mark_run_complete(thread_id, run_id)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to stamp cubepi_runs for {}/{}: {}",
+                        thread_id,
+                        run_id,
+                        exc,
+                    )
+    except Exception as exc:
+        logger.warning("Could not open checkpointer for recovery: {}", exc)
+
+
+async def _fail_stranded_scheduled_runs(run_ids: list[str]) -> None:
+    from cubebox.schedules.completion_hook import (
+        record_scheduled_run_terminal_state,
+    )
+
+    for run_id in run_ids:
+        try:
+            await record_scheduled_run_terminal_state(run_id=run_id, run_status="cancelled")
+        except Exception as exc:
+            logger.warning(
+                "Failed to mark scheduled run {} as failed: {}",
+                run_id,
+                exc,
+            )
+
+
+async def _repair_stranded_threads(conversation_ids: list[str]) -> None:
+    from cubebox.streams.run_manager import _repair_dangling_tool_calls
+
+    for conv_id in conversation_ids:
+        try:
+            await _repair_dangling_tool_calls(conv_id)
+        except Exception as exc:
+            logger.warning(
+                "Failed to repair dangling tool_calls for {}: {}",
+                conv_id,
+                exc,
+            )

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,7 +27,11 @@ if __name__ == "__main__":
         # checkout / worktree would crash on `python main.py` before it exists.
         # mkdir it up front so the existing-dir short-circuit always applies.
         backend_dir = Path(__file__).resolve().parent
-        excluded_dirs = [backend_dir / ".venv", backend_dir / "cubepi-traces"]
+        excluded_dirs = [
+            backend_dir / ".venv",
+            backend_dir / "cubepi-traces",
+            backend_dir / "skills_cache",
+        ]
         for d in excluded_dirs:
             d.mkdir(parents=True, exist_ok=True)
         reload_kwargs = {

--- a/backend/tests/e2e/test_stranded_run_recovery.py
+++ b/backend/tests/e2e/test_stranded_run_recovery.py
@@ -1,0 +1,142 @@
+"""E2E: startup recovery for stranded runs.
+
+Simulates a process crash leaving behind a Redis active-run key with
+status=running and a cubepi_runs row with completed_at IS NULL, then
+calls recover_stranded_runs() and verifies cleanup.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import asyncpg
+import pytest
+from redis.asyncio import Redis
+
+from cubebox.agents.checkpointer import _build_dsn
+from cubebox.streams.recovery import recover_stranded_runs
+
+
+def _test_prefix() -> str:
+    base = "cubebox"
+    env = os.getenv("ENV_FOR_DYNACONF", "development")
+    return f"{base}:{env}"
+
+
+async def _plant_stranded_run(
+    redis: Redis,
+    prefix: str,
+) -> tuple[str, str]:
+    """Plant a stranded run in Redis + Postgres. Returns (conv_id, run_id)."""
+    conv_id = f"conv-recovery-{uuid.uuid4().hex[:8]}"
+    run_id = str(uuid.uuid4())
+    stale_time = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+
+    active_key = f"{prefix}:conversation_active_run:{conv_id}"
+    meta_key = f"{prefix}:run_meta:v2:{run_id}"
+    await redis.set(active_key, run_id, ex=43200)
+    await redis.hset(
+        meta_key,
+        mapping={
+            "run_id": run_id,
+            "conversation_id": conv_id,
+            "status": "running",
+            "started_at": stale_time,
+        },
+    )
+    await redis.expire(meta_key, 43200)
+
+    conn = await asyncpg.connect(_build_dsn())
+    try:
+        await conn.execute(
+            "INSERT INTO cubepi_threads (thread_id) VALUES ($1) ON CONFLICT DO NOTHING",
+            conv_id,
+        )
+        await conn.execute(
+            "INSERT INTO cubepi_runs (thread_id, run_id, claimed_at) VALUES ($1, $2, $3)",
+            conv_id,
+            run_id,
+            datetime.now(UTC) - timedelta(minutes=10),
+        )
+    finally:
+        await conn.close()
+
+    return conv_id, run_id
+
+
+async def _cleanup_thread(conv_id: str, run_id: str, prefix: str, redis: Redis) -> None:
+    await redis.delete(
+        f"{prefix}:conversation_active_run:{conv_id}",
+        f"{prefix}:run_meta:v2:{run_id}",
+    )
+    conn = await asyncpg.connect(_build_dsn())
+    try:
+        await conn.execute(
+            "DELETE FROM cubepi_runs WHERE thread_id = $1",
+            conv_id,
+        )
+        await conn.execute(
+            "DELETE FROM cubepi_threads WHERE thread_id = $1",
+            conv_id,
+        )
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_recover_stranded_runs_clears_redis_and_stamps_db() -> None:
+    from cubebox.config import config
+
+    prefix = _test_prefix()
+    redis = Redis.from_url(
+        config.get("redis.url", "redis://127.0.0.1:6379/0"),
+        decode_responses=True,
+    )
+    try:
+        conv_id, run_id = await _plant_stranded_run(redis, prefix)
+        try:
+            active_key = f"{prefix}:conversation_active_run:{conv_id}"
+            assert await redis.exists(active_key)
+
+            count = await recover_stranded_runs(redis, prefix=prefix)
+            assert count >= 1
+
+            assert not await redis.exists(active_key)
+
+            meta_key = f"{prefix}:run_meta:v2:{run_id}"
+            status = await redis.hget(meta_key, "status")
+            assert status == "stale"
+
+            conn = await asyncpg.connect(_build_dsn())
+            try:
+                row = await conn.fetchrow(
+                    "SELECT completed_at FROM cubepi_runs WHERE thread_id = $1 AND run_id = $2",
+                    conv_id,
+                    run_id,
+                )
+                assert row is not None
+                assert row["completed_at"] is not None
+            finally:
+                await conn.close()
+        finally:
+            await _cleanup_thread(conv_id, run_id, prefix, redis)
+    finally:
+        await redis.aclose()
+
+
+@pytest.mark.asyncio
+async def test_recover_noop_when_no_stranded_runs() -> None:
+    from cubebox.config import config
+
+    prefix = _test_prefix()
+    redis = Redis.from_url(
+        config.get("redis.url", "redis://127.0.0.1:6379/0"),
+        decode_responses=True,
+    )
+    try:
+        count = await recover_stranded_runs(redis, prefix=prefix)
+        assert count == 0
+    finally:
+        await redis.aclose()


### PR DESCRIPTION
## Summary
- Add `skills_cache/` to uvicorn `reload_excludes` — skill cache writes `.py` files during agent runs that trigger uvicorn reload, killing in-flight runs mid-tool-execution.
- Add startup recovery for stranded runs: on boot, SCAN Redis for active-run keys still in `status=running` (left by a crashed/killed process), mark them stale, stamp `cubepi_runs.completed_at`, fail orphaned `ScheduledTaskRun` rows, and repair dangling tool_calls.

**Root cause**: scheduled tasks (and any agent run) that invoke tools trigger skill cache extraction, writing `.py` files into `backend/skills_cache/`. With `reload: true`, uvicorn's file watcher picks these up and restarts the process mid-run. The 5s drain timeout isn't enough for tool execution to complete, so `CancelledError` fires but `cubepi_runs.completed_at` is never stamped — leaving the conversation locked until Redis TTL expires (12h).

## Test plan
- [x] `tests/e2e/test_stranded_run_recovery.py` — plants a stranded run in Redis + Postgres, calls `recover_stranded_runs()`, verifies Redis key deleted, meta status=stale, DB completed_at stamped
- [x] Noop test — no stranded runs returns 0
- [x] Pre-push CI passes (ruff, mypy, pytest unit, frontend build+lint+typecheck)
- [x] Manual verification: created a scheduled task, confirmed it ran to completion without restart after `reload: false`