### PR TITLE
MCP OAuth: react to 401 with forced token refresh

### DIFF
--- a/backend/cubeplex/mcp/cubepi_runtime.py
+++ b/backend/cubeplex/mcp/cubepi_runtime.py
@@ -10,6 +10,7 @@ import asyncio
 import dataclasses
 import logging
 from collections import Counter
+from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from typing import Any, Literal, cast
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
@@ -28,6 +29,7 @@ from cubeplex.mcp.exceptions import (
     OAuthInvalidServerState,
     OAuthRefreshContention,
     OAuthRefreshFailed,
+    is_unauthorized_error,
 )
 from cubeplex.mcp.oauth.token_manager import OAuthTokenManager
 from cubeplex.mcp.user_token import MCPUserTokenSigner
@@ -123,11 +125,83 @@ async def load_workspace_mcp_tools_for_cubepi(
     )
 
 
+def _make_refresh_auth_callback(
+    *,
+    spec: MCPRuntimeConnectorSpec,
+    token_manager: OAuthTokenManager,
+) -> Callable[[], Awaitable[str | None]] | None:
+    """Build the 401-recovery callback for one OAuth spec, or None.
+
+    Tool calls run long after the loader's request session has closed, so
+    the callback opens its own short-lived session (same reason
+    ``_load_tools_for_specs_deferred`` exists) and rebinds the token
+    manager's credential repo to it. Returns a fresh access token, or
+    None when the refresh fails — callers then surface the original 401.
+    """
+    grant = spec.grant
+    if spec.auth_method != "oauth" or grant is None or grant.refresh_credential_id is None:
+        return None
+
+    async def _refresh_auth() -> str | None:
+        from cubeplex.db.engine import async_session_maker
+        from cubeplex.repositories.credential import CredentialRepository
+
+        try:
+            async with async_session_maker() as session:
+                grant_repo = MCPCredentialGrantRepository(session, org_id=spec.org_id)
+                manager = token_manager.with_credential_repo(
+                    CredentialRepository(session, org_id=spec.org_id)
+                )
+                token = await manager.get_access_token_for_grant(
+                    grant=grant,
+                    grant_repo=grant_repo,
+                    server_url=spec.server_url,
+                    oauth_client_config=spec.oauth_client_config,
+                    force_refresh=True,
+                )
+                await session.commit()
+                return token
+        except Exception as exc:  # noqa: BLE001 — recovery is best-effort
+            logger.warning(
+                "MCP install '%s' forced token refresh after 401 failed: %s",
+                spec.name,
+                exc,
+            )
+            return None
+
+    return _refresh_auth
+
+
+async def _mark_grant_expired_for_spec(spec: MCPRuntimeConnectorSpec) -> None:
+    """Best-effort: flip the spec's grant to 'expired' in its own session.
+
+    Called when the MCP server rejects even a freshly-refreshed token —
+    reauthorization is needed and the UI must surface Reconnect instead
+    of a grant that still claims to be valid.
+    """
+    grant = spec.grant
+    if grant is None:
+        return
+    from contextlib import suppress
+
+    from cubeplex.db.engine import async_session_maker
+
+    with suppress(Exception):
+        async with async_session_maker() as session:
+            grant_repo = MCPCredentialGrantRepository(session, org_id=spec.org_id)
+            fresh = await session.get(type(grant), grant.id)
+            if fresh is not None:
+                fresh.grant_status = "expired"
+                await grant_repo.update(fresh)
+                await session.commit()
+
+
 def _build_tools_from_cache(
     *,
     spec: MCPRuntimeConnectorSpec,
     headers: dict[str, str],
     server_url: str,
+    refresh_auth: Callable[[], Awaitable[str | None]] | None = None,
 ) -> list[AgentTool[Any]] | None:
     """Build executable AgentTools from the install's persisted ``tools_cache``.
 
@@ -136,6 +210,11 @@ def _build_tools_from_cache(
     descriptor (name / description / input_schema), and cubepi MCP tools
     open a fresh session per ``tools/call`` anyway, so execution is
     identical to a live-discovered tool.
+
+    ``refresh_auth`` (OAuth specs only) recovers from a server-side token
+    revocation: on a 401 the call forces one token refresh, updates the
+    shared ``headers`` dict in place (so every tool of this spec reuses
+    the new token), and retries once.
 
     Returns None when the cache is unusable (empty, or cubepi's private
     helpers moved) — callers fall back to the live loader.
@@ -161,7 +240,7 @@ def _build_tools_from_cache(
     timeout = spec.timeout
     transport = cast(MCPTransport, spec.transport)
 
-    async def _call_remote(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+    async def _call_once(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
         # Mirrors cubepi.mcp.http_loader's per-call session semantics,
         # including W3C traceparent propagation into the MCP server.
         from cubepi.mcp._tracing import current_traceparent
@@ -176,6 +255,32 @@ def _build_tools_from_cache(
             await asyncio.wait_for(session.initialize(), timeout=timeout)
             resp = await asyncio.wait_for(session.call_tool(tool_name, args), timeout=timeout)
             return _serialize_call_tool_response(resp)
+
+    async def _call_remote(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        try:
+            return await _call_once(tool_name, args)
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:
+            if refresh_auth is None or not is_unauthorized_error(exc):
+                raise
+            try:
+                fresh_token = await refresh_auth()
+            except Exception:  # noqa: BLE001 — never mask the original 401
+                logger.exception("MCP install '%s' refresh_auth raised", spec.name)
+                raise exc from None
+            if fresh_token is None:
+                raise
+            headers["Authorization"] = f"Bearer {fresh_token}"
+            try:
+                return await _call_once(tool_name, args)
+            except asyncio.CancelledError:
+                raise
+            except BaseException as retry_exc:
+                if is_unauthorized_error(retry_exc):
+                    # Fresh token also rejected — reauthorization needed.
+                    await _mark_grant_expired_for_spec(spec)
+                raise
 
     address, port = _split_address(server_url)
     tools: list[AgentTool[Any]] = []
@@ -286,6 +391,38 @@ def schedule_tools_cache_refresh(
         del task
 
 
+async def _load_live_tools_with_401_retry(
+    *,
+    spec: MCPRuntimeConnectorSpec,
+    headers: dict[str, str],
+    server_url: str,
+    refresh_auth: Callable[[], Awaitable[str | None]] | None,
+) -> list[AgentTool[Any]]:
+    """Live discovery with the same single 401-recovery as tool calls."""
+
+    async def _load_once() -> list[AgentTool[Any]]:
+        discovery = await load_mcp_tools_http(
+            server_url,
+            headers=headers or None,
+            timeout=spec.timeout,
+            transport=cast(MCPTransport, spec.transport),
+        )
+        return discovery.tools
+
+    try:
+        return await _load_once()
+    except asyncio.CancelledError:
+        raise
+    except BaseException as exc:
+        if refresh_auth is None or not is_unauthorized_error(exc):
+            raise
+        fresh_token = await refresh_auth()
+        if fresh_token is None:
+            raise
+        headers["Authorization"] = f"Bearer {fresh_token}"
+        return await _load_once()
+
+
 async def _load_tools_for_specs(
     *,
     specs: list[MCPRuntimeConnectorSpec],
@@ -349,20 +486,23 @@ async def _load_tools_for_specs(
             )
             continue
 
+        refresh_auth = _make_refresh_auth_callback(spec=spec, token_manager=token_manager)
+
         # Cache-first: build tools from the persisted tools_cache and skip
         # the live initialize+tools/list round trip. Falls back to live
         # discovery when the cache is empty/unusable (e.g. first run before
         # discovery persisted, or cubepi internals drifted).
-        tools = _build_tools_from_cache(spec=spec, headers=headers, server_url=server_url)
+        tools = _build_tools_from_cache(
+            spec=spec, headers=headers, server_url=server_url, refresh_auth=refresh_auth
+        )
         if tools is None:
             try:
-                discovery = await load_mcp_tools_http(
-                    server_url,
-                    headers=headers or None,
-                    timeout=spec.timeout,
-                    transport=cast(MCPTransport, spec.transport),
+                tools = await _load_live_tools_with_401_retry(
+                    spec=spec,
+                    headers=headers,
+                    server_url=server_url,
+                    refresh_auth=refresh_auth,
                 )
-                tools = discovery.tools
             except asyncio.CancelledError:
                 raise
             except Exception as exc:  # noqa: BLE001

--- a/backend/cubeplex/mcp/exceptions.py
+++ b/backend/cubeplex/mcp/exceptions.py
@@ -1,5 +1,26 @@
 """MCP OAuth domain exceptions."""
 
+import httpx
+
+
+def is_unauthorized_error(exc: BaseException) -> bool:
+    """True when ``exc`` is (or wraps) an httpx 401 response error.
+
+    The MCP SDK opens sessions inside asyncio TaskGroups, so an auth
+    rejection reaches callers as one or more ``ExceptionGroup`` layers
+    around the underlying ``httpx.HTTPStatusError``. Every leaf is
+    inspected — connection-cleanup noise can precede the real cause.
+    """
+    stack: list[BaseException] = [exc]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, BaseExceptionGroup):
+            stack.extend(current.exceptions)
+            continue
+        if isinstance(current, httpx.HTTPStatusError) and current.response.status_code == 401:
+            return True
+    return False
+
 
 class OAuthError(Exception):
     """Base class for MCP OAuth-related failures."""

--- a/backend/cubeplex/mcp/oauth/token_manager.py
+++ b/backend/cubeplex/mcp/oauth/token_manager.py
@@ -75,6 +75,24 @@ class OAuthTokenManager:
         self._refresh_buffer = refresh_buffer_seconds
         self._lock_ttl = lock_ttl_seconds
 
+    def with_credential_repo(self, credential_repo: CredentialRepository) -> OAuthTokenManager:
+        """Clone bound to a different (fresh-session) credential repo.
+
+        The runtime tool-call retry runs long after the request session
+        that built this manager has closed; the clone shares the http
+        client, redis, encryption backend, and metadata cache but reads
+        and writes vault rows through the new session's repo.
+        """
+        return OAuthTokenManager(
+            http_client=self._http,
+            redis=self._redis,
+            encryption_backend=self._backend,
+            credential_repo=credential_repo,
+            metadata=self._metadata,
+            refresh_buffer_seconds=self._refresh_buffer,
+            lock_ttl_seconds=self._lock_ttl,
+        )
+
     async def get_access_token_for_grant(
         self,
         *,
@@ -82,6 +100,7 @@ class OAuthTokenManager:
         grant_repo: MCPCredentialGrantRepository,
         server_url: str,
         oauth_client_config: dict[str, Any],
+        force_refresh: bool = False,
     ) -> str:
         """Return a valid access token for a four-layer OAuth grant.
 
@@ -93,6 +112,12 @@ class OAuthTokenManager:
           (required to perform a refresh; absent → terminal failure).
         * ``grant.expires_at`` is the cached access-token expiry. Refresh
           fires when this is within ``refresh_buffer_seconds`` of now.
+        * ``force_refresh=True`` refreshes regardless of ``expires_at`` —
+          for callers that saw the server reject the cached token (401)
+          before its recorded expiry. ``grant.expires_at`` doubles as the
+          caller's snapshot: if the re-read row inside the lock carries a
+          different expiry, another worker already rotated and the current
+          token is returned without a second rotation.
         * ``oauth_client_config`` carries ``client_id`` (and optionally
           ``client_secret_credential_id``) on the install row.
 
@@ -109,7 +134,7 @@ class OAuthTokenManager:
                 f"grant {grant.id} has no refresh_credential_id; cannot refresh"
             )
 
-        if not self._needs_refresh(grant.expires_at):
+        if not force_refresh and not self._needs_refresh(grant.expires_at):
             return await self._read_credential(grant.credential_id)
 
         # Lock on the access-token credential id — the row we'll rotate.
@@ -120,6 +145,7 @@ class OAuthTokenManager:
                 grant_repo=grant_repo,
                 server_url=server_url,
                 oauth_client_config=oauth_client_config,
+                force=force_refresh,
             ),
             re_read=lambda: self._read_grant_after_lock(
                 grant=grant,
@@ -150,6 +176,7 @@ class OAuthTokenManager:
         grant_repo: MCPCredentialGrantRepository,
         server_url: str,
         oauth_client_config: dict[str, Any],
+        force: bool = False,
     ) -> str:
         """Perform the refresh inside the lock; persist credentials + grant."""
         # Re-read inside the lock so we don't double-refresh if another worker
@@ -161,7 +188,13 @@ class OAuthTokenManager:
             raise OAuthInvalidServerState(
                 f"grant {fresh.id} has no refresh_credential_id; cannot refresh"
             )
-        if not self._needs_refresh(fresh.expires_at):
+        if force:
+            # Forced path (caller saw a 401): the caller's grant.expires_at is
+            # its snapshot. A different value on the re-read row means another
+            # worker rotated since — reuse its token instead of rotating twice.
+            if grant.expires_at is not None and fresh.expires_at != grant.expires_at:
+                return await self._read_credential(fresh.credential_id)
+        elif not self._needs_refresh(fresh.expires_at):
             return await self._read_credential(fresh.credential_id)
 
         refresh_token = await self._read_credential(fresh.refresh_credential_id)

--- a/backend/cubeplex/services/mcp_discovery.py
+++ b/backend/cubeplex/services/mcp_discovery.py
@@ -27,6 +27,7 @@ carry ``input_schema``, so the helper accepts either shape.
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -37,7 +38,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from cubeplex.mcp._constants import slugify_for_namespace
 from cubeplex.mcp.cubepi_runtime import MCPTransport
 from cubeplex.mcp.effective import MCPEffectiveConnectorService
-from cubeplex.mcp.exceptions import MCPDiscoveryFailed
+from cubeplex.mcp.exceptions import (
+    MCPDiscoveryFailed,
+    OAuthRefreshFailed,
+    is_unauthorized_error,
+)
 from cubeplex.mcp.oauth.token_manager import OAuthTokenManager
 from cubeplex.mcp.user_token import MCPUserTokenSigner
 from cubeplex.repositories.mcp import (
@@ -438,21 +443,9 @@ async def discover_tools_for_install(
         )
     headers, server_url = resolved
 
-    try:
-        discovered = await asyncio.wait_for(
-            _list_raw_mcp_tools(
-                server_url,
-                headers=headers or None,
-                timeout=install.timeout,
-                transport=cast(MCPTransport, install.transport),
-            ),
-            timeout=_DISCOVERY_TIMEOUT_SECONDS,
-        )
-    except Exception as exc:  # noqa: BLE001
-        formatted = _format_discovery_error(exc)
-        logger.warning("MCP discovery failed for {}: {}", connector_id, formatted)
+    async def _persist_error(message: str) -> DiscoveryResult:
         install.discovery_status = "error"
-        install.last_error = formatted[:2048]
+        install.last_error = message[:2048]
         if connector is not None:
             connector.discovery_status = install.discovery_status
             connector.last_error = install.last_error
@@ -465,6 +458,64 @@ async def discover_tools_for_install(
             tools_cache_raw=list(install.tools_cache or []),
             last_error=install.last_error,
         )
+
+    async def _attempt() -> _DiscoveredRaw:
+        return await asyncio.wait_for(
+            _list_raw_mcp_tools(
+                server_url,
+                headers=headers or None,
+                timeout=install.timeout,
+                transport=cast(MCPTransport, install.transport),
+            ),
+            timeout=_DISCOVERY_TIMEOUT_SECONDS,
+        )
+
+    try:
+        discovered = await _attempt()
+    except Exception as exc:  # noqa: BLE001
+        formatted = _format_discovery_error(exc)
+        logger.warning("MCP discovery failed for {}: {}", connector_id, formatted)
+        # A 401 against an OAuth grant that still looks valid means the
+        # provider revoked the token before its recorded expiry (providers
+        # may; expires_in is a hint, not a contract). Force one refresh and
+        # retry before persisting the failure.
+        refreshable = (
+            is_unauthorized_error(exc)
+            and grant is not None
+            and grant.auth_method == "oauth"
+            and grant.refresh_credential_id is not None
+            and token_mgr is not None
+        )
+        if not refreshable:
+            return await _persist_error(formatted)
+        assert grant is not None  # narrowed by `refreshable`
+        try:
+            fresh_token = await token_mgr.get_access_token_for_grant(
+                grant=grant,
+                grant_repo=grant_repo,
+                server_url=install.server_url,
+                oauth_client_config=dict(install.oauth_client_config or {}),
+                force_refresh=True,
+            )
+        except Exception as refresh_exc:  # noqa: BLE001
+            # OAuthRefreshFailed already flipped the grant to 'expired';
+            # surface the reauthorization need instead of the raw 401.
+            prefix = (
+                "oauth_reauthorization_required"
+                if isinstance(refresh_exc, OAuthRefreshFailed)
+                else "credential_resolution_failed"
+            )
+            return await _persist_error(f"{prefix}: {_format_discovery_error(refresh_exc)}")
+        headers = {**(headers or {}), "Authorization": f"Bearer {fresh_token}"}
+        try:
+            discovered = await _attempt()
+        except Exception as retry_exc:  # noqa: BLE001
+            if is_unauthorized_error(retry_exc):
+                # Even a freshly-minted token is rejected — reauthorize.
+                with suppress(Exception):
+                    grant.grant_status = "expired"
+                    await grant_repo.update(grant)
+            return await _persist_error(_format_discovery_error(retry_exc))
 
     tools_cache_raw: list[dict[str, Any]] = [_tool_to_dict(t) for t in discovered.tools]
     # Strip orphan citation mapping keys whose tool no longer exists in

--- a/backend/docs/mcp_catalog_oauth.md
+++ b/backend/docs/mcp_catalog_oauth.md
@@ -198,6 +198,18 @@ read / refresh / persist cycle for OAuth-scoped connectors. Behavior:
   connector, and surfaces a reauthorization-required signal to the UI;
   the user gets a "Reconnect" prompt at the next interaction with the
   connector.
+- **Early revocation (401 with a valid-looking grant).** Providers may
+  invalidate an access token before the `expires_in` they reported
+  (Cloudflare did, 2026-07-17). When the MCP server answers 401 even
+  though `oauth_expires_at` is still in the future, both discovery and
+  runtime tool calls force one refresh
+  (`get_access_token_for_grant(force_refresh=True)`) and retry the
+  request once. Concurrent forced refreshes collapse to a single
+  rotation via the redis lock plus an `expires_at` snapshot check. If
+  the refresh fails — or the server rejects even the fresh token — the
+  grant flips to `expired` and the UI shows Reconnect; discovery
+  records `last_error` starting with `oauth_reauthorization_required:`
+  for the refresh-failure case.
 
 ## Catalog seeder
 
@@ -313,6 +325,13 @@ would change without committing.
   the AS response. The UI surfaces a "Reauthorize" affordance —
   clicking re-enters the OAuth start route and overwrites the
   credential.
+- **`last_error` starts with `oauth_reauthorization_required:`**: the
+  MCP server rejected the access token with 401 before its recorded
+  expiry, and the automatic forced refresh also failed (see "Token
+  refresh" → early revocation). The grant is already `expired`; the
+  user must reconnect. A plain 401 in `last_error` without that prefix
+  means the failure predates the retry, or auth isn't OAuth — check
+  the grant row.
 - **Tools missing after distributing a connector**: discovery runs once
   on distribute and again after each successful OAuth grant. Re-trigger
   via `POST /api/v1/admin/mcp/installs/{connector_id}/refresh-discovery`;

--- a/backend/tests/e2e/test_mcp_oauth_401_retry.py
+++ b/backend/tests/e2e/test_mcp_oauth_401_retry.py
@@ -1,0 +1,327 @@
+"""E2E coverage for discovery's 401 → forced-refresh → retry behavior.
+
+Business invariant (spec 2026-07-17-mcp-oauth-401-refresh): a provider
+may revoke an access token before its reported ``expires_in`` elapses
+(Cloudflare did). When discovery hits a 401 with an OAuth grant that
+still has a refresh credential, it must force one token refresh and
+retry — not persist a sticky "Discovery error … 401" while the grant
+sits ``valid`` for hours. If the refresh fails, or the server rejects
+even the refreshed token, the grant must flip to ``expired`` so the UI
+surfaces the Reconnect prompt.
+
+The MCP server round trip (``_list_raw_mcp_tools``) and the AS token
+endpoint (via a scripted token-manager stand-in) are the two outermost
+externals and are stubbed; everything else — routes, repos, grant rows,
+Postgres — is real.
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from cubeplex.db.engine import _build_database_url
+from cubeplex.mcp.exceptions import OAuthRefreshFailed
+from cubeplex.models import MCPCredentialGrant
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def db_session_maker() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    eng = create_async_engine(_build_database_url(), poolclass=NullPool)
+    try:
+        yield async_sessionmaker(eng, class_=AsyncSession, expire_on_commit=False)
+    finally:
+        await eng.dispose()
+
+
+def _tool(name: str) -> SimpleNamespace:
+    return SimpleNamespace(name=name, description=None, input_schema=None, icons=None)
+
+
+def _unauthorized() -> BaseException:
+    request = httpx.Request("POST", "https://mcp.example.com/mcp")
+    response = httpx.Response(401, request=request)
+    err = httpx.HTTPStatusError("401 Unauthorized", request=request, response=response)
+    return ExceptionGroup("unhandled errors in a TaskGroup", [err])
+
+
+class _ScriptedTokenManager:
+    """Stands in for OAuthTokenManager: non-forced reads return the stale
+    token; forced refreshes follow the scripted outcome."""
+
+    def __init__(self, *, refresh_fails: bool = False) -> None:
+        self.refresh_fails = refresh_fails
+        self.force_calls = 0
+
+    async def get_access_token_for_grant(
+        self,
+        *,
+        grant: MCPCredentialGrant,
+        grant_repo: Any,
+        server_url: str,
+        oauth_client_config: dict[str, Any],
+        force_refresh: bool = False,
+    ) -> str:
+        if not force_refresh:
+            return "stale-token"
+        self.force_calls += 1
+        if self.refresh_fails:
+            # Mirror the real manager's failure side effect.
+            grant.grant_status = "expired"
+            await grant_repo.update(grant)
+            raise OAuthRefreshFailed(400, error="invalid_grant")
+        return "fresh-token"
+
+
+async def _seed_oauth_org_install(
+    client: httpx.AsyncClient,
+    db_session_maker: async_sessionmaker[AsyncSession],
+) -> tuple[str, str]:
+    """Create an oauth/org-policy template+connector and a valid-looking
+    org grant whose token the fake MCP server will reject.
+
+    Returns ``(connector_id, grant_id)``.
+    """
+    suffix = secrets.token_hex(4)
+    tpl_resp = await client.post(
+        "/api/v1/admin/mcp/templates",
+        json={
+            "name": f"OAuth 401 Retry {suffix}",
+            "server_url": f"https://oauth-401-{suffix}.example.com/mcp",
+            "transport": "streamable_http",
+            "auth_method": "oauth",
+            "default_credential_policy": "org",
+        },
+    )
+    assert tpl_resp.status_code == 201, tpl_resp.text
+    template_id = tpl_resp.json()["template_id"]
+    dist_resp = await client.post(
+        f"/api/v1/admin/mcp/templates/{template_id}/distribute",
+        json={"enable_existing": False, "auto_enroll": False},
+    )
+    assert dist_resp.status_code == 200, dist_resp.text
+    connector_id = dist_resp.json()["connector"]["connector_id"]
+
+    async with db_session_maker() as session:
+        from cubeplex.models import Credential
+        from cubeplex.models.mcp import MCPConnector
+
+        connector = await session.get(MCPConnector, connector_id)
+        assert connector is not None
+        access = Credential(
+            org_id=connector.org_id,
+            kind="mcp_oauth_access_token",
+            name=f"access-{suffix}",
+            value_encrypted=b"opaque",
+        )
+        refresh = Credential(
+            org_id=connector.org_id,
+            kind="mcp_oauth_refresh_token",
+            name=f"refresh-{suffix}",
+            value_encrypted=b"opaque",
+        )
+        session.add(access)
+        session.add(refresh)
+        await session.flush()
+        grant = MCPCredentialGrant(
+            org_id=connector.org_id,
+            connector_id=connector_id,
+            grant_scope="org",
+            auth_method="oauth",
+            credential_id=access.id,
+            refresh_credential_id=refresh.id,
+            # The incident shape: recorded expiry is far away, token dead.
+            expires_at=datetime.now(UTC) + timedelta(hours=10),
+            grant_status="valid",
+        )
+        session.add(grant)
+        await session.commit()
+        grant_id = grant.id
+    return connector_id, grant_id
+
+
+async def _run_discovery(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+    *,
+    connector_id: str,
+    token_mgr: _ScriptedTokenManager,
+) -> Any:
+    from cubeplex.credentials.dependencies import build_credential_service
+    from cubeplex.credentials.encryption import FernetBackend
+    from cubeplex.mcp.dependencies import build_user_token_signer
+    from cubeplex.services.mcp_discovery import discover_tools_for_install
+
+    me_resp = await client.get("/api/v1/auth/me")
+    assert me_resp.status_code == 200, me_resp.text
+    user_id = me_resp.json()["id"]
+    ws_resp = await client.get("/api/v1/workspaces")
+    assert ws_resp.status_code == 200, ws_resp.text
+    org_id = ws_resp.json()[0]["org_id"]
+
+    from cryptography.fernet import Fernet
+
+    backend = FernetBackend([Fernet.generate_key()])
+    cred_service = build_credential_service(session, backend, org_id=org_id, actor_user_id=user_id)
+    return await discover_tools_for_install(
+        connector_id=connector_id,
+        workspace_id=None,
+        actor_user_id=user_id,
+        session=session,
+        cred_service=cred_service,
+        signer=build_user_token_signer(),
+        token_mgr=token_mgr,  # type: ignore[arg-type]
+    )
+
+
+async def _grant_status(db_session_maker: async_sessionmaker[AsyncSession], grant_id: str) -> str:
+    async with db_session_maker() as session:
+        grant = await session.get(MCPCredentialGrant, grant_id)
+        assert grant is not None
+        return grant.grant_status
+
+
+async def test_401_then_success_after_forced_refresh(
+    admin_client: tuple[httpx.AsyncClient, str],
+    db_session_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stale token 401s; the retry must carry the refreshed token and
+    the run must end 'ok' with no persisted error."""
+    client, _ws = admin_client
+    connector_id, grant_id = await _seed_oauth_org_install(client, db_session_maker)
+    token_mgr = _ScriptedTokenManager()
+    seen_auth: list[str | None] = []
+
+    async def fake_load(*args: object, **kwargs: object) -> object:
+        headers = kwargs.get("headers") or {}
+        auth = headers.get("Authorization") if isinstance(headers, dict) else None
+        seen_auth.append(auth)
+        if auth != "Bearer fresh-token":
+            raise _unauthorized()
+        return SimpleNamespace(tools=[_tool("ping")], init_result=SimpleNamespace(serverInfo=None))
+
+    monkeypatch.setattr("cubeplex.services.mcp_discovery._list_raw_mcp_tools", fake_load)
+
+    async with db_session_maker() as session:
+        result = await _run_discovery(
+            client, session, connector_id=connector_id, token_mgr=token_mgr
+        )
+        await session.commit()
+
+    assert result.discovery_status == "ok"
+    assert result.last_error is None
+    assert result.tool_count == 1
+    assert token_mgr.force_calls == 1
+    assert seen_auth == ["Bearer stale-token", "Bearer fresh-token"]
+    assert await _grant_status(db_session_maker, grant_id) == "valid"
+
+
+async def test_401_and_refresh_failure_marks_reauthorization_required(
+    admin_client: tuple[httpx.AsyncClient, str],
+    db_session_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ws = admin_client
+    connector_id, grant_id = await _seed_oauth_org_install(client, db_session_maker)
+    token_mgr = _ScriptedTokenManager(refresh_fails=True)
+
+    async def fake_load(*args: object, **kwargs: object) -> object:
+        raise _unauthorized()
+
+    monkeypatch.setattr("cubeplex.services.mcp_discovery._list_raw_mcp_tools", fake_load)
+
+    async with db_session_maker() as session:
+        result = await _run_discovery(
+            client, session, connector_id=connector_id, token_mgr=token_mgr
+        )
+        await session.commit()
+
+    assert result.discovery_status == "error"
+    assert result.last_error is not None
+    assert result.last_error.startswith("oauth_reauthorization_required:")
+    assert await _grant_status(db_session_maker, grant_id) == "expired"
+
+
+async def test_401_twice_marks_grant_expired(
+    admin_client: tuple[httpx.AsyncClient, str],
+    db_session_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The server rejecting even a freshly-refreshed token means
+    reauthorization is needed — the grant must not stay 'valid'."""
+    client, _ws = admin_client
+    connector_id, grant_id = await _seed_oauth_org_install(client, db_session_maker)
+    token_mgr = _ScriptedTokenManager()
+
+    async def fake_load(*args: object, **kwargs: object) -> object:
+        raise _unauthorized()
+
+    monkeypatch.setattr("cubeplex.services.mcp_discovery._list_raw_mcp_tools", fake_load)
+
+    async with db_session_maker() as session:
+        result = await _run_discovery(
+            client, session, connector_id=connector_id, token_mgr=token_mgr
+        )
+        await session.commit()
+
+    assert result.discovery_status == "error"
+    assert token_mgr.force_calls == 1
+    assert await _grant_status(db_session_maker, grant_id) == "expired"
+
+
+async def test_non_oauth_401_keeps_existing_behavior(
+    admin_client: tuple[httpx.AsyncClient, str],
+    db_session_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No-auth installs must not enter the refresh loop on a 401."""
+    client, _ws = admin_client
+    suffix = secrets.token_hex(4)
+    tpl_resp = await client.post(
+        "/api/v1/admin/mcp/templates",
+        json={
+            "name": f"No Auth 401 {suffix}",
+            "server_url": f"https://noauth-401-{suffix}.example.com/mcp",
+            "transport": "streamable_http",
+            "auth_method": "none",
+            "default_credential_policy": "none",
+        },
+    )
+    assert tpl_resp.status_code == 201, tpl_resp.text
+    dist_resp = await client.post(
+        f"/api/v1/admin/mcp/templates/{tpl_resp.json()['template_id']}/distribute",
+        json={"enable_existing": False, "auto_enroll": False},
+    )
+    assert dist_resp.status_code == 200, dist_resp.text
+    connector_id = dist_resp.json()["connector"]["connector_id"]
+    token_mgr = _ScriptedTokenManager()
+    calls = 0
+
+    async def fake_load(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise _unauthorized()
+
+    monkeypatch.setattr("cubeplex.services.mcp_discovery._list_raw_mcp_tools", fake_load)
+
+    async with db_session_maker() as session:
+        result = await _run_discovery(
+            client, session, connector_id=connector_id, token_mgr=token_mgr
+        )
+        await session.commit()
+
+    assert result.discovery_status == "error"
+    assert calls == 1
+    assert token_mgr.force_calls == 0

--- a/backend/tests/unit/mcp/test_exceptions.py
+++ b/backend/tests/unit/mcp/test_exceptions.py
@@ -1,0 +1,51 @@
+"""Unit tests for the shared 401 classifier.
+
+The MCP SDK opens sessions inside asyncio TaskGroups, so an auth
+rejection reaches callers as ``ExceptionGroup`` layers wrapping the
+underlying ``httpx.HTTPStatusError``. Both the discovery service and
+the runtime tool-call retry key their refresh-and-retry behavior on
+``is_unauthorized_error`` — misclassifying would either retry on
+non-auth failures (wasted refresh-token rotations) or never recover
+from a revoked token.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from cubeplex.mcp.exceptions import is_unauthorized_error
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://mcp.example.com/mcp")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
+
+
+def test_bare_401_is_unauthorized() -> None:
+    assert is_unauthorized_error(_http_status_error(401))
+
+
+def test_group_wrapped_401_is_unauthorized() -> None:
+    group = ExceptionGroup("unhandled errors in a TaskGroup", [_http_status_error(401)])
+    assert is_unauthorized_error(group)
+
+
+def test_nested_group_with_leading_noise_is_unauthorized() -> None:
+    # httpx connection-cleanup noise can precede the real cause; every
+    # leaf must be inspected, not just the first.
+    inner = ExceptionGroup(
+        "transport",
+        [RuntimeError("connection reset"), _http_status_error(401)],
+    )
+    group = ExceptionGroup("unhandled errors in a TaskGroup", [inner])
+    assert is_unauthorized_error(group)
+
+
+def test_non_401_http_error_is_not_unauthorized() -> None:
+    assert not is_unauthorized_error(_http_status_error(500))
+    assert not is_unauthorized_error(ExceptionGroup("group", [_http_status_error(403)]))
+
+
+def test_unrelated_exception_is_not_unauthorized() -> None:
+    assert not is_unauthorized_error(RuntimeError("boom"))

--- a/backend/tests/unit/mcp/test_oauth_token_manager.py
+++ b/backend/tests/unit/mcp/test_oauth_token_manager.py
@@ -1,0 +1,261 @@
+"""Unit tests for ``OAuthTokenManager`` forced refresh.
+
+Providers may revoke access tokens before the ``expires_in`` they
+reported (Cloudflare did, 2026-07-17). The contract under test: a
+caller that saw a live 401 can demand a refresh regardless of the
+recorded expiry (``force_refresh=True``), concurrent forced refreshes
+collapse to a single rotation, and failure semantics (grant flipped to
+``expired``) survive the forced path.
+
+Everything external is faked in-process: redis (lock ops only), the
+credential vault repo, the encryption backend, the grant repo, and the
+AS token endpoint (httpx.MockTransport).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import pytest
+
+from cubeplex.mcp.exceptions import OAuthRefreshFailed
+from cubeplex.mcp.oauth.token_manager import OAuthTokenManager
+from cubeplex.models import MCPCredentialGrant
+
+_TOKEN_ENDPOINT = "https://auth.example.com/token"
+
+
+class _FakeRedis:
+    """Just enough of redis.asyncio for the refresh lock."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    async def set(self, key: str, value: str, *, nx: bool = False, ex: int = 0) -> bool:
+        if nx and key in self._store:
+            return False
+        self._store[key] = value
+        return True
+
+    async def delete(self, key: str) -> None:
+        self._store.pop(key, None)
+
+    async def exists(self, key: str) -> int:
+        return int(key in self._store)
+
+
+class _IdentityBackend:
+    async def encrypt(self, plaintext: bytes) -> bytes:
+        return plaintext
+
+    async def decrypt(self, ciphertext: bytes) -> bytes:
+        return ciphertext
+
+
+@dataclass
+class _Cred:
+    id: str
+    value_encrypted: bytes
+
+
+class _FakeCredentialRepo:
+    def __init__(self, creds: dict[str, bytes]) -> None:
+        self._rows = {cid: _Cred(cid, val) for cid, val in creds.items()}
+
+    async def get(self, credential_id: str) -> _Cred | None:
+        return self._rows.get(credential_id)
+
+    async def update(self, cred: _Cred) -> _Cred:
+        self._rows[cred.id] = cred
+        return cred
+
+
+@dataclass
+class _FakeGrantRepo:
+    """Scope-keyed lookups return ``current``; ``update`` records writes."""
+
+    current: MCPCredentialGrant
+    updated: list[MCPCredentialGrant] = field(default_factory=list)
+
+    async def get_org_grant_for_connector(self, connector_id: str) -> MCPCredentialGrant:
+        return self.current
+
+    async def get_workspace_grant_for_connector(
+        self, connector_id: str, workspace_id: str
+    ) -> MCPCredentialGrant:
+        return self.current
+
+    async def get_user_grant_for_connector(
+        self, connector_id: str, user_id: str, *, workspace_id: str
+    ) -> MCPCredentialGrant:
+        return self.current
+
+    async def update(self, grant: MCPCredentialGrant) -> MCPCredentialGrant:
+        self.updated.append(grant)
+        return grant
+
+
+class _FakeMetadata:
+    async def discover_for_resource(self, server_url: str) -> tuple[Any, Any]:
+        from types import SimpleNamespace
+
+        return None, SimpleNamespace(token_endpoint=_TOKEN_ENDPOINT)
+
+
+def _make_grant(*, expires_at: datetime | None) -> MCPCredentialGrant:
+    return MCPCredentialGrant(
+        org_id="org_1",
+        connector_id="mcpco_1",
+        grant_scope="workspace",
+        auth_method="oauth",
+        workspace_id="ws_1",
+        credential_id="cred_access",
+        refresh_credential_id="cred_refresh",
+        expires_at=expires_at,
+        grant_status="valid",
+    )
+
+
+def _make_manager(
+    *,
+    grant_repo_grant: MCPCredentialGrant,
+    token_status: int = 200,
+    calls: list[httpx.Request] | None = None,
+) -> tuple[OAuthTokenManager, _FakeGrantRepo, _FakeCredentialRepo]:
+    recorded = calls if calls is not None else []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        recorded.append(request)
+        if token_status != 200:
+            return httpx.Response(token_status, json={"error": "invalid_grant"})
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "new-access",
+                "refresh_token": "new-refresh",
+                "expires_in": 3600,
+            },
+        )
+
+    cred_repo = _FakeCredentialRepo({"cred_access": b"old-access", "cred_refresh": b"old-refresh"})
+    grant_repo = _FakeGrantRepo(current=grant_repo_grant)
+    manager = OAuthTokenManager(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(_handler)),
+        redis=_FakeRedis(),  # type: ignore[arg-type]
+        encryption_backend=_IdentityBackend(),  # type: ignore[arg-type]
+        credential_repo=cred_repo,  # type: ignore[arg-type]
+        metadata=_FakeMetadata(),  # type: ignore[arg-type]
+    )
+    return manager, grant_repo, cred_repo
+
+
+_CLIENT_CONFIG = {"client_id": "client-1"}
+
+
+@pytest.mark.asyncio
+async def test_force_refresh_rotates_despite_future_expiry() -> None:
+    """A revoked-but-unexpired token must be replaceable on demand —
+    the time-based check alone left dead tokens in play for hours."""
+    grant = _make_grant(expires_at=datetime.now(UTC) + timedelta(hours=10))
+    calls: list[httpx.Request] = []
+    manager, _grant_repo, cred_repo = _make_manager(grant_repo_grant=grant, calls=calls)
+
+    token = await manager.get_access_token_for_grant(
+        grant=grant,
+        grant_repo=_grant_repo,  # type: ignore[arg-type]
+        server_url="https://mcp.example.com/mcp",
+        oauth_client_config=_CLIENT_CONFIG,
+        force_refresh=True,
+    )
+
+    assert token == "new-access"
+    assert len(calls) == 1
+    assert grant.grant_status == "valid"
+    assert grant.expires_at is not None
+    assert grant.expires_at - datetime.now(UTC) < timedelta(hours=2)
+    stored_access = await cred_repo.get("cred_access")
+    stored_refresh = await cred_repo.get("cred_refresh")
+    assert stored_access is not None and stored_access.value_encrypted == b"new-access"
+    assert stored_refresh is not None and stored_refresh.value_encrypted == b"new-refresh"
+
+
+@pytest.mark.asyncio
+async def test_force_refresh_skips_rotation_when_another_worker_won() -> None:
+    """Two workers racing on the same 401 must not double-rotate: the
+    second one sees the advanced expires_at and reuses the new token."""
+    observed = _make_grant(expires_at=datetime.now(UTC) - timedelta(minutes=5))
+    already_rotated = _make_grant(expires_at=datetime.now(UTC) + timedelta(hours=1))
+    calls: list[httpx.Request] = []
+    manager, _grant_repo, _cred_repo = _make_manager(grant_repo_grant=already_rotated, calls=calls)
+
+    token = await manager.get_access_token_for_grant(
+        grant=observed,
+        grant_repo=_grant_repo,  # type: ignore[arg-type]
+        server_url="https://mcp.example.com/mcp",
+        oauth_client_config=_CLIENT_CONFIG,
+        force_refresh=True,
+    )
+
+    # The other worker's rotation already wrote the vault row; no second
+    # token-endpoint hit.
+    assert token == "old-access"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_force_refresh_failure_marks_grant_expired() -> None:
+    grant = _make_grant(expires_at=datetime.now(UTC) + timedelta(hours=10))
+    manager, grant_repo, _cred_repo = _make_manager(grant_repo_grant=grant, token_status=400)
+
+    with pytest.raises(OAuthRefreshFailed):
+        await manager.get_access_token_for_grant(
+            grant=grant,
+            grant_repo=grant_repo,  # type: ignore[arg-type]
+            server_url="https://mcp.example.com/mcp",
+            oauth_client_config=_CLIENT_CONFIG,
+            force_refresh=True,
+        )
+
+    assert grant.grant_status == "expired"
+    assert grant_repo.updated, "expired status must be persisted"
+
+
+@pytest.mark.asyncio
+async def test_default_path_still_time_based() -> None:
+    grant = _make_grant(expires_at=datetime.now(UTC) + timedelta(hours=10))
+    calls: list[httpx.Request] = []
+    manager, grant_repo, _cred_repo = _make_manager(grant_repo_grant=grant, calls=calls)
+
+    token = await manager.get_access_token_for_grant(
+        grant=grant,
+        grant_repo=grant_repo,  # type: ignore[arg-type]
+        server_url="https://mcp.example.com/mcp",
+        oauth_client_config=_CLIENT_CONFIG,
+    )
+
+    assert token == "old-access"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_with_credential_repo_clone_reads_from_new_repo() -> None:
+    """The runtime retry path rebinds the manager to a fresh session's
+    credential repo; the clone must read/write through the new repo."""
+    grant = _make_grant(expires_at=datetime.now(UTC) + timedelta(hours=10))
+    manager, grant_repo, _old_repo = _make_manager(grant_repo_grant=grant)
+
+    new_repo = _FakeCredentialRepo(
+        {"cred_access": b"other-access", "cred_refresh": b"other-refresh"}
+    )
+    clone = manager.with_credential_repo(new_repo)  # type: ignore[arg-type]
+
+    token = await clone.get_access_token_for_grant(
+        grant=grant,
+        grant_repo=grant_repo,  # type: ignore[arg-type]
+        server_url="https://mcp.example.com/mcp",
+        oauth_client_config=_CLIENT_CONFIG,
+    )
+    assert token == "other-access"

--- a/backend/tests/unit/mcp/test_runtime_tools_cache.py
+++ b/backend/tests/unit/mcp/test_runtime_tools_cache.py
@@ -15,9 +15,15 @@ trip per send. These tests protect the two invariants that matter:
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from types import SimpleNamespace
 from typing import Any
 
-from cubeplex.mcp.cubepi_runtime import _build_tools_from_cache
+import httpx
+import pytest
+
+from cubeplex.mcp.cubepi_runtime import _build_tools_from_cache, _make_refresh_auth_callback
 from cubeplex.mcp.effective import MCPRuntimeConnectorSpec
 
 _WEATHER_SCHEMA: dict[str, Any] = {
@@ -96,3 +102,148 @@ def test_empty_cache_returns_none_for_live_fallback() -> None:
 def test_nameless_entries_are_skipped_and_all_nameless_falls_back() -> None:
     spec = _make_spec([{"description": "no name"}, {"name": ""}])
     assert _build_tools_from_cache(spec=spec, headers={}, server_url=spec.server_url) is None
+
+
+# ---------------------------------------------------------------------------
+# 401 → forced-refresh → retry on tool calls (spec 2026-07-17).
+# ---------------------------------------------------------------------------
+
+
+def _unauthorized() -> BaseException:
+    request = httpx.Request("POST", "https://mcp.example.com/mcp")
+    response = httpx.Response(401, request=request)
+    err = httpx.HTTPStatusError("401 Unauthorized", request=request, response=response)
+    return ExceptionGroup("unhandled errors in a TaskGroup", [err])
+
+
+def _install_fake_session(monkeypatch: Any, opened_auth: list[str | None]) -> None:
+    """Fake cubepi's ``_open_session``: 401 unless the fresh token is sent.
+
+    Records the Authorization header of every session-open attempt.
+    """
+
+    @asynccontextmanager
+    async def fake_open_session(server_url: str, *, headers=None, timeout=None, transport=None):
+        auth = (headers or {}).get("Authorization")
+        opened_auth.append(auth)
+        if auth != "Bearer fresh":
+            raise _unauthorized()
+
+        class _Session:
+            async def initialize(self) -> None:
+                return None
+
+            async def call_tool(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
+                return {"content": [{"type": "text", "text": "ok"}], "isError": False}
+
+        yield _Session(), lambda: None
+
+    monkeypatch.setattr("cubepi.mcp.http_loader._open_session", fake_open_session)
+    monkeypatch.setattr("cubepi.mcp.http_loader._serialize_call_tool_response", lambda resp: resp)
+
+
+_PING_CACHE = [{"name": "ping", "description": "", "input_schema": {"type": "object"}}]
+
+
+async def test_tool_call_401_refreshes_and_retries(monkeypatch: Any) -> None:
+    """A revoked-but-unexpired token must not fail the whole agent turn:
+    the call refreshes once, retries with the new token, and later calls
+    reuse the refreshed header without another refresh."""
+
+    opened_auth: list[str | None] = []
+    _install_fake_session(monkeypatch, opened_auth)
+    refresh_calls = 0
+
+    async def refresh_auth() -> str | None:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        return "fresh"
+
+    spec = _make_spec(_PING_CACHE)
+    headers = {"Authorization": "Bearer stale"}
+    tools = _build_tools_from_cache(
+        spec=spec, headers=headers, server_url=spec.server_url, refresh_auth=refresh_auth
+    )
+    assert tools is not None
+
+    result = await tools[0].execute("tc1", {})
+    assert result.is_error is None
+    assert refresh_calls == 1
+    assert opened_auth == ["Bearer stale", "Bearer fresh"]
+    # Shared header dict updated in place → the next call skips the refresh.
+    assert headers["Authorization"] == "Bearer fresh"
+    await tools[0].execute("tc2", {})
+    assert refresh_calls == 1
+    assert opened_auth[-1] == "Bearer fresh"
+
+
+async def test_tool_call_401_without_callback_propagates(monkeypatch: Any) -> None:
+    """Static/no-auth connectors keep today's behavior: no retry loop."""
+
+    opened_auth: list[str | None] = []
+    _install_fake_session(monkeypatch, opened_auth)
+
+    spec = _make_spec(_PING_CACHE)
+    tools = _build_tools_from_cache(
+        spec=spec, headers={"Authorization": "Bearer stale"}, server_url=spec.server_url
+    )
+    assert tools is not None
+    with pytest.raises(BaseExceptionGroup):
+        await tools[0].execute("tc1", {})
+    assert opened_auth == ["Bearer stale"]
+
+
+async def test_tool_call_refresh_returning_none_propagates_original(monkeypatch: Any) -> None:
+    opened_auth: list[str | None] = []
+    _install_fake_session(monkeypatch, opened_auth)
+
+    async def refresh_auth() -> str | None:
+        return None
+
+    spec = _make_spec(_PING_CACHE)
+    tools = _build_tools_from_cache(
+        spec=spec,
+        headers={"Authorization": "Bearer stale"},
+        server_url=spec.server_url,
+        refresh_auth=refresh_auth,
+    )
+    assert tools is not None
+    with pytest.raises(BaseExceptionGroup):
+        await tools[0].execute("tc1", {})
+    assert opened_auth == ["Bearer stale"]
+
+
+async def test_tool_call_refresh_raising_propagates_original(monkeypatch: Any) -> None:
+    opened_auth: list[str | None] = []
+    _install_fake_session(monkeypatch, opened_auth)
+
+    async def refresh_auth() -> str | None:
+        raise RuntimeError("refresh infra down")
+
+    spec = _make_spec(_PING_CACHE)
+    tools = _build_tools_from_cache(
+        spec=spec,
+        headers={"Authorization": "Bearer stale"},
+        server_url=spec.server_url,
+        refresh_auth=refresh_auth,
+    )
+    assert tools is not None
+    with pytest.raises(BaseExceptionGroup):
+        await tools[0].execute("tc1", {})
+
+
+def test_make_refresh_auth_callback_gating() -> None:
+    """Only OAuth specs with a refresh credential get a callback — the
+    retry loop must be unreachable for static/none auth."""
+    static_spec = _make_spec(_PING_CACHE)  # auth_method="static"
+    assert _make_refresh_auth_callback(spec=static_spec, token_manager=object()) is None
+
+    oauth_no_refresh = replace(
+        _make_spec(_PING_CACHE),
+        auth_method="oauth",
+        grant=SimpleNamespace(refresh_credential_id=None),
+    )
+    assert _make_refresh_auth_callback(spec=oauth_no_refresh, token_manager=object()) is None
+
+    oauth_ok = replace(oauth_no_refresh, grant=SimpleNamespace(refresh_credential_id="cred_r"))
+    assert _make_refresh_auth_callback(spec=oauth_ok, token_manager=object()) is not None

--- a/backend/tests/unit/test_sandbox.py
+++ b/backend/tests/unit/test_sandbox.py
@@ -220,6 +220,9 @@ async def test_execute_tool_no_exit_code_suffix_on_success() -> None:
 async def test_write_file_uploads_to_sandbox() -> None:
     sandbox = _make_sandbox()
     sandbox.upload = AsyncMock()
+    check_result = MagicMock()
+    check_result.output = "MISSING"
+    sandbox.execute = AsyncMock(return_value=check_result)
 
     tool = _make_write_file_tool(sandbox)
     args = _WriteFileArgs(file_path="/work/hello.txt", content="Hello!")

--- a/docs/dev/plans/2026-07-17-mcp-oauth-401-refresh.md
+++ b/docs/dev/plans/2026-07-17-mcp-oauth-401-refresh.md
@@ -1,0 +1,168 @@
+# Plan: MCP OAuth 401 → forced refresh + retry
+
+Spec: [2026-07-17-mcp-oauth-401-refresh-design.md](../specs/2026-07-17-mcp-oauth-401-refresh-design.md)
+
+**Goal.** On a 401 from an MCP server against a supposedly-valid OAuth
+token, force one refresh and retry; on refresh failure or a repeat 401,
+mark the grant expired so Reconnect surfaces.
+
+**Architecture.** One new capability on `OAuthTokenManager`
+(`force_refresh`) consumed by the two places that talk to MCP servers
+with an OAuth bearer: the discovery service and the runtime tool-call
+closures. A shared `is_unauthorized_error` helper classifies the
+exception-group-wrapped 401s both places see. The runtime path opens its
+own short-lived DB session at retry time (loader session is closed by
+then), mirroring `_load_tools_for_specs_deferred`.
+
+**Tech stack.** Existing: httpx, redis lock, SQLAlchemy async, pytest.
+No new dependencies.
+
+---
+
+## Unit 1 — token manager: forced refresh
+
+**Files.** `backend/cubeplex/mcp/oauth/token_manager.py`
+
+**Interfaces.**
+
+- `get_access_token_for_grant(..., force_refresh: bool = False) -> str`
+- `with_credential_repo(credential_repo: CredentialRepository) -> OAuthTokenManager`
+  — clone bound to a different (fresh-session) credential repo; shares
+  http client, redis, encryption backend, metadata cache, buffers.
+
+**Core logic.** `force_refresh=True` skips the `_needs_refresh` early
+return before the lock. Inside the lock, `_refresh_grant` gains the
+caller's `expires_at` snapshot: if the re-read row's `expires_at`
+differs from the snapshot, another worker already rotated — return the
+current token without refreshing. The non-forced path keeps the
+existing time-based in-lock guard. `OAuthRefreshFailed` semantics
+(flip `grant_status='expired'`, propagate) unchanged.
+
+**Tests.** New `backend/tests/unit/mcp/test_oauth_token_manager.py`
+(pure in-process: stub redis with an in-memory fake, stub repos and
+encryption; httpx via `httpx.MockTransport`). Invariants:
+
+- forced refresh rotates even when `expires_at` is far in the future;
+- forced refresh with a changed `expires_at` snapshot does NOT hit the
+  token endpoint (double-rotation guard);
+- refresh failure under force still flips grant to expired and raises;
+- `force_refresh=False` keeps the time-based behavior.
+
+## Unit 2 — 401 classifier
+
+**Files.** `backend/cubeplex/mcp/exceptions.py`
+
+**Interfaces.** `is_unauthorized_error(exc: BaseException) -> bool`.
+
+**Core logic.** Iteratively unwrap `BaseExceptionGroup` (first
+non-group leaf, matching `_format_discovery_error`'s walk), return True
+iff the leaf is `httpx.HTTPStatusError` with `response.status_code ==
+401`. Walk ALL leaves of a group, not just the first — httpx task
+groups can put connection-cleanup noise first.
+
+**Tests.** In Unit 1's file or a small
+`tests/unit/mcp/test_exceptions.py`: bare 401, group-wrapped 401,
+nested groups, non-401 HTTPStatusError, unrelated exception.
+
+## Unit 3 — discovery retry
+
+**Files.** `backend/cubeplex/services/mcp_discovery.py`
+
+**Core logic.** In `discover_tools_for_install`, the
+`_list_raw_mcp_tools` except-block branches:
+
+1. `is_unauthorized_error(exc)` and grant is OAuth with
+   `refresh_credential_id` →
+   `token_mgr.get_access_token_for_grant(force_refresh=True)`.
+   - `OAuthRefreshFailed` → persist error with
+     `last_error = "oauth_reauthorization_required: " + formatted cause`
+     (grant already expired by the manager). Return error result.
+   - Success → set `headers["Authorization"] = "Bearer " + token`,
+     retry `_list_raw_mcp_tools` once. Second failure of any kind →
+     if it is again a 401, best-effort `grant.grant_status = "expired"`
+     + `grant_repo.update(grant)`; persist error as today.
+2. Anything else → existing persist-error path, byte-identical.
+
+Grant availability: the org-scope and workspace-scope branches both
+already produce `grant`; the retry only activates when
+`grant.auth_method == "oauth"` and `grant.refresh_credential_id` is set.
+
+**Tests.** e2e (opens AsyncSession) alongside
+`backend/tests/e2e/test_mcp_restore_lost_ui.py` conventions: stub
+`_list_raw_mcp_tools` (monkeypatch) with scripted outcomes and a stub
+token manager. Invariants = spec success criteria 1–3:
+
+- 401 then success after forced refresh → status ok, last_error None,
+  header carried the refreshed token on the retry;
+- refresh failure → error persisted with
+  `oauth_reauthorization_required:` prefix, grant expired;
+- 401 twice → grant expired, error persisted;
+- non-OAuth install 401 → no token manager call, error persisted as
+  before.
+
+## Unit 4 — runtime tool-call retry
+
+**Files.** `backend/cubeplex/mcp/cubepi_runtime.py`
+
+**Interfaces.**
+
+- `_build_tools_from_cache(*, spec, headers, server_url, refresh_auth:
+  Callable[[], Awaitable[str | None]] | None = None)` — callback
+  returns a fresh access token or None (not refreshable / failed).
+- `_make_refresh_auth_callback(spec, token_manager) -> callback | None`
+  in the same module; returns None unless
+  `spec.auth_method == "oauth"` and `spec.grant.refresh_credential_id`
+  is set.
+
+**Core logic.**
+
+- Callback body: `async with async_session_maker()` → org-scoped
+  `MCPCredentialGrantRepository` + `CredentialRepository` →
+  `token_manager.with_credential_repo(...)` →
+  `get_access_token_for_grant(grant=spec.grant, force_refresh=True)` →
+  commit → return token. Any exception → log warning, return None.
+- `_call_remote`: wrap the open/initialize/call block in try/except; on
+  `is_unauthorized_error` with a callback, invoke it; on a token,
+  mutate the shared `headers` dict's `Authorization` (later calls in
+  the turn reuse it) and retry the block once. Retry 401 again →
+  best-effort flip grant to expired (own short session, suppressed
+  errors) and re-raise. Callback returned None → re-raise original.
+- The live-loader fallback (`load_mcp_tools_http` inside
+  `_load_tools_for_specs`) gets the same single-retry treatment: on
+  401 + callback, refresh, rebuild header, one more attempt, else skip
+  the spec as today.
+- Cache discipline note: headers never enter the LLM byte stream; tool
+  list and ordering are untouched.
+
+**Tests.** Extend
+`backend/tests/unit/mcp/test_runtime_tools_cache.py` (already stubs
+cubepi session internals). Invariants = spec criteria 4–5:
+
+- call 401s once, callback yields token → call retried with new
+  Authorization header and succeeds; shared headers dict updated;
+- second call after a refresh does not invoke the callback again;
+- callback None (static auth) → 401 propagates, no retry;
+- callback raises → original 401 propagates.
+
+## Unit 5 — docs
+
+**Files.** `backend/docs/mcp_catalog_oauth.md` ("Token refresh" +
+"Troubleshooting" sections).
+
+State the new behavior: 401 with a valid-looking grant triggers one
+forced refresh + retry; repeat-401/refresh-failure flips the grant to
+expired and surfaces Reconnect; `oauth_reauthorization_required:` is
+the last_error marker. No `docs/site` page documents token-refresh
+internals (user-visible flow — the Reconnect prompt — already
+documented), so no site page change.
+
+---
+
+## Plan self-review notes
+
+- Spec §1→U1, §2→U2, §3→U3, §4→U4, §5/out-of-scope→U5 + untouched
+  paths. Covered.
+- Interface names consistent: `force_refresh`, `is_unauthorized_error`,
+  `with_credential_repo`, `refresh_auth` used identically across units.
+- Deliberate exclusions (Try It route, banner auto-clear,
+  `_resolve_auth_from_spec` fallback) are in the spec's out-of-scope.

--- a/docs/dev/specs/2026-07-17-mcp-oauth-401-refresh-design.md
+++ b/docs/dev/specs/2026-07-17-mcp-oauth-401-refresh-design.md
@@ -1,0 +1,170 @@
+# MCP OAuth: react to 401 with a forced token refresh
+
+## Goal
+
+When an MCP server rejects an access token with `401 Unauthorized` even
+though the grant's recorded `expires_at` says the token is still valid,
+force one token refresh and retry the request; if the refresh fails, or
+the server still rejects the refreshed token, mark the grant `expired`
+so the UI surfaces the Reconnect prompt.
+
+## Context
+
+Production incident (2026-07-17, `cloudflare-api` connector): Cloudflare
+issued an access token claiming a 16-hour lifetime (`expires_in=57600`),
+then started rejecting it with 401 roughly 2.5 hours **before** the
+recorded expiry. The same server's newer tokens carry a 1-hour lifetime,
+so this was a provider-side TTL/revocation change — which providers are
+allowed to do at any time: `expires_in` is a hint, not a contract.
+
+Today every consumer of an OAuth grant trusts `expires_at` blindly:
+
+- `OAuthTokenManager.get_access_token_for_grant` refreshes only when
+  `now` is within 60s of `expires_at` (`_needs_refresh`); otherwise it
+  returns the cached token, even if the server has revoked it.
+- `discover_tools_for_install` (also reached by the background
+  tools-cache TTL refresh) catches the 401, persists it into
+  `connector.last_error`, and the UI shows a sticky
+  "Discovery error, HTTPStatusError: … 401 …" banner. The grant stays
+  `valid`, so even a manual Retry re-sends the same dead token.
+- The runtime tool loader (`_load_tools_for_specs`) bakes the resolved
+  `Authorization` header into each tool's call closure at turn start;
+  every tool call in the turn then fails with 401.
+
+Nothing in the system reacts to a 401. The connector stays broken until
+the wall clock finally passes `expires_at` (hours later), and the error
+banner stays up even after that.
+
+## Approaches considered
+
+1. **401-triggered forced refresh at the consumption points (chosen).**
+   Add a `force_refresh` mode to `OAuthTokenManager`; on a 401, the
+   discovery path and the tool-call path force one refresh and retry
+   once. Recovers within the same operation; refresh cost is paid only
+   when a server actually rejects a token.
+2. **Mark the grant expired on 401 and let the existing time-based
+   machinery refresh on next use.** Simpler, but the current operation
+   still fails, the user sees one error per revocation, and the runtime
+   currently *falls back to the cached token* when a grant is expired-
+   but-refreshable — so the retry semantics would stay muddy.
+3. **Stop trusting long `expires_in` values (cap the recorded lifetime
+   at e.g. 15 minutes).** Refreshes far more often for all providers,
+   still cannot handle mid-lifetime revocation, and burns refresh-token
+   rotations for nothing.
+
+## Design
+
+### 1. `OAuthTokenManager` grows a forced-refresh mode
+
+`get_access_token_for_grant(..., force_refresh: bool = False)`.
+
+- `force_refresh=False`: behavior unchanged (time-based check).
+- `force_refresh=True`: skip the `_needs_refresh` early return and go
+  straight to the locked refresh path.
+- Double-rotation guard: the caller's `grant.expires_at` snapshot is
+  compared with the re-read row inside the redis lock. If they differ,
+  another worker already rotated the token since the caller observed the
+  401 — return the current (fresh) token without refreshing again.
+  The existing time-based guard inside the lock keeps working for the
+  non-forced path.
+- Failure semantics unchanged: `OAuthRefreshFailed` still flips
+  `grant_status = "expired"` and propagates.
+
+### 2. Shared 401 detection helper
+
+`cubeplex/mcp/exceptions.py` gains
+`is_unauthorized_error(exc: BaseException) -> bool`: unwraps any layers
+of `BaseExceptionGroup` (the MCP SDK wraps transport errors in TaskGroup
+groups) and returns True when an inner `httpx.HTTPStatusError` has
+status 401. Used by both the discovery and the runtime paths.
+
+### 3. Discovery: refresh-and-retry once
+
+In `discover_tools_for_install`, when `_list_raw_mcp_tools` fails:
+
+- If the failure is a 401 **and** the resolved grant is an OAuth grant
+  with a `refresh_credential_id`: call the token manager with
+  `force_refresh=True`, rebuild the `Authorization` header, retry
+  `_list_raw_mcp_tools` once.
+  - Refresh raises `OAuthRefreshFailed` → the grant is already marked
+    expired by the manager; persist `discovery_status='error'` with a
+    `last_error` that names the real state
+    (`oauth_reauthorization_required: <formatted cause>`).
+  - Retry succeeds → normal success path (cache updated, error cleared).
+  - Retry still 401s → the server rejects even a brand-new token, so
+    reauthorization is needed: set `grant_status='expired'` (best
+    effort) and persist the discovery error.
+- Any other failure, or a non-refreshable grant (static / none auth, no
+  refresh credential): behavior unchanged.
+
+This automatically covers the background tools-cache TTL refresh and the
+manual Retry button — both call `discover_tools_for_install`.
+
+### 4. Runtime tool calls: refresh-and-retry once
+
+The tool-call closures built by `_build_tools_from_cache` (and the live
+`load_mcp_tools_http` fallback right next to it) currently capture a
+fixed `headers` dict. Change:
+
+- `_load_tools_for_specs` builds, for each OAuth spec whose grant has a
+  `refresh_credential_id`, an async `refresh_auth` callback and threads
+  it into `_build_tools_from_cache`.
+- The callback opens its **own** short-lived session via
+  `async_session_maker` (the loader's session is closed by the time
+  tool calls run — same reason `_load_tools_for_specs_deferred`
+  exists), rebuilds the org-scoped grant/credential repos, and calls the
+  token manager with `force_refresh=True`. To reuse the app-level
+  singletons (http client, redis, encryption backend, metadata cache)
+  without reaching into privates, `OAuthTokenManager` gains
+  `with_credential_repo(repo) -> OAuthTokenManager` returning a clone
+  bound to the new session's credential repo.
+- `_call_remote` wraps the session-open/initialize/call block: on a 401
+  (`is_unauthorized_error`) with a callback available, invoke it, merge
+  the returned `Authorization` header into the **shared** per-spec
+  headers dict (so later calls in the same turn reuse the fresh token),
+  and retry the call once. A second 401 propagates to the agent as
+  today, after best-effort flipping the grant to `expired`.
+- Refresh callback failures never mask the original 401: on any
+  exception from the callback, log and re-raise the original error.
+- Concurrency: two tool calls hitting 401 at once both invoke the
+  callback; the token manager's redis lock plus the double-rotation
+  guard collapse them to a single refresh.
+
+### 5. What is NOT changing
+
+- `_resolve_auth_from_spec`'s turn-start behavior (including the
+  fall-back-to-cached-token on refresh failure) stays as is; the
+  call-time retry now provides the recovery that fallback was papering
+  over.
+- The `expires_at`-based proactive refresh stays the primary mechanism;
+  the 401 path is the corrective for providers that lie.
+
+## Out of scope
+
+- UI changes. The existing banner / Reconnect affordances already key
+  off `discovery_status` and `grant_status`; this change only makes
+  those fields truthful.
+- Auto-clearing a stale "Discovery error" banner without a discovery
+  run (the background TTL refresh + retry-on-401 already shrinks the
+  window this matters in).
+- The workspace "Try It" tool-invoke route (`ws_mcp.py`) — a failed
+  manual invocation is immediately visible and re-clickable; can adopt
+  the same helper later if it proves annoying.
+
+## Success criteria
+
+1. Discovery against a server that 401s the cached token but accepts a
+   refreshed one → `discovery_status='ok'`, `last_error` cleared, grant
+   `valid` with advanced `expires_at`. No user action needed.
+2. Discovery where the refresh grant is rejected by the AS →
+   `grant_status='expired'`, `last_error` starts with
+   `oauth_reauthorization_required:`, UI shows Reconnect.
+3. Discovery where even the refreshed token gets 401 →
+   `grant_status='expired'`.
+4. A tool call in an agent turn whose baked token has been revoked
+   succeeds transparently after one forced refresh; subsequent tool
+   calls in the same turn send the new token without another refresh.
+5. Static-token and no-auth connectors: byte-for-byte unchanged
+   behavior on 401 (no retry loop).
+6. Forced refresh never double-rotates when two workers race (redis
+   lock + expires_at snapshot guard).


### PR DESCRIPTION
## Summary

Makes the MCP OAuth stack react to a 401 from an MCP server instead of blindly trusting the recorded `expires_at`.

**Incident**: `cloudflare-api` (mcp.cloudflare.com) issued a token claiming a 16h lifetime, then revoked it ~2.5h before recorded expiry. The grant stayed `valid`, every consumer kept sending the dead token, and the UI showed a sticky "Discovery error … 401 Unauthorized" banner with no recovery until the wall clock passed `expires_at`.

Spec: `docs/dev/specs/2026-07-17-mcp-oauth-401-refresh-design.md` · Plan: `docs/dev/plans/2026-07-17-mcp-oauth-401-refresh.md`

## Changes

- **`OAuthTokenManager.force_refresh`** — refresh on demand regardless of `expires_at`, with a double-rotation guard (redis lock + `expires_at` snapshot) so racing workers collapse to one rotation. `with_credential_repo()` clones the manager onto a fresh session for post-request-lifetime callers.
- **`is_unauthorized_error`** — shared classifier that unwraps the MCP SDK's TaskGroup `ExceptionGroup` layers to find an httpx 401 (all leaves inspected).
- **Discovery** (`discover_tools_for_install`) — on 401 with a refreshable OAuth grant: force one refresh, retry once. Refresh failure persists `last_error: oauth_reauthorization_required: …` (grant already `expired`); a repeat 401 flips the grant to `expired` so Reconnect surfaces. Covers the manual Retry button and the background tools-cache TTL refresh.
- **Runtime tool calls** (`_build_tools_from_cache` / live-loader fallback) — same single refresh-and-retry per call via a callback that opens its own short-lived session (the loader's session is closed by tool-call time). The shared per-spec headers dict is updated in place so subsequent calls in the turn reuse the fresh token.
- **Docs** — `backend/docs/mcp_catalog_oauth.md` "Token refresh" + "Troubleshooting".
- **Unrelated CI unblock** (`test(sandbox)` commit): `test_write_file_uploads_to_sandbox` was failing on main (missing `execute` stub for the new write_file overwrite guard) and blocked every pre-push; fixed the stub here.

## Tests

- `tests/unit/mcp/test_oauth_token_manager.py` (new) — forced rotation, double-rotation guard, expired-on-failure, time-based default, repo rebind.
- `tests/unit/mcp/test_exceptions.py` (new) — 401 classifier incl. nested groups.
- `tests/unit/mcp/test_runtime_tools_cache.py` — call 401 → refresh → retry; shared-header reuse; no-callback/None/raising-callback propagation; callback gating.
- `tests/e2e/test_mcp_oauth_401_retry.py` (new) — discovery success-after-refresh, refresh-failure → `oauth_reauthorization_required` + grant expired, repeat-401 → grant expired, non-OAuth unchanged.

## Verification

- `pytest tests/unit/mcp tests/unit/test_mcp_effective_service.py tests/unit/test_mcp_disclosure.py tests/unit/test_post_grant_discovery_swallows.py tests/e2e/test_mcp_oauth_401_retry.py tests/e2e/test_mcp_restore_lost_ui.py` → **119 passed**
- Pre-push `make check-ci` (backend ruff + mypy + unit suite, frontend full) → **passed**