### PR TITLE
Normalize docs URLs without trailing slashes

### DIFF
--- a/docs/dev/notes/2026-07-16-docs-no-trailing-slash.md
+++ b/docs/dev/notes/2026-07-16-docs-no-trailing-slash.md
@@ -1,0 +1,11 @@
+# Docs URL normalization implementation note
+
+`trailingSlash: false` makes document routes and normal links slashless, but
+Docusaurus still emits a trailing slash for locale roots such as
+`/zh-Hans/` and the localized docs landing route `/zh-Hans/docs/`. Those are
+internal URLs, so the Cloudflare Worker alone is not enough: the generated
+HTML and sitemap would still advertise the non-canonical form.
+
+The build now runs a post-build normalizer over generated HTML and XML. It
+removes the final slash only from same-origin, non-root URLs. The following
+audit then checks the normalized output and fails on future regressions.

--- a/docs/dev/plans/2026-07-16-docs-no-trailing-slash.md
+++ b/docs/dev/plans/2026-07-16-docs-no-trailing-slash.md
@@ -1,0 +1,87 @@
+# Docs URLs without trailing slashes
+
+**Goal:** Generate slashless docs URLs, redirect legacy slash-suffixed
+requests, and continuously verify sitemap and internal HTML URLs.
+
+**Architecture:** Docusaurus owns canonical route generation through
+`trailingSlash: false`. A Pages advanced-mode Worker at the static asset
+boundary handles requests made with a legacy trailing slash, then delegates
+canonical requests to `env.ASSETS`. A post-build Node audit checks the generated
+HTML and sitemap files so CI protects the same invariant at build time.
+
+**Tech stack:** Docusaurus 3, TypeScript, Cloudflare Pages advanced-mode
+Worker, Node.js built-ins, GitHub Actions.
+
+## Unit 1 — Freeze the URL policy in Docusaurus
+
+**Files:**
+
+- `docs/site/docusaurus.config.ts` — set the explicit slashless URL option.
+- `docs/dev/specs/2026-07-16-docs-no-trailing-slash-design.md` — record the
+  behavior and boundaries.
+
+**Interface:** The generated site treats `/` as the only URL allowed to end in
+`/`; every other generated route is slashless.
+
+**Core logic:** Docusaurus generates `.html` files for document routes and
+rewrites its own canonical links and sitemap entries to match the setting.
+
+**Tests:** The production docs build must complete with broken-link checking
+enabled, and the output audit in Unit 3 must find no non-root slash-suffixed
+internal URLs.
+
+## Unit 2 — Normalize legacy requests at Pages
+
+**Files:**
+
+- `docs/site/static/_worker.js` — add the advanced-mode Worker.
+
+**Interface:** `fetch(request, env)` returns a 301 for a non-root pathname
+ending in `/`, with the final slash removed and the query string preserved;
+all other requests are passed to `env.ASSETS.fetch(request)`.
+
+**Core logic:** Clone the request URL, inspect only the pathname, and return a
+redirect before calling the asset binding. Do not store request state globally
+or consume the asset response body.
+
+**Tests:** Execute the Worker handler in a small Node harness with a mocked
+asset binding for root, slash-suffixed, query-string, canonical, and asset
+requests. Assert status, `Location`, and delegation behavior.
+
+## Unit 3 — Audit generated sitemap and internal URLs
+
+**Files:**
+
+- `docs/site/scripts/check-url-format.mjs` — inspect generated HTML and sitemap
+  output using Node built-ins.
+- `docs/site/package.json` — run the audit as part of `pnpm check`.
+
+**Interface:** `node scripts/check-url-format.mjs [build-directory]` exits 0
+when all internal generated URLs are canonical and exits nonzero with the file
+and offending URL when it finds a violation.
+
+**Core logic:** Walk generated `.html` and `.xml` files, extract URL-bearing
+HTML attributes/metadata and sitemap `<loc>` values, resolve same-origin
+absolute URLs, and reject only non-root paths ending in `/`. Ignore fragments,
+data URLs, and external origins.
+
+**Tests:** Run the audit against the real Docusaurus build and include a small
+fixture-oriented test or deterministic harness for root, canonical,
+slash-suffixed, external, and fragment URLs.
+
+## Unit 4 — Verify the CI/deployment contract
+
+**Files:**
+
+- `.github/workflows/docs.yml` — keep the existing build and Pages deployment
+  path; no new secret or deployment mechanism is needed.
+
+**Interface:** Pull requests run the enhanced `pnpm check`; main deployments
+upload the build containing `_worker.js` to the `cubeplex-docs` Pages project.
+
+**Core logic:** The audit runs after the build, so deployment cannot publish a
+  site whose generated sitemap or internal HTML links violate the URL policy.
+
+**Tests:** Run `pnpm install --frozen-lockfile`, `pnpm check`, inspect the build
+  tree for `_worker.js`, and verify the generated sitemap and canonical links
+  with the audit output.

--- a/docs/dev/specs/2026-07-16-docs-no-trailing-slash-design.md
+++ b/docs/dev/specs/2026-07-16-docs-no-trailing-slash-design.md
@@ -1,0 +1,85 @@
+# Docs URLs without trailing slashes
+
+## Goal
+
+Make the CubePlex docs site use one canonical URL shape: every non-root URL
+has no trailing slash, while requests that still include a trailing slash
+receive a permanent redirect to the slashless URL.
+
+## Context
+
+The Docusaurus site currently leaves `trailingSlash` unset. The generated
+routes, sitemap, and links therefore follow Docusaurus' default static output
+shape rather than an explicit project-wide URL policy. Cloudflare Pages also
+needs an edge rule for old slash-suffixed URLs, otherwise both forms can remain
+reachable.
+
+The CubePi docs site already uses a Pages advanced-mode `_worker.js` copied
+from `static/` into the deployment output. CubePlex can use the same deployment
+boundary for URL normalization.
+
+## Approaches considered
+
+1. **Docusaurus configuration only.** Set `trailingSlash: false`. This makes
+   newly generated links and sitemap entries canonical, but does not guarantee
+   that old slash-suffixed requests redirect at the edge.
+2. **Static `_redirects` rules only.** Add Pages redirect rules. This avoids a
+   Worker, but a single rule cannot express the full dynamic path
+   slash-removal policy as clearly as the existing advanced-mode pattern.
+3. **Docusaurus plus an advanced-mode Worker (recommended).** Set
+   `trailingSlash: false`, add a Worker that redirects every non-root path
+   ending in `/`, and add a build audit that fails if generated internal URLs
+   or sitemap entries end in `/`. This covers both newly generated addresses
+   and legacy requests.
+
+## Design
+
+### Canonical generation
+
+Set `trailingSlash: false` in `docs/site/docusaurus.config.ts`. Docusaurus will
+generate slashless document URLs and corresponding `.html` output files. The
+root URL `/` remains `/`, because it is the origin root rather than a
+slash-suffixed document path.
+
+### Cloudflare redirect
+
+Add `docs/site/static/_worker.js`. The Worker will:
+
+- leave `/` unchanged;
+- for any other pathname ending in `/`, remove only the final slash;
+- preserve the original query string;
+- return HTTP 301 for the normalized request; and
+- delegate all other requests to `env.ASSETS.fetch(request)`.
+
+The Worker will not rewrite external hosts or alter paths that are already
+canonical. It will be copied into `docs/site/build/_worker.js` by Docusaurus
+and deployed with the existing Pages Direct Upload workflow.
+
+### Generated-output audit
+
+Add a small Node script under `docs/site/scripts/` and run it from `pnpm check`
+after the build. The audit will inspect generated HTML and every generated
+sitemap file. It will reject non-root internal URLs with a trailing slash in
+HTML URL attributes, canonical/metadata URLs, or sitemap `<loc>` values. It
+will ignore fragments, data URLs, external origins, and the root URL `/`.
+
+This makes the URL policy part of the existing CI check instead of relying on
+manual inspection after each docs change.
+
+## Out of scope
+
+- Redirecting external URLs, API URLs, or links to other domains.
+- Changing the public docs domain or locale prefixes.
+- Rewriting prose examples that are not generated site URLs.
+- Adding a redirect for `/` to an empty path.
+
+## Success criteria
+
+- The production Docusaurus build succeeds with `trailingSlash: false`.
+- Every generated sitemap URL is slashless except the root URL.
+- Generated internal HTML URLs are slashless except the root URL.
+- `/docs/example/` returns a 301 redirect to `/docs/example` while
+  preserving its query string in Cloudflare Pages advanced mode.
+- `/docs/example` and static assets are delegated to Pages unchanged.
+- `pnpm check` fails if a future docs change reintroduces a trailing slash in a
+  generated internal URL or sitemap entry.

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -23,8 +23,13 @@ The local server watches the site files and reloads after changes.
 pnpm check
 ```
 
-This runs the production Docusaurus build and the TypeScript check. The static
-output is written to `build/`.
+This runs the production Docusaurus build, the TypeScript check, the generated
+URL audit, and the Cloudflare Worker normalization test. The static output is
+written to `build/`.
+
+The site uses slashless URLs for every non-root page. Cloudflare Pages
+redirects legacy URLs such as `/docs/getting-started/quick-start/` to
+`/docs/getting-started/quick-start`; the root URL `/` remains unchanged.
 
 To serve an already-built site locally:
 

--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -25,6 +25,7 @@ const config: Config = {
 
   url: 'https://docs.cubeplex.ai',
   baseUrl: '/',
+  trailingSlash: false,
   organizationName: 'cubeplexai',
   projectName: 'cubeplex',
 

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -11,8 +11,11 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
+    "postbuild": "node scripts/normalize-url-format.mjs build",
     "typecheck": "tsc",
-    "check": "pnpm build && pnpm typecheck",
+    "check:urls": "node scripts/check-url-format.mjs build",
+    "test:worker": "node scripts/test-worker.mjs",
+    "check": "pnpm build && pnpm typecheck && pnpm check:urls && pnpm test:worker",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/docs/site/scripts/check-url-format.mjs
+++ b/docs/site/scripts/check-url-format.mjs
@@ -1,0 +1,99 @@
+import {readdir, readFile} from 'node:fs/promises';
+import {join, relative, resolve} from 'node:path';
+
+const buildDirectory = resolve(process.argv[2] ?? 'build');
+const siteOrigin = 'https://docs.cubeplex.ai';
+const issues = [];
+
+async function walk(directory) {
+  const entries = await readdir(directory, {withFileTypes: true});
+  const files = [];
+
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await walk(path));
+    } else {
+      files.push(path);
+    }
+  }
+
+  return files;
+}
+
+function internalPath(value) {
+  const trimmed = value.trim();
+  if (
+    !trimmed ||
+    trimmed.startsWith('#') ||
+    trimmed.startsWith('data:') ||
+    trimmed.startsWith('mailto:') ||
+    trimmed.startsWith('tel:') ||
+    trimmed.startsWith('javascript:')
+  ) {
+    return null;
+  }
+
+  let url;
+  try {
+    if (trimmed.startsWith('//')) {
+      url = new URL(`https:${trimmed}`);
+    } else if (trimmed.startsWith('/')) {
+      url = new URL(trimmed, siteOrigin);
+    } else if (trimmed.startsWith(siteOrigin)) {
+      url = new URL(trimmed);
+    } else {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  return url.origin === siteOrigin ? url.pathname : null;
+}
+
+function checkValue(value, file, context) {
+  const pathname = internalPath(value);
+  if (pathname && pathname !== '/' && pathname.endsWith('/')) {
+    issues.push(`${relative(process.cwd(), file)}: ${context} has ${value}`);
+  }
+}
+
+function checkHtml(content, file) {
+  const attributePattern = /\b(?:href|src|content)=["']([^"']+)["']/gi;
+  for (const match of content.matchAll(attributePattern)) {
+    checkValue(match[1], file, 'HTML URL');
+  }
+
+  const absoluteUrlPattern = /https?:\/\/[^\s"'<>]+/gi;
+  for (const match of content.matchAll(absoluteUrlPattern)) {
+    checkValue(match[0].replace(/[),.;]+$/, ''), file, 'HTML URL');
+  }
+}
+
+function checkSitemap(content, file) {
+  const locationPattern = /<loc>([^<]+)<\/loc>/gi;
+  for (const match of content.matchAll(locationPattern)) {
+    checkValue(match[1], file, 'sitemap URL');
+  }
+}
+
+const files = await walk(buildDirectory);
+for (const file of files) {
+  const content = await readFile(file, 'utf8');
+  if (file.endsWith('.html')) {
+    checkHtml(content, file);
+  } else if (file.endsWith('.xml')) {
+    checkSitemap(content, file);
+  }
+}
+
+if (issues.length > 0) {
+  console.error('Found non-canonical trailing-slash URLs:');
+  for (const issue of issues) {
+    console.error(`- ${issue}`);
+  }
+  process.exitCode = 1;
+} else {
+  console.log(`URL format check passed for ${files.length} generated files.`);
+}

--- a/docs/site/scripts/normalize-url-format.mjs
+++ b/docs/site/scripts/normalize-url-format.mjs
@@ -1,0 +1,91 @@
+import {readdir, readFile, writeFile} from 'node:fs/promises';
+import {join, resolve} from 'node:path';
+
+const buildDirectory = resolve(process.argv[2] ?? 'build');
+const siteOrigin = 'https://docs.cubeplex.ai';
+
+async function walk(directory) {
+  const entries = await readdir(directory, {withFileTypes: true});
+  const files = [];
+
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await walk(path));
+    } else {
+      files.push(path);
+    }
+  }
+
+  return files;
+}
+
+function normalizeUrl(value) {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith('#')) {
+    return value;
+  }
+
+  let url;
+  let relative = false;
+  try {
+    if (trimmed.startsWith('/')) {
+      url = new URL(trimmed, siteOrigin);
+      relative = true;
+    } else if (trimmed.startsWith(siteOrigin)) {
+      url = new URL(trimmed);
+    } else {
+      return value;
+    }
+  } catch {
+    return value;
+  }
+
+  if (url.origin !== siteOrigin || url.pathname === '/' || !url.pathname.endsWith('/')) {
+    return value;
+  }
+
+  url.pathname = url.pathname.slice(0, -1);
+  if (relative) {
+    return `${url.pathname}${url.search}${url.hash}`;
+  }
+  return url.toString();
+}
+
+function normalizeHtml(content) {
+  const attributePattern = /\b(?:href|src|content)=["']([^"']+)["']/gi;
+  const normalizedAttributes = content.replace(attributePattern, (match, value) => {
+    return match.replace(value, normalizeUrl(value));
+  });
+
+  const absoluteUrlPattern = /https?:\/\/[^\s"'<>]+/gi;
+  return normalizedAttributes.replace(absoluteUrlPattern, (value) => {
+    const url = value.replace(/[),.;]+$/, '');
+    return normalizeUrl(url) + value.slice(url.length);
+  });
+}
+
+function normalizeSitemap(content) {
+  return content.replace(/<loc>([^<]+)<\/loc>/gi, (match, value) => {
+    return match.replace(value, normalizeUrl(value));
+  });
+}
+
+const files = await walk(buildDirectory);
+let changedFiles = 0;
+for (const file of files) {
+  if (!file.endsWith('.html') && !file.endsWith('.xml')) {
+    continue;
+  }
+
+  const original = await readFile(file, 'utf8');
+  const normalized = file.endsWith('.html')
+    ? normalizeHtml(original)
+    : normalizeSitemap(original);
+  if (normalized !== original) {
+    await writeFile(file, normalized);
+    changedFiles += 1;
+  }
+}
+
+console.log(`Normalized trailing-slash URLs in ${changedFiles} generated files.`);

--- a/docs/site/scripts/test-worker.mjs
+++ b/docs/site/scripts/test-worker.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import {readFile} from 'node:fs/promises';
+import {join} from 'node:path';
+
+const workerSource = await readFile(join('static', '_worker.js'), 'utf8');
+const workerModule = await import(`data:text/javascript,${encodeURIComponent(workerSource)}`);
+const worker = workerModule.default;
+const delegatedRequests = [];
+
+const env = {
+  ASSETS: {
+    fetch(request) {
+      delegatedRequests.push(request.url);
+      return Promise.resolve(new Response('asset', {status: 200}));
+    },
+  },
+};
+
+const redirected = await worker.fetch(
+  new Request('https://docs.cubeplex.ai/docs/intro/?source=legacy'),
+  env,
+);
+assert.equal(redirected.status, 301);
+assert.equal(
+  redirected.headers.get('location'),
+  'https://docs.cubeplex.ai/docs/intro?source=legacy',
+);
+
+const root = await worker.fetch(new Request('https://docs.cubeplex.ai/'), env);
+assert.equal(root.status, 200);
+
+const canonical = await worker.fetch(new Request('https://docs.cubeplex.ai/docs/intro'), env);
+assert.equal(canonical.status, 200);
+
+assert.deepEqual(delegatedRequests, [
+  'https://docs.cubeplex.ai/',
+  'https://docs.cubeplex.ai/docs/intro',
+]);
+console.log('Cloudflare URL normalization check passed.');

--- a/docs/site/static/_worker.js
+++ b/docs/site/static/_worker.js
@@ -1,0 +1,16 @@
+// Cloudflare Pages advanced-mode Worker.
+//
+// Docusaurus generates slashless document URLs. Normalize old slash-suffixed
+// requests at the edge before delegating canonical requests to Pages assets.
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
+      url.pathname = url.pathname.slice(0, -1);
+      return Response.redirect(url.toString(), 301);
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};


### PR DESCRIPTION
## What changed

- Add Docusaurus `trailingSlash: false` so generated document routes are slashless.
- Add a Cloudflare Pages advanced-mode Worker at `docs/site/static/_worker.js` that sends non-root trailing-slash requests to the canonical URL with HTTP 301 and preserves query strings.
- Normalize the remaining Docusaurus locale-root URLs in generated HTML and sitemap files during `postbuild`.
- Add a generated-output audit for internal HTML URLs and sitemap `<loc>` entries.
- Add a Node harness that verifies Worker redirect, root passthrough, canonical passthrough, and delegation behavior.
- Document the URL policy and the Docusaurus locale-root behavior.

## Why

The docs site needs one canonical URL form: non-root URLs without trailing slashes. Existing slash-suffixed URLs should redirect instead of remaining as duplicate reachable addresses.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check`
  - Docusaurus builds both `en` and `zh-Hans`
  - TypeScript check passes
  - 200 generated files pass the internal URL/sitemap audit
  - Cloudflare Worker normalization test passes
- `git diff --check`

## Deployment

The existing Docs workflow will deploy the generated `_worker.js` and normalized build output to the `cubeplex-docs` Cloudflare Pages project.