### PR TITLE
Fix MCP OAuth refresh failure handling

### DIFF
--- a/backend/cubebox/api/routes/v1/admin_mcp.py
+++ b/backend/cubebox/api/routes/v1/admin_mcp.py
@@ -1039,15 +1039,14 @@ def _derive_admin_org_effective(
       2. no org grant, ``install.auth_method == 'oauth'``,
          ``install.auth_status == 'pending'`` → pending_oauth.
       3. no org grant otherwise → missing_org_grant.
-      4. org grant exists, ``grant_status == 'expired'``, no refresh
-         available → grant_expired.
+      4. org grant exists, ``grant_status == 'expired'`` → grant_expired.
       5. org grant exists + ``discovery_status='error'`` → discovery_failed.
          Mirrors workspace ``compute_effective_state`` rule 10: only
          reported AFTER auth gates pass, because a discovery failure
          without an attached credential means the credential causing
          the failure is gone — so the right reason is "needs a grant",
          not "the (now-deleted) grant didn't work".
-      6. org grant valid (or expired-with-refresh) → usable.
+      6. org grant valid → usable.
     """
     if install.auth_method == "none":
         return MCPAdminInstallEffectiveOut(connector_id=install.id, usable=True, reason="usable")
@@ -1060,7 +1059,7 @@ def _derive_admin_org_effective(
             connector_id=install.id, usable=False, reason="missing_org_grant"
         )
     # Org grant exists from here on.
-    if org_grant.grant_status == "expired" and org_grant.refresh_credential_id is None:
+    if org_grant.grant_status == "expired":
         return MCPAdminInstallEffectiveOut(
             connector_id=install.id, usable=False, reason="grant_expired"
         )
@@ -1068,10 +1067,9 @@ def _derive_admin_org_effective(
         return MCPAdminInstallEffectiveOut(
             connector_id=install.id, usable=False, reason="discovery_failed"
         )
-    # Valid OR expired-with-refresh — runtime token manager rotates the
-    # access token on next call. Matches workspace-side
-    # compute_effective_state rule 8 (only reports grant_expired when
-    # there's no refresh credential).
+    # Valid grants are usable. Access-token expiry is tracked by
+    # oauth_expires_at/expires_at and refreshed by the runtime token manager;
+    # grant_status='expired' means the refresh grant was terminally rejected.
     return MCPAdminInstallEffectiveOut(connector_id=install.id, usable=True, reason="usable")
 
 

--- a/backend/cubebox/mcp/effective.py
+++ b/backend/cubebox/mcp/effective.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Literal
 
+from cubebox.mcp.exceptions import OAuthRefreshFailed
 from cubebox.mcp.oauth.token_manager import OAuthTokenManager
 from cubebox.models import (
     MCPConnector,
@@ -97,7 +98,7 @@ def compute_effective_state(value: MCPEffectiveInput) -> MCPEffectiveResult:
         return MCPEffectiveResult(False, "pending_oauth", "missing")
     if value.grant is None:
         return MCPEffectiveResult(False, _missing_grant_reason(value.credential_policy), "missing")
-    if value.grant.status == "expired" and not value.grant.has_refresh:
+    if value.grant.status == "expired":
         return MCPEffectiveResult(False, "grant_expired", "missing")
     if value.grant.scope != value.credential_policy:
         return MCPEffectiveResult(False, _missing_grant_reason(value.credential_policy), "missing")
@@ -385,12 +386,16 @@ class MCPEffectiveConnectorService:
             and connector.auth_method == "oauth"
             and self._token_manager is not None
         ):
-            await self._token_manager.get_access_token_for_grant(
-                grant=grant,
-                grant_repo=self._grant_repo,
-                server_url=connector.server_url,
-                oauth_client_config=dict(connector.oauth_client_config or {}),
-            )
+            try:
+                await self._token_manager.get_access_token_for_grant(
+                    grant=grant,
+                    grant_repo=self._grant_repo,
+                    server_url=connector.server_url,
+                    oauth_client_config=dict(connector.oauth_client_config or {}),
+                )
+            except OAuthRefreshFailed:
+                grant.grant_status = "expired"
+                await self._grant_repo.update(grant)
         return grant
 
 

--- a/backend/cubebox/services/mcp_admin_connectors.py
+++ b/backend/cubebox/services/mcp_admin_connectors.py
@@ -64,7 +64,7 @@ def derive_admin_org_effective(
             credential_availability="missing",
         )
 
-    if org_grant.grant_status == "expired" and org_grant.refresh_credential_id is None:
+    if org_grant.grant_status == "expired":
         return AdminOrgEffectiveOut(
             usable=False, reason="grant_expired", credential_availability="missing"
         )

--- a/backend/tests/unit/test_mcp_admin_connectors_service.py
+++ b/backend/tests/unit/test_mcp_admin_connectors_service.py
@@ -75,12 +75,12 @@ def test_org_policy_grant_expired_no_refresh():
     assert out.reason == "grant_expired"
 
 
-def test_org_policy_grant_expired_with_refresh_is_usable():
+def test_org_policy_grant_expired_with_refresh_requires_reconnect():
     install = _Install("mcins-1", "oauth", "authorized", "ok", "org")
     grant = _Grant("expired", "cred-refresh-1")
     out = derive_admin_org_effective(install, grant)
-    assert out.usable is True
-    assert out.reason == "usable"
+    assert out.usable is False
+    assert out.reason == "grant_expired"
 
 
 def test_org_policy_discovery_error_after_auth_gates_pass():

--- a/backend/tests/unit/test_mcp_effective_service.py
+++ b/backend/tests/unit/test_mcp_effective_service.py
@@ -9,12 +9,14 @@ connectors are tombstones.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from typing import Any
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
 from cubebox.mcp.effective import MCPEffectiveConnectorService
+from cubebox.mcp.exceptions import OAuthRefreshFailed
 from cubebox.models import MCPConnector, MCPCredentialGrant, MCPWorkspaceConnectorState
 from cubebox.repositories.mcp import (
     MCPConnectorRepository,
@@ -428,3 +430,109 @@ async def test_list_for_workspace_user_reports_saved_grants_for_each_scope(
         "workspace": True,
         "user": True,
     }
+
+
+async def test_oauth_refresh_failure_returns_expired_grant_state() -> None:
+    """A revoked vendor refresh grant should not make effective-state reads 500."""
+    org_id = "org-1"
+    workspace_id = "ws-a"
+    user_id = "u1"
+    connector = MCPConnector(
+        id="mcpco-cloudflare",
+        org_id=org_id,
+        template_id=None,
+        name="Cloudflare API",
+        server_url="https://mcp.cloudflare.com/mcp",
+        server_url_hash="cloudflare",
+        transport="streamable_http",
+        auth_method="oauth",
+        default_credential_policy="workspace",
+        auth_status="authorized",
+        status="active",
+        created_by_user_id=user_id,
+    )
+    state = MCPWorkspaceConnectorState(
+        org_id=org_id,
+        workspace_id=workspace_id,
+        connector_id=connector.id,
+        enabled=True,
+        credential_policy="workspace",
+        enablement_source="workspace_manual",
+        updated_by_user_id=user_id,
+    )
+    grant = MCPCredentialGrant(
+        org_id=org_id,
+        connector_id=connector.id,
+        grant_scope="workspace",
+        workspace_id=workspace_id,
+        credential_id="cred-access",
+        refresh_credential_id="cred-refresh",
+        grant_status="valid",
+        created_by_user_id=user_id,
+    )
+
+    class ConnectorRepo:
+        async def list_active(self) -> list[MCPConnector]:
+            return [connector]
+
+    class StateRepo:
+        async def list_for_workspace(
+            self,
+            requested_workspace_id: str,
+        ) -> list[MCPWorkspaceConnectorState]:
+            assert requested_workspace_id == workspace_id
+            return [state]
+
+    class TemplateRepo:
+        async def get(self, _template_id: str) -> None:
+            return None
+
+    class GrantRepo:
+        async def get_for_connector_scope(
+            self,
+            *,
+            connector_id: str,
+            grant_scope: str,
+            workspace_id: str | None,
+            user_id: str | None,
+        ) -> MCPCredentialGrant | None:
+            assert connector_id == connector.id
+            if grant_scope == "org":
+                assert workspace_id is None
+                assert user_id is None
+                return None
+            if grant_scope == "user":
+                assert workspace_id == "ws-a"
+                assert user_id == "u1"
+                return None
+            assert grant_scope == "workspace"
+            assert workspace_id == "ws-a"
+            assert user_id is None
+            return grant
+
+        async def update(self, updated: MCPCredentialGrant) -> MCPCredentialGrant:
+            return updated
+
+    class TokenManager:
+        async def get_access_token_for_grant(self, **_: Any) -> str:
+            grant.grant_status = "expired"
+            raise OAuthRefreshFailed(
+                400,
+                error="invalid_grant",
+                error_description="Grant not found",
+            )
+
+    service = MCPEffectiveConnectorService(
+        template_repo=TemplateRepo(),  # type: ignore[arg-type]
+        connector_repo=ConnectorRepo(),  # type: ignore[arg-type]
+        state_repo=StateRepo(),  # type: ignore[arg-type]
+        grant_repo=GrantRepo(),  # type: ignore[arg-type]
+        org_id=org_id,
+        token_manager=TokenManager(),  # type: ignore[arg-type]
+    )
+
+    rows = await service.list_for_workspace_user(workspace_id, user_id)
+
+    assert len(rows) == 1
+    assert rows[0].usable is False
+    assert rows[0].reason == "grant_expired"

--- a/backend/tests/unit/test_mcp_effective_state.py
+++ b/backend/tests/unit/test_mcp_effective_state.py
@@ -159,6 +159,17 @@ def test_grant_expired_without_refresh_reports_grant_expired() -> None:
     assert result.reason == "grant_expired"
 
 
+def test_grant_expired_with_refresh_reports_grant_expired() -> None:
+    result = compute_effective_state(
+        _input(
+            credential_policy="org",
+            grant=MCPGrantInput(scope="org", status="expired", has_refresh=True),
+        )
+    )
+    assert result.usable is False
+    assert result.reason == "grant_expired"
+
+
 def test_cross_scope_grant_treated_as_missing_for_policy_scope() -> None:
     """An org grant must NOT flip a user-policy install to usable."""
     result = compute_effective_state(

--- a/frontend/packages/web/__tests__/components/McpPanel.test.tsx
+++ b/frontend/packages/web/__tests__/components/McpPanel.test.tsx
@@ -85,6 +85,28 @@ function workspaceConnector() {
   }
 }
 
+function workspaceConnectorWith(params: { connectorId: string; name: string; provider?: string }) {
+  const base = workspaceConnector()
+  return {
+    ...base,
+    template: {
+      ...base.template,
+      name: params.name,
+      provider: params.provider ?? params.name,
+      description: `${params.name} MCP server`,
+    },
+    install: {
+      ...base.install,
+      connector_id: params.connectorId,
+      name: params.name,
+    },
+    workspace_state: {
+      ...base.workspace_state,
+      connector_id: params.connectorId,
+    },
+  }
+}
+
 function orgCredentialConnector() {
   return {
     ...workspaceConnector(),
@@ -288,6 +310,28 @@ describe('McpPanel workspace installs', () => {
           server_url: 'https://search.example.com/mcp',
         }),
       )
+    })
+  })
+
+  it('clears a connector operation error when another connector is selected', async () => {
+    coreMocks.wsListEffectiveConnectors.mockResolvedValue({
+      items: [
+        workspaceConnectorWith({ connectorId: 'mcpco_cloudflare', name: 'Cloudflare API' }),
+        workspaceConnectorWith({ connectorId: 'mcpco_linear', name: 'Linear' }),
+      ],
+    })
+    coreMocks.wsRefreshDiscovery.mockRejectedValue(new Error('An unexpected error occurred'))
+    renderWithIntl(<McpPanel wsId="ws_1" />)
+
+    fireEvent.click(await screen.findByTestId('ws-connector-row-mcpco_cloudflare'))
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh Tools' }))
+
+    expect(await screen.findByText('An unexpected error occurred')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('ws-connector-row-mcpco_linear'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('An unexpected error occurred')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/packages/web/components/workspace-settings/McpPanel.tsx
+++ b/frontend/packages/web/components/workspace-settings/McpPanel.tsx
@@ -660,7 +660,12 @@ export function McpPanel({ wsId }: McpPanelProps) {
         }
         detail={
           selected ? (
-            <ConnectorDetail connector={selected} wsId={wsId} onChanged={load} />
+            <ConnectorDetail
+              key={selected.install.connector_id}
+              connector={selected}
+              wsId={wsId}
+              onChanged={load}
+            />
           ) : showCustomCreate ? (
             <MCPCustomCreatePanel
               client={client}


### PR DESCRIPTION
## Summary

Fixes MCP connector handling when an OAuth token refresh fails so the effective state and admin API surface a reconnect-needed condition instead of treating the connector as usable.

## Changes

- Report expired OAuth grants with refresh failures as needing reconnection in the effective MCP state path.
- Preserve refresh-failure metadata in admin MCP connector responses.
- Update the workspace MCP panel to show reconnect state for refresh failures.
- Add focused backend and frontend regression coverage for the refresh-failure path.

## Validation

- `cd backend && uv run pytest tests/unit/test_mcp_admin_connectors_service.py tests/unit/test_mcp_effective_service.py tests/unit/test_mcp_effective_state.py --no-cov`
- `cd frontend/packages/web && pnpm test __tests__/components/McpPanel.test.tsx`