### PR TITLE
fix(frontend): pin types to node in core tsconfig for TypeScript 6

### DIFF
--- a/frontend/packages/core/tsconfig.json
+++ b/frontend/packages/core/tsconfig.json
@@ -4,6 +4,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
+    "types": ["node"],
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary
`@cubeplex/core` fails to build (`tsc` TS2591: cannot find name 'process' in `src/api/cookieNames.ts`) after the TypeScript 6 upgrade, because implicit `@types` inclusion no longer picks up node. Pin `"types": ["node"]` in the core tsconfig.

This currently breaks `make check-ci` on main for every branch — the two sandbox PRs are blocked on it and should be rebased after this merges.

## Verification
Full pre-push `make check-ci` gate passed on this branch (build-core green).