### PR TITLE
edit_file: fuzzy matching + diff preview panel

### DIFF
--- a/backend/cubeplex/middleware/sandbox.py
+++ b/backend/cubeplex/middleware/sandbox.py
@@ -16,7 +16,10 @@ command execution.
 from __future__ import annotations
 
 import asyncio
+import difflib
+import re
 import shlex
+import unicodedata
 from collections import deque
 from collections.abc import Callable
 from typing import Any
@@ -242,6 +245,98 @@ def _make_write_file_tool(sandbox: Sandbox) -> AgentTool[_WriteFileArgs]:
     )
 
 
+_SMART_SINGLE_QUOTES = re.compile(r"[‘’‚‛]")
+_SMART_DOUBLE_QUOTES = re.compile(r"[“”„‟]")
+_UNICODE_DASHES = re.compile(r"[‐‑‒–—―−]")
+_UNICODE_SPACES = re.compile(r"[  -   　]")
+
+
+def _normalize_for_fuzzy(text: str) -> str:
+    """Normalize text for fuzzy matching.
+
+    Applies the same transforms as pi's normalizeForFuzzyMatch: NFKC,
+    trailing whitespace per line, smart quotes/dashes/spaces → ASCII.
+    Only used for match location — replacements are always applied to the
+    original bytes so non-matched content is never altered.
+    """
+    text = unicodedata.normalize("NFKC", text)
+    text = "\n".join(line.rstrip() for line in text.split("\n"))
+    text = _SMART_SINGLE_QUOTES.sub("'", text)
+    text = _SMART_DOUBLE_QUOTES.sub('"', text)
+    text = _UNICODE_DASHES.sub("-", text)
+    text = _UNICODE_SPACES.sub(" ", text)
+    return text
+
+
+def _partial_normalize(text: str) -> str:
+    """Apply all fuzzy normalizations except trailing-whitespace stripping.
+
+    This is character-stable: each original char maps to \u22651 output chars with
+    a predictable position mapping. Used by _fuzzy_replace to build a
+    position map before applying the trailing-whitespace stripping step.
+    """
+    text = unicodedata.normalize("NFKC", text)
+    text = _SMART_SINGLE_QUOTES.sub("'", text)
+    text = _SMART_DOUBLE_QUOTES.sub('"', text)
+    text = _UNICODE_DASHES.sub("-", text)
+    text = _UNICODE_SPACES.sub(" ", text)
+    return text
+
+
+def _fuzzy_replace(current: str, old_string: str, new_string: str) -> str | None:
+    """Find old_string in current via normalization and replace the original span.
+
+    Returns the updated content, or None if old_string is not found exactly
+    once after normalization (caller should already have verified count == 1).
+
+    Two-phase strategy to avoid the trailing-whitespace-stripping complication:
+    1. Apply NFKC + substitutions (character-stable) to get `partial`.
+       Build partial_to_orig: for each position in `partial`, which original index?
+    2. Strip trailing whitespace from `partial` line-by-line (same as _normalize_for_fuzzy).
+       Track which positions in `partial` survive into norm_content.
+    3. Use those maps to convert norm_start/norm_end back to original positions.
+    """
+    norm_content = _normalize_for_fuzzy(current)
+    norm_old = _normalize_for_fuzzy(old_string)
+
+    if norm_content.count(norm_old) != 1:
+        return None
+
+    norm_start = norm_content.index(norm_old)
+    norm_end = norm_start + len(norm_old)
+
+    # Phase 1: character-stable normalization -> partial
+    partial = _partial_normalize(current)
+
+    # Build partial_to_orig: partial[i] came from current[partial_to_orig[i]]
+    partial_to_orig: list[int] = []
+    for orig_idx, ch in enumerate(current):
+        n = _partial_normalize(ch)
+        partial_to_orig.extend([orig_idx] * len(n))
+
+    # Phase 2: strip trailing whitespace from partial line-by-line -> norm_content.
+    # Record which positions in partial survive into norm_content.
+    partial_lines = partial.split("\n")
+    partial_survived: list[int] = []  # partial positions that appear in norm_content
+    p_pos = 0
+    for li, line in enumerate(partial_lines):
+        stripped = line.rstrip()
+        for j in range(len(stripped)):
+            partial_survived.append(p_pos + j)
+        p_pos += len(line)
+        if li < len(partial_lines) - 1:
+            partial_survived.append(p_pos)  # the \n that joins lines
+            p_pos += 1
+
+    if len(partial_survived) != len(norm_content):
+        return None
+
+    orig_start = partial_to_orig[partial_survived[norm_start]]
+    orig_end = partial_to_orig[partial_survived[norm_end - 1]] + 1
+
+    return current[:orig_start] + new_string + current[orig_end:]
+
+
 def _make_edit_file_tool(sandbox: Sandbox) -> AgentTool[_EditFileArgs]:
     """Build the edit_file cubepi.AgentTool backed by a sandbox instance."""
 
@@ -269,12 +364,13 @@ def _make_edit_file_tool(sandbox: Sandbox) -> AgentTool[_EditFileArgs]:
                 content=[TextContent(text=f"Error reading {args.file_path}: {exc}")]
             )
         current = files[0][1].decode()
+
+        # --- exact match ---
         count = current.count(args.old_string)
-        if count == 0:
-            return AgentToolResult(
-                content=[TextContent(text=f"Error: old_string not found in {args.file_path}")]
-            )
-        if count > 1:
+        fuzzy_matched = False
+        if count == 1:
+            updated = current.replace(args.old_string, args.new_string, 1)
+        elif count > 1:
             return AgentToolResult(
                 content=[
                     TextContent(
@@ -285,9 +381,52 @@ def _make_edit_file_tool(sandbox: Sandbox) -> AgentTool[_EditFileArgs]:
                     )
                 ]
             )
-        updated = current.replace(args.old_string, args.new_string, 1)
+        else:
+            # --- fuzzy fallback ---
+            norm_count = _normalize_for_fuzzy(current).count(_normalize_for_fuzzy(args.old_string))
+            if norm_count == 0:
+                return AgentToolResult(
+                    content=[TextContent(text=f"Error: old_string not found in {args.file_path}")]
+                )
+            if norm_count > 1:
+                return AgentToolResult(
+                    content=[
+                        TextContent(
+                            text=(
+                                f"Error: old_string appears {norm_count} times in "
+                                f"{args.file_path}. It must be unique — provide more context."
+                            )
+                        )
+                    ]
+                )
+            result = _fuzzy_replace(current, args.old_string, args.new_string)
+            if result is None:
+                return AgentToolResult(
+                    content=[TextContent(text=f"Error: old_string not found in {args.file_path}")]
+                )
+            updated = result
+            fuzzy_matched = True
+
         await sandbox.upload([(args.file_path, updated.encode())])
-        return AgentToolResult(content=[TextContent(text=f"Successfully edited {args.file_path}")])
+
+        diff_lines = list(
+            difflib.unified_diff(
+                current.splitlines(keepends=True),
+                updated.splitlines(keepends=True),
+                fromfile=f"a/{args.file_path}",
+                tofile=f"b/{args.file_path}",
+                n=4,
+            )
+        )
+        suffix = " (fuzzy match)" if fuzzy_matched else ""
+        return AgentToolResult(
+            content=[TextContent(text=f"Successfully edited {args.file_path}{suffix}")],
+            details={
+                "file_path": args.file_path,
+                "unified_diff": "".join(diff_lines),
+                "fuzzy_matched": fuzzy_matched,
+            },
+        )
 
     return AgentTool(
         name="edit_file",

--- a/backend/cubeplex/middleware/sandbox.py
+++ b/backend/cubeplex/middleware/sandbox.py
@@ -409,10 +409,16 @@ def _make_edit_file_tool(sandbox: Sandbox) -> AgentTool[_EditFileArgs]:
 
         await sandbox.upload([(args.file_path, updated.encode())])
 
+        def _lines_for_diff(text: str) -> list[str]:
+            lines = text.splitlines(keepends=True)
+            if lines and not lines[-1].endswith("\n"):
+                lines[-1] += "\n"
+            return lines
+
         diff_lines = list(
             difflib.unified_diff(
-                current.splitlines(keepends=True),
-                updated.splitlines(keepends=True),
+                _lines_for_diff(current),
+                _lines_for_diff(updated),
                 fromfile=f"a/{args.file_path}",
                 tofile=f"b/{args.file_path}",
                 n=4,

--- a/backend/tests/unit/test_sandbox.py
+++ b/backend/tests/unit/test_sandbox.py
@@ -20,6 +20,7 @@ from cubeplex.middleware.sandbox import (
     _make_execute_tool,
     _make_file_read_tool,
     _make_write_file_tool,
+    _normalize_for_fuzzy,
     _WriteFileArgs,
 )
 from cubeplex.prompts.sandbox import SANDBOX_PROMPT_TEMPLATE
@@ -296,6 +297,132 @@ async def test_edit_file_non_unique_old_string_returns_error() -> None:
 
     tool = _make_edit_file_tool(sandbox)
     args = _EditFileArgs(file_path="/work/f.txt", old_string="dup", new_string="rep")
+    result = await tool.execute("tc-1", args)
+    assert "Error" in _text(result)
+    assert "2 times" in _text(result)
+
+
+@pytest.mark.asyncio
+async def test_edit_file_exact_match_returns_diff_in_details() -> None:
+    sandbox = _make_sandbox()
+    original = "line1\nfoo bar\nline3"
+    sandbox.download = AsyncMock(return_value=[("/work/f.txt", original.encode())])
+    sandbox.upload = AsyncMock()
+
+    tool = _make_edit_file_tool(sandbox)
+    args = _EditFileArgs(file_path="/work/f.txt", old_string="foo bar", new_string="baz qux")
+    result = await tool.execute("tc-1", args)
+
+    assert "Successfully edited" in _text(result)
+    assert result.details is not None
+    assert isinstance(result.details, dict)
+    assert result.details["unified_diff"].startswith("--- a/")
+    assert result.details["fuzzy_matched"] is False
+
+
+# ---------------------------------------------------------------------------
+# _normalize_for_fuzzy
+
+
+def test_normalize_for_fuzzy_smart_single_quotes() -> None:
+    assert _normalize_for_fuzzy("‘hello’") == "'hello'"
+
+
+def test_normalize_for_fuzzy_smart_double_quotes() -> None:
+    assert _normalize_for_fuzzy("“hello”") == '"hello"'
+
+
+def test_normalize_for_fuzzy_en_dash() -> None:
+    assert _normalize_for_fuzzy("a–b") == "a-b"
+
+
+def test_normalize_for_fuzzy_nbsp() -> None:
+    assert _normalize_for_fuzzy("a b") == "a b"
+
+
+def test_normalize_for_fuzzy_strips_trailing_whitespace() -> None:
+    assert _normalize_for_fuzzy("hello   \nworld  ") == "hello\nworld"
+
+
+# ---------------------------------------------------------------------------
+# edit_file fuzzy matching
+
+
+@pytest.mark.asyncio
+async def test_edit_file_fuzzy_smart_quotes() -> None:
+    sandbox = _make_sandbox()
+    # File uses ASCII quotes; LLM sends smart quotes in old_string
+    original = "print('hello')"
+    sandbox.download = AsyncMock(return_value=[("/work/f.py", original.encode())])
+    sandbox.upload = AsyncMock()
+
+    tool = _make_edit_file_tool(sandbox)
+    args = _EditFileArgs(
+        file_path="/work/f.py",
+        old_string="print(‘hello’)",  # smart single quotes
+        new_string="print('world')",
+    )
+    result = await tool.execute("tc-1", args)
+
+    assert "Successfully edited" in _text(result)
+    sandbox.upload.assert_called_once_with([("/work/f.py", b"print('world')")])
+    assert result.details is not None
+    assert isinstance(result.details, dict)
+    assert result.details["fuzzy_matched"] is True
+    assert result.details["unified_diff"].startswith("--- a/")
+
+
+@pytest.mark.asyncio
+async def test_edit_file_fuzzy_nbsp() -> None:
+    sandbox = _make_sandbox()
+    original = "hello world"
+    sandbox.download = AsyncMock(return_value=[("/work/f.txt", original.encode())])
+    sandbox.upload = AsyncMock()
+
+    tool = _make_edit_file_tool(sandbox)
+    args = _EditFileArgs(
+        file_path="/work/f.txt",
+        old_string="hello world",  # NBSP
+        new_string="goodbye world",
+    )
+    result = await tool.execute("tc-1", args)
+
+    assert "Successfully edited" in _text(result)
+    sandbox.upload.assert_called_once_with([("/work/f.txt", b"goodbye world")])
+    assert result.details is not None
+    assert isinstance(result.details, dict)
+    assert result.details["fuzzy_matched"] is True
+
+
+@pytest.mark.asyncio
+async def test_edit_file_fuzzy_no_match_returns_error() -> None:
+    sandbox = _make_sandbox()
+    sandbox.download = AsyncMock(return_value=[("/work/f.txt", b"hello world")])
+
+    tool = _make_edit_file_tool(sandbox)
+    args = _EditFileArgs(
+        file_path="/work/f.txt",
+        old_string="completely absent text",
+        new_string="replacement",
+    )
+    result = await tool.execute("tc-1", args)
+    assert "Error" in _text(result)
+    assert "not found" in _text(result)
+
+
+@pytest.mark.asyncio
+async def test_edit_file_fuzzy_ambiguous_returns_error() -> None:
+    sandbox = _make_sandbox()
+    # Two lines both using smart quotes -> both normalize to same ASCII form -> ambiguous
+    original = "print(‘dup’)\nprint(‘dup’)"
+    sandbox.download = AsyncMock(return_value=[("/work/f.txt", original.encode())])
+
+    tool = _make_edit_file_tool(sandbox)
+    args = _EditFileArgs(
+        file_path="/work/f.txt",
+        old_string="print('dup')",  # ASCII quotes: matches both lines after normalization
+        new_string="print('rep')",
+    )
     result = await tool.execute("tc-1", args)
     assert "Error" in _text(result)
     assert "2 times" in _text(result)

--- a/docs/dev/plans/2026-07-19-edit-file-fuzzy-diff.md
+++ b/docs/dev/plans/2026-07-19-edit-file-fuzzy-diff.md
@@ -1,0 +1,252 @@
+# edit_file: fuzzy matching + diff preview — implementation plan
+
+**Goal**: Increase `edit_file` success rate via fuzzy normalization and show a
+colored diff with line numbers in the right panel after every successful edit.
+
+**Architecture**: Backend acquires the diff (has the file; knows line numbers);
+passes it to the frontend in `AgentToolResult.details → SSE details field`.
+Frontend adds a new panel type `edit_file` with a diff renderer. No external
+diff library needed on either side.
+
+**Tech stack**: Python `difflib` (stdlib) for unified diff; React + Tailwind
+for `DiffViewer`; no new npm packages.
+
+---
+
+## Unit 1: Backend — fuzzy normalization helper
+
+**Files**: `backend/cubeplex/middleware/sandbox.py`
+
+**What changes**: Add `_normalize_for_fuzzy(text: str) -> str` as a
+module-level pure function above `_make_edit_file_tool`. It applies:
+NFKC → strip trailing whitespace per line → smart quotes → smart dashes →
+Unicode spaces. No imports needed beyond stdlib `unicodedata` (already
+available; NFKC via `str.encode`/`str.normalize` is in Python `unicodedata`
+— actually just call `unicodedata.normalize("NFKC", text)` then the regex
+replacements).
+
+**Interface**:
+```python
+def _normalize_for_fuzzy(text: str) -> str: ...
+```
+
+**Core logic**:
+```
+unicodedata.normalize("NFKC", text)
+→ split on "\n", strip each line trailing, rejoin
+→ re.sub smart single quotes → '
+→ re.sub smart double quotes → "
+→ re.sub unicode dashes → -
+→ re.sub unicode spaces → (space)
+```
+
+**Tests** (`backend/tests/unit/test_sandbox_fuzzy.py`, new):
+- `_normalize_for_fuzzy` with smart quotes round-trips to ASCII
+- with en-dash → hyphen
+- with NBSP → space
+- with mixed content: preserves actual text, only changes variant chars
+
+---
+
+## Unit 2: Backend — fuzzy match in `_edit_file`
+
+**Files**: `backend/cubeplex/middleware/sandbox.py`
+
+**What changes**: Extend `_edit_file` function body. After the existing
+`count == 0` path, try the fuzzy path: normalize both `current` and
+`args.old_string`; find unique occurrence in normalized content; map byte
+offset back to original content; replace original slice.
+
+**Interface** (internal, no API change):
+Fuzzy path returns the same `AgentToolResult` shape as exact match.
+Success message gains suffix `" (fuzzy match)"` when fuzzy was used.
+
+**Core logic**:
+```
+norm_content = _normalize_for_fuzzy(current)
+norm_old = _normalize_for_fuzzy(args.old_string)
+norm_count = norm_content.count(norm_old)
+if norm_count == 0:
+    return error "old_string not found..."
+if norm_count > 1:
+    return error "old_string appears N times..."
+# find start position in normalized content
+norm_start = norm_content.index(norm_old)
+# walk original content char-by-char, counting normalized chars to find
+# the matching span — simplest correct approach: build a char-level
+# mapping from normalized positions back to original positions
+# (normalize char-by-char, track cumulative offsets)
+# replace original[orig_start:orig_end] with args.new_string
+# fuzzy_matched = True
+```
+
+The char-level offset mapping: build `norm_to_orig: list[int]` where
+`norm_to_orig[i]` = index in `current` corresponding to `norm_content[i]`.
+Then `orig_start = norm_to_orig[norm_start]`,
+`orig_end = norm_to_orig[norm_start + len(norm_old)]`.
+
+**Tests** (extend `test_sandbox_fuzzy.py`):
+- `_edit_file` mock: smart-quote `old_string` matches file with ASCII quotes
+- `_edit_file` mock: NBSP in `old_string` matches file with regular space
+- no match after normalization: returns error
+- >1 match after normalization: returns error
+- exact match still works (no regression)
+
+---
+
+## Unit 3: Backend — diff in `AgentToolResult.details`
+
+**Files**: `backend/cubeplex/middleware/sandbox.py`
+
+**What changes**: After `updated = current.replace(...)` (or fuzzy replace),
+compute unified diff and attach to `details`.
+
+**Interface**:
+```python
+AgentToolResult(
+    content=[TextContent(text="Successfully edited /path/to/file")],
+    details={
+        "file_path": args.file_path,
+        "unified_diff": "".join(diff_lines),   # str
+        "fuzzy_matched": fuzzy_matched,          # bool
+    },
+)
+```
+
+`difflib.unified_diff` with `n=4` context lines.
+
+**Core logic**:
+```python
+import difflib
+diff_lines = list(difflib.unified_diff(
+    current.splitlines(keepends=True),
+    updated.splitlines(keepends=True),
+    fromfile=f"a/{args.file_path}",
+    tofile=f"b/{args.file_path}",
+    n=4,
+))
+```
+
+**Tests** (unit, add to `test_sandbox_fuzzy.py`):
+- successful edit: `details["unified_diff"]` is non-empty string starting with
+  `--- a/`
+- successful edit: `details["fuzzy_matched"]` is `False` for exact, `True`
+  for fuzzy
+- error cases: no `details` (or `details` is not set) when returning errors
+
+---
+
+## Unit 4: Frontend — types and routing
+
+**Files**:
+- `frontend/packages/core/src/types/events.ts`
+- `frontend/packages/core/src/stores/panelStore.ts`
+
+**What changes**:
+
+`events.ts`: add `'edit_file'` to `PanelContentType` union.
+
+`panelStore.ts`: in `mapContentType`, add before the fallthrough:
+```typescript
+if (bare === 'edit_file') return 'edit_file'
+```
+
+**Interface**: no new types; `edit_file` panel receives same `PanelView`
+shape as other tool panels. The `details` field is already `unknown` on
+`ToolResultMessage`; `EditFilePreviewView` will narrow it locally.
+
+**Tests**: none needed for a 2-line routing change; covered by the E2E below.
+
+---
+
+## Unit 5: Frontend — `DiffViewer` component
+
+**Files**: `frontend/packages/web/components/panel/DiffViewer.tsx` (new)
+
+**Interface**:
+```typescript
+interface DiffViewerProps {
+  diff: string   // unified diff string from backend
+}
+export function DiffViewer({ diff }: DiffViewerProps)
+```
+
+**Core logic**:
+Parse unified diff line-by-line:
+- Lines starting with `---` / `+++`: file header (skip or render as header)
+- Lines starting with `@@`: hunk header — render as gray separator
+- Lines starting with `-`: removed line (red)
+- Lines starting with `+`: added line (green)
+- Other: context line (neutral)
+
+Line numbers: parse `@@` hunk header (`@@ -a,b +c,d @@`) to get `oldStart`
+and `newStart`. Increment `oldLine` for `-` and context; `newLine` for `+`
+and context. Render two gutter columns.
+
+Styling:
+- Container: `font-mono text-xs overflow-x-auto` (horizontal scroll, no wrap)
+- Gutter: two `w-10 text-right pr-2 text-muted-foreground select-none` spans
+- Removed: `bg-red-50 dark:bg-red-950 text-red-700 dark:text-red-300`
+- Added: `bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300`
+- Context: no background
+- Hunk header: `text-muted-foreground bg-muted`
+
+No external dependency.
+
+**Tests**: none (pure presentational; covered by E2E visual check).
+
+---
+
+## Unit 6: Frontend — `EditFilePreviewView` component
+
+**Files**:
+- `frontend/packages/web/components/panel/EditFilePreviewView.tsx` (new)
+- `frontend/packages/web/components/panel/ToolDetailPanel.tsx`
+
+**Interface** (what `ToolDetailPanel` passes in):
+```typescript
+interface EditFilePreviewViewProps {
+  toolArgs: Record<string, unknown>    // { file_path, old_string, new_string }
+  toolResult: { content: string; details?: unknown } | null
+}
+```
+
+**Core logic**:
+
+1. Extract `file_path` from `toolArgs`.
+2. Narrow `toolResult?.details` — if it has `unified_diff: string`, render
+   `<DiffViewer diff={unified_diff} />`.
+3. If no `unified_diff` (pending / error): show
+   `old_string` → `new_string` plaintext block as fallback (keeps the panel
+   useful even before the tool completes).
+4. If `details.fuzzy_matched === true`: render a small `Badge` chip
+   `"fuzzy matched"` beside the file path.
+
+**`ToolDetailPanel.tsx`** change: add case
+```typescript
+case 'edit_file':
+  return <EditFilePreviewView toolArgs={...} toolResult={...} />
+```
+
+**Tests** (E2E, `tests/e2e/test_edit_file_panel.py`):
+- Run an agent that calls `edit_file` on a known file
+- Assert SSE `tool_result` event has `details.unified_diff` starting with `---`
+- Assert SSE `details.fuzzy_matched` is boolean
+
+(UI panel rendering is verified manually / Playwright in the verify step.)
+
+---
+
+## Sequence
+
+1. Unit 1 + tests → green
+2. Unit 2 + tests → green
+3. Unit 3 + tests → green
+4. Commit backend: `feat(sandbox): fuzzy matching and diff details for edit_file`
+5. Unit 4 (2-line type + routing change)
+6. Unit 5 (`DiffViewer`)
+7. Unit 6 (`EditFilePreviewView` + `ToolDetailPanel` wire-up)
+8. E2E test (Unit 6 tests)
+9. Commit frontend: `feat(panel): edit_file diff viewer`
+10. Verify in browser: run agent, call `edit_file`, confirm diff appears in panel
+11. Push PR

--- a/docs/dev/specs/2026-07-19-edit-file-fuzzy-diff-design.md
+++ b/docs/dev/specs/2026-07-19-edit-file-fuzzy-diff-design.md
@@ -1,0 +1,173 @@
+# edit_file: fuzzy matching + diff preview
+
+## Goal
+
+Increase `edit_file` tool success rate by tolerating common Unicode and
+whitespace variations in `old_string`, and display a colored, line-numbered
+diff of the edit in the right-side preview panel.
+
+## Context
+
+The current `_make_edit_file_tool` in
+`backend/cubeplex/middleware/sandbox.py` does an exact `str.count` /
+`str.replace` on the raw file bytes. This fails whenever the LLM's
+`old_string` diverges from the file due to:
+
+- Smart quotes / em-dashes / en-dashes (copy from a rendered doc)
+- Non-breaking spaces or other Unicode space variants
+- Trailing whitespace differences (line ending normalization)
+
+When an `edit_file` call fails, the agent must retry with adjusted text,
+burning tokens and time. A fuzzy-match fallback (exact → normalized) raises
+the first-try success rate without changing semantics for clean matches.
+
+The current frontend renders `edit_file` via `GenericToolView` (shows raw
+Request/Response JSON). Users cannot see what changed without inspecting
+`old_string` / `new_string` themselves.
+
+## Approaches considered
+
+**A. Pure backend fuzzy match, return plain text result** — minimal change,
+improves reliability but no UX improvement.
+
+**B. Frontend diff from args** — compute diff client-side from `old_string` /
+`new_string`. Avoids backend change but loses line numbers (we don't know
+where in the file the edit landed) and requires shipping a diff library to
+the frontend.
+
+**C. Backend fuzzy match + structured diff in `details`** — backend computes
+the unified diff (it has the full file and knows the line numbers), returns it
+in `AgentToolResult.details`. Frontend renders it. **Chosen** — correct line
+numbers, no extra frontend dependency, consistent with how citations use
+`details`.
+
+## Design
+
+### Backend: fuzzy matching (`sandbox.py`)
+
+Add `_normalize_for_fuzzy(text: str) -> str` that applies the same
+normalizations as pi's `normalizeForFuzzyMatch`:
+
+1. Unicode NFKC normalization
+2. Strip trailing whitespace from each line
+3. Smart single quotes (`‘’‚‛`) → `'`
+4. Smart double quotes (`“”„‟`) → `"`
+5. Unicode dashes (`‐`–`―`, `−`) → `-`
+6. Unicode spaces (` `, ` `–` `, ` `, ` `, `　`) → ` `
+
+Matching strategy in `_edit_file`:
+
+1. **Exact match** (current `str.count`). If count == 1: apply.
+2. **Fuzzy match**: normalize both `current` and `args.old_string`, find
+   position of normalized `old_string` in normalized content. Map back to a
+   byte offset in the original `current`, extract the original slice of the
+   same length as `old_string`, verify it normalizes to the same thing.
+   If unambiguous (exactly one occurrence after normalization): replace that
+   original slice.
+3. **Fail** with existing error messages (0 or >1 occurrences after fuzzy).
+
+When fuzzy match is used, append a note to the success message:
+`"(fuzzy-matched: whitespace or quote normalization was applied)"`.
+
+### Backend: diff in `details`
+
+After a successful edit, compute:
+
+```python
+import difflib
+diff_lines = list(difflib.unified_diff(
+    current.splitlines(keepends=True),
+    updated.splitlines(keepends=True),
+    fromfile=f"a/{args.file_path}",
+    tofile=f"b/{args.file_path}",
+    n=4,
+))
+```
+
+Return in `AgentToolResult`:
+
+```python
+AgentToolResult(
+    content=[TextContent(text=f"Successfully edited {args.file_path}")],
+    details={
+        "file_path": args.file_path,
+        "unified_diff": "".join(diff_lines),
+        "fuzzy_matched": <bool>,
+    },
+)
+```
+
+`AgentToolResult.details` is already forwarded to the frontend via the
+`details` key in the SSE `tool_result` event (see `stream.py` line 499).
+
+### Frontend: new panel type
+
+**`frontend/packages/core/src/types/events.ts`**
+
+Add `'edit_file'` to `PanelContentType`.
+
+**`frontend/packages/core/src/stores/panelStore.ts`**
+
+In `mapContentType`: add `if (bare === 'edit_file') return 'edit_file'`
+before the fallthrough.
+
+**`frontend/packages/core/src/types/message.ts`** (or wherever
+`ToolResultMessage` is defined)
+
+The `details` field already exists on `ToolResultMessage` as `unknown`. No
+change needed — the `EditFilePreviewView` reads it via a type-narrowed
+accessor.
+
+**`frontend/packages/web/components/panel/EditFilePreviewView.tsx`** (new)
+
+Receives `toolArgs` (has `file_path`, `old_string`, `new_string`) and
+`toolResult` (has `content: string`, `details: unknown`).
+
+Rendering:
+- Header: file path (same style as `WriteFilePreviewView`)
+- If `details.unified_diff` exists: render it with `<DiffViewer>`
+- Else (tool is still pending / details missing): show a skeleton or
+  `old_string` → `new_string` plaintext fallback
+- Fuzzy match badge: if `details.fuzzy_matched === true`, show a small
+  inline chip `"fuzzy matched"` next to the filename
+
+**`frontend/packages/web/components/panel/DiffViewer.tsx`** (new)
+
+Parses a unified diff string and renders:
+- Each hunk with a `@@` separator line (gray, dimmed)
+- Removed lines (`-`) in red (`bg-red-50 dark:bg-red-950`, text `text-red-700`)
+- Added lines (`+`) in green (`bg-green-50 dark:bg-green-950`, text `text-green-700`)
+- Context lines in neutral (no background)
+- Left gutter: two columns — old line number and new line number, both
+  right-aligned, monospace, `text-muted-foreground`. Removed lines show only
+  old number; added lines show only new number; context lines show both.
+- Monospace font, no word wrap (horizontal scroll on overflow)
+
+The component accepts `{ diff: string }` and parses the unified diff
+in-component (no external library — unified diff is a simple line-by-line
+format).
+
+**`frontend/packages/web/components/panel/ToolDetailPanel.tsx`**
+
+Add a case for `edit_file` that renders `<EditFilePreviewView>`.
+
+## Out of scope
+
+- Multi-edit (array of edits) in one `edit_file` call — keep single
+  old_string/new_string for now
+- CRLF / BOM handling — sandbox files are uploaded as UTF-8; CRLF edge cases
+  are uncommon and can be addressed in a follow-up
+- Word-level intra-line highlighting — line-level diff is sufficient for MVP
+
+## Success criteria
+
+1. `edit_file` succeeds on a file containing smart quotes when `old_string`
+   uses ASCII quotes (currently fails, must succeed after fuzzy match).
+2. `edit_file` still fails with the existing error message when `old_string`
+   is genuinely absent from the file after normalization.
+3. After a successful `edit_file`, clicking "View in Panel" shows a diff with
+   line numbers and red/green line highlighting.
+4. `edit_file` called with an already-exact match still succeeds and shows
+   the same diff view (not fuzzy badge).
+5. Unit tests cover: exact match, fuzzy match (smart quotes, Unicode space),
+   no-match error, >1-match error, diff generation.

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -816,6 +816,7 @@ function buildTurnMessages(
       timestamp: receivedAtMs / 1000,
       run_id: runId,
       metadata: {},
+      details: mapEntry?.details,
     })
   }
 
@@ -1369,6 +1370,21 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
         const nextError =
           seedError ?? (!hasPersistedAssistant && currentError !== null ? currentError : null)
 
+        // Restore toolResultMap entries that have details from history, so
+        // tool preview panels (e.g. edit_file diff) remain interactive on reload.
+        const restoredToolResultMap: MessageStore['toolResultMap'] = {}
+        for (const msg of messages) {
+          if (msg.role !== 'tool_result' || !msg.tool_call_id || !msg.details) continue
+          restoredToolResultMap[msg.tool_call_id] = {
+            content: msg.content
+              .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
+              .map((b) => b.text)
+              .join(''),
+            receivedAt: (msg.timestamp ?? 0) * 1000,
+            details: msg.details,
+          }
+        }
+
         set((s) => ({
           messages: { ...s.messages, [conversationId]: messages },
           oldestSeqByConv: { ...s.oldestSeqByConv, [conversationId]: bootstrap.oldest_seq },
@@ -1382,7 +1398,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
           streamAgents: nextStreamAgents,
           pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
           toolStartedMap: {},
-          toolResultMap: {},
+          toolResultMap: restoredToolResultMap,
           // When `skipSeed` fired (we just answered/cancelled this exact
           // question), preserve the current pendingAsk / pendingConfirmMap
           // instead of clearing them. The form stays mounted in its

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -1370,11 +1370,11 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
         const nextError =
           seedError ?? (!hasPersistedAssistant && currentError !== null ? currentError : null)
 
-        // Restore toolResultMap entries that have details from history, so
-        // tool preview panels (e.g. edit_file diff) remain interactive on reload.
+        // Restore toolResultMap from history so tool preview panels remain
+        // interactive on reload (e.g. edit_file diff, write_file completed state).
         const restoredToolResultMap: MessageStore['toolResultMap'] = {}
         for (const msg of messages) {
-          if (msg.role !== 'tool_result' || !msg.tool_call_id || !msg.details) continue
+          if (msg.role !== 'tool_result' || !msg.tool_call_id) continue
           restoredToolResultMap[msg.tool_call_id] = {
             content: msg.content
               .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -110,7 +110,13 @@ export interface MessageStore {
   toolStartedMap: Record<string, number>
   toolResultMap: Record<
     string,
-    { content: string; receivedAt: number; startedAt?: number; contentType?: string }
+    {
+      content: string
+      receivedAt: number
+      startedAt?: number
+      contentType?: string
+      details?: unknown
+    }
   >
   turnUsage: Record<string, import('../types').TurnUsage | null>
   sessionUsage: Record<string, import('../types').SessionUsage | null>
@@ -598,6 +604,7 @@ function applyStreamEvent(state: MessageStore, event: AgentEvent): Partial<Messa
           state.toolStartedMap[tcId] ??
           (e.data.started_at ? timestampToMs(e.data.started_at) : undefined),
         contentType: e.data.content_type,
+        details: e.data.details,
       }
     }
 

--- a/frontend/packages/core/src/stores/panelStore.ts
+++ b/frontend/packages/core/src/stores/panelStore.ts
@@ -9,6 +9,7 @@ function mapContentType(toolName: string, backendContentType?: string): PanelCon
   if (bare === 'load_skill') return 'skill'
   if (bare === 'execute') return 'terminal'
   if (bare === 'write_file') return 'write_file'
+  if (bare === 'edit_file') return 'edit_file'
   if (bare === 'code_execute' || bare === 'python') return 'code_execute'
   if (bare === 'file_read') return 'file_read'
   if (backendContentType === 'file_read') return 'file_read'

--- a/frontend/packages/core/src/types/events.ts
+++ b/frontend/packages/core/src/types/events.ts
@@ -43,6 +43,7 @@ export type PanelContentType =
   | 'web_fetch'
   | 'terminal'
   | 'write_file'
+  | 'edit_file'
   | 'generic'
   | 'artifact'
   | 'skill'
@@ -158,6 +159,7 @@ export interface ToolResultEvent extends AgentEvent {
     content: string
     started_at?: string
     content_type?: string
+    details?: unknown
   }
 }
 

--- a/frontend/packages/web/components/chat/ToolCallGroup.tsx
+++ b/frontend/packages/web/components/chat/ToolCallGroup.tsx
@@ -59,9 +59,11 @@ export function ToolCallGroup({
         name={block.name}
         arguments={block.arguments}
         toolCallId={block.id}
-        contentTypeOverride={block.name === 'write_file' ? 'write_file' : undefined}
+        contentTypeOverride={
+          block.name === 'write_file' || block.name === 'edit_file' ? block.name : undefined
+        }
         toolRef={
-          block.name === 'write_file'
+          block.name === 'write_file' || block.name === 'edit_file'
             ? ({
                 agent_id: agentId ?? null,
                 tool_call_id: block.id,
@@ -72,7 +74,7 @@ export function ToolCallGroup({
         toolResult={result}
         timestamp={messageCreatedAt}
         isPending={isPending}
-        allowOpenWhenPending={block.name === 'write_file'}
+        allowOpenWhenPending={block.name === 'write_file' || block.name === 'edit_file'}
         showDivider={i > 0}
         pendingConfirm={pendingConfirmMap?.[block.id] ?? null}
         onSandboxConfirm={onSandboxConfirm ? (d) => onSandboxConfirm(block.id, d) : undefined}

--- a/frontend/packages/web/components/panel/DiffViewer.tsx
+++ b/frontend/packages/web/components/panel/DiffViewer.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+interface DiffViewerProps {
+  diff: string
+}
+
+interface HunkLine {
+  type: 'header' | 'removed' | 'added' | 'context' | 'file-header'
+  content: string
+  oldLine: number | null
+  newLine: number | null
+}
+
+function parseUnifiedDiff(diff: string): HunkLine[] {
+  const lines = diff.split('\n')
+  const result: HunkLine[] = []
+  let oldLine = 0
+  let newLine = 0
+
+  for (const raw of lines) {
+    if (raw === '') continue
+
+    if (raw.startsWith('--- ') || raw.startsWith('+++ ')) {
+      result.push({ type: 'file-header', content: raw, oldLine: null, newLine: null })
+      continue
+    }
+
+    if (raw.startsWith('@@ ')) {
+      // Parse @@ -a,b +c,d @@
+      const m = raw.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+      if (m) {
+        oldLine = parseInt(m[1], 10)
+        newLine = parseInt(m[2], 10)
+      }
+      result.push({ type: 'header', content: raw, oldLine: null, newLine: null })
+      continue
+    }
+
+    if (raw.startsWith('-')) {
+      result.push({ type: 'removed', content: raw.slice(1), oldLine: oldLine++, newLine: null })
+    } else if (raw.startsWith('+')) {
+      result.push({ type: 'added', content: raw.slice(1), oldLine: null, newLine: newLine++ })
+    } else {
+      const ctx = raw.startsWith(' ') ? raw.slice(1) : raw
+      result.push({ type: 'context', content: ctx, oldLine: oldLine++, newLine: newLine++ })
+    }
+  }
+
+  return result
+}
+
+export function DiffViewer({ diff }: DiffViewerProps) {
+  const lines = parseUnifiedDiff(diff)
+
+  return (
+    <div className="font-mono text-xs overflow-x-auto">
+      <table className="w-full border-collapse">
+        <tbody>
+          {lines.map((line, i) => {
+            if (line.type === 'file-header') return null
+
+            if (line.type === 'header') {
+              return (
+                <tr key={i} className="bg-muted">
+                  <td className="w-10 text-right pr-2 text-muted-foreground select-none py-0.5 pl-2" />
+                  <td className="w-10 text-right pr-2 text-muted-foreground select-none py-0.5" />
+                  <td className="px-3 py-0.5 text-muted-foreground whitespace-pre">
+                    {line.content}
+                  </td>
+                </tr>
+              )
+            }
+
+            const rowClass =
+              line.type === 'removed'
+                ? 'bg-destructive/8'
+                : line.type === 'added'
+                  ? 'bg-success-surface/60'
+                  : ''
+
+            const textClass =
+              line.type === 'removed'
+                ? 'text-destructive'
+                : line.type === 'added'
+                  ? 'text-success-fg'
+                  : ''
+
+            const marker = line.type === 'removed' ? '-' : line.type === 'added' ? '+' : ' '
+
+            return (
+              <tr key={i} className={rowClass}>
+                <td className="w-10 text-right pr-2 text-muted-foreground select-none py-0.5 pl-2 min-w-[2.5rem]">
+                  {line.oldLine ?? ''}
+                </td>
+                <td className="w-10 text-right pr-2 text-muted-foreground select-none py-0.5 min-w-[2.5rem]">
+                  {line.newLine ?? ''}
+                </td>
+                <td className={`px-3 py-0.5 whitespace-pre ${textClass}`}>
+                  <span className="select-none mr-1">{marker}</span>
+                  {line.content}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/packages/web/components/panel/EditFilePreviewView.tsx
+++ b/frontend/packages/web/components/panel/EditFilePreviewView.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import type { ToolCallRef } from '@cubeplex/core'
+import { useMessageStore } from '@cubeplex/core'
+import { DiffViewer } from './DiffViewer'
+
+interface EditFilePreviewViewProps {
+  args: Record<string, unknown>
+  result: string | null
+  toolRef: ToolCallRef | null
+}
+
+interface EditFileDetails {
+  file_path?: string
+  unified_diff?: string
+  fuzzy_matched?: boolean
+}
+
+function isEditFileDetails(v: unknown): v is EditFileDetails {
+  return typeof v === 'object' && v !== null
+}
+
+export function EditFilePreviewView({ args, result, toolRef }: EditFilePreviewViewProps) {
+  const toolCallId = toolRef?.tool_call_id ?? null
+  const details = useMessageStore((s) =>
+    toolCallId ? s.toolResultMap[toolCallId]?.details : undefined,
+  )
+
+  const filePath = typeof args.file_path === 'string' ? args.file_path : (result ?? 'Unknown file')
+
+  const editDetails = isEditFileDetails(details) ? details : null
+  const unifiedDiff = editDetails?.unified_diff
+  const fuzzyMatched = editDetails?.fuzzy_matched === true
+
+  // Fallback: show old_string → new_string plaintext if diff isn't available yet
+  const oldString = typeof args.old_string === 'string' ? args.old_string : null
+  const newString = typeof args.new_string === 'string' ? args.new_string : null
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="px-4 py-3 border-b border-border bg-card flex items-center gap-2">
+        <div className="text-sm font-medium text-foreground truncate flex-1">{filePath}</div>
+        {fuzzyMatched && (
+          <span className="shrink-0 text-xs px-1.5 py-0.5 rounded bg-warning-surface text-warning-fg font-medium">
+            fuzzy match
+          </span>
+        )}
+      </div>
+
+      {unifiedDiff ? (
+        <DiffViewer diff={unifiedDiff} />
+      ) : result ? (
+        // Tool completed but no diff — shouldn't happen, show fallback
+        <div className="p-4 text-sm text-muted-foreground">{result}</div>
+      ) : (
+        // Tool still pending: show old_string → new_string plaintext
+        <div className="p-4 space-y-3">
+          {oldString !== null && (
+            <div>
+              <div className="text-xs font-medium text-muted-foreground mb-1">Old</div>
+              <pre className="text-xs bg-destructive/8 text-destructive p-3 rounded overflow-x-auto whitespace-pre">
+                {oldString}
+              </pre>
+            </div>
+          )}
+          {newString !== null && (
+            <div>
+              <div className="text-xs font-medium text-muted-foreground mb-1">New</div>
+              <pre className="text-xs bg-success-surface/60 text-success-fg p-3 rounded overflow-x-auto whitespace-pre">
+                {newString}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/packages/web/components/panel/ToolDetailPanel.tsx
+++ b/frontend/packages/web/components/panel/ToolDetailPanel.tsx
@@ -9,6 +9,7 @@ import { WebFetchView } from './WebFetchView'
 import { GenericToolView } from './GenericToolView'
 import { SkillView } from './SkillView'
 import { WriteFilePreviewView } from './WriteFilePreviewView'
+import { EditFilePreviewView } from './EditFilePreviewView'
 import { FileReadView } from './FileReadView'
 
 export function ToolDetailPanel() {
@@ -47,6 +48,9 @@ export function ToolDetailPanel() {
         {contentType === 'skill' && <SkillView args={toolArgs} result={toolResult} />}
         {contentType === 'write_file' && (
           <WriteFilePreviewView args={toolArgs} result={toolResult} toolRef={toolRef} />
+        )}
+        {contentType === 'edit_file' && (
+          <EditFilePreviewView args={toolArgs} result={toolResult} toolRef={toolRef} />
         )}
         {contentType === 'file_read' && (
           <FileReadView

--- a/frontend/packages/web/components/panel/WriteFilePreviewView.tsx
+++ b/frontend/packages/web/components/panel/WriteFilePreviewView.tsx
@@ -8,6 +8,10 @@ import { MarkdownWithCitations } from '@/components/shared/MarkdownWithCitations
 import { parseWriteFileArgs, resolveLiveWriteFile } from '@/lib/writeFilePreview'
 import { useSandboxMarkdownContext } from '@/hooks/useSandboxMarkdownContext'
 
+// Stable empty fallback — avoids returning a new [] literal from the Zustand
+// selector on every call, which would cause an infinite render loop.
+const EMPTY_BLOCKS: never[] = []
+
 interface WriteFilePreviewViewProps {
   args: Record<string, unknown>
   result: string | null
@@ -193,7 +197,7 @@ export function WriteFilePreviewView({ args, result, toolRef }: WriteFilePreview
   const prevStreamingRef = useRef(false)
   const liveBlocks = useMessageStore((s) => {
     const agentId = toolRef?.agent_id
-    return agentId ? (s.streamAgents[agentId]?.blocks ?? []) : []
+    return agentId ? (s.streamAgents[agentId]?.blocks ?? EMPTY_BLOCKS) : EMPTY_BLOCKS
   })
 
   const parsed = useMemo(() => {


### PR DESCRIPTION
## Summary

- **Spec**: `docs/dev/specs/2026-07-19-edit-file-fuzzy-diff-design.md`
- **Plan**: `docs/dev/plans/2026-07-19-edit-file-fuzzy-diff.md`

Design for two improvements to the `edit_file` sandbox tool:

1. **Fuzzy matching** — tolerate common Unicode/whitespace variants in `old_string` (smart quotes, em-dashes, NBSP, trailing whitespace) using a normalize-then-match fallback, so the tool succeeds on first try instead of requiring agent retries.

2. **Diff preview in panel** — backend computes a unified diff after each successful edit and returns it in `AgentToolResult.details`; frontend adds a new `edit_file` panel type with a colored, line-numbered diff viewer.

No code yet — just the spec and plan for review before implementation.