### PR TITLE
perf: cut chat turn latency (send→first-token, last-token→done)

### DIFF
--- a/backend/cubebox/agents/checkpointer.py
+++ b/backend/cubebox/agents/checkpointer.py
@@ -1,12 +1,19 @@
 """cubepi-backed Postgres checkpointer for cubebox.
 
-Thin wrapper around ``cubepi.PostgresCheckpointer``. Owns the connection
-pool lifecycle and exposes a context-manager init for use in cubebox's
-agent factory.
+Thin wrapper around ``cubepi.PostgresCheckpointer``. Two access modes:
+
+- ``shared_checkpointer()`` — the process-wide instance backed by one
+  asyncpg pool, opened lazily and closed by the app lifespan. All
+  request/run hot paths use this; opening a pool per call added a
+  TCP+auth+schema-check round trip to every send.
+- ``init_checkpointer()`` — owns a private pool for the duration of the
+  context. For CLI scripts, workers with their own event loop, and tests
+  that need isolation.
 """
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from urllib.parse import quote_plus
@@ -56,3 +63,57 @@ async def init_checkpointer(
     )
     async with cp:
         yield cp
+
+
+# asyncpg pools are bound to the event loop that created them. In the app
+# there is exactly one loop for the process lifetime, so this is a plain
+# process-wide singleton. Tests (anyio) run each case on a fresh loop —
+# keying by the running loop keeps a stale pool from a torn-down loop from
+# poisoning the next case; entries for dead loops are dropped, not closed
+# (their loop is gone; the OS reaps the sockets).
+_shared_by_loop: dict[int, PostgresCheckpointer] = {}
+_shared_locks: dict[int, asyncio.Lock] = {}
+
+
+async def get_shared_checkpointer() -> PostgresCheckpointer:
+    """Return this loop's shared checkpointer, opening its pool on first use.
+
+    The app lifespan warms it at startup and closes it on shutdown. CLI
+    scripts and workers with their own short-lived loops should prefer
+    ``init_checkpointer()``.
+    """
+    loop_id = id(asyncio.get_running_loop())
+    cp = _shared_by_loop.get(loop_id)
+    if cp is not None:
+        return cp
+    lock = _shared_locks.setdefault(loop_id, asyncio.Lock())
+    async with lock:
+        cp = _shared_by_loop.get(loop_id)
+        if cp is None:
+            cp = PostgresCheckpointer(
+                dsn=_build_dsn(),
+                min_pool_size=int(_config.get("database.cubepi_pool_min", 1)),
+                max_pool_size=int(_config.get("database.cubepi_pool_max", 10)),
+            )
+            await cp.__aenter__()
+            _shared_by_loop[loop_id] = cp
+    return cp
+
+
+@asynccontextmanager
+async def shared_checkpointer() -> AsyncIterator[PostgresCheckpointer]:
+    """Context-manager view of the shared checkpointer (never closes it).
+
+    Drop-in replacement for hot-path ``async with init_checkpointer()``
+    blocks: same usage shape, no per-call pool churn.
+    """
+    yield await get_shared_checkpointer()
+
+
+async def close_shared_checkpointer() -> None:
+    """Close this loop's shared pool. Called by the app lifespan on shutdown."""
+    loop_id = id(asyncio.get_running_loop())
+    _shared_locks.pop(loop_id, None)
+    cp = _shared_by_loop.pop(loop_id, None)
+    if cp is not None:
+        await cp.__aexit__(None, None, None)

--- a/backend/cubebox/api/app.py
+++ b/backend/cubebox/api/app.py
@@ -372,6 +372,16 @@ async def lifespan(_app: FastAPI):  # type: ignore
 
     await recover_stranded_runs(redis_client, prefix=_app.state.redis_key_prefix)
 
+    # Warm the process-wide cubepi checkpointer pool so the first send
+    # doesn't pay the pool-open round trips. Best-effort: on failure the
+    # first shared_checkpointer() call retries the open.
+    from cubebox.agents.checkpointer import get_shared_checkpointer
+
+    try:
+        await get_shared_checkpointer()
+    except Exception as exc:
+        logger.warning("Shared checkpointer warmup failed (will retry lazily): {}", exc)
+
     yield
 
     # ==================== Shutdown ====================
@@ -412,6 +422,12 @@ async def lifespan(_app: FastAPI):  # type: ignore
             await tracer.shutdown()
         except Exception as exc:  # tracing teardown must never break shutdown
             logger.warning("Tracer shutdown failed: {}", exc)
+    from cubebox.agents.checkpointer import close_shared_checkpointer
+
+    try:
+        await close_shared_checkpointer()
+    except Exception as exc:
+        logger.warning("Shared checkpointer close failed: {}", exc)
     if redis_client is not None:
         await redis_client.aclose()
     mcp_oauth_http_client = getattr(_app.state, "_mcp_oauth_http_client", None)

--- a/backend/cubebox/api/routes/v1/conversations.py
+++ b/backend/cubebox/api/routes/v1/conversations.py
@@ -1322,10 +1322,10 @@ async def send_message(
                     workspace_id=ctx.workspace_id,
                     user_id=ctx.user.id,
                 )
-                from cubebox.agents.checkpointer import init_checkpointer
+                from cubebox.agents.checkpointer import shared_checkpointer
 
                 now = time.time()
-                async with init_checkpointer() as _cp:
+                async with shared_checkpointer() as _cp:
                     await _cp.append(
                         conversation_id,
                         [
@@ -1525,6 +1525,7 @@ async def send_message(
             ctx=run_ctx,
             model_key=effective_model_key,
             reasoning=request_obj.reasoning,
+            llm_snapshot=_snap,
         )
     except RuntimeError as exc:
         raise HTTPException(
@@ -1557,9 +1558,9 @@ async def _load_pending_hitl(
     conversation_id: str,
 ) -> tuple[Any, str | None]:
     """Read cubepi-persisted pending_request + persisted run_id in one checkpointer open."""
-    from cubebox.agents.checkpointer import init_checkpointer
+    from cubebox.agents.checkpointer import shared_checkpointer
 
-    async with init_checkpointer() as cp:
+    async with shared_checkpointer() as cp:
         pending_req = await cp.load_pending_request(conversation_id)
         persisted_run_id = await cp.load_pending_run_id(conversation_id)
     return pending_req, persisted_run_id
@@ -1910,7 +1911,7 @@ async def cancel_active_run(
         rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
     )
 
-    from cubebox.agents.checkpointer import init_checkpointer
+    from cubebox.agents.checkpointer import shared_checkpointer
 
     run_manager = raw_request.app.state.run_manager
     run_ctx = RunContext(
@@ -1931,7 +1932,7 @@ async def cancel_active_run(
     if active_run is not None and active_run.status == "paused_hitl":
         paused_run_id = active_run.run_id
     elif active_run is None:
-        async with init_checkpointer() as _cp:
+        async with shared_checkpointer() as _cp:
             persisted_run_id = await _cp.load_pending_run_id(conversation_id)
         if persisted_run_id is not None:
             paused_run_id = persisted_run_id
@@ -2128,7 +2129,7 @@ async def submit_sandbox_confirm(
 
     from cubepi.hitl.types import ApproveAnswer
 
-    from cubebox.agents.checkpointer import init_checkpointer
+    from cubebox.agents.checkpointer import shared_checkpointer
 
     active_run = await get_active_run(
         rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
@@ -2136,11 +2137,11 @@ async def submit_sandbox_confirm(
     if active_run is not None:
         run_id = active_run.run_id
     else:
-        async with init_checkpointer() as _cp:
+        async with shared_checkpointer() as _cp:
             persisted_run_id = await _cp.load_pending_run_id(conversation_id)
         if persisted_run_id is None:
             # Distinguish 404 no_pending vs 500 missing_run_id legacy row.
-            async with init_checkpointer() as _cp:
+            async with shared_checkpointer() as _cp:
                 if await _cp.load_pending_request(conversation_id) is None:
                     raise HTTPException(status_code=404, detail={"code": "no_pending"})
             raise HTTPException(
@@ -2234,7 +2235,7 @@ async def submit_ask_user_answer(
         _topic_creator_user_id,
     ) = await _resolve_topic_run_context(conversation, ctx, session=session)
 
-    from cubebox.agents.checkpointer import init_checkpointer
+    from cubebox.agents.checkpointer import shared_checkpointer
 
     active_run = await get_active_run(
         rds.client, prefix=rds.key_prefix, conversation_id=conversation_id
@@ -2242,11 +2243,11 @@ async def submit_ask_user_answer(
     if active_run is not None:
         run_id = active_run.run_id
     else:
-        async with init_checkpointer() as _cp:
+        async with shared_checkpointer() as _cp:
             persisted_run_id = await _cp.load_pending_run_id(conversation_id)
         if persisted_run_id is None:
             # Distinguish 404 no_pending vs 500 missing_run_id legacy row.
-            async with init_checkpointer() as _cp:
+            async with shared_checkpointer() as _cp:
                 if await _cp.load_pending_request(conversation_id) is None:
                     raise HTTPException(status_code=404, detail={"code": "no_pending"})
             raise HTTPException(

--- a/backend/cubebox/im/resume.py
+++ b/backend/cubebox/im/resume.py
@@ -210,9 +210,9 @@ async def resolve_full_question_id(run_id: str, short_qid: str) -> str:
             return short_qid
         conversation_id = resolved[0]
 
-        from cubebox.agents.checkpointer import init_checkpointer
+        from cubebox.agents.checkpointer import shared_checkpointer
 
-        async with init_checkpointer() as cp:
+        async with shared_checkpointer() as cp:
             pending = await cp.load_pending_request(conversation_id)
         if pending is not None and pending.question_id.startswith(short_qid):
             return pending.question_id

--- a/backend/cubebox/mcp/cubepi_runtime.py
+++ b/backend/cubebox/mcp/cubepi_runtime.py
@@ -123,6 +123,167 @@ async def load_workspace_mcp_tools_for_cubepi(
     )
 
 
+def _build_tools_from_cache(
+    *,
+    spec: MCPRuntimeConnectorSpec,
+    headers: dict[str, str],
+    server_url: str,
+) -> list[AgentTool[Any]] | None:
+    """Build executable AgentTools from the install's persisted ``tools_cache``.
+
+    Skips the per-send ``initialize`` + ``tools/list`` round trip: the cache
+    already carries every field the live loader would extract from the
+    descriptor (name / description / input_schema), and cubepi MCP tools
+    open a fresh session per ``tools/call`` anyway, so execution is
+    identical to a live-discovered tool.
+
+    Returns None when the cache is unusable (empty, or cubepi's private
+    helpers moved) — callers fall back to the live loader.
+
+    NOTE: reaches into ``cubepi.mcp``'s private modules for the session
+    opener and result serializer the live loader uses. cubepi doesn't yet
+    expose "build tool from cached descriptor" publicly; upstream that
+    instead of growing this.
+    """
+    if not spec.tools_cache:
+        return None
+    try:
+        from cubepi.mcp._adapter import make_mcp_agent_tool
+        from cubepi.mcp.http_loader import (
+            _open_session,
+            _serialize_call_tool_response,
+            _split_address,
+        )
+    except ImportError as exc:  # cubepi internals moved — live loader still works
+        logger.warning("tools_cache fast path unavailable (cubepi drift): %s", exc)
+        return None
+
+    timeout = spec.timeout
+    transport = cast(MCPTransport, spec.transport)
+
+    async def _call_remote(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        # Mirrors cubepi.mcp.http_loader's per-call session semantics,
+        # including W3C traceparent propagation into the MCP server.
+        from cubepi.mcp._tracing import current_traceparent
+
+        call_headers = headers or None
+        tp = current_traceparent()
+        if tp is not None:
+            call_headers = {**(headers or {}), "traceparent": tp}
+        async with _open_session(
+            server_url, headers=call_headers, timeout=timeout, transport=transport
+        ) as (session, _get_session_id):
+            await asyncio.wait_for(session.initialize(), timeout=timeout)
+            resp = await asyncio.wait_for(session.call_tool(tool_name, args), timeout=timeout)
+            return _serialize_call_tool_response(resp)
+
+    address, port = _split_address(server_url)
+    tools: list[AgentTool[Any]] = []
+    for entry in spec.tools_cache:
+        name = entry.get("name")
+        if not name:
+            continue
+        try:
+            tools.append(
+                make_mcp_agent_tool(
+                    name=name,
+                    description=entry.get("description") or "",
+                    input_schema=entry.get("input_schema") or {"type": "object", "properties": {}},
+                    call_remote=_call_remote,
+                    server_address=address,
+                    server_port=port,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — one bad cached schema must not sink the rest
+            logger.warning("tools_cache entry %s/%s failed to build: %s", spec.name, name, exc)
+    return tools or None
+
+
+_cache_refresh_in_flight: set[str] = set()
+
+
+def schedule_tools_cache_refresh(
+    *,
+    specs: list[MCPRuntimeConnectorSpec],
+    actor_user_id: str,
+    encryption_backend: Any,
+    http_client: Any,
+    metadata_discovery: Any,
+    redis: Any,
+    signer: MCPUserTokenSigner,
+) -> None:
+    """Kick detached re-discovery for installs whose ``tools_cache`` is stale.
+
+    Never blocks or raises into the send path. Debounced per install via an
+    in-process set; the TTL gate (``mcp.tools_cache_ttl_hours``, default 24)
+    bounds cross-process stampedes to one refresh per process per TTL.
+    """
+    from datetime import UTC, datetime
+    from datetime import timedelta as _td
+
+    from cubebox.config import config as _cfg
+
+    try:
+        ttl_hours = float(_cfg.get("mcp.tools_cache_ttl_hours", 24))
+    except Exception:  # noqa: BLE001
+        ttl_hours = 24.0
+    if ttl_hours <= 0:
+        return
+    now = datetime.now(UTC)
+
+    async def _refresh_one(spec: MCPRuntimeConnectorSpec) -> None:
+        from cubebox.credentials.dependencies import build_credential_service
+        from cubebox.db.engine import async_session_maker
+        from cubebox.repositories.credential import CredentialRepository
+        from cubebox.services.mcp_discovery import run_post_grant_discovery
+
+        try:
+            async with async_session_maker() as session:
+                cred_service = build_credential_service(
+                    session,
+                    encryption_backend,
+                    org_id=spec.org_id,
+                    actor_user_id=actor_user_id,
+                )
+                token_mgr = OAuthTokenManager(
+                    http_client=http_client,
+                    redis=redis,
+                    encryption_backend=encryption_backend,
+                    credential_repo=CredentialRepository(session, org_id=spec.org_id),
+                    metadata=metadata_discovery,
+                )
+                await run_post_grant_discovery(
+                    install_id=spec.install_id,
+                    workspace_id=spec.workspace_id or None,
+                    actor_user_id=actor_user_id,
+                    session=session,
+                    cred_service=cred_service,
+                    signer=signer,
+                    token_mgr=token_mgr,
+                )
+                await session.commit()
+        except Exception as exc:  # noqa: BLE001 — background refresh must never surface
+            logger.warning("tools_cache refresh failed for %s: %s", spec.install_id, exc)
+        finally:
+            _cache_refresh_in_flight.discard(spec.install_id)
+
+    for spec in specs:
+        if not spec.tools_cache:
+            continue  # nothing cached — the send path already live-loads
+        last = spec.last_discovered_at
+        if last is not None and last.tzinfo is None:
+            last = last.replace(tzinfo=UTC)
+        if last is not None and now - last < _td(hours=ttl_hours):
+            continue
+        if spec.install_id in _cache_refresh_in_flight:
+            continue
+        _cache_refresh_in_flight.add(spec.install_id)
+        task = asyncio.create_task(_refresh_one(spec), name=f"mcp-cache-refresh:{spec.install_id}")
+        # Detached by design; reference kept alive by the event loop via the
+        # in-flight set lifecycle inside _refresh_one.
+        del task
+
+
 async def _load_tools_for_specs(
     *,
     specs: list[MCPRuntimeConnectorSpec],
@@ -186,24 +347,30 @@ async def _load_tools_for_specs(
             )
             continue
 
-        try:
-            discovery = await load_mcp_tools_http(
-                server_url,
-                headers=headers or None,
-                timeout=spec.timeout,
-                transport=cast(MCPTransport, spec.transport),
-            )
-            tools = discovery.tools
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "Failed to load MCP install %s (%s): %s",
-                spec.name,
-                spec.install_id,
-                exc,
-            )
-            continue
+        # Cache-first: build tools from the persisted tools_cache and skip
+        # the live initialize+tools/list round trip. Falls back to live
+        # discovery when the cache is empty/unusable (e.g. first run before
+        # discovery persisted, or cubepi internals drifted).
+        tools = _build_tools_from_cache(spec=spec, headers=headers, server_url=server_url)
+        if tools is None:
+            try:
+                discovery = await load_mcp_tools_http(
+                    server_url,
+                    headers=headers or None,
+                    timeout=spec.timeout,
+                    transport=cast(MCPTransport, spec.transport),
+                )
+                tools = discovery.tools
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to load MCP install %s (%s): %s",
+                    spec.name,
+                    spec.install_id,
+                    exc,
+                )
+                continue
 
         slug = proposed_slugs[spec.install_id]
         explicit_collision = slug_counts[slug] > 1

--- a/backend/cubebox/mcp/effective.py
+++ b/backend/cubebox/mcp/effective.py
@@ -240,6 +240,9 @@ class MCPRuntimeConnectorSpec:
     # built from one ``list_runtime_specs`` call without re-reading
     # install rows.
     discovery_metadata: dict[str, Any] = field(default_factory=dict)
+    # When ``tools_cache`` was last refreshed; the runtime loader uses it
+    # to decide whether to kick a background re-discovery.
+    last_discovered_at: datetime | None = None
     # Static-auth shape (see ``MCPConnectorInstall``/``MCPConnectorTemplate``).
     # ``bearer`` (default) ⇒ ``Authorization: Bearer <token>``;
     # ``header`` ⇒ inject ``static_auth_header_name: <token>``;
@@ -352,6 +355,7 @@ class MCPEffectiveConnectorService:
                     grant=row.grant,
                     oauth_client_config=dict(install.oauth_client_config or {}),
                     discovery_metadata=dict(install.discovery_metadata or {}),
+                    last_discovered_at=install.last_discovered_at,
                     static_auth_style=install.static_auth_style or "bearer",
                     static_auth_header_name=install.static_auth_header_name,
                     static_auth_query_param=install.static_auth_query_param,

--- a/backend/cubebox/repositories/conversation.py
+++ b/backend/cubebox/repositories/conversation.py
@@ -17,7 +17,7 @@ from cubepi.checkpointer.exceptions import (
 from sqlalchemy import and_, case, desc, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from cubebox.agents.checkpointer import init_checkpointer
+from cubebox.agents.checkpointer import shared_checkpointer
 from cubebox.models import Conversation
 from cubebox.models.conversation_participant import ConversationParticipant
 from cubebox.models.public_id import generate_public_id
@@ -320,7 +320,7 @@ class ConversationRepository(ScopedRepository[Conversation]):
             "forked_at": utc_isoformat(datetime.now(UTC)),
         }
         try:
-            async with init_checkpointer() as cp:
+            async with shared_checkpointer() as cp:
                 await cp.fork(
                     src.id,
                     new_id,

--- a/backend/cubebox/services/conversation_search/worker.py
+++ b/backend/cubebox/services/conversation_search/worker.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from collections.abc import Sequence
 
-from cubebox.agents.checkpointer import init_checkpointer
+from cubebox.agents.checkpointer import shared_checkpointer
 from cubebox.config import config
 from cubebox.db.engine import async_session_maker
 from cubebox.models.conversation_chunk import ConversationChunk
@@ -87,7 +87,7 @@ class EmbeddingWorker:
 
     async def _process(self, job: EmbeddingJob) -> None:
         # 1. Load all messages for the conversation (cubepi load is per-thread).
-        async with init_checkpointer() as cp:
+        async with shared_checkpointer() as cp:
             data = await cp.load(job.conversation_id)
         if data is None:
             return

--- a/backend/cubebox/services/conversation_sharing.py
+++ b/backend/cubebox/services/conversation_sharing.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from loguru import logger
 
-from cubebox.agents.checkpointer import init_checkpointer
+from cubebox.agents.checkpointer import shared_checkpointer
 from cubebox.objectstore.client import get_objectstore_client
 
 _ATTACHMENT_KEEP_KEYS = {"filename", "mime_type", "size"}
@@ -53,7 +53,7 @@ async def build_snapshot(conversation_id: str) -> list[dict[str, Any]]:
     """Load messages from cubepi checkpointer, filter for public snapshot."""
     from cubebox.agents.stream import unwrap_deferred_in_message_dicts
 
-    async with init_checkpointer() as cp:
+    async with shared_checkpointer() as cp:
         data = await cp.load(conversation_id)
     if data is None:
         return []

--- a/backend/cubebox/services/memory_consolidation.py
+++ b/backend/cubebox/services/memory_consolidation.py
@@ -241,7 +241,7 @@ async def run_consolidation(
     """
     from cubepi.providers.base import Message, TextContent, UserMessage
 
-    from cubebox.agents.checkpointer import init_checkpointer
+    from cubebox.agents.checkpointer import shared_checkpointer
     from cubebox.repositories.memory import MemoryRepository
 
     token = await acquire_lock(redis, prefix, conversation_id, ttl_s=LOCK_TTL_S)
@@ -250,7 +250,7 @@ async def run_consolidation(
     cutoff = time.time()
     consumed = await _counter(redis, prefix, conversation_id)
     try:
-        async with init_checkpointer() as cp:
+        async with shared_checkpointer() as cp:
             data = await cp.load(conversation_id)
         if data is None or not data.messages:
             await mark_consolidated(

--- a/backend/cubebox/streams/recovery.py
+++ b/backend/cubebox/streams/recovery.py
@@ -55,10 +55,10 @@ async def recover_stranded_runs(redis: Redis, *, prefix: str) -> int:
 
 async def _stamp_cubepi_runs(pairs: list[tuple[str, str]]) -> None:
     """Mark stranded cubepi_runs rows as completed so history is consistent."""
-    from cubebox.agents.checkpointer import init_checkpointer
+    from cubebox.agents.checkpointer import shared_checkpointer
 
     try:
-        async with init_checkpointer() as cp:
+        async with shared_checkpointer() as cp:
             for thread_id, run_id in pairs:
                 try:
                     await cp.mark_run_complete(thread_id, run_id)

--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -619,9 +619,9 @@ async def _repair_dangling_tool_calls(conversation_id: str) -> None:
         ToolResultMessage,
     )
 
-    from cubebox.agents.checkpointer import init_checkpointer
+    from cubebox.agents.checkpointer import shared_checkpointer
 
-    async with init_checkpointer() as cp:
+    async with shared_checkpointer() as cp:
         data = await cp.load(conversation_id)
         if data is None or not data.messages:
             return
@@ -902,6 +902,7 @@ class RunManager:
         model_key: str | None = None,
         reasoning: ReasoningControl | None = None,
         cancel_pending_hitl: bool = False,
+        llm_snapshot: Any | None = None,
     ) -> str:
         """Create and start a new background run.
 
@@ -921,9 +922,9 @@ class RunManager:
         # exceeds run_event_ttl_seconds the key disappears and create_run
         # below would otherwise succeed for a brand-new run_id, racing
         # the in-flight resume path and orphaning the pending answer.
-        from cubebox.agents.checkpointer import init_checkpointer
+        from cubebox.agents.checkpointer import shared_checkpointer
 
-        async with init_checkpointer() as _cp:
+        async with shared_checkpointer() as _cp:
             _db_pending = await _cp.load_pending(conversation_id)
         if _db_pending is not None:
             if not cancel_pending_hitl:
@@ -1002,6 +1003,7 @@ class RunManager:
                 ctx=ctx,
                 model_key=model_key,
                 reasoning=reasoning or ReasoningControl(),
+                llm_snapshot=llm_snapshot,
             ),
             name=f"run:{run_id}",
         )
@@ -1117,12 +1119,12 @@ class RunManager:
 
         Returns the run_id (echoed back so the route response carries it).
         """
-        from cubebox.agents.checkpointer import init_checkpointer
+        from cubebox.agents.checkpointer import shared_checkpointer
         from cubebox.streams.hitl_resume import ClaimResumeOutcome, claim_resume
 
         # 1. Authoritative: DB pending. load_pending_request shape unchanged
         #    per cubepi v3 prereq — returns HitlRequest | None.
-        async with init_checkpointer() as cp:
+        async with shared_checkpointer() as cp:
             pending = await cp.load_pending_request(conversation_id)
         if pending is None:
             raise ResumeNoPending(f"no pending for {conversation_id}")
@@ -1185,12 +1187,12 @@ class RunManager:
         question off-base? What did you have in mind?"). Run finalises
         as ``completed`` via the normal respond path.
         """
-        from cubebox.agents.checkpointer import init_checkpointer
+        from cubebox.agents.checkpointer import shared_checkpointer
         from cubebox.streams.hitl_resume import ClaimResumeOutcome, claim_resume
 
         # 1. DB pending recovers started_at — needed for claim_resume's
         #    rebuild branch (long-pause case where Redis meta has aged out).
-        async with init_checkpointer() as cp:
+        async with shared_checkpointer() as cp:
             pending = await cp.load_pending_request(conversation_id)
         if pending is None:
             raise ResumeNoPending(f"no pending for {conversation_id}")
@@ -1248,9 +1250,9 @@ class RunManager:
         Emits a terminal DoneEvent so any live OutboundRunTailer exits
         cleanly instead of polling until TTL expiry.
         """
-        from cubebox.agents.checkpointer import init_checkpointer
+        from cubebox.agents.checkpointer import shared_checkpointer
 
-        async with init_checkpointer() as cp:
+        async with shared_checkpointer() as cp:
             await cp.save_pending_request(conversation_id, None)
 
         await _repair_dangling_tool_calls(conversation_id)
@@ -1571,7 +1573,7 @@ class RunManager:
           - load_skill (catalog + workspace/org)
           - MCP tools (workspace-enabled HTTP MCP servers)
         """
-        from cubebox.agents.checkpointer import init_checkpointer
+        from cubebox.agents.checkpointer import shared_checkpointer
         from cubebox.agents.stream import StreamConverter
         from cubebox.middleware.citations.counter import citation_counter_var
 
@@ -1593,7 +1595,7 @@ class RunManager:
         # signals the drainer to exit so we can finish citation flushing.
         sse_queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
 
-        async with init_checkpointer() as cp:
+        async with shared_checkpointer() as cp:
             # Seed the citation counter past any 【N-M】 markers already
             # persisted in this conversation's tool-result history so
             # cross-turn ids don't collide in the frontend store (which is
@@ -1608,6 +1610,15 @@ class RunManager:
                 if _counter is not None:
                     await _counter.seed_from_messages(_hist.messages)
 
+            with suppress(Exception):
+                await self._append_event(
+                    run_id,
+                    conversation_id,
+                    StatusEvent(
+                        timestamp=datetime.now(UTC).isoformat(),
+                        data={"phase": "loading_tools"},
+                    ),
+                )
             # all_tools is part of the factory contract for future callers
             # (e.g. T8/T10) but the prompt path doesn't need it directly —
             # the agent already has the tools bound at construction time.
@@ -1627,6 +1638,17 @@ class RunManager:
                 model_key=model_key,
                 reasoning=reasoning or ReasoningControl(),
             )
+            # Hand the history already loaded for the citation seed to the
+            # agent (mirrors prompt()'s own restore: messages + extra).
+            # prompt() skips its checkpointer load when messages are already
+            # present, so each send reads the full thread once, not twice.
+            # In-place extra mutation keeps the dict identity that the
+            # extra_ref closures below capture.
+            if _hist is not None and _hist.messages:
+                agent._state.messages = list(_hist.messages)
+                agent._extra.clear()
+                agent._extra.update(_hist.extra)
+
             # Late-bind extra_ref to the live agent._extra dict so compaction /
             # skills / todo middleware can read and write persistent state.
             # The factory already populated the closure via extra_ref_holder;
@@ -1756,6 +1778,15 @@ class RunManager:
                 if v is not None
             }
             final_status: str = "completed"
+            with suppress(Exception):
+                await self._append_event(
+                    run_id,
+                    conversation_id,
+                    StatusEvent(
+                        timestamp=datetime.now(UTC).isoformat(),
+                        data={"phase": "starting"},
+                    ),
+                )
             try:
                 with tracing_context(metadata=_trace_meta):
                     async with trace(tracer, agent):
@@ -2046,7 +2077,7 @@ class RunManager:
           :func:`finalize_run_meta_if_claim_matches` so we only clobber the
           meta row while our claim still owns it.
         """
-        from cubebox.agents.checkpointer import init_checkpointer
+        from cubebox.agents.checkpointer import shared_checkpointer
         from cubebox.agents.stream import StreamConverter
         from cubebox.middleware.citations.counter import citation_counter_var
         from cubebox.streams.hitl_resume import (
@@ -2064,7 +2095,7 @@ class RunManager:
 
         sse_queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
 
-        async with init_checkpointer() as cp:
+        async with shared_checkpointer() as cp:
             # Seed the citation counter past markers already persisted in
             # this conversation. The respond turn appends new tool results,
             # so without seeding we'd collide with citations the original
@@ -2572,6 +2603,21 @@ class RunManager:
                 _mcp_specs = await _effective_service.list_runtime_specs(
                     ctx.workspace_id,
                     ctx.user_id,
+                )
+
+                # Detached TTL re-discovery for stale tools_cache entries so
+                # the cache-first loader below never serves a permanently
+                # stale schema. Fire-and-forget; never blocks the send.
+                from cubebox.mcp.cubepi_runtime import schedule_tools_cache_refresh
+
+                schedule_tools_cache_refresh(
+                    specs=_mcp_specs,
+                    actor_user_id=ctx.user_id,
+                    encryption_backend=self._app.state.encryption_backend,
+                    http_client=_http_client,
+                    metadata_discovery=_metadata,
+                    redis=self._redis,
+                    signer=self._app.state.mcp_user_token_signer,
                 )
 
                 import json as _json
@@ -3263,6 +3309,7 @@ class RunManager:
         ctx: RunContext,
         model_key: str | None = None,
         reasoning: ReasoningControl | None = None,
+        llm_snapshot: Any | None = None,
     ) -> None:
         from cubebox.api.routes.v1.conversations import (
             _enqueue_search_index,
@@ -3280,6 +3327,7 @@ class RunManager:
         sandbox_manager = None
         sandbox_create_task: asyncio.Task[Any] | None = None
         stream_task: asyncio.Task[None] | None = None
+        usage_task: asyncio.Task[Any] | None = None
         catalog_session_ctx: Any | None = None
         catalog_session: Any | None = None
         skill_catalog: Any | None = None
@@ -3378,6 +3426,12 @@ class RunManager:
             name=f"event_q_drainer:{run_id}",
         )
 
+        # First sign of life on the stream: the frontend renders these
+        # phases in the assistant placeholder instead of dead air while
+        # snapshots / tools / MCP are prepared below.
+        with suppress(Exception):
+            await emit_status("preparing")
+
         # Outer-scope default so `finally` can branch on terminal status.
         # The success path inside `try` overwrites this with the real
         # status returned by `_run_cubepi_path`; on exception the default
@@ -3452,18 +3506,23 @@ class RunManager:
             # actual cubepi.Provider construction happens inside _run_cubepi_path.
             # Stash the snapshot in extra_ref_holder so the subsequent
             # _build_agent_for_conversation call reuses it instead of loading
-            # the same providers/credentials again (Fix-8).
+            # the same providers/credentials again (Fix-8). The route already
+            # loaded a snapshot for preset validation — reuse it when passed
+            # in, skipping a second _load_providers + credential-decrypt pass.
             from cubebox.db.engine import async_session_maker
             from cubebox.llm.resolver import parse_model_ref, resolve_model_preset
-            from cubebox.llm.snapshot import load_llm_snapshot
+            from cubebox.llm.snapshot import LLMSnapshot, load_llm_snapshot
 
             context_window: int = 0
             try:
-                async with async_session_maker() as ctx_session:
-                    ctx_snap = await load_llm_snapshot(
-                        ctx_session, ctx.org_id, self._app.state.encryption_backend
-                    )
-                    await ctx_session.commit()
+                if isinstance(llm_snapshot, LLMSnapshot):
+                    ctx_snap = llm_snapshot
+                else:
+                    async with async_session_maker() as ctx_session:
+                        ctx_snap = await load_llm_snapshot(
+                            ctx_session, ctx.org_id, self._app.state.encryption_backend
+                        )
+                        await ctx_session.commit()
                 extra_ref_holder["llm_snapshot"] = ctx_snap
                 _ctx_preset = resolve_model_preset(ctx_snap, None)
                 _slug, _mid = parse_model_ref(_ctx_preset.chain[0])
@@ -3549,24 +3608,21 @@ class RunManager:
                 model_key=model_key,
                 reasoning=reasoning or ReasoningControl(),
             )
-            await _update_conversation_timestamp(
-                conversation_id,
-                org_id=ctx.org_id,
-                workspace_id=ctx.workspace_id,
-                user_id=ctx.user_id,
-            )
-            await self._bump_topic_activity(ctx)
-            # Indexing is enqueued AFTER the run finishes writing history to
-            # the checkpointer — see _enqueue_search_index docstring. The
-            # finally block re-enqueues on cancel/exception paths where
-            # cubepi may have written partial history before the failure.
-            await _enqueue_search_index(
-                conversation_id,
-                org_id=ctx.org_id,
-                workspace_id=ctx.workspace_id,
-                user_id=ctx.user_id,
-            )
-            search_index_enqueued = True
+            # Kick the session-usage aggregate NOW so it overlaps the queue
+            # drain below — both must finish before DoneEvent, so running
+            # them concurrently trims the last-token→done tail. The three
+            # bookkeeping writes (timestamp / topic bump / search-index
+            # enqueue) moved AFTER DoneEvent: nothing the frontend needs on
+            # `done` depends on them.
+            from cubebox.services.usage import SessionUsage, get_session_usage
+
+            async def _query_session_usage() -> SessionUsage:
+                from cubebox.db.engine import async_session_maker
+
+                async with async_session_maker() as billing_session:
+                    return await get_session_usage(billing_session, conversation_id)
+
+            usage_task = asyncio.create_task(_query_session_usage(), name=f"session_usage:{run_id}")
             # Drain the subagent/citation queue BEFORE DoneEvent: SSE
             # consumers (and the frontend) close on `done`, so any event
             # still sitting in the drainer after the final tool call would
@@ -3586,9 +3642,7 @@ class RunManager:
                         with suppress(asyncio.CancelledError, Exception):
                             await event_q_drainer
                 event_q_drainer = None
-            # --- Aggregate session-level token totals ---
-            from cubebox.services.usage import SessionUsage, get_session_usage
-
+            # --- Aggregate session-level token totals (kicked pre-drain) ---
             session_usage: SessionUsage = {
                 "total_input_tokens": 0,
                 "total_output_tokens": 0,
@@ -3596,10 +3650,7 @@ class RunManager:
                 "total_cache_write_tokens": 0,
             }
             try:
-                from cubebox.db.engine import async_session_maker
-
-                async with async_session_maker() as billing_session:
-                    session_usage = await get_session_usage(billing_session, conversation_id)
+                session_usage = await usage_task
             except Exception:
                 logger.warning("Failed to query session usage for done event")
 
@@ -3640,6 +3691,31 @@ class RunManager:
                 status=final_status,
             )
             await record_scheduled_run_terminal_state(run_id=run_id, run_status=final_status)
+            # Post-done bookkeeping: the stream is closed, so failures here
+            # must not surface as SSE error events — log and move on. The
+            # search-index enqueue still runs after cubepi finished writing
+            # history (that happened inside agent.prompt()); `done` never
+            # depended on it.
+            try:
+                await _update_conversation_timestamp(
+                    conversation_id,
+                    org_id=ctx.org_id,
+                    workspace_id=ctx.workspace_id,
+                    user_id=ctx.user_id,
+                )
+                await self._bump_topic_activity(ctx)
+            except Exception:
+                logger.opt(exception=True).warning("post-done activity bookkeeping failed")
+            try:
+                await _enqueue_search_index(
+                    conversation_id,
+                    org_id=ctx.org_id,
+                    workspace_id=ctx.workspace_id,
+                    user_id=ctx.user_id,
+                )
+                search_index_enqueued = True
+            except Exception:
+                logger.opt(exception=True).warning("post-done search-index enqueue failed")
             await self._maybe_consolidate_memory(
                 conversation_id=conversation_id,
                 ctx=ctx,
@@ -3725,6 +3801,13 @@ class RunManager:
                 with suppress(asyncio.CancelledError):
                     await stream_task
 
+            # Error/cancel paths can bail between kicking the usage query
+            # and awaiting it — reap it so the task doesn't leak.
+            if usage_task is not None and not usage_task.done():
+                usage_task.cancel()
+                with suppress(asyncio.CancelledError, Exception):
+                    await usage_task
+
             # Safety net for error/cancel paths that bypassed the
             # pre-DoneEvent drain — shut the drainer down so the task
             # doesn't leak. The success path nulls `event_q_drainer` after
@@ -3758,6 +3841,34 @@ class RunManager:
             except ValueError:
                 citation_event_queue.set(None)
 
+            self._agents.pop(run_id, None)
+            # Release the turn lock BEFORE the sandbox/session teardown below:
+            # `done` has already been emitted, and holding the active-run key
+            # through a (remote) sandbox release gave the next send a 409
+            # window. Sandbox release is only an activity-timestamp update —
+            # a new run re-acquiring the same scope sandbox is unaffected.
+            #
+            # paused_hitl: keep the Redis active-run key as the lock that
+            # blocks `start_run` from spawning a brand-new turn while the
+            # user still owes an answer. Clearing it here would let a
+            # racing send pass create_run() and skip the DB-pending guard
+            # in start_run (the guard only fires when create_run failed),
+            # orphaning the paused turn. The respond / cancel paths clear
+            # the lock when they terminate.
+            if final_status != "paused_hitl":
+                await clear_active_run(
+                    self._redis,
+                    prefix=self._key_prefix,
+                    conversation_id=conversation_id,
+                    run_id=run_id,
+                )
+                await expire_run_data(
+                    self._redis,
+                    prefix=self._key_prefix,
+                    run_id=run_id,
+                    ttl_seconds=self._run_event_ttl_seconds,
+                )
+
             if sandbox:
                 from cubebox.sandbox.lazy import LazySandbox
 
@@ -3779,28 +3890,6 @@ class RunManager:
             if catalog_session_ctx is not None:
                 with suppress(Exception):
                     await catalog_session_ctx.__aexit__(None, None, None)
-
-            self._agents.pop(run_id, None)
-            # paused_hitl: keep the Redis active-run key as the lock that
-            # blocks `start_run` from spawning a brand-new turn while the
-            # user still owes an answer. Clearing it here would let a
-            # racing send pass create_run() and skip the DB-pending guard
-            # in start_run (the guard only fires when create_run failed),
-            # orphaning the paused turn. The respond / cancel paths clear
-            # the lock when they terminate.
-            if final_status != "paused_hitl":
-                await clear_active_run(
-                    self._redis,
-                    prefix=self._key_prefix,
-                    conversation_id=conversation_id,
-                    run_id=run_id,
-                )
-                await expire_run_data(
-                    self._redis,
-                    prefix=self._key_prefix,
-                    run_id=run_id,
-                    ttl_seconds=self._run_event_ttl_seconds,
-                )
 
     async def _execute_respond_run(
         self,

--- a/backend/tests/unit/mcp/test_runtime_tools_cache.py
+++ b/backend/tests/unit/mcp/test_runtime_tools_cache.py
@@ -1,0 +1,100 @@
+"""Unit tests for the tools_cache fast path in cubepi_runtime.
+
+The eager MCP loader now builds AgentTools from the install's persisted
+``tools_cache`` instead of a live ``initialize`` + ``tools/list`` round
+trip per send. These tests protect the two invariants that matter:
+
+1. **Schema parity** — a cache-built tool must expose the same name,
+   description, and parameter schema the live loader would produce from
+   the same descriptor, or the serialized tool payload sent to the LLM
+   (and therefore the prompt-cache prefix) would drift between a
+   cache-hit send and a live-load send.
+2. **Fallback** — an empty/unusable cache returns None so the caller
+   falls back to live discovery instead of silently dropping a server.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cubebox.mcp.cubepi_runtime import _build_tools_from_cache
+from cubebox.mcp.effective import MCPRuntimeConnectorSpec
+
+_WEATHER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "city": {"type": "string", "description": "City name"},
+        "days": {"type": "integer"},
+    },
+    "required": ["city"],
+}
+
+
+def _make_spec(tools_cache: list[dict[str, Any]]) -> MCPRuntimeConnectorSpec:
+    return MCPRuntimeConnectorSpec(
+        install_id="mcins_cache",
+        name="weather",
+        server_url="https://mcp.example.com/mcp",
+        transport="streamable_http",
+        auth_method="static",
+        grant_scope="org",
+        credential_id="cred_test",
+        refresh_credential_id=None,
+        tool_citations={},
+        tools_cache=tools_cache,
+    )
+
+
+def test_cache_built_tool_matches_live_loader_shape() -> None:
+    """If the cache-built tool schema drifted from what the live loader
+    produces for the same descriptor, the LLM tool payload (and the
+    prompt-cache prefix) would differ between cache-hit and live sends."""
+    from cubepi.mcp._adapter import make_mcp_agent_tool
+
+    entry = {
+        "name": "get_weather",
+        "description": "Look up the weather",
+        "input_schema": _WEATHER_SCHEMA,
+        "output_schema": None,
+    }
+    spec = _make_spec([entry])
+
+    cached_tools = _build_tools_from_cache(
+        spec=spec, headers={"Authorization": "Bearer t"}, server_url=spec.server_url
+    )
+    assert cached_tools is not None and len(cached_tools) == 1
+    cached = cached_tools[0]
+
+    async def _noop_call_remote(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"content": [], "isError": False}
+
+    live = make_mcp_agent_tool(
+        name="get_weather",
+        description="Look up the weather",
+        input_schema=_WEATHER_SCHEMA,
+        call_remote=_noop_call_remote,
+    )
+
+    assert cached.name == live.name
+    assert cached.description == live.description
+    assert (
+        cached.parameters.model_json_schema() == live.parameters.model_json_schema()
+    )
+
+
+def test_cache_entry_without_schema_gets_empty_object_schema() -> None:
+    spec = _make_spec([{"name": "ping", "description": None, "input_schema": None}])
+    tools = _build_tools_from_cache(spec=spec, headers={}, server_url=spec.server_url)
+    assert tools is not None and len(tools) == 1
+    assert tools[0].name == "ping"
+    assert tools[0].description == ""
+
+
+def test_empty_cache_returns_none_for_live_fallback() -> None:
+    spec = _make_spec([])
+    assert _build_tools_from_cache(spec=spec, headers={}, server_url=spec.server_url) is None
+
+
+def test_nameless_entries_are_skipped_and_all_nameless_falls_back() -> None:
+    spec = _make_spec([{"description": "no name"}, {"name": ""}])
+    assert _build_tools_from_cache(spec=spec, headers={}, server_url=spec.server_url) is None

--- a/backend/tests/unit/test_memory_consolidation_pass.py
+++ b/backend/tests/unit/test_memory_consolidation_pass.py
@@ -107,7 +107,7 @@ async def test_run_consolidation_uses_tracer_oneshot_when_provided(monkeypatch):
         cp.load = AsyncMock(return_value=MagicMock(messages=[]))
         yield cp
 
-    monkeypatch.setattr("cubebox.agents.checkpointer.init_checkpointer", _fake_init_checkpointer)
+    monkeypatch.setattr("cubebox.agents.checkpointer.shared_checkpointer", _fake_init_checkpointer)
 
     # Lock helpers — return a token so we pass acquire_lock guard.
     monkeypatch.setattr(mc, "acquire_lock", AsyncMock(return_value="tok"))
@@ -141,7 +141,7 @@ async def test_run_consolidation_uses_tracer_oneshot_when_provided(monkeypatch):
         yield cp
 
     monkeypatch.setattr(
-        "cubebox.agents.checkpointer.init_checkpointer",
+        "cubebox.agents.checkpointer.shared_checkpointer",
         _fake_init_checkpointer_nonempty,
     )
 
@@ -199,7 +199,7 @@ async def test_run_consolidation_fallback_uses_provider_generate(monkeypatch):
         yield cp
 
     monkeypatch.setattr(
-        "cubebox.agents.checkpointer.init_checkpointer",
+        "cubebox.agents.checkpointer.shared_checkpointer",
         _fake_init_checkpointer_nonempty,
     )
     monkeypatch.setattr(mc, "acquire_lock", AsyncMock(return_value="tok"))
@@ -266,7 +266,7 @@ async def test_run_consolidation_fallback_treats_provider_error_as_failed_pass(
         yield cp
 
     monkeypatch.setattr(
-        "cubebox.agents.checkpointer.init_checkpointer",
+        "cubebox.agents.checkpointer.shared_checkpointer",
         _fake_init_checkpointer_nonempty,
     )
     monkeypatch.setattr(mc, "acquire_lock", AsyncMock(return_value="tok"))

--- a/backend/tests/unit/test_run_manager_cancel_paused.py
+++ b/backend/tests/unit/test_run_manager_cancel_paused.py
@@ -58,7 +58,7 @@ def _patch_checkpointer(monkeypatch: pytest.MonkeyPatch, *, pending: Any) -> Asy
         yield cp
 
     monkeypatch.setattr(
-        "cubebox.agents.checkpointer.init_checkpointer",
+        "cubebox.agents.checkpointer.shared_checkpointer",
         _fake_cm,
     )
     return load_mock

--- a/backend/tests/unit/test_run_manager_resume_run_with_answer.py
+++ b/backend/tests/unit/test_run_manager_resume_run_with_answer.py
@@ -59,7 +59,7 @@ def _patch_checkpointer(monkeypatch: pytest.MonkeyPatch, *, pending: Any) -> Asy
         yield cp
 
     monkeypatch.setattr(
-        "cubebox.agents.checkpointer.init_checkpointer",
+        "cubebox.agents.checkpointer.shared_checkpointer",
         _fake_cm,
     )
     return load_mock

--- a/backend/tests/unit/test_run_manager_start_run_paused.py
+++ b/backend/tests/unit/test_run_manager_start_run_paused.py
@@ -66,7 +66,7 @@ def stub_no_db_pending(monkeypatch: pytest.MonkeyPatch) -> None:
         yield cp
 
     monkeypatch.setattr(
-        "cubebox.agents.checkpointer.init_checkpointer",
+        "cubebox.agents.checkpointer.shared_checkpointer",
         _fake_cm,
     )
 
@@ -127,7 +127,7 @@ async def test_start_run_rejects_when_db_pending_present(
         yield cp
 
     monkeypatch.setattr(
-        "cubebox.agents.checkpointer.init_checkpointer",
+        "cubebox.agents.checkpointer.shared_checkpointer",
         _fake_cm,
     )
 
@@ -175,7 +175,7 @@ async def test_start_run_succeeds_when_no_pending(
         yield cp
 
     monkeypatch.setattr(
-        "cubebox.agents.checkpointer.init_checkpointer",
+        "cubebox.agents.checkpointer.shared_checkpointer",
         _fake_cm,
     )
 

--- a/docs/dev/plans/2026-07-06-run-latency-optimization.md
+++ b/docs/dev/plans/2026-07-06-run-latency-optimization.md
@@ -218,13 +218,37 @@ making the round-trip-count reductions the most valuable thing to verify.
 
 ### T8 (follow-up, not in this branch) — collapse the agent-build DB work
 
-The decomposition points the next effort at `_build_agent_for_conversation`:
-coalesce its ~4 independent `async_session_maker()` opens (MCP effective,
-membership role, org, skills-adapter) into one shared session and/or run
-the independent reads under `asyncio.gather`; evaluate dropping
-`pool_pre_ping` (or replacing it with a cheaper liveness check) for the
-hot pool. Deferred to a separate change — it is orthogonal to the
-send/done round-trip work here and wants its own measurement.
+**Verdict after co-located re-measurement (2026-07-06): NOT worth doing.**
+
+Re-ran the A/B on 215 where Postgres/Redis are co-located with the app
+(<5ms RTT vs the 210ms dev tunnel):
+
+| phase | dev tunnel (210ms) | 215 co-located (<5ms) |
+|---|---|---|
+| prep → loading_tools | ~3s | 0.02–0.04s |
+| build (loading_tools → starting) | 17–23s | **2.0–4.5s** |
+| TTFT (LLM) | 12–23s | 6–14.5s |
+| tail | 15–21s | 6–7.8s |
+
+End-to-end on 215: first feedback 21.6s → **0.22s** (status events),
+first token 21.6s → 14.8s, done 29.5s → 21.3s, tail 7.3s (flat).
+
+The build's ~85% collapse (17–23s → 2–4.5s) confirms the tunnel RTT was
+the amplifier the three DB-oriented changes would have targeted — and it
+is a test-environment artifact, not production. The residual 2–4.5s build
+cost **persists at <5ms RTT**, so it is not round-trip-count bound; it is
+CPU/setup bound (constructing 21 tool schemas + 11 middleware per send,
+credential/snapshot crypto). Dropping `pool_pre_ping`, merging sessions,
+or `asyncio.gather` all target I/O-wait, which is already near-zero on a
+co-located DB — they would move the production number by tens of
+milliseconds, against a real reliability cost (pre_ping) and added
+complexity. **Skip them.**
+
+If the residual 2–4.5s build is ever pursued, it needs CPU profiling of
+tool/middleware construction (cache tool schemas across turns; the tool
+set is stable per workspace), not DB-session surgery — a different effort
+with uncertain payoff, since build is ~15–20% of a TTFT dominated by the
+6–14s LLM call.
 
 ## Sequencing & PR split
 

--- a/docs/dev/plans/2026-07-06-run-latency-optimization.md
+++ b/docs/dev/plans/2026-07-06-run-latency-optimization.md
@@ -1,0 +1,203 @@
+# Run latency optimization — send→first-token & last-token→done
+
+- **Date**: 2026-07-06
+- **Branch**: `feat/2026-07-06-run-latency`
+- **Status**: in progress
+
+## Problem
+
+Users see two long dead-air windows on every chat turn:
+
+1. **Send → first assistant token.** After the optimistic user message
+   renders, nothing happens on screen until the LLM's first `text_delta`
+   arrives. All backend preparation work sits in this window, serialized,
+   and emits no SSE events.
+2. **Last token → input re-enabled.** The frontend keeps `isStreaming`
+   until the `done` event; everything the backend does between the final
+   `text_delta` and `DoneEvent` extends this window.
+
+## Measured/traced causes (from code walk, to be confirmed by baseline)
+
+Window 1, in execution order:
+
+| # | Cost | Where |
+|---|---|---|
+| C1 | ~7 sequential short-lived DB sessions in the route (conv lookup, auto-join, attachment check, snapshot load #1, topic ctx, mark_attached, timestamp bump) | `conversations.py::send_message` |
+| C2 | `init_checkpointer()` creates a **fresh asyncpg pool** (TCP+auth+schema check) per call; ≥2 creates per send (`start_run` pending check, `_run_cubepi_path`) | `agents/checkpointer.py:31`, `run_manager.py:926,1596` |
+| C3 | `load_llm_snapshot` runs **twice** per send (route validation + `_execute_run`), each decrypting all provider credentials | `conversations.py:1425`, `run_manager.py:3461` |
+| C4 | Full conversation history loaded **twice** (citation seed `cp.load`, then cubepi `Agent.prompt` internal load) | `run_manager.py:1604`, cubepi `agent.py:510` |
+| C5 | **MCP eager load: live `initialize` + `tools/list` round-trip to every enabled server, sequentially, every send** — even though `tools_cache` (name/description/input_schema/output_schema) is already persisted on the install row. A slow server blocks up to `spec.timeout`. | `run_manager.py:2612` → `mcp/cubepi_runtime.py:126` |
+| C6 | No status events during build — `emit_status` exists but only fires on `sandbox_failed`, so the frontend `statusPhase` stays null | `run_manager.py:3307` |
+
+Window 2, in execution order (all before `DoneEvent`):
+
+| # | Cost | Where |
+|---|---|---|
+| C7 | `_update_conversation_timestamp` + `_bump_topic_activity` + `_enqueue_search_index`: three sequential DB/Redis writes that don't need to precede `done` | `run_manager.py:3551-3568` |
+| C8 | `get_session_usage`: SUM+JOIN over **all** billing rows of the conversation, recomputed every turn, grows with conversation length | `services/usage.py:49` |
+| C9 | In `finally`, sandbox release (a remote opensandbox call) runs **before** `clear_active_run` — after `done` the user can still hit 409 on the next send until release finishes | `run_manager.py:3761-3800` |
+
+Non-goals: LLM provider TTFT itself (model choice, prompt-cache hit rate)
+is out of scope except for not regressing the cache prefix; the
+reflection/consolidation background tasks are already detached and stay
+as-is.
+
+## Tasks
+
+### T0 — Baseline measurement harness
+
+Script `backend/scripts/dev/measure_run_latency.py`: sends a message via
+the HTTP API with `Accept: text/event-stream`, records wall-clock marks —
+request-sent, first SSE event, first `text_delta`, last `text_delta`,
+`done` — and prints one row per run. Run N=5 against (a) a fresh
+conversation, (b) a conversation with long history and MCP connectors
+enabled. Store outputs in `tmp/latency-baseline.txt`.
+
+**Verify**: script runs against the dev backend with the test API key;
+numbers are plausible and stable enough to compare (±20%).
+
+### T1 — MCP tools from `tools_cache` (biggest win, C5)
+
+In `_build_agent_for_conversation`'s eager branch, replace
+`_load_tools_for_specs` with a cache-based builder:
+
+- New `_build_tools_from_cache(specs, all_specs, auth...) ` in
+  `mcp/cubepi_runtime.py`: for each spec with non-empty `tools_cache` and
+  `discovery_status == "ok"`, resolve auth exactly as today
+  (`_resolve_auth_from_spec` — local DB/Redis work, no MCP round-trip),
+  then build tools via cubepi `make_mcp_agent_tool(name, description,
+  input_schema, call_remote)` with the same per-call fresh-session
+  `_call_remote` the http_loader uses (tool calls already open a fresh
+  session per call — cubepi v1 semantics — so skipping discovery changes
+  nothing at call time). Namespacing/citation logic reused unchanged.
+- Specs with an empty/stale cache fall back to today's live load, but all
+  per-server loads (cache misses) run under `asyncio.gather`.
+- Staleness: after the tool list is built, if `last_discovered_at` is
+  older than `mcp.tools_cache_ttl_hours` (default 24), fire a detached
+  refresh task reusing the existing discovery service. Never blocks the
+  run.
+- Note: `make_mcp_agent_tool` lives in `cubepi.mcp._adapter` and isn't in
+  `__all__` — either import from the private module with a comment or add
+  a small wrapper upstream later.
+
+**Verify**: unit test for `_build_tools_from_cache` (tool schema equals
+what the live loader would produce for the same cache content); e2e:
+enable ≥1 MCP connector, send message, assert tools usable and no
+`tools/list` request hits the server during send (assert via server-side
+counter in the test MCP fixture); baseline re-run shows window-1 drop.
+
+### T2 — Process-level shared checkpointer pool (C2)
+
+`agents/checkpointer.py`: add a module-level shared
+`PostgresCheckpointer` opened once (lazily on first use, or explicitly in
+the app lifespan) and a `shared_checkpointer()` async context manager
+that yields it without closing. Migrate the hot-path call sites
+(`run_manager.py` ×7, `conversations.py` ×6, `repositories/conversation.py`,
+`im/resume.py`, `services/conversation_sharing.py`) to the shared
+instance. `init_checkpointer()` stays for scripts/workers/tests that need
+an isolated pool. Lifespan shutdown closes the shared pool after the run
+manager drains.
+
+**Verify**: existing e2e suite for conversations/runs passes; grep shows
+no hot-path `init_checkpointer()` left; log pool-create count during one
+send == 0 (pool pre-created).
+
+### T3 — Load once, reuse: LLM snapshot & history (C3, C4)
+
+- Route → run: `send_message` passes its validated `LLMSnapshot` through
+  `start_run(..., llm_snapshot=snap)` into `_execute_run`'s
+  `extra_ref_holder["llm_snapshot"]` (the reuse mechanism inside the run
+  already exists; this closes the route→run gap). Same for the
+  `_execute_respond_run` path where applicable.
+- History: `_run_cubepi_path` already does `cp.load()` for the citation
+  seed. Hand that loaded state to the agent — set `agent.messages` /
+  restore `extra` from the same `CheckpointData` (cubepi `AgentState`
+  exposes a public messages setter; `prompt()` skips its internal load
+  when messages are non-empty). One full-history load per send instead of
+  two.
+
+**Verify**: unit test that the snapshot object identity is preserved
+route→run; e2e multi-turn conversation still replays correctly (history
+not duplicated/lost — assert message count via list_messages); prompt
+prefix stability spot-check per prompt-cache-discipline (cache_read
+tokens non-zero on turn 2 with Anthropic-format provider).
+
+### T4 — Slim the pre-`done` tail (C7, C8)
+
+- ~~Redis running totals~~ **Revised during implementation**: the SQL SUM
+  stays (it is already approximate — `CostMiddleware._write` is a
+  fire-and-forget task racing `done`, and a Redis counter incremented in
+  the same detached write would carry the identical race), but it now
+  runs as an `asyncio.Task` kicked **before** the queue drain, so the
+  tail pays `max(drain, usage-query)` instead of their sum.
+  `ix_billing_events_conversation` already indexes the lookup. This
+  avoids adding a cache-consistency surface to billing for the same
+  observable accuracy.
+- Reorder: append `DoneEvent` right after the queue drain; move
+  `_update_conversation_timestamp` / `_bump_topic_activity` /
+  `_enqueue_search_index` after it (search-index enqueue still happens
+  after cubepi finished writing history — that ordering constraint is
+  about the checkpointer write, which completes inside `agent.prompt()`,
+  not about `DoneEvent`). Post-done failures log instead of emitting SSE
+  error events (the stream is already closed).
+
+**Verify**: e2e run asserts done-event usage matches SQL SUM; baseline
+re-run shows window-2 drop; existing search-index e2e still passes.
+
+### T5 — Status events during build (perceived latency, C6)
+
+Emit `emit_status` phases in `_execute_run` / `_run_cubepi_path`:
+`preparing` (entry), `loading_tools` (before MCP/action tools),
+`starting` (right before `agent.prompt`). Frontend already stores
+`statusPhase` (`messageStore.ts:620`) — render a subtle phase hint in the
+assistant placeholder (i18n keys for zh/en). Docs page for the chat flow
+updated in the same PR (docs-ship-with-code rule) if any user-facing doc
+describes the loading behavior.
+
+**Verify**: Playwright: after send, the placeholder shows a phase hint
+before the first token (only asserted as a step inside the existing
+chat-flow test, not a standalone presence test).
+
+### T6 — Release the turn lock before sandbox release (C9)
+
+In `_execute_run`'s `finally`, move `clear_active_run` +
+`expire_run_data` ahead of the sandbox release block (keep the
+`paused_hitl` guard exactly as-is). Sandbox release cannot affect the
+next turn's correctness — LazySandbox re-acquires by scope, and release
+is already best-effort (`suppress(Exception)`).
+
+**Verify**: e2e: send turn A with a sandbox-using tool, immediately send
+turn B on `done` — no 409. Existing pause/resume sandbox e2e still
+passes.
+
+### T7 — Re-measure & compare
+
+Re-run T0's script against the worktree backend on the same infra/DB;
+produce a before/after table for both windows (fresh + long conversation,
+MCP on). Full pre-PR sweep (`make check-ci` equivalent + changed-module
+e2e).
+
+## Sequencing & PR split
+
+T0 first (baseline before any change). Then T2 → T3 → T1 → T4 → T6 → T5
+(shared-pool and reuse changes are low-risk enablers; MCP cache is the
+big one; T5 touches frontend last). One PR for the backend latency work
+(T1–T4, T6, tightly coupled by run_manager), a separate small PR for T5
+if the frontend change grows; plan doc rides with the first PR.
+
+## Risks
+
+- **Stale MCP tool schema** (T1): a server changed its tools since
+  discovery → model calls a tool with an outdated schema. Mitigated by
+  TTL-triggered background refresh + fallback to live load when cache is
+  empty; call-time errors surface to the model as tool errors (same as
+  today's mid-conversation server drift).
+- **Prompt-cache prefix**: T1/T3 must not change tool ordering or
+  serialized tool schemas (cache-built tools must serialize byte-identical
+  to live-built ones — covered by the T1 unit test).
+- **Shared pool sizing** (T2): one pool now serves all concurrent runs;
+  keep max_pool_size configurable (`database.cubepi_pool_max`, default
+  10) and watch for exhaustion in the drain logs.
+- **Usage hash drift** (T4): Redis increments can lag the DB on crash;
+  done-event usage is display-only, and the SQL fallback bounds the error
+  to one turn.

--- a/docs/dev/plans/2026-07-06-run-latency-optimization.md
+++ b/docs/dev/plans/2026-07-06-run-latency-optimization.md
@@ -177,6 +177,55 @@ produce a before/after table for both windows (fresh + long conversation,
 MCP on). Full pre-PR sweep (`make check-ci` equivalent + changed-module
 e2e).
 
+**Results (2026-07-06, fresh conversation, 5 runs each, no MCP connectors
+installed, dev DB via 215 tunnel ~210ms RTT):**
+
+| metric | baseline | optimized | delta |
+|---|---|---|---|
+| first backend feedback | 64.1s (== first token; no early events) | ~3s (`preparing`) | dead air removed |
+| time to first token | 64.1s | 51.4s | −20% |
+| time to `done` | 97.1s | 73.5s | −24% |
+| tail (last token → done) | 17.2s | 19.8s | ~flat |
+
+Per-run internal decomposition (Redis stream timestamps, one run) reveals
+where the remaining time sits — the send-side is now dominated by two
+costs **outside** what this change set targeted:
+
+| phase | cost | note |
+|---|---|---|
+| preparing → loading_tools | ~3s | route prep + early run setup |
+| **loading_tools → starting** | **15–23s** | `_build_agent_for_conversation` — serial DB round-trips |
+| starting → first token | 12–23s | LLM TTFT via the litellm proxy |
+| last token → usage event | ~7s | proxy stream finalization |
+| usage → done | ~14s | cubepi prompt finalization + drain + done |
+
+**Interpretation.** The wins that landed: dead-air before first feedback
+is gone (T5), and the removed-round-trip changes (shared checkpointer
+pool, snapshot reuse, single history load) plus the post-`done`
+bookkeeping move cut ~24s off total `done` time. What the decomposition
+exposes as the *next* bottleneck is `_build_agent_for_conversation`
+(15–23s) — and this workspace has **no MCP connectors**, so T1's cache is
+not even exercised here; the cost is the sheer count of serial DB session
+opens in the build path, each paying `pool_pre_ping` (`SELECT 1`, ~210ms)
++ the actual query (~210ms) under the 210ms tunnel RTT. Provider TTFT and
+the proxy's stream finalization (the 7s usage lag + tail) are
+environmental (litellm proxy on 215) and out of code scope.
+
+The 210ms RTT is a **test-environment artifact** (VM → VPN → 215). A
+co-located production Postgres (<5ms RTT) shrinks every serial-DB cost by
+~40×, so the absolute seconds here overstate the real deployment, while
+making the round-trip-count reductions the most valuable thing to verify.
+
+### T8 (follow-up, not in this branch) — collapse the agent-build DB work
+
+The decomposition points the next effort at `_build_agent_for_conversation`:
+coalesce its ~4 independent `async_session_maker()` opens (MCP effective,
+membership role, org, skills-adapter) into one shared session and/or run
+the independent reads under `asyncio.gather`; evaluate dropping
+`pool_pre_ping` (or replacing it with a cheaper liveness check) for the
+hot pool. Deferred to a separate change — it is orthogonal to the
+send/done round-trip work here and wants its own measurement.
+
 ## Sequencing & PR split
 
 T0 first (baseline before any change). Then T2 → T3 → T1 → T4 → T6 → T5

--- a/docs/site/docs/admin/mcp-connectors.md
+++ b/docs/site/docs/admin/mcp-connectors.md
@@ -61,6 +61,12 @@ This is a deploy-time step, not something you enter in the admin UI. Until those
 
 For connectors that authenticate with a static API token or bearer token (for example, the search connectors Tavily, Exa, and Jina AI), the token is requested in the install form. CubeBox encrypts it into the credential vault.
 
+## Tool discovery & caching
+
+Installing a connector (or saving its credential) runs **tool discovery**: CubeBox connects to the MCP server, lists its tools, and stores the tool list on the install. Agent runs use this cached list to register the connector's tools — they do not re-contact the server on every message, which keeps chat start fast even with several connectors enabled. Actually *calling* a tool always goes to the live server.
+
+The cache refreshes automatically in the background when it is older than 24 hours (config key `mcp.tools_cache_ttl_hours`; set `0` to disable background refresh). If a server changed its tools and you don't want to wait, use **Retry discovery** on the install's detail page to refresh immediately.
+
 ## Install connectors
 
 Connectors can be installed at the **organization level** (available to all workspaces) or at the **workspace level** (available only to that workspace).

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -471,6 +471,10 @@ function applyStreamEvent(state: MessageStore, event: AgentEvent): Partial<Messa
     const prev = state.streamAgents[agentKey] ?? emptyStream(event.agent_name)
     return {
       ...base,
+      // Model output supersedes any build-phase hint (preparing /
+      // loading_tools / starting / sandbox_creating) — clear so the
+      // indicator falls back to the plain streaming dots.
+      statusPhase: null,
       streamAgents: {
         ...state.streamAgents,
         [agentKey]: {

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -739,7 +739,15 @@ export function AssistantMessage({
             )}
             {isStreaming && (
               <div data-testid="loading-indicator" className="flex items-center gap-1 pl-1 h-6">
-                {statusPhase === 'sandbox_creating' ? (
+                {statusPhase === 'preparing' || statusPhase === 'loading_tools' ? (
+                  <span className="text-xs text-muted-foreground animate-pulse">
+                    {statusPhase === 'preparing' ? t('runPreparing') : t('runLoadingTools')}
+                  </span>
+                ) : statusPhase === 'starting' ? (
+                  <span className="text-xs text-muted-foreground animate-pulse">
+                    {t('runStarting')}
+                  </span>
+                ) : statusPhase === 'sandbox_creating' ? (
                   <span className="text-xs text-muted-foreground animate-pulse">
                     {t('sandboxPreparing')}
                   </span>

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -346,7 +346,10 @@
       "openPage": "Open memory",
       "openPageAria": "Go to memory page",
       "empty": "No memories yet"
-    }
+    },
+    "runPreparing": "Preparing...",
+    "runLoadingTools": "Loading tools...",
+    "runStarting": "Contacting model..."
   },
   "subagent": {
     "cluster": "Agent cluster",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -346,7 +346,10 @@
       "openPage": "打开记忆页",
       "openPageAria": "跳转到记忆页面",
       "empty": "暂无记忆"
-    }
+    },
+    "runPreparing": "正在准备...",
+    "runLoadingTools": "正在加载工具...",
+    "runStarting": "正在请求模型..."
   },
   "subagent": {
     "cluster": "Agent 集群",


### PR DESCRIPTION
## What & why

Two dead-air windows on every chat turn: (1) after the optimistic user
message renders, nothing shows until the LLM's first token; (2) after the
last token, the input stays locked until `done`. All backend prep sat in
window 1 serialized and emitted no SSE events. This trims both windows and,
more importantly, kills the perceived dead air.

Full analysis, task breakdown, and A/B numbers live in
`docs/dev/plans/2026-07-06-run-latency-optimization.md`.

## Changes

**Send → first token**
- **Status events during build** — emit `preparing` / `loading_tools` /
  `starting` before `agent.prompt()`; the web placeholder renders them and
  clears on the first `text_delta`. This is the biggest *perceived* win and
  is RTT-independent.
- **Shared cubepi checkpointer pool** — every hot-path `init_checkpointer()`
  opened a fresh asyncpg pool (TCP+auth+schema check), ≥2 per send. Replaced
  with a per-loop shared instance warmed at lifespan startup, closed at
  shutdown. `init_checkpointer()` stays for scripts/tests needing isolation.
- **MCP tools from `tools_cache`** — build tools from the install's persisted
  tool list instead of a live `initialize`+`tools/list` round trip per send;
  stale caches refresh in a detached task (`mcp.tools_cache_ttl_hours`,
  default 24h). Live load remains the fallback for empty caches.
- **Reuse loads** — the route-validated LLM snapshot is passed through to the
  run (drops a second credential-decrypt pass); the history loaded for the
  citation seed is handed to the agent (drops cubepi's duplicate load).

**Last token → done**
- session-usage aggregate runs concurrently with the event-queue drain.
- conversation timestamp / topic bump / search-index enqueue moved *after*
  `DoneEvent` (log-only on failure; stream already closed).
- active-run lock clears *before* sandbox release in `finally`, closing the
  post-`done` 409 window for the next send.

## Results (215, co-located DB, fresh conv ×5)

| metric | main | this PR |
|---|---|---|
| first feedback | 21.6s (no early events) | **0.22s** |
| first token | 21.6s | 14.8s |
| done | 29.5s | 21.3s |
| tail (last token→done) | 7.3s | 7.3s (proxy-side, flat) |

## Scope note (why no DB-session micro-opts)

An earlier idea — drop `pool_pre_ping`, merge the build's ~4 sessions,
`asyncio.gather` them — was **evaluated and rejected**. On co-located DB the
agent-build cost is 2–4.5s and does *not* shrink with RTT (it's CPU/setup
bound: 21 tool schemas + 11 middleware + crypto per send), so those
round-trip-oriented changes buy tens of ms against a real reliability cost.
The 17–23s build seen on the high-RTT dev tunnel was an environment artifact.
Detail in the plan doc's T8 section.

## Tests
- New unit: `tests/unit/mcp/test_runtime_tools_cache.py` (cache-built tool
  schema matches the live loader; empty cache falls back).
- Patched `init_checkpointer` → `shared_checkpointer` monkeypatch targets in
  4 run-manager/memory unit tests.
- `pytest tests/unit` green (pre-existing `test_scheduled_task_service.py`
  errors are unrelated DB-fixture issues on main); mypy + ruff clean;
  frontend `tsc` clean.
- Docs: `docs/site/docs/admin/mcp-connectors.md` gains a tool-discovery /
  caching section (docs-ship-with-code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)