### PR TITLE
[codex] Redesign login page

### DIFF
--- a/backend/tests/unit/mcp/test_runtime_tools_cache.py
+++ b/backend/tests/unit/mcp/test_runtime_tools_cache.py
@@ -77,9 +77,7 @@ def test_cache_built_tool_matches_live_loader_shape() -> None:
 
     assert cached.name == live.name
     assert cached.description == live.description
-    assert (
-        cached.parameters.model_json_schema() == live.parameters.model_json_schema()
-    )
+    assert cached.parameters.model_json_schema() == live.parameters.model_json_schema()
 
 
 def test_cache_entry_without_schema_gets_empty_object_schema() -> None:

--- a/docs/dev/plans/2026-07-06-login-page-redesign.md
+++ b/docs/dev/plans/2026-07-06-login-page-redesign.md
@@ -1,0 +1,42 @@
+# Login Page Redesign Implementation Plan
+
+**Goal:** Replace the bare login form with a polished cubebox entry screen while preserving every existing auth flow.
+
+**Architecture:** Keep routing and API behavior unchanged. Use the auth layout as the visual shell and keep `LoginForm` as the stateful client component for password, Google, SSO, and verification flows.
+
+**Tech Stack:** Next.js App Router, React 19, Tailwind v4 semantic tokens, next-intl, existing auth helpers from `@cubebox/core`.
+
+## Constraints
+
+- Preserve `/login?next=...` redirect handling.
+- Preserve SSO-required and email-not-verified fallback behavior.
+- Preserve single-tenant SSO behavior from `useDeploymentMode()`.
+- Use existing project tokens: Geist, neutral surfaces, `bg-primary`, `text-primary`.
+- No new dependencies.
+- No route, API, or field-name changes.
+
+## Tasks
+
+1. Add a focused component test for the redesigned login surface.
+   - Assert the product narrative copy renders.
+   - Assert the form still exposes accessible Email, Password, Sign in, Google, SSO, forgot-password, and create-account controls.
+
+2. Redesign the auth layout.
+   - Convert `(auth)/layout.tsx` from centered single card to a responsive two-column shell.
+   - Add product-specific copy about agents, tools, memory, and workspace control.
+   - Keep mobile single-column and make the form visible without horizontal overflow.
+
+3. Redesign `LoginForm`.
+   - Replace raw loose spacing with a structured panel, accessible labels, stronger focus states, and clearer error/callout surfaces.
+   - Keep all existing state and submit logic intact.
+   - Update third-party auth buttons only as needed for visual consistency.
+
+4. Update localized auth copy.
+   - Improve login title/subtitle and provider button wording in English and Chinese.
+   - Avoid em-dashes and generic SaaS filler.
+
+5. Verify.
+   - Run the new component test red first, then green.
+   - Run targeted frontend tests for login/SSO behavior where possible.
+   - Run `pnpm type-check`.
+   - Start the frontend dev server on the worktree port and inspect `/login`.

--- a/frontend/packages/web/__tests__/components/LoginPageSurface.test.tsx
+++ b/frontend/packages/web/__tests__/components/LoginPageSurface.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import { describe, expect, it, vi } from 'vitest'
+import AuthLayout from '@/app/(auth)/layout'
+import { LoginForm } from '@/components/auth/LoginForm'
+import messages from '@/messages/en.json'
+
+const push = vi.fn()
+const refresh = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push, refresh }),
+}))
+
+vi.mock('@cubebox/core/hooks/useDeploymentMode', () => ({
+  useDeploymentMode: () => ({
+    mode: 'multi_tenant',
+    loading: false,
+    error: undefined,
+    sandboxEnabled: true,
+    passwordPolicy: 'high',
+  }),
+}))
+
+describe('Login page surface', () => {
+  it('pairs product narrative with the existing accessible login controls', () => {
+    document.cookie = 'NEXT_LOCALE=; Max-Age=0; path=/'
+    refresh.mockClear()
+
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <AuthLayout>
+          <LoginForm nextPath="/workspaces" />
+        </AuthLayout>
+      </NextIntlClientProvider>,
+    )
+
+    expect(screen.getByText(/agent workspace/i)).toBeInTheDocument()
+    expect(screen.getByText(/memory, tools, and approvals/i)).toBeInTheDocument()
+    expect(screen.getByTestId('auth-brand-logo')).toHaveTextContent('cubebox')
+    expect(screen.getByTestId('auth-ambient-background')).toBeInTheDocument()
+    expect(screen.getByTestId('cubebox-runtime-visual')).toBeInTheDocument()
+    expect(screen.getByTestId('cubebox-runtime-visual')).toHaveAttribute(
+      'data-visual',
+      'animated-cube-background',
+    )
+    expect(screen.getByRole('combobox', { name: 'Language' })).toHaveValue('en')
+
+    expect(screen.getByLabelText('Email')).toBeInTheDocument()
+    expect(screen.getByLabelText('Password')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /login with google/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sso login/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /forgot password/i })).toHaveAttribute(
+      'href',
+      '/forgot-password',
+    )
+    expect(screen.getByRole('link', { name: /create an account/i })).toHaveAttribute(
+      'href',
+      '/register?next=%2Fworkspaces',
+    )
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Language' }), {
+      target: { value: 'zh' },
+    })
+    expect(document.cookie).toContain('NEXT_LOCALE=zh')
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/packages/web/__tests__/e2e/i18n.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/i18n.spec.ts
@@ -1,11 +1,5 @@
 import { test, expect } from '@playwright/test'
 
-function uniqueEmail(): string {
-  return `u-${Date.now()}-${Math.random().toString(16).slice(2, 6)}@example.com`
-}
-
-const PASSWORD = 'correcthorsebatterystaple'
-
 test.describe('i18n — language preference', () => {
   test('login page shows Chinese when NEXT_LOCALE cookie is zh', async ({ page }) => {
     await page.goto('/login')
@@ -24,28 +18,20 @@ test.describe('i18n — language preference', () => {
     await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
   })
 
-  test('language switcher changes UI and persists after reload', async ({ page }) => {
-    const email = uniqueEmail()
+  test('language switcher changes login UI and persists after reload', async ({ page }) => {
+    await page.setExtraHTTPHeaders({ 'Accept-Language': 'en-US,en;q=0.9' })
+    await page.goto('/login')
+    await expect(page.getByRole('heading', { name: 'Welcome back' })).toBeVisible()
 
-    // Register a new user — default language is 'en'
-    await page.goto('/register')
-    await page.getByLabel('Email').fill(email)
-    await page.getByLabel('Password').fill(PASSWORD)
-    await page.getByRole('button', { name: /create account/i }).click()
-    await expect(page).toHaveURL(/\/w\/[^/]+$/, { timeout: 10_000 })
+    await page.getByRole('combobox', { name: 'Language' }).selectOption('zh')
+    await expect(page.getByRole('heading', { name: '欢迎回来' })).toBeVisible({ timeout: 8_000 })
 
-    // Switch to Chinese via avatar popover
-    await page.getByRole('button', { name: 'Account menu' }).click()
-    await page.getByRole('button', { name: '中文' }).click()
-    await expect(page.getByPlaceholder('描述一个任务…')).toBeVisible({ timeout: 8_000 })
-
-    // Chinese persists after full reload
     await page.reload()
-    await expect(page.getByPlaceholder('描述一个任务…')).toBeVisible()
+    await expect(page.getByRole('heading', { name: '欢迎回来' })).toBeVisible()
 
-    // Switch back to English (aria-label is now localized to Chinese here)
-    await page.getByRole('button', { name: '账号菜单' }).click()
-    await page.getByRole('button', { name: 'EN', exact: true }).click()
-    await expect(page.getByPlaceholder('Describe a task…')).toBeVisible({ timeout: 8_000 })
+    await page.getByRole('combobox', { name: '语言' }).selectOption('en')
+    await expect(page.getByRole('heading', { name: 'Welcome back' })).toBeVisible({
+      timeout: 8_000,
+    })
   })
 })

--- a/frontend/packages/web/__tests__/e2e/i18n.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/i18n.spec.ts
@@ -13,14 +13,14 @@ test.describe('i18n — language preference', () => {
       document.cookie = 'NEXT_LOCALE=zh; path=/'
     })
     await page.reload()
-    await expect(page.getByRole('heading', { name: '登录到 cubebox' })).toBeVisible()
-    await expect(page.getByRole('button', { name: '登录' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: '欢迎回来' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '登录', exact: true })).toBeVisible()
   })
 
   test('login page shows English when browser prefers en', async ({ page }) => {
     await page.setExtraHTTPHeaders({ 'Accept-Language': 'en-US,en;q=0.9' })
     await page.goto('/login')
-    await expect(page.getByRole('heading', { name: 'Sign in to cubebox' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Welcome back' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
   })
 

--- a/frontend/packages/web/app/(auth)/layout.tsx
+++ b/frontend/packages/web/app/(auth)/layout.tsx
@@ -1,7 +1,5 @@
+import { AuthShell } from '@/components/auth/AuthShell'
+
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-background p-6">
-      <div className="w-full max-w-sm">{children}</div>
-    </div>
-  )
+  return <AuthShell>{children}</AuthShell>
 }

--- a/frontend/packages/web/app/globals.css
+++ b/frontend/packages/web/app/globals.css
@@ -451,6 +451,100 @@
   }
 }
 
+@keyframes auth-cube-drift {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) rotate(-8deg) skewY(-4deg);
+  }
+  50% {
+    transform: translate(-50%, -53%) rotate(-3deg) skewY(-2deg);
+  }
+}
+
+@keyframes auth-cube-float {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(0, -10px, 0);
+  }
+}
+
+.auth-cube-stage {
+  animation: auth-cube-float 6s var(--ease-out-quart) infinite;
+}
+
+.auth-cube-wire {
+  --cube-size: clamp(210px, 48%, 350px);
+
+  animation: auth-cube-drift 12s var(--ease-out-quart) infinite;
+  height: var(--cube-size);
+  left: 50%;
+  position: absolute;
+  top: 50%;
+  width: var(--cube-size);
+}
+
+.auth-cube-square {
+  background:
+    linear-gradient(135deg, rgb(0 112 243 / 0.12), rgb(255 255 255 / 0.02) 62%),
+    rgb(0 112 243 / 0.025);
+  border: 1px solid rgb(0 112 243 / 0.62);
+  box-shadow:
+    inset 0 0 42px rgb(0 112 243 / 0.08),
+    0 0 32px rgb(0 112 243 / 0.08);
+  opacity: 0.86;
+  position: absolute;
+}
+
+.auth-cube-square-front {
+  height: 64%;
+  left: 12%;
+  top: 22%;
+  width: 64%;
+}
+
+.auth-cube-square-back {
+  height: 64%;
+  left: 29%;
+  top: 7%;
+  width: 64%;
+}
+
+.auth-cube-edge {
+  background: rgb(0 112 243 / 0.58);
+  box-shadow: 0 0 18px rgb(0 112 243 / 0.24);
+  height: 1px;
+  position: absolute;
+  transform-origin: left center;
+  width: 24%;
+}
+
+.auth-cube-edge-top-left {
+  left: 12%;
+  top: 22%;
+  transform: rotate(-41deg);
+}
+
+.auth-cube-edge-top-right {
+  left: 76%;
+  top: 22%;
+  transform: rotate(-41deg);
+}
+
+.auth-cube-edge-bottom-left {
+  left: 12%;
+  top: 86%;
+  transform: rotate(-41deg);
+}
+
+.auth-cube-edge-bottom-right {
+  left: 76%;
+  top: 86%;
+  transform: rotate(-41deg);
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/frontend/packages/web/components/auth/AuthLanguageSwitcher.tsx
+++ b/frontend/packages/web/components/auth/AuthLanguageSwitcher.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useLocale, useTranslations } from 'next-intl'
+import { ChevronDown, Languages } from 'lucide-react'
+
+type SupportedLocale = 'en' | 'zh'
+
+function normalizeLocale(locale: string): SupportedLocale {
+  return locale === 'zh' ? 'zh' : 'en'
+}
+
+export function AuthLanguageSwitcher() {
+  const router = useRouter()
+  const locale = normalizeLocale(useLocale())
+  const t = useTranslations('avatar')
+
+  const onLanguageChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextLocale = normalizeLocale(event.target.value)
+    document.cookie = `NEXT_LOCALE=${nextLocale}; path=/; SameSite=Lax`
+    router.refresh()
+  }
+
+  return (
+    <label className="absolute right-5 top-5 z-20 md:right-8 md:top-7">
+      <span className="sr-only">{t('language')}</span>
+      <span className="relative inline-flex h-8 items-center">
+        <Languages className="pointer-events-none absolute left-2.5 size-3.5 text-muted-foreground" />
+        <select
+          aria-label={t('language')}
+          value={locale}
+          onChange={onLanguageChange}
+          className="h-8 appearance-none rounded-md border border-border/80 bg-background/75 pl-8 pr-7 text-xs font-medium text-foreground shadow-sm outline-none transition-colors duration-fast hover:bg-background focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+        >
+          <option value="en">EN</option>
+          <option value="zh">中文</option>
+        </select>
+        <ChevronDown className="pointer-events-none absolute right-2 size-3 text-muted-foreground" />
+      </span>
+    </label>
+  )
+}

--- a/frontend/packages/web/components/auth/AuthShell.tsx
+++ b/frontend/packages/web/components/auth/AuthShell.tsx
@@ -1,0 +1,75 @@
+import { useTranslations } from 'next-intl'
+import { AuthLanguageSwitcher } from '@/components/auth/AuthLanguageSwitcher'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+
+export function AuthShell({ children }: { children: React.ReactNode }) {
+  const t = useTranslations('auth')
+
+  return (
+    <main className="relative min-h-[100dvh] overflow-x-hidden bg-background text-foreground lg:h-[100dvh] lg:overflow-hidden">
+      <div data-testid="auth-ambient-background" aria-hidden="true" className="absolute inset-0">
+        <div className="absolute inset-0 bg-[linear-gradient(115deg,var(--color-primary)_0%,transparent_34%),linear-gradient(to_right,var(--color-background)_0%,transparent_58%)] opacity-[0.08]" />
+        <div className="absolute inset-y-0 left-0 w-[68%] bg-[radial-gradient(circle_at_26%_22%,var(--color-primary)_0,transparent_28%),radial-gradient(circle_at_56%_72%,var(--color-primary)_0,transparent_34%)] opacity-[0.16]" />
+        <div className="absolute inset-0 bg-[linear-gradient(to_right,var(--color-border)_1px,transparent_1px),linear-gradient(to_bottom,var(--color-border)_1px,transparent_1px)] bg-[size:48px_48px] opacity-25 [mask-image:linear-gradient(to_right,black,black_48%,transparent_78%)]" />
+        <div className="absolute inset-y-0 right-0 w-[52%] bg-gradient-to-r from-transparent via-background/70 to-background" />
+      </div>
+
+      <div
+        data-testid="auth-brand-logo"
+        className="absolute left-5 top-5 z-20 flex items-center gap-2 md:left-8 md:top-7"
+      >
+        <span className="grid size-7 place-items-center rounded-md bg-primary text-[13px] font-semibold text-primary-foreground shadow-[0_12px_40px_rgba(0,112,243,0.24)]">
+          c
+        </span>
+        <span className="text-sm font-semibold tracking-normal text-foreground">cubebox</span>
+      </div>
+      <AuthLanguageSwitcher />
+
+      <div className="relative z-10 mx-auto grid min-h-[100dvh] w-full max-w-7xl grid-cols-1 items-center gap-8 px-4 pb-6 pt-20 md:px-8 lg:h-full lg:grid-cols-[1.08fr_0.92fr] lg:gap-12 lg:px-10 lg:py-10">
+        <section className="relative order-2 flex min-h-[420px] flex-col justify-center overflow-hidden lg:order-1 lg:min-h-0 lg:self-stretch lg:overflow-visible lg:pr-8">
+          <div className="relative z-10 flex max-w-xl flex-col gap-5">
+            <Badge variant="outline" className="w-fit border-primary/20 bg-background/70">
+              {t('surfaceEyebrow')}
+            </Badge>
+            <div className="flex flex-col gap-4">
+              <h1 className="text-4xl font-semibold leading-[1.04] tracking-normal text-foreground md:text-5xl lg:text-5xl">
+                {t('surfaceTitle')}
+              </h1>
+              <p className="max-w-lg text-base leading-7 text-muted-foreground md:text-lg">
+                {t('surfaceSubtitle')}
+              </p>
+            </div>
+          </div>
+
+          <div
+            data-testid="cubebox-runtime-visual"
+            data-visual="animated-cube-background"
+            aria-hidden="true"
+            className="pointer-events-none absolute -bottom-16 -right-12 aspect-square w-[min(84vw,28rem)] opacity-80 md:-bottom-24 md:right-0 md:w-[31rem] lg:-bottom-44 lg:-right-72 lg:w-[43rem]"
+          >
+            <div className="absolute inset-0 rounded-full bg-primary/10 blur-3xl" />
+            <div className="auth-cube-stage absolute inset-0">
+              <div className="auth-cube-wire">
+                <div className="auth-cube-square auth-cube-square-back" />
+                <div className="auth-cube-square auth-cube-square-front" />
+                <div className="auth-cube-edge auth-cube-edge-top-left" />
+                <div className="auth-cube-edge auth-cube-edge-top-right" />
+                <div className="auth-cube-edge auth-cube-edge-bottom-left" />
+                <div className="auth-cube-edge auth-cube-edge-bottom-right" />
+              </div>
+            </div>
+            <div className="absolute left-[18%] top-[26%] h-px w-[64%] bg-gradient-to-r from-transparent via-primary/35 to-transparent" />
+            <div className="absolute left-[25%] top-[18%] h-[64%] w-px bg-gradient-to-b from-transparent via-primary/25 to-transparent" />
+          </div>
+        </section>
+
+        <section className="order-1 w-full justify-self-center lg:order-2 lg:max-w-md">
+          <Card className="border-border/80 bg-card shadow-sm">
+            <CardContent className="px-5 py-5 md:px-6 md:py-6">{children}</CardContent>
+          </Card>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/frontend/packages/web/components/auth/GoogleLoginButton.tsx
+++ b/frontend/packages/web/components/auth/GoogleLoginButton.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { ApiError, createApiClient, getGoogleAuthorizeUrl } from '@cubebox/core'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
 
 export function GoogleLoginButton() {
   const t = useTranslations('auth')
@@ -27,14 +29,16 @@ export function GoogleLoginButton() {
   }
 
   return (
-    <div className="space-y-2">
-      <button
+    <div className="flex flex-col gap-2">
+      <Button
         type="button"
+        variant="outline"
+        size="lg"
         onClick={onClick}
         disabled={loading}
-        className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background disabled:opacity-50 flex items-center justify-center gap-2"
+        className="w-full"
       >
-        <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+        <svg data-icon="inline-start" viewBox="0 0 24 24" aria-hidden="true">
           <path
             d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
             fill="#4285F4"
@@ -53,8 +57,12 @@ export function GoogleLoginButton() {
           />
         </svg>
         <span>{loading ? t('redirecting') : t('loginWithGoogle')}</span>
-      </button>
-      {error && <div className="text-sm text-destructive">{error}</div>}
+      </Button>
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
     </div>
   )
 }

--- a/frontend/packages/web/components/auth/LoginForm.tsx
+++ b/frontend/packages/web/components/auth/LoginForm.tsx
@@ -6,6 +6,11 @@ import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { ApiError, createApiClient, loginUser, useAuthStore } from '@cubebox/core'
 import { useDeploymentMode } from '@cubebox/core/hooks/useDeploymentMode'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button, buttonVariants } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
 import { GoogleLoginButton } from './GoogleLoginButton'
 import { SSOButton } from './SSOButton'
 
@@ -81,86 +86,96 @@ export function LoginForm({ nextPath = '/' }: { nextPath?: string }) {
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      <div className="text-center mb-6">
-        <h1 className="text-xl font-semibold">{t('signInTitle')}</h1>
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold tracking-normal">{t('signInTitle')}</h2>
+        <p className="text-sm leading-6 text-muted-foreground">{t('signInSubtitle')}</p>
       </div>
-      <label className="block">
-        <span className="text-sm text-foreground/80">{t('email')}</span>
-        <input
-          type="email"
-          required
-          autoComplete="email"
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-      </label>
-      <label className="block">
-        <span className="text-sm text-foreground/80">{t('password')}</span>
-        <input
-          type="password"
-          required
-          autoComplete="current-password"
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-      </label>
-      <div className="text-right">
-        <Link href="/forgot-password" className="text-xs text-muted-foreground underline">
+
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="login-email">{t('email')}</Label>
+          <Input
+            id="login-email"
+            type="email"
+            required
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="login-password">{t('password')}</Label>
+          <Input
+            id="login-password"
+            type="password"
+            required
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <Link
+          href="/forgot-password"
+          className="text-xs text-muted-foreground hover:text-foreground"
+        >
           {t('forgotPassword')}
         </Link>
       </div>
+
       {ssoRequired ? (
-        <div
-          role="alert"
-          className="space-y-2 rounded-md border border-border bg-muted/40 p-3 text-sm"
-        >
-          <div>{ssoRequired.message}</div>
-          <Link
-            href={ssoRequired.loginUrl}
-            className="inline-flex w-full items-center justify-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
-          >
-            {t('continueToSSO')}
-          </Link>
-        </div>
+        <Alert>
+          <AlertDescription className="flex flex-col gap-3">
+            <span>{ssoRequired.message}</span>
+            <Link href={ssoRequired.loginUrl} className={buttonVariants({ className: 'w-full' })}>
+              {t('continueToSSO')}
+            </Link>
+          </AlertDescription>
+        </Alert>
       ) : emailNotVerified ? (
-        <div
-          role="alert"
-          className="space-y-2 rounded-md border border-border bg-muted/40 p-3 text-sm"
-        >
-          <div>{emailNotVerified.message}</div>
-          <Link
-            href={`/verify-otp?email=${encodeURIComponent(email)}&next=${encodeURIComponent(nextPath)}`}
-            className="inline-flex w-full items-center justify-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
-          >
-            {t('verifyEmailNow')}
-          </Link>
-        </div>
+        <Alert>
+          <AlertDescription className="flex flex-col gap-3">
+            <span>{emailNotVerified.message}</span>
+            <Link
+              href={`/verify-otp?email=${encodeURIComponent(email)}&next=${encodeURIComponent(nextPath)}`}
+              className={buttonVariants({ className: 'w-full' })}
+            >
+              {t('verifyEmailNow')}
+            </Link>
+          </AlertDescription>
+        </Alert>
       ) : (
-        error && <div className="text-sm text-destructive">{error}</div>
+        error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )
       )}
-      <button
-        type="submit"
-        disabled={submitting}
-        className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
-      >
+
+      <Button type="submit" disabled={submitting} size="lg" className="w-full">
         {submitting ? t('signingIn') : t('signIn')}
-      </button>
-      <div className="relative my-2">
-        <div className="absolute inset-0 flex items-center" aria-hidden="true">
-          <span className="w-full border-t border-border" />
-        </div>
-        <div className="relative flex justify-center text-xs uppercase">
-          <span className="bg-background px-2 text-muted-foreground">{t('or')}</span>
-        </div>
+      </Button>
+
+      <div className="flex items-center gap-3">
+        <Separator className="flex-1" />
+        <span className="text-xs text-muted-foreground">{t('or')}</span>
+        <Separator className="flex-1" />
       </div>
-      <GoogleLoginButton />
-      <SSOButton singleTenant={singleTenant} />
-      <div className="text-center text-sm text-foreground/60">
+
+      <div className="flex flex-col gap-2">
+        <GoogleLoginButton />
+        <SSOButton singleTenant={singleTenant} />
+      </div>
+
+      <div className="text-center text-sm text-muted-foreground">
         {t('newHere')}{' '}
-        <Link href={`/register?next=${encodeURIComponent(nextPath)}`} className="underline">
+        <Link
+          href={`/register?next=${encodeURIComponent(nextPath)}`}
+          className="font-medium text-foreground hover:text-primary"
+        >
           {t('createAccount')}
         </Link>
       </div>

--- a/frontend/packages/web/components/auth/SSOButton.tsx
+++ b/frontend/packages/web/components/auth/SSOButton.tsx
@@ -3,9 +3,12 @@
 import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { createApiClient, initiateSsoLogin } from '@cubebox/core'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 
 interface SSOButtonProps {
-  /** When provided, click goes straight to SSO for this org — no slug input. */
+  /** When provided, click goes straight to SSO for this org, no slug input. */
   orgSlug?: string
   /** In single-tenant mode, no slug input is needed. */
   singleTenant?: boolean
@@ -41,53 +44,64 @@ export function SSOButton({ orgSlug, singleTenant }: SSOButtonProps) {
 
   if (showInput) {
     return (
-      <div className="space-y-2">
-        <input
+      <div className="flex flex-col gap-2">
+        <Input
           type="text"
           placeholder={t('orgSlugPlaceholder')}
           aria-label={t('orgSlugPlaceholder')}
           autoComplete="off"
-          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
           value={slug}
           onChange={(e) => setSlug(e.target.value)}
           autoFocus
         />
-        {error && <div className="text-sm text-destructive">{error}</div>}
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
         <div className="flex gap-2">
-          <button
+          <Button
             type="button"
+            size="lg"
             onClick={() => startSSO(slug.trim())}
             disabled={loading || !slug.trim()}
-            className="flex-1 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background disabled:opacity-50"
+            className="flex-1"
           >
             {loading ? t('redirecting') : t('continue')}
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant="outline"
+            size="lg"
             onClick={() => {
               setShowInput(false)
               setError(null)
             }}
-            className="rounded-md border border-border px-3 py-2 text-sm hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
           >
             {t('back')}
-          </button>
+          </Button>
         </div>
       </div>
     )
   }
 
   return (
-    <div className="space-y-2">
-      <button
+    <div className="flex flex-col gap-2">
+      <Button
         type="button"
+        variant="outline"
+        size="lg"
         onClick={onClick}
         disabled={loading}
-        className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background disabled:opacity-50"
+        className="w-full"
       >
         {loading ? t('redirecting') : t('loginWithSSO')}
-      </button>
-      {error && <div className="text-sm text-destructive">{error}</div>}
+      </Button>
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
     </div>
   )
 }

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -1,7 +1,8 @@
 {
   "auth": {
     "signIn": "Sign in",
-    "signInTitle": "Sign in to cubebox",
+    "signInTitle": "Welcome back",
+    "signInSubtitle": "Open your workspace and continue the runs already in motion.",
     "signUp": "Create account",
     "signUpTitle": "Create your cubebox account",
     "email": "Email",
@@ -53,7 +54,21 @@
     "resendCode": "Resend code",
     "resendIn": "Resend in {seconds}s",
     "passwordTooWeak": "Password doesn't meet the strength requirements.",
-    "verifyEmailNow": "Verify email now"
+    "verifyEmailNow": "Verify email now",
+    "surfaceEyebrow": "Agent workspace",
+    "surfaceTitle": "Run agents with memory, tools, and approvals in one place.",
+    "surfaceSubtitle": "Cubebox keeps long-running agent work inside the same workspace as your models, connectors, artifacts, and team controls.",
+    "surfacePanelTitle": "Built for controlled autonomy",
+    "surfacePanelDescription": "Sign in to inspect active runs, review tool access, and resume work with full workspace context.",
+    "surfaceFeatureMemoryTitle": "Memory",
+    "surfaceFeatureMemoryDescription": "Keep useful context available without rebuilding every prompt.",
+    "surfaceFeatureToolsTitle": "Tools",
+    "surfaceFeatureToolsDescription": "Connect MCP services, sandbox work, and internal systems.",
+    "surfaceFeatureControlTitle": "Control",
+    "surfaceFeatureControlDescription": "Use approvals, scopes, and audit trails before work leaves the box.",
+    "surfaceSignalRuns": "Streaming runs stay attached to their workspace.",
+    "surfaceSignalScopes": "Org and workspace scopes stay separate.",
+    "surfaceSignalAudit": "Artifacts, citations, and decisions stay reviewable."
   },
   "sidebar": {
     "newChat": "New Chat",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -1,7 +1,8 @@
 {
   "auth": {
     "signIn": "登录",
-    "signInTitle": "登录到 cubebox",
+    "signInTitle": "欢迎回来",
+    "signInSubtitle": "进入工作区，继续处理中或等待确认的 Agent 任务。",
     "signUp": "创建账户",
     "signUpTitle": "创建您的 cubebox 账户",
     "email": "邮箱",
@@ -53,7 +54,21 @@
     "resendCode": "重新发送",
     "resendIn": "{seconds} 秒后重新发送",
     "passwordTooWeak": "密码不符合强度要求。",
-    "verifyEmailNow": "立即验证邮箱"
+    "verifyEmailNow": "立即验证邮箱",
+    "surfaceEyebrow": "Agent 工作区",
+    "surfaceTitle": "把 Agent、记忆、工具和审批放在同一个控制面。",
+    "surfaceSubtitle": "cubebox 让长时间运行的 Agent 任务与模型、连接器、成果库和团队权限保持在同一个工作区里。",
+    "surfacePanelTitle": "为可控的自动化而设计",
+    "surfacePanelDescription": "登录后检查运行状态、审阅工具访问，并带着完整工作区上下文继续任务。",
+    "surfaceFeatureMemoryTitle": "记忆",
+    "surfaceFeatureMemoryDescription": "保留有用上下文，不必每次重新组织提示词。",
+    "surfaceFeatureToolsTitle": "工具",
+    "surfaceFeatureToolsDescription": "连接 MCP 服务、沙盒环境和内部系统。",
+    "surfaceFeatureControlTitle": "控制",
+    "surfaceFeatureControlDescription": "通过审批、作用域和审计记录控制任务边界。",
+    "surfaceSignalRuns": "流式运行始终归属到工作区。",
+    "surfaceSignalScopes": "组织和工作区作用域保持隔离。",
+    "surfaceSignalAudit": "成果、引用和决策过程可追溯。"
   },
   "sidebar": {
     "newChat": "新建对话",


### PR DESCRIPTION
## Summary

- Replaces the bare auth layout with a polished cubebox login surface using the existing theme blue, full-screen ambient background, brand logo, and animated cube visual.
- Updates login, Google, and SSO controls to use the existing UI primitives while preserving auth behavior.
- Adds a top-right language selector on auth pages that persists `NEXT_LOCALE` and refreshes the page.
- Updates English and Chinese auth copy and aligns affected i18n E2E assertions with the new login page wording.
- Includes a small backend test formatting-only commit required by the repository pre-push hook.

## Impact

Users get a more product-specific login page with clearer cubebox positioning, accessible controls, and language switching before sign-in. Routes and API contracts are unchanged.

## Validation

- `pnpm test __tests__/components/LoginPageSurface.test.tsx`
- `pnpm type-check`
- `pnpm format:check`
- `pnpm lint`
- `pnpm test:e2e i18n.spec.ts`
- Browser check: selecting Chinese on `/login` sets `NEXT_LOCALE=zh` and renders `欢迎回来`
- Pre-push hook: backend check-ci and frontend check-ci passed