### PR TITLE
feat(im): parse Feishu rich-text (post) inbound messages

### DIFF
--- a/backend/cubebox/im/feishu/connector.py
+++ b/backend/cubebox/im/feishu/connector.py
@@ -71,17 +71,24 @@ def _parse_feishu_attachments(
         return []
     kind = {"audio": "audio", "media": "video"}.get(message_type, "file")
     name = str(content_obj.get("file_name") or message_type)
-    raw_size = content_obj.get("file_size")
-    size_hint: int | None = None
-    if isinstance(raw_size, int):
-        size_hint = raw_size
-    elif isinstance(raw_size, str) and raw_size.isdigit():
-        size_hint = int(raw_size)
     return [
         InboundAttachmentRef(
-            kind=kind, filename=name, mime=None, handle=str(key), size_hint=size_hint
+            kind=kind,
+            filename=name,
+            mime=None,
+            handle=str(key),
+            size_hint=_parse_size_hint(content_obj.get("file_size")),
         )
     ]
+
+
+def _parse_size_hint(raw: Any) -> int | None:
+    """Coerce a Feishu file_size (int or numeric str) to an int hint, else None."""
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str) and raw.isdigit():
+        return int(raw)
+    return None
 
 
 def _substitute_mentions(
@@ -124,12 +131,14 @@ def _render_post_at(
     elem: dict[str, Any], mention_index: dict[str, dict[str, str]], bot_open_id: str | None
 ) -> str:
     uid = str(elem.get("user_id", "")).strip()
+    if uid == "@_all":
+        return "@all"
     entry = mention_index.get(uid)
     open_id = (entry or {}).get("open_id") or uid
     if bot_open_id and open_id == bot_open_id:
         return ""  # drop the bot's own mention
-    name = (entry or {}).get("name") or str(elem.get("user_name", "")).strip() or "user"
-    return f"@{name}"
+    name = (entry or {}).get("name") or str(elem.get("user_name", "")).strip()
+    return f"@{name}" if name else ""
 
 
 def _resolve_post_payload(content_obj: dict[str, Any]) -> dict[str, Any]:
@@ -140,6 +149,12 @@ def _resolve_post_payload(content_obj: dict[str, Any]) -> dict[str, Any]:
     """
     if isinstance(content_obj.get("content"), list):
         return content_obj
+    # Multi-language send-shape ({"zh_cn": {...}, "en_us": {...}}): prefer a
+    # known locale order so the choice isn't dict-iteration-order roulette.
+    for locale in ("zh_cn", "zh_hk", "zh_tw", "en_us", "ja_jp"):
+        value = content_obj.get(locale)
+        if isinstance(value, dict) and isinstance(value.get("content"), list):
+            return value
     for value in content_obj.values():
         if isinstance(value, dict) and isinstance(value.get("content"), list):
             return value
@@ -194,9 +209,15 @@ def _parse_feishu_post(
                 key = str(elem.get("file_key", "")).strip()
                 if key:
                     name = str(elem.get("file_name") or elem.get("title") or "file")
-                    kind = {"audio": "audio", "video": "video", "media": "video"}.get(tag, "file")
+                    kind = {"audio": "audio", "media": "video", "video": "video"}.get(tag, "file")
                     attachments.append(
-                        InboundAttachmentRef(kind=kind, filename=name, mime=None, handle=key)
+                        InboundAttachmentRef(
+                            kind=kind,
+                            filename=name,
+                            mime=None,
+                            handle=key,
+                            size_hint=_parse_size_hint(elem.get("file_size")),
+                        )
                     )
         line = "".join(parts).strip()
         if line:

--- a/backend/cubebox/im/feishu/connector.py
+++ b/backend/cubebox/im/feishu/connector.py
@@ -84,6 +84,126 @@ def _parse_feishu_attachments(
     ]
 
 
+def _substitute_mentions(
+    raw_text: str, mentions: list[dict[str, Any]], bot_open_id: str | None
+) -> str:
+    """Replace Feishu ``@_user_N`` placeholders with ``@name``; drop the bot's
+    own mention so the LLM sees only the message body."""
+    for mention in mentions:
+        key = mention.get("key") or ""
+        if not key:
+            continue
+        mid = (mention.get("id") or {}).get("open_id")
+        name = mention.get("name") or ""
+        if mid and mid == bot_open_id:
+            raw_text = raw_text.replace(key, "")
+        elif name:
+            raw_text = raw_text.replace(key, f"@{name}")
+    return _AT_TAG_RE.sub("", raw_text).strip()
+
+
+def _index_mentions(mentions: list[dict[str, Any]]) -> dict[str, dict[str, str]]:
+    """Index mentions by BOTH placeholder key and open_id → {open_id, name}.
+
+    Post ``at`` elements carry ``user_id`` that may be either the placeholder
+    (``@_user_N``) or the real open_id, so we index both ways.
+    """
+    index: dict[str, dict[str, str]] = {}
+    for m in mentions:
+        oid = (m.get("id") or {}).get("open_id") or ""
+        entry = {"open_id": oid, "name": m.get("name") or ""}
+        key = m.get("key") or ""
+        if key:
+            index[key] = entry
+        if oid:
+            index[oid] = entry
+    return index
+
+
+def _render_post_at(
+    elem: dict[str, Any], mention_index: dict[str, dict[str, str]], bot_open_id: str | None
+) -> str:
+    uid = str(elem.get("user_id", "")).strip()
+    entry = mention_index.get(uid)
+    open_id = (entry or {}).get("open_id") or uid
+    if bot_open_id and open_id == bot_open_id:
+        return ""  # drop the bot's own mention
+    name = (entry or {}).get("name") or str(elem.get("user_name", "")).strip() or "user"
+    return f"@{name}"
+
+
+def _resolve_post_payload(content_obj: dict[str, Any]) -> dict[str, Any]:
+    """Unwrap a possibly language-keyed post payload to ``{title, content}``.
+
+    The receive event usually sends the post body directly, but the send-API
+    shape is language-wrapped (``{"zh_cn": {...}}``); accept either.
+    """
+    if isinstance(content_obj.get("content"), list):
+        return content_obj
+    for value in content_obj.values():
+        if isinstance(value, dict) and isinstance(value.get("content"), list):
+            return value
+    return content_obj
+
+
+def _parse_feishu_post(
+    content_obj: dict[str, Any], mentions: list[dict[str, Any]], bot_open_id: str | None
+) -> tuple[str, list[InboundAttachmentRef]]:
+    """Walk a Feishu post (rich-text) body into ``(text, attachments)``.
+
+    A post is a list of paragraphs, each a list of tagged elements:
+    ``text``/``a``/``at`` render into the text; ``img``/``media``/``file``/
+    ``audio`` become attachment refs resolved to bytes later, exactly like a
+    flat media message. One post can mix text + several images + files.
+    """
+    payload = _resolve_post_payload(content_obj)
+    rows = payload.get("content")
+    if not isinstance(rows, list):
+        return "", []
+    mention_index = _index_mentions(mentions)
+    lines: list[str] = []
+    title = str(payload.get("title") or "").strip()
+    if title:
+        lines.append(title)
+    attachments: list[InboundAttachmentRef] = []
+    for paragraph in rows:
+        if not isinstance(paragraph, list):
+            continue
+        parts: list[str] = []
+        for elem in paragraph:
+            if not isinstance(elem, dict):
+                continue
+            tag = str(elem.get("tag", "")).strip().lower()
+            if tag == "text":
+                parts.append(str(elem.get("text", "")))
+            elif tag == "a":
+                href = str(elem.get("href", "")).strip()
+                label = str(elem.get("text", "") or href).strip()
+                parts.append(f"[{label}]({href})" if href else label)
+            elif tag == "at":
+                parts.append(_render_post_at(elem, mention_index, bot_open_id))
+            elif tag in ("img", "image"):
+                key = str(elem.get("image_key", "")).strip()
+                if key:
+                    attachments.append(
+                        InboundAttachmentRef(
+                            kind="image", filename="image.png", mime=None, handle=key
+                        )
+                    )
+            elif tag in ("media", "file", "audio", "video"):
+                key = str(elem.get("file_key", "")).strip()
+                if key:
+                    name = str(elem.get("file_name") or elem.get("title") or "file")
+                    kind = {"audio": "audio", "video": "video", "media": "video"}.get(tag, "file")
+                    attachments.append(
+                        InboundAttachmentRef(kind=kind, filename=name, mime=None, handle=key)
+                    )
+        line = "".join(parts).strip()
+        if line:
+            lines.append(line)
+    return "\n".join(lines).strip(), attachments
+
+
 # Feishu reaction_type literals (no enum in the SDK). Names are UPPERCASE
 # in Feishu's emoji_type set — mixed case (e.g. "ThumbsUp") is rejected with
 # code=231001 "reaction type is invalid".
@@ -158,7 +278,7 @@ class FeishuConnector:
         if self._bot_open_id is not None and sender_open_id == self._bot_open_id:
             return None
         message_type = message.get("message_type")
-        if message_type != "text" and message_type not in _FEISHU_MEDIA_TYPES:
+        if message_type not in ("text", "post") and message_type not in _FEISHU_MEDIA_TYPES:
             return None
 
         try:
@@ -166,27 +286,16 @@ class FeishuConnector:
         except json.JSONDecodeError:
             return None
 
+        # Feishu inbound mentions use ``@_user_N`` placeholders + a separate
+        # ``mentions[]`` array (NOT inline ``<at>`` tags — those are the
+        # outbound shape). The bot's own mention is dropped; others become
+        # ``@name`` so the LLM reads a name, not a placeholder.
+        mentions = message.get("mentions") or []
         attachments: list[InboundAttachmentRef] = []
         if message_type == "text":
-            raw_text = content_obj.get("text", "")
-            # Feishu inbound text uses ``@_user_N`` placeholders + a separate
-            # ``mentions[]`` array (NOT inline ``<at>`` tags — those are the
-            # outbound shape). Drop the bot's own at-mention (so the LLM sees
-            # only the message body) and substitute remaining ``@_user_N`` with
-            # the mention's human-readable ``name`` (e.g. "@巩向锋") so the LLM
-            # gets a name it can actually reason about instead of a placeholder.
-            mentions = message.get("mentions") or []
-            for mention in mentions:
-                key = mention.get("key") or ""
-                if not key:
-                    continue
-                mid = (mention.get("id") or {}).get("open_id")
-                name = mention.get("name") or ""
-                if mid and mid == self._bot_open_id:
-                    raw_text = raw_text.replace(key, "")
-                elif name:
-                    raw_text = raw_text.replace(key, f"@{name}")
-            text = _AT_TAG_RE.sub("", raw_text).strip()
+            text = _substitute_mentions(content_obj.get("text", ""), mentions, self._bot_open_id)
+        elif message_type == "post":
+            text, attachments = _parse_feishu_post(content_obj, mentions, self._bot_open_id)
         else:
             text = ""
             attachments = _parse_feishu_attachments(message_type, content_obj)

--- a/backend/tests/unit/test_feishu_parse_inbound.py
+++ b/backend/tests/unit/test_feishu_parse_inbound.py
@@ -427,3 +427,23 @@ def test_post_language_wrapped_payload_unwrapped() -> None:
     ev = FeishuConnector(bot_open_id="ou_bot").parse_inbound(raw)
     assert ev is not None
     assert "wrapped body" in ev.text
+
+
+def test_post_group_without_bot_mention_dropped() -> None:
+    # Defense-in-depth: a group post that does NOT @ the bot must be dropped,
+    # exactly like a group text message.
+    raw = _post_event(
+        {"content": [[{"tag": "text", "text": "闲聊一下"}, {"tag": "img", "image_key": "x"}]]},
+        chat_type="group",
+        mentions=[],
+    )
+    assert FeishuConnector(bot_open_id="ou_bot").parse_inbound(raw) is None
+
+
+def test_post_at_all_renders_at_all() -> None:
+    raw = _post_event(
+        {"content": [[{"tag": "at", "user_id": "@_all"}, {"tag": "text", "text": " 通知"}]]}
+    )
+    ev = FeishuConnector(bot_open_id="ou_bot").parse_inbound(raw)
+    assert ev is not None
+    assert "@all" in ev.text

--- a/backend/tests/unit/test_feishu_parse_inbound.py
+++ b/backend/tests/unit/test_feishu_parse_inbound.py
@@ -324,3 +324,106 @@ def test_open_id_fallback_when_union_id_missing() -> None:
     assert ev is not None
     assert ev.sender_ref == "ou_user"
     assert ev.scope_key == "u:ou_user"
+
+
+def _post_event(content: dict, *, chat_type: str = "p2p", mentions: list | None = None) -> dict:
+    msg: dict = {
+        "message_id": "om_post",
+        "chat_id": "oc_dm",
+        "chat_type": chat_type,
+        "message_type": "post",
+        "content": json.dumps(content),
+    }
+    if mentions is not None:
+        msg["mentions"] = mentions
+    return {
+        "header": {"event_id": "ev_post", "event_type": "im.message.receive_v1"},
+        "event": {
+            "sender": {
+                "sender_id": {"open_id": "ou_user", "union_id": "on_user"},
+                "sender_type": "user",
+            },
+            "message": msg,
+        },
+    }
+
+
+def test_post_mixes_text_and_image() -> None:
+    # The headline case: a rich-text post with text + an embedded image must
+    # yield BOTH the text and an image attachment — previously the whole
+    # message (text included) was dropped.
+    raw = _post_event(
+        {
+            "title": "周报",
+            "content": [
+                [{"tag": "text", "text": "这是本周进展："}],
+                [{"tag": "img", "image_key": "img_v2_abc"}],
+                [{"tag": "text", "text": "请查收。"}],
+            ],
+        }
+    )
+    ev = FeishuConnector(bot_open_id="ou_bot").parse_inbound(raw)
+    assert ev is not None
+    assert "周报" in ev.text and "本周进展" in ev.text and "请查收" in ev.text
+    assert len(ev.attachments) == 1
+    assert ev.attachments[0].kind == "image"
+    assert ev.attachments[0].handle == "img_v2_abc"
+
+
+def test_post_renders_links_and_files() -> None:
+    raw = _post_event(
+        {
+            "content": [
+                [
+                    {"tag": "text", "text": "见文档 "},
+                    {"tag": "a", "text": "设计稿", "href": "https://x.test/d"},
+                ],
+                [{"tag": "media", "file_key": "file_v3_1", "file_name": "spec.pdf"}],
+            ]
+        }
+    )
+    ev = FeishuConnector(bot_open_id="ou_bot").parse_inbound(raw)
+    assert ev is not None
+    assert "[设计稿](https://x.test/d)" in ev.text
+    assert len(ev.attachments) == 1
+    assert ev.attachments[0].handle == "file_v3_1"
+    assert ev.attachments[0].filename == "spec.pdf"
+
+
+def test_post_image_only_no_text_still_parsed() -> None:
+    raw = _post_event({"content": [[{"tag": "img", "image_key": "img_only"}]]})
+    ev = FeishuConnector(bot_open_id="ou_bot").parse_inbound(raw)
+    assert ev is not None
+    assert ev.text == ""
+    assert len(ev.attachments) == 1
+
+
+def test_post_group_drops_bot_mention_and_passes_gate() -> None:
+    # A group post that @-mentions the bot passes the group gate, and the bot's
+    # own @ is stripped from the reconstructed text.
+    raw = _post_event(
+        {
+            "content": [
+                [
+                    {"tag": "at", "user_id": "@_user_1"},
+                    {"tag": "text", "text": " 看下这个"},
+                    {"tag": "img", "image_key": "img_grp"},
+                ]
+            ]
+        },
+        chat_type="group",
+        mentions=[{"key": "@_user_1", "id": {"open_id": "ou_bot"}, "name": "Bot"}],
+    )
+    ev = FeishuConnector(bot_open_id="ou_bot").parse_inbound(raw)
+    assert ev is not None
+    assert "@Bot" not in ev.text and "看下这个" in ev.text
+    assert len(ev.attachments) == 1
+
+
+def test_post_language_wrapped_payload_unwrapped() -> None:
+    raw = _post_event(
+        {"zh_cn": {"title": "T", "content": [[{"tag": "text", "text": "wrapped body"}]]}}
+    )
+    ev = FeishuConnector(bot_open_id="ou_bot").parse_inbound(raw)
+    assert ev is not None
+    assert "wrapped body" in ev.text


### PR DESCRIPTION
## What

Feishu's rich-text "post" message — the big input box that mixes **text + images + files in one bubble** — was dropped entirely (`message_type: "post"` wasn't recognized, so even the text was lost). This parses it into `text` + `attachments[]`.

Follow-up to the merged IM file-transfer feature (#288). Reported by a user who noticed rich-text messages weren't handled.

## How

`parse_inbound` now dispatches `message_type == "post"` to `_parse_feishu_post`, which walks the nested post body (a list of paragraphs, each a list of tagged elements):

- `text` / `a` (→ markdown link) / `at` (→ `@name`, bot mention dropped, `@_all` → `@all`) reconstruct the **text**;
- `img` → image attachment ref, `media`/`file`/`audio`/`video` → file attachment ref — resolved to bytes later by the worker via the **same `download_for` path** as flat media messages (`image_key`→type=image, `file_key`→type=file).

The whole downstream is **unchanged** — `InboundEvent` already carries `text` + `attachments[]`, and the worker resolves multiple attachments + text into one `start_run`. So a mixed text+image post now reaches the agent intact.

Supporting bits:
- factored the `@_user_N` mention substitution out of the text branch so text and post share it (`_substitute_mentions`); mentions indexed by both placeholder key and open_id;
- `_resolve_post_payload` unwraps a language-keyed payload, preferring `zh_cn` → … over dict-iteration order;
- `size_hint` is set on post file/media elements too, so the oversize pre-download guard applies inside posts.

## Testing

`tests/unit/test_feishu_parse_inbound.py` — mixed text+image, links/files, image-only, group bot-mention gating (both pass and the inverse drop), `@_all`, language-wrapped payload. `make check-ci` green (2177 passed); mypy strict clean (458 files).

## Reference

hermes has equivalent post support (`parse_feishu_post_payload` / `_render_post_element`); openclaw has no Feishu support at all. Reviewed via one multi-agent pass — no correctness/buildability blockers; the cleanup items it surfaced (size_hint parity, locale preference, `@_all`) are folded in.