### PR TITLE
Design Docker image CI/CD workflow

### DIFF
--- a/docs/dev/plans/2026-07-18-docker-image-ci.md
+++ b/docs/dev/plans/2026-07-18-docker-image-ci.md
@@ -1,0 +1,164 @@
+# Docker Image CI/CD Implementation Plan
+
+**Goal:** Build affected cubeplex images by change, publish immutable commit images,
+and use a release manifest to pin the application and sandbox image combination.
+
+**Architecture:** GitHub Actions handles PR build validation, `main` SHA-image
+publication, and Git-tag release promotion. Image digests are the release outputs;
+the release values/manifest is the deployment input. Helm and Compose consume that
+input instead of inferring or overriding production versions. Sandbox has an independent
+workflow and version, while the release gate checks its compatibility with backend.
+
+**Tech stack:** GitHub Actions, Docker Buildx, GHCR, Helm, Docker Compose, shell
+scripts, and the existing backend/frontend/sandbox Dockerfiles.
+
+## Unit 1 — Define image metadata and changed-area contract
+
+**Files**
+
+- `.github/workflows/images.yml` — declare PR, main, release, and manual sandbox job
+  boundaries, or split them into separate workflows if that matches repository style.
+- `.github/scripts/` changed-area/metadata helper, if needed — calculate source commit,
+  image tags, and targets without owning publication permissions.
+
+**Interfaces**
+
+- Inputs: GitHub event, source commit, Git tag, and changed-file list.
+- Outputs: `targets` (backend/frontend/sandbox/egress-webhook), `sha_tag`, release
+  version, and build metadata for later jobs.
+
+**Core logic**
+
+- Extend the existing CI change detection to include Dockerfiles, deploy scripts,
+  workflows, and shared build configuration.
+- PR events cannot enter a formal publication job. Main publishes only
+  `sha-<full-sha>`. A release consumes an existing main build.
+- Sandbox paths are detected independently so ordinary application changes do not
+  trigger the large sandbox build.
+
+**Tests**
+
+- Shell/unit tests cover backend, frontend, sandbox, egress webhook, shared deploy
+  changes, and unrelated documentation changes.
+- Static workflow validation covers pull request, main push, tag, and manual events;
+  PR execution must not push release or `latest` tags.
+
+## Unit 2 — Build and publish commit images
+
+**Files**
+
+- `.github/workflows/images.yml` or equivalent publication workflow — build with Buildx,
+  publish SHA images to GHCR, and upload digest/build metadata.
+- `deploy/kubernetes/scripts/build-and-push.sh` — align local image names, tags, targets,
+  build args, and registry parameters with CI while keeping private-registry support.
+- A `.dockerignore` or build metadata file only if the actual build context requires it.
+
+**Interfaces**
+
+- Inputs: `REGISTRY`, `REPO`, target list, image tag, and existing mirror build args.
+- Outputs: image reference, digest, and source commit for every target.
+- Image names remain `cubeplex-backend`, `cubeplex-frontend`, `cubeplex-sandbox`, and
+  `cubeplex-egress-webhook`.
+
+**Core logic**
+
+- CI logs in to GHCR with GitHub Actions permissions, not a repository password.
+- Build cache, SBOM/provenance, and digest output are build artifacts. A commit tag
+  cannot be overwritten with different content.
+- `latest`/`edge` are not production inputs; if retained, they are updated only by an
+  explicit development job.
+- Sandbox failures do not fail unrelated image jobs, but the release gate fails when a
+  required sandbox image or compatibility result is missing.
+
+**Tests**
+
+- PR workflow performs real Docker builds for affected targets.
+- Backend/frontend health or startup smoke tests run after build; sandbox tests cover
+  command execution, workspace file writes, and browser runtime startup.
+- The workflow verifies that every output digest is non-empty and pullable.
+
+## Unit 3 — Publish release tags and release manifest
+
+**Files**
+
+- `.github/workflows/release.yml` — respond to `v*` tags, verify main metadata, add the
+  release tag to the same digest, and generate the manifest.
+- `deploy/releases/` manifest/values template — store non-secret image combinations;
+  exact naming follows the existing deployment convention during implementation.
+- `deploy/README.md`, `deploy/kubernetes/INSTALL.md`, `deploy/kubernetes/INSTALL.zh.md`,
+  and `deploy/docker-compose/INSTALL.md` — document registry selection, manifest usage,
+  and version updates.
+
+**Interfaces**
+
+- Inputs: `v<semver>`, source commit, image SHA digests, and the verified sandbox digest.
+- Output: a manifest containing release, source commit, backend, frontend, sandbox, and
+  egress webhook references.
+- Helm and Compose commands accept the manifest separately from operator secrets.
+
+**Core logic**
+
+- The release workflow looks up digests from the main build. If they are missing, it
+  fails instead of rebuilding implicitly.
+- A sandbox digest may come from a recent independent sandbox release, but it must have
+  a compatibility result. Backend/sandbox contract changes require a new sandbox build.
+- The manifest is the rollback unit. Reusing it cannot pull a moving `latest` tag.
+
+**Tests**
+
+- Generate a manifest for a release tag and verify all required image fields.
+- Render Helm with the generated image values and confirm backend/frontend/egress image
+  references and sandbox secret/config wiring.
+- Render Compose config from the same release result and verify non-empty matching
+  `BACKEND_TAG` and `FRONTEND_TAG` values.
+
+## Unit 4 — Independent sandbox release and compatibility gate
+
+**Files**
+
+- `.github/workflows/sandbox-image.yml` or a sandbox job in the image workflow — path,
+  manual, and scheduled triggers; publish sandbox SHA/version tags.
+- `deploy/images/sandbox/` — change only when tests expose a build or startup issue;
+  avoid unrelated refactoring.
+- Sandbox compatibility smoke script in the existing deployment script location — cover
+  OpenSandbox create, exec, workspace files, and browser paths where available.
+
+**Interfaces**
+
+- Inputs: sandbox source revision, independent sandbox version, and OpenSandbox config.
+- Outputs: sandbox digest, runtime compatibility result, and a manifest-ready reference.
+
+**Core logic**
+
+- Build sandbox only for sandbox changes, scheduled security rebuilds, or manual triggers.
+- OpenSandbox server/execd/egress remain deployment-configured; tests report whether the
+  configured runtime and sandbox image work together.
+- The egress webhook uses the cubeplex application commit tag and must match the chart's
+  egress-image matching rule.
+
+**Tests**
+
+- Sandbox Docker build smoke test.
+- OpenSandbox runtime e2e test for sandbox creation, command execution, workspace files,
+  and browser/egress paths when enabled.
+- Release-gate test: backend contract changes without a new sandbox compatibility result
+  must fail the release.
+
+## Verification and rollout order
+
+1. Add metadata/change detection and PR build-only validation; confirm PRs cannot publish production tags.
+2. Add main SHA publication and digest artifacts; verify GHCR permissions and cache.
+3. Add the independent sandbox workflow and compatibility smoke test.
+4. Add release-tag promotion and manifest generation.
+5. Update Helm/Compose deployment docs and operator entry points, then switch production deployment to manifests.
+
+Each implementation unit runs only its changed-module tests during development. A code
+PR containing workflows, Dockerfiles, or deployment docs uses the repository pre-push
+CI-equivalent gate before publication.
+
+## Explicit non-goals
+
+- Automatic Kubernetes rollout or a GitOps controller.
+- Changes to upstream OpenSandbox image build processes.
+- Secrets in release manifests.
+- Production version advancement by editing Helm default tags.

--- a/docs/dev/specs/2026-07-18-docker-image-ci-design.md
+++ b/docs/dev/specs/2026-07-18-docker-image-ci-design.md
@@ -1,0 +1,183 @@
+# Docker Image CI/CD Design
+
+## Goal
+
+Build a repeatable and auditable Docker image pipeline for cubeplex: validate image
+builds on pull requests, publish immutable commit images from `main`, promote the
+same verified digests on formal releases, and make Kubernetes Helm and Docker Compose
+use the same version-selection rules.
+
+## Context
+
+The repository already has backend/frontend Dockerfiles and
+`deploy/kubernetes/scripts/build-and-push.sh`. The script pushes backend/frontend
+images to an internal registry with a git short SHA tag and `latest`. Kubernetes
+operators manually set image tags in `values.local.yaml`; Compose operators manually
+set `BACKEND_TAG` and `FRONTEND_TAG` in `.env`. This works for manual deployment but
+does not provide a reliable GitHub Actions build, publication, and release flow.
+
+The sandbox image is different from the application images. It contains browsers,
+fonts, Office, Python, and Node runtimes, so it is large and slow to build. Its
+lifecycle is driven by sandbox Dockerfile changes, OpenSandbox/execd compatibility,
+and base-image security updates. OpenSandbox server, execd, and egress are upstream
+runtime images, not part of the cubeplex sandbox image. The Kubernetes egress webhook
+is a separate cubeplex-owned image.
+
+## Approaches considered
+
+### 1. Build every image for every application release
+
+Build backend, frontend, and sandbox in one workflow under one version.
+
+This is simple, but rebuilds the large sandbox for unrelated application changes and
+does not prove that the release uses the same image content that was previously tested.
+
+### 2. Build on `main` and deploy `latest`
+
+Build after every merge and have deployments pull `latest`.
+
+This is easy to implement, but deployments are not auditable and rollback is unsafe
+because a registry can move the tag.
+
+### 3. Build application images and sandbox independently, then pin the release combination
+
+Build backend/frontend for application commits and releases. Build sandbox only when
+its context or security inputs change. A release manifest records the exact application
+and sandbox digests that were tested together.
+
+This is the selected approach because it avoids unnecessary sandbox builds while still
+making each release reproducible.
+
+## Design
+
+### Image names and tags
+
+GHCR is the canonical registry for GitHub Actions. Deployment configuration can point
+to Harbor or the existing internal registry:
+
+```text
+ghcr.io/<owner>/cubeplex-backend
+ghcr.io/<owner>/cubeplex-frontend
+ghcr.io/<owner>/cubeplex-sandbox
+ghcr.io/<owner>/cubeplex-egress-webhook
+```
+
+Each build produces at least:
+
+- `sha-<full-commit-sha>` for an immutable commit selector;
+- `v<semver>` for a formal release, pointing to the already verified digest.
+
+`latest` or `edge` may remain as development convenience tags, but production must
+not depend on them. Production should record and preferably consume image digests. If
+the first Helm/Compose implementation only supports tags, it must use immutable SHA
+or release tags.
+
+Backend and frontend share the application release version. Sandbox has an independent
+version such as `sandbox-v0.3.2`; it does not increment for every application release.
+OpenSandbox server, execd, and egress versions remain managed by their own deployment
+configuration.
+
+### Workflow stages
+
+#### Pull request
+
+After the existing code CI, the image workflow builds affected images without publishing
+production tags:
+
+- `backend/**` or the backend Dockerfile: build backend;
+- `frontend/**` or the frontend Dockerfile: build frontend;
+- `deploy/images/sandbox/**`: build sandbox;
+- `deploy/kubernetes/egress-bundle/**`: build the egress webhook;
+- workflow, deployment-template, or shared-build changes: build all affected images.
+
+Images use temporary PR tags or remain local to the runner. The workflow validates the
+Docker build and, where runtime dependencies are available, runs backend health,
+frontend startup, and basic sandbox execution smoke tests. It must not write `latest`,
+release tags, or production registry namespaces.
+
+#### `main`
+
+After code CI succeeds, the workflow builds affected images and publishes
+`sha-<full-commit-sha>`. It stores each digest, affected image, and source commit as
+build metadata for the release workflow. A commit tag must never be overwritten with
+different content.
+
+#### Formal release
+
+When a `v<semver>` Git tag is pushed, the release workflow confirms that the commit's
+SHA images exist and passed validation. It then adds the release tag to those same
+digests; it does not silently rebuild a different image.
+
+The workflow also creates an auditable manifest:
+
+```yaml
+release: v0.8.0
+source_commit: 6f3de2eb...
+images:
+  backend: ghcr.io/<owner>/cubeplex-backend@sha256:...
+  frontend: ghcr.io/<owner>/cubeplex-frontend@sha256:...
+  sandbox: ghcr.io/<owner>/cubeplex-sandbox@sha256:...
+  egress_webhook: ghcr.io/<owner>/cubeplex-egress-webhook@sha256:...
+```
+
+If sandbox did not change in the application commit, the manifest references the most
+recent sandbox digest that passed compatibility tests. If the backend/sandbox contract
+changes, the release gate requires a new sandbox build and compatibility test.
+
+### Registry authentication and publication
+
+GitHub Actions uses repository permissions to log in to GHCR; registry passwords are
+not stored in the repository. Private-registry mirroring is a later deployment concern
+and must copy the same digest rather than rebuild different content.
+
+Image names are configurable through Helm `image.registry`/`image.repository` and
+Compose `IMAGE_REGISTRY`/`IMAGE_REPO`.
+
+The local `build-and-push.sh` remains useful for operators and private registries, but
+it must follow the same names and tag rules as CI. Production must not depend on a
+manual `latest` update.
+
+### Deployment version selection
+
+`deploy/kubernetes/charts/cubeplex/values.yaml` keeps safe defaults and does not store
+the production tag for a particular release. A committed release values/manifest file
+contains backend, frontend, sandbox, and egress webhook versions or digests. Secrets
+remain in the operator's gitignored `values.local.yaml` or a secret manager.
+
+Helm passes default values, release image values, and operator secrets as separate
+layers. Compose uses the same release result to fill `.env` values. Updating a version
+means selecting a new release manifest, not modifying chart defaults or overwriting a
+tag.
+
+Chart `version` and `appVersion` describe Helm metadata. The image tag/digest and the
+release manifest are the deployment lock.
+
+### Sandbox build policy
+
+The sandbox workflow supports three triggers:
+
+1. automatic builds for sandbox Dockerfile, fonts, startup scripts, or build dependency changes;
+2. `workflow_dispatch` for explicit rebuilds after OpenSandbox compatibility changes;
+3. scheduled security rebuilds for base-image and browser dependency updates.
+
+Successful builds publish independent `sha-*` and `sandbox-v*` tags. An application
+release selects a sandbox digest that has passed compatibility tests; it does not
+rebuild sandbox merely because backend/frontend changed.
+
+## Out of scope
+
+- Changing OpenSandbox server, execd, or upstream egress image build processes.
+- Automatic Kubernetes rollout, rollback controllers, or a GitOps platform.
+- Storing registry, LLM, or sandbox credentials in Git.
+- Requiring digest-only Helm/Compose support in the first implementation.
+- Implementing the workflows in this PR; this PR contains only design and plan documents.
+
+## Success criteria
+
+- PRs validate affected Docker builds without publishing production tags.
+- `main` publishes backend/frontend images tagged with the full source commit and emits digests.
+- A release tag promotes already verified digests instead of rebuilding different content.
+- Sandbox builds occur only for sandbox changes, security rebuilds, or explicit triggers.
+- One release manifest identifies the complete backend/frontend/sandbox/egress image set.
+- Helm and Compose can deploy from the same version selection without relying on `latest`.
+- Redeploying the same manifest produces the same image content; rollback only selects an older manifest.


### PR DESCRIPTION
## Summary

- Add the Docker image CI/CD design spec.
- Add the implementation plan for PR build validation, main SHA image publication, release digest promotion, and deployment manifests.
- Define independent sandbox image versioning and compatibility gating.

## Scope

This PR contains design and implementation planning only. It does not add GitHub Actions workflows or change deployment behavior.

## Validation

- `git diff --check`
- pre-commit hooks passed
- Worktree provisioning completed successfully, including database migration

Design: `docs/dev/specs/2026-07-18-docker-image-ci-design.md`
Plan: `docs/dev/plans/2026-07-18-docker-image-ci.md`
