### PR TITLE
perf: move span export off the run path (usage→done gap)

### DIFF
--- a/backend/cubebox/streams/run_manager.py
+++ b/backend/cubebox/streams/run_manager.py
@@ -1789,7 +1789,11 @@ class RunManager:
                 )
             try:
                 with tracing_context(metadata=_trace_meta):
-                    async with trace(tracer, agent):
+                    # flush="background": span export must not gate the
+                    # turn's DoneEvent (it added seconds to the tail against
+                    # a slow OTLP collector); lifespan's tracer.shutdown()
+                    # settles pending flushes.
+                    async with trace(tracer, agent, flush="background"):
                         # Pass cubebox's run_id so cubepi stamps it onto
                         # cubepi_messages.run_id (instead of generating its own).
                         # Aligns the cubepi message ledger with cubebox's redis
@@ -2179,7 +2183,7 @@ class RunManager:
             try:
                 try:
                     with tracing_context(metadata=_trace_meta):
-                        async with trace(tracer, agent):
+                        async with trace(tracer, agent, flush="background"):
                             await agent.respond(question_id=question_id, answer=answer)
                             _raise_if_cubepi_agent_failed(agent)
                 except BaseException as _run_exc:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -185,7 +185,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "9d4b11b6222891ed45fddf99bc984d5a4992f191" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "94d0ca7380502506042390ce73a02de1060387b0" }
 
 [dependency-groups]
 dev = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -185,7 +185,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "020ebda0a8568cd52597551f181e77c0ec777338" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "9d4b11b6222891ed45fddf99bc984d5a4992f191" }
 
 [dependency-groups]
 dev = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -968,7 +968,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=48.0.1" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=9d4b11b6222891ed45fddf99bc984d5a4992f191" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=94d0ca7380502506042390ce73a02de1060387b0" },
     { name = "dingtalk-stream", specifier = ">=0.24.3" },
     { name = "discord-py", specifier = ">=2.7.1" },
     { name = "dynaconf", specifier = ">=3.2.11" },
@@ -1025,7 +1025,7 @@ dev = [
 [[package]]
 name = "cubepi"
 version = "0.13.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=9d4b11b6222891ed45fddf99bc984d5a4992f191#9d4b11b6222891ed45fddf99bc984d5a4992f191" }
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=94d0ca7380502506042390ce73a02de1060387b0#94d0ca7380502506042390ce73a02de1060387b0" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -968,7 +968,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=48.0.1" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=020ebda0a8568cd52597551f181e77c0ec777338" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=9d4b11b6222891ed45fddf99bc984d5a4992f191" },
     { name = "dingtalk-stream", specifier = ">=0.24.3" },
     { name = "discord-py", specifier = ">=2.7.1" },
     { name = "dynaconf", specifier = ">=3.2.11" },
@@ -1024,8 +1024,8 @@ dev = [
 
 [[package]]
 name = "cubepi"
-version = "0.12.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=020ebda0a8568cd52597551f181e77c0ec777338#020ebda0a8568cd52597551f181e77c0ec777338" }
+version = "0.13.0"
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=9d4b11b6222891ed45fddf99bc984d5a4992f191#9d4b11b6222891ed45fddf99bc984d5a4992f191" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },

--- a/docs/dev/notes/2026-07-06-usage-done-gap-trace-flush.md
+++ b/docs/dev/notes/2026-07-06-usage-done-gap-trace-flush.md
@@ -1,0 +1,55 @@
+# usage→done 间隔 5–20s：根因与修复（trace flush 阻塞）
+
+日期：2026-07-06。承接 run-latency 优化（PR #304 / plan
+`docs/dev/plans/2026-07-06-run-latency-optimization.md`）后用户追问：
+`done` 事件总在 `usage` 事件后再等 5–10s 才到，且不像是 LLM 慢。
+
+## 定位过程
+
+1. Redis run_events 流的毫秒时间戳确认：usage→done 间隔 19.6s（高 RTT
+   开发机）；后端日志在该窗口内完全静默。
+2. py-spy dump 显示事件循环空转（`select`）——run task 在 await 外部 I/O
+   或定时器，不是 CPU。
+3. 在 done 路径插 10 个计时日志，一轮跑出分解：**退出
+   `async with trace(tracer, agent)` 占 8.65s**；其余为 HITL pending 读
+   0.9s、session-usage 聚合 1.7s、杂项 <0.3s。
+4. `CUBEBOX_TRACING__ENABLED=false` A/B：trace 退出 8.65s→0ms，tail 中位
+   17s→8.2s。证据闭合。
+
+## 根因（三层叠加）
+
+- `cubepi.tracing.trace()` 退出时 **await span flush**（设计如此：
+  "exit means exported"）——遥测导出 gate 了用户可见的 done。
+- `Tracer.force_flush` 是 `async def` 却内联调用 OTel provider 的
+  **同步** `force_flush()`——flush 期间整个事件循环被卡住，进程内所有
+  并发请求同步停摆。
+- 每 turn 仅 3 个 span 但 JSONL ~190KB（span 属性携带完整 prompt/响应
+  内容），经隧道 POST 到 collector 要数秒。**span 内容瘦身经讨论明确
+  不做**——保留完整内容对排查有价值，修复只针对"挡路"本身。
+
+## 修复
+
+- cubepi PR #199（rev `9d4b11b6`）：`Tracer.force_flush` /
+  `Meter.force_flush` 改 `asyncio.to_thread`（await 不再卡 loop）；
+  `trace()` 增加 `flush="await"|"background"`，background 模式同步
+  detach、导出转后台受监督任务，tracer 持强引用、`shutdown()` 兜底
+  settle——干净退出不丢 span。
+- cubebox（本分支）：bump cubepi rev（0.12.0→0.13.0），
+  `run_manager` 两处 `trace(...)` 调用点改 `flush="background"`；
+  lifespan 已有 `await tracer.shutdown()`，链条闭合。
+
+## 结果（开发机，210ms RTT 到 collector，tracing 开启）
+
+| | tail（末 token→done）中位 |
+|---|---|
+| 修复前 | 14–21s |
+| 修复后 | **9.4s**（与 tracing 完全关闭时的 8.2s 基本一致） |
+
+spans 照常落盘/导出（每 run 一个 JSONL，无 flush 失败日志）。
+
+## 剩余尾巴（未做，量化过）
+
+- `agent.prompt()` 返回前的 cubepi 收尾 ~4–8s（checkpointer 终写 + 提供
+  商流关闭，RTT 放大；215 同机环境小得多）。
+- session-usage 聚合 1.3–2s（已与 drain 并行，是聚合查询本身的耗时）。
+- HITL pending 读 0.5–0.9s。

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -739,15 +739,7 @@ export function AssistantMessage({
             )}
             {isStreaming && (
               <div data-testid="loading-indicator" className="flex items-center gap-1 pl-1 h-6">
-                {statusPhase === 'preparing' || statusPhase === 'loading_tools' ? (
-                  <span className="text-xs text-muted-foreground animate-pulse">
-                    {statusPhase === 'preparing' ? t('runPreparing') : t('runLoadingTools')}
-                  </span>
-                ) : statusPhase === 'starting' ? (
-                  <span className="text-xs text-muted-foreground animate-pulse">
-                    {t('runStarting')}
-                  </span>
-                ) : statusPhase === 'sandbox_creating' ? (
+                {statusPhase === 'sandbox_creating' ? (
                   <span className="text-xs text-muted-foreground animate-pulse">
                     {t('sandboxPreparing')}
                   </span>

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -346,10 +346,7 @@
       "openPage": "Open memory",
       "openPageAria": "Go to memory page",
       "empty": "No memories yet"
-    },
-    "runPreparing": "Preparing...",
-    "runLoadingTools": "Loading tools...",
-    "runStarting": "Contacting model..."
+    }
   },
   "subagent": {
     "cluster": "Agent cluster",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -346,10 +346,7 @@
       "openPage": "打开记忆页",
       "openPageAria": "跳转到记忆页面",
       "empty": "暂无记忆"
-    },
-    "runPreparing": "正在准备...",
-    "runLoadingTools": "正在加载工具...",
-    "runStarting": "正在请求模型..."
+    }
   },
   "subagent": {
     "cluster": "Agent 集群",


### PR DESCRIPTION
## Problem

After PR #304, `done` still trailed the final `usage` event by 5–20s. Timing
probes localized **8.65s to the exit of `async with trace(tracer, agent)`**:

- cubepi's `trace()` awaits span flush on exit ("exit means exported") — so
  telemetry export to the OTLP collector gated the user-visible `done`.
- Worse, `Tracer.force_flush` ran the OTel provider's **synchronous** flush
  inline on the event loop, freezing every concurrent task in the process
  while exporters drained (~190KB of span payload per turn).

A/B confirmed: with tracing disabled the trace-exit cost drops 8.65s→0ms and
tail median 17s→8.2s. Full investigation:
`docs/dev/notes/2026-07-06-usage-done-gap-trace-flush.md`.

## Change

Paired with cubepi PR cubeplexai/cubepi#199 (merged rev pinned here):

- bump cubepi `020ebda0` → `9d4b11b6` (0.12.0 → 0.13.0)
- switch both run-path trace scopes to `flush="background"`: detach stays
  synchronous, export runs as a tracer-tracked background task
  (`force_flush` now runs in a worker thread, so it can't stall the loop
  either way). Lifespan's existing `await tracer.shutdown()` settles pending
  flushes on clean shutdown — spans are not lost.

Span content slimming was considered and explicitly deferred — full content
is valuable for debugging; this PR only takes export off the critical path.

## Measured (dev box, tracing ON, fresh conv ×3)

| | tail (last token → done) |
|---|---|
| before | 14–21s |
| after | **9.4s median** (matches tracing-off baseline 8.2s) |

Spans verified still exported (one JSONL per run, no flush-failure logs).

## Tests

- Behavior is pinned in cubepi (`tests/tracing/test_nonblocking_flush.py`,
  1842-test suite green there): off-loop flush, background-mode exit timing,
  shutdown settlement, failure logging, default-mode regression pin.
- cubebox unit suite against cubepi 0.13.0: 1887 passed (the 10
  `test_scheduled_task_service.py` errors are pre-existing on main).
- ruff + format + mypy clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR (per review discussion)

`revert(web)`: the run build phase text hints from PR #304 ("Preparing... / Loading tools... / Contacting model...") are dropped — those phases fall back to the bouncing-dots loader. The backend still emits the `preparing`/`loading_tools`/`starting` SSE status events (kept for future UI); `sandbox_creating`/`sandbox_failed` rendering is unchanged. The three i18n keys are removed with their last consumer.