### PR TITLE
fix(chat): show group-chat sender badge live, not just after refresh

### DIFF
--- a/backend/cubebox/agents/schemas.py
+++ b/backend/cubebox/agents/schemas.py
@@ -169,7 +169,12 @@ class InjectedMessageEvent(AgentEvent):
     """
 
     type: Literal["injected_message"] = "injected_message"
-    data: dict[str, Any] = Field(description="Event data with content and steer_id")
+    data: dict[str, Any] = Field(
+        description=(
+            "Event data with content and steer_id, plus sender_user_id and "
+            "sender_display_name when the injected message came from a group chat"
+        )
+    )
 
 
 class SandboxConfirmRequestEvent(AgentEvent):

--- a/backend/cubebox/agents/stream.py
+++ b/backend/cubebox/agents/stream.py
@@ -519,10 +519,21 @@ def _convert_terminal_agent_event(evt: AgentEvent) -> list[dict[str, Any]]:
             ]
 
     if isinstance(evt, MessageEndEvent) and isinstance(evt.message, UserMessage):
-        steer_id = evt.message.metadata.get("steer_id")
+        meta = evt.message.metadata
+        steer_id = meta.get("steer_id")
         if steer_id:
             text = "".join(c.text for c in evt.message.content if isinstance(c, TextContent))
-            return [{"type": "injected_message", "content": text, "steer_id": steer_id}]
+            injected: dict[str, Any] = {
+                "type": "injected_message",
+                "content": text,
+                "steer_id": steer_id,
+            }
+            # Group-chat sender identity so live viewers render the SenderBadge
+            # without waiting for a refresh (history reads these from metadata).
+            if meta.get("sender_user_id") and meta.get("sender_display_name"):
+                injected["sender_user_id"] = meta["sender_user_id"]
+                injected["sender_display_name"] = meta["sender_display_name"]
+            return [injected]
 
     if isinstance(evt, HitlRequestEvent):
         req = evt.request

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -121,8 +121,10 @@ async def _resolve_topic_run_context(
             async with async_session_maker() as topic_session:
                 sandbox_mode, topic_creator_user_id = await _read(topic_session)
 
-    if is_group_chat:
-        sender_display_name = ctx.user.display_name or ctx.user.email
+    # Stamp the sender on every message (1:1 included) so a later 1:1→group
+    # conversion can attribute past messages. Display is gated on is_group_chat
+    # in the frontend, not on the presence of this field.
+    sender_display_name = ctx.user.display_name or ctx.user.email
 
     return (
         topic_id,
@@ -2006,7 +2008,7 @@ async def steer_active_run(
         return {"status": "no_active_run", "run_id": None}
 
     steer_metadata: dict[str, Any] = {}
-    if _is_group_chat and _sender_display_name:
+    if _sender_display_name:
         steer_metadata["sender_user_id"] = ctx.user.id
         steer_metadata["sender_display_name"] = _sender_display_name
 

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -338,10 +338,14 @@ def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent 
 
     t = d.get("type")
     if t == "injected_message":
-        return InjectedMessageEvent(
-            timestamp=timestamp,
-            data={"content": d.get("content", ""), "steer_id": d.get("steer_id", "")},
-        )
+        injected_data: dict[str, Any] = {
+            "content": d.get("content", ""),
+            "steer_id": d.get("steer_id", ""),
+        }
+        if d.get("sender_user_id") and d.get("sender_display_name"):
+            injected_data["sender_user_id"] = d["sender_user_id"]
+            injected_data["sender_display_name"] = d["sender_display_name"]
+        return InjectedMessageEvent(timestamp=timestamp, data=injected_data)
     if t == "text_delta":
         return TextDeltaEvent(
             timestamp=timestamp,

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1685,7 +1685,9 @@ class RunManager:
                 except Exception as _att_exc:
                     logger.warning("Failed to build attachment blocks for cubepi run: {}", _att_exc)
 
-            if ctx.is_group_chat and ctx.sender_display_name:
+            # Stamp on every message (1:1 included) so a later 1:1→group
+            # conversion attributes past messages; UI gates display on group.
+            if ctx.sender_display_name:
                 _user_msg_metadata["sender_user_id"] = ctx.user_id
                 _user_msg_metadata["sender_display_name"] = ctx.sender_display_name
 

--- a/backend/tests/e2e/test_group_chat.py
+++ b/backend/tests/e2e/test_group_chat.py
@@ -222,8 +222,10 @@ class TestGroupChatRunContextResolution:
         self, four_layer_admin_and_member: FourLayerFixture
     ) -> None:
         """Personal (non-topic) conversations: resolver returns no group-chat
-        signal — guaranteeing the memory-snapshot branch fires and sender
-        attribution is NOT applied.
+        signal (so the memory-snapshot branch fires) but still resolves a
+        sender_display_name. Sender identity is now stamped on every message
+        (1:1 included) so a later 1:1->group conversion can attribute past
+        messages; the frontend gates the badge on is_group_chat.
         """
         from cubebox.api.routes.v1.conversations import _resolve_topic_run_context
         from cubebox.auth.context import RequestContext
@@ -266,7 +268,9 @@ class TestGroupChatRunContextResolution:
 
         assert topic_id is None
         assert is_group_chat is False
-        assert sender_display_name is None
+        # Stamped on 1:1 too now (drives post-conversion attribution); the
+        # resolver falls back to email when display_name is unset.
+        assert sender_display_name is not None
         assert sandbox_mode is None
         assert topic_creator_user_id is None
 

--- a/backend/tests/unit/test_run_manager_translate.py
+++ b/backend/tests/unit/test_run_manager_translate.py
@@ -9,3 +9,23 @@ def test_injected_message_dict_becomes_typed_event():
     )
     assert isinstance(evt, InjectedMessageEvent)
     assert evt.data == {"content": "do X", "steer_id": "s1"}
+
+
+def test_injected_message_dict_forwards_group_chat_sender():
+    evt = cubepi_dict_to_agent_event(
+        {
+            "type": "injected_message",
+            "content": "do X",
+            "steer_id": "s1",
+            "sender_user_id": "user_abc",
+            "sender_display_name": "Alice",
+        },
+        "2026-05-25T00:00:00+00:00",
+    )
+    assert isinstance(evt, InjectedMessageEvent)
+    assert evt.data == {
+        "content": "do X",
+        "steer_id": "s1",
+        "sender_user_id": "user_abc",
+        "sender_display_name": "Alice",
+    }

--- a/backend/tests/unit/test_stream.py
+++ b/backend/tests/unit/test_stream.py
@@ -340,6 +340,36 @@ def test_injected_user_message_without_steer_id_is_dropped() -> None:
     assert convert_agent_event_to_sse(MessageEndEvent(message=msg)) == []
 
 
+def test_injected_group_chat_message_carries_sender_identity() -> None:
+    # Group-chat steers persist sender_user_id/sender_display_name in metadata;
+    # the SSE event must forward them so live viewers render the SenderBadge.
+    msg = UserMessage(
+        content=[TextContent(text="hi team")],
+        metadata={
+            "steer_id": "s1",
+            "sender_user_id": "user_abc",
+            "sender_display_name": "Alice",
+        },
+    )
+    out = convert_agent_event_to_sse(MessageEndEvent(message=msg))
+    assert out == [
+        {
+            "type": "injected_message",
+            "content": "hi team",
+            "steer_id": "s1",
+            "sender_user_id": "user_abc",
+            "sender_display_name": "Alice",
+        }
+    ]
+
+
+def test_injected_message_omits_sender_identity_when_absent() -> None:
+    # 1:1 chats persist no sender fields; the event stays minimal.
+    msg = UserMessage(content=[TextContent(text="solo steer")], metadata={"steer_id": "s2"})
+    out = convert_agent_event_to_sse(MessageEndEvent(message=msg))
+    assert out == [{"type": "injected_message", "content": "solo steer", "steer_id": "s2"}]
+
+
 # ---------------------------------------------------------------------------
 # convert_agent_event_to_sse — HitlRequestEvent → sandbox_confirm_request
 

--- a/docs/site/docs/guides/conversations/topics.md
+++ b/docs/site/docs/guides/conversations/topics.md
@@ -91,6 +91,8 @@ In "reuse the creator's sandbox" mode, other members' actions execute inside you
 
 A topic starts with one conversation, but any participant can open more — for example, one conversation per sub-task. All of them are visible to every participant and appear nested under the topic in the sidebar. There is no separate "topic page"; you work inside the topic's conversations just like any other chat.
 
+**Who sent each message.** In a shared topic, every message is tagged with the participant who sent it, so you can tell contributors apart at a glance, and the agent is told who is speaking so it can keep track. In a plain 1:1 chat this tag is hidden — there's only you. When you **upgrade** a 1:1 conversation into a topic, messages you send from then on carry your name, so the new participants can see who said what.
+
 ## Ordering, pinning, and archiving
 
 - **Ordering.** Topics and standalone conversations share one sidebar list, ordered by most recent activity. A topic floats up whenever any conversation inside it gets a new message.

--- a/frontend/packages/core/__tests__/stores/messageStoreCommitSteer.test.ts
+++ b/frontend/packages/core/__tests__/stores/messageStoreCommitSteer.test.ts
@@ -62,6 +62,25 @@ describe('commit on injected_message', () => {
     expect(roles).toEqual(['user', 'user'])
   })
 
+  it('stamps group-chat sender identity onto the injected user message', () => {
+    useMessageStore.getState().__commitTurnAndInject('c1', {
+      content: 'do X',
+      steer_id: 's1',
+      sender_user_id: 'user_abc',
+      sender_display_name: 'Alice',
+    })
+    const injected = useMessageStore.getState().messages.c1.at(-1)
+    expect(injected?.metadata?.sender_user_id).toBe('user_abc')
+    expect(injected?.metadata?.sender_display_name).toBe('Alice')
+  })
+
+  it('omits sender identity for non-group steers', () => {
+    applyInjected('c1', 'do X', 's1')
+    const injected = useMessageStore.getState().messages.c1.at(-1)
+    expect(injected?.metadata?.sender_user_id).toBeUndefined()
+    expect(injected?.metadata?.sender_display_name).toBeUndefined()
+  })
+
   it('is idempotent — re-applying the same steer_id is a no-op', () => {
     applyInjected('c1', 'do X', 's1')
     const before = useMessageStore.getState().messages.c1.length

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -36,10 +36,20 @@ import {
   streamMessages,
   streamRun,
 } from '../api'
+import { useAuthStore } from './authStore'
 import { useCitationStore } from './citationStore'
 import { useConversationStore } from './conversationStore'
 
 const YIELD_EVERY = 200
+
+// Payload carried by the `injected_message` SSE event. `sender_*` are present
+// only for group-chat messages and drive the live SenderBadge.
+type InjectedMessageData = {
+  content: string
+  steer_id: string
+  sender_user_id?: string
+  sender_display_name?: string
+}
 
 function yieldToEventLoop(): Promise<void> {
   const sched = (globalThis as { scheduler?: { yield?: () => Promise<void> } }).scheduler
@@ -157,7 +167,7 @@ export interface MessageStore {
   cancelStream(client: ApiClient, conversationId: string): Promise<void>
   steer(client: ApiClient, conversationId: string, content: string): Promise<void>
   cancelSteer(client: ApiClient, conversationId: string, steerId: string): Promise<void>
-  __commitTurnAndInject(conversationId: string, data: { content: string; steer_id: string }): void
+  __commitTurnAndInject(conversationId: string, data: InjectedMessageData): void
   clearStream(): void
   clearLastRunStatus(): void
   /** Test hook: apply a single AgentEvent synchronously */
@@ -1056,7 +1066,7 @@ async function consumeRunStream(
         }
         break
       } else if (event.type === 'injected_message') {
-        const d = event.data as { content: string; steer_id: string }
+        const d = event.data as InjectedMessageData
         // Flush batched stream mutations so the commit reads fully-applied
         // streamAgents, not a stale snapshot.
         flush()
@@ -1470,12 +1480,25 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       void useConversationStore.getState().generateTitle(client, conversationId, content)
     }
 
+    // In a group chat, stamp the local sender's identity onto the optimistic
+    // bubble so their own SenderBadge shows immediately (history returns these
+    // fields on refresh; without them the badge would only appear after reload).
+    const isGroupChat =
+      useConversationStore.getState().conversations.find((c) => c.id === conversationId)
+        ?.is_group_chat ?? false
+    const me = isGroupChat ? useAuthStore.getState().user : null
+    const senderMeta =
+      me != null ? { sender_user_id: me.id, sender_display_name: me.display_name ?? me.email } : {}
+
     const userMessage: UserMessageType = {
       id: nextMessageId('user-temp'),
       role: 'user',
       content: [{ type: 'text', text: content }],
       timestamp: Date.now() / 1000,
-      metadata: attachments && attachments.length > 0 ? { attachments } : {},
+      metadata: {
+        ...(attachments && attachments.length > 0 ? { attachments } : {}),
+        ...senderMeta,
+      },
     }
 
     set((state) => ({
@@ -1628,7 +1651,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
             }
             break outer
           } else if (event.type === 'injected_message') {
-            const d = event.data as { content: string; steer_id: string }
+            const d = event.data as InjectedMessageData
             // Flush batched stream mutations so the commit reads fully-applied
             // streamAgents, not a stale snapshot.
             flush()
@@ -1763,7 +1786,17 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       role: 'user',
       content: [{ type: 'text', text: data.content }],
       timestamp: Date.now() / 1000,
-      metadata: { steer_id: data.steer_id },
+      metadata: {
+        steer_id: data.steer_id,
+        // Group-chat sender identity (present only for group chats) so the
+        // SenderBadge renders live, matching what history returns on refresh.
+        ...(data.sender_user_id && data.sender_display_name
+          ? {
+              sender_user_id: data.sender_user_id,
+              sender_display_name: data.sender_display_name,
+            }
+          : {}),
+      },
     }
 
     set((s) => ({

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -1480,13 +1480,10 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
       void useConversationStore.getState().generateTitle(client, conversationId, content)
     }
 
-    // In a group chat, stamp the local sender's identity onto the optimistic
-    // bubble so their own SenderBadge shows immediately (history returns these
-    // fields on refresh; without them the badge would only appear after reload).
-    const isGroupChat =
-      useConversationStore.getState().conversations.find((c) => c.id === conversationId)
-        ?.is_group_chat ?? false
-    const me = isGroupChat ? useAuthStore.getState().user : null
+    // Stamp the local sender's identity onto every optimistic bubble (1:1
+    // included) so a later 1:1→group conversion can attribute the message and
+    // the badge shows live in group chats. The UI gates display on is_group_chat.
+    const me = useAuthStore.getState().user
     const senderMeta =
       me != null ? { sender_user_id: me.id, sender_display_name: me.display_name ?? me.email } : {}
 

--- a/frontend/packages/core/src/types/message.ts
+++ b/frontend/packages/core/src/types/message.ts
@@ -81,8 +81,9 @@ interface MessageBase {
     // Never rendered as a user bubble; synthetic_source is trace-only.
     synthetic?: boolean
     synthetic_source?: string
-    // Set on user messages sent into a group-chat conversation (is_group_chat=True).
-    // Frontend uses presence of `sender_display_name` to render the SenderBadge.
+    // Stamped on every user message (1:1 included) so a 1:1→group conversion
+    // can attribute past messages. The SenderBadge is gated on the conversation
+    // being a group chat (is_group_chat), not on the mere presence of these.
     sender_user_id?: string
     sender_display_name?: string
   }

--- a/frontend/packages/web/components/chat/MessageList.tsx
+++ b/frontend/packages/web/components/chat/MessageList.tsx
@@ -579,12 +579,17 @@ export function MessageList({ conversationId }: MessageListProps) {
           <div key={msg.id} id={msg.seq != null ? `msg-${msg.seq}` : undefined}>
             {msg.role === 'user' && msg.metadata?.synthetic !== true && (
               <>
-                {msg.metadata?.sender_display_name && msg.metadata?.sender_user_id && (
-                  <SenderBadge
-                    userId={msg.metadata.sender_user_id}
-                    displayName={msg.metadata.sender_display_name}
-                  />
-                )}
+                {/* Sender identity is stamped on every user message (incl. 1:1)
+                    so a 1:1→group conversion attributes past messages, but the
+                    badge only shows in group chats. */}
+                {isGroupChat &&
+                  msg.metadata?.sender_display_name &&
+                  msg.metadata?.sender_user_id && (
+                    <SenderBadge
+                      userId={msg.metadata.sender_user_id}
+                      displayName={msg.metadata.sender_display_name}
+                    />
+                  )}
                 {msg.metadata?.attachments && msg.metadata.attachments.length > 0 && (
                   <MessageAttachments
                     attachments={msg.metadata.attachments}


### PR DESCRIPTION
## Problem

Two related issues with group-chat sender identity:

1. **Badge only after refresh.** In a group chat, the sender's name + initial-tile avatar (`SenderBadge`) only appeared after a page reload, not during the live conversation.
2. **1:1→group conversion loses authorship.** Messages sent while a conversation was a 1:1 carried no sender identity, so after upgrading it to a topic/group you couldn't tell who sent the earlier messages.

## Root cause

Sender identity (`sender_user_id` / `sender_display_name`) was persisted into message metadata **only for group chats**, and the live SSE path dropped it at three points (event build in `stream.py`, dict→event conversion in `run_manager.py`, and the client SSE handler / optimistic `send()`).

## Fix

**Live display (issue 1)**
- Forward sender fields through the `injected_message` SSE event + its conversion.
- Populate them client-side (`__commitTurnAndInject`) and on the local optimistic `send()` bubble.

**Always-store + group-gated display (issue 2)**
- Stamp `sender_user_id` / `sender_display_name` on **every** user message (1:1 included) — removed the `is_group_chat` write gates in the send path, the steer endpoint, and the run-context resolver.
- Display moves from "metadata present" → **`is_group_chat`**: the `SenderBadge` renders only in group chats, so a 1:1 stays clean even though the data is now stored. After a 1:1→group upgrade, messages sent post-upgrade are attributed.

### Trade-off (intentional)

cubepi's `apply_sender_attribution` (provider boundary, all of anthropic/openai/openai_responses) prefixes `"[name]: "` into the prompt **whenever `metadata.sender_display_name` is present** — it is gated on the field, not on `is_group_chat`. Storing the field in 1:1 therefore means the model now sees the sender prefix in 1:1 too. Accepted in exchange for simpler code and no frontend participant lookup. (The prompt cache is unaffected: each row is immutable and replayed byte-identically.)

## Tests

- Backend unit (`test_stream.py`, `test_run_manager_translate.py`): injected event forwards sender fields when present, stays minimal when absent.
- Backend e2e (`test_group_chat.py`): resolver now returns a `sender_display_name` for 1:1; group resolver + cubepi attribution smoke tests still green.
- Frontend unit (`messageStoreCommitSteer.test.ts`): injected message stamps / omits sender identity per the event payload.

## Docs

`docs/site/docs/guides/conversations/topics.md` — documents per-message sender attribution in shared topics and after a 1:1→group upgrade.

## Verification

- `mypy` (changed files): clean
- backend unit: 35 passed; e2e resolver+attribution: 4 passed
- frontend `@cubebox/core` + `web` type-check: clean; core lint + web MessageList lint: clean; store tests: 66 passed