### PR TITLE
Prevent Chrome autofill on secret fields

### DIFF
--- a/frontend/packages/web/app/(auth)/reset-password/page.tsx
+++ b/frontend/packages/web/app/(auth)/reset-password/page.tsx
@@ -62,9 +62,13 @@ export default function ResetPasswordPage({
         <span className="text-sm text-foreground/80">{t('newPassword')}</span>
         <input
           type="password"
+          name="reset-password-new"
           required
           minLength={8}
           autoComplete="new-password"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
           className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
@@ -74,9 +78,13 @@ export default function ResetPasswordPage({
         <span className="text-sm text-foreground/80">{t('confirmPassword')}</span>
         <input
           type="password"
+          name="reset-password-confirm"
           required
           minLength={8}
           autoComplete="new-password"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
           className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
           value={confirm}
           onChange={(e) => setConfirm(e.target.value)}

--- a/frontend/packages/web/components/admin/SSOConfigForm.tsx
+++ b/frontend/packages/web/components/admin/SSOConfigForm.tsx
@@ -522,9 +522,14 @@ export function SSOConfigForm({ connection, orgSlug, onUpdated }: SSOConfigFormP
                 <Input
                   id="oidc-client-secret"
                   type="password"
+                  name="oidc-client-secret"
                   value={state.clientSecret}
                   onChange={(e) => update('clientSecret', e.target.value)}
                   placeholder={isEdit ? t('oidc.clientSecretPlaceholder') : ''}
+                  autoComplete="new-password"
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  spellCheck={false}
                   data-testid="sso-client-secret"
                   aria-invalid={Boolean(errors.clientSecret)}
                 />

--- a/frontend/packages/web/components/admin/models/ProviderConfigForm.tsx
+++ b/frontend/packages/web/components/admin/models/ProviderConfigForm.tsx
@@ -316,9 +316,14 @@ export function ProviderConfigForm({
           <Input
             id="pcf-api-key"
             type="password"
+            name="provider-api-key"
             value={apiKey}
             onChange={(e) => setApiKey(e.target.value)}
             placeholder={isCreate ? 'sk-…' : t('apiKeyEditHint')}
+            autoComplete="new-password"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
           />
           <span className="text-[11px] text-muted-foreground">
             {isCreate ? tc('apiKeyRequired') : t('apiKeyEditHint')}

--- a/frontend/packages/web/components/auth/RegisterForm.tsx
+++ b/frontend/packages/web/components/auth/RegisterForm.tsx
@@ -93,9 +93,13 @@ export function RegisterForm({ nextPath = '/' }: { nextPath?: string }) {
         <span className="text-sm text-foreground/80">{t('password')}</span>
         <input
           type="password"
+          name="register-password"
           required
           minLength={8}
           autoComplete="new-password"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
           className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
           value={password}
           onChange={(e) => setPassword(e.target.value)}

--- a/frontend/packages/web/components/im/ImConnectWizard/steps/StepDingtalkCredentials.tsx
+++ b/frontend/packages/web/components/im/ImConnectWizard/steps/StepDingtalkCredentials.tsx
@@ -105,9 +105,14 @@ export function StepDingtalkCredentials({
         <Input
           id="cred-app_secret"
           type="password"
+          name="dingtalk-app-secret"
           required
           value={appSecret}
           onChange={(e) => onChange({ app_secret: e.target.value })}
+          autoComplete="new-password"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
         />
       </div>
 

--- a/frontend/packages/web/components/mcp/AuthBandFrame.tsx
+++ b/frontend/packages/web/components/mcp/AuthBandFrame.tsx
@@ -210,6 +210,11 @@ function StaticTokenForm({
             type="password"
             value={token}
             onChange={(e) => setToken(e.target.value)}
+            name="mcp-band-static-token"
+            autoComplete="new-password"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
             placeholder={t('staticTokenLabel')}
             className="max-w-xs"
             aria-label={t('staticTokenLabel')}

--- a/frontend/packages/web/components/mcp/MCPCustomCreatePanel.tsx
+++ b/frontend/packages/web/components/mcp/MCPCustomCreatePanel.tsx
@@ -139,7 +139,7 @@ export function MCPCustomCreatePanel({
         </p>
       </header>
 
-      <form className="flex flex-col gap-4" onSubmit={(e) => void handleSubmit(e)}>
+      <form className="flex flex-col gap-4" autoComplete="off" onSubmit={(e) => void handleSubmit(e)}>
         <Card>
           <CardHeader>
             <CardTitle>{t('customSectionServer')}</CardTitle>
@@ -149,9 +149,14 @@ export function MCPCustomCreatePanel({
               <Label htmlFor="custom-name">{t('customFieldName')}</Label>
               <Input
                 id="custom-name"
+                name="mcp-connector-name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder={t('customFieldNamePlaceholder')}
+                autoComplete="off"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
                 required
               />
             </div>
@@ -161,9 +166,14 @@ export function MCPCustomCreatePanel({
               <Input
                 id="custom-url"
                 type="url"
+                name="mcp-connector-server-url"
                 value={serverUrl}
                 onChange={(e) => setServerUrl(e.target.value)}
                 placeholder="https://example.com/mcp"
+                autoComplete="off"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
                 required
               />
             </div>
@@ -245,6 +255,11 @@ export function MCPCustomCreatePanel({
                       type={revealSecret ? 'text' : 'password'}
                       value={credentialPlaintext}
                       onChange={(e) => setCredentialPlaintext(e.target.value)}
+                      name="mcp-credential-plaintext"
+                      autoComplete="new-password"
+                      autoCapitalize="off"
+                      autoCorrect="off"
+                      spellCheck={false}
                       required
                     />
                     <button

--- a/frontend/packages/web/components/mcp/MCPToolbar.tsx
+++ b/frontend/packages/web/components/mcp/MCPToolbar.tsx
@@ -71,6 +71,11 @@ export function MCPToolbar({ search, onSearchChange, filter, onFilterChange }: M
           placeholder={t('searchPlaceholder')}
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
+          name="mcp-admin-search"
+          autoComplete="off"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
           className="pl-7"
           aria-label={t('searchAriaLabel')}
         />

--- a/frontend/packages/web/components/mcp/detail/MasterDetailList.tsx
+++ b/frontend/packages/web/components/mcp/detail/MasterDetailList.tsx
@@ -69,6 +69,11 @@ export function MasterDetailList<T extends { name?: string; description?: string
           onChange={(e) => setQuery(e.target.value)}
           placeholder={searchPlaceholder}
           aria-label={searchPlaceholder}
+          name="mcp-detail-search"
+          autoComplete="off"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
           className="h-9 pl-7 text-sm"
         />
       </div>

--- a/frontend/packages/web/components/profile/ChangePasswordForm.tsx
+++ b/frontend/packages/web/components/profile/ChangePasswordForm.tsx
@@ -45,29 +45,41 @@ export function ChangePasswordForm() {
       <form onSubmit={onSubmit} className="space-y-3 max-w-sm">
         <input
           type="password"
+          name="change-password-current"
           required
           placeholder={t('currentPassword')}
-          autoComplete="current-password"
+          autoComplete="new-password"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
           className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
           value={current}
           onChange={(e) => setCurrent(e.target.value)}
         />
         <input
           type="password"
+          name="change-password-new"
           required
           minLength={8}
           placeholder={t('newPassword')}
           autoComplete="new-password"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
           className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
           value={newPw}
           onChange={(e) => setNewPw(e.target.value)}
         />
         <input
           type="password"
+          name="change-password-confirm"
           required
           minLength={8}
           placeholder={t('confirmPassword')}
           autoComplete="new-password"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
           className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
           value={confirm}
           onChange={(e) => setConfirm(e.target.value)}

--- a/frontend/packages/web/components/profile/DeleteAccountDialog.tsx
+++ b/frontend/packages/web/components/profile/DeleteAccountDialog.tsx
@@ -98,10 +98,14 @@ export function DeleteAccountDialog({ open, onOpenChange }: DeleteAccountDialogP
           <div className="mt-3">
             <input
               type="password"
+              name="delete-account-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder={t('passwordPlaceholder')}
-              autoComplete="current-password"
+              autoComplete="new-password"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
               disabled={deleting}
               className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
               onKeyDown={(e) => {

--- a/frontend/packages/web/components/sandbox-env/EnvModal.tsx
+++ b/frontend/packages/web/components/sandbox-env/EnvModal.tsx
@@ -301,11 +301,15 @@ export function EnvModal({ mode, onSubmit, onClose }: Props) {
             <Input
               id="env-value"
               type="password"
+              name="sandbox-env-secret-value"
               value={value}
               onChange={(e) => setValue(e.target.value)}
               className="font-mono text-sm"
               placeholder="••••••••"
-              autoComplete="off"
+              autoComplete="new-password"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
               maxLength={isSecret ? undefined : 4096}
             />
           </div>

--- a/frontend/packages/web/components/triggers/SecretRevealAndRotate.tsx
+++ b/frontend/packages/web/components/triggers/SecretRevealAndRotate.tsx
@@ -118,9 +118,14 @@ export function SecretRevealAndRotate({
                 <Input
                   id="new-secret"
                   type="password"
+                  name="trigger-rotated-secret"
                   value={newSecret}
                   onChange={(e) => setNewSecret(e.target.value)}
                   placeholder={t('newSecretPlaceholder')}
+                  autoComplete="new-password"
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  spellCheck={false}
                   data-testid="new-secret-input"
                 />
               </div>

--- a/frontend/packages/web/components/triggers/TriggerForm.tsx
+++ b/frontend/packages/web/components/triggers/TriggerForm.tsx
@@ -173,9 +173,14 @@ export function TriggerForm({ wsId, open, onOpenChange, onCreated, onSubmit }: T
               <Input
                 id="trigger-secret"
                 type="password"
+                name="trigger-webhook-secret"
                 value={webhookSecret}
                 onChange={(e) => setWebhookSecret(e.target.value)}
                 placeholder={t('fieldWebhookSecretPlaceholder')}
+                autoComplete="new-password"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
                 data-testid="trigger-secret-input"
               />
               <p className="text-xs text-muted-foreground">{t('fieldWebhookSecretHint')}</p>

--- a/frontend/packages/web/components/workspace-settings/McpPanel.tsx
+++ b/frontend/packages/web/components/workspace-settings/McpPanel.tsx
@@ -568,6 +568,11 @@ export function McpPanel({ wsId }: McpPanelProps) {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder={t('searchPlaceholder')}
+          name="mcp-connector-search"
+          autoComplete="off"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
           className="max-w-xs"
         />
       </header>


### PR DESCRIPTION
## What changed
- Added autofill suppression to MCP secret/token fields and other non-login password inputs.
- Updated related forms and search inputs so Chrome does not reuse saved credentials on these pages.

## Why
Chrome was autofilling the MCP page search box and secret fields with saved site credentials, which could leak the wrong values into the form.

## Impact
- MCP auth/token fields no longer pick up browser-saved username/password values.
- Other non-login password fields use `autocomplete="new-password"` instead of login autofill behavior.

## Validation
- `frontend/packages/web/node_modules/.bin/tsc --noEmit`
