### PR TITLE
Use real Feishu/DingTalk group names for IM topic titles

### DIFF
--- a/backend/cubebox/api/routes/v1/im_ingress.py
+++ b/backend/cubebox/api/routes/v1/im_ingress.py
@@ -300,6 +300,11 @@ async def feishu_events(
         )
         return Response(status_code=status.HTTP_200_OK)
 
+    # Resolve group display name for Topic titles (im.v1.chats.get). Needs
+    # the live client on gate_connector; no-ops on DM / failure.
+    if gate_connector is not None:
+        await gate_connector.enrich_inbound_channel_name(event)
+
     # Use the module-level session maker so ingest_inbound_event owns its
     # own transaction (the request's session is bound to FastAPI's
     # dependency lifetime and isn't safe to share across transactions).

--- a/backend/cubebox/im/bot_settings.py
+++ b/backend/cubebox/im/bot_settings.py
@@ -76,8 +76,13 @@ def bot_display_name(config: dict[str, Any] | None) -> str:
 
 
 def im_topic_title(*, scope_kind: str, bot_name: str, channel_name: str | None) -> str:
-    """Topic title: bot name for a DM, channel name for a group."""
-    title = bot_name if scope_kind == "dm" else (channel_name or "群聊")
+    """Topic title: bot name for a DM, channel name for a group.
+
+    When the platform did not supply a group name, return ``""`` rather than a
+    localized phrase. The sidebar already does ``title || t('newGroupChat')``,
+    so an empty title stays i18n-clean and is not frozen in the writer's locale.
+    """
+    title = bot_name if scope_kind == "dm" else (channel_name or "")
     return title[:255]
 
 

--- a/backend/cubebox/im/conversation_resolver.py
+++ b/backend/cubebox/im/conversation_resolver.py
@@ -139,12 +139,14 @@ async def resolve_im_conversation(
         anchored = await session.get(Topic, existing_link.topic_id)
         if anchored is not None and not anchored.is_archived:
             topic_id = anchored.id
-            # Refresh titles that still show the raw channel id (legacy
-            # before we resolved real names) or a stale cached name.
-            if resolved_channel_name is not None:
-                _maybe_refresh_topic_channel_name(
-                    anchored, channel_id=channel_id, channel_name=resolved_channel_name
-                )
+            # Refresh / clear platform-derived titles on every inbound.
+            # With a real name: promote placeholder or platform-tracked titles.
+            # Without a name: still clear legacy channel-id / "群聊" placeholders
+            # so the UI can localize — otherwise failed lookups leave oc_…
+            # titles stuck forever.
+            _maybe_refresh_topic_channel_name(
+                anchored, channel_id=channel_id, channel_name=resolved_channel_name
+            )
         else:
             # The linked Topic was archived/deleted in the UI. Don't keep
             # appending under a Topic the user removed (topic + conversation
@@ -292,35 +294,54 @@ async def resolve_im_conversation(
     )
 
 
-def _maybe_refresh_topic_channel_name(topic: Topic, *, channel_id: str, channel_name: str) -> None:
-    """Update a live Topic when we learn (or re-learn) the group display name.
+def _maybe_refresh_topic_channel_name(
+    topic: Topic, *, channel_id: str, channel_name: str | None
+) -> None:
+    """Update a live Topic's title / ``attributes.im`` from platform group name.
 
-    Title is rewritten only when it still looks platform-derived:
-    - empty (i18n-friendly "no name yet" sentinel — UI shows localized label),
-    - the opaque channel id (legacy before real names),
-    - the short-lived Chinese ``群聊`` fallback from an earlier build, or
-    - equal to the previously stored ``attributes.im.channel_name``
-      (so a platform rename follows through without clobbering a title
-      the user edited in the UI).
+    When ``channel_name`` is set:
+    - rewrite title if it still looks platform-derived (empty, channel id,
+      legacy ``群聊``, or equal to the previously stored channel_name);
+    - keep ``attributes.im.channel_name`` in sync.
 
-    ``attributes.im.channel_name`` is always kept in sync with the latest
-    resolved name. Mutates ``topic`` in place (already session-tracked).
+    When ``channel_name`` is missing (lookup failed / no scope granted):
+    - only clear *legacy placeholder* titles (channel id / ``群聊``) to ``""``
+      so the UI can localize; never touch user-edited titles;
+    - clear ``attributes.im.channel_name`` if it still holds the opaque id.
+
+    Mutates ``topic`` in place (already session-tracked).
     """
-    desired = channel_name[:255]
     im_blob = (topic.attributes or {}).get("im")
     stored_name = im_blob.get("channel_name") if isinstance(im_blob, dict) else None
-    # "群聊" kept as a placeholder for rows written before the empty-title fix.
-    title_is_placeholder = topic.title in (channel_id, "群聊", "") or not topic.title
-    title_tracks_platform = stored_name is not None and topic.title == stored_name
-    name_changed = stored_name != desired
-    if not title_is_placeholder and not name_changed:
+    title_is_legacy_id = topic.title == channel_id
+    title_is_legacy_label = topic.title == "群聊"
+    title_is_empty = not topic.title
+
+    if channel_name:
+        desired = channel_name[:255]
+        title_is_placeholder = title_is_legacy_id or title_is_legacy_label or title_is_empty
+        title_tracks_platform = stored_name is not None and topic.title == stored_name
+        name_changed = stored_name != desired
+        if not title_is_placeholder and not name_changed:
+            return
+        if title_is_placeholder or title_tracks_platform:
+            topic.title = desired
+        if name_changed or not isinstance(im_blob, dict) or stored_name is None:
+            attrs = dict(topic.attributes or {})
+            im = dict(attrs.get("im") or {})
+            im["channel_name"] = desired
+            im["channel_id"] = channel_id
+            attrs["im"] = im
+            topic.attributes = attrs
         return
-    if title_is_placeholder or title_tracks_platform:
-        topic.title = desired
-    if name_changed or not isinstance(im_blob, dict) or stored_name is None:
+
+    # No resolved name: clear only opaque / legacy-label placeholders.
+    if title_is_legacy_id or title_is_legacy_label:
+        topic.title = ""
+    if stored_name in (channel_id, "群聊"):
         attrs = dict(topic.attributes or {})
         im = dict(attrs.get("im") or {})
-        im["channel_name"] = desired
+        im["channel_name"] = None
         im["channel_id"] = channel_id
         attrs["im"] = im
         topic.attributes = attrs

--- a/backend/cubebox/im/conversation_resolver.py
+++ b/backend/cubebox/im/conversation_resolver.py
@@ -101,8 +101,8 @@ async def resolve_im_conversation(
     bot_avatar_url = (account.config or {}).get("bot_avatar_url")
     # Display name for group topics. Prefer the platform-supplied name;
     # never substitute the opaque channel_id (that produced unreadable
-    # ``oc_…`` / ``cid…`` titles). Missing name → ``im_topic_title`` falls
-    # back to the generic "群聊" label.
+    # ``oc_…`` / ``cid…`` titles). Missing name → empty title; the UI
+    # localizes via ``t('newGroupChat')``.
     resolved_channel_name: str | None
     if scope_kind == "dm":
         resolved_channel_name = None
@@ -296,8 +296,9 @@ def _maybe_refresh_topic_channel_name(topic: Topic, *, channel_id: str, channel_
     """Update a live Topic when we learn (or re-learn) the group display name.
 
     Title is rewritten only when it still looks platform-derived:
+    - empty (i18n-friendly "no name yet" sentinel — UI shows localized label),
     - the opaque channel id (legacy before real names),
-    - the generic ``群聊`` fallback, or
+    - the short-lived Chinese ``群聊`` fallback from an earlier build, or
     - equal to the previously stored ``attributes.im.channel_name``
       (so a platform rename follows through without clobbering a title
       the user edited in the UI).
@@ -308,6 +309,7 @@ def _maybe_refresh_topic_channel_name(topic: Topic, *, channel_id: str, channel_
     desired = channel_name[:255]
     im_blob = (topic.attributes or {}).get("im")
     stored_name = im_blob.get("channel_name") if isinstance(im_blob, dict) else None
+    # "群聊" kept as a placeholder for rows written before the empty-title fix.
     title_is_placeholder = topic.title in (channel_id, "群聊", "") or not topic.title
     title_tracks_platform = stored_name is not None and topic.title == stored_name
     name_changed = stored_name != desired

--- a/backend/cubebox/im/conversation_resolver.py
+++ b/backend/cubebox/im/conversation_resolver.py
@@ -69,6 +69,7 @@ async def resolve_im_conversation(
     effective_user_id: str,
     title_hint: str,
     origin: Literal["inbound", "schedule", "trigger"],
+    channel_name: str | None = None,
 ) -> ResolvedIMConversation:
     """Resolve the cubebox conversation that should host the next message.
 
@@ -77,6 +78,10 @@ async def resolve_im_conversation(
     observability (per-source counters, structured logs) needs to
     differentiate dispatcher entrypoints without changing this signature
     again.
+
+    ``channel_name`` is the human-readable group title when the platform
+    supplied one (DingTalk ``conversationTitle``, Feishu ``im.v1.chats.get``).
+    Group topics use it as the title; never fall back to the raw channel id.
     """
     del origin  # currently unused; reserved for future observability.
 
@@ -94,9 +99,16 @@ async def resolve_im_conversation(
     # The bot avatar is hydrated into account.config at connect time; the
     # sidebar renders it as the Topic avatar via attributes.im.
     bot_avatar_url = (account.config or {}).get("bot_avatar_url")
-    # channel_name is not yet fetched from the platform — group topics fall
-    # back to the channel id. Lazy fetch is a follow-up (see spec).
-    channel_name = None if scope_kind == "dm" else channel_id
+    # Display name for group topics. Prefer the platform-supplied name;
+    # never substitute the opaque channel_id (that produced unreadable
+    # ``oc_…`` / ``cid…`` titles). Missing name → ``im_topic_title`` falls
+    # back to the generic "群聊" label.
+    resolved_channel_name: str | None
+    if scope_kind == "dm":
+        resolved_channel_name = None
+    else:
+        stripped = (channel_name or "").strip()
+        resolved_channel_name = stripped or None
     im_attrs = build_im_attributes(
         platform=account.platform,
         account_id=account.id,
@@ -104,7 +116,7 @@ async def resolve_im_conversation(
         bot_name=bot_name,
         bot_avatar_url=bot_avatar_url,
         channel_id=channel_id,
-        channel_name=channel_name,
+        channel_name=resolved_channel_name,
     )
 
     # The Topic anchor lives on the IMThreadLink and survives /new (which
@@ -127,6 +139,12 @@ async def resolve_im_conversation(
         anchored = await session.get(Topic, existing_link.topic_id)
         if anchored is not None and not anchored.is_archived:
             topic_id = anchored.id
+            # Refresh titles that still show the raw channel id (legacy
+            # before we resolved real names) or a stale cached name.
+            if resolved_channel_name is not None:
+                _maybe_refresh_topic_channel_name(
+                    anchored, channel_id=channel_id, channel_name=resolved_channel_name
+                )
         else:
             # The linked Topic was archived/deleted in the UI. Don't keep
             # appending under a Topic the user removed (topic + conversation
@@ -150,7 +168,9 @@ async def resolve_im_conversation(
             workspace_id=account.workspace_id,
             creator_user_id=account.acting_user_id if is_shared else effective_user_id,
             title=im_topic_title(
-                scope_kind=scope_kind, bot_name=bot_name, channel_name=channel_name
+                scope_kind=scope_kind,
+                bot_name=bot_name,
+                channel_name=resolved_channel_name,
             ),
             sandbox_mode=sandbox_mode or "dedicated",
             attributes=dict(im_attrs),
@@ -270,6 +290,38 @@ async def resolve_im_conversation(
         is_group_chat=is_shared,
         sandbox_mode=sandbox_mode,
     )
+
+
+def _maybe_refresh_topic_channel_name(topic: Topic, *, channel_id: str, channel_name: str) -> None:
+    """Update a live Topic when we learn (or re-learn) the group display name.
+
+    Title is rewritten only when it still looks platform-derived:
+    - the opaque channel id (legacy before real names),
+    - the generic ``群聊`` fallback, or
+    - equal to the previously stored ``attributes.im.channel_name``
+      (so a platform rename follows through without clobbering a title
+      the user edited in the UI).
+
+    ``attributes.im.channel_name`` is always kept in sync with the latest
+    resolved name. Mutates ``topic`` in place (already session-tracked).
+    """
+    desired = channel_name[:255]
+    im_blob = (topic.attributes or {}).get("im")
+    stored_name = im_blob.get("channel_name") if isinstance(im_blob, dict) else None
+    title_is_placeholder = topic.title in (channel_id, "群聊", "") or not topic.title
+    title_tracks_platform = stored_name is not None and topic.title == stored_name
+    name_changed = stored_name != desired
+    if not title_is_placeholder and not name_changed:
+        return
+    if title_is_placeholder or title_tracks_platform:
+        topic.title = desired
+    if name_changed or not isinstance(im_blob, dict) or stored_name is None:
+        attrs = dict(topic.attributes or {})
+        im = dict(attrs.get("im") or {})
+        im["channel_name"] = desired
+        im["channel_id"] = channel_id
+        attrs["im"] = im
+        topic.attributes = attrs
 
 
 async def _ensure_topic_participant(session: AsyncSession, topic_id: str, user_id: str) -> None:

--- a/backend/cubebox/im/dingtalk/connector.py
+++ b/backend/cubebox/im/dingtalk/connector.py
@@ -82,6 +82,11 @@ class DingtalkConnector:
         if not msg_id or not conversation_id or not sender_staff_id:
             return None
 
+        # DingTalk includes the group title on every robot receive callback
+        # (field ``conversationTitle`` — group only). No extra API / scope.
+        # https://open.dingtalk.com/document/orgapp/receive-message
+        channel_name: str | None = None
+
         if conversation_type == "1":
             scope_key = DM_SCOPE_KEY
             scope_kind = "dm"
@@ -96,6 +101,9 @@ class DingtalkConnector:
                 scope_key = make_participant_scope(sender_staff_id)
                 scope_kind = "group"
             text = re.sub(r"^\s+", "", text)
+            title = raw.get("conversationTitle")
+            if isinstance(title, str) and title.strip():
+                channel_name = title.strip()
 
         return InboundEvent(
             platform="dingtalk",
@@ -109,6 +117,7 @@ class DingtalkConnector:
             sender_ref=sender_staff_id,
             sender_open_id=sender_staff_id,
             text=text,
+            channel_name=channel_name,
         )
 
     # ------------------------------------------------------------------

--- a/backend/cubebox/im/discord/connector.py
+++ b/backend/cubebox/im/discord/connector.py
@@ -159,6 +159,10 @@ class DiscordConnector:
         if not self._mentions_bot(message):
             return None
 
+        # Guild channel / thread names are on the object; free for Topic titles.
+        raw_name = getattr(channel, "name", None)
+        channel_name = str(raw_name).strip() if raw_name else None
+
         if is_thread:
             thread_id = str(channel.id)
             if binding_mode == "shared":
@@ -178,6 +182,7 @@ class DiscordConnector:
                 sender_open_id=sender_ref,
                 text=text,
                 attachments=attachments,
+                channel_name=channel_name,
             )
 
         if binding_mode == "shared":
@@ -197,6 +202,7 @@ class DiscordConnector:
             sender_open_id=sender_ref,
             text=text,
             attachments=attachments,
+            channel_name=channel_name,
         )
 
     def _mentions_bot(self, message: Any) -> bool:

--- a/backend/cubebox/im/feishu/connector.py
+++ b/backend/cubebox/im/feishu/connector.py
@@ -459,6 +459,54 @@ class FeishuConnector:
         email = getattr(user_obj, "enterprise_email", None) or getattr(user_obj, "email", None)
         return str(email) if email else None
 
+    async def get_chat_name(self, chat_id: str) -> str | None:
+        """Fetch a group display name via ``GET /open-apis/im/v1/chats/:chat_id``.
+
+        Requires one of: ``im:chat:readonly`` / ``im:chat:read`` / ``im:chat``.
+        Without the scope Feishu returns a non-zero code — we log and return
+        None so topic creation falls back to the generic ``群聊`` label rather
+        than failing the whole inbound.
+
+        Docs: https://open.feishu.cn/document/server-docs/group/chat/get-2
+        """
+        if self._client is None or not chat_id:
+            return None
+        from lark_oapi.api.im.v1 import GetChatRequest
+
+        req = GetChatRequest.builder().chat_id(chat_id).build()
+        try:
+            response = await asyncio.to_thread(self._client.im.v1.chat.get, req)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "[Feishu] get_chat_name raised for chat_id={}", chat_id
+            )
+            return None
+        if not getattr(response, "success", lambda: False)():
+            logger.warning(
+                "[Feishu] get_chat_name failed: code={} msg={} chat_id={}",
+                getattr(response, "code", None),
+                getattr(response, "msg", None),
+                chat_id,
+            )
+            return None
+        data = getattr(response, "data", None)
+        name = getattr(data, "name", None) if data is not None else None
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+        return None
+
+    async def enrich_inbound_channel_name(self, event: InboundEvent) -> None:
+        """Fill ``event.channel_name`` for group chats via ``get_chat_name``.
+
+        No-op for DMs, when a name is already present, or when no outbound
+        client is bound. Failures leave ``channel_name`` as None.
+        """
+        if event.scope_kind == "dm" or event.channel_name or not event.channel_id:
+            return
+        name = await self.get_chat_name(event.channel_id)
+        if name:
+            event.channel_name = name
+
     async def send_to_chat(self, chat_id: str, reply_to_id: str | None, text: str) -> str | None:
         """Send a one-off plain text bubble to a chat, optionally as a thread reply.
 

--- a/backend/cubebox/im/feishu/connector.py
+++ b/backend/cubebox/im/feishu/connector.py
@@ -464,7 +464,7 @@ class FeishuConnector:
 
         Requires one of: ``im:chat:readonly`` / ``im:chat:read`` / ``im:chat``.
         Without the scope Feishu returns a non-zero code — we log and return
-        None so topic creation falls back to the generic ``群聊`` label rather
+        None so topic creation keeps an empty title (UI localizes) rather
         than failing the whole inbound.
 
         Docs: https://open.feishu.cn/document/server-docs/group/chat/get-2

--- a/backend/cubebox/im/feishu/long_connection.py
+++ b/backend/cubebox/im/feishu/long_connection.py
@@ -264,6 +264,8 @@ def build_event_handler(
                 if gate_connector is not None:
                     kwargs["identity_resolver"] = gate_connector
                     kwargs["rejection_notifier"] = gate_connector
+                    # Resolve group display name for Topic titles (im.v1.chats.get).
+                    await gate_connector.enrich_inbound_channel_name(event)
                 res = await ingest(
                     event,
                     account=account,

--- a/backend/cubebox/im/inbound.py
+++ b/backend/cubebox/im/inbound.py
@@ -162,6 +162,7 @@ async def ingest_inbound_event(
             effective_user_id=effective_user_id,
             title_hint=event.text,
             origin="inbound",
+            channel_name=event.channel_name,
         )
 
         item = IMRunQueueItem(

--- a/backend/cubebox/im/teams/connector.py
+++ b/backend/cubebox/im/teams/connector.py
@@ -67,6 +67,13 @@ class TeamsConnector:
         conversation: dict[str, Any] = activity.get("conversation", {})
         conv_type: str = str(conversation.get("conversationType") or "personal")
         conv_id: str = str(conversation.get("id") or "")
+        # Group chats often include a display name; channel activities may not.
+        raw_conv_name = conversation.get("name")
+        channel_name = (
+            str(raw_conv_name).strip()
+            if isinstance(raw_conv_name, str) and raw_conv_name.strip()
+            else None
+        )
         message_id: str = str(activity.get("id") or "")
         reply_to_id: str | None = activity.get("replyToId")
 
@@ -113,6 +120,7 @@ class TeamsConnector:
                 sender_ref=sender_ref,
                 sender_open_id=aad_object_id or None,
                 text=text.strip(),
+                channel_name=channel_name,
             )
 
         scope_kind = "group" if conv_type == "groupChat" else "channel"
@@ -128,6 +136,7 @@ class TeamsConnector:
             sender_ref=sender_ref,
             sender_open_id=aad_object_id or None,
             text=text.strip(),
+            channel_name=channel_name,
         )
 
     def _is_bot_mentioned(self, activity: dict[str, Any]) -> bool:

--- a/backend/cubebox/im/types.py
+++ b/backend/cubebox/im/types.py
@@ -177,6 +177,10 @@ class InboundEvent:
     - ``sender_open_id``: app-scoped id (mention gating only).
     - ``attachments``: parsed file refs (empty for text-only / connectors that
       don't parse files), resolved to attachment ids by the worker.
+    - ``channel_name``: human-readable group/channel title when the platform
+      supplies it (DingTalk ``conversationTitle``) or after a lazy API lookup
+      (Feishu ``im.v1.chats.get``). Used as the Topic title for group chats;
+      DMs leave this None.
     """
 
     platform: str
@@ -191,6 +195,7 @@ class InboundEvent:
     sender_open_id: str | None
     text: str
     attachments: list[InboundAttachmentRef] = field(default_factory=list)
+    channel_name: str | None = None
 
 
 @dataclass(slots=True)

--- a/backend/docs/im-feishu-setup.md
+++ b/backend/docs/im-feishu-setup.md
@@ -26,8 +26,8 @@ cubebox can bind a Feishu (Lark) bot to a workspace so messages and
      for group Topic titles. CubeBox calls
      `GET /open-apis/im/v1/chats/:chat_id` on first group message to
      resolve the human-readable group name. Without this scope the
-     Topic still works but its title falls back to the generic label
-     `群聊` instead of the real group name.
+     Topic still works but its title stays empty until a name is
+     resolved (the UI shows a localized "New Group Chat" placeholder).
    - `contact:user.base:readonly` (sender display name)
    - `contact:user.email:readonly` — **REQUIRED** for the sender
      identity gate. Without it, Feishu omits `user.email` from

--- a/backend/docs/im-feishu-setup.md
+++ b/backend/docs/im-feishu-setup.md
@@ -22,6 +22,12 @@ cubebox can bind a Feishu (Lark) bot to a workspace so messages and
    - `im:message.group_at_msg` (group @mentions delivered)
    - `im:message.p2p_msg` (DMs delivered)
    - `im:message.reaction:write` (processing reactions)
+   - `im:chat:readonly` (or `im:chat:read` / `im:chat`) — **REQUIRED**
+     for group Topic titles. CubeBox calls
+     `GET /open-apis/im/v1/chats/:chat_id` on first group message to
+     resolve the human-readable group name. Without this scope the
+     Topic still works but its title falls back to the generic label
+     `群聊` instead of the real group name.
    - `contact:user.base:readonly` (sender display name)
    - `contact:user.email:readonly` — **REQUIRED** for the sender
      identity gate. Without it, Feishu omits `user.email` from

--- a/backend/tests/e2e/test_im_shared_mode_ingest.py
+++ b/backend/tests/e2e/test_im_shared_mode_ingest.py
@@ -180,7 +180,7 @@ async def test_first_shared_message_creates_topic(
         assert conv.attributes.get("im", {}).get("account_id") == _ACCOUNT
 
         topic = (await s.execute(select(Topic).where(Topic.id == conv.topic_id))).scalar_one()
-        assert topic.title == _CHANNEL  # group title falls back to channel id
+        assert topic.title == "群聊"  # no platform name → generic label, never channel id
         assert topic.max_participants == 100
         assert topic.attributes["im"]["scope_kind"] == "channel"
 

--- a/backend/tests/e2e/test_im_shared_mode_ingest.py
+++ b/backend/tests/e2e/test_im_shared_mode_ingest.py
@@ -180,7 +180,7 @@ async def test_first_shared_message_creates_topic(
         assert conv.attributes.get("im", {}).get("account_id") == _ACCOUNT
 
         topic = (await s.execute(select(Topic).where(Topic.id == conv.topic_id))).scalar_one()
-        assert topic.title == "群聊"  # no platform name → generic label, never channel id
+        assert topic.title == ""  # no platform name → empty (UI localizes), never channel id
         assert topic.max_participants == 100
         assert topic.attributes["im"]["scope_kind"] == "channel"
 

--- a/backend/tests/e2e/test_resolve_im_conversation.py
+++ b/backend/tests/e2e/test_resolve_im_conversation.py
@@ -307,6 +307,63 @@ async def test_shared_topic_refreshes_legacy_channel_id_title(
         assert topic.attributes["im"]["channel_name"] == "研发大群"
 
 
+async def test_shared_topic_clears_legacy_channel_id_without_name(
+    _seeded: tuple[async_sessionmaker[AsyncSession], IMConnectorAccount],
+) -> None:
+    """When name lookup fails, still clear legacy channel-id titles to empty."""
+    maker, account = _seeded
+    _with_settings(account, IMBotSettings(routing_mode="shared"))
+
+    async with maker() as session:
+        r1 = await resolve_im_conversation(
+            session,
+            account,
+            channel_id=_CHANNEL,
+            scope_key="ch",
+            scope_kind="channel",
+            effective_user_id=_USER,
+            title_hint="first",
+            origin="inbound",
+        )
+        await session.commit()
+        topic_id = r1.topic_id
+        assert topic_id is not None
+        topic = (await session.execute(select(Topic).where(Topic.id == topic_id))).scalar_one()
+        topic.title = _CHANNEL
+        attrs = dict(topic.attributes or {})
+        im = dict(attrs.get("im") or {})
+        im["channel_name"] = _CHANNEL
+        attrs["im"] = im
+        topic.attributes = attrs
+        session.add(topic)
+        await session.commit()
+
+    async with maker() as session:
+        account = (
+            await session.execute(
+                select(IMConnectorAccount).where(IMConnectorAccount.id == _ACCOUNT)
+            )
+        ).scalar_one()
+        _with_settings(account, IMBotSettings(routing_mode="shared"))
+        await resolve_im_conversation(
+            session,
+            account,
+            channel_id=_CHANNEL,
+            scope_key="ch",
+            scope_kind="channel",
+            effective_user_id=_USER,
+            title_hint="second",
+            origin="inbound",
+            # no channel_name — lookup failed / scope missing
+        )
+        await session.commit()
+
+    async with maker() as session:
+        topic = (await session.execute(select(Topic).where(Topic.id == topic_id))).scalar_one()
+        assert topic.title == ""
+        assert topic.attributes["im"]["channel_name"] is None
+
+
 async def test_isolated_topic_mode_creates_per_sender_topic(
     _seeded: tuple[async_sessionmaker[AsyncSession], IMConnectorAccount],
 ) -> None:

--- a/backend/tests/e2e/test_resolve_im_conversation.py
+++ b/backend/tests/e2e/test_resolve_im_conversation.py
@@ -178,9 +178,9 @@ async def test_shared_creates_topic_and_link(
         topic = (
             await session.execute(select(Topic).where(Topic.id == resolved.topic_id))
         ).scalar_one()
-        # Without a platform-supplied channel_name, group title falls back to
-        # the generic "群聊" label (never the opaque channel id).
-        assert topic.title == "群聊"
+        # Without a platform-supplied channel_name, title stays empty so the
+        # UI can localize (never the opaque channel id, never a frozen phrase).
+        assert topic.title == ""
         assert topic.attributes.get("im", {}).get("channel_name") is None
         assert topic.creator_user_id == _USER  # acting user owns shared topics
         assert topic.attributes.get("im", {}).get("account_id") == _ACCOUNT
@@ -265,7 +265,7 @@ async def test_shared_topic_refreshes_legacy_channel_id_title(
             effective_user_id=_USER,
             title_hint="first",
             origin="inbound",
-            # no channel_name → title "群聊"
+            # no channel_name → empty title (UI localizes)
         )
         await session.commit()
         topic_id = r1.topic_id

--- a/backend/tests/e2e/test_resolve_im_conversation.py
+++ b/backend/tests/e2e/test_resolve_im_conversation.py
@@ -178,8 +178,10 @@ async def test_shared_creates_topic_and_link(
         topic = (
             await session.execute(select(Topic).where(Topic.id == resolved.topic_id))
         ).scalar_one()
-        # Group title falls back to the channel id (no per-channel name yet).
-        assert topic.title == _CHANNEL
+        # Without a platform-supplied channel_name, group title falls back to
+        # the generic "群聊" label (never the opaque channel id).
+        assert topic.title == "群聊"
+        assert topic.attributes.get("im", {}).get("channel_name") is None
         assert topic.creator_user_id == _USER  # acting user owns shared topics
         assert topic.attributes.get("im", {}).get("account_id") == _ACCOUNT
         assert topic.attributes["im"]["scope_kind"] == "channel"
@@ -213,6 +215,96 @@ async def test_shared_creates_topic_and_link(
             )
         ).scalar_one_or_none()
         assert cp is not None
+
+
+async def test_shared_topic_uses_channel_name_as_title(
+    _seeded: tuple[async_sessionmaker[AsyncSession], IMConnectorAccount],
+) -> None:
+    """When the platform supplies a group display name, use it as Topic title."""
+    maker, account = _seeded
+    _with_settings(account, IMBotSettings(routing_mode="shared"))
+
+    async with maker() as session:
+        resolved = await resolve_im_conversation(
+            session,
+            account,
+            channel_id=_CHANNEL,
+            scope_key="ch",
+            scope_kind="channel",
+            effective_user_id=_USER,
+            title_hint="hello",
+            origin="inbound",
+            channel_name="项目 Alpha",
+        )
+        await session.commit()
+
+    assert resolved.topic_id is not None
+    async with maker() as session:
+        topic = (
+            await session.execute(select(Topic).where(Topic.id == resolved.topic_id))
+        ).scalar_one()
+        assert topic.title == "项目 Alpha"
+        assert topic.attributes["im"]["channel_name"] == "项目 Alpha"
+        assert topic.attributes["im"]["channel_id"] == _CHANNEL
+
+
+async def test_shared_topic_refreshes_legacy_channel_id_title(
+    _seeded: tuple[async_sessionmaker[AsyncSession], IMConnectorAccount],
+) -> None:
+    """A subsequent resolve with a real name rewrites a legacy channel-id title."""
+    maker, account = _seeded
+    _with_settings(account, IMBotSettings(routing_mode="shared"))
+
+    async with maker() as session:
+        r1 = await resolve_im_conversation(
+            session,
+            account,
+            channel_id=_CHANNEL,
+            scope_key="ch",
+            scope_kind="channel",
+            effective_user_id=_USER,
+            title_hint="first",
+            origin="inbound",
+            # no channel_name → title "群聊"
+        )
+        await session.commit()
+        topic_id = r1.topic_id
+        assert topic_id is not None
+        # Simulate pre-fix rows that used channel_id as the title.
+        topic = (await session.execute(select(Topic).where(Topic.id == topic_id))).scalar_one()
+        topic.title = _CHANNEL
+        attrs = dict(topic.attributes or {})
+        im = dict(attrs.get("im") or {})
+        im["channel_name"] = _CHANNEL
+        attrs["im"] = im
+        topic.attributes = attrs
+        session.add(topic)
+        await session.commit()
+
+    async with maker() as session:
+        account = (
+            await session.execute(
+                select(IMConnectorAccount).where(IMConnectorAccount.id == _ACCOUNT)
+            )
+        ).scalar_one()
+        _with_settings(account, IMBotSettings(routing_mode="shared"))
+        await resolve_im_conversation(
+            session,
+            account,
+            channel_id=_CHANNEL,
+            scope_key="ch",
+            scope_kind="channel",
+            effective_user_id=_USER,
+            title_hint="second",
+            origin="inbound",
+            channel_name="研发大群",
+        )
+        await session.commit()
+
+    async with maker() as session:
+        topic = (await session.execute(select(Topic).where(Topic.id == topic_id))).scalar_one()
+        assert topic.title == "研发大群"
+        assert topic.attributes["im"]["channel_name"] == "研发大群"
 
 
 async def test_isolated_topic_mode_creates_per_sender_topic(

--- a/backend/tests/unit/im/discord/test_connector.py
+++ b/backend/tests/unit/im/discord/test_connector.py
@@ -26,6 +26,7 @@ def _make_message(
     msg.author.id = author_id
     msg.author.bot = author_bot
     msg.channel.id = thread_id or channel_id
+    msg.channel.name = "general" if not is_dm else None
     msg.channel.type = MagicMock()
     if is_dm:
         msg.channel.type.value = 1  # DM
@@ -38,6 +39,7 @@ def _make_message(
     if thread_id is not None:
         msg.channel.type.value = 11  # PUBLIC_THREAD
         msg.channel.parent_id = channel_id
+        msg.channel.name = "thread-topic"
     # User mentions
     if mentions_bot:
         mention = MagicMock()
@@ -77,6 +79,13 @@ class TestDiscordConnectorParseInbound:
         assert event.scope_key == "u:111"
         assert event.scope_kind == "channel"
         assert event.reply_to_id == "333"
+        assert event.channel_name == "general"
+
+    def test_dm_has_no_channel_name(self) -> None:
+        msg = _make_message(is_dm=True, mentions_bot=False)
+        event = self.connector.parse_inbound(msg)
+        assert event is not None
+        assert event.channel_name is None
 
     def test_guild_no_mention_ignored(self) -> None:
         msg = _make_message(mentions_bot=False)

--- a/backend/tests/unit/im/test_bot_settings.py
+++ b/backend/tests/unit/im/test_bot_settings.py
@@ -57,8 +57,10 @@ class TestTitleAndAttributes:
     def test_group_title_is_channel_name(self) -> None:
         assert im_topic_title(scope_kind="channel", bot_name="MyBot", channel_name="Team") == "Team"
 
-    def test_group_title_falls_back_when_no_channel_name(self) -> None:
-        assert im_topic_title(scope_kind="channel", bot_name="MyBot", channel_name=None) == "群聊"
+    def test_group_title_empty_when_no_channel_name(self) -> None:
+        # Empty string — UI localizes via t('newGroupChat'); do not bake a
+        # locale-specific phrase into the stored title.
+        assert im_topic_title(scope_kind="channel", bot_name="MyBot", channel_name=None) == ""
 
     def test_bot_display_name_default(self) -> None:
         assert bot_display_name(None) == "cubebox"

--- a/backend/tests/unit/im/test_dingtalk_connector.py
+++ b/backend/tests/unit/im/test_dingtalk_connector.py
@@ -37,6 +37,7 @@ class TestParseInbound:
             "msgId": "msg_002",
             "conversationId": "cid_group_456",
             "conversationType": "2",
+            "conversationTitle": "项目协作群",
             "senderId": "staff_def",
             "senderStaffId": "staff_def",
             "chatbotUserId": "bot_999",
@@ -51,6 +52,25 @@ class TestParseInbound:
         assert event.scope_key == "u:staff_def"
         assert event.scope_kind == "group"
         assert event.text == "what time is it"
+        assert event.channel_name == "项目协作群"
+
+    def test_dm_has_no_channel_name(self) -> None:
+        raw = {
+            "msgtype": "text",
+            "text": {"content": "hello"},
+            "msgId": "msg_dm_name",
+            "conversationId": "cid_dm_123",
+            "conversationType": "1",
+            "conversationTitle": "should-be-ignored",
+            "senderId": "staff_abc",
+            "senderStaffId": "staff_abc",
+            "chatbotUserId": "bot_999",
+        }
+        connector = DingtalkConnector(bot_user_id="bot_999")
+        event = connector.parse_inbound(raw)
+        assert event is not None
+        assert event.scope_kind == "dm"
+        assert event.channel_name is None
 
     def test_non_text_ignored(self) -> None:
         raw = {

--- a/backend/tests/unit/im/test_feishu_get_chat_name.py
+++ b/backend/tests/unit/im/test_feishu_get_chat_name.py
@@ -1,0 +1,104 @@
+"""Unit tests for FeishuConnector.get_chat_name / enrich_inbound_channel_name."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from cubebox.im.feishu.connector import FeishuConnector
+from cubebox.im.types import InboundEvent
+
+
+def _inbound(*, scope_kind: str = "channel", channel_id: str = "oc_g1") -> InboundEvent:
+    return InboundEvent(
+        platform="feishu",
+        account_external_id="cli_x",
+        platform_event_id="ev1",
+        channel_id=channel_id,
+        scope_key="ch",
+        scope_kind=scope_kind,
+        reply_to_id="m1",
+        inbound_message_id="m1",
+        sender_ref="ou_x",
+        sender_open_id="ou_x",
+        text="hi",
+    )
+
+
+def _ok_response(name: str | None) -> Any:
+    data = SimpleNamespace(name=name)
+    resp = MagicMock()
+    resp.success.return_value = True
+    resp.data = data
+    return resp
+
+
+def _err_response(*, code: int = 99991663, msg: str = "no scope") -> Any:
+    resp = MagicMock()
+    resp.success.return_value = False
+    resp.code = code
+    resp.msg = msg
+    resp.data = None
+    return resp
+
+
+class TestGetChatName:
+    @pytest.mark.asyncio
+    async def test_returns_name_on_success(self) -> None:
+        client = MagicMock()
+        client.im.v1.chat.get.return_value = _ok_response("研发大群")
+        connector = FeishuConnector(bot_open_id="ou_bot", client=client)
+        assert await connector.get_chat_name("oc_g1") == "研发大群"
+        client.im.v1.chat.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_client(self) -> None:
+        connector = FeishuConnector(bot_open_id="ou_bot")
+        assert await connector.get_chat_name("oc_g1") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_api_error(self) -> None:
+        client = MagicMock()
+        client.im.v1.chat.get.return_value = _err_response()
+        connector = FeishuConnector(bot_open_id="ou_bot", client=client)
+        assert await connector.get_chat_name("oc_g1") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_empty_name(self) -> None:
+        client = MagicMock()
+        client.im.v1.chat.get.return_value = _ok_response(None)
+        connector = FeishuConnector(bot_open_id="ou_bot", client=client)
+        assert await connector.get_chat_name("oc_g1") is None
+
+
+class TestEnrichInboundChannelName:
+    @pytest.mark.asyncio
+    async def test_fills_group_channel_name(self) -> None:
+        client = MagicMock()
+        client.im.v1.chat.get.return_value = _ok_response("项目 Alpha")
+        connector = FeishuConnector(bot_open_id="ou_bot", client=client)
+        event = _inbound(scope_kind="channel")
+        await connector.enrich_inbound_channel_name(event)
+        assert event.channel_name == "项目 Alpha"
+
+    @pytest.mark.asyncio
+    async def test_skips_dm(self) -> None:
+        client = MagicMock()
+        connector = FeishuConnector(bot_open_id="ou_bot", client=client)
+        event = _inbound(scope_kind="dm")
+        await connector.enrich_inbound_channel_name(event)
+        assert event.channel_name is None
+        client.im.v1.chat.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_already_set(self) -> None:
+        client = MagicMock()
+        connector = FeishuConnector(bot_open_id="ou_bot", client=client)
+        event = _inbound(scope_kind="channel")
+        event.channel_name = "已有名称"
+        await connector.enrich_inbound_channel_name(event)
+        assert event.channel_name == "已有名称"
+        client.im.v1.chat.get.assert_not_called()

--- a/docs/site/docs/guides/im/dingtalk.md
+++ b/docs/site/docs/guides/im/dingtalk.md
@@ -56,6 +56,8 @@ In the app's **Permissions** section, grant the following scopes:
 
 The bot-message send/receive permission (`qyapi_robot_sendmsg`) is granted by default when you add the bot capability — no action needed for that one.
 
+Group Topic titles use the `conversationTitle` field that DingTalk already includes on every robot receive callback — **no extra permission** is required for the group name.
+
 :::info 📸 Screenshot placeholder
 **Capture:** The app Permissions page with the bot-message send/receive permission and the user-profile (email) read permission granted.
 **Asset:** `/img/im/dingtalk-permissions.png`

--- a/docs/site/docs/guides/im/feishu.md
+++ b/docs/site/docs/guides/im/feishu.md
@@ -36,10 +36,18 @@ Under the app's **Features**, add the **Bot** capability and publish the bot ide
 
 ## Step 3 — Grant message permissions
 
-Under **Permissions & Scopes**, grant the scopes the bot needs to read mentions and send messages. To let CubeBox auto-resolve a sender's email (so users don't have to run `/link` manually), also grant the contact/read-email scope.
+Under **Permissions & Scopes**, grant the scopes the bot needs to read mentions, send messages, and resolve group names. To let CubeBox auto-resolve a sender's email (so users don't have to run `/link` manually), also grant the contact/read-email scope.
+
+| Scope | Required | Purpose |
+|---|---|---|
+| Message read / send (`im:message`, `im:message:send_as_bot`, …) | Yes | Receive @-mentions / DMs and reply as the bot. |
+| `im:chat:readonly` (or `im:chat:read` / `im:chat`) | Yes | Look up the group display name via `GET /open-apis/im/v1/chats/:chat_id` so CubeBox Topic titles show the real group name instead of a generic label. |
+| Contact email read (`contact:user.email:readonly` + related) | Recommended | Auto-match the sender's Feishu email to a CubeBox account (avoids manual `link`). |
+
+After adding scopes, **publish a new app version** so the tenant grants take effect — Feishu does not apply new scopes until the version is published.
 
 :::info 📸 Screenshot placeholder
-**Capture:** The app Permissions & Scopes page with the message read/send and contact email scopes selected.
+**Capture:** The app Permissions & Scopes page with the message read/send, group-info read (`im:chat:readonly`), and contact email scopes selected.
 **Asset:** `/img/im/feishu/console-permissions.png`
 :::
 

--- a/docs/site/docs/guides/im/feishu.md
+++ b/docs/site/docs/guides/im/feishu.md
@@ -41,7 +41,7 @@ Under **Permissions & Scopes**, grant the scopes the bot needs to read mentions,
 | Scope | Required | Purpose |
 |---|---|---|
 | Message read / send (`im:message`, `im:message:send_as_bot`, …) | Yes | Receive @-mentions / DMs and reply as the bot. |
-| `im:chat:readonly` (or `im:chat:read` / `im:chat`) | Yes | Look up the group display name via `GET /open-apis/im/v1/chats/:chat_id` so CubeBox Topic titles show the real group name instead of a generic label. |
+| `im:chat:readonly` (or `im:chat:read` / `im:chat`) | Yes | Look up the group display name via `GET /open-apis/im/v1/chats/:chat_id` so CubeBox Topic titles show the real group name. Without it the title stays empty and the UI shows a localized "New Group Chat" placeholder. |
 | Contact email read (`contact:user.email:readonly` + related) | Recommended | Auto-match the sender's Feishu email to a CubeBox account (avoids manual `link`). |
 
 After adding scopes, **publish a new app version** so the tenant grants take effect — Feishu does not apply new scopes until the version is published.

--- a/frontend/packages/web/app/(app)/w/[wsId]/scheduled-tasks/components/DestinationCell.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/scheduled-tasks/components/DestinationCell.tsx
@@ -6,6 +6,7 @@ import { Hash, MessageCircle, MessageSquare } from 'lucide-react'
 import { createApiClient, getTopic, getConversation } from '@cubebox/core'
 import type { ScheduledTaskOut } from '@cubebox/core'
 import { cn } from '@/lib/utils'
+import { topicDisplayTitle } from '@/lib/topicTitle'
 
 interface DestinationCellProps {
   /** Workspace whose /topics + /conversations routes the chip looks up. */
@@ -25,6 +26,7 @@ interface DestinationCellProps {
  */
 export function DestinationCell({ wsId, task, className }: DestinationCellProps) {
   const t = useTranslations('scheduledTasks')
+  const tTopics = useTranslations('topics')
   const client = useMemo(() => {
     const c = createApiClient('')
     c.setWorkspaceId(wsId)
@@ -89,7 +91,9 @@ export function DestinationCell({ wsId, task, className }: DestinationCellProps)
         >
           <MessageSquare className="size-3 shrink-0" />
           <span className="max-w-[14ch] truncate">
-            {topicTitle ?? t('destinationTopicFallback')}
+            {topicTitle === null
+              ? t('destinationTopicFallback')
+              : topicDisplayTitle(topicTitle, tTopics('newGroupChat'))}
           </span>
         </span>
       )

--- a/frontend/packages/web/app/(app)/w/[wsId]/scheduled-tasks/components/TopicPicker.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/scheduled-tasks/components/TopicPicker.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { Check, ChevronDown, MessageSquare, X } from 'lucide-react'
 import { createApiClient, listTopics } from '@cubebox/core'
 import type { Topic } from '@cubebox/core'
 import { cn } from '@/lib/utils'
+import { topicDisplayTitle } from '@/lib/topicTitle'
 
 interface TopicPickerProps {
   /** Workspace whose topics should be listed; required so the API client
@@ -42,6 +44,8 @@ export function TopicPicker({
   id,
   'aria-labelledby': ariaLabelledBy,
 }: TopicPickerProps) {
+  const tTopics = useTranslations('topics')
+  const emptyTitle = tTopics('newGroupChat')
   const [topics, setTopics] = useState<Topic[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -77,12 +81,13 @@ export function TopicPicker({
   }, [client])
 
   const selected = topics.find((t) => t.id === value) ?? null
+  const selectedLabel = selected ? topicDisplayTitle(selected.title, emptyTitle) : null
 
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase()
     if (!q) return topics
-    return topics.filter((t) => t.title.toLowerCase().includes(q))
-  }, [topics, filter])
+    return topics.filter((t) => topicDisplayTitle(t.title, emptyTitle).toLowerCase().includes(q))
+  }, [topics, filter, emptyTitle])
 
   return (
     <div className="flex flex-col gap-1.5">
@@ -109,7 +114,7 @@ export function TopicPicker({
             <span
               className={cn('truncate', selected ? 'text-foreground' : 'text-muted-foreground')}
             >
-              {selected ? selected.title : placeholder}
+              {selected ? selectedLabel : placeholder}
             </span>
           </span>
           <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
@@ -184,7 +189,7 @@ export function TopicPicker({
                   )}
                   data-testid={`topic-option-${topic.id}`}
                 >
-                  <span className="truncate">{topic.title}</span>
+                  <span className="truncate">{topicDisplayTitle(topic.title, emptyTitle)}</span>
                   {value === topic.id && <Check className="size-3.5 shrink-0 text-primary" />}
                 </button>
               ))}

--- a/frontend/packages/web/components/mcp/MCPCustomCreatePanel.tsx
+++ b/frontend/packages/web/components/mcp/MCPCustomCreatePanel.tsx
@@ -139,7 +139,11 @@ export function MCPCustomCreatePanel({
         </p>
       </header>
 
-      <form className="flex flex-col gap-4" autoComplete="off" onSubmit={(e) => void handleSubmit(e)}>
+      <form
+        className="flex flex-col gap-4"
+        autoComplete="off"
+        onSubmit={(e) => void handleSubmit(e)}
+      >
         <Card>
           <CardHeader>
             <CardTitle>{t('customSectionServer')}</CardTitle>

--- a/frontend/packages/web/components/sidebar/TopicNode.tsx
+++ b/frontend/packages/web/components/sidebar/TopicNode.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog'
 import { cn } from '@/lib/utils'
+import { topicDisplayTitle } from '@/lib/topicTitle'
 import {
   type Conversation,
   type Topic,
@@ -159,7 +160,7 @@ export function TopicNode({
           <Layers className="size-3 shrink-0 text-primary/70" />
         )}
         <div className="flex-1 min-w-0 truncate text-[12.5px] font-medium leading-tight">
-          {topic.title || tTopics('newGroupChat')}
+          {topicDisplayTitle(topic.title, tTopics('newGroupChat'))}
         </div>
         {participants.length > 0 ? (
           <AvatarStack

--- a/frontend/packages/web/components/triggers/DestinationCell.tsx
+++ b/frontend/packages/web/components/triggers/DestinationCell.tsx
@@ -6,6 +6,7 @@ import { Hash, MessageCircle, MessageSquare } from 'lucide-react'
 import { createApiClient, getTopic } from '@cubebox/core'
 import type { Trigger } from '@cubebox/core'
 import { cn } from '@/lib/utils'
+import { topicDisplayTitle } from '@/lib/topicTitle'
 
 interface DestinationCellProps {
   /** Workspace for resolving /api/v1/topics → workspace-scoped path. */
@@ -26,6 +27,7 @@ interface DestinationCellProps {
  */
 export function DestinationCell({ wsId, trigger, className }: DestinationCellProps) {
   const t = useTranslations('triggers')
+  const tTopics = useTranslations('topics')
   const client = useMemo(() => {
     const c = createApiClient('')
     c.setWorkspaceId(wsId)
@@ -62,7 +64,11 @@ export function DestinationCell({ wsId, trigger, className }: DestinationCellPro
           data-testid="trigger-destination-topic"
         >
           <MessageSquare className="size-3 shrink-0" />
-          <span className="max-w-[14ch] truncate">{topicTitle ?? t('destTopicFallback')}</span>
+          <span className="max-w-[14ch] truncate">
+            {topicTitle === null
+              ? t('destTopicFallback')
+              : topicDisplayTitle(topicTitle, tTopics('newGroupChat'))}
+          </span>
         </span>
       )
     }

--- a/frontend/packages/web/components/triggers/TopicPicker.tsx
+++ b/frontend/packages/web/components/triggers/TopicPicker.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { Check, ChevronDown, MessageSquare, X } from 'lucide-react'
 import { createApiClient, listTopics } from '@cubebox/core'
 import type { Topic } from '@cubebox/core'
 import { cn } from '@/lib/utils'
+import { topicDisplayTitle } from '@/lib/topicTitle'
 
 interface TopicPickerProps {
   /** Workspace whose topics should be listed. Required so the API client
@@ -44,6 +46,8 @@ export function TriggerTopicPicker({
   id,
   'aria-labelledby': ariaLabelledBy,
 }: TopicPickerProps) {
+  const tTopics = useTranslations('topics')
+  const emptyTitle = tTopics('newGroupChat')
   const [topics, setTopics] = useState<Topic[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -79,12 +83,13 @@ export function TriggerTopicPicker({
   }, [client])
 
   const selected = topics.find((t) => t.id === value) ?? null
+  const selectedLabel = selected ? topicDisplayTitle(selected.title, emptyTitle) : null
 
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase()
     if (!q) return topics
-    return topics.filter((t) => t.title.toLowerCase().includes(q))
-  }, [topics, filter])
+    return topics.filter((t) => topicDisplayTitle(t.title, emptyTitle).toLowerCase().includes(q))
+  }, [topics, filter, emptyTitle])
 
   return (
     <div className="flex flex-col gap-1.5">
@@ -111,7 +116,7 @@ export function TriggerTopicPicker({
             <span
               className={cn('truncate', selected ? 'text-foreground' : 'text-muted-foreground')}
             >
-              {selected ? selected.title : placeholder}
+              {selected ? selectedLabel : placeholder}
             </span>
           </span>
           <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
@@ -186,7 +191,7 @@ export function TriggerTopicPicker({
                   )}
                   data-testid={`trigger-topic-option-${topic.id}`}
                 >
-                  <span className="truncate">{topic.title}</span>
+                  <span className="truncate">{topicDisplayTitle(topic.title, emptyTitle)}</span>
                   {value === topic.id && <Check className="size-3.5 shrink-0 text-primary" />}
                 </button>
               ))}

--- a/frontend/packages/web/components/workspace-settings/sandboxes/SandboxCard.tsx
+++ b/frontend/packages/web/components/workspace-settings/sandboxes/SandboxCard.tsx
@@ -16,6 +16,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { topicDisplayTitle } from '@/lib/topicTitle'
 import { StatusBadge } from './StatusBadge'
 
 interface SandboxCardProps {
@@ -32,6 +33,8 @@ interface SandboxCardProps {
  */
 export function SandboxCard({ sandbox, wsId, onMutated }: SandboxCardProps) {
   const t = useTranslations('wsSandboxes')
+  const tTopics = useTranslations('topics')
+  const tSidebar = useTranslations('sidebar')
   const tTime = useTranslations('time')
   // `mutate` is bound to the same SWR key the panel reads, so a restart/
   // delete revalidates the whole list (status flips to "Off", row disappears).
@@ -42,7 +45,9 @@ export function SandboxCard({ sandbox, wsId, onMutated }: SandboxCardProps) {
   const [busy, setBusy] = useState<'restart' | 'delete' | null>(null)
 
   // scope → human label (spec §7.4). conversation/topic fall back to
-  // "(deleted)" when the backing row is gone (scope_title null).
+  // "(deleted)" when the backing row is gone (scope_title null). Empty
+  // titles (IM topics without a resolved channel name) keep the row and
+  // use the localized empty-name label — do not treat "" as deleted.
   const deleted = t('scope.deleted')
   let label: string
   switch (sandbox.scope_type) {
@@ -50,10 +55,20 @@ export function SandboxCard({ sandbox, wsId, onMutated }: SandboxCardProps) {
       label = t('scope.user')
       break
     case 'conversation':
-      label = t('scope.conversation', { title: sandbox.scope_title ?? deleted })
+      label = t('scope.conversation', {
+        title:
+          sandbox.scope_title === null
+            ? deleted
+            : topicDisplayTitle(sandbox.scope_title, tSidebar('untitledChat')),
+      })
       break
     case 'topic':
-      label = t('scope.topic', { title: sandbox.scope_title ?? deleted })
+      label = t('scope.topic', {
+        title:
+          sandbox.scope_title === null
+            ? deleted
+            : topicDisplayTitle(sandbox.scope_title, tTopics('newGroupChat')),
+      })
       break
     default:
       label = t('scope.unknown', { type: sandbox.scope_type })

--- a/frontend/packages/web/lib/__tests__/topicTitle.test.ts
+++ b/frontend/packages/web/lib/__tests__/topicTitle.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { topicDisplayTitle } from '../topicTitle'
+
+describe('topicDisplayTitle', () => {
+  it('returns title when non-empty', () => {
+    expect(topicDisplayTitle('项目 Alpha', 'New Group Chat')).toBe('项目 Alpha')
+  })
+
+  it('falls back on empty / whitespace / null', () => {
+    expect(topicDisplayTitle('', 'New Group Chat')).toBe('New Group Chat')
+    expect(topicDisplayTitle('   ', 'New Group Chat')).toBe('New Group Chat')
+    expect(topicDisplayTitle(null, 'New Group Chat')).toBe('New Group Chat')
+    expect(topicDisplayTitle(undefined, 'New Group Chat')).toBe('New Group Chat')
+  })
+})

--- a/frontend/packages/web/lib/topicTitle.ts
+++ b/frontend/packages/web/lib/topicTitle.ts
@@ -1,0 +1,11 @@
+/**
+ * Display label for a Topic title that may be empty.
+ *
+ * IM topics without a resolved platform channel name persist ``""`` so the
+ * stored value stays locale-neutral. Callers pass the localized empty label
+ * (typically ``t('topics.newGroupChat')``).
+ */
+export function topicDisplayTitle(title: string | null | undefined, emptyLabel: string): string {
+  const trimmed = (title ?? '').trim()
+  return trimmed || emptyLabel
+}


### PR DESCRIPTION
## Summary

- Group IM topics were titled with opaque channel ids (`oc_…` / conversation ids) because `channel_name` was never resolved from the platform.
- **DingTalk:** parse `conversationTitle` from robot receive callbacks (no new permission).
- **Feishu:** lazy-fetch via `GET /open-apis/im/v1/chats/:chat_id` (`im.v1.chats.get`); requires `im:chat:readonly` (or `im:chat:read` / `im:chat`).
- Fall back to `群聊` instead of the raw channel id; refresh legacy channel-id titles on the next inbound without overwriting user-edited titles.
- Document the new Feishu scope in setup guides.

## Test plan

- [x] Unit: `tests/unit/im/test_dingtalk_connector.py`, `test_feishu_get_chat_name.py`, `test_bot_settings.py` (28 passed)
- [x] E2E: `tests/e2e/test_resolve_im_conversation.py`, `test_im_shared_mode_ingest.py` (20 passed)
- [ ] Manual: Feishu app grant `im:chat:readonly`, publish version, @bot in a group → Topic title is group name
- [ ] Manual: DingTalk group @bot → Topic title matches `conversationTitle`
- [ ] Manual: Existing topic titled with channel id gets renamed on next group message