### PR TITLE
Support TypeScript 7 docs config

### DIFF
--- a/docs/site/tsconfig.json
+++ b/docs/site/tsconfig.json
@@ -1,7 +1,17 @@
 {
-  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "noEmit": true,
+    "paths": {
+      "@site/*": ["./*"]
+    },
+    "skipLibCheck": true,
     "ignoreDeprecations": "6.0",
     "strict": true
   },


### PR DESCRIPTION
## What changed

Update the docs TypeScript configuration to work with TypeScript 7 by removing the incompatible Docusaurus tsconfig inheritance and preserving the required compiler options and `@site/*` path mapping.

## Root cause

TypeScript 7 removed `baseUrl`, which was inherited from `@docusaurus/tsconfig`; docs type-checking failed with TS5102 after the dependency upgrade.

## Validation

- `pnpm dlx --package typescript@7.0.2 tsc --noEmit`
- `pnpm check`
- Repository pre-push checks passed after retry