### PR TITLE
fix(im): stamp sender identity on IM-originated messages

### DIFF
--- a/backend/cubebox/im/worker.py
+++ b/backend/cubebox/im/worker.py
@@ -104,6 +104,15 @@ async def process_one_queue_item(
             ).scalar_one_or_none()
             if link is not None:
                 effective_user_id = link.user_id
+        # Resolve the sender's display name from the run's effective user so the
+        # group-chat SenderBadge + cubepi sender attribution fire for IM
+        # messages, mirroring the in-app send path (display_name or email).
+        from cubebox.models.user import User
+
+        sender_user = await session.get(User, effective_user_id)
+        sender_display_name: str | None = (
+            (sender_user.display_name or sender_user.email) if sender_user is not None else None
+        )
         # Refuse to dispatch IM messages against topic or standalone group
         # chat conversations — the group-chat / topic-aware path is not
         # implemented for IM in v1, so silently running with
@@ -156,6 +165,7 @@ async def process_one_queue_item(
             "org_id": account.org_id,
             "workspace_id": account.workspace_id,
             "acting_user_id": effective_user_id,
+            "sender_display_name": sender_display_name,
             "topic_id": (conv_row.topic_id if conv_row is not None else None),
             "is_group_chat": (conv_row.is_group_chat if conv_row is not None else False),
             "sandbox_mode": sandbox_mode,
@@ -204,6 +214,7 @@ async def process_one_queue_item(
                 is_group_chat=captured["is_group_chat"],
                 sandbox_mode=captured["sandbox_mode"],
                 topic_creator_user_id=(captured["topic_creator_user_id"]),
+                sender_display_name=captured["sender_display_name"],
             ),
             cancel_pending_hitl=True,
         )

--- a/backend/tests/e2e/test_im_worker.py
+++ b/backend/tests/e2e/test_im_worker.py
@@ -105,6 +105,7 @@ class _FakeRunManager:
                 "org_id": ctx.org_id,
                 "workspace_id": ctx.workspace_id,
                 "trigger": ctx.trigger,
+                "sender_display_name": ctx.sender_display_name,
                 "cancel_pending_hitl": cancel_pending_hitl,
             }
         )
@@ -150,6 +151,10 @@ async def test_worker_processes_one_item_and_completes_receipt(
     assert rm.calls[0]["org_id"] == account.org_id
     assert rm.calls[0]["workspace_id"] == account.workspace_id
     assert rm.calls[0]["trigger"] == "im"
+    # Sender identity is derived from the effective user (here the acting user,
+    # seeded with no display_name → falls back to email) so cubepi attribution
+    # and the group-chat SenderBadge fire for IM messages.
+    assert rm.calls[0]["sender_display_name"] == f"{account.acting_user_id}@example.com"
 
     assert captured_runs and captured_runs[0][0] == "run-fake-1"
 


### PR DESCRIPTION
## Problem

Messages sent via IM (Feishu/Lark, Slack, etc.) into a group chat did **not** carry sender identity (`sender_user_id` / `sender_display_name`) on the resulting cubepi user message — so no `SenderBadge` and no `"[name]: "` prompt attribution, unlike in-app messages. (Follow-up to #293, which fixed the in-app paths.)

## Root cause

The IM queue worker (`im/worker.py`) builds its own `RunContext` by hand and **never set `sender_display_name`**. `run_manager`'s stamping is gated on `if ctx.sender_display_name:` (run_manager.py:1690), so for IM-origin messages the gate never fired and the metadata was never attached. cubepi's `apply_sender_attribution` then found no name and skipped the prefix.

The IM path does *not* go through `_resolve_topic_run_context` (the in-app helper that resolves `sender_display_name`), so it bypassed the only place that populated the field.

## Fix

In the worker, after resolving the run's `effective_user_id` (the linked workspace member, or the account's acting user in shared mode), load that `User` and derive `sender_display_name = user.display_name or user.email` — mirroring the in-app path — then pass it into `RunContext`. `run_manager` stamps it exactly as it already does for in-app sends; no change needed there.

- **Identity-gated mode:** each IM sender resolves to their real workspace user, so group messages now attribute to the right person.
- **Shared mode:** all senders share the account's acting user, so the badge/attribution reflect that single identity — consistent with how that mode already models the run's identity (memory, billing, permissions all run as the acting user).

`sender_user_id` is set by `run_manager` from `ctx.user_id` (= `effective_user_id`), so it matches the identity the run actually executes as.

## Tests

`tests/e2e/test_im_worker.py`: the happy-path test now asserts the worker passes `sender_display_name` derived from the effective user (here the acting user, seeded without a display_name → falls back to email). `_FakeRunManager` captures `ctx.sender_display_name`.

## Docs

No doc change: this brings IM in line with already-documented behavior — `topics.md` already states "in a shared topic, every message is tagged with the participant who sent it," and IM-bound group chats are shared topics. This was a bug preventing that documented behavior.

## Verification

- `mypy cubebox/im/worker.py`: clean
- `pytest tests/e2e/test_im_worker.py`: 3 passed (incl. the new assertion)
- broader IM e2e: `test_im_shared_mode_ingest`, `test_im_runtime_aggregates` green; the 2 failures in `test_im_inbound_attachments` are a pre-existing rustfs/S3 `PutObject 400` in this worktree (confirmed failing on baseline via `git stash`), unrelated to this change.
- pre-push `check-ci` (backend ruff+mypy+unit, frontend build/lint/type-check/vitest/next build): Passed