### PR TITLE
fix(sandbox): migration hotfix — dedup duplicate scope rows before unique index create

### DIFF
--- a/backend/alembic/versions/ef2d2e6c9c7d_fix_sandbox_entity_dedup_rebuild_index.py
+++ b/backend/alembic/versions/ef2d2e6c9c7d_fix_sandbox_entity_dedup_rebuild_index.py
@@ -1,0 +1,81 @@
+"""fix sandbox entity dedup + rebuild index
+
+Revision ID: ef2d2e6c9c7d
+Revises: 66c3b3dfdec3
+Create Date: 2026-06-28 12:54:48.588289
+
+The previous migration (66c3b3dfdec3) created the `deleted_at` column and
+tried to replace the unique index from `WHERE status IN ('provisioning',
+'running')` to `WHERE deleted_at IS NULL`. The data cleanup only handled
+`terminated` rows and dedicated-topic/conversation rows. But the old index
+did not cover paused/pausing/resuming/failed/kill_pending — so duplicate
+scope keys could exist in those statuses. This migration deduplicates ALL
+remaining duplicates (keeping the newest row per scope key) and then creates
+the index that the previous migration could not.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401
+
+
+revision: str = 'ef2d2e6c9c7d'
+down_revision: Union[str, Sequence[str], None] = '66c3b3dfdec3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Deduplicate: for each scope key with multiple live rows, keep the
+    # newest one (by last_activity_at DESC, fallback created_at DESC),
+    # soft-delete the rest. The old partial unique index only covered
+    # (provisioning, running), so rows in other statuses (paused, failed,
+    # kill_pending, pausing, resuming) could duplicate a running row.
+    conn.execute(
+        sa.text(
+            """
+            WITH ranked AS (
+                SELECT id,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY org_id, workspace_id, scope_type, scope_id
+                           ORDER BY COALESCE(last_activity_at, created_at) DESC
+                       ) AS rn
+                FROM user_sandboxes
+                WHERE deleted_at IS NULL
+            )
+            UPDATE user_sandboxes
+            SET deleted_at  = now(),
+                status      = CASE
+                    WHEN status IN ('provisioning','running','pausing','paused',
+                                     'resuming','kill_pending')
+                    THEN 'terminated'
+                    ELSE status
+                END,
+                sandbox_id  = CASE WHEN rn > 1 THEN NULL ELSE sandbox_id END
+            FROM ranked
+            WHERE user_sandboxes.id = ranked.id AND ranked.rn > 1
+            """
+        )
+    )
+
+    # Now that duplicates are resolved, create the index the previous
+    # migration could not. Idempotent: IF NOT EXISTS so this is safe on
+    # databases where the original migration's create_index DID succeed.
+    conn.execute(
+        sa.text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_user_sandbox_active_scope "
+            "ON user_sandboxes (org_id, workspace_id, scope_type, scope_id) "
+            "WHERE deleted_at IS NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("DROP INDEX IF EXISTS uq_user_sandbox_active_scope")
+    )


### PR DESCRIPTION
## Summary

Hotfix for the `66c3b3dfdec3` migration (from PR #297) that fails on production databases with duplicate scope keys.

### Root cause

The old unique index `uq_user_sandbox_active_scope` was partial `WHERE status IN ('provisioning','running')`. Rows with other statuses (`paused`, `pausing`, `resuming`, `failed`, `kill_pending`) were NOT covered by this constraint — so a single scope key could have both a `running` row AND a `paused`/`failed` row simultaneously.

The migration's data cleanup only handled `terminated` rows and dedicated topic/conversation rows. When the new index `WHERE deleted_at IS NULL` tried to create, these non-terminated duplicates violated the unique constraint.

### Fix

New migration `ef2d2e6c9c7d` (revises `66c3b3dfdec3`):

1. **Data dedup**: `ROW_NUMBER() OVER (PARTITION BY org_id, workspace_id, scope_type, scope_id ORDER BY last_activity_at DESC)` — keeps the newest row per scope key, soft-deletes all duplicates (sets `deleted_at = now()`, `status = 'terminated'`, `sandbox_id = NULL`)
2. **Index rebuild**: `CREATE UNIQUE INDEX IF NOT EXISTS uq_user_sandbox_active_scope ... WHERE deleted_at IS NULL` — idempotent, safe on databases where the original migration succeeded

### Alembic chain

```
74a3486fa05d → 66c3b3dfdec3 → ef2d2e6c9c7d (head)
  (Spec 1)     (entity schema)   (hotfix — dedup + rebuild)
```

Tested on worktree DB (index already exists) — idempotent, upgrade succeeds.