### PR TITLE
Wire /new across IM platforms via shared reset command

### DIFF
--- a/backend/cubebox/api/routes/v1/im_ingress.py
+++ b/backend/cubebox/api/routes/v1/im_ingress.py
@@ -529,6 +529,29 @@ async def teams_messages(
         )
         return Response(status_code=status.HTTP_200_OK)
 
+    from cubebox.im.reset_command import (
+        apply_reset_command,
+        format_reset_reply,
+        parse_reset_command,
+    )
+
+    if parse_reset_command(event.text):
+        channel_id = event.channel_id or ""
+        scope_key = event.scope_key or ""
+        if not channel_id or not scope_key:
+            if gate_connector is not None:
+                await gate_connector.send_to_chat(channel_id, None, "无法确定会话范围。")
+        else:
+            outcome = await apply_reset_command(
+                session_maker=async_session_maker,
+                account_id=account.id,
+                channel_id=channel_id,
+                scope_key=scope_key,
+            )
+            if gate_connector is not None:
+                await gate_connector.send_to_chat(channel_id, None, format_reset_reply(outcome))
+        return Response(status_code=status.HTTP_200_OK)
+
     maker: async_sessionmaker[AsyncSession] = async_session_maker
     result = await ingest_inbound_event(
         event,

--- a/backend/cubebox/im/conversation_resolver.py
+++ b/backend/cubebox/im/conversation_resolver.py
@@ -273,6 +273,17 @@ async def resolve_im_conversation(
                     )
                 await session.flush()
 
+    # After /new rotation the fresh conversation starts with an empty title.
+    # When the first real message reuses that row (``_make_conversation_id``
+    # does not run), stamp a provisional title from the message text — same
+    # as brand-new create via title_hint. Never overwrite a non-empty title.
+    if reused is not None and not (reused.title or "").strip():
+        hint = (title_hint or "").strip()
+        if hint:
+            reused.title = hint[:80]
+            session.add(reused)
+            await session.flush()
+
     # Topic visibility is gated on TopicParticipant (a topic conversation is
     # NOT visible to its creator unless they're also a participant). So ensure
     # the sender is a participant of ANY topic they're routed into — shared
@@ -440,7 +451,11 @@ async def reset_im_conversation(
         org_id=old.org_id,
         workspace_id=old.workspace_id,
         creator_user_id=old.creator_user_id,
-        title=old.title,
+        # Fresh conversation — do not copy the old title. A non-empty title
+        # would also block web auto-title (generate_and_apply_title skips
+        # when title != ""). The next inbound message stamps a provisional
+        # title from title_hint when the field is still empty.
+        title="",
         # The link is the authoritative Topic anchor — old.topic_id can lag it
         # (e.g. a conversation adopted into a topic after a mode change).
         topic_id=link.topic_id,

--- a/backend/cubebox/im/dingtalk/gateway.py
+++ b/backend/cubebox/im/dingtalk/gateway.py
@@ -130,6 +130,7 @@ class DingtalkGateway:
             await self._handle_link_command(raw)
             return
 
+        from cubebox.im.reset_command import parse_reset_command
         from cubebox.im.types import lookup_binding_mode
 
         channel_id = raw.get("conversationId", "")
@@ -138,6 +139,10 @@ class DingtalkGateway:
         if parsed is None:
             return
         parsed.account_external_id = account.external_account_id
+
+        if parse_reset_command(parsed.text):
+            await self._handle_reset_command(parsed, account, session_maker)
+            return
 
         is_dm = parsed.scope_kind == "dm"
         gate_connector = DingtalkConnector(
@@ -167,6 +172,55 @@ class DingtalkGateway:
                 parsed.platform_event_id,
             )
 
+    def _reply_connector(
+        self, *, conversation_id: str, sender_staff_id: str, is_dm: bool
+    ) -> DingtalkConnector:
+        return DingtalkConnector(
+            bot_user_id=self._app_key,
+            access_token=self._access_token,
+            conversation_id=conversation_id,
+            sender_staff_id=sender_staff_id,
+            is_dm=is_dm,
+            http_client=self._shared_http,
+        )
+
+    async def _handle_reset_command(
+        self,
+        event: Any,
+        account: Any,
+        session_maker: Any,
+    ) -> None:
+        """Handle /new or /reset by rotating the IM conversation binding."""
+        from cubebox.im.reset_command import apply_reset_command, format_reset_reply
+
+        channel_id = event.channel_id or ""
+        scope_key = event.scope_key or ""
+        sender_staff_id = event.sender_ref or ""
+        if not channel_id or not scope_key or not sender_staff_id:
+            return
+
+        try:
+            outcome = await apply_reset_command(
+                session_maker=session_maker,
+                account_id=account.id,
+                channel_id=channel_id,
+                scope_key=scope_key,
+            )
+        except Exception:
+            logger.exception("[DingTalk] /new handler failed for {}", event.platform_event_id)
+            return
+
+        is_dm = event.scope_kind == "dm"
+        await self._reply_connector(
+            conversation_id=channel_id,
+            sender_staff_id=sender_staff_id,
+            is_dm=is_dm,
+        ).reply_markdown(
+            title="New conversation",
+            text=format_reset_reply(outcome),
+            open_conversation_id=channel_id,
+        )
+
     async def _handle_link_command(self, raw: dict[str, Any]) -> None:
         """Handle 'link alice@example.com' by sending an identity-link URL."""
         sender_staff_id = raw.get("senderStaffId", "")
@@ -175,20 +229,16 @@ class DingtalkGateway:
         if not sender_staff_id or not conversation_id:
             return
 
-        def _make_reply_connector() -> DingtalkConnector:
-            return DingtalkConnector(
-                bot_user_id=self._app_key,
-                access_token=self._access_token,
-                conversation_id=conversation_id,
-                sender_staff_id=sender_staff_id,
-                is_dm=is_dm,
-                http_client=self._shared_http,
-            )
+        reply = self._reply_connector(
+            conversation_id=conversation_id,
+            sender_staff_id=sender_staff_id,
+            is_dm=is_dm,
+        )
 
         connector = DingtalkConnector(bot_user_id=self._app_key)
         email = connector.parse_link_email(raw)
         if not email:
-            await _make_reply_connector().reply_markdown(
+            await reply.reply_markdown(
                 title="Link",
                 text="Usage: `link alice@example.com`",
                 open_conversation_id=conversation_id,
@@ -213,7 +263,7 @@ class DingtalkGateway:
         base = get_frontend_base_url()
         url = f"{base}/im-link?token={token}"
 
-        await _make_reply_connector().reply_markdown(
+        await reply.reply_markdown(
             title="Link your account",
             text=f"Click to bind your cubebox account:\n\n[Link your account]({url})",
             open_conversation_id=conversation_id,

--- a/backend/cubebox/im/discord/commands.py
+++ b/backend/cubebox/im/discord/commands.py
@@ -32,8 +32,9 @@ async def register_commands(bot: commands.Bot) -> None:
 
 
 async def _reset_conversation(interaction: discord.Interaction, bot: commands.Bot) -> None:
-    """Delete the IMThreadLink for the current channel/scope so the next
-    message starts a fresh conversation."""
+    """Delete/rotate the IMThreadLink for the current channel/scope so the
+    next message starts a fresh conversation."""
+    from cubebox.im.reset_command import apply_reset_command, format_reset_reply
     from cubebox.im.types import (
         DM_SCOPE_KEY,
         make_participant_scope,
@@ -59,8 +60,6 @@ async def _reset_conversation(interaction: discord.Interaction, bot: commands.Bo
     else:
         scope_key = make_participant_scope(sender_ref)
 
-    from cubebox.im.conversation_resolver import reset_im_conversation
-
     session_maker = getattr(bot, "_cubebox_session_maker", None)
     account_id = getattr(bot, "_cubebox_account_id", None)
     if session_maker is None or account_id is None:
@@ -70,18 +69,13 @@ async def _reset_conversation(interaction: discord.Interaction, bot: commands.Bo
     # Route through the mode-aware reset so topic-mode accounts rotate the
     # conversation under the same durable Topic instead of dropping the anchor
     # (which would spawn a second Topic on the next message).
-    async with session_maker() as session:
-        outcome = await reset_im_conversation(
-            session, account_id=account_id, channel_id=channel_id, scope_key=scope_key
-        )
-        await session.commit()
-
-    msg = (
-        "ℹ️ 当前还没有进行中的会话，直接发送消息即可开始新对话。"
-        if outcome == "none"
-        else "✅ 新对话已开始。"
+    outcome = await apply_reset_command(
+        session_maker=session_maker,
+        account_id=account_id,
+        channel_id=channel_id,
+        scope_key=scope_key,
     )
-    await interaction.response.send_message(msg, ephemeral=True)
+    await interaction.response.send_message(format_reset_reply(outcome), ephemeral=True)
 
 
 async def _initiate_link(

--- a/backend/cubebox/im/feishu/reset_command.py
+++ b/backend/cubebox/im/feishu/reset_command.py
@@ -1,36 +1,27 @@
-"""Feishu /new and /reset command parsing + reply.
+"""Feishu /new and /reset command reply (parse/apply live in ``im.reset_command``).
 
 Both the webhook ingress and the long-connection path must intercept
 ``/new`` / ``/reset`` (or the Chinese alias ``新对话``) BEFORE handing the
 message to ``ingest_inbound_event`` — otherwise the message gets routed
-to the agent as ordinary text, which politely acknowledges the request
-without actually rotating the conversation.
-
-The reset is mode-aware (see ``reset_im_conversation``):
-
-- ``flat`` mode (no Topic): delete the ``IMThreadLink``; the next message
-  hits ``conversation_resolver`` with no link and starts fresh. Mirrors the
-  Discord ``/new`` handler at ``cubebox/im/discord/commands.py``.
-- ``topic`` mode: repoint the link to a fresh ``Conversation`` under the
-  same Topic so the old conversation stays as history under the Topic.
+to the agent as ordinary text.
 """
 
 from __future__ import annotations
 
-import re as _re
 from typing import Any
 
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from cubebox.im.reset_command import (
+    apply_reset_command,
+    format_reset_reply,
+    parse_reset_command,
+)
 from cubebox.models.im_connector import IMConnectorAccount
 
-_RESET_RE = _re.compile(r"^\s*(?:/new|/reset|新对话)\s*$", _re.IGNORECASE)
-
-
-def parse_reset_command(text: str) -> bool:
-    """Return True if the message is a /new, /reset, or 新对话 command."""
-    return bool(_RESET_RE.match(text or ""))
+# Re-export so existing Feishu call sites keep a stable import path.
+__all__ = ["handle_reset_command", "parse_reset_command"]
 
 
 async def handle_reset_command(
@@ -41,8 +32,6 @@ async def handle_reset_command(
     connector: Any,
 ) -> None:
     """Reset the current scope's conversation and reply with confirmation."""
-    from cubebox.im.conversation_resolver import reset_im_conversation
-
     channel_id = event.channel_id or ""
     scope_key = event.scope_key or ""
     if not channel_id or not scope_key:
@@ -50,22 +39,15 @@ async def handle_reset_command(
             await connector.send_to_chat(channel_id, event.reply_to_id, "无法确定会话范围。")
         return
 
-    async with session_maker() as session:
-        outcome = await reset_im_conversation(
-            session,
-            account_id=account.id,
-            channel_id=channel_id,
-            scope_key=scope_key,
-        )
-        await session.commit()
+    outcome = await apply_reset_command(
+        session_maker=session_maker,
+        account_id=account.id,
+        channel_id=channel_id,
+        scope_key=scope_key,
+    )
 
     if connector is None:
         logger.warning("[Feishu] no connector to confirm /new reset")
         return
 
-    msg = (
-        "ℹ️ 当前还没有进行中的会话，直接发送消息即可开始新对话。"
-        if outcome == "none"
-        else "✅ 新对话已开始。"
-    )
-    await connector.send_to_chat(channel_id, event.reply_to_id, msg)
+    await connector.send_to_chat(channel_id, event.reply_to_id, format_reset_reply(outcome))

--- a/backend/cubebox/im/reset_command.py
+++ b/backend/cubebox/im/reset_command.py
@@ -1,0 +1,57 @@
+"""Shared ``/new`` / ``/reset`` command parse + apply for all IM platforms.
+
+Platform ingress must intercept these BEFORE ``ingest_inbound_event`` —
+otherwise the message is routed to the agent as ordinary text and never
+rotates the conversation binding.
+
+The apply path is mode-aware (see ``reset_im_conversation``):
+
+- ``flat`` mode (no Topic): delete the ``IMThreadLink``; the next message
+  starts fresh.
+- ``topic`` mode: repoint the link to a fresh ``Conversation`` under the
+  same Topic so the old conversation stays as history.
+"""
+
+from __future__ import annotations
+
+import re as _re
+from typing import Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+ResetOutcome = Literal["none", "flat", "rotated"]
+
+_RESET_RE = _re.compile(r"^\s*(?:/new|/reset|新对话)\s*$", _re.IGNORECASE)
+
+
+def parse_reset_command(text: str) -> bool:
+    """Return True if the message is a /new, /reset, or 新对话 command."""
+    return bool(_RESET_RE.match(text or ""))
+
+
+def format_reset_reply(outcome: ResetOutcome) -> str:
+    """User-facing confirmation for a completed reset attempt."""
+    if outcome == "none":
+        return "ℹ️ 当前还没有进行中的会话，直接发送消息即可开始新对话。"
+    return "✅ 新对话已开始。"
+
+
+async def apply_reset_command(
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+    account_id: str,
+    channel_id: str,
+    scope_key: str,
+) -> ResetOutcome:
+    """Run ``reset_im_conversation`` and commit. Returns the outcome label."""
+    from cubebox.im.conversation_resolver import reset_im_conversation
+
+    async with session_maker() as session:
+        outcome = await reset_im_conversation(
+            session,
+            account_id=account_id,
+            channel_id=channel_id,
+            scope_key=scope_key,
+        )
+        await session.commit()
+    return outcome

--- a/backend/cubebox/im/slack/commands.py
+++ b/backend/cubebox/im/slack/commands.py
@@ -1,4 +1,4 @@
-"""Slack slash commands: /link."""
+"""Slack slash commands: /link, /new, /reset."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ def register_commands(
     workspace_id: str,
     session_maker: Any,
 ) -> None:
-    """Register /link slash command on the Slack app."""
+    """Register /link, /new, and /reset slash commands on the Slack app."""
 
     @app.command("/link")  # type: ignore[untyped-decorator]
     async def cmd_link(ack: Any, command: dict[str, Any], respond: Any) -> None:
@@ -57,3 +57,63 @@ def register_commands(
             f"Click to complete linking:\n{url}",
             response_type="ephemeral",
         )
+
+    @app.command("/new")  # type: ignore[untyped-decorator]
+    async def cmd_new(ack: Any, command: dict[str, Any], respond: Any) -> None:
+        await ack()
+        await _handle_reset_slash(
+            command, respond, account_id=account_id, session_maker=session_maker
+        )
+
+    @app.command("/reset")  # type: ignore[untyped-decorator]
+    async def cmd_reset(ack: Any, command: dict[str, Any], respond: Any) -> None:
+        await ack()
+        await _handle_reset_slash(
+            command, respond, account_id=account_id, session_maker=session_maker
+        )
+
+
+async def _handle_reset_slash(
+    command: dict[str, Any],
+    respond: Any,
+    *,
+    account_id: str,
+    session_maker: Any,
+) -> None:
+    """Rotate the IM conversation for the slash-command's channel/scope."""
+    from cubebox.im.reset_command import apply_reset_command, format_reset_reply
+    from cubebox.im.types import (
+        DM_SCOPE_KEY,
+        lookup_binding_mode,
+        make_channel_scope,
+        make_participant_scope,
+    )
+
+    channel_id = command.get("channel_id") or ""
+    user_id = command.get("user_id") or ""
+    if not channel_id or not user_id:
+        await respond("Could not determine channel or user.", response_type="ephemeral")
+        return
+
+    # Slack DM channel IDs start with ``D``.
+    if channel_id.startswith("D"):
+        scope_key = DM_SCOPE_KEY
+    else:
+        binding_mode = await lookup_binding_mode(session_maker, account_id, channel_id)
+        scope_key = (
+            make_channel_scope() if binding_mode == "shared" else make_participant_scope(user_id)
+        )
+
+    try:
+        outcome = await apply_reset_command(
+            session_maker=session_maker,
+            account_id=account_id,
+            channel_id=channel_id,
+            scope_key=scope_key,
+        )
+    except Exception:
+        logger.opt(exception=True).warning("[Slack] /new slash handler failed")
+        await respond("Failed to start a new conversation.", response_type="ephemeral")
+        return
+
+    await respond(format_reset_reply(outcome), response_type="ephemeral")

--- a/backend/cubebox/im/slack/gateway.py
+++ b/backend/cubebox/im/slack/gateway.py
@@ -127,6 +127,33 @@ class SlackGateway:
             return
         parsed.account_external_id = account.external_account_id
 
+        from cubebox.im.reset_command import (
+            apply_reset_command,
+            format_reset_reply,
+            parse_reset_command,
+        )
+
+        if parse_reset_command(parsed.text):
+            try:
+                outcome = await apply_reset_command(
+                    session_maker=session_maker,
+                    account_id=account.id,
+                    channel_id=parsed.channel_id,
+                    scope_key=parsed.scope_key,
+                )
+                gate = SlackConnector(
+                    bot_user_id=bot_user_id,
+                    client=self._client,
+                    channel_id=parsed.channel_id,
+                    thread_ts=parsed.reply_to_id,
+                )
+                await gate.send_to_chat(
+                    parsed.channel_id, parsed.reply_to_id, format_reset_reply(outcome)
+                )
+            except Exception:
+                logger.exception("[Slack] /new handler failed for {}", parsed.platform_event_id)
+            return
+
         gate_connector = SlackConnector(
             bot_user_id=bot_user_id,
             client=self._client,

--- a/backend/tests/e2e/test_resolve_im_conversation.py
+++ b/backend/tests/e2e/test_resolve_im_conversation.py
@@ -969,6 +969,9 @@ async def test_new_rotates_conversation_under_same_topic(
             )
         ).scalar_one()
         assert new_conv.topic_id == topic_id
+        # Must not inherit the previous conversation's title (that also blocked
+        # web auto-title, which skips when title is non-empty).
+        assert new_conv.title == ""
 
         # The old conversation survives as history (not soft-deleted).
         old_conv = (
@@ -976,3 +979,25 @@ async def test_new_rotates_conversation_under_same_topic(
         ).scalar_one()
         assert old_conv.deleted_at is None
         assert old_conv.topic_id == topic_id
+        assert old_conv.title == "before /new"
+
+    # First real message after /new stamps a provisional title from title_hint.
+    async with maker() as session:
+        r2 = await resolve_im_conversation(
+            session,
+            account,
+            channel_id=_CHANNEL,
+            scope_key="dm",
+            scope_kind="dm",
+            effective_user_id=_USER,
+            title_hint="hello after /new",
+            origin="inbound",
+        )
+        await session.commit()
+    async with maker() as session:
+        after = (
+            await session.execute(select(Conversation).where(Conversation.id == r2.conversation_id))
+        ).scalar_one()
+        assert after.title == "hello after /new"
+        assert r2.conversation_id != first_conv
+        assert r2.topic_id == topic_id

--- a/backend/tests/unit/im/test_dingtalk_reset_command.py
+++ b/backend/tests/unit/im/test_dingtalk_reset_command.py
@@ -1,0 +1,93 @@
+"""DingTalk gateway intercepts /new before agent ingest."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cubebox.im.dingtalk.gateway import DingtalkGateway
+from cubebox.im.types import DM_SCOPE_KEY
+
+
+def _dm_raw(text: str = "/new") -> dict[str, Any]:
+    return {
+        "msgtype": "text",
+        "text": {"content": text},
+        "msgId": "msg_reset_1",
+        "conversationId": "cid_dm_1",
+        "conversationType": "1",
+        "senderStaffId": "staff_1",
+        "chatbotUserId": "bot_1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_new_command_resets_and_skips_ingest() -> None:
+    account = SimpleNamespace(id="acc_1", external_account_id="ext_1", workspace_id="ws_1")
+    session_maker = MagicMock()
+    ingest = AsyncMock()
+
+    gw = DingtalkGateway(
+        account=account,
+        app_key="app_key",
+        app_secret="app_secret",
+        ingest=ingest,
+        session_maker=session_maker,
+        run_manager=None,
+        redis_key_prefix="test",
+    )
+    gw._access_token = "tok"
+
+    reply = AsyncMock()
+    with (
+        patch(
+            "cubebox.im.types.lookup_binding_mode",
+            new=AsyncMock(return_value="isolated"),
+        ),
+        patch(
+            "cubebox.im.reset_command.apply_reset_command",
+            new=AsyncMock(return_value="flat"),
+        ) as apply_reset,
+        patch.object(gw, "_reply_connector", return_value=SimpleNamespace(reply_markdown=reply)),
+    ):
+        await gw._handle_inbound(_dm_raw("/new"), account, session_maker, ingest)
+
+    apply_reset.assert_awaited_once_with(
+        session_maker=session_maker,
+        account_id="acc_1",
+        channel_id="cid_dm_1",
+        scope_key=DM_SCOPE_KEY,
+    )
+    reply.assert_awaited_once()
+    text = reply.await_args.kwargs.get("text") or ""
+    assert "新对话已开始" in text
+    ingest.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_normal_message_still_ingests() -> None:
+    account = SimpleNamespace(id="acc_1", external_account_id="ext_1", workspace_id="ws_1")
+    session_maker = MagicMock()
+    ingest = AsyncMock(return_value=SimpleNamespace(outcome="enqueued"))
+
+    gw = DingtalkGateway(
+        account=account,
+        app_key="app_key",
+        app_secret="app_secret",
+        ingest=ingest,
+        session_maker=session_maker,
+        run_manager=None,
+        redis_key_prefix="test",
+    )
+    gw._access_token = "tok"
+
+    with patch(
+        "cubebox.im.types.lookup_binding_mode",
+        new=AsyncMock(return_value="isolated"),
+    ):
+        await gw._handle_inbound(_dm_raw("hello"), account, session_maker, ingest)
+
+    ingest.assert_awaited_once()

--- a/backend/tests/unit/im/test_feishu_reset_intercept.py
+++ b/backend/tests/unit/im/test_feishu_reset_intercept.py
@@ -1,31 +1,13 @@
-"""Test Feishu /new and /reset command interception."""
+"""Feishu still re-exports shared /new parse for stable call-site imports."""
 
 from __future__ import annotations
 
 from cubebox.im.feishu.reset_command import parse_reset_command
 
 
-class TestParseResetCommand:
+class TestFeishuParseResetCommand:
     def test_slash_new(self) -> None:
         assert parse_reset_command("/new") is True
 
-    def test_slash_reset(self) -> None:
-        assert parse_reset_command("/reset") is True
-
-    def test_chinese_alias(self) -> None:
-        assert parse_reset_command("新对话") is True
-
-    def test_extra_whitespace(self) -> None:
-        assert parse_reset_command("  /new  ") is True
-        assert parse_reset_command("\n/reset\n") is True
-
-    def test_case_insensitive(self) -> None:
-        assert parse_reset_command("/NEW") is True
-        assert parse_reset_command("/Reset") is True
-
     def test_not_a_reset_command(self) -> None:
-        assert parse_reset_command("hello world") is False
         assert parse_reset_command("/link chris@example.com") is False
-        assert parse_reset_command("/new please") is False  # trailing text
-        assert parse_reset_command("再来一个新对话") is False  # not exact
-        assert parse_reset_command("") is False

--- a/backend/tests/unit/im/test_reset_command.py
+++ b/backend/tests/unit/im/test_reset_command.py
@@ -1,0 +1,50 @@
+"""Shared IM /new and /reset command parsing + reply formatting."""
+
+from __future__ import annotations
+
+from cubebox.im.reset_command import format_reset_reply, parse_reset_command
+
+
+class TestParseResetCommand:
+    def test_slash_new(self) -> None:
+        assert parse_reset_command("/new") is True
+
+    def test_slash_reset(self) -> None:
+        assert parse_reset_command("/reset") is True
+
+    def test_chinese_alias(self) -> None:
+        assert parse_reset_command("新对话") is True
+
+    def test_extra_whitespace(self) -> None:
+        assert parse_reset_command("  /new  ") is True
+        assert parse_reset_command("\n/reset\n") is True
+
+    def test_case_insensitive(self) -> None:
+        assert parse_reset_command("/NEW") is True
+        assert parse_reset_command("/Reset") is True
+
+    def test_not_a_reset_command(self) -> None:
+        assert parse_reset_command("hello world") is False
+        assert parse_reset_command("/link chris@example.com") is False
+        assert parse_reset_command("/new please") is False  # trailing text
+        assert parse_reset_command("再来一个新对话") is False  # not exact
+        assert parse_reset_command("") is False
+
+
+class TestFormatResetReply:
+    def test_none(self) -> None:
+        assert "没有进行中的会话" in format_reset_reply("none")
+
+    def test_flat_or_rotated(self) -> None:
+        assert "新对话已开始" in format_reset_reply("flat")
+        assert "新对话已开始" in format_reset_reply("rotated")
+
+
+class TestFeishuReexport:
+    """Feishu path keeps a stable import for parse_reset_command."""
+
+    def test_feishu_reexports_shared_parse(self) -> None:
+        from cubebox.im.feishu.reset_command import parse_reset_command as feishu_parse
+        from cubebox.im.reset_command import parse_reset_command as shared_parse
+
+        assert feishu_parse is shared_parse

--- a/docs/site/docs/guides/im/dingtalk.md
+++ b/docs/site/docs/guides/im/dingtalk.md
@@ -93,15 +93,14 @@ Once linked, the bot replies with a live-updating interactive card as the agent 
 
 ## Conversation commands
 
-The DingTalk bot recognizes the link command in any chat it's in:
+The DingTalk bot recognizes these as text messages (in a group, @ the bot first):
 
 | Command | Aliases | Effect |
 |---|---|---|
 | `link <email>` | `/link <email>` | Link your DingTalk identity to your CubeBox account (see [Identity linking](./overview.md#identity-linking)). |
+| `/new` | `/reset`, `新对话` | Start a fresh conversation; your next message begins a new one. |
 
-:::note
-The `/new` and `/reset` "start a fresh conversation" commands are **not** wired up on the DingTalk connector today — they work on Feishu/Lark and Discord but are silently ignored on DingTalk. To start over, message the bot fresh; per-channel conversation behavior follows the [channel binding mode](./overview.md#channel-binding-modes).
-:::
+`/new` and `/reset` are equivalent. Per-channel conversation behavior follows the [channel binding mode](./overview.md#channel-binding-modes).
 
 ## Rotating credentials
 

--- a/docs/site/docs/guides/im/overview.md
+++ b/docs/site/docs/guides/im/overview.md
@@ -25,8 +25,8 @@ CubeBox ships connector code for five platforms. They are **not** equally mature
 | Platform | Maturity | Delivery mode | Setup guide |
 |---|---|---|---|
 | **Feishu / Lark** | Most developed — interactive streaming cards, message encryption, signature verification, in-place card edits, human-in-the-loop button actions. | Long-connection (default) or webhook | [Feishu / Lark](./feishu.md) |
-| **Slack** | Working connector — in-place message edits, automatic email-based identity resolution, native `/link` slash command. | Gateway (Socket Mode) | [Slack](./slack.md) |
-| **DingTalk** | Working connector — automatic email-based identity resolution. | Stream | [DingTalk](./dingtalk.md) |
+| **Slack** | Working connector — in-place message edits, automatic email-based identity resolution, native `/link` / `/new` / `/reset` slash commands. | Gateway (Socket Mode) | [Slack](./slack.md) |
+| **DingTalk** | Working connector — automatic email-based identity resolution; text `/new` / `/reset` / `link`. | Stream | [DingTalk](./dingtalk.md) |
 | **Microsoft Teams** | Working connector — validates the Azure Bot Framework JWT on each inbound activity; requires a publicly reachable host. | Webhook | [Microsoft Teams](./teams.md) |
 | **Discord** | Working connector — native `/new`, `/reset`, `/link` slash commands. | Gateway | [Discord](./discord.md) |
 
@@ -76,7 +76,7 @@ Command support differs by platform — not every command exists everywhere.
 | Command | Effect | Available on |
 |---|---|---|
 | `/link <email>` | Links your chat identity to your CubeBox account (see [Identity linking](#identity-linking)). | All platforms. Native slash command on Slack and Discord; a text message on Feishu, DingTalk, and Teams. The Chinese alias `绑定 <email>` works on Feishu only. |
-| `/new` (alias `/reset`, `新对话`) | Starts a fresh conversation — drops the current conversation binding for the chat scope you're in, so the bot starts clean on your next message. | **Feishu** (text command) and **Discord** (native slash command) only. Not yet wired up on Slack, DingTalk, or Teams. |
+| `/new` (alias `/reset`, `新对话`) | Starts a fresh conversation — drops the current conversation binding for the chat scope you're in, so the bot starts clean on your next message. | All platforms. Native slash command on Discord and Slack; a text message on Feishu, DingTalk, and Teams (and as a plain `@bot /new` message on Slack). The Chinese alias `新对话` works everywhere the text form is accepted. |
 
 See each platform's setup guide for the exact command form.
 

--- a/docs/site/docs/guides/im/slack.md
+++ b/docs/site/docs/guides/im/slack.md
@@ -124,15 +124,15 @@ Once linked (or auto-resolved), the bot replies in-channel and edits its message
 
 ## Conversation commands
 
-Slack registers **one** native slash command:
+Slack registers these native slash commands (create matching slash commands in the Slack app if you use the slash form; typed messages also work):
 
 | Command | Effect |
 |---|---|
 | `/link <email>` | Link your Slack identity to your CubeBox account (see [Step 8](#step-8--link-your-identity)). Replies privately. |
+| `/new` | Start a fresh conversation; your next message begins a new one. Replies privately for the slash form. |
+| `/reset` | Same as `/new`. |
 
-:::note `/new` and `/reset` are not wired on Slack
-The shared conversation model documents `/new` and `/reset` for starting a fresh conversation, and Feishu and Discord support them. The Slack connector does **not** register or parse `/new` / `/reset` today — only `/link` is wired. To start a clean conversation on Slack, use a new DM or thread, or manage channel bindings from the workspace IM settings.
-:::
+You can also type `/new`, `/reset`, or `新对话` as a normal message (in a channel, @ the bot). That path does not require a Slack slash-command registration.
 
 ## Rotating credentials
 

--- a/docs/site/docs/guides/im/teams.md
+++ b/docs/site/docs/guides/im/teams.md
@@ -128,8 +128,10 @@ Once linked, your messages run as that user, with the same skills, memory, and t
 |---|---|
 | `/link <email>` | Link your Teams identity to your CubeBox account. |
 | `/new` | Start a fresh conversation; your next message begins a new one. |
+| `/reset` | Same as `/new`. |
+| `新对话` | Same as `/new` (text form). |
 
-`/reset` is an alias for `/new`. (The Chinese `绑定` / `新对话` aliases documented for Feishu are not part of the Teams reply flow.)
+`/new`, `/reset`, and `新对话` are equivalent. (The Chinese `绑定` alias for `/link` is Feishu-only.)
 
 ## How inbound messages are authenticated
 


### PR DESCRIPTION
## Summary
- Extract shared IM `/new` / `/reset` parse + apply + reply helpers to `cubebox/im/reset_command.py`.
- Intercept the command before agent ingest on DingTalk, Slack, and Teams; point Feishu and Discord at the same path.
- Update IM platform docs so command support matches the code.

## Test plan
- [x] `uv run pytest tests/unit/im/test_reset_command.py tests/unit/im/test_dingtalk_reset_command.py tests/unit/im/test_feishu_reset_intercept.py --no-cov`
- [x] `uv run pytest tests/e2e/test_resolve_im_conversation.py::test_new_rotates_conversation_under_same_topic --no-cov`
- [ ] Manual: DingTalk DM or group `@bot /new` returns confirmation and next message starts a fresh conversation