### PR TITLE
feat(artifact): multi-image artifact preview + library cover

### DIFF
--- a/backend/cubebox/api/routes/v1/artifacts.py
+++ b/backend/cubebox/api/routes/v1/artifacts.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response
 from loguru import logger
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubebox.auth.context import RequestContext
@@ -26,6 +27,8 @@ from cubebox.repositories import (
     ConversationRepository,
 )
 from cubebox.utils.http import content_disposition
+
+IMAGE_EXTENSIONS = frozenset({"png", "jpg", "jpeg", "gif", "webp", "svg", "bmp"})
 
 router = APIRouter(
     prefix="/ws/{workspace_id}/conversations/{conversation_id}/artifacts",
@@ -184,6 +187,58 @@ async def download_artifact(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to download artifact",
         ) from None
+
+
+class ArtifactFilesOut(BaseModel):
+    version: int
+    files: list[str]
+
+
+@router.get("/{artifact_id}/files", response_model=ArtifactFilesOut)
+async def list_artifact_files(
+    conversation_id: str,
+    artifact_id: str,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    ctx: Annotated[RequestContext, Depends(require_member)],
+    version: int | None = Query(default=None),
+    filter: str | None = Query(default=None),
+) -> ArtifactFilesOut:
+    """List the files stored for an artifact version.
+
+    ``filter=image`` restricts to image extensions (sorted ascending by
+    filename); without ``filter`` all files are returned sorted. Used by the
+    preview panel to render a multi-image directory as a carousel.
+    """
+    await _require_conversation(session, ctx, conversation_id)
+    repo = ArtifactRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
+    artifact = await repo.get_by_id(artifact_id)
+    if not artifact or artifact.conversation_id != conversation_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Artifact {artifact_id} not found",
+        )
+
+    target_version = version or artifact.version
+    prefix = f"artifacts/{conversation_id}/{artifact_id}/v{target_version}/"
+
+    try:
+        store = get_objectstore_client()
+        keys = await store.list_objects(prefix)
+    except Exception as e:
+        logger.error("Error listing artifact files: {}", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list artifact files",
+        ) from None
+
+    rel_files = [k[len(prefix) :] for k in keys]
+    if filter == "image":
+        rel_files = [
+            f for f in rel_files if "." in f and f.rsplit(".", 1)[-1].lower() in IMAGE_EXTENSIONS
+        ]
+    rel_files.sort()
+
+    return ArtifactFilesOut(version=target_version, files=rel_files)
 
 
 OFFICE_EXTENSIONS = frozenset({".docx", ".xlsx", ".pptx"})

--- a/backend/cubebox/api/routes/v1/ws_sandbox.py
+++ b/backend/cubebox/api/routes/v1/ws_sandbox.py
@@ -37,6 +37,7 @@ from cubebox.repositories.user_sandbox import UserSandboxRepository
 from cubebox.sandbox import SandboxError
 from cubebox.sandbox.manager import get_sandbox_manager
 from cubebox.sandbox.opensandbox import OpenSandbox
+from cubebox.utils.http import content_disposition
 from cubebox.utils.time import utc_isoformat
 
 router = APIRouter(prefix="/ws/{workspace_id}/sandbox", tags=["ws-sandbox"])
@@ -380,9 +381,7 @@ async def download_sandbox_file(
     return StreamingResponse(
         stream,
         media_type=mime or "application/octet-stream",
-        headers={
-            "Content-Disposition": f'attachment; filename="{filename}"',
-        },
+        headers={"Content-Disposition": content_disposition(filename)},
     )
 
 

--- a/backend/cubebox/prompts/artifacts.py
+++ b/backend/cubebox/prompts/artifacts.py
@@ -12,7 +12,10 @@ register it using the `save_artifact` tool so the user can preview and download 
 **artifact_type guide:**
 - "website" — HTML/CSS/JS sites or apps (set entry_file to the main HTML file)
 - "document" — Markdown, text, or generated documents (PDF, DOCX, etc.)
-- "image" — PNG, SVG, JPG images (e.g. matplotlib output)
+- "image" — PNG, SVG, JPG images (e.g. matplotlib output). Point `path` at a single \
+image file. If you produce multiple images as one deliverable, save them in a directory, \
+number the filenames (`1_*.png`, `2_*.png`, …) so they preview in order, and leave \
+`entry_file` unset — the preview renders them as a navigable gallery.
 - "code" — Source code files or projects
 - "data" — CSV, JSON, Excel data files
 - "skill" — A skill bundle directory with SKILL.md at its root. Use this when the \

--- a/backend/tests/e2e/test_artifact_files.py
+++ b/backend/tests/e2e/test_artifact_files.py
@@ -67,12 +67,23 @@ async def _seed(client: TestClient) -> AsyncIterator[None]:
             ("script.py", b"print(1)"),
         ):
             await store.upload_file(f"{_PREFIX}{name}", data)
+        # v2 files — separate version prefix to test ?version=N param.
+        for name, data in (
+            ("1_v2.png", b"\x89PNG\r\n\x1a\n-v2-first"),
+            ("2_v2.png", b"\x89PNG\r\n\x1a\n-v2-second"),
+        ):
+            await store.upload_file(f"artifacts/{_CONV}/{_ART}/v2/{name}", data)
         yield
     finally:
         store = get_objectstore_client()
         for name in ("2_second.png", "1_first.png", "3_third.png", "script.py"):
             try:
                 await store.delete_file(f"{_PREFIX}{name}")
+            except Exception:
+                pass
+        for name in ("1_v2.png", "2_v2.png"):
+            try:
+                await store.delete_file(f"artifacts/{_CONV}/{_ART}/v2/{name}")
             except Exception:
                 pass
         async with maker() as s:
@@ -116,3 +127,87 @@ def test_files_cross_workspace_404(_seed: None, client: TestClient) -> None:
         params={"filter": "image"},
     )
     assert res.status_code == 404
+
+
+_CONV2 = "conv-nonimg"
+_ART2 = "art-nonimg"
+_PREFIX2 = f"artifacts/{_CONV2}/{_ART2}/v1/"
+
+
+@pytest_asyncio.fixture
+async def _seed_non_image(client: TestClient) -> AsyncIterator[None]:
+    me = client.get("/api/v1/auth/me")
+    assert me.status_code == 200, me.text
+    my_user_id = me.json()["id"]
+
+    engine = create_async_engine(_build_database_url(), poolclass=NullPool)
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with maker() as s:
+            await s.execute(
+                text(
+                    "INSERT INTO conversations (id, org_id, workspace_id,"
+                    " creator_user_id, title, has_messages, is_group_chat,"
+                    " created_at, updated_at)"
+                    " VALUES (:id, :org, :ws, :uid, 'notes-only', true, false, NOW(), NOW())"
+                    " ON CONFLICT (id) DO NOTHING"
+                ),
+                {"id": _CONV2, "org": DEFAULT_ORG_ID, "ws": DEFAULT_WS_ID, "uid": my_user_id},
+            )
+            await s.execute(
+                text(
+                    "INSERT INTO artifacts (id, org_id, workspace_id, conversation_id,"
+                    " name, artifact_type, path, entry_file, mime_type, description,"
+                    " version, created_at, updated_at)"
+                    " VALUES (:id, :org, :ws, :conv, 'Notes', 'text',"
+                    " '/workspace/notes', NULL, NULL, NULL, 1, NOW(), NOW())"
+                    " ON CONFLICT (id) DO NOTHING"
+                ),
+                {
+                    "id": _ART2,
+                    "org": DEFAULT_ORG_ID,
+                    "ws": DEFAULT_WS_ID,
+                    "conv": _CONV2,
+                },
+            )
+            await s.commit()
+
+        store = get_objectstore_client()
+        await store.upload_file(f"{_PREFIX2}notes.txt", b"hello")
+        yield
+    finally:
+        store = get_objectstore_client()
+        try:
+            await store.delete_file(f"{_PREFIX2}notes.txt")
+        except Exception:
+            pass
+        async with maker() as s:
+            await s.execute(text("DELETE FROM artifacts WHERE id = :id"), {"id": _ART2})
+            await s.execute(text("DELETE FROM conversations WHERE id = :id"), {"id": _CONV2})
+            await s.commit()
+        await engine.dispose()
+
+
+def test_files_version_param(_seed: None, client: TestClient) -> None:
+    """?version=N returns files from that version's prefix."""
+    res = client.get(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/{_ART}/files",
+        params={"version": 2, "filter": "image"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["version"] == 2
+    assert body["files"] == ["1_v2.png", "2_v2.png"]
+
+
+def test_files_filter_image_empty_when_only_non_image(
+    _seed_non_image: None,
+    client: TestClient,
+) -> None:
+    """Directory with only non-image files returns files: [], not 404."""
+    res = client.get(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV2}/artifacts/{_ART2}/files",
+        params={"filter": "image"},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["files"] == []

--- a/backend/tests/e2e/test_artifact_files.py
+++ b/backend/tests/e2e/test_artifact_files.py
@@ -1,0 +1,118 @@
+"""E2E tests for the artifact file-list endpoint."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from cubebox.db.engine import _build_database_url
+from cubebox.objectstore import get_objectstore_client
+from tests.e2e.conftest import DEFAULT_ORG_ID, DEFAULT_WS_ID
+
+pytestmark = pytest.mark.asyncio
+
+_CONV = "conv-artfiles"
+_ART = "art-artfiles"
+_PREFIX = f"artifacts/{_CONV}/{_ART}/v1/"
+
+
+@pytest_asyncio.fixture
+async def _seed(client: TestClient) -> AsyncIterator[None]:
+    me = client.get("/api/v1/auth/me")
+    assert me.status_code == 200, me.text
+    my_user_id = me.json()["id"]
+
+    engine = create_async_engine(_build_database_url(), poolclass=NullPool)
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with maker() as s:
+            await s.execute(
+                text(
+                    "INSERT INTO conversations (id, org_id, workspace_id,"
+                    " creator_user_id, title, has_messages, is_group_chat,"
+                    " created_at, updated_at)"
+                    " VALUES (:id, :org, :ws, :uid, 'seed', true, false, NOW(), NOW())"
+                    " ON CONFLICT (id) DO NOTHING"
+                ),
+                {"id": _CONV, "org": DEFAULT_ORG_ID, "ws": DEFAULT_WS_ID, "uid": my_user_id},
+            )
+            await s.execute(
+                text(
+                    "INSERT INTO artifacts (id, org_id, workspace_id, conversation_id,"
+                    " name, artifact_type, path, entry_file, mime_type, description,"
+                    " version, created_at, updated_at)"
+                    " VALUES (:id, :org, :ws, :conv, 'Charts', 'image',"
+                    " '/workspace/charts', NULL, NULL, NULL, 1, NOW(), NOW())"
+                    " ON CONFLICT (id) DO NOTHING"
+                ),
+                {
+                    "id": _ART,
+                    "org": DEFAULT_ORG_ID,
+                    "ws": DEFAULT_WS_ID,
+                    "conv": _CONV,
+                },
+            )
+            await s.commit()
+
+        store = get_objectstore_client()
+        # Unsorted on purpose: 2_ before 1_ to prove the endpoint sorts.
+        for name, data in (
+            ("2_second.png", b"\x89PNG\r\n\x1a\n-second"),
+            ("1_first.png", b"\x89PNG\r\n\x1a\n-first"),
+            ("3_third.png", b"\x89PNG\r\n\x1a\n-third"),
+            ("script.py", b"print(1)"),
+        ):
+            await store.upload_file(f"{_PREFIX}{name}", data)
+        yield
+    finally:
+        store = get_objectstore_client()
+        for name in ("2_second.png", "1_first.png", "3_third.png", "script.py"):
+            try:
+                await store.delete_file(f"{_PREFIX}{name}")
+            except Exception:
+                pass
+        async with maker() as s:
+            await s.execute(text("DELETE FROM artifacts WHERE id = :id"), {"id": _ART})
+            await s.execute(text("DELETE FROM conversations WHERE id = :id"), {"id": _CONV})
+            await s.commit()
+        await engine.dispose()
+
+
+def test_files_filter_image_sorted(_seed: None, client: TestClient) -> None:
+    res = client.get(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/{_ART}/files",
+        params={"filter": "image"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["version"] == 1
+    # Sorted ascending; non-image script.py excluded; prefix stripped.
+    assert body["files"] == ["1_first.png", "2_second.png", "3_third.png"]
+
+
+def test_files_no_filter_returns_all(_seed: None, client: TestClient) -> None:
+    res = client.get(f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/{_ART}/files")
+    assert res.status_code == 200, res.text
+    names = res.json()["files"]
+    assert "script.py" in names
+    assert names == sorted(names)
+
+
+def test_files_missing_artifact_404(client: TestClient) -> None:
+    res = client.get(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/art-nonexistent/files"
+    )
+    assert res.status_code == 404
+
+
+def test_files_cross_workspace_404(_seed: None, client: TestClient) -> None:
+    # _seed is owned by DEFAULT_WS_ID; query a foreign workspace id.
+    res = client.get(
+        f"/api/v1/ws/ws-foreign/conversations/{_CONV}/artifacts/{_ART}/files",
+        params={"filter": "image"},
+    )
+    assert res.status_code == 404

--- a/docs/dev/plans/2026-06-29-multi-image-artifact-preview.md
+++ b/docs/dev/plans/2026-06-29-multi-image-artifact-preview.md
@@ -1,0 +1,940 @@
+# 多图 Artifact 预览与成果库封面 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让"一组图片"作为单一 artifact 时可正常预览（轮播画廊）并在成果库卡片用首图当封面 + 数量角标；同时引导 agent 正确产出多图交付物。
+
+**Architecture:** 新增后端 `GET /artifacts/{id}/files?filter=image` 接口（复用 `list_objects`，文件名升序、按扩展名过滤）；前端 `ImagePreview` 用启发式判定单图 vs 多图目录，多图时渲染新 `ImageCarousel` 组件（复用 `ImageViewer`）；成果库卡片复用同一启发式取首图封面 + `×N` 角标；prompt 引导 agent 编号文件名、不设 `entry_file`。
+
+**Tech Stack:** FastAPI（后端路由）、SQLModel/aioboto3 rustfs（object store）、React 19 + Next.js + next-intl（前端）、vitest（前端单测）、Playwright（前端 e2e）、pytest（后端 e2e）。
+
+## Global Constraints
+
+- 后端类型注解全覆盖，mypy strict；行宽 100。
+- 时间列 tz-aware；DB→API 用 `utc_isoformat()`。（本计划无新时间列）
+- Scope-isolated：新接口走 workspace 路由 `/api/v1/ws/{ws}/conversations/{conv}/artifacts/...`，无 admin 对应。
+- 依赖：`uv add`（后端）、`pnpm add`（前端）；本计划不新增依赖。
+- 前端用 pnpm；`@cubebox/core` 改动需 build 后 web 才能看到（本计划不改 core）。
+- 文档随代码：本特性不改 user-facing 文档页（artifact 预览是既有行为的多图扩展，无新 route/enum/option 暴露给用户配置）；prompt 文案改动属内部。
+- 图片扩展名集合 `IMAGE_EXTENSIONS = {png,jpg,jpeg,gif,webp,svg,bmp}`（小写，无点）。
+- 临时脚本放 `backend/scripts/dev/`；spec/plan 已在 `docs/dev/`。
+
+参考 spec：`docs/dev/specs/2026-06-29-multi-image-artifact-preview-design.md`
+
+---
+
+## File Structure
+
+**后端：**
+- Modify: `backend/cubebox/api/routes/v1/artifacts.py` — 新增 `GET /{artifact_id}/files` 路由 + `IMAGE_EXTENSIONS` 常量 + 响应模型。
+- Test: `backend/tests/e2e/test_artifact_files.py`（新建）— `/files` 契约 + RBAC + 过滤/排序。
+
+**前端：**
+- Modify: `frontend/packages/web/components/panel/artifact/previewUtils.ts` — 加 `IMAGE_EXTENSIONS` 常量 + `hasImageExt(filename)` 纯函数。
+- Create: `frontend/packages/web/components/panel/artifact/ImageCarousel.tsx` — 多图轮播，复用 `ImageViewer`。
+- Modify: `frontend/packages/web/components/panel/artifact/ImagePreview.tsx` — 启发式判定：单图直接渲染，多图目录拉 `/files` 渲染 `ImageCarousel`。
+- Create: `frontend/packages/web/components/panel/artifact/useArtifactCover.ts` — hook：启发式取封面 URL + 数量（供卡片用）。
+- Modify: `frontend/packages/web/components/artifacts/ArtifactLibraryCard.tsx` — 用 `useArtifactCover` 取首图封面 + `×N` 角标。
+- Test: `frontend/packages/web/__tests__/components/previewUtils.test.ts`（新建，纯函数）。
+- Test: `frontend/packages/web/__tests__/e2e/artifact-multi-image.spec.ts`（新建，Playwright）。
+
+**Prompt：**
+- Modify: `backend/cubebox/prompts/artifacts.py` — `image` 条目加多图引导。
+
+---
+
+### Task 1: 后端 — `/files` 接口
+
+**Files:**
+- Modify: `backend/cubebox/api/routes/v1/artifacts.py`
+- Test: `backend/tests/e2e/test_artifact_files.py`
+
+**Interfaces:**
+- Consumes: `get_objectstore_client().list_objects(prefix)`（已存在，返回 `list[str]`）；`ArtifactRepository.get_by_id(artifact_id)`（已存在）；`_require_conversation(session, ctx, conversation_id)`（已存在于该文件）。
+- Produces: `GET /ws/{workspace_id}/conversations/{conversation_id}/artifacts/{artifact_id}/files?version=&filter=` → `{ version: int, files: list[str] }`；模块级常量 `IMAGE_EXTENSIONS: frozenset[str]`。
+
+- [ ] **Step 1: 写失败的 e2e 测试**
+
+创建 `backend/tests/e2e/test_artifact_files.py`。该测试用真实 rustfs object store（conftest 已配 `127.0.0.1:9000` + rustfsadmin），直接调 `get_objectstore_client().upload_file()` 灌数据，再用 `TestClient` 打接口。
+
+```python
+"""E2E tests for the artifact file-list endpoint."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from cubebox.db.engine import _build_database_url
+from cubebox.objectstore import get_objectstore_client
+from tests.e2e.conftest import DEFAULT_ORG_ID, DEFAULT_WS_ID
+
+pytestmark = pytest.mark.asyncio
+
+_CONV = "conv-artfiles"
+_ART = "art-artfiles"
+_PREFIX = f"artifacts/{_CONV}/{_ART}/v1/"
+
+
+@pytest_asyncio.fixture
+async def _seed(client: TestClient) -> AsyncIterator[None]:
+    me = client.get("/api/v1/auth/me")
+    assert me.status_code == 200, me.text
+    my_user_id = me.json()["id"]
+
+    engine = create_async_engine(_build_database_url(), poolclass=NullPool)
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with maker() as s:
+            await s.execute(
+                text(
+                    "INSERT INTO conversations (id, org_id, workspace_id,"
+                    " creator_user_id, title, has_messages, is_group_chat,"
+                    " created_at, updated_at)"
+                    " VALUES (:id, :org, :ws, :uid, 'seed', true, false, NOW(), NOW())"
+                    " ON CONFLICT (id) DO NOTHING"
+                ),
+                {"id": _CONV, "org": DEFAULT_ORG_ID, "ws": DEFAULT_WS_ID, "uid": my_user_id},
+            )
+            await s.execute(
+                text(
+                    "INSERT INTO artifacts (id, org_id, workspace_id, conversation_id,"
+                    " name, artifact_type, path, entry_file, mime_type, description,"
+                    " version, created_at, updated_at)"
+                    " VALUES (:id, :org, :ws, :conv, 'Charts', 'image',"
+                    " '/workspace/charts', NULL, NULL, NULL, 1, NOW(), NOW())"
+                    " ON CONFLICT (id) DO NOTHING"
+                ),
+                {
+                    "id": _ART,
+                    "org": DEFAULT_ORG_ID,
+                    "ws": DEFAULT_WS_ID,
+                    "conv": _CONV,
+                },
+            )
+            await s.commit()
+
+        store = get_objectstore_client()
+        # Unsorted on purpose: 2_ before 1_ to prove the endpoint sorts.
+        for name, data in (
+            ("2_second.png", b"\x89PNG\r\n\x1a\n-second"),
+            ("1_first.png", b"\x89PNG\r\n\x1a\n-first"),
+            ("3_third.png", b"\x89PNG\r\n\x1a\n-third"),
+            ("script.py", b"print(1)"),
+        ):
+            await store.upload_file(f"{_PREFIX}{name}", data)
+        yield
+    finally:
+        store = get_objectstore_client()
+        for name in ("2_second.png", "1_first.png", "3_third.png", "script.py"):
+            try:
+                await store.delete_object(f"{_PREFIX}{name}")
+            except Exception:
+                pass
+        async with maker() as s:
+            await s.execute(text("DELETE FROM artifacts WHERE id = :id"), {"id": _ART})
+            await s.execute(text("DELETE FROM conversations WHERE id = :id"), {"id": _CONV})
+            await s.commit()
+        await engine.dispose()
+
+
+def test_files_filter_image_sorted(_seed: None, client: TestClient) -> None:
+    res = client.get(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/{_ART}/files",
+        params={"filter": "image"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["version"] == 1
+    # Sorted ascending; non-image script.py excluded; prefix stripped.
+    assert body["files"] == ["1_first.png", "2_second.png", "3_third.png"]
+
+
+def test_files_no_filter_returns_all(_seed: None, client: TestClient) -> None:
+    res = client.get(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/{_ART}/files"
+    )
+    assert res.status_code == 200, res.text
+    names = res.json()["files"]
+    assert "script.py" in names
+    assert names == sorted(names)
+
+
+def test_files_missing_artifact_404(client: TestClient) -> None:
+    res = client.get(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/art-nonexistent/files"
+    )
+    assert res.status_code == 404
+
+
+def test_files_cross_workspace_404(_seed: None, client: TestClient) -> None:
+    # _seed is owned by DEFAULT_WS_ID; query a foreign workspace id.
+    res = client.get(
+        f"/api/v1/ws/ws-foreign/conversations/{_CONV}/artifacts/{_ART}/files",
+        params={"filter": "image"},
+    )
+    assert res.status_code == 404
+```
+
+注：`delete_object` 若 `ObjectStoreClient` 无此方法，实现 Step 3 时确认；若没有，用 `list_objects(_PREFIX)` + 现有删除手段，或测试 cleanup 改用 `list_objects` 枚举后逐个删（见 Step 3 备注）。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd backend && uv run pytest tests/e2e/test_artifact_files.py -v 2>&1 | tee tmp/artifact-files.log | tail -15`
+Expected: FAIL — 404（路由不存在）或 405。
+
+- [ ] **Step 3: 实现 `/files` 路由**
+
+先确认 `ObjectStoreClient` 有无 `delete_object`：
+
+Run: `cd backend && grep -n "def delete_object\|def delete" cubebox/objectstore/client.py`
+- 若有 → 上面 cleanup 直接可用。
+- 若无 → 把测试 cleanup 改为：`keys = await store.list_objects(_PREFIX); for k in keys: ... ` 仍需一个删除方法。若完全没有删除方法，cleanup 用 `upload_file` 覆盖空字节不可行（list 仍返回）。此时最稳妥：在 `ObjectStoreClient` 加一个 `delete_object(key)` 方法（aioboto3 `delete_object(Bucket, Key)`），并在本任务一并实现 + 提交（它是个合理的通用缺失方法，cleanup 需要）。**先 grep 确认再决定。**
+
+在 `backend/cubebox/api/routes/v1/artifacts.py` 顶部 import 区下方（`router = APIRouter(...)` 之前）加常量：
+
+```python
+IMAGE_EXTENSIONS = frozenset({"png", "jpg", "jpeg", "gif", "webp", "svg", "bmp"})
+```
+
+并在 import 区加 `from pydantic import BaseModel`（若尚未导入）。
+
+在 `download_artifact` 路由之后（`OFFICE_EXTENSIONS` 定义之前）加响应模型 + 路由：
+
+```python
+class ArtifactFilesOut(BaseModel):
+    version: int
+    files: list[str]
+
+
+@router.get("/{artifact_id}/files", response_model=ArtifactFilesOut)
+async def list_artifact_files(
+    conversation_id: str,
+    artifact_id: str,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    ctx: Annotated[RequestContext, Depends(require_member)],
+    version: int | None = Query(default=None),
+    filter: str | None = Query(default=None),
+) -> ArtifactFilesOut:
+    """List the files stored for an artifact version.
+
+    ``filter=image`` restricts to image extensions (sorted ascending by
+    filename); without ``filter`` all files are returned sorted. Used by the
+    preview panel to render a multi-image directory as a carousel.
+    """
+    await _require_conversation(session, ctx, conversation_id)
+    repo = ArtifactRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
+    artifact = await repo.get_by_id(artifact_id)
+    if not artifact or artifact.conversation_id != conversation_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Artifact {artifact_id} not found",
+        )
+
+    target_version = version or artifact.version
+    prefix = f"artifacts/{conversation_id}/{artifact_id}/v{target_version}/"
+
+    try:
+        store = get_objectstore_client()
+        keys = await store.list_objects(prefix)
+    except Exception as e:
+        logger.error("Error listing artifact files: {}", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list artifact files",
+        ) from None
+
+    rel_files = [k[len(prefix):] for k in keys]
+    if filter == "image":
+        rel_files = [
+            f
+            for f in rel_files
+            if "." in f and f.rsplit(".", 1)[-1].lower() in IMAGE_EXTENSIONS
+        ]
+    rel_files.sort()
+
+    return ArtifactFilesOut(version=target_version, files=rel_files)
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd backend && uv run pytest tests/e2e/test_artifact_files.py -v 2>&1 | tee tmp/artifact-files.log | tail -15`
+Expected: 4 passed。
+
+若 `test_files_cross_workspace_404` 不过（返回非 404），检查 `require_member` / `_require_conversation` 在跨 workspace 时的行为——`ArtifactRepository` 用 `(org_id, workspace_id)` scope，跨 ws 的 `get_by_id` 应返回 None → 404。若 conv 先于 artifact 校验且跨 ws 的 conv 也 404，同样满足。
+
+- [ ] **Step 5: mypy + 提交**
+
+Run: `cd backend && uv run mypy cubebox/api/routes/v1/artifacts.py 2>&1 | tail -5`
+Expected: no errors.
+
+```bash
+cd backend
+git add tests/e2e/test_artifact_files.py cubebox/api/routes/v1/artifacts.py
+# 若加了 delete_object:
+# git add cubebox/objectstore/client.py
+git commit -m "feat(artifacts): add GET /files endpoint for multi-image preview"
+```
+
+---
+
+### Task 2: 前端 — `previewUtils` 图片扩展名启发式（纯函数）
+
+**Files:**
+- Modify: `frontend/packages/web/components/panel/artifact/previewUtils.ts`
+- Test: `frontend/packages/web/__tests__/components/previewUtils.test.ts`
+
+**Interfaces:**
+- Produces: `IMAGE_EXTENSIONS: ReadonlySet<string>`；`hasImageExt(filename: string): boolean`。
+
+- [ ] **Step 1: 写失败的纯函数测试**
+
+创建 `frontend/packages/web/__tests__/components/previewUtils.test.ts`：
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { hasImageExt } from '../../components/panel/artifact/previewUtils'
+
+describe('hasImageExt', () => {
+  it('true for image extensions (case-insensitive)', () => {
+    expect(hasImageExt('1_镇街贷款金额.png')).toBe(true)
+    expect(hasImageExt('chart.JPG')).toBe(true)
+    expect(hasImageExt('a.svg')).toBe(true)
+    expect(hasImageExt('a.webp')).toBe(true)
+  })
+
+  it('false for non-image extensions and extensionless names', () => {
+    expect(hasImageExt('charts')).toBe(false)
+    expect(hasImageExt('script.py')).toBe(false)
+    expect(hasImageExt('data.csv')).toBe(false)
+    expect(hasImageExt('')).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd frontend && pnpm vitest run __tests__/components/previewUtils.test.ts 2>&1 | tail -15`
+Expected: FAIL — `hasImageExt` 未导出。
+
+- [ ] **Step 3: 实现常量与函数**
+
+在 `frontend/packages/web/components/panel/artifact/previewUtils.ts` 末尾追加：
+
+```typescript
+export const IMAGE_EXTENSIONS = new Set([
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'webp',
+  'svg',
+  'bmp',
+])
+
+export function hasImageExt(filename: string): boolean {
+  const dot = filename.lastIndexOf('.')
+  if (dot < 0) return false
+  return IMAGE_EXTENSIONS.has(filename.slice(dot + 1).toLowerCase())
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd frontend && pnpm vitest run __tests__/components/previewUtils.test.ts 2>&1 | tail -15`
+Expected: PASS。
+
+- [ ] **Step 5: lint + 提交**
+
+Run: `cd frontend && pnpm lint 2>&1 | tail -5`
+Expected: no errors.
+
+```bash
+cd frontend
+git add packages/web/components/panel/artifact/previewUtils.ts packages/web/__tests__/components/previewUtils.test.ts
+git commit -m "feat(artifact): add hasImageExt helper for image path detection"
+```
+
+---
+
+### Task 3: 前端 — `ImageCarousel` 组件
+
+**Files:**
+- Create: `frontend/packages/web/components/panel/artifact/ImageCarousel.tsx`
+
+**Interfaces:**
+- Consumes: `ImageViewer`（`@/components/shared/previews`，props `{ url, alt }`）；`buildPreviewUrl(artifact, filePath, version, workspaceId)`（Task 既有）；`Artifact`（`@cubebox/core`）。
+- Produces: `ImageCarousel` 组件，props `{ artifact: Artifact; imageFiles: string[]; version: number | null; workspaceId: string }`。
+
+- [ ] **Step 1: 创建组件**
+
+创建 `frontend/packages/web/components/panel/artifact/ImageCarousel.tsx`：
+
+```typescript
+'use client'
+
+import { useState, useCallback } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import type { Artifact } from '@cubebox/core'
+import { buildPreviewUrl } from './previewUtils'
+import { ImageViewer } from '@/components/shared/previews'
+
+interface ImageCarouselProps {
+  artifact: Artifact
+  imageFiles: string[]
+  version: number | null
+  workspaceId: string
+}
+
+export function ImageCarousel({
+  artifact,
+  imageFiles,
+  version,
+  workspaceId,
+}: ImageCarouselProps): React.ReactElement {
+  const [index, setIndex] = useState(0)
+  const count = imageFiles.length
+
+  const go = useCallback(
+    (delta: number) => {
+      setIndex((i) => Math.min(count - 1, Math.max(0, i + delta)))
+    },
+    [count],
+  )
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        go(-1)
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        go(1)
+      }
+    },
+    [go],
+  )
+
+  const url = buildPreviewUrl(artifact, imageFiles[index], version, workspaceId)
+
+  return (
+    <div className="flex h-full flex-col" tabIndex={0} onKeyDown={onKeyDown}>
+      <div className="relative flex-1 overflow-hidden">
+        <ImageViewer url={url} alt={`${artifact.name} ${index + 1}/${count}`} />
+        {count > 1 && (
+          <>
+            <button
+              onClick={() => go(-1)}
+              disabled={index === 0}
+              aria-label="Previous image"
+              className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70
+                p-1.5 text-foreground backdrop-blur-sm transition-colors hover:bg-background
+                disabled:opacity-30"
+            >
+              <ChevronLeft className="size-5" />
+            </button>
+            <button
+              onClick={() => go(1)}
+              disabled={index === count - 1}
+              aria-label="Next image"
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70
+                p-1.5 text-foreground backdrop-blur-sm transition-colors hover:bg-background
+                disabled:opacity-30"
+            >
+              <ChevronRight className="size-5" />
+            </button>
+            <div className="absolute bottom-2 left-1/2 -translate-x-1/2 rounded-full
+              bg-background/70 px-2 py-0.5 text-xs tabular-nums text-muted-foreground
+              backdrop-blur-sm">
+              {index + 1} / {count}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 类型检查 + lint**
+
+Run: `cd frontend && pnpm tsc --noEmit 2>&1 | tail -10 && pnpm lint 2>&1 | tail -5`
+Expected: no errors.
+
+- [ ] **Step 3: 提交**
+
+```bash
+cd frontend
+git add packages/web/components/panel/artifact/ImageCarousel.tsx
+git commit -m "feat(artifact): add ImageCarousel for multi-image preview"
+```
+
+---
+
+### Task 4: 前端 — `ImagePreview` 启发式集成
+
+**Files:**
+- Modify: `frontend/packages/web/components/panel/artifact/ImagePreview.tsx`
+
+**Interfaces:**
+- Consumes: `hasImageExt`（Task 2）；`ImageCarousel`（Task 3）；`buildPreviewUrl`（既有）；`FallbackPreview`（`./FallbackPreview`，既有）；`PreviewLoading`（`./PreviewLoading`，既有）。
+- Produces: `ImagePreview` 仍导出同名组件，行为升级为启发式。
+
+- [ ] **Step 1: 重写 `ImagePreview.tsx`**
+
+完整替换 `frontend/packages/web/components/panel/artifact/ImagePreview.tsx`：
+
+```typescript
+'use client'
+
+import { useState, useEffect } from 'react'
+import type { Artifact } from '@cubebox/core'
+import { buildPreviewUrl, hasImageExt } from './previewUtils'
+import { ImageViewer } from '@/components/shared/previews'
+import { PreviewLoading } from './PreviewLoading'
+import { FallbackPreview } from './FallbackPreview'
+import { ImageCarousel } from './ImageCarousel'
+
+interface ImagePreviewProps {
+  artifact: Artifact
+  version: number | null
+  workspaceId: string
+}
+
+interface FilesResponse {
+  version: number
+  files: string[]
+}
+
+export function ImagePreview({
+  artifact,
+  version,
+  workspaceId,
+}: ImagePreviewProps): React.ReactElement {
+  const filename = artifact.entry_file || artifact.path.split('/').pop() || ''
+
+  // Heuristic: a path that already points at an image file → single image,
+  // no list call. Otherwise (directory like /workspace/charts) fetch the
+  // file list and render a carousel.
+  if (hasImageExt(filename)) {
+    const url = buildPreviewUrl(artifact, filename, version, workspaceId)
+    return <ImageViewer url={url} alt={artifact.name} />
+  }
+
+  const v = version ?? artifact.version
+  const [files, setFiles] = useState<string[] | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const url =
+      `/api/v1/ws/${workspaceId}/conversations/${artifact.conversation_id}` +
+      `/artifacts/${artifact.id}/files?filter=image&version=${v}`
+    fetch(url)
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status}`)
+        return res.json() as Promise<FilesResponse>
+      })
+      .then((body) => {
+        if (!cancelled) setFiles(body.files)
+      })
+      .catch(() => {
+        if (!cancelled) setError(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [artifact.id, artifact.conversation_id, v, workspaceId])
+
+  if (error) {
+    return <FallbackPreview artifact={artifact} version={version} workspaceId={workspaceId} />
+  }
+  if (files === null) {
+    return <PreviewLoading />
+  }
+  if (files.length === 0) {
+    return <FallbackPreview artifact={artifact} version={version} workspaceId={workspaceId} />
+  }
+  if (files.length === 1) {
+    const url = buildPreviewUrl(artifact, files[0], version, workspaceId)
+    return <ImageViewer url={url} alt={artifact.name} />
+  }
+  return (
+    <ImageCarousel
+      artifact={artifact}
+      imageFiles={files}
+      version={version}
+      workspaceId={workspaceId}
+    />
+  )
+}
+```
+
+- [ ] **Step 2: 确认 `FallbackPreview` props 形态**
+
+Run: `cd frontend && grep -n "export function FallbackPreview\|interface FallbackPreviewProps" packages/web/components/panel/artifact/FallbackPreview.tsx`
+Expected: 确认 props 为 `{ artifact, version, workspaceId }`（与其它 preview 一致）。若不一致，调整上面调用。
+
+- [ ] **Step 3: 类型检查 + lint**
+
+Run: `cd frontend && pnpm tsc --noEmit 2>&1 | tail -10 && pnpm lint 2>&1 | tail -5`
+Expected: no errors.
+
+- [ ] **Step 4: 提交**
+
+```bash
+cd frontend
+git add packages/web/components/panel/artifact/ImagePreview.tsx
+git commit -m "feat(artifact): ImagePreview renders carousel for multi-image dirs"
+```
+
+---
+
+### Task 5: 前端 — `useArtifactCover` hook + 成果库卡片封面
+
+**Files:**
+- Create: `frontend/packages/web/components/panel/artifact/useArtifactCover.ts`
+- Modify: `frontend/packages/web/components/artifacts/ArtifactLibraryCard.tsx`
+
+**Interfaces:**
+- Consumes: `hasImageExt`、`buildPreviewUrl`（Task 2 既有）；`Artifact`（`@cubebox/core`）。
+- Produces: `useArtifactCover(artifact, workspaceId)` → `{ coverUrl: string | null; count: number; loading: boolean }`。
+
+- [ ] **Step 1: 创建 hook**
+
+创建 `frontend/packages/web/components/panel/artifact/useArtifactCover.ts`：
+
+```typescript
+'use client'
+
+import { useState, useEffect } from 'react'
+import type { Artifact } from '@cubebox/core'
+import { buildPreviewUrl, hasImageExt } from './previewUtils'
+
+interface FilesResponse {
+  version: number
+  files: string[]
+}
+
+interface CoverState {
+  coverUrl: string | null
+  count: number
+  loading: boolean
+}
+
+export function useArtifactCover(
+  artifact: Artifact,
+  workspaceId: string,
+): CoverState {
+  const filename = artifact.entry_file || artifact.path.split('/').pop() || ''
+
+  // Single image path → cover is that file, no list call, count 1.
+  if (hasImageExt(filename)) {
+    return {
+      coverUrl: buildPreviewUrl(artifact, filename, null, workspaceId),
+      count: 1,
+      loading: false,
+    }
+  }
+
+  // Directory path → fetch first image as cover.
+  const [state, setState] = useState<CoverState>({
+    coverUrl: null,
+    count: 0,
+    loading: true,
+  })
+
+  useEffect(() => {
+    let cancelled = false
+    const url =
+      `/api/v1/ws/${workspaceId}/conversations/${artifact.conversation_id}` +
+      `/artifacts/${artifact.id}/files?filter=image`
+    fetch(url)
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status}`)
+        return res.json() as Promise<FilesResponse>
+      })
+      .then((body) => {
+        if (cancelled) return
+        const first = body.files[0]
+        setState({
+          coverUrl: first
+            ? buildPreviewUrl(artifact, first, null, workspaceId)
+            : null,
+          count: body.files.length,
+          loading: false,
+        })
+      })
+      .catch(() => {
+        if (!cancelled) setState({ coverUrl: null, count: 0, loading: false })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [artifact.id, artifact.conversation_id, workspaceId])
+
+  return state
+}
+```
+
+- [ ] **Step 2: 改造 `ArtifactLibraryCard.tsx`**
+
+在 `frontend/packages/web/components/artifacts/ArtifactLibraryCard.tsx`：
+
+1) 顶部 import 加：
+```typescript
+import { useArtifactCover } from '@/components/panel/artifact/useArtifactCover'
+```
+
+2) 删除旧的 `thumbFailed`/`thumbFile`/`thumbUrl` 逻辑（第 45–52 行附近），替换为 hook + 派生：
+
+把组件内（`const Icon = ...` 之后、`return` 之前）改为：
+```typescript
+  const cover = useArtifactCover(artifact, workspaceId)
+  const [thumbFailed, setThumbFailed] = useState(false)
+  const showImage = isImageArtifact(artifact) && !thumbFailed && cover.coverUrl !== null
+  const showHtml = !showImage && isHtmlArtifact(artifact)
+  const fallbackFile = isHtmlArtifact(artifact) ? 'index.html' : ''
+  const thumbUrl =
+    cover.coverUrl ??
+    buildPreviewUrl(artifact, artifact.entry_file || fallbackFile, null, workspaceId)
+```
+
+注意：HTML artifact 仍走 `thumbFile = entry_file || 'index.html'` 的既有逻辑（不被 cover hook 影响，因为 `isHtmlArtifact` 时 `hasImageExt` 多半为 false 但 HTML 缩略图用 `ArtifactHtmlThumb`）。为避免回归，HTML 分支保持原 `thumbUrl` 计算。更稳妥的写法：
+
+```typescript
+  const cover = useArtifactCover(artifact, workspaceId)
+  const [thumbFailed, setThumbFailed] = useState(false)
+  const isHtml = isHtmlArtifact(artifact)
+  const showImage = isImageArtifact(artifact) && !thumbFailed && cover.coverUrl !== null
+  const showHtml = !showImage && isHtml
+  const fallbackFile = isHtml ? 'index.html' : ''
+  // HTML keeps its own thumb URL; image uses the cover hook result.
+  const thumbUrl = isHtml
+    ? buildPreviewUrl(artifact, artifact.entry_file || fallbackFile, null, workspaceId)
+    : cover.coverUrl ?? buildPreviewUrl(artifact, '', null, workspaceId)
+```
+
+3) 在缩略图区域（`<img ... onError={() => setThumbFailed(true)} />`）下方、`DropdownMenu` 之前，加数量角标。在 `<div className="relative aspect-video ...">` 内最末尾（`</div>` 关闭前）追加：
+
+```tsx
+        {cover.count > 1 && !thumbFailed && (
+          <span
+            className="absolute bottom-2 right-2 rounded-full bg-background/80 px-1.5
+              py-0.5 text-[10px] font-medium text-muted-foreground backdrop-blur-sm"
+            data-testid="artifact-card-count"
+          >
+            ×{cover.count}
+          </span>
+        )}
+```
+
+4) `loading` 时（`cover.loading && showImage`）可显示 `PreviewLoading` 或保持 `bg-muted/40` 占位（当前 img 未渲染时容器本身就是灰底）。为简单起见，`cover.loading` 期间 `showImage` 为 false（因 `cover.coverUrl === null`）→ 自动落到图标兜底，加载完成后再切到图片。无需额外 loading UI。
+
+- [ ] **Step 3: 类型检查 + lint**
+
+Run: `cd frontend && pnpm tsc --noEmit 2>&1 | tail -10 && pnpm lint 2>&1 | tail -5`
+Expected: no errors.
+
+- [ ] **Step 4: 提交**
+
+```bash
+cd frontend
+git add packages/web/components/panel/artifact/useArtifactCover.ts packages/web/components/artifacts/ArtifactLibraryCard.tsx
+git commit -m "feat(artifacts): library card shows first-image cover + count badge for multi-image dirs"
+```
+
+---
+
+### Task 6: Prompt 引导
+
+**Files:**
+- Modify: `backend/cubebox/prompts/artifacts.py`
+
+- [ ] **Step 1: 改 `image` 条目**
+
+在 `backend/cubebox/prompts/artifacts.py` 的 `ARTIFACT_PROMPT` 中，把：
+
+```
+- "image" — PNG, SVG, JPG images (e.g. matplotlib output)
+```
+
+改为：
+
+```
+- "image" — PNG, SVG, JPG images (e.g. matplotlib output). Point `path` at a single \
+image file. If you produce multiple images as one deliverable, save them in a directory, \
+number the filenames (`1_*.png`, `2_*.png`, …) so they preview in order, and leave \
+`entry_file` unset — the preview renders them as a navigable gallery.
+```
+
+- [ ] **Step 2: 确认既有 prompt 测试不破**
+
+Run: `cd backend && grep -rln "ARTIFACT_PROMPT\|artifacts.py" tests/ | head`
+若有断言 prompt 内容的测试，更新之；否则跳过。跑相关单测：
+Run: `cd backend && uv run pytest tests/unit/test_builtin_tools.py -v 2>&1 | tail -10`
+Expected: PASS（或无相关测试）。
+
+- [ ] **Step 3: 提交**
+
+```bash
+cd backend
+git add cubebox/prompts/artifacts.py
+git commit -m "feat(artifact): guide agents on multi-image artifact authoring"
+```
+
+---
+
+### Task 7: 前端 e2e — 多图预览 + 卡片封面
+
+**Files:**
+- Test: `frontend/packages/web/__tests__/e2e/artifact-multi-image.spec.ts`
+
+**Interfaces:**
+- Consumes: 既有 Playwright fixtures + 真实后端。需一个已存在的多图 image artifact。最稳妥：用 e2e 里既有的"发送消息让 agent 产图"流程不现实（依赖 LLM），改为**直接灌库 + 灌 object store** 的 setup（参考后端 e2e 的 seeding 思路），但前端 e2e 无法直接访问 DB/store。
+
+**策略：** 前端 e2e 不易直接造多图 artifact。改用**前端组件交互测试（vitest + @testing-library）**覆盖画廊导航状态机（这是后端观测不到的客户端状态机，符合前端 e2e 的职责），用 mock 的 `/files` 响应驱动。Playwright 真实流程留给手动验收。
+
+- [ ] **Step 1: 写 `ImageCarousel` 交互测试**
+
+创建 `frontend/packages/web/__tests__/components/ImageCarousel.test.tsx`：
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { Artifact } from '@cubebox/core'
+
+const mockUrl = (file: string) => `/preview/${file}`
+vi.mock('../../../components/panel/artifact/previewUtils', () => ({
+  buildPreviewUrl: (_a: unknown, file: string) => mockUrl(file as string),
+}))
+
+// Stub ImageViewer to surface the url it received.
+vi.mock('../../../components/shared/previews', () => ({
+  ImageViewer: ({ url }: { url: string }) => (
+    <img data-testid="carousel-img" src={url} alt="" />
+  ),
+}))
+
+import { ImageCarousel } from '../../../components/panel/artifact/ImageCarousel'
+
+const artifact = {
+  id: 'art-1',
+  conversation_id: 'conv-1',
+  name: 'Charts',
+  artifact_type: 'image' as const,
+  path: '/workspace/charts',
+  entry_file: null,
+  mime_type: null,
+  description: null,
+  created_at: '2026-06-29T00:00:00Z',
+  updated_at: '2026-06-29T00:00:00Z',
+  version: 1,
+} as unknown as Artifact
+
+describe('ImageCarousel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows first image and counter 1/3, navigates with next/prev', () => {
+    render(
+      <ImageCarousel
+        artifact={artifact}
+        imageFiles={['1_a.png', '2_b.png', '3_c.png']}
+        version={1}
+        workspaceId="ws"
+      />,
+    )
+    expect(screen.getByTestId('carousel-img')).toHaveAttribute('src', '/preview/1_a.png')
+    expect(screen.getByText('1 / 3')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Next image'))
+    expect(screen.getByTestId('carousel-img')).toHaveAttribute('src', '/preview/2_b.png')
+    expect(screen.getByText('2 / 3')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Previous image'))
+    expect(screen.getByTestId('carousel-img')).toHaveAttribute('src', '/preview/1_a.png')
+  })
+
+  it('disables prev at start and next at end', () => {
+    render(
+      <ImageCarousel
+        artifact={artifact}
+        imageFiles={['1_a.png', '2_b.png']}
+        version={1}
+        workspaceId="ws"
+      />,
+    )
+    expect(screen.getByLabelText('Previous image')).toBeDisabled()
+    fireEvent.click(screen.getByLabelText('Next image'))
+    expect(screen.getByLabelText('Next image')).toBeDisabled()
+  })
+
+  it('hides nav chrome when single image', () => {
+    render(
+      <ImageCarousel
+        artifact={artifact}
+        imageFiles={['only.png']}
+        version={1}
+        workspaceId="ws"
+      />,
+    )
+    expect(screen.getByTestId('carousel-img')).toHaveAttribute('src', '/preview/only.png')
+    expect(screen.queryByLabelText('Next image')).not.toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试确认通过**
+
+Run: `cd frontend && pnpm vitest run __tests__/components/ImageCarousel.test.tsx 2>&1 | tail -20`
+Expected: 3 passed。
+
+若 mock 路径不对（`previewUtils` 相对路径），用 `vi.mock('@/components/panel/artifact/previewUtils', ...)` 配合 vitest 的 `@` alias；先确认 `vitest.config.ts` 有 `@` alias：`grep -n "alias\|@" packages/web/vitest.config.ts`。
+
+- [ ] **Step 3: 跑前端全套单测 + lint 兜底**
+
+Run: `cd frontend && pnpm vitest run 2>&1 | tail -15 && pnpm lint 2>&1 | tail -5`
+Expected: all pass。
+
+- [ ] **Step 4: 提交**
+
+```bash
+cd frontend
+git add packages/web/__tests__/components/ImageCarousel.test.tsx
+git commit -m "test(artifact): cover ImageCarousel navigation state machine"
+```
+
+---
+
+### Task 8: 收尾 — 后端全测 + 验收
+
+- [ ] **Step 1: 后端 e2e + mypy 全扫**
+
+Run: `cd backend && uv run pytest tests/e2e/test_artifact_files.py tests/e2e/test_ws_artifacts.py -v 2>&1 | tee tmp/artifact-sweep.log | tail -15`
+Expected: all pass.
+
+Run: `cd backend && uv run mypy cubebox/api/routes/v1/artifacts.py cubebox/prompts/artifacts.py 2>&1 | tail -5`
+Expected: no errors.
+
+- [ ] **Step 2: 手动验收清单**
+
+启动后端 + 前端，对一个多图目录 artifact 验证：
+1. 成果库卡片显示首图缩略图 + `×6` 角标。
+2. 点开预览面板：显示轮播，`1/6` 计数器，左右箭头 + 键盘 ←/→ 翻页。
+3. 单图 artifact 仍正常显示（无角标、无轮播 chrome）。
+4. 非图片目录 artifact 仍走 `FallbackPreview`。
+5. 下载多图 artifact 仍返回 tar（既有行为不回归）。
+
+- [ ] **Step 3: 推送 + PR review 循环**
+
+```bash
+cd /home/chris/cubebox
+git push -u origin <branch>
+```
+按 `pr-codex-review-loop` skill 走 push → poll → fix → reply 循环。

--- a/docs/dev/specs/2026-06-29-multi-image-artifact-preview-design.md
+++ b/docs/dev/specs/2026-06-29-multi-image-artifact-preview-design.md
@@ -1,0 +1,163 @@
+# 多图 Artifact 预览与成果库封面 — 设计
+
+日期：2026-06-29
+状态：已批准，待写实现计划
+
+## 背景
+
+预览 sandbox 里的 PNG 文件时报 `UnicodeEncodeError`（CJK 文件名），根因不止一处。
+先修了 `ws_sandbox.py` 的 `Content-Disposition`（用已有 `content_disposition` helper，
+发 RFC 5987 `filename*=UTF-8''`）。修完后发现更深的建模问题：一次"导出静态图片"的
+run 把 6 张 PNG 存成了**一个目录型 image artifact**（`path=/workspace/charts`、
+`entry_file=null`、`mime_type=null`），预览完全失败。
+
+失败链路（trace `07c8740de2a4d40500dd4117b8e0de9a`）：
+
+1. agent 调 `save_artifact`，`artifact_type=image`、`path` 指向含 6 张 PNG 的目录、
+   `entry_file` 未设。
+2. `register_artifact_from_sandbox` 对目录路径 `mimetypes.guess_type` 返回 `None` →
+   artifact 的 `mime_type=null`、`entry_file=null`。
+3. `upload_from_sandbox` 用 `relpath` 上传，object store 里实际 key 是
+   `artifacts/{conv}/{id}/v1/1_镇街贷款金额.png` 等 6 个，没有叫 `charts` 的对象。
+4. 前端 `ImagePreview.tsx` 用 `path.split('/').pop()` 算文件名 → `"charts"`（目录名）。
+5. 请求 `.../artifacts/{id}/preview/v1/charts` → 后端拼 key `.../v1/charts` → S3
+   `NoSuchKey` → 404 → 预览失败。
+
+根因是建模不匹配：image artifact 的预览假设"一个 artifact = 一张图"，而 agent 合理地
+把一组图表作为一个交付物存进目录。下载能工作（多文件打成 tar），预览没有"图片集合"概念。
+
+## 目标
+
+让"一组图片"作为单一 artifact 时可正常预览：预览面板渲染可翻页画廊；成果库卡片用
+首图当封面并标注数量。同时降低 agent 再次踩坑的频率。
+
+非目标：share 页面的公共预览（`/api/v1/shares/...`，单独的 token 流程，本期不动）；
+非图片目录的"文件浏览器"（只处理图片集合）。
+
+## 设计决策
+
+- 画廊交互：**轮播**（一次一张，复用 `ImageViewer` 的缩放/旋转，左右箭头 + `3 / 6`
+  计数器 + 键盘 ←/→）。
+- 排序：**文件名升序，后端排**。agent 给文件编号（`1_*.png`、`2_*.png`…）时正好是
+  自然顺序；不编号时 alphabetical 仍是合理默认。
+- 触发方式：**启发式判定**。`entry_file || path.split('/').pop()` 命中图片扩展名 →
+  单图模式，不调列表；否则拉文件列表，1 张→单图、≥2 张→轮播、0 张→FallbackPreview。
+- 目录内容：**只列图片**（按扩展名过滤），`charts` 目录里的 csv/py 不进画廊。
+- 成果库卡片：多图目录取**首图当封面 + 右下角 `×N` 数量角标**（`N>1` 才显示）。
+- prompt 引导：告诉 agent 多图交付物存目录、编号文件名、不设 `entry_file`。
+
+## 架构
+
+### 后端：文件列表接口
+
+新路由 `backend/cubebox/api/routes/v1/artifacts.py`：
+
+```
+GET /api/v1/ws/{ws}/conversations/{conv}/artifacts/{artifact_id}/files?version=N&filter=image
+```
+
+- 复用 `_require_conversation` + 所有权检查（同 `download_artifact`）。
+- `target_version = version or artifact.version`；
+  `prefix = artifacts/{conv}/{id}/v{target_version}/`。
+- `keys = await store.list_objects(prefix)`，去 prefix → 相对路径。
+- 文件名升序排序。
+- `filter=image`（可选）→ 仅保留扩展名在 `IMAGE_EXTENSIONS` frozenset 里的文件
+  （png/jpg/jpeg/gif/webp/svg/bmp），仿照已有的 `OFFICE_EXTENSIONS` 模式。不传 `filter`
+  → 返回全部文件（排序后），便于未来复用为通用文件列表。
+- 返回 `{ version: int, files: list[str] }`。
+- artifact 不存在/跨会话 → 404；过滤后为空 → `files: []`（不报错，前端兜底）。
+- 仅 workspace 路由，无 admin 对应（admin artifact 面板尚不存在）。
+
+### 前端：画廊组件与 ImagePreview 集成
+
+新组件 `components/panel/artifact/ImageGallery.tsx`：
+- props：`imageFiles: string[]` + `artifact/version/workspaceId`。
+- `currentIndex` 状态（0）。
+- 用 `ImageViewer` 渲染当前图（复用，保留缩放/旋转），URL 由
+  `buildPreviewUrl(artifact, imageFiles[currentIndex], version, workspaceId)` 生成。
+- 左右箭头（边界 disabled）、`3 / 6` 计数器、聚焦时 ←/→ 键盘导航。
+- `imageFiles.length === 1` → 直接渲染 `ImageViewer`，无画廊 chrome（与现状一致）。
+
+重构 `components/panel/artifact/ImagePreview.tsx` 应用启发式：
+
+```
+filename = entry_file || path.split('/').pop()
+if IMAGE_EXT.test(filename) → 单 <ImageViewer>（不调列表）
+else → fetch /files?filter=image
+       1 张 → 单 ImageViewer
+       ≥2 张 → <ImageGallery>
+       0 张  → <FallbackPreview>
+```
+
+loading 用 `PreviewLoading`；错误/空用 `FallbackPreview`。
+
+图片扩展名集合放 `previewUtils.ts` 共享常量，`ImagePreview`（客户端启发式）与画廊共用，
+与后端 `IMAGE_EXTENSIONS` 对应。
+
+### 前端：成果库卡片封面
+
+`components/artifacts/ArtifactLibraryCard.tsx`，复用 `previewUtils` 扩展名常量：
+- `thumbFile = entry_file || path.split('/').pop()`。
+- 命中图片扩展名 → 直接 `buildPreviewUrl(thumbFile)`，**零额外请求**（单图同现状）。
+- 否则 → 卡片挂载时调 `GET /artifacts/{id}/files?filter=image`，取 `files[0]` 当封面，
+  记 `files.length`。
+- 右下角数量角标 `×{count}`，仅 `count > 1` 显示。半透明药丸样式，参照现有
+  `DropdownMenu` 角标视觉密度。
+- `/files` 失败或空 → 落回通用图标兜底（现有 `thumbFailed` 分支），不裂图。
+
+抽 `useArtifactCover(artifact, workspaceId)` hook（放 `previewUtils` 旁或 card 内），
+封装"启发式取封面 URL + 数量"，与 `ImagePreview` 的列表逻辑共享同一套扩展名常量与
+`/files` 调用。
+
+### Prompt 引导
+
+`backend/cubebox/prompts/artifacts.py` 的 `ARTIFACT_PROMPT`，`image` 条目改为：
+
+> - "image" — PNG, SVG, JPG images (e.g. matplotlib output). Point `path` at a single
+>   image file. If you produce multiple images as one deliverable, save them in a
+>   directory, **number the filenames** (`1_*.png`, `2_*.png`, …) so they preview in
+>   order, and leave `entry_file` unset — the preview renders them as a navigable gallery.
+
+编码两点：多图目录不要设 `entry_file`（否则只显示那一张）；编号文件名让后端文件名升序
+等于预期顺序。不改 tool schema、不加校验，仅引导。已存在未编号的多图 artifact 仍可用
+（alphabetical 兜底）。
+
+## 错误处理与边界
+
+- **空图片列表**（目录只有非图文件）：`/files?filter=image` 返回 `files: []` →
+  `ImagePreview` 渲染 `FallbackPreview`。不崩、不裂图。
+- **列表接口 404**（artifact 已删/跨会话）：fetch 捕获 → `FallbackPreview`。
+- **单图加载失败**（损坏/缺对象）：`ImageViewer` 现有 `onError` → "Failed to load image"。
+- **多图目录却设了 `entry_file`**：启发式用 `entry_file` → 单图模式只显示那一张。接受——
+  agent 显式选了入口；prompt 告诉 agent 画廊别这么做。不静默覆盖显式 `entry_file`。
+- **非 ASCII 文件名**（`1_镇街贷款金额.png`）：`buildPreviewUrl` 路径段已 percent-encode；
+  下载 header 已由 `content_disposition` 修好；预览路由按 key 取字节，文件名不入 header。
+- **版本**：接口收 `?version=`，画廊透传 `selectedVersion`，与 `PdfPreview`/`DataPreview`
+  一致。
+
+无新增失败模式；每个分支都落到现有兜底面。
+
+## 测试
+
+按仓库分层（后端 e2e 管契约/不变量，前端 e2e 管客户端状态机，单测管纯函数）：
+
+**后端 e2e**（`backend/tests/e2e/`）：
+- 多图目录 artifact `GET /files?filter=image` → 返回排序后的图片文件名，非图文件
+  （如 `script.py`）被排除，prefix 已去。（契约 + DB/storage 不变量）
+- `?version=` → 返回该版本文件。
+- artifact 缺失/跨会话 → 404。
+- 跨 workspace → 404（RBAC 不变量）。
+- 过滤后为空 → `files: []`（不报错）。
+
+**前端单测**（vitest）：
+- `previewUtils` 图片扩展名启发式（纯函数）：单图路径不触发列表；目录路径触发列表。
+  顺序由后端定，客户端不测排序。
+
+**前端 e2e**（Playwright，仅后端观测不到的客户端状态机）：
+- 多图 artifact 预览：画廊渲染，←/→ 与箭头导航，计数器 `1/6 → 2/6`。
+- 卡片封面：多图卡显示首图缩略图 + `×6` 角标；单图卡无角标。
+
+无 `content_disposition` 单测（他处已覆盖）；无 DOM count/snapshot 测试。
+
+符合"这测试能抓住 bug 吗"的门槛：后端测抓住坏掉的文件列表契约；前端 e2e 抓住不导航的
+画廊；卡片测抓住缺失封面。

--- a/frontend/packages/web/__tests__/components/ImageCarousel.test.tsx
+++ b/frontend/packages/web/__tests__/components/ImageCarousel.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { Artifact } from '@cubebox/core'
+
+const mockUrl = (file: string) => `/preview/${file}`
+vi.mock('@/components/panel/artifact/previewUtils', () => ({
+  buildPreviewUrl: (_a: unknown, file: string) => mockUrl(file as string),
+}))
+
+// Stub ImageViewer to surface the url it received.
+vi.mock('@/components/shared/previews', () => ({
+  ImageViewer: ({ url }: { url: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element -- test stub
+    <img data-testid="carousel-img" src={url} alt="" />
+  ),
+}))
+
+import { ImageCarousel } from '@/components/panel/artifact/ImageCarousel'
+
+const artifact = {
+  id: 'art-1',
+  conversation_id: 'conv-1',
+  name: 'Charts',
+  artifact_type: 'image' as const,
+  path: '/workspace/charts',
+  entry_file: null,
+  mime_type: null,
+  description: null,
+  created_at: '2026-06-29T00:00:00Z',
+  updated_at: '2026-06-29T00:00:00Z',
+  version: 1,
+} as unknown as Artifact
+
+describe('ImageCarousel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows first image and counter 1/3, navigates with next/prev', () => {
+    render(
+      <ImageCarousel
+        artifact={artifact}
+        imageFiles={['1_a.png', '2_b.png', '3_c.png']}
+        version={1}
+        workspaceId="ws"
+      />,
+    )
+    expect(screen.getByTestId('carousel-img')).toHaveAttribute('src', '/preview/1_a.png')
+    expect(screen.getByText('1 / 3')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Next image'))
+    expect(screen.getByTestId('carousel-img')).toHaveAttribute('src', '/preview/2_b.png')
+    expect(screen.getByText('2 / 3')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Previous image'))
+    expect(screen.getByTestId('carousel-img')).toHaveAttribute('src', '/preview/1_a.png')
+  })
+
+  it('disables prev at start and next at end', () => {
+    render(
+      <ImageCarousel
+        artifact={artifact}
+        imageFiles={['1_a.png', '2_b.png']}
+        version={1}
+        workspaceId="ws"
+      />,
+    )
+    expect(screen.getByLabelText('Previous image')).toBeDisabled()
+    fireEvent.click(screen.getByLabelText('Next image'))
+    expect(screen.getByLabelText('Next image')).toBeDisabled()
+  })
+
+  it('hides nav chrome when single image', () => {
+    render(
+      <ImageCarousel artifact={artifact} imageFiles={['only.png']} version={1} workspaceId="ws" />,
+    )
+    expect(screen.getByTestId('carousel-img')).toHaveAttribute('src', '/preview/only.png')
+    expect(screen.queryByLabelText('Next image')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/packages/web/__tests__/components/previewUtils.test.ts
+++ b/frontend/packages/web/__tests__/components/previewUtils.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { hasImageExt } from '../../components/panel/artifact/previewUtils'
+
+describe('hasImageExt', () => {
+  it('true for image extensions (case-insensitive)', () => {
+    expect(hasImageExt('1_镇街贷款金额.png')).toBe(true)
+    expect(hasImageExt('chart.JPG')).toBe(true)
+    expect(hasImageExt('a.svg')).toBe(true)
+    expect(hasImageExt('a.webp')).toBe(true)
+  })
+
+  it('false for non-image extensions and extensionless names', () => {
+    expect(hasImageExt('charts')).toBe(false)
+    expect(hasImageExt('script.py')).toBe(false)
+    expect(hasImageExt('data.csv')).toBe(false)
+    expect(hasImageExt('')).toBe(false)
+  })
+})

--- a/frontend/packages/web/components/artifacts/ArtifactLibraryCard.tsx
+++ b/frontend/packages/web/components/artifacts/ArtifactLibraryCard.tsx
@@ -8,6 +8,7 @@ import { usePanelStore } from '@cubebox/core'
 import type { Artifact } from '@cubebox/core'
 import { getArtifactIcon } from '@/components/panel/artifact/artifactIcons'
 import { buildDownloadUrl, buildPreviewUrl } from '@/components/panel/artifact/previewUtils'
+import { useArtifactCover } from '@/components/panel/artifact/useArtifactCover'
 import { ArtifactHtmlThumb } from './ArtifactHtmlThumb'
 import {
   DropdownMenu,
@@ -42,14 +43,16 @@ export function ArtifactLibraryCard({
   // Carry the artifact id so the conversation page auto-opens its preview panel.
   const conversationHref = `/w/${workspaceId}/conversations/${artifact.conversation_id}?artifact=${artifact.id}`
 
+  const cover = useArtifactCover(artifact, workspaceId)
   const [thumbFailed, setThumbFailed] = useState(false)
-  const showImage = isImageArtifact(artifact) && !thumbFailed
-  const showHtml = !showImage && isHtmlArtifact(artifact)
-  // Website artifacts default to index.html (matching HtmlPreview); others use
-  // the explicit entry file or the path basename.
-  const fallbackFile = isHtmlArtifact(artifact) ? 'index.html' : ''
-  const thumbFile = artifact.entry_file || artifact.path.split('/').pop() || fallbackFile
-  const thumbUrl = buildPreviewUrl(artifact, thumbFile, null, workspaceId)
+  const isHtml = isHtmlArtifact(artifact)
+  const showImage = isImageArtifact(artifact) && !thumbFailed && cover.coverUrl !== null
+  const showHtml = !showImage && isHtml
+  const fallbackFile = isHtml ? 'index.html' : ''
+  // HTML keeps its own thumb URL; image uses the cover hook result.
+  const thumbUrl = isHtml
+    ? buildPreviewUrl(artifact, artifact.entry_file || fallbackFile, null, workspaceId)
+    : (cover.coverUrl ?? buildPreviewUrl(artifact, '', null, workspaceId))
 
   const handlePreview = useCallback(() => {
     openArtifact(artifact.conversation_id, artifact.id)
@@ -132,6 +135,15 @@ export function ArtifactLibraryCard({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+        {cover.count > 1 && !thumbFailed && (
+          <span
+            className="absolute bottom-2 right-2 rounded-full bg-background/80 px-1.5
+              py-0.5 text-[10px] font-medium text-muted-foreground backdrop-blur-sm"
+            data-testid="artifact-card-count"
+          >
+            ×{cover.count}
+          </span>
+        )}
       </div>
       <div className="min-w-0 p-3">
         <div className="flex items-center gap-2">

--- a/frontend/packages/web/components/panel/artifact/ImageCarousel.tsx
+++ b/frontend/packages/web/components/panel/artifact/ImageCarousel.tsx
@@ -22,6 +22,10 @@ export function ImageCarousel({
   const [index, setIndex] = useState(0)
   const count = imageFiles.length
 
+  // Defensive clamp: the parent remounts this component on version changes,
+  // so `index` stays in range in practice — but never read past the end.
+  const safeIndex = Math.min(index, Math.max(0, count - 1))
+
   const go = useCallback(
     (delta: number) => {
       setIndex((i) => Math.min(count - 1, Math.max(0, i + delta)))
@@ -42,17 +46,17 @@ export function ImageCarousel({
     [go],
   )
 
-  const url = buildPreviewUrl(artifact, imageFiles[index], version, workspaceId)
+  const url = buildPreviewUrl(artifact, imageFiles[safeIndex], version, workspaceId)
 
   return (
     <div className="flex h-full flex-col" tabIndex={0} onKeyDown={onKeyDown}>
       <div className="relative flex-1 overflow-hidden">
-        <ImageViewer url={url} alt={`${artifact.name} ${index + 1}/${count}`} />
+        <ImageViewer url={url} alt={`${artifact.name} ${safeIndex + 1}/${count}`} />
         {count > 1 && (
           <>
             <button
               onClick={() => go(-1)}
-              disabled={index === 0}
+              disabled={safeIndex === 0}
               aria-label="Previous image"
               className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70
                 p-1.5 text-foreground backdrop-blur-sm transition-colors hover:bg-background
@@ -62,7 +66,7 @@ export function ImageCarousel({
             </button>
             <button
               onClick={() => go(1)}
-              disabled={index === count - 1}
+              disabled={safeIndex === count - 1}
               aria-label="Next image"
               className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70
                 p-1.5 text-foreground backdrop-blur-sm transition-colors hover:bg-background
@@ -75,7 +79,7 @@ export function ImageCarousel({
               bg-background/70 px-2 py-0.5 text-xs tabular-nums text-muted-foreground
               backdrop-blur-sm"
             >
-              {index + 1} / {count}
+              {safeIndex + 1} / {count}
             </div>
           </>
         )}

--- a/frontend/packages/web/components/panel/artifact/ImageCarousel.tsx
+++ b/frontend/packages/web/components/panel/artifact/ImageCarousel.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import type { Artifact } from '@cubebox/core'
+import { buildPreviewUrl } from './previewUtils'
+import { ImageViewer } from '@/components/shared/previews'
+
+interface ImageCarouselProps {
+  artifact: Artifact
+  imageFiles: string[]
+  version: number | null
+  workspaceId: string
+}
+
+export function ImageCarousel({
+  artifact,
+  imageFiles,
+  version,
+  workspaceId,
+}: ImageCarouselProps): React.ReactElement {
+  const [index, setIndex] = useState(0)
+  const count = imageFiles.length
+
+  const go = useCallback(
+    (delta: number) => {
+      setIndex((i) => Math.min(count - 1, Math.max(0, i + delta)))
+    },
+    [count],
+  )
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        go(-1)
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        go(1)
+      }
+    },
+    [go],
+  )
+
+  const url = buildPreviewUrl(artifact, imageFiles[index], version, workspaceId)
+
+  return (
+    <div className="flex h-full flex-col" tabIndex={0} onKeyDown={onKeyDown}>
+      <div className="relative flex-1 overflow-hidden">
+        <ImageViewer url={url} alt={`${artifact.name} ${index + 1}/${count}`} />
+        {count > 1 && (
+          <>
+            <button
+              onClick={() => go(-1)}
+              disabled={index === 0}
+              aria-label="Previous image"
+              className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70
+                p-1.5 text-foreground backdrop-blur-sm transition-colors hover:bg-background
+                disabled:opacity-30"
+            >
+              <ChevronLeft className="size-5" />
+            </button>
+            <button
+              onClick={() => go(1)}
+              disabled={index === count - 1}
+              aria-label="Next image"
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70
+                p-1.5 text-foreground backdrop-blur-sm transition-colors hover:bg-background
+                disabled:opacity-30"
+            >
+              <ChevronRight className="size-5" />
+            </button>
+            <div
+              className="absolute bottom-2 left-1/2 -translate-x-1/2 rounded-full
+              bg-background/70 px-2 py-0.5 text-xs tabular-nums text-muted-foreground
+              backdrop-blur-sm"
+            >
+              {index + 1} / {count}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/packages/web/components/panel/artifact/ImagePreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/ImagePreview.tsx
@@ -1,8 +1,12 @@
 'use client'
 
+import { useState, useEffect } from 'react'
 import type { Artifact } from '@cubebox/core'
-import { buildPreviewUrl } from './previewUtils'
+import { buildPreviewUrl, hasImageExt } from './previewUtils'
 import { ImageViewer } from '@/components/shared/previews'
+import { PreviewLoading } from './PreviewLoading'
+import { FallbackPreview } from './FallbackPreview'
+import { ImageCarousel } from './ImageCarousel'
 
 interface ImagePreviewProps {
   artifact: Artifact
@@ -10,9 +14,71 @@ interface ImagePreviewProps {
   workspaceId: string
 }
 
-export function ImagePreview({ artifact, version, workspaceId }: ImagePreviewProps) {
-  const filename = artifact.path.split('/').pop() || 'image'
-  const previewUrl = buildPreviewUrl(artifact, filename, version, workspaceId)
+interface FilesResponse {
+  version: number
+  files: string[]
+}
 
-  return <ImageViewer url={previewUrl} alt={artifact.name} />
+export function ImagePreview({
+  artifact,
+  version,
+  workspaceId,
+}: ImagePreviewProps): React.ReactElement {
+  const filename = artifact.entry_file || artifact.path.split('/').pop() || ''
+
+  const v = version ?? artifact.version
+  const [files, setFiles] = useState<string[] | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    if (hasImageExt(filename)) return
+    let cancelled = false
+    const url =
+      `/api/v1/ws/${workspaceId}/conversations/${artifact.conversation_id}` +
+      `/artifacts/${artifact.id}/files?filter=image&version=${v}`
+    fetch(url)
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status}`)
+        return res.json() as Promise<FilesResponse>
+      })
+      .then((body) => {
+        if (!cancelled) setFiles(body.files)
+      })
+      .catch(() => {
+        if (!cancelled) setError(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [artifact.id, artifact.conversation_id, v, workspaceId, filename])
+
+  // Heuristic: a path that already points at an image file → single image,
+  // no list call. Otherwise (directory like /workspace/charts) fetch the
+  // file list and render a carousel.
+  if (hasImageExt(filename)) {
+    const url = buildPreviewUrl(artifact, filename, version, workspaceId)
+    return <ImageViewer url={url} alt={artifact.name} />
+  }
+
+  if (error) {
+    return <FallbackPreview artifact={artifact} version={version} workspaceId={workspaceId} />
+  }
+  if (files === null) {
+    return <PreviewLoading />
+  }
+  if (files.length === 0) {
+    return <FallbackPreview artifact={artifact} version={version} workspaceId={workspaceId} />
+  }
+  if (files.length === 1) {
+    const url = buildPreviewUrl(artifact, files[0], version, workspaceId)
+    return <ImageViewer url={url} alt={artifact.name} />
+  }
+  return (
+    <ImageCarousel
+      artifact={artifact}
+      imageFiles={files}
+      version={version}
+      workspaceId={workspaceId}
+    />
+  )
 }

--- a/frontend/packages/web/components/panel/artifact/ImagePreview.tsx
+++ b/frontend/packages/web/components/panel/artifact/ImagePreview.tsx
@@ -27,7 +27,10 @@ export function ImagePreview({
   const filename = artifact.entry_file || artifact.path.split('/').pop() || ''
 
   const v = version ?? artifact.version
-  const [files, setFiles] = useState<string[] | null>(null)
+  // Tag the cached file list with the version it was fetched for, so a
+  // version switch shows loading instead of the old version's images while
+  // the new /files request is in flight.
+  const [data, setData] = useState<{ files: string[]; version: number } | null>(null)
   const [error, setError] = useState(false)
 
   useEffect(() => {
@@ -42,7 +45,7 @@ export function ImagePreview({
         return res.json() as Promise<FilesResponse>
       })
       .then((body) => {
-        if (!cancelled) setFiles(body.files)
+        if (!cancelled) setData({ files: body.files, version: v })
       })
       .catch(() => {
         if (!cancelled) setError(true)
@@ -63,9 +66,11 @@ export function ImagePreview({
   if (error) {
     return <FallbackPreview artifact={artifact} version={version} workspaceId={workspaceId} />
   }
-  if (files === null) {
+  // No data yet, or data is from a different version than the one selected.
+  if (!data || data.version !== v) {
     return <PreviewLoading />
   }
+  const files = data.files
   if (files.length === 0) {
     return <FallbackPreview artifact={artifact} version={version} workspaceId={workspaceId} />
   }

--- a/frontend/packages/web/components/panel/artifact/previewUtils.ts
+++ b/frontend/packages/web/components/panel/artifact/previewUtils.ts
@@ -17,6 +17,14 @@ export function buildPreviewUrl(
   )
 }
 
+export const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp'])
+
+export function hasImageExt(filename: string): boolean {
+  const dot = filename.lastIndexOf('.')
+  if (dot < 0) return false
+  return IMAGE_EXTENSIONS.has(filename.slice(dot + 1).toLowerCase())
+}
+
 export function buildDownloadUrl(
   artifact: Artifact,
   workspaceId: string,

--- a/frontend/packages/web/components/panel/artifact/useArtifactCover.ts
+++ b/frontend/packages/web/components/panel/artifact/useArtifactCover.ts
@@ -17,7 +17,7 @@ interface CoverState {
 
 export function useArtifactCover(artifact: Artifact, workspaceId: string): CoverState {
   const filename = artifact.entry_file || artifact.path.split('/').pop() || ''
-  const { id, conversation_id, version: artifactVersion } = artifact
+  const { id, conversation_id } = artifact
 
   // Hooks FIRST — before any early return (rules-of-hooks).
   const [state, setState] = useState<CoverState>({
@@ -40,13 +40,7 @@ export function useArtifactCover(artifact: Artifact, workspaceId: string): Cover
       .then((body) => {
         if (cancelled) return
         const first = body.files[0]
-        // Build preview URL inline so the effect doesn't reference the full
-        // artifact object, keeping the dep array narrow and clean.
-        const v = artifactVersion
-        const coverUrl = first
-          ? `/api/v1/ws/${workspaceId}/conversations/${conversation_id}` +
-            `/artifacts/${id}/preview/v${v}/${first}`
-          : null
+        const coverUrl = first ? buildPreviewUrl(artifact, first, null, workspaceId) : null
         setState({
           coverUrl,
           count: body.files.length,
@@ -59,7 +53,7 @@ export function useArtifactCover(artifact: Artifact, workspaceId: string): Cover
     return () => {
       cancelled = true
     }
-  }, [id, conversation_id, artifactVersion, workspaceId, filename])
+  }, [id, conversation_id, artifact, workspaceId, filename])
 
   // Single image path -> cover is that file, no list call, count 1.
   // (Computed as plain const, not via hook -- hooks are already at the top.)

--- a/frontend/packages/web/components/panel/artifact/useArtifactCover.ts
+++ b/frontend/packages/web/components/panel/artifact/useArtifactCover.ts
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import type { Artifact } from '@cubebox/core'
+import { buildPreviewUrl, hasImageExt } from './previewUtils'
+
+interface FilesResponse {
+  version: number
+  files: string[]
+}
+
+interface CoverState {
+  coverUrl: string | null
+  count: number
+  loading: boolean
+}
+
+export function useArtifactCover(artifact: Artifact, workspaceId: string): CoverState {
+  const filename = artifact.entry_file || artifact.path.split('/').pop() || ''
+  const { id, conversation_id, version: artifactVersion } = artifact
+
+  // Hooks FIRST — before any early return (rules-of-hooks).
+  const [state, setState] = useState<CoverState>({
+    coverUrl: null,
+    count: 0,
+    loading: true,
+  })
+
+  useEffect(() => {
+    if (hasImageExt(filename)) return
+    let cancelled = false
+    const url =
+      `/api/v1/ws/${workspaceId}/conversations/${conversation_id}` +
+      `/artifacts/${id}/files?filter=image`
+    fetch(url)
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status}`)
+        return res.json() as Promise<FilesResponse>
+      })
+      .then((body) => {
+        if (cancelled) return
+        const first = body.files[0]
+        // Build preview URL inline so the effect doesn't reference the full
+        // artifact object, keeping the dep array narrow and clean.
+        const v = artifactVersion
+        const coverUrl = first
+          ? `/api/v1/ws/${workspaceId}/conversations/${conversation_id}` +
+            `/artifacts/${id}/preview/v${v}/${first}`
+          : null
+        setState({
+          coverUrl,
+          count: body.files.length,
+          loading: false,
+        })
+      })
+      .catch(() => {
+        if (!cancelled) setState({ coverUrl: null, count: 0, loading: false })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, conversation_id, artifactVersion, workspaceId, filename])
+
+  // Single image path -> cover is that file, no list call, count 1.
+  // (Computed as plain const, not via hook -- hooks are already at the top.)
+  if (hasImageExt(filename)) {
+    return {
+      coverUrl: buildPreviewUrl(artifact, filename, null, workspaceId),
+      count: 1,
+      loading: false,
+    }
+  }
+
+  return state
+}


### PR DESCRIPTION
## What

Makes a **directory of images saved as a single `image` artifact** previewable, instead of 404ing. Also fixes a CJK-filename crash in the sandbox download route.

## Background

An agent run saved 6 PNGs under `/workspace/charts` as one image artifact (`entry_file=null`, `mime_type=null`). The preview panel computed the filename as the path basename `"charts"`, requested `/preview/v1/charts`, and 404'd — because object-store keys are stored by relpath (`1_*.png`, `2_*.png`, …), never `charts`. Download worked (multi-file → tar), preview had no concept of an image set.

## Changes

**Backend**
- New `GET /ws/{ws}/conversations/{conv}/artifacts/{id}/files?filter=image&version=N` endpoint — lists stored files for a version, prefix-stripped, sorted ascending, optional image-extension filter. Reuses `list_objects` + `_require_conversation` + `ArtifactRepository` scoping (same pattern as `download_artifact`).
- `ws_sandbox.py` download: use existing `content_disposition` helper for the `Content-Disposition` header — fixes `UnicodeEncodeError` on CJK filenames (latin-1).
- `ARTIFACT_PROMPT` image bullet: guide agents to number filenames (`1_*.png`, …) and leave `entry_file` unset for multi-image dirs.

**Frontend**
- `ImagePreview` heuristic: path points at an image file → single `ImageViewer` (no fetch); otherwise fetch `/files?filter=image` → carousel (≥2), single image (1), or `FallbackPreview` (0/error). Cached file list is version-tagged so a version switch shows loading instead of the old version's images.
- `ImageCarousel` — new component, reuses `ImageViewer` (zoom/rotate) + prev/next arrows, `3 / 6` counter, keyboard ←/→, defensive index clamp.
- `useArtifactCover` hook + `ArtifactLibraryCard` — multi-image card shows the first image as a cover thumbnail with a `×N` count badge; single-image cards unchanged (no extra fetch).
- `previewUtils` — shared `IMAGE_EXTENSIONS` + `hasImageExt` (matches the backend set).

## Tests
- Backend e2e (`test_artifact_files.py`): filter+sort, no-filter, `?version=`, empty-filter → `[]`, missing-artifact 404, cross-workspace 404 (RBAC).
- Frontend unit: `hasImageExt` heuristic.
- Frontend component test: `ImageCarousel` navigation state machine (next/prev, disabled bounds, single-image hides chrome).
- Pre-push `check-ci` green: build-core + lint + format + type-check + vitest + next build.

## Review
Two local codex review rounds (no \`@codex\`): R1 found 1 MEDIUM (preview state not reset on version change), fixed in \`9a15d36f\`; R2 confirmed no CRITICAL/HIGH.

## Out of scope
- Share page public preview (`/api/v1/shares/...`) — separate token flow, unchanged.
- Non-image directory file browser — gallery handles images only.

## Manual verification still needed
Real multi-image artifact: card cover + \`×N\` badge, carousel nav + counter, download tar, and single-image / non-image-dir regression.