### PR TITLE
fix(skills): hand the agent the exact sandbox path for bundled skill files

### DIFF
--- a/backend/cubebox/middleware/skills.py
+++ b/backend/cubebox/middleware/skills.py
@@ -116,10 +116,24 @@ class SkillsMiddleware(Middleware):
         if not output.loaded or not output.content:
             return None
 
+        # Carry the sandbox file path *into* the persisted content. The
+        # immediate tool result has `path`, but subsequent model calls only see
+        # what transform_system_prompt re-injects from extra — so without this
+        # the model loses the exact path and goes back to guessing it (the very
+        # 404 this skill's `path` is meant to prevent). Keeping it inside the
+        # content string preserves the str-valued loaded_skills contract.
+        content = output.content
+        if output.path:
+            content = (
+                f"Skill files (scripts, templates, references) are in "
+                f"`{output.path}` — reference them using that path verbatim.\n\n"
+                f"{content}"
+            )
+
         # Write into the live extra dict so transform_system_prompt can read it.
         extra = self._extra_ref()
         loaded: dict[str, str] = extra.setdefault(_LOADED_SKILLS_KEY, {})
-        loaded[output.skill_name] = output.content
+        loaded[output.skill_name] = content
 
         return None
 

--- a/backend/cubebox/prompts/skills.py
+++ b/backend/cubebox/prompts/skills.py
@@ -7,7 +7,8 @@ SKILLS_PROMPT_TEMPLATE = """\
 
 {skills_list}
 
-Use `load_skill(name)` to read a skill's instructions. Skills' sibling files
-(scripts, templates) are available at `/.skills/<name>/<version>/` inside the
-sandbox when you actually use them.
+Use `load_skill(name)` to read a skill's instructions. Its result includes a
+`path` field — the exact sandbox directory holding that skill's sibling files
+(scripts, templates, references). Reference those files using that `path`
+verbatim; do not construct the path from the skill name yourself.
 """

--- a/backend/cubebox/sandbox/lazy.py
+++ b/backend/cubebox/sandbox/lazy.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from cubebox.sandbox.base import ExecuteResult, Sandbox
+from cubebox.skills.sandbox_paths import sandbox_skill_dir
 
 if TYPE_CHECKING:
     from cubebox.sandbox.manager import SandboxManager
@@ -41,7 +42,7 @@ async def _sync_skills(
         per_skill = await catalog.list_files_for_sandbox_sync(
             s.skill_version_id, storage_prefix=s.storage_prefix
         )
-        target_root = f"/.skills/{s.name}/{s.version}/"
+        target_root = sandbox_skill_dir(s.name, s.version) + "/"
         files = [(target_root + rel, data) for rel, data in per_skill]
         if files:
             await sandbox.upload(files)
@@ -242,14 +243,15 @@ class LazySandbox(Sandbox):
 
     async def download(self, paths: list[str]) -> list[tuple[str, bytes]]:
         sandbox = await self._ensure_with_retry()
-        try:
-            return await sandbox.download(paths)
-        except Exception:
-            async with self._lock:
-                self._sandbox = None
-            logger.warning("Lazy sandbox: download failed, recreating sandbox")
-            sandbox = await self._ensure()
-            return await sandbox.download(paths)
+        # A download failure is almost always a missing / unreadable path (e.g.
+        # the agent guessed a wrong skill-file path), NOT a dead sandbox.
+        # Recreating the sandbox here would wipe /workspace AND still not
+        # produce the file (a fresh sandbox can't hold work it never ran), so
+        # the recreate is pure data loss. Surface the error to the caller
+        # instead — the file_read tool turns it into a corrigible error the
+        # agent can act on. A genuinely dead sandbox is detected and recreated
+        # by the next execute/upload call.
+        return await sandbox.download(paths)
 
     async def close(self) -> None:
         if self._sandbox is not None:

--- a/backend/cubebox/sandbox/manager.py
+++ b/backend/cubebox/sandbox/manager.py
@@ -9,7 +9,9 @@ Core responsibilities:
 Note: skill sync no longer happens here. After M3 it is handled by
 ``LazySandbox._ensure()`` via the SkillCatalogService — only the skills
 that are enabled for the request's workspace get pushed, and they get
-versioned paths under ``/.skills/<name>/<version>/``.
+versioned paths under ``/.skills/<name>/<version>/`` (see
+``cubebox.skills.sandbox_paths.sandbox_skill_dir`` — a ``:`` in the canonical
+name is normalised to ``__`` so the path is filesystem-safe).
 """
 
 import asyncio

--- a/backend/cubebox/skills/sandbox_paths.py
+++ b/backend/cubebox/skills/sandbox_paths.py
@@ -1,0 +1,28 @@
+"""Single source of truth for where a skill's files live inside the sandbox.
+
+Both the sandbox file-sync (``cubebox.sandbox.lazy._sync_skills``) and the
+``load_skill`` tool import ``sandbox_skill_dir`` so the directory the files are
+written to is exactly the directory the agent is told to read from — the agent
+never has to construct the path itself.
+
+Canonical skill names can contain a colon (``<org>:<skill>`` for
+registry-installed skills). A colon is hostile to filesystem paths and the LLM
+reliably mis-renders it as a path separator (and drops the version segment),
+so reads of bundled scripts/templates fail. We normalise ``:`` to ``__`` and
+hand the resolved path back to the agent via ``load_skill``.
+"""
+
+from __future__ import annotations
+
+SKILLS_ROOT = "/.skills"
+
+
+def sandbox_skill_dir(name: str, version: str) -> str:
+    """Absolute directory a skill's sibling files are mounted at in the sandbox.
+
+    Returns a path with no trailing slash, e.g.
+    ``/.skills/acme__my-skill/1.2.0``. Preinstalled skills have plain names
+    (no colon) and are unaffected by the normalisation.
+    """
+    safe_name = name.replace(":", "__")
+    return f"{SKILLS_ROOT}/{safe_name}/{version}"

--- a/backend/cubebox/tools/builtin/load_skill.py
+++ b/backend/cubebox/tools/builtin/load_skill.py
@@ -18,6 +18,7 @@ from cubepi.agent.types import AgentTool, AgentToolResult
 from cubepi.providers.base import TextContent
 from pydantic import BaseModel, Field
 
+from cubebox.skills.sandbox_paths import sandbox_skill_dir
 from cubebox.skills.service import SkillCatalogService
 
 
@@ -35,6 +36,10 @@ class LoadSkillOutput(BaseModel):
     content: str
     version: str
     loaded: bool
+    # Absolute directory the skill's sibling files (scripts/, templates/,
+    # references/) are mounted at in the sandbox. Use this path verbatim — do
+    # not construct it from the skill name yourself. Empty when not loaded.
+    path: str = ""
     error: str | None = None
 
     def __str__(self) -> str:
@@ -93,6 +98,7 @@ def create_load_skill_tool(
             content=content,
             version=resolved.version,
             loaded=True,
+            path=sandbox_skill_dir(resolved.name, resolved.version),
             error=None,
         ).model_dump_json()
         return AgentToolResult(content=[TextContent(text=text)])
@@ -100,8 +106,12 @@ def create_load_skill_tool(
     return AgentTool(
         name="load_skill",
         description=(
-            "Read a skill's instructions. Returns SKILL.md content plus version. "
-            "Skills are listed in your system prompt; pass the exact name."
+            "Read a skill's instructions. Returns the SKILL.md content, its "
+            "version, and `path` — the exact sandbox directory holding the "
+            "skill's sibling files (scripts/, templates/, references/). Use that "
+            "`path` verbatim to reference those files; do not build the path from "
+            "the skill name. Skills are listed in your system prompt; pass the "
+            "exact name."
         ),
         parameters=LoadSkillInput,
         execute=_execute,

--- a/backend/tests/unit/test_lazy_sandbox_download.py
+++ b/backend/tests/unit/test_lazy_sandbox_download.py
@@ -1,0 +1,66 @@
+"""Unit test: LazySandbox.download must not recreate the sandbox on failure.
+
+A download failure is overwhelmingly a missing / unreadable path (e.g. the
+agent referenced a skill file that isn't there). The previous behaviour nulled
+and recreated the sandbox on ANY download error — which wiped /workspace AND
+could not produce the file anyway, so a single bad path read destroyed the
+agent's in-progress work and triggered recreate storms. The read error must
+instead surface to the caller; a genuinely dead sandbox is recovered by the
+next execute/upload call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cubebox.sandbox.lazy import LazySandbox
+
+
+class _FakeSandbox:
+    def __init__(self, sandbox_id: str) -> None:
+        self.id = sandbox_id
+
+    async def download(self, paths: list[str]) -> list[tuple[str, bytes]]:
+        raise FileNotFoundError(paths[0])
+
+
+class _CountingManager:
+    """Counts get_or_create so the test can assert no recreate happened."""
+
+    def __init__(self) -> None:
+        self.create_count = 0
+
+    async def get_or_create(self, **_kwargs: object) -> _FakeSandbox:
+        self.create_count += 1
+        return _FakeSandbox(f"sbx-{self.create_count}")
+
+    async def touch(self, *_a: object, **_k: object) -> None:
+        return None
+
+    async def renew_lease(self, *_a: object, **_k: object) -> None:
+        return None
+
+
+def _make_lazy(manager: _CountingManager) -> LazySandbox:
+    return LazySandbox(
+        manager=manager,  # type: ignore[arg-type]
+        scope_type="user",
+        scope_id="usr-1",
+        user_id="usr-1",
+        org_id="org-1",
+        workspace_id="ws-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_failure_does_not_recreate_sandbox() -> None:
+    manager = _CountingManager()
+    lazy = _make_lazy(manager)
+
+    with pytest.raises(FileNotFoundError):
+        await lazy.download(["/.skills/acme__x/1.0/missing.py"])
+
+    # Exactly one create (the initial _ensure); the failed read must NOT have
+    # triggered a recreate, and the live sandbox handle must be preserved.
+    assert manager.create_count == 1
+    assert lazy.initialized is True

--- a/backend/tests/unit/test_load_skill.py
+++ b/backend/tests/unit/test_load_skill.py
@@ -95,6 +95,32 @@ async def test_load_skill_returns_content(catalog: _FakeCatalog) -> None:
 
 
 @pytest.mark.asyncio
+async def test_load_skill_returns_sandbox_path(catalog: _FakeCatalog) -> None:
+    # The agent must be handed the exact sandbox dir for sibling files instead
+    # of guessing it from the name.
+    tool = create_load_skill_tool(catalog=catalog, workspace_id="ws-1", org_id="org-1")
+    result = await tool.execute(
+        "tc-1", tool.parameters(skill_name="writing"), signal=None, on_update=None
+    )
+    payload = json.loads(result.content[0].text)
+    assert payload["path"] == "/.skills/writing/1.0.0"
+
+
+@pytest.mark.asyncio
+async def test_load_skill_path_normalises_colon_name() -> None:
+    # Registry canonical name <org>:<skill> — the returned path must not carry
+    # the path-hostile colon that broke bundled-file reads.
+    catalog = _FakeCatalog({"acme:designer": ("3.0.0", "Design boldly.")})
+    tool = create_load_skill_tool(catalog=catalog, workspace_id="ws-1", org_id="org-1")
+    result = await tool.execute(
+        "tc-c", tool.parameters(skill_name="acme:designer"), signal=None, on_update=None
+    )
+    payload = json.loads(result.content[0].text)
+    assert payload["path"] == "/.skills/acme__designer/3.0.0"
+    assert ":" not in payload["path"]
+
+
+@pytest.mark.asyncio
 async def test_load_skill_second_skill_returns_content(catalog: _FakeCatalog) -> None:
     tool = create_load_skill_tool(catalog=catalog, workspace_id="ws-1", org_id="org-1")
     args = tool.parameters(skill_name="math")

--- a/backend/tests/unit/test_sandbox_paths.py
+++ b/backend/tests/unit/test_sandbox_paths.py
@@ -1,0 +1,29 @@
+"""Unit tests for sandbox skill-dir path construction.
+
+Guards the fix for the bug where registry-installed skills (canonical name
+``<org>:<skill>``) mounted their bundled files at a colon-bearing path that the
+agent mis-constructed, so reads of scripts/references failed. The colon must be
+normalised so the path is filesystem-safe and the agent gets it verbatim.
+"""
+
+from __future__ import annotations
+
+from cubebox.skills.sandbox_paths import sandbox_skill_dir
+
+
+def test_plain_name_unchanged() -> None:
+    # Preinstalled skills have plain names — path must be untouched.
+    assert sandbox_skill_dir("create-pptx", "1.0.0") == "/.skills/create-pptx/1.0.0"
+
+
+def test_colon_name_is_normalised() -> None:
+    # Registry canonical name <org>:<skill> — the colon is the bug; it must not
+    # survive into the path as a separator.
+    got = sandbox_skill_dir("acme-org:my-skill", "2.1.0")
+    assert ":" not in got
+    assert got == "/.skills/acme-org__my-skill/2.1.0"
+
+
+def test_no_trailing_slash() -> None:
+    # Callers append their own separator; the dir itself has none.
+    assert not sandbox_skill_dir("x", "1.0").endswith("/")

--- a/backend/tests/unit/test_skills.py
+++ b/backend/tests/unit/test_skills.py
@@ -127,6 +127,35 @@ async def test_after_tool_call_writes_skill_to_extra() -> None:
 
 
 @pytest.mark.asyncio
+async def test_after_tool_call_persists_sandbox_path_in_content() -> None:
+    # The sandbox `path` must survive into the persisted content so it is
+    # re-injected on later turns (the tool result alone is gone by then), or
+    # colon-named multi-file skills resume guessing the path.
+    extra: dict[str, Any] = {}
+    mw = _make_middleware(extra)
+
+    result_obj = LoadSkillOutput(
+        skill_name="acme:designer",
+        content="# Designer\n\nDesign boldly.",
+        version="2.0.0",
+        loaded=True,
+        path="/.skills/acme__designer/2.0.0",
+    )
+    ctx = _make_after_ctx(
+        result=AgentToolResult(content=[TextContent(text=result_obj.model_dump_json())]),
+    )
+    await mw.after_tool_call(ctx)
+
+    stored = extra["loaded_skills"]["acme:designer"]
+    assert "/.skills/acme__designer/2.0.0" in stored
+    assert stored.endswith("# Designer\n\nDesign boldly.")
+
+    # And it renders into the system prompt on a subsequent call.
+    out = await mw.transform_system_prompt("BASE", ctx=_make_context(extra))
+    assert "/.skills/acme__designer/2.0.0" in out
+
+
+@pytest.mark.asyncio
 async def test_after_tool_call_accumulates_multiple_skills() -> None:
     """Loading a second skill appends to existing loaded_skills dict."""
     extra: dict[str, Any] = {"loaded_skills": {"alpha": "Alpha content"}}

--- a/docs/dev/notes/2026-06-24-ppt-skills-eval.md
+++ b/docs/dev/notes/2026-06-24-ppt-skills-eval.md
@@ -1,0 +1,134 @@
+# PPT Skills Evaluation — picking a default-preinstall slide skill
+
+Date: 2026-06-24
+Author: agent eval (worktree `feat/2026-06-24-office-skills`)
+
+## Goal
+
+We had collected several third-party PPT/Excel/PDF/Word skills from the web but
+only smoke-tested them. This pass deeply evaluates the **PowerPoint** skills to
+decide what (if anything) cubebox should preinstall. PPT splits into two camps:
+
+- **Native `.pptx`** — produce an editable PowerPoint binary (python-pptx / PptxGenJS / html2pptx).
+- **HTML decks** — produce a self-contained HTML slide deck.
+
+We pick **one winner per camp** for preinstall, scored on **process** (agent
+trace: steps, tool errors, robustness) and **result** (downloaded artifact:
+visual quality, content, layout integrity, editability).
+
+## Method
+
+1. Brought up the worktree backend (8024) + frontend (3024), registered a user
+   (multi_tenant → org owner), minted an API key.
+2. Org admin: installed the **clawhub** and **skills.sh** registries; set the
+   org sandbox `network_default_action` to `allow`.
+3. Discovered candidates via `GET /ws/{ws}/skills/discover` (53 unique PPT
+   candidates across both registries) + read each shortlist `SKILL.md`.
+4. Shortlisted 3 per camp, installed them, and ran the **same task** (a 6-slide
+   "Rise of SLMs in 2026" deck) on the `pro` model, one skill per conversation.
+5. Downloaded each artifact; rendered `.pptx` via LibreOffice→PDF→PNG and HTML
+   via headless Chromium; inspected per-slide screenshots + python-pptx structure.
+6. Pulled per-run tool-call sequences from the messages API for the process score.
+
+### Two install paths tested
+
+A key methodological point emerged: **registry-installed** skills get a
+canonical name with a colon (`<org>:<skill>`), while **preinstalled** skills
+have a plain name. This changes the sandbox mount path and turned out to
+dominate multi-file-skill behaviour (see Bug 1). So each multi-file candidate
+was tested both as a registry install *and* as a clean preinstalled skill
+(staged into `skills/preinstalled/` + reseeded). The preinstall path is the one
+that matters for the actual decision.
+
+## Candidates & results
+
+Task held constant; model = `pro`; same prompt.
+
+### Native `.pptx`
+
+| Skill (source) | Registry install | Clean preinstall | Result quality | Process |
+|---|---|---|---|---|
+| **create-pptx** (clawhub/scottliu007) | ⚠ recovered after failed ref reads | ✅ clean | **Best**: dark, 156 shapes, driver cards + styled comparison, **no overlap/overflow**, fully editable | 26 tools, reads refs |
+| pptx-generator (clawhub/tobewin) | ✅ clean (self-contained) | = same | Clean, real table; emoji render as □ (font), some low-contrast table labels | **Cleanest**: 12 tools, no file reads |
+| pptx (Anthropic, preinstalled baseline) | ❌ fork w/ hardcoded `/skills/pptx/` paths stuck | ✅ 186KB | Richest design *intent* (18 palettes) but html2pptx produced **title overlap + clipped card text** | Heaviest: html2pptx + LibreOffice + Playwright; 26 tools |
+
+**Native winner: `create-pptx`** — cleanest, defect-free, best-looking output;
+only python-pptx + pillow. Robust runner-up: **pptx-generator** (zero external
+deps, fastest, survives even the hostile registry path).
+
+### HTML
+
+| Skill (source) | Registry install | Result quality | Process |
+|---|---|---|---|
+| **openclaw-slides** (clawhub/leoyeai) | ✅ worked (inlines critical CSS/JS) | Excellent: techy dark, structured comparison table | **8 tools**, self-contained |
+| frontend-slides (clawhub/ken0122) | ❌ failed (depends on reference files) | Best-looking: editorial serif, winner-highlighted table | 16 tools (clean) |
+| html-slides (skills.sh, reveal.js) | ✅ worked | Stock reveal.js, sparse, CDN-dependent at runtime | 8 tools |
+
+**HTML winner: `openclaw-slides`** — beautiful, self-contained, efficient, and
+the only one robust enough to also work on the hostile registry path.
+Runner-up: **frontend-slides** (marginally more refined editorial aesthetic, but
+fragile — fails entirely if its reference files aren't readable).
+
+### Also evaluated: `ppt-master` (github.com/hugohe3/ppt-master)
+
+The most ambitious candidate by far: source docs → Markdown → hand-authored SVG
+pages → PPTX, with a 7-step interactive pipeline, brand/layout/deck templates,
+icon libraries, LaTeX rendering, AI image generation.
+
+**Not recommended for preinstall.** Disqualifiers:
+- **Size**: skill payload is **97 MB / 12,146 files** — over the registry 50 MB
+  bundle cap (registry install timed out) and impractical to vendor as a preinstall.
+- **External deps**: needs OpenAI/MiniMax API keys (images), codecogs/quicklatex
+  (LaTeX web services), pixabay/pexels (image search) — network + paid keys.
+- **Interactive by design**: Flask "Eight Confirmations" browser UI + live-preview
+  editor with blocking gates — built for human-in-the-loop, stalls an autonomous run.
+- **Output**: SVG→PPTX embeds PNG+SVG images → slides are not natively editable.
+
+Design ambition ~9/10, but platform fit ~2/10. It's a standalone interactive
+design product, not a lightweight agent skill.
+
+## Recommendation
+
+- Preinstall **`create-pptx`** for the native-pptx camp.
+- Preinstall **`openclaw-slides`** for the HTML camp.
+- Do not preinstall the Anthropic html2pptx `pptx` (conversion defects + heaviest
+  toolchain), reveal.js `html-slides` (stock + runtime CDN), or `ppt-master` (too
+  heavy / interactive / external-dependent).
+
+## Platform bugs found (independent of skill choice)
+
+### Bug 1 — registry-installed skills can't read their bundled files
+
+Registry skills get a colon canonical name (`<org>:<skill>`). Files mount at
+`/.skills/{name}/{version}/` (`cubebox/sandbox/lazy.py`), and the system prompt
+only told the agent the *pattern* `/.skills/<name>/<version>/`. The LLM
+mis-renders the colon as a path separator and drops the version segment, so
+reads of `scripts/`/`references/` fail. Preinstalled (plain-name) skills had 0
+read errors. **Fix:** normalise `:`→`__` in a single `sandbox_skill_dir()` helper
+(`cubebox/skills/sandbox_paths.py`) used by both the file-sync and `load_skill`;
+`load_skill` now returns the exact `path` and the prompt tells the agent to use
+it verbatim instead of constructing it.
+
+### Bug 2 — a missing-file read tears down the whole sandbox
+
+`LazySandbox.download()` caught *any* exception (incl. file-not-found) as
+"sandbox died" → nulled and **recreated the sandbox**, wiping `/workspace`. This
+amplified Bug 1 into recreate-storms that destroyed in-progress work. **Fix:**
+`download()` no longer recreates on failure — the read error surfaces to the
+agent (a corrigible `file_read` error); a genuinely dead sandbox is still
+recovered by the next `execute`/`upload`.
+
+### Bug 3 — worktree backend crashes without egress mTLS certs
+
+`config.development.local.yaml` enables the egress mTLS listener with relative
+cert paths `certs/egress/*.pem`, but worktree provisioning doesn't generate
+them, so the uvicorn listener's `serve()` fails to load the cert chain and takes
+the backend down on teardown. Handled out-of-band (env var disables the
+exchanger in worktrees); worktree `init` should generate the certs or default
+the listener off when certs are absent.
+
+> Note: the repeated backend deaths during this eval were primarily an
+> environment collision — a *separate* session running the main-repo backend was
+> periodically `pkill -f main.py`-ing (matching the worktree's same-named
+> process) and holding egress port 9443. Worked around by running the eval
+> backend as `eval_server_8024.py` with the egress listener on 9444.


### PR DESCRIPTION
## Problem

While evaluating third-party PPT skills for preinstall, every **multi-file skill installed from a registry** (clawhub/skills.sh) failed to read its own bundled `scripts/`/`references/` files. Two bugs compounded:

1. **Colon path.** Registry skills get a canonical name `<org>:<skill>` and mount at `/.skills/<name>/<version>/`. The system prompt only told the agent the *pattern*, so the LLM rendered the colon as a path separator and dropped the version segment → reads like `/.skills/<org>/<skill>/references/x.md` 404.
2. **Recreate storm.** `LazySandbox.download()` caught *any* read error (incl. file-not-found) as "sandbox died" and recreated the sandbox — wiping `/workspace` and the agent's in-progress work, looping.

Preinstalled (plain-name) skills were unaffected, which is what surfaced the colon as root cause.

## Fix

- `cubebox/skills/sandbox_paths.py` (new): `sandbox_skill_dir()` — single source of truth, normalises `:` → `__`.
- `_sync_skills` mounts via the helper.
- `load_skill` now returns the exact `path`; tool description + skills prompt tell the agent to use it verbatim instead of constructing it.
- `download()` no longer recreates the sandbox on a read failure — the error surfaces to the agent (corrigible `file_read` error); a genuinely dead sandbox is still recovered by the next `execute`/`upload`.

## Verification

Re-ran a colon-named skill (`<org>:create-pptx`) end-to-end:
- `load_skill` returned `path = /.skills/<org>__create-pptx/1.0.0`
- agent read `…/scripts/pptx_helpers.py` and `…/references/standard-slides.md` successfully
- **0 failed reads, 0 sandbox recreations** (was 6 failed reads + recreate storms), produced a valid editable `.pptx`

Unit tests: `test_sandbox_paths.py`, `test_lazy_sandbox_download.py`, extended `test_load_skill.py` (12 tests). mypy + ruff clean.

Full eval context: `docs/dev/notes/2026-06-24-ppt-skills-eval.md`.

@codex please review