### PR TITLE
Build multi-platform container images

### DIFF
--- a/.agents/skills/release/references/release-workflow.md
+++ b/.agents/skills/release/references/release-workflow.md
@@ -92,6 +92,10 @@ The application release tags are aliases for the already built image manifests,
 not new builds. The manifest records backend/frontend image digests and the
 selected sandbox version tag.
 
+Published application and sandbox tags contain `linux/amd64` and `linux/arm64`
+manifests. Any `unknown/unknown` entry shown by GHCR is a provenance attestation,
+not a runtime platform.
+
 ## Deploy the release
 
 Use the release manifest as the deployment input. For tag-based deployment:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -71,10 +71,15 @@ jobs:
             git diff --name-only "$BASE_SHA" "$TARGET_SHA" > changed-files.txt
             while IFS= read -r path; do
               case "$path" in
-                backend/*|deploy/images/backend/*|deploy/kubernetes/scripts/build-and-push.sh|Makefile|.github/workflows/images.yml)
+                deploy/kubernetes/scripts/build-and-push.sh|scripts/image-tag.sh|Makefile|.github/workflows/images.yml)
+                  backend=true
+                  frontend=true
+                  egress_webhook=true
+                  ;;
+                backend/*|deploy/images/backend/*)
                   backend=true
                   ;;
-                frontend/*|deploy/images/frontend/*|deploy/kubernetes/scripts/build-and-push.sh|Makefile|.github/workflows/images.yml)
+                frontend/*|deploy/images/frontend/*)
                   frontend=true
                   ;;
                 deploy/kubernetes/egress-bundle/*)

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -130,6 +130,14 @@ jobs:
             --no-hashes --no-dev --no-editable --no-emit-project \
             > requirements-frozen.txt
 
+      - uses: docker/setup-qemu-action@v3
+        if: |
+          (matrix.target == 'backend' && needs.changes.outputs.backend == 'true') ||
+          (matrix.target == 'frontend' && needs.changes.outputs.frontend == 'true') ||
+          (matrix.target == 'egress-webhook' && needs.changes.outputs.egress_webhook == 'true')
+        with:
+          platforms: arm64
+
       - uses: docker/setup-buildx-action@v3
         if: |
           (matrix.target == 'backend' && needs.changes.outputs.backend == 'true') ||

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -177,6 +177,7 @@ jobs:
         with:
           context: .
           file: ${{ steps.dockerfile.outputs.path }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ needs.changes.outputs.publish == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           context: deploy/images/sandbox
           file: deploy/images/sandbox/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Read sandbox version

--- a/deploy/kubernetes/INSTALL.md
+++ b/deploy/kubernetes/INSTALL.md
@@ -87,6 +87,10 @@ ghcr.io/cubeplexai/cubeplex-backend:<YYMMDD>-<branch>-<short-sha>
 ghcr.io/cubeplexai/cubeplex-frontend:<YYMMDD>-<branch>-<short-sha>
 ```
 
+Each published tag is a multi-platform manifest for `linux/amd64` and
+`linux/arm64`. GHCR may also display an `unknown/unknown` provenance entry; it is
+metadata and is not a runnable image platform.
+
 Formal `v<semver>` releases promote the same image digests and publish a
 release manifest as a GitHub Release asset. Production deployments must use the
 commit or release tag from that manifest, not `latest`.

--- a/deploy/kubernetes/INSTALL.zh.md
+++ b/deploy/kubernetes/INSTALL.zh.md
@@ -85,6 +85,9 @@ ghcr.io/cubeplexai/cubeplex-backend:<YYMMDD>-<branch>-<short-sha>
 ghcr.io/cubeplexai/cubeplex-frontend:<YYMMDD>-<branch>-<short-sha>
 ```
 
+每个发布 tag 都是同时包含 `linux/amd64` 和 `linux/arm64` 的多平台 manifest。
+GHCR 还可能显示 `unknown/unknown` 的 provenance 条目；它是元数据，不是可运行的镜像平台。
+
 正式 `v<semver>` release 会将相同 digest 提升为 release tag，并把 release
 manifest 作为 GitHub Release asset 发布。生产部署不要使用 `latest`。
 

--- a/docs/dev/plans/2026-07-18-docker-image-ci.md
+++ b/docs/dev/plans/2026-07-18-docker-image-ci.md
@@ -13,6 +13,9 @@ part of image publication or release gating.
 **Tech stack:** GitHub Actions, Docker Buildx, GHCR, Helm, Docker Compose, shell
 scripts, and the existing backend/frontend/sandbox Dockerfiles.
 
+Published images target both `linux/amd64` and `linux/arm64`. Build provenance
+attestations are retained separately from runnable platform manifests.
+
 ## Unit 1 — Define image metadata and changed-area contract
 
 **Files**

--- a/docs/dev/specs/2026-07-18-docker-image-ci-design.md
+++ b/docs/dev/specs/2026-07-18-docker-image-ci-design.md
@@ -70,6 +70,10 @@ Each build produces at least:
   are lowercased and sanitized to Docker-tag-safe characters;
 - `v<semver>` for a formal release, pointing to the already verified digest.
 
+Published images are multi-platform manifests containing `linux/amd64` and
+`linux/arm64` images. Build provenance attestations may also appear as
+`unknown/unknown` entries; those are metadata, not runnable platforms.
+
 `latest` or `edge` may remain as development convenience tags, but production must
 not depend on them. Production should record and preferably consume image digests. If
 the first Helm/Compose implementation only supports tags, it must use immutable SHA


### PR DESCRIPTION
## Summary

- build backend, frontend, egress-webhook, and sandbox images for `linux/amd64` and `linux/arm64`
- retain provenance attestations while documenting `unknown/unknown` entries
- update release and deployment documentation for multi-platform manifests

## Verification

- YAML parsing passed for all image and release workflows
- shell syntax and image-tag checks passed
- repository pre-push checks passed
