### PR TITLE
perf(conversations): tail-load bootstrap history + paginate older windows

### DIFF
--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -1547,33 +1547,41 @@ async def send_message(
     return SendMessageResponse(run_id=run_id)
 
 
-async def _get_history_messages(raw_request: Request, conversation_id: str) -> dict[str, object]:
-    """Read cubepi-runtime conversation history.
+_DEFAULT_HISTORY_TAIL = 300
+_MAX_HISTORY_WINDOW = 500
 
-    Messages are returned in cubepi's native shape (UserMessage / AssistantMessage /
-    ToolResultMessage as pydantic dumps). The frontend consumes this shape directly;
-    no cubebox-specific wire conversion layer.
-    """
+
+def _history_tail_limit() -> int:
+    """Default tail size for bootstrap. Configurable via lifecycle config."""
+    return int(_config.get("lifecycle.bootstrap_history_tail", _DEFAULT_HISTORY_TAIL))
+
+
+async def _load_pending_hitl(
+    conversation_id: str,
+) -> tuple[Any, str | None]:
+    """Read cubepi-persisted pending_request + persisted run_id in one checkpointer open."""
     from cubebox.agents.checkpointer import init_checkpointer
-    from cubebox.agents.stream import unwrap_deferred_in_message_dicts
 
-    del raw_request  # checkpointer factory override hook (unused; preserved for future use)
     async with init_checkpointer() as cp:
-        data = await cp.load(conversation_id)
-    if data is None:
-        return {"messages": [], "total": 0}
-    messages = unwrap_deferred_in_message_dicts([m.model_dump(mode="json") for m in data.messages])
-    return {"messages": messages, "total": len(messages)}
+        pending_req = await cp.load_pending_request(conversation_id)
+        persisted_run_id = await cp.load_pending_run_id(conversation_id)
+    return pending_req, persisted_run_id
 
 
 @router.get("/{conversation_id}/messages")
 async def list_messages(
     conversation_id: str,
-    raw_request: Request,
     session: Annotated[AsyncSession, Depends(get_session)],
     ctx: Annotated[RequestContext, Depends(require_member)],
+    before_seq: int | None = None,
+    limit: int | None = None,
 ) -> dict[str, object]:
-    """List messages in a conversation, read from cubepi PostgresCheckpointer state."""
+    """Return a paginated slice of a conversation's history (newest tail by default).
+
+    ``before_seq`` is an exclusive cursor (use the previous slice's ``oldest_seq``);
+    ``limit`` is clamped to ``_MAX_HISTORY_WINDOW`` so a client cannot ask for the
+    whole history in one shot.
+    """
     conv_repo = ConversationRepository(
         session,
         org_id=ctx.org_id,
@@ -1587,7 +1595,17 @@ async def list_messages(
             detail=f"Conversation {conversation_id} not found",
         )
 
-    return await _get_history_messages(raw_request, conversation_id)
+    from cubebox.services.history_window import load_history_window
+
+    effective_limit = min(limit or _history_tail_limit(), _MAX_HISTORY_WINDOW)
+    window = await load_history_window(
+        session, conversation_id, before_seq=before_seq, limit=effective_limit
+    )
+    return {
+        "messages": window.messages,
+        "oldest_seq": window.oldest_seq,
+        "has_more": window.has_more,
+    }
 
 
 @router.get("/{conversation_id}/bootstrap")
@@ -1598,7 +1616,17 @@ async def get_conversation_bootstrap(
     ctx: Annotated[RequestContext, Depends(require_member)],
     rds: Annotated[RedisHandle, Depends(redis_dep)],
 ) -> dict[str, object]:
-    """Return history baseline plus active run metadata."""
+    """Return history tail + active-run metadata + usage panel data in one round trip.
+
+    History is the most recent ``lifecycle.bootstrap_history_tail`` messages
+    (default 300). The frontend uses ``oldest_seq`` + ``has_more`` to lazy-load
+    older windows via ``/{conversation_id}/messages?before_seq=...``.
+    """
+    import asyncio
+
+    from cubebox.services.history_window import load_history_window
+    from cubebox.streams.hitl_resume import serialize_pending_hitl
+
     conv_repo = ConversationRepository(
         session,
         org_id=ctx.org_id,
@@ -1612,16 +1640,21 @@ async def get_conversation_bootstrap(
             detail=f"Conversation {conversation_id} not found",
         )
 
-    from cubebox.config import config as _cfg
-
-    history = await _get_history_messages(raw_request, conversation_id)
-    active_run = await get_active_run(
-        rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
+    # Stage A: the session-bound history read runs concurrently with the
+    # Redis + cubepi-pool work — those do not touch ``session``, so there is
+    # no SQLAlchemy concurrency conflict.
+    history, active_run, pending_pair, last_run_error_raw = await asyncio.gather(
+        load_history_window(session, conversation_id, limit=_history_tail_limit()),
+        get_active_run(rds.client, prefix=rds.key_prefix, conversation_id=conversation_id),
+        _load_pending_hitl(conversation_id),
+        get_conversation_last_error(
+            rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
+        ),
     )
 
     last_run_status: str | None = None
     if active_run is not None:
-        threshold = int(_cfg.get("lifecycle.stale_run_threshold_seconds", 120))
+        threshold = int(_config.get("lifecycle.stale_run_threshold_seconds", 120))
         if is_stale_meta(active_run, threshold_seconds=threshold):
             await mark_run_stale(
                 rds.client,
@@ -1648,10 +1681,35 @@ async def get_conversation_bootstrap(
             "error_message": active_run.error_message,
         }
 
-    # --- Token usage for the usage panel ---
-    msgs: list[dict[str, Any]] = history["messages"]  # type: ignore[assignment]
+    pending_req, persisted_run_id = pending_pair
+    pending_hitl: dict[str, Any] | None = None
+    if pending_req is not None:
+        # Run_id resolution order: Redis active-run (already fetched above) first,
+        # DB-persisted fallback for long-pause TTL recovery.
+        run_id_for_pending = active_run.run_id if active_run is not None else persisted_run_id
+        if run_id_for_pending is None:
+            # Legacy row (pre-cubepi-v3) — log + degrade to null so the user
+            # can at least see other conversation state.
+            logger.warning(
+                "pending_request for %s has no recoverable run_id; pending_hitl set to null",
+                conversation_id,
+            )
+        else:
+            pending_hitl = serialize_pending_hitl(pending_req, run_id=run_id_for_pending)
+
+    last_run_error_payload: dict[str, Any] | None = None
+    if last_run_error_raw is not None:
+        last_run_error_payload = {
+            "run_id": last_run_error_raw.get("run_id"),
+            "error_code": last_run_error_raw.get("error_code"),
+            "error_params": _parse_error_params(last_run_error_raw.get("error_params")),
+            "error_message": last_run_error_raw.get("error_message"),
+        }
+
+    # Stage B: usage summary depends on (a) the session being free and (b)
+    # the last user message timestamp from history.
     last_user_ts: str | None = None
-    for msg in reversed(msgs):
+    for msg in reversed(history.messages):
         if isinstance(msg, dict) and msg.get("role") == "user":
             ts = msg.get("timestamp")
             if isinstance(ts, (int, float)):
@@ -1668,49 +1726,10 @@ async def get_conversation_bootstrap(
         last_user_message_ts=last_user_ts,
     )
 
-    # --- pending_hitl: cold-start fallback when Redis event log has aged out ---
-    from cubebox.agents.checkpointer import init_checkpointer
-    from cubebox.streams.hitl_resume import serialize_pending_hitl
-
-    async with init_checkpointer() as cp:
-        pending_req = await cp.load_pending_request(conversation_id)
-        persisted_run_id = await cp.load_pending_run_id(conversation_id)
-
-    pending_hitl: dict[str, Any] | None = None
-    if pending_req is not None:
-        # Run_id resolution order: Redis active-run first (cheapest, hot
-        # path), DB-persisted fallback (long-pause TTL recovery).
-        active_for_pending = await get_active_run(
-            rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
-        )
-        run_id_for_pending = (
-            active_for_pending.run_id if active_for_pending is not None else persisted_run_id
-        )
-        if run_id_for_pending is None:
-            # Legacy row (pre-cubepi-v3) — log + degrade to null so the user
-            # can at least see other conversation state.
-            logger.warning(
-                "pending_request for %s has no recoverable run_id; pending_hitl set to null",
-                conversation_id,
-            )
-        else:
-            pending_hitl = serialize_pending_hitl(pending_req, run_id=run_id_for_pending)
-
-    last_run_error_raw = await get_conversation_last_error(
-        rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
-    )
-    last_run_error_payload: dict[str, Any] | None = None
-    if last_run_error_raw is not None:
-        last_run_error_payload = {
-            "run_id": last_run_error_raw.get("run_id"),
-            "error_code": last_run_error_raw.get("error_code"),
-            "error_params": _parse_error_params(last_run_error_raw.get("error_params")),
-            "error_message": last_run_error_raw.get("error_message"),
-        }
-
     return {
-        "messages": history["messages"],
-        "total": history["total"],
+        "messages": history.messages,
+        "oldest_seq": history.oldest_seq,
+        "has_more": history.has_more,
         "active_run": active_run_payload,
         "last_run_status": last_run_status,
         "last_run_error": last_run_error_payload,

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -1624,7 +1624,7 @@ async def get_conversation_bootstrap(
     """
     import asyncio
 
-    from cubebox.services.history_window import load_history_window
+    from cubebox.services.history_window import find_latest_todos, load_history_window
     from cubebox.streams.hitl_resume import serialize_pending_hitl
 
     conv_repo = ConversationRepository(
@@ -1684,9 +1684,19 @@ async def get_conversation_bootstrap(
     pending_req, persisted_run_id = pending_pair
     pending_hitl: dict[str, Any] | None = None
     if pending_req is not None:
-        # Run_id resolution order: Redis active-run (already fetched above) first,
-        # DB-persisted fallback for long-pause TTL recovery.
-        run_id_for_pending = active_run.run_id if active_run is not None else persisted_run_id
+        # Run_id resolution order: Redis active-run (cheapest, hot path) first,
+        # DB-persisted fallback for long-pause TTL recovery. When the stage-A
+        # active_run was None (or got cleared by the staleness check above),
+        # a fresh fetch may pick up a brand-new run a worker just created —
+        # preserve the original semantics by re-checking Redis in that case.
+        run_id_for_pending: str | None
+        if active_run is not None:
+            run_id_for_pending = active_run.run_id
+        else:
+            fresh = await get_active_run(
+                rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
+            )
+            run_id_for_pending = fresh.run_id if fresh is not None else persisted_run_id
         if run_id_for_pending is None:
             # Legacy row (pre-cubepi-v3) — log + degrade to null so the user
             # can at least see other conversation state.
@@ -1725,11 +1735,15 @@ async def get_conversation_bootstrap(
         encryption_backend=raw_request.app.state.encryption_backend,
         last_user_message_ts=last_user_ts,
     )
+    # Todos can live below the bootstrap tail — walk the most recent assistant
+    # rows directly so the panel hydrates correctly on long conversations.
+    todos = await find_latest_todos(session, conversation_id)
 
     return {
         "messages": history.messages,
         "oldest_seq": history.oldest_seq,
         "has_more": history.has_more,
+        "todos": todos,
         "active_run": active_run_payload,
         "last_run_status": last_run_status,
         "last_run_error": last_run_error_payload,

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -1696,7 +1696,14 @@ async def get_conversation_bootstrap(
             fresh = await get_active_run(
                 rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
             )
-            run_id_for_pending = fresh.run_id if fresh is not None else persisted_run_id
+            # Apply the same staleness gate stage-A does: a row that's already
+            # past the heartbeat threshold would point pending_hitl at a dead
+            # run, and every approve/decline from the client would 404.
+            threshold = int(_config.get("lifecycle.stale_run_threshold_seconds", 120))
+            if fresh is not None and not is_stale_meta(fresh, threshold_seconds=threshold):
+                run_id_for_pending = fresh.run_id
+            else:
+                run_id_for_pending = persisted_run_id
         if run_id_for_pending is None:
             # Legacy row (pre-cubepi-v3) — log + degrade to null so the user
             # can at least see other conversation state.

--- a/backend/cubebox/services/history_window.py
+++ b/backend/cubebox/services/history_window.py
@@ -121,25 +121,30 @@ async def find_latest_todos(
         if not isinstance(content, list):
             continue
         for block in content:
-            if (
+            if not (
                 isinstance(block, dict)
                 and block.get("type") == "tool_call"
                 and block.get("name") == "write_todos"
             ):
-                args = block.get("arguments") or {}
-                raw_todos = args.get("todos") if isinstance(args, dict) else None
-                if not isinstance(raw_todos, list):
-                    return []
-                out: list[dict[str, Any]] = []
-                for t in raw_todos:
-                    if not isinstance(t, dict):
-                        continue
-                    description = t.get("content")
-                    if not isinstance(description, str) or not description.strip():
-                        continue
-                    status = t.get("status")
-                    if status not in ("in_progress", "completed"):
-                        status = "pending"
-                    out.append({"id": None, "description": description.strip(), "status": status})
-                return out
+                continue
+            args = block.get("arguments")
+            raw_todos = args.get("todos") if isinstance(args, dict) else None
+            if not isinstance(raw_todos, list):
+                # Malformed call (e.g. mid-stream tool args truncated, or a
+                # future schema with a different field name): fall through to
+                # an older assistant row rather than clobbering a still-valid
+                # todo list with an empty panel.
+                continue
+            out: list[dict[str, Any]] = []
+            for t in raw_todos:
+                if not isinstance(t, dict):
+                    continue
+                description = t.get("content")
+                if not isinstance(description, str) or not description.strip():
+                    continue
+                status = t.get("status")
+                if status not in ("in_progress", "completed"):
+                    status = "pending"
+                out.append({"id": None, "description": description.strip(), "status": status})
+            return out
     return None

--- a/backend/cubebox/services/history_window.py
+++ b/backend/cubebox/services/history_window.py
@@ -1,0 +1,85 @@
+"""Paginated read access to a cubepi conversation's checkpoint history.
+
+cubepi's ``PostgresCheckpointer.load()`` returns the entire history with no
+LIMIT — for long conversations the wire payload, msgpack/Pydantic decode,
+and JSON re-serialization are the dominant bootstrap cost.
+
+This helper queries ``cubepi_messages`` directly through cubebox's existing
+SQLAlchemy pool (no extra asyncpg pool), pages by ``seq``, and skips the
+Pydantic round-trip — the stored payload is already
+``Message.model_dump(mode="json")`` shape, so we can hand it to the frontend
+verbatim after metadata patching and deferred-tool unwrapping.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import msgpack
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.agents.stream import unwrap_deferred_in_message_dicts
+
+
+@dataclass(frozen=True)
+class HistoryWindow:
+    """Result of a paginated history read.
+
+    ``messages`` is in chronological (oldest-first) order so callers can append
+    in render order. ``oldest_seq`` is the ``seq`` of the first message in
+    the slice (or ``None`` when empty) — pass it back as ``before_seq`` on
+    the next call to fetch the older page. ``has_more`` is true iff at
+    least one message exists with ``seq < oldest_seq``.
+    """
+
+    messages: list[dict[str, Any]]
+    oldest_seq: int | None
+    has_more: bool
+
+
+async def load_history_window(
+    session: AsyncSession,
+    thread_id: str,
+    *,
+    before_seq: int | None = None,
+    limit: int,
+) -> HistoryWindow:
+    """Load up to ``limit`` messages ending at ``before_seq`` (exclusive).
+
+    ``before_seq=None`` returns the most recent ``limit`` messages, which is
+    what conversation bootstrap wants. A subsequent backscroll request passes
+    the previous slice's ``oldest_seq`` as ``before_seq``.
+    """
+    if limit <= 0:
+        return HistoryWindow(messages=[], oldest_seq=None, has_more=False)
+
+    # +1 probe row tells us whether older messages exist without a COUNT(*)
+    params: dict[str, Any] = {"tid": thread_id, "limit": limit + 1}
+    sql = "SELECT seq, role, metadata, payload FROM cubepi_messages WHERE thread_id = :tid"
+    if before_seq is not None:
+        sql += " AND seq < :before"
+        params["before"] = before_seq
+    sql += " ORDER BY seq DESC LIMIT :limit"
+
+    rows = (await session.execute(text(sql), params)).all()
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+
+    decoded: list[dict[str, Any]] = []
+    for row in reversed(rows):  # DB returned newest-first; flip to chronological
+        _seq, _role, raw_meta, payload = row
+        data = msgpack.unpackb(bytes(payload), raw=False)
+        if isinstance(raw_meta, str):
+            data["metadata"] = json.loads(raw_meta)
+        elif raw_meta is not None:
+            data["metadata"] = raw_meta
+        else:
+            data["metadata"] = {}
+        decoded.append(data)
+
+    messages = unwrap_deferred_in_message_dicts(decoded)
+    oldest_seq = int(rows[-1][0]) if rows else None
+    return HistoryWindow(messages=messages, oldest_seq=oldest_seq, has_more=has_more)

--- a/backend/cubebox/services/history_window.py
+++ b/backend/cubebox/services/history_window.py
@@ -70,7 +70,7 @@ async def load_history_window(
 
     decoded: list[dict[str, Any]] = []
     for row in reversed(rows):  # DB returned newest-first; flip to chronological
-        _seq, _role, raw_meta, payload = row
+        seq, _role, raw_meta, payload = row
         data = msgpack.unpackb(bytes(payload), raw=False)
         if isinstance(raw_meta, str):
             data["metadata"] = json.loads(raw_meta)
@@ -78,8 +78,68 @@ async def load_history_window(
             data["metadata"] = raw_meta
         else:
             data["metadata"] = {}
+        # seq is the stable per-message cursor the frontend uses for the
+        # ``#msg-<seq>`` anchor (search deep-links rely on this), and the
+        # caller uses ``oldest_seq`` to drive backscroll pagination.
+        data["seq"] = int(seq)
         decoded.append(data)
 
     messages = unwrap_deferred_in_message_dicts(decoded)
     oldest_seq = int(rows[-1][0]) if rows else None
     return HistoryWindow(messages=messages, oldest_seq=oldest_seq, has_more=has_more)
+
+
+# Walk this many recent assistant messages when looking up todo state. Agents
+# typically rewrite the todo list every few turns; the bound caps decode work
+# on long conversations and matches the practical depth where todos go stale.
+_TODOS_LOOKBACK_ASSISTANTS = 100
+
+
+async def find_latest_todos(
+    session: AsyncSession,
+    thread_id: str,
+    *,
+    limit: int = _TODOS_LOOKBACK_ASSISTANTS,
+) -> list[dict[str, Any]] | None:
+    """Return the parsed todo list from the most recent ``write_todos`` call.
+
+    The conversation bootstrap returns only a tail of the history, so a
+    naive client-side walk over the tail can miss a still-current todo
+    list whose ``write_todos`` call lives further back. We scan the
+    newest ``limit`` assistant rows directly; ``None`` means no todos
+    were ever written (or none within the bound).
+    """
+    sql = (
+        "SELECT payload FROM cubepi_messages "
+        "WHERE thread_id = :tid AND role = 'assistant' "
+        "ORDER BY seq DESC LIMIT :limit"
+    )
+    rows = (await session.execute(text(sql), {"tid": thread_id, "limit": limit})).all()
+    for (payload,) in rows:
+        msg = msgpack.unpackb(bytes(payload), raw=False)
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_call"
+                and block.get("name") == "write_todos"
+            ):
+                args = block.get("arguments") or {}
+                raw_todos = args.get("todos") if isinstance(args, dict) else None
+                if not isinstance(raw_todos, list):
+                    return []
+                out: list[dict[str, Any]] = []
+                for t in raw_todos:
+                    if not isinstance(t, dict):
+                        continue
+                    description = t.get("content")
+                    if not isinstance(description, str) or not description.strip():
+                        continue
+                    status = t.get("status")
+                    if status not in ("in_progress", "completed"):
+                        status = "pending"
+                    out.append({"id": None, "description": description.strip(), "status": status})
+                return out
+    return None

--- a/backend/tests/e2e/test_cubepi_history_round_trip.py
+++ b/backend/tests/e2e/test_cubepi_history_round_trip.py
@@ -38,7 +38,8 @@ async def test_cubepi_history_round_trip(member_client) -> None:
     resp.raise_for_status()
     body = resp.json()
     messages = body["messages"]
-    assert body["total"] >= 2, f"expected ≥2 messages, got {body!r}"
+    assert len(messages) >= 2, f"expected ≥2 messages, got {body!r}"
+    assert body["has_more"] is False, f"two-message history shouldn't paginate: {body!r}"
     roles = [m.get("role") for m in messages]
     assert "user" in roles, f"no user message in history: {roles}"
     assert "assistant" in roles, f"no assistant message in history: {roles}"

--- a/backend/tests/e2e/test_history_window.py
+++ b/backend/tests/e2e/test_history_window.py
@@ -175,3 +175,48 @@ async def test_find_latest_todos_no_write_returns_none(db_session: AsyncSession)
         assert await find_latest_todos(db_session, thread_id) is None
     finally:
         await _delete_thread(thread_id)
+
+
+@pytest.mark.asyncio
+async def test_find_latest_todos_skips_malformed_args(db_session: AsyncSession) -> None:
+    """A write_todos call with non-list ``todos`` (or non-dict ``arguments``)
+    should be skipped, not clobber a still-valid earlier call. Pre-fix the
+    scan returned ``[]`` on the first bad call and silently wiped the panel."""
+    thread_id = "t-hwin-bad-args"
+    async with init_checkpointer() as cp:
+        # Older valid call
+        await cp.append(
+            thread_id,
+            [
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="tc-good",
+                            name="write_todos",
+                            arguments={
+                                "todos": [{"content": "real task", "status": "in_progress"}]
+                            },
+                        )
+                    ],
+                    stop_reason="tool_use",
+                ),
+            ],
+        )
+        # Newer malformed call (e.g. mid-stream truncation / schema drift)
+        await cp.append(
+            thread_id,
+            [
+                AssistantMessage(
+                    content=[ToolCall(id="tc-bad", name="write_todos", arguments={"todos": None})],
+                    stop_reason="tool_use",
+                ),
+            ],
+        )
+
+    try:
+        result = await find_latest_todos(db_session, thread_id)
+        assert result == [
+            {"id": None, "description": "real task", "status": "in_progress"},
+        ]
+    finally:
+        await _delete_thread(thread_id)

--- a/backend/tests/e2e/test_history_window.py
+++ b/backend/tests/e2e/test_history_window.py
@@ -14,11 +14,16 @@ from __future__ import annotations
 
 import asyncpg
 import pytest
-from cubepi.providers.base import TextContent, UserMessage
+from cubepi.providers.base import (
+    AssistantMessage,
+    TextContent,
+    ToolCall,
+    UserMessage,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.agents.checkpointer import _build_dsn, init_checkpointer
-from cubebox.services.history_window import load_history_window
+from cubebox.services.history_window import find_latest_todos, load_history_window
 
 pytestmark = pytest.mark.e2e
 
@@ -111,5 +116,62 @@ async def test_zero_limit_short_circuits(db_session: AsyncSession) -> None:
         window = await load_history_window(db_session, thread_id, limit=0)
         assert window.messages == []
         assert window.has_more is False
+    finally:
+        await _delete_thread(thread_id)
+
+
+async def _seed_with_todos(thread_id: str, padding_before: int, todos: list[dict]) -> None:
+    """Seed ``padding_before`` filler user messages, then an assistant message
+    that calls ``write_todos`` with the given todo list."""
+    async with init_checkpointer() as cp:
+        await cp.append(
+            thread_id,
+            [UserMessage(content=[TextContent(text=f"pad-{i}")]) for i in range(padding_before)],
+        )
+        await cp.append(
+            thread_id,
+            [
+                AssistantMessage(
+                    content=[
+                        ToolCall(id="tc-todo", name="write_todos", arguments={"todos": todos})
+                    ],
+                    stop_reason="tool_use",
+                ),
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_find_latest_todos_returns_most_recent(db_session: AsyncSession) -> None:
+    """``find_latest_todos`` should pick the latest ``write_todos`` call and
+    normalize unknown statuses to ``pending`` (matches the frontend parser)."""
+    thread_id = "t-hwin-todos"
+    await _seed_with_todos(
+        thread_id,
+        padding_before=2,
+        todos=[
+            {"content": "first task", "status": "in_progress"},
+            {"content": "second task", "status": "weird-status"},
+            {"content": "  ", "status": "pending"},  # blank — dropped
+            {"content": "third task"},  # missing status — defaults to pending
+        ],
+    )
+    try:
+        result = await find_latest_todos(db_session, thread_id)
+        assert result == [
+            {"id": None, "description": "first task", "status": "in_progress"},
+            {"id": None, "description": "second task", "status": "pending"},
+            {"id": None, "description": "third task", "status": "pending"},
+        ]
+    finally:
+        await _delete_thread(thread_id)
+
+
+@pytest.mark.asyncio
+async def test_find_latest_todos_no_write_returns_none(db_session: AsyncSession) -> None:
+    thread_id = "t-hwin-no-todos"
+    await _seed(thread_id, 3)
+    try:
+        assert await find_latest_todos(db_session, thread_id) is None
     finally:
         await _delete_thread(thread_id)

--- a/backend/tests/e2e/test_history_window.py
+++ b/backend/tests/e2e/test_history_window.py
@@ -1,0 +1,115 @@
+"""E2E for ``load_history_window`` — the paginated reader behind the
+conversation bootstrap and the messages-window endpoint.
+
+The contract these tests pin:
+
+- Default (no cursor) returns the newest ``limit`` messages, oldest-first.
+- ``has_more`` is true iff at least one message exists below ``oldest_seq``.
+- ``before_seq`` is exclusive — passing the previous slice's ``oldest_seq``
+  yields the next older window with no overlap.
+- Empty / non-existent thread returns no rows and ``has_more=False``.
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+from cubepi.providers.base import TextContent, UserMessage
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubebox.agents.checkpointer import _build_dsn, init_checkpointer
+from cubebox.services.history_window import load_history_window
+
+pytestmark = pytest.mark.e2e
+
+
+async def _delete_thread(thread_id: str) -> None:
+    conn = await asyncpg.connect(_build_dsn())
+    try:
+        await conn.execute("DELETE FROM cubepi_threads WHERE thread_id = $1", thread_id)
+    finally:
+        await conn.close()
+
+
+async def _seed(thread_id: str, count: int) -> None:
+    async with init_checkpointer() as cp:
+        await cp.append(
+            thread_id,
+            [UserMessage(content=[TextContent(text=f"msg-{i}")]) for i in range(count)],
+        )
+
+
+@pytest.mark.asyncio
+async def test_returns_tail_in_chronological_order(db_session: AsyncSession) -> None:
+    """Without a cursor the loader returns the newest ``limit`` messages,
+    flipped back to oldest-first so the frontend can render them in order."""
+    thread_id = "t-hwin-tail"
+    await _seed(thread_id, 10)
+    try:
+        window = await load_history_window(db_session, thread_id, limit=3)
+        texts = [m["content"][0]["text"] for m in window.messages]
+        assert texts == ["msg-7", "msg-8", "msg-9"]
+        assert window.has_more is True
+        assert window.oldest_seq is not None
+    finally:
+        await _delete_thread(thread_id)
+
+
+@pytest.mark.asyncio
+async def test_before_seq_cursor_yields_next_older_page(db_session: AsyncSession) -> None:
+    """``before_seq`` is exclusive — the previous slice's ``oldest_seq`` cursor
+    fetches the immediately preceding window without overlap."""
+    thread_id = "t-hwin-cursor"
+    await _seed(thread_id, 6)
+    try:
+        latest = await load_history_window(db_session, thread_id, limit=2)
+        assert [m["content"][0]["text"] for m in latest.messages] == ["msg-4", "msg-5"]
+        assert latest.has_more is True
+
+        older = await load_history_window(
+            db_session, thread_id, before_seq=latest.oldest_seq, limit=2
+        )
+        assert [m["content"][0]["text"] for m in older.messages] == ["msg-2", "msg-3"]
+        assert older.has_more is True
+
+        oldest = await load_history_window(
+            db_session, thread_id, before_seq=older.oldest_seq, limit=2
+        )
+        assert [m["content"][0]["text"] for m in oldest.messages] == ["msg-0", "msg-1"]
+        assert oldest.has_more is False
+    finally:
+        await _delete_thread(thread_id)
+
+
+@pytest.mark.asyncio
+async def test_has_more_is_false_when_limit_covers_history(
+    db_session: AsyncSession,
+) -> None:
+    thread_id = "t-hwin-fits"
+    await _seed(thread_id, 3)
+    try:
+        window = await load_history_window(db_session, thread_id, limit=10)
+        assert len(window.messages) == 3
+        assert window.has_more is False
+    finally:
+        await _delete_thread(thread_id)
+
+
+@pytest.mark.asyncio
+async def test_empty_thread_returns_empty_window(db_session: AsyncSession) -> None:
+    window = await load_history_window(db_session, "t-hwin-nope", limit=50)
+    assert window.messages == []
+    assert window.oldest_seq is None
+    assert window.has_more is False
+
+
+@pytest.mark.asyncio
+async def test_zero_limit_short_circuits(db_session: AsyncSession) -> None:
+    thread_id = "t-hwin-zero"
+    await _seed(thread_id, 2)
+    try:
+        window = await load_history_window(db_session, thread_id, limit=0)
+        assert window.messages == []
+        assert window.has_more is False
+    finally:
+        await _delete_thread(thread_id)

--- a/frontend/packages/core/src/api/conversations.ts
+++ b/frontend/packages/core/src/api/conversations.ts
@@ -1,4 +1,4 @@
-import type { Artifact, ArtifactVersion, Conversation, Message } from '../types'
+import type { Artifact, ArtifactVersion, Conversation } from '../types'
 import { toApiError, type ApiClient } from './client'
 
 export async function createConversation(
@@ -89,19 +89,6 @@ export async function generateConversationTitle(
   const res = await client.post(`/api/v1/conversations/${id}/generate-title`, { content })
   if (!res.ok) throw await toApiError(res)
   return res.json() as Promise<Conversation>
-}
-
-export async function listMessages(
-  client: ApiClient,
-  conversationId: string,
-  limit = 50,
-  offset = 0,
-): Promise<Message[]> {
-  const url = `/api/v1/conversations/${conversationId}/messages?limit=${limit}&offset=${offset}`
-  const res = await client.get(url)
-  if (!res.ok) throw await toApiError(res)
-  const data = (await res.json()) as { messages?: Message[] }
-  return data.messages || []
 }
 
 export async function listArtifacts(

--- a/frontend/packages/core/src/api/runStreams.ts
+++ b/frontend/packages/core/src/api/runStreams.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent, Message, PendingHitl } from '../types'
+import type { AgentEvent, Message, PendingHitl, TodoItem } from '../types'
 import { toApiError, type ApiClient } from './client'
 import { CSRF_COOKIE_NAME } from './cookieNames'
 
@@ -34,6 +34,10 @@ export interface HistoryWindowPage {
 }
 
 export interface ConversationBootstrap extends HistoryWindowPage {
+  /** Latest write_todos state, precomputed from the full history (not just
+   *  the tail) so the panel hydrates correctly on long conversations.
+   *  ``null`` when no write_todos has ever been observed for this thread. */
+  todos: TodoItem[] | null
   active_run: ActiveRunBootstrap | null
   last_run_status: 'stale' | null
   last_run_error?: LastRunError | null

--- a/frontend/packages/core/src/api/runStreams.ts
+++ b/frontend/packages/core/src/api/runStreams.ts
@@ -24,9 +24,16 @@ export interface LastRunError {
   error_message: string
 }
 
-export interface ConversationBootstrap {
+export interface HistoryWindowPage {
   messages: Message[]
-  total: number
+  /** seq of the oldest message in this slice (null when empty). Pass as
+   *  ``before_seq`` to fetch the next older window. */
+  oldest_seq: number | null
+  /** True iff at least one message exists with ``seq < oldest_seq``. */
+  has_more: boolean
+}
+
+export interface ConversationBootstrap extends HistoryWindowPage {
   active_run: ActiveRunBootstrap | null
   last_run_status: 'stale' | null
   last_run_error?: LastRunError | null
@@ -88,6 +95,20 @@ export async function getConversationBootstrap(
   const res = await client.get(`/api/v1/conversations/${conversationId}/bootstrap`)
   if (!res.ok) throw await toApiError(res)
   return res.json() as Promise<ConversationBootstrap>
+}
+
+export async function getHistoryWindow(
+  client: ApiClient,
+  conversationId: string,
+  opts: { beforeSeq: number; limit?: number },
+): Promise<HistoryWindowPage> {
+  const params = new URLSearchParams({ before_seq: String(opts.beforeSeq) })
+  if (opts.limit != null) params.set('limit', String(opts.limit))
+  const res = await client.get(
+    `/api/v1/conversations/${conversationId}/messages?${params.toString()}`,
+  )
+  if (!res.ok) throw await toApiError(res)
+  return res.json() as Promise<HistoryWindowPage>
 }
 
 export async function startMessageRun(

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -30,6 +30,7 @@ import {
   cancelActiveRun,
   cancelSteer,
   getConversationBootstrap,
+  getHistoryWindow,
   steerRun,
   streamMessages,
   streamRun,
@@ -113,8 +114,20 @@ export interface MessageStore {
    * cleared with the rest of the in-flight stream state on send / cancel.
    */
   failoverEvents: Record<string, FailoverEvent[]>
+  /** Per-conversation cursor into ``cubepi_messages.seq`` of the oldest message
+   *  currently held in ``messages[conversationId]``. Pass as ``before_seq`` when
+   *  the user scrolls up. ``null`` means the conversation is empty. */
+  oldestSeqByConv: Record<string, number | null>
+  /** Per-conversation flag: is there anything older than ``oldestSeqByConv``? */
+  hasMoreByConv: Record<string, boolean>
+  /** Backscroll-in-flight guard so a click-spam on "Load earlier" only fires once. */
+  loadingOlderByConv: Record<string, boolean>
 
   loadMessages(client: ApiClient, conversationId: string): Promise<void>
+  /** Fetch one older window using ``oldestSeqByConv[conversationId]`` as the
+   *  cursor and prepend it to ``messages[conversationId]``. Noop when already
+   *  in flight, when ``hasMore`` is false, or when no cursor is set yet. */
+  loadOlderMessages(client: ApiClient, conversationId: string): Promise<void>
   send(
     client: ApiClient,
     conversationId: string,
@@ -140,6 +153,10 @@ export interface MessageStore {
 }
 
 let activeStreamController: AbortController | null = null
+
+/** Dedup map for ``loadMessages``: the page-level effect and ``<MessageList>``'s
+ *  effect both fire on mount, but we only want one bootstrap fetch per open. */
+const loadMessagesInFlight = new Map<string, Promise<void>>()
 
 const MAIN_AGENT_KEY = 'main'
 
@@ -1095,6 +1112,9 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
   sessionUsage: {},
   contextWindow: {},
   contextTokens: {},
+  oldestSeqByConv: {},
+  hasMoreByConv: {},
+  loadingOlderByConv: {},
 
   appendFailoverEvent(conversationId, event) {
     set((s) => ({
@@ -1108,222 +1128,268 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
   async loadMessages(client: ApiClient, conversationId: string) {
     const state = get()
     if (state.isStreaming && state.streamingConversationId === conversationId) return
+    // The page-level effect and <MessageList>'s own effect both fire on mount
+    // — dedupe so the (heavy) bootstrap fetch runs once per conversation open.
+    if (loadMessagesInFlight.has(conversationId)) return loadMessagesInFlight.get(conversationId)
+    const promise = (async () => {
+      try {
+        const bootstrap = await getConversationBootstrap(client, conversationId)
+        const current = get()
+        if (current.isStreaming && current.streamingConversationId === conversationId) return
 
-    try {
-      const bootstrap = await getConversationBootstrap(client, conversationId)
-      const current = get()
-      if (current.isStreaming && current.streamingConversationId === conversationId) return
-
-      let messages = normalizeMessages(bootstrap.messages ?? [])
-      if (bootstrap.active_run?.user_message) {
-        messages = trimHistoryForActiveRun(
-          messages,
-          bootstrap.active_run.run_id,
-          bootstrap.active_run.user_message,
-          bootstrap.active_run.started_at ?? null,
-        )
-      }
-
-      const restoredTodos = restoreTodosFromHistory(messages)
-      hydrateCitationsFromHistory(conversationId, messages)
-      const usageSummary = bootstrap.usage_summary
-      const newTurnUsage = {
-        ...get().turnUsage,
-        [conversationId]: (usageSummary?.turn ?? null) as import('../types').TurnUsage | null,
-      }
-      const newSessionUsage = {
-        ...get().sessionUsage,
-        [conversationId]: (usageSummary?.session ?? null) as import('../types').SessionUsage | null,
-      }
-      const newContextWindow = {
-        ...get().contextWindow,
-        [conversationId]: usageSummary?.context_window ?? null,
-      }
-      const newContextTokens = {
-        ...get().contextTokens,
-        [conversationId]: usageSummary?.context_tokens ?? null,
-      }
-      const nextStreamAgents: Record<string, AgentStream> = bootstrap.active_run
-        ? { [MAIN_AGENT_KEY]: emptyStream() }
-        : {}
-
-      // Cold-start fallback: when the Redis event log has aged out, the
-      // backend returns the unresolved HITL request inline. Seed the same
-      // pendingAsk / pendingConfirmMap slots the live SSE path populates so
-      // the card re-renders on refresh without replaying events.
-      //
-      // Post-answer race: when the user just submitted an answer, the
-      // optimistic clear set pendingAsk = null, but the bootstrap that
-      // follows can race the backend's `save_pending_request(None)` —
-      // the DB pending row is still there, so this code would re-seed
-      // the form for the same run_id and the user would see a momentary
-      // re-flash of the question they already answered. Skip the seed
-      // when the store is already tracking this exact run; the SSE
-      // reattach (which starts strictly after the paused-done event)
-      // will land the ask_user_resolved any moment now anyway.
-      const pending = bootstrap.pending_hitl ?? null
-      const currentState = get()
-      // If the user just answered this exact question, the backend's
-      // `save_pending_request(None)` may not have committed yet when
-      // bootstrap fetched — DB pending_hitl is stale. Skip the re-seed
-      // so the form doesn't flash back. SSE delivers
-      // `ask_user_resolved` shortly after either way.
-      const alreadyAnsweredThisQuestion =
-        pending !== null && pending.question_id === currentState.lastAnsweredAskQuestionId
-      const alreadyResolvedThisConfirm =
-        pending !== null &&
-        pending.kind === 'sandbox_confirm' &&
-        pending.question_id === currentState.lastResolvedSandboxQuestionId
-      const skipSeed = alreadyAnsweredThisQuestion || alreadyResolvedThisConfirm
-      let seedPendingAsk: PendingAsk | null = null
-      let seedPendingConfirmMap: Record<string, PendingConfirm> = {}
-      if (pending && pending.kind === 'ask_user' && !skipSeed) {
-        const requestedAt = Date.parse(pending.requested_at)
-        seedPendingAsk = {
-          question_id: pending.question_id,
-          questions: pending.questions,
-          timeout_seconds: null,
-          requestedAt: Number.isNaN(requestedAt) ? Date.now() : requestedAt,
-          run_id: pending.run_id,
+        let messages = normalizeMessages(bootstrap.messages ?? [])
+        if (bootstrap.active_run?.user_message) {
+          messages = trimHistoryForActiveRun(
+            messages,
+            bootstrap.active_run.run_id,
+            bootstrap.active_run.user_message,
+            bootstrap.active_run.started_at ?? null,
+          )
         }
-      } else if (pending && pending.kind === 'sandbox_confirm' && !skipSeed) {
-        const requestedAt = Date.parse(pending.requested_at)
-        seedPendingConfirmMap = {
-          [pending.tool_call_id]: {
+
+        const restoredTodos = restoreTodosFromHistory(messages)
+        hydrateCitationsFromHistory(conversationId, messages)
+        const usageSummary = bootstrap.usage_summary
+        const newTurnUsage = {
+          ...get().turnUsage,
+          [conversationId]: (usageSummary?.turn ?? null) as import('../types').TurnUsage | null,
+        }
+        const newSessionUsage = {
+          ...get().sessionUsage,
+          [conversationId]: (usageSummary?.session ?? null) as
+            | import('../types').SessionUsage
+            | null,
+        }
+        const newContextWindow = {
+          ...get().contextWindow,
+          [conversationId]: usageSummary?.context_window ?? null,
+        }
+        const newContextTokens = {
+          ...get().contextTokens,
+          [conversationId]: usageSummary?.context_tokens ?? null,
+        }
+        const nextStreamAgents: Record<string, AgentStream> = bootstrap.active_run
+          ? { [MAIN_AGENT_KEY]: emptyStream() }
+          : {}
+
+        // Cold-start fallback: when the Redis event log has aged out, the
+        // backend returns the unresolved HITL request inline. Seed the same
+        // pendingAsk / pendingConfirmMap slots the live SSE path populates so
+        // the card re-renders on refresh without replaying events.
+        //
+        // Post-answer race: when the user just submitted an answer, the
+        // optimistic clear set pendingAsk = null, but the bootstrap that
+        // follows can race the backend's `save_pending_request(None)` —
+        // the DB pending row is still there, so this code would re-seed
+        // the form for the same run_id and the user would see a momentary
+        // re-flash of the question they already answered. Skip the seed
+        // when the store is already tracking this exact run; the SSE
+        // reattach (which starts strictly after the paused-done event)
+        // will land the ask_user_resolved any moment now anyway.
+        const pending = bootstrap.pending_hitl ?? null
+        const currentState = get()
+        // If the user just answered this exact question, the backend's
+        // `save_pending_request(None)` may not have committed yet when
+        // bootstrap fetched — DB pending_hitl is stale. Skip the re-seed
+        // so the form doesn't flash back. SSE delivers
+        // `ask_user_resolved` shortly after either way.
+        const alreadyAnsweredThisQuestion =
+          pending !== null && pending.question_id === currentState.lastAnsweredAskQuestionId
+        const alreadyResolvedThisConfirm =
+          pending !== null &&
+          pending.kind === 'sandbox_confirm' &&
+          pending.question_id === currentState.lastResolvedSandboxQuestionId
+        const skipSeed = alreadyAnsweredThisQuestion || alreadyResolvedThisConfirm
+        let seedPendingAsk: PendingAsk | null = null
+        let seedPendingConfirmMap: Record<string, PendingConfirm> = {}
+        if (pending && pending.kind === 'ask_user' && !skipSeed) {
+          const requestedAt = Date.parse(pending.requested_at)
+          seedPendingAsk = {
             question_id: pending.question_id,
-            command: pending.command,
-            matched_pattern: pending.matched_pattern,
+            questions: pending.questions,
             timeout_seconds: null,
             requestedAt: Number.isNaN(requestedAt) ? Date.now() : requestedAt,
             run_id: pending.run_id,
-          },
+          }
+        } else if (pending && pending.kind === 'sandbox_confirm' && !skipSeed) {
+          const requestedAt = Date.parse(pending.requested_at)
+          seedPendingConfirmMap = {
+            [pending.tool_call_id]: {
+              question_id: pending.question_id,
+              command: pending.command,
+              matched_pattern: pending.matched_pattern,
+              timeout_seconds: null,
+              requestedAt: Number.isNaN(requestedAt) ? Date.now() : requestedAt,
+              run_id: pending.run_id,
+            },
+          }
         }
-      }
 
-      // pending_hitl fallback: when the Redis active-run key has aged out
-      // during a long pause, bootstrap.active_run is null but the DB
-      // pending + run_id ARE still recoverable (via pending_hitl). Treat
-      // the pending_hitl payload as "this conversation is paused on
-      // run_id, the card must render, and we should tail the run stream
-      // so a resume turn from any worker reaches this tab".
-      //
-      // MessageList gates AskUserCard on `streamingConversationId ===
-      // conversationId`; without this, an ask_user paused beyond Redis
-      // TTL has its pendingAsk seeded but the card stays hidden.
-      const pendingHitlRunId = bootstrap.pending_hitl?.run_id ?? null
-      const hasPendingHitl = pendingHitlRunId !== null
-      const streamRunId = bootstrap.active_run?.run_id ?? pendingHitlRunId
-      const streamingActive = !!bootstrap.active_run || hasPendingHitl
-      // Paused HITL: SSE is attached but the worker has detached. Don't
-      // light up "is streaming" indicators (typing dots etc.); the
-      // <AskUserCard> / composer lock already convey state. `pendingAsk`
-      // and `pendingConfirmMap` are the truth signals here. We keep
-      // `streamingConversationId` set so MessageList's `pendingAsk &&
-      // streamingConversationId === conversationId` gate still fires.
-      const isPaused = bootstrap.active_run?.status === 'paused_hitl' || hasPendingHitl
-      const isStreamingActive = streamingActive && !isPaused
-      // `bootstrap.messages` already includes everything up to the latest
-      // event in the Redis stream at fetch time. The SSE reattach should
-      // pick up STRICTLY-NEW events from here; without this cursor the
-      // post-answer reattach replays the paused turn (doubling the
-      // assistant message into streamAgents) and hits the paused `done`
-      // event mid-replay, breaking out of consumeRunStream before any
-      // resume-turn events can be read. Seed both the XREAD cursor and
-      // the in-store dedupe guard from `active_run.last_event_id`.
-      const streamCursor = bootstrap.active_run?.last_event_id ?? null
+        // pending_hitl fallback: when the Redis active-run key has aged out
+        // during a long pause, bootstrap.active_run is null but the DB
+        // pending + run_id ARE still recoverable (via pending_hitl). Treat
+        // the pending_hitl payload as "this conversation is paused on
+        // run_id, the card must render, and we should tail the run stream
+        // so a resume turn from any worker reaches this tab".
+        //
+        // MessageList gates AskUserCard on `streamingConversationId ===
+        // conversationId`; without this, an ask_user paused beyond Redis
+        // TTL has its pendingAsk seeded but the card stays hidden.
+        const pendingHitlRunId = bootstrap.pending_hitl?.run_id ?? null
+        const hasPendingHitl = pendingHitlRunId !== null
+        const streamRunId = bootstrap.active_run?.run_id ?? pendingHitlRunId
+        const streamingActive = !!bootstrap.active_run || hasPendingHitl
+        // Paused HITL: SSE is attached but the worker has detached. Don't
+        // light up "is streaming" indicators (typing dots etc.); the
+        // <AskUserCard> / composer lock already convey state. `pendingAsk`
+        // and `pendingConfirmMap` are the truth signals here. We keep
+        // `streamingConversationId` set so MessageList's `pendingAsk &&
+        // streamingConversationId === conversationId` gate still fires.
+        const isPaused = bootstrap.active_run?.status === 'paused_hitl' || hasPendingHitl
+        const isStreamingActive = streamingActive && !isPaused
+        // `bootstrap.messages` already includes everything up to the latest
+        // event in the Redis stream at fetch time. The SSE reattach should
+        // pick up STRICTLY-NEW events from here; without this cursor the
+        // post-answer reattach replays the paused turn (doubling the
+        // assistant message into streamAgents) and hits the paused `done`
+        // event mid-replay, breaking out of consumeRunStream before any
+        // resume-turn events can be read. Seed both the XREAD cursor and
+        // the in-store dedupe guard from `active_run.last_event_id`.
+        const streamCursor = bootstrap.active_run?.last_event_id ?? null
 
-      // Hydrate per-conversation error from bootstrap if the last run ended
-      // with a classified error (e.g. context_length_exceeded). This lets the
-      // bubble reappear on page reload without waiting for an SSE event.
-      //
-      // Priority: active_run.error_code > last_run_error > leave existing state.
-      // The active-run pointer is cleared when the run reaches a terminal status,
-      // so after a failed run completes the active slot is gone but last_run_error
-      // persists independently (separate Redis key, same TTL).
-      let seedError: { runId: string; data: ErrorEventData } | null | undefined
-      if (bootstrap.active_run?.error_code) {
-        seedError = {
-          runId: bootstrap.active_run.run_id,
-          data: {
-            error_code: bootstrap.active_run.error_code,
-            params: bootstrap.active_run.error_params ?? undefined,
-            message: bootstrap.active_run.error_message ?? bootstrap.active_run.error_code,
-          },
+        // Hydrate per-conversation error from bootstrap if the last run ended
+        // with a classified error (e.g. context_length_exceeded). This lets the
+        // bubble reappear on page reload without waiting for an SSE event.
+        //
+        // Priority: active_run.error_code > last_run_error > leave existing state.
+        // The active-run pointer is cleared when the run reaches a terminal status,
+        // so after a failed run completes the active slot is gone but last_run_error
+        // persists independently (separate Redis key, same TTL).
+        let seedError: { runId: string; data: ErrorEventData } | null | undefined
+        if (bootstrap.active_run?.error_code) {
+          seedError = {
+            runId: bootstrap.active_run.run_id,
+            data: {
+              error_code: bootstrap.active_run.error_code,
+              params: bootstrap.active_run.error_params ?? undefined,
+              message: bootstrap.active_run.error_message ?? bootstrap.active_run.error_code,
+            },
+          }
+        } else if (bootstrap.last_run_error) {
+          seedError = {
+            runId: bootstrap.last_run_error.run_id,
+            data: {
+              error_code: bootstrap.last_run_error.error_code,
+              params: (bootstrap.last_run_error.error_params ?? undefined) as
+                | Record<string, unknown>
+                | undefined,
+              message: bootstrap.last_run_error.error_message,
+            },
+          }
         }
-      } else if (bootstrap.last_run_error) {
-        seedError = {
-          runId: bootstrap.last_run_error.run_id,
-          data: {
-            error_code: bootstrap.last_run_error.error_code,
-            params: (bootstrap.last_run_error.error_params ?? undefined) as
-              | Record<string, unknown>
-              | undefined,
-            message: bootstrap.last_run_error.error_message,
-          },
-        }
-      }
-      set((s) => ({
-        messages: { ...s.messages, [conversationId]: messages },
-        todos: restoredTodos,
-        // When neither active_run nor last_run_error carries error info, clear the
-        // conversation's stale error so a successful retry does not keep showing the
-        // previous failure bubble. seedError is null means server reports no error.
-        errors: { ...s.errors, [conversationId]: seedError ?? null },
-        lastRunStatus: bootstrap.last_run_status ?? null,
-        streamAgents: nextStreamAgents,
-        pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
-        toolStartedMap: {},
-        toolResultMap: {},
-        // When `skipSeed` fired (we just answered/cancelled this exact
-        // question), preserve the current pendingAsk / pendingConfirmMap
-        // instead of clearing them. The form stays mounted in its
-        // submitting/cancelling state until the SSE `ask_user_resolved`
-        // event arrives, which avoids the visible blank gap that
-        // optimistic-clear used to produce.
-        pendingConfirmMap: skipSeed ? s.pendingConfirmMap : seedPendingConfirmMap,
-        pendingAsk: skipSeed ? s.pendingAsk : seedPendingAsk,
-        isStreaming: isStreamingActive,
-        streamingConversationId: streamingActive ? conversationId : null,
-        currentRunId: streamRunId,
-        lastAppliedEventId: streamCursor,
-        statusPhase: null,
-        turnUsage: newTurnUsage,
-        sessionUsage: newSessionUsage,
-        contextWindow: newContextWindow,
-        contextTokens: newContextTokens,
-      }))
+        set((s) => ({
+          messages: { ...s.messages, [conversationId]: messages },
+          oldestSeqByConv: { ...s.oldestSeqByConv, [conversationId]: bootstrap.oldest_seq },
+          hasMoreByConv: { ...s.hasMoreByConv, [conversationId]: bootstrap.has_more },
+          todos: restoredTodos,
+          // When neither active_run nor last_run_error carries error info, clear the
+          // conversation's stale error so a successful retry does not keep showing the
+          // previous failure bubble. seedError is null means server reports no error.
+          errors: { ...s.errors, [conversationId]: seedError ?? null },
+          lastRunStatus: bootstrap.last_run_status ?? null,
+          streamAgents: nextStreamAgents,
+          pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
+          toolStartedMap: {},
+          toolResultMap: {},
+          // When `skipSeed` fired (we just answered/cancelled this exact
+          // question), preserve the current pendingAsk / pendingConfirmMap
+          // instead of clearing them. The form stays mounted in its
+          // submitting/cancelling state until the SSE `ask_user_resolved`
+          // event arrives, which avoids the visible blank gap that
+          // optimistic-clear used to produce.
+          pendingConfirmMap: skipSeed ? s.pendingConfirmMap : seedPendingConfirmMap,
+          pendingAsk: skipSeed ? s.pendingAsk : seedPendingAsk,
+          isStreaming: isStreamingActive,
+          streamingConversationId: streamingActive ? conversationId : null,
+          currentRunId: streamRunId,
+          lastAppliedEventId: streamCursor,
+          statusPhase: null,
+          turnUsage: newTurnUsage,
+          sessionUsage: newSessionUsage,
+          contextWindow: newContextWindow,
+          contextTokens: newContextTokens,
+        }))
 
-      if (streamRunId !== null) {
-        activeStreamController?.abort()
-        const controller = new AbortController()
-        activeStreamController = controller
-        const runId = streamRunId
-        const lastEventId = streamCursor ?? undefined
-        queueMicrotask(() => {
-          void consumeRunStream(
-            client,
-            conversationId,
-            runId,
-            lastEventId,
-            set,
-            get,
-            controller.signal,
-          ).finally(() => {
-            if (activeStreamController === controller) {
-              activeStreamController = null
-            }
+        if (streamRunId !== null) {
+          activeStreamController?.abort()
+          const controller = new AbortController()
+          activeStreamController = controller
+          const runId = streamRunId
+          const lastEventId = streamCursor ?? undefined
+          queueMicrotask(() => {
+            void consumeRunStream(
+              client,
+              conversationId,
+              runId,
+              lastEventId,
+              set,
+              get,
+              controller.signal,
+            ).finally(() => {
+              if (activeStreamController === controller) {
+                activeStreamController = null
+              }
+            })
           })
-        })
-      }
-    } catch (err) {
-      set((s) => ({
-        errors: {
-          ...s.errors,
-          [conversationId]: {
-            runId: s.currentRunId ?? '',
-            data: { error_code: 'internal_error', message: (err as Error).message },
+        }
+      } catch (err) {
+        set((s) => ({
+          errors: {
+            ...s.errors,
+            [conversationId]: {
+              runId: s.currentRunId ?? '',
+              data: { error_code: 'internal_error', message: (err as Error).message },
+            },
           },
+        }))
+      }
+    })()
+    loadMessagesInFlight.set(conversationId, promise)
+    try {
+      await promise
+    } finally {
+      loadMessagesInFlight.delete(conversationId)
+    }
+  },
+
+  async loadOlderMessages(client: ApiClient, conversationId: string) {
+    const state = get()
+    if (state.loadingOlderByConv[conversationId]) return
+    if (!state.hasMoreByConv[conversationId]) return
+    const cursor = state.oldestSeqByConv[conversationId]
+    if (cursor == null) return
+
+    set((s) => ({
+      loadingOlderByConv: { ...s.loadingOlderByConv, [conversationId]: true },
+    }))
+    try {
+      const page = await getHistoryWindow(client, conversationId, { beforeSeq: cursor })
+      const older = normalizeMessages(page.messages)
+      hydrateCitationsFromHistory(conversationId, older)
+      set((s) => ({
+        messages: {
+          ...s.messages,
+          [conversationId]: [...older, ...(s.messages[conversationId] ?? [])],
         },
+        oldestSeqByConv: {
+          ...s.oldestSeqByConv,
+          [conversationId]: page.oldest_seq ?? s.oldestSeqByConv[conversationId],
+        },
+        hasMoreByConv: { ...s.hasMoreByConv, [conversationId]: page.has_more },
+      }))
+    } finally {
+      set((s) => ({
+        loadingOlderByConv: { ...s.loadingOlderByConv, [conversationId]: false },
       }))
     }
   },

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -27,6 +27,7 @@ import type {
 import { getTextContent } from '../types'
 import type { ApiClient } from '../api'
 import {
+  ApiError,
   cancelActiveRun,
   cancelSteer,
   getConversationBootstrap,
@@ -128,6 +129,11 @@ export interface MessageStore {
    *  cursor and prepend it to ``messages[conversationId]``. Noop when already
    *  in flight, when ``hasMore`` is false, or when no cursor is set yet. */
   loadOlderMessages(client: ApiClient, conversationId: string): Promise<void>
+  /** Repeatedly fetch older windows until ``oldestSeqByConv[conversationId]``
+   *  reaches ``targetSeq`` or there is no more history. Used by the search
+   *  deep-link path to make ``#msg-<seq>`` anchors reachable even when the
+   *  requested message lives below the bootstrap tail. */
+  loadOlderUntilSeq(client: ApiClient, conversationId: string, targetSeq: number): Promise<void>
   send(
     client: ApiClient,
     conversationId: string,
@@ -1147,7 +1153,11 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
           )
         }
 
-        const restoredTodos = restoreTodosFromHistory(messages)
+        // Prefer the backend-precomputed todos (walks the full history, so
+        // the panel hydrates correctly even when the last ``write_todos`` lives
+        // below the bootstrap tail). Fall back to the in-tail scan only if the
+        // server didn't send the field (older deployments).
+        const restoredTodos = bootstrap.todos ?? restoreTodosFromHistory(messages)
         hydrateCitationsFromHistory(conversationId, messages)
         const usageSummary = bootstrap.usage_summary
         const newTurnUsage = {
@@ -1343,6 +1353,12 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
           })
         }
       } catch (err) {
+        // 404/403 just mean the conversation was deleted or the user lost
+        // access — the page-level effect renders ErrorState for those, so we
+        // don't want to *also* seed an internal_error bubble that flashes on
+        // the next navigation. Surface anything else (network, 5xx, …) as
+        // before so the user sees the failure.
+        if (err instanceof ApiError && (err.status === 404 || err.status === 403)) return
         set((s) => ({
           errors: {
             ...s.errors,
@@ -1387,10 +1403,41 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
         },
         hasMoreByConv: { ...s.hasMoreByConv, [conversationId]: page.has_more },
       }))
+    } catch (err) {
+      // Surface the failure through the same per-conversation errors slice
+      // ``loadMessages`` uses, so a failed backscroll renders the existing
+      // RunErrorBubble instead of silently re-enabling the button.
+      set((s) => ({
+        errors: {
+          ...s.errors,
+          [conversationId]: {
+            runId: s.currentRunId ?? '',
+            data: { error_code: 'internal_error', message: (err as Error).message },
+          },
+        },
+      }))
     } finally {
       set((s) => ({
         loadingOlderByConv: { ...s.loadingOlderByConv, [conversationId]: false },
       }))
+    }
+  },
+
+  async loadOlderUntilSeq(client: ApiClient, conversationId: string, targetSeq: number) {
+    // Bounded by the dataset (each iteration either advances ``oldestSeq``
+    // toward ``targetSeq`` or trips ``hasMore=false``); ``loadOlderMessages``
+    // self-dedups so concurrent triggers don't double-fire.
+    while (true) {
+      const s = get()
+      const oldest = s.oldestSeqByConv[conversationId]
+      if (oldest != null && oldest <= targetSeq) return
+      if (!s.hasMoreByConv[conversationId]) return
+      const before = s.messages[conversationId]?.length ?? 0
+      await get().loadOlderMessages(client, conversationId)
+      const after = get().messages[conversationId]?.length ?? 0
+      // Stall guard: if a fetch returned no new rows (or failed into the
+      // errors slice), abandon rather than loop forever.
+      if (after === before) return
     }
   },
 

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -132,8 +132,14 @@ export interface MessageStore {
   /** Repeatedly fetch older windows until ``oldestSeqByConv[conversationId]``
    *  reaches ``targetSeq`` or there is no more history. Used by the search
    *  deep-link path to make ``#msg-<seq>`` anchors reachable even when the
-   *  requested message lives below the bootstrap tail. */
-  loadOlderUntilSeq(client: ApiClient, conversationId: string, targetSeq: number): Promise<void>
+   *  requested message lives below the bootstrap tail. Pass ``signal`` to
+   *  stop the loop when the user navigates away mid-walk. */
+  loadOlderUntilSeq(
+    client: ApiClient,
+    conversationId: string,
+    targetSeq: number,
+    signal?: AbortSignal,
+  ): Promise<void>
   send(
     client: ApiClient,
     conversationId: string,
@@ -163,6 +169,12 @@ let activeStreamController: AbortController | null = null
 /** Dedup map for ``loadMessages``: the page-level effect and ``<MessageList>``'s
  *  effect both fire on mount, but we only want one bootstrap fetch per open. */
 const loadMessagesInFlight = new Map<string, Promise<void>>()
+
+/** Dedup map for ``loadOlderMessages``: a user click on "Load earlier" and the
+ *  ``loadOlderUntilSeq`` deep-link loop may both fire concurrently. Sharing
+ *  the in-flight promise lets the loop ``await`` the click's fetch instead
+ *  of short-circuiting without progress. */
+const loadOlderInFlight = new Map<string, Promise<void>>()
 
 const MAIN_AGENT_KEY = 'main'
 
@@ -377,19 +389,6 @@ export function trimHistoryForActiveRun(
     // Not the original (e.g. a steer turn) — keep scanning back.
   }
   return [...messages, buildPendingUserMessage(runId, content)]
-}
-
-function restoreTodosFromHistory(messages: Message[]): TodoItem[] {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]
-    if (msg.role !== 'assistant') continue
-    for (const block of msg.content) {
-      if (block.type === 'tool_call' && block.name === 'write_todos') {
-        return parseTodosFromToolCall(block.arguments)
-      }
-    }
-  }
-  return []
 }
 
 function hydrateCitationsFromHistory(conversationId: string, messages: Message[]): void {
@@ -1153,11 +1152,11 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
           )
         }
 
-        // Prefer the backend-precomputed todos (walks the full history, so
-        // the panel hydrates correctly even when the last ``write_todos`` lives
-        // below the bootstrap tail). Fall back to the in-tail scan only if the
-        // server didn't send the field (older deployments).
-        const restoredTodos = bootstrap.todos ?? restoreTodosFromHistory(messages)
+        // Backend walks the full history (not just the tail) to pick the
+        // latest ``write_todos`` state — see ``find_latest_todos`` in
+        // services/history_window.py. ``null`` means no todos were ever
+        // written for this thread.
+        const restoredTodos = bootstrap.todos ?? []
         hydrateCitationsFromHistory(conversationId, messages)
         const usageSummary = bootstrap.usage_summary
         const newTurnUsage = {
@@ -1380,64 +1379,81 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
 
   async loadOlderMessages(client: ApiClient, conversationId: string) {
     const state = get()
-    if (state.loadingOlderByConv[conversationId]) return
     if (!state.hasMoreByConv[conversationId]) return
     const cursor = state.oldestSeqByConv[conversationId]
     if (cursor == null) return
+    // Click-spam + deep-link loop share one fetch — see ``loadOlderInFlight``.
+    const existing = loadOlderInFlight.get(conversationId)
+    if (existing) return existing
 
     set((s) => ({
       loadingOlderByConv: { ...s.loadingOlderByConv, [conversationId]: true },
     }))
-    try {
-      const page = await getHistoryWindow(client, conversationId, { beforeSeq: cursor })
-      const older = normalizeMessages(page.messages)
-      hydrateCitationsFromHistory(conversationId, older)
-      set((s) => ({
-        messages: {
-          ...s.messages,
-          [conversationId]: [...older, ...(s.messages[conversationId] ?? [])],
-        },
-        oldestSeqByConv: {
-          ...s.oldestSeqByConv,
-          [conversationId]: page.oldest_seq ?? s.oldestSeqByConv[conversationId],
-        },
-        hasMoreByConv: { ...s.hasMoreByConv, [conversationId]: page.has_more },
-      }))
-    } catch (err) {
-      // Surface the failure through the same per-conversation errors slice
-      // ``loadMessages`` uses, so a failed backscroll renders the existing
-      // RunErrorBubble instead of silently re-enabling the button.
-      set((s) => ({
-        errors: {
-          ...s.errors,
-          [conversationId]: {
-            runId: s.currentRunId ?? '',
-            data: { error_code: 'internal_error', message: (err as Error).message },
+    const promise = (async () => {
+      try {
+        const page = await getHistoryWindow(client, conversationId, { beforeSeq: cursor })
+        const older = normalizeMessages(page.messages)
+        hydrateCitationsFromHistory(conversationId, older)
+        set((s) => ({
+          messages: {
+            ...s.messages,
+            [conversationId]: [...older, ...(s.messages[conversationId] ?? [])],
           },
-        },
-      }))
+          oldestSeqByConv: {
+            ...s.oldestSeqByConv,
+            [conversationId]: page.oldest_seq ?? s.oldestSeqByConv[conversationId],
+          },
+          hasMoreByConv: { ...s.hasMoreByConv, [conversationId]: page.has_more },
+        }))
+      } catch (err) {
+        // Surface the failure through the same per-conversation errors slice
+        // ``loadMessages`` uses, so a failed backscroll renders the existing
+        // RunErrorBubble instead of silently re-enabling the button.
+        set((s) => ({
+          errors: {
+            ...s.errors,
+            [conversationId]: {
+              runId: s.currentRunId ?? '',
+              data: { error_code: 'internal_error', message: (err as Error).message },
+            },
+          },
+        }))
+      } finally {
+        set((s) => ({
+          loadingOlderByConv: { ...s.loadingOlderByConv, [conversationId]: false },
+        }))
+      }
+    })()
+    loadOlderInFlight.set(conversationId, promise)
+    try {
+      await promise
     } finally {
-      set((s) => ({
-        loadingOlderByConv: { ...s.loadingOlderByConv, [conversationId]: false },
-      }))
+      loadOlderInFlight.delete(conversationId)
     }
   },
 
-  async loadOlderUntilSeq(client: ApiClient, conversationId: string, targetSeq: number) {
+  async loadOlderUntilSeq(
+    client: ApiClient,
+    conversationId: string,
+    targetSeq: number,
+    signal?: AbortSignal,
+  ) {
     // Bounded by the dataset (each iteration either advances ``oldestSeq``
     // toward ``targetSeq`` or trips ``hasMore=false``); ``loadOlderMessages``
     // self-dedups so concurrent triggers don't double-fire.
     while (true) {
+      if (signal?.aborted) return
       const s = get()
       const oldest = s.oldestSeqByConv[conversationId]
       if (oldest != null && oldest <= targetSeq) return
       if (!s.hasMoreByConv[conversationId]) return
-      const before = s.messages[conversationId]?.length ?? 0
       await get().loadOlderMessages(client, conversationId)
-      const after = get().messages[conversationId]?.length ?? 0
-      // Stall guard: if a fetch returned no new rows (or failed into the
-      // errors slice), abandon rather than loop forever.
-      if (after === before) return
+      // Stall guard: only ``oldestSeq`` retreating signals a real prepend.
+      // A length / dedup-skip / fetch-failure leaves ``oldestSeq`` pinned,
+      // so we abandon instead of looping forever — but a concurrent click
+      // on "Load earlier" that also moves the cursor counts as progress.
+      const next = get().oldestSeqByConv[conversationId]
+      if (next == null || next === oldest) return
     }
   },
 

--- a/frontend/packages/core/src/types/message.ts
+++ b/frontend/packages/core/src/types/message.ts
@@ -56,6 +56,12 @@ export interface MessageUsage {
 interface MessageBase {
   // Synthesized client-side for React keys; never sent to the backend.
   id: string
+  // Server-side cubepi_messages.seq for this row. Stable across reloads and
+  // tail/backscroll pagination — drives the ``#msg-<seq>`` DOM anchor that
+  // conversation-search deep-links into. Absent on in-memory messages that
+  // have not yet been persisted (e.g. the optimistic user bubble before the
+  // run claims it).
+  seq?: number
   timestamp?: number | null // epoch seconds (cubepi convention)
   // Identifies the agent run this message belongs to. User + assistant
   // messages produced within the same turn share a run_id. Null on

--- a/frontend/packages/web/app/(app)/w/[wsId]/conversations/[id]/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/conversations/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
   type Conversation,
   useArtifactStore,
   useConversationStore,
+  useMessageStore,
   usePanelStore,
 } from '@cubebox/core'
 import { useTranslations } from 'next-intl'
@@ -57,6 +58,12 @@ export default function ChatPage({ params }: { params: Promise<{ wsId: string; i
     let cancelled = false
     const opened = getPresetSelectionStore(wsId).getState()
     const before = { modelKey: opened.modelKey, thinking: opened.thinking }
+    // Kick off all three initial loads in parallel — the conversation
+    // metadata fetch, the artifacts list, and the messages bootstrap.
+    // Previously the bootstrap (the largest payload by far) didn't start
+    // until <MessageList> mounted in its own useEffect.
+    void useMessageStore.getState().loadMessages(client, conversationId)
+    loadArtifacts(client, conversationId)
     ;(async () => {
       const res = await client.get(`/api/v1/conversations/${conversationId}`)
       if (cancelled) return
@@ -86,7 +93,6 @@ export default function ChatPage({ params }: { params: Promise<{ wsId: string; i
         }
       } else setStatus('notfound')
     })()
-    loadArtifacts(client, conversationId)
     return () => {
       cancelled = true
     }

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -216,6 +216,7 @@ export function MessageList({ conversationId }: MessageListProps) {
   const loadOlderUntilSeq = useMessageStore((s) => s.loadOlderUntilSeq)
   const hasMoreOlder = useMessageStore((s) => s.hasMoreByConv[conversationId] ?? false)
   const isLoadingOlder = useMessageStore((s) => s.loadingOlderByConv[conversationId] ?? false)
+  const oldestSeq = useMessageStore((s) => s.oldestSeqByConv[conversationId] ?? null)
   const lastRunStatus = useMessageStore((s) => s.lastRunStatus)
   const pendingConfirmMap = useMessageStore((s) => s.pendingConfirmMap)
   const pendingAsk = useMessageStore((s) => s.pendingAsk)
@@ -505,13 +506,19 @@ export function MessageList({ conversationId }: MessageListProps) {
     void loadOlderMessages(client, conversationId)
   }, [conversationId, loadOlderMessages, workspaceId])
 
+  // ``oldestSeq`` moves only when older messages are prepended (bootstrap
+  // arrival or backscroll); appended turns / mid-stream finalizes don't
+  // touch it. Keying the anchor restore on that signal — instead of
+  // ``messages.length`` — avoids consuming the snapshot on an unrelated
+  // append that happens to land between Load earlier's click and its
+  // network response.
   useLayoutEffect(() => {
     const anchor = pendingAnchorRef.current
     const scroller = scrollRef.current
     if (!anchor || !scroller) return
     scroller.scrollTop = anchor.scrollTop + (scroller.scrollHeight - anchor.scrollHeight)
     pendingAnchorRef.current = null
-  }, [messages?.length])
+  }, [oldestSeq])
 
   // Deep-link from conversation search: ``#msg-<seq>`` may target a message
   // older than the bootstrap tail. After the initial load completes, walk
@@ -528,18 +535,21 @@ export function MessageList({ conversationId }: MessageListProps) {
     if (!m) return
     const targetSeq = parseInt(m[1], 10)
     if (Number.isNaN(targetSeq)) return
-    let cancelled = false
+    // Abort the backscroll walk on conv switch / unmount so we don't keep
+    // pulling pages into a conversation the user has left (which would also
+    // bleed an error bubble into the foreground conv on 404).
+    const controller = new AbortController()
     void (async () => {
       const client = createApiClient('')
       if (workspaceId) client.setWorkspaceId(workspaceId)
-      await loadOlderUntilSeq(client, conversationId, targetSeq)
-      if (cancelled) return
+      await loadOlderUntilSeq(client, conversationId, targetSeq, controller.signal)
+      if (controller.signal.aborted) return
       requestAnimationFrame(() => {
         document.getElementById(`msg-${targetSeq}`)?.scrollIntoView({ block: 'start' })
       })
     })()
     return () => {
-      cancelled = true
+      controller.abort()
     }
   }, [conversationId, messagesLoaded, loadOlderUntilSeq, workspaceId])
 

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -212,6 +212,9 @@ export function MessageList({ conversationId }: MessageListProps) {
     contextTokens,
   } = useMessages(conversationId)
   const loadMessages = useMessageStore((s) => s.loadMessages)
+  const loadOlderMessages = useMessageStore((s) => s.loadOlderMessages)
+  const hasMoreOlder = useMessageStore((s) => s.hasMoreByConv[conversationId] ?? false)
+  const isLoadingOlder = useMessageStore((s) => s.loadingOlderByConv[conversationId] ?? false)
   const lastRunStatus = useMessageStore((s) => s.lastRunStatus)
   const pendingConfirmMap = useMessageStore((s) => s.pendingConfirmMap)
   const pendingAsk = useMessageStore((s) => s.pendingAsk)
@@ -478,9 +481,27 @@ export function MessageList({ conversationId }: MessageListProps) {
     }
   }, [isStreaming])
 
+  const handleLoadEarlier = useCallback(() => {
+    const client = createApiClient('')
+    if (workspaceId) client.setWorkspaceId(workspaceId)
+    void loadOlderMessages(client, conversationId)
+  }, [conversationId, loadOlderMessages, workspaceId])
+
   return (
     <ScrollArea ref={scrollRef} className="flex-1 p-4" onScroll={handleScroll}>
       <div ref={contentRef} className="space-y-4 max-w-2xl mx-auto px-4 md:px-0">
+        {hasMoreOlder && (
+          <div className="flex justify-center py-2">
+            <button
+              type="button"
+              onClick={handleLoadEarlier}
+              disabled={isLoadingOlder}
+              className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-60 transition-colors px-3 py-1 rounded-md border border-border bg-background/60"
+            >
+              {isLoadingOlder ? t('loadingEarlier') : t('loadEarlier')}
+            </button>
+          </div>
+        )}
         {(messages ?? []).map((msg, idx) => (
           // id="msg-{seq}" matches the conversation-search route's
           // matched_message_seq (1-based load order over cubepi's

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useCallback, useMemo } from 'react'
+import { useEffect, useLayoutEffect, useRef, useCallback, useMemo } from 'react'
 import { useTranslations } from 'next-intl'
 import {
   useMessageStore,
@@ -213,6 +213,7 @@ export function MessageList({ conversationId }: MessageListProps) {
   } = useMessages(conversationId)
   const loadMessages = useMessageStore((s) => s.loadMessages)
   const loadOlderMessages = useMessageStore((s) => s.loadOlderMessages)
+  const loadOlderUntilSeq = useMessageStore((s) => s.loadOlderUntilSeq)
   const hasMoreOlder = useMessageStore((s) => s.hasMoreByConv[conversationId] ?? false)
   const isLoadingOlder = useMessageStore((s) => s.loadingOlderByConv[conversationId] ?? false)
   const lastRunStatus = useMessageStore((s) => s.lastRunStatus)
@@ -481,11 +482,66 @@ export function MessageList({ conversationId }: MessageListProps) {
     }
   }, [isStreaming])
 
+  // Scroll-anchor snapshot taken right before a backscroll request. After the
+  // older slice renders we shift scrollTop by exactly (newHeight - oldHeight),
+  // so the message that was at the top of the viewport stays at the top
+  // instead of jumping when content is prepended.
+  const pendingAnchorRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null)
+
   const handleLoadEarlier = useCallback(() => {
+    const scroller = scrollRef.current
+    if (scroller) {
+      pendingAnchorRef.current = {
+        scrollHeight: scroller.scrollHeight,
+        scrollTop: scroller.scrollTop,
+      }
+      // Suppress the streaming-stick-to-bottom auto-scroll for this update —
+      // the user is reading old history, they don't want to be yanked back
+      // to the live tail.
+      stickToBottom.current = false
+    }
     const client = createApiClient('')
     if (workspaceId) client.setWorkspaceId(workspaceId)
     void loadOlderMessages(client, conversationId)
   }, [conversationId, loadOlderMessages, workspaceId])
+
+  useLayoutEffect(() => {
+    const anchor = pendingAnchorRef.current
+    const scroller = scrollRef.current
+    if (!anchor || !scroller) return
+    scroller.scrollTop = anchor.scrollTop + (scroller.scrollHeight - anchor.scrollHeight)
+    pendingAnchorRef.current = null
+  }, [messages?.length])
+
+  // Deep-link from conversation search: ``#msg-<seq>`` may target a message
+  // older than the bootstrap tail. After the initial load completes, walk
+  // backscroll until ``oldest_seq <= targetSeq``, then scroll the anchor
+  // into view. Ref-guarded so we only resolve the hash once per conv open.
+  const hashResolvedForRef = useRef<string | null>(null)
+  const messagesLoaded = (messages?.length ?? 0) > 0
+  useEffect(() => {
+    if (!messagesLoaded) return
+    if (typeof window === 'undefined') return
+    if (hashResolvedForRef.current === conversationId) return
+    hashResolvedForRef.current = conversationId
+    const m = /^#msg-(\d+)$/.exec(window.location.hash)
+    if (!m) return
+    const targetSeq = parseInt(m[1], 10)
+    if (Number.isNaN(targetSeq)) return
+    let cancelled = false
+    void (async () => {
+      const client = createApiClient('')
+      if (workspaceId) client.setWorkspaceId(workspaceId)
+      await loadOlderUntilSeq(client, conversationId, targetSeq)
+      if (cancelled) return
+      requestAnimationFrame(() => {
+        document.getElementById(`msg-${targetSeq}`)?.scrollIntoView({ block: 'start' })
+      })
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [conversationId, messagesLoaded, loadOlderUntilSeq, workspaceId])
 
   return (
     <ScrollArea ref={scrollRef} className="flex-1 p-4" onScroll={handleScroll}>
@@ -502,13 +558,15 @@ export function MessageList({ conversationId }: MessageListProps) {
             </button>
           </div>
         )}
-        {(messages ?? []).map((msg, idx) => (
+        {(messages ?? []).map((msg) => (
           // id="msg-{seq}" matches the conversation-search route's
-          // matched_message_seq (1-based load order over cubepi's
-          // data.messages — see backend/cubebox/search/worker.py).
-          // SearchResultRow links to #msg-N; the browser scrolls to this
-          // anchor when the user clicks a search hit.
-          <div key={msg.id} id={`msg-${idx + 1}`}>
+          // matched_message_seq (cubepi_messages.seq — see
+          // backend/cubebox/search/worker.py). SearchResultRow links to
+          // #msg-N; the browser scrolls to this anchor when the user
+          // clicks a search hit. ``seq`` is missing only on the optimistic
+          // user bubble before the run is claimed — those are never search
+          // targets, so we just skip the anchor.
+          <div key={msg.id} id={msg.seq != null ? `msg-${msg.seq}` : undefined}>
             {msg.role === 'user' && msg.metadata?.synthetic !== true && (
               <>
                 {msg.metadata?.sender_display_name && msg.metadata?.sender_user_id && (

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -280,6 +280,8 @@
   },
   "chat": {
     "incompletePreviousAnswer": "Previous response was incomplete (service exit). Please retry.",
+    "loadEarlier": "Load earlier messages",
+    "loadingEarlier": "Loading earlier messages…",
     "thinking": "Thinking...",
     "thinkingProcess": "Thinking",
     "sandboxPreparing": "Preparing sandbox environment...",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -280,6 +280,8 @@
   },
   "chat": {
     "incompletePreviousAnswer": "上次回答未完成（服务异常退出），请重试。",
+    "loadEarlier": "加载更早的消息",
+    "loadingEarlier": "正在加载更早的消息…",
     "thinking": "思考中...",
     "thinkingProcess": "思考过程",
     "sandboxPreparing": "正在准备沙箱环境...",


### PR DESCRIPTION
## Summary

- Opening a long conversation was dominated by ``/bootstrap`` serializing the entire history (~6 MB, ~300 ms on a 1386-msg thread) plus a sequential fan-out of independent awaits.
- Bootstrap now returns the most recent ``lifecycle.bootstrap_history_tail`` messages (default 300) + an ``oldest_seq``/``has_more`` cursor; backscroll loads older windows on demand. Stage-A fans out ``history`` + ``active_run`` + cubepi ``pending_hitl`` + Redis ``last_error`` into one ``asyncio.gather``. ``find_latest_todos`` walks the most recent assistant rows directly so the todo panel hydrates correctly even when the last ``write_todos`` lives below the tail.
- Frontend: page-level effect kicks off ``loadMessages`` in parallel with the conversation-meta + artifacts fetches (single in-flight promise dedups the two on-mount triggers). ``<MessageList>`` renders a "Load earlier" button gated on ``has_more``, scrolls the search deep-link ``#msg-<seq>`` anchor into view by walking backscroll until the target is loaded, and pins the scroll anchor on prepend.

## Measured impact

On the actual slow conversation (``conv-1fwZQ8u3ZDukx3``, 1386 messages):

|                          | before  | after            |
|--------------------------|---------|------------------|
| ``/bootstrap`` backend   | ~305 ms | **~22 ms** (~14×)|
| ``/bootstrap`` payload   | 6.15 MB | **1.51 MB** (−75%)|

## Test plan

- [x] ``backend/tests/e2e/test_history_window.py`` — 8 tests pin tail / cursor / has_more / malformed-write_todos / empty-thread behavior
- [x] ``backend/tests/e2e/test_cubepi_history_round_trip.py`` updated for the dropped ``total`` field
- [x] Existing bootstrap-touching e2e (``test_hitl_pause_resume`` bootstrap cases, ``test_steer_endpoint``, ``test_graceful_restart``) pass
- [x] Frontend ``pnpm --filter web type-check / lint / test`` — 230 vitest tests pass
- [x] Two rounds of workflow-backed ``/code-review high`` ran; all confirmed findings addressed in the follow-up commits (e574d431, f1384bea)
- [ ] Manual smoke against the slow conversation in the dev environment to confirm wall-clock open time

## Notable design notes

- ``load_history_window`` queries ``cubepi_messages`` directly through the existing SQLAlchemy pool — cubepi's ``cp.load()`` has no LIMIT and re-validates every row through Pydantic. We trust the stored ``model_dump(mode="json")`` shape (which cubepi itself wrote) and skip the round-trip; this is the main backend-time win.
- ``messages[].seq`` (the cubepi row's ``seq``) is now exposed on the wire so the ``#msg-<seq>`` DOM anchor is stable across tail-loading + prepends. The conversation-search route already emits ``matched_message_seq`` matching this column.
- ``loadOlderMessages`` shares an in-flight promise (same pattern as ``loadMessages``) so a user click + the deep-link auto-walk dedupe cleanly.
- Pending-HITL ``active_run`` race semantics from the original sequential bootstrap are preserved, with the same ``is_stale_meta`` gate applied to the refetched value.