### PR TITLE
fix(egress): fail fast on exchange listener startup errors

### DIFF
--- a/backend/cubebox/sandbox_env/exchange_listener.py
+++ b/backend/cubebox/sandbox_env/exchange_listener.py
@@ -85,6 +85,11 @@ class ExchangeListener:
         keyfile: str,
         ca_certs: str,
     ) -> None:
+        self._host = host
+        self._port = port
+        self._certfile = certfile
+        self._keyfile = keyfile
+        self._ca_certs = ca_certs
         config = uvicorn.Config(
             app,
             host=host,
@@ -100,9 +105,33 @@ class ExchangeListener:
         self._server = _NoSignalServer(config)
         self._task: asyncio.Task[None] | None = None
 
+    def _preflight(self) -> None:
+        """Fail fast before ``serve()`` if the listener obviously can't start."""
+        import socket
+        from pathlib import Path
+
+        for label, path in [
+            ("certfile", self._certfile),
+            ("keyfile", self._keyfile),
+            ("ca_certs", self._ca_certs),
+        ]:
+            if not Path(path).is_file():
+                raise RuntimeError(f"Egress exchange listener: {label} not found: {path}")
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.bind((self._host, self._port))
+        except OSError as exc:
+            raise RuntimeError(
+                f"Egress exchange listener: cannot bind {self._host}:{self._port}: {exc}"
+            ) from exc
+        finally:
+            sock.close()
+
     async def start(self) -> None:
+        self._preflight()
         self._task = asyncio.create_task(self._server.serve())
-        logger.info("Egress exchange mTLS listener started")
+        logger.info("Egress exchange mTLS listener started on port {}", self._port)
 
     async def stop(self) -> None:
         self._server.should_exit = True

--- a/scripts/worktree-env
+++ b/scripts/worktree-env
@@ -274,6 +274,10 @@ def write_worktree_env(
         f"\n"
         f"# Backend: frontend URL for link generation (IM identity link etc.)\n"
         f"CUBEBOX_FRONTEND_BASE_URL=http://localhost:{fe}\n"
+        f"\n"
+        f"# Disable the egress exchange mTLS listener — worktrees share the\n"
+        f"# host network and the main backend already owns port 9443.\n"
+        f"CUBEBOX_EGRESS_EXCHANGE__LISTENER__ENABLED=false\n"
     )
     env_file_path(worktree_root).write_text(content)
 


### PR DESCRIPTION
## Summary
- Exchange listener 之前 fire-and-forget uvicorn task，启动失败（证书缺失/端口冲突）时无日志、运行中莫名崩溃
- 添加 `_preflight()` 检查：启动前验证证书文件存在 + 端口可绑定，失败时 `RuntimeError` 直接阻止进程启动
- Worktree 环境默认禁用 exchange listener（`CUBEBOX_EGRESS_EXCHANGE__LISTENER__ENABLED=false`），避免与主 backend 的 9443 端口冲突

## Test plan
- [x] 端口被占时启动 → `RuntimeError: cannot bind 0.0.0.0:9443: Address already in use`，进程立即退出
- [x] 证书缺失时启动 → `RuntimeError: certfile not found: certs/egress/server.cert.pem`，进程立即退出
- [x] 正常启动 → `Egress exchange mTLS listener started on port 9443`，8080 + 9443 均正常监听
- [x] pre-push hooks (ruff + mypy + pytest unit + frontend CI) 全部通过