### PR TITLE
fix(ci): build and push container images only on release tag or manual trigger

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -15,20 +15,19 @@ the exact version, image, tag, and deployment contracts.
 2. Prepare a release PR that bumps the application package/chart versions and,
    only when sandbox contents change, `deploy/images/sandbox/VERSION`.
 3. Run the version-consistency check and the repository CI-equivalent checks.
-4. Merge the release PR into `main`; wait for the main image workflow to publish
-   commit-tagged images.
+4. Merge the release PR into `main`.
 5. Create `v<semver>` on that exact merged commit and push the tag.
-6. Let the release workflow verify versions, wait for the commit images, promote
-   the same manifests to release tags, and attach the release manifest.
+6. The tag push triggers two concurrent workflows: `images.yml` builds and pushes
+   version-tagged images; `release.yml` verifies versions, waits for those images,
+   writes the release manifest, and creates the GitHub Release.
 7. Deploy using the manifest's release tags or digests. Do not edit chart defaults
    or use `latest` for production.
 
 ## Guardrails
 
-- Never rebuild different image content during tag promotion.
 - Never overwrite an existing application or sandbox version tag.
 - Do not run sandbox runtime compatibility tests from the image release workflow;
   existing sandbox E2E/nightly workflows remain separate.
 - Keep registry credentials and runtime secrets out of release manifests.
-- If the main image workflow failed or the expected commit image does not appear,
-  stop and fix the build; do not create a replacement image under the same tag.
+- If the image build fails, fix the build; do not manually push a replacement image
+  under the same tag.

--- a/.agents/skills/release/references/release-workflow.md
+++ b/.agents/skills/release/references/release-workflow.md
@@ -43,11 +43,15 @@ release manifest and operator environment.
 
 ## Image publication order
 
-The `main` image workflow builds affected application images and publishes:
+Application images are built and pushed only on a release tag push or a manual
+`workflow_dispatch`. There are no per-PR or per-merge image builds.
+
+When a `v<semver>` tag is pushed, `images.yml` publishes:
 
 ```text
-ghcr.io/cubeplexai/cubeplex-backend:<YYMMDD>-main-<short-sha>
-ghcr.io/cubeplexai/cubeplex-frontend:<YYMMDD>-main-<short-sha>
+ghcr.io/cubeplexai/cubeplex-backend:v<semver>
+ghcr.io/cubeplexai/cubeplex-frontend:v<semver>
+ghcr.io/cubeplexai/cubeplex-egress-webhook:v<semver>
 ```
 
 The sandbox workflow publishes:
@@ -58,11 +62,10 @@ ghcr.io/cubeplexai/cubeplex-sandbox:sandbox-v<version>
 ```
 
 The sandbox workflow rejects an already existing `sandbox-v<version>` tag.
-PR workflows build without pushing production tags.
 
 ## Create the application release
 
-After the version-bump commit is merged and the main image workflow succeeds:
+After the version-bump commit is merged:
 
 ```bash
 git fetch origin main --tags
@@ -72,19 +75,24 @@ git tag -a v0.3.0 -m "Release v0.3.0" HEAD
 git push origin v0.3.0
 ```
 
-The tag must point to the same commit whose `<YYMMDD>-main-<short-sha>` images were built.
-The release workflow accepts a tag immediately after merge and waits for the
-commit images for a bounded period. If they never appear, it fails instead of
-rebuilding.
+Pushing the tag triggers `images.yml` (builds and pushes version-tagged images)
+and `release.yml` (waits for those images, then creates the manifest and GitHub
+Release) concurrently. The image build takes up to ~30 minutes; the release
+workflow polls until the images appear or times out.
 
 ## Release workflow behavior
 
-For `v0.3.0`, the workflow:
+For `v0.3.0`, the two triggered workflows do:
 
+**`images.yml`** (triggered by the tag push):
+1. builds backend, frontend, and egress-webhook images for `linux/amd64` and `linux/arm64`;
+2. pushes them to GHCR with the `v0.3.0` tag.
+
+**`release.yml`** (triggered by the same tag push, runs concurrently):
 1. checks that all package/chart versions equal `0.3.0`;
 2. reads the sandbox version from `deploy/images/sandbox/VERSION`;
-3. computes the date/branch/short-SHA tag from the release commit and waits for backend/frontend images;
-4. adds `v0.3.0` to the same backend/frontend image manifests;
+3. polls for `ghcr.io/.../cubeplex-backend:v0.3.0` and `cubeplex-frontend:v0.3.0` (up to ~30 min);
+4. records their digests in the manifest;
 5. waits for the corresponding `sandbox-v<version>` image;
 6. creates `release-manifest-v0.3.0.yaml` and uploads it to the GitHub Release.
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,30 +1,15 @@
 name: Container images
 
 on:
-  pull_request:
-    paths:
-      - "backend/**"
-      - "frontend/**"
-      - "deploy/images/backend/**"
-      - "deploy/images/frontend/**"
-      - "deploy/kubernetes/egress-bundle/**"
-      - "deploy/kubernetes/scripts/build-and-push.sh"
-      - "scripts/image-tag.sh"
-      - "Makefile"
-      - ".github/workflows/images.yml"
   push:
-    branches: [main]
-    paths:
-      - "backend/**"
-      - "frontend/**"
-      - "deploy/images/backend/**"
-      - "deploy/images/frontend/**"
-      - "deploy/kubernetes/egress-bundle/**"
-      - "deploy/kubernetes/scripts/build-and-push.sh"
-      - "scripts/image-tag.sh"
-      - "Makefile"
-      - ".github/workflows/images.yml"
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Push images to registry
+        type: boolean
+        default: false
 
 concurrency:
   group: images-${{ github.ref }}
@@ -53,54 +38,26 @@ jobs:
         id: detect
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
-          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          TARGET_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          TARGET_SHA: ${{ github.sha }}
+          TARGET_BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
-          backend=false
-          frontend=false
-          egress_webhook=false
-
-          if [[ "$EVENT_NAME" == "workflow_dispatch" || -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
-            backend=true
-            frontend=true
-            egress_webhook=true
-          else
-            git diff --name-only "$BASE_SHA" "$TARGET_SHA" > changed-files.txt
-            while IFS= read -r path; do
-              case "$path" in
-                deploy/kubernetes/scripts/build-and-push.sh|scripts/image-tag.sh|Makefile|.github/workflows/images.yml)
-                  backend=true
-                  frontend=true
-                  egress_webhook=true
-                  ;;
-                backend/*|deploy/images/backend/*)
-                  backend=true
-                  ;;
-                frontend/*|deploy/images/frontend/*)
-                  frontend=true
-                  ;;
-                deploy/kubernetes/egress-bundle/*)
-                  egress_webhook=true
-                  ;;
-              esac
-            done < changed-files.txt
-          fi
-
-          image_tag=$(scripts/image-tag.sh "$TARGET_SHA" "$TARGET_BRANCH")
           publish=false
-          if [[ "$EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            image_tag="$TARGET_BRANCH"
             publish=true
+          else
+            image_tag=$(scripts/image-tag.sh "$TARGET_SHA" "$TARGET_BRANCH")
+            publish="${{ inputs.publish }}"
           fi
 
-          echo "backend=$backend" >> "$GITHUB_OUTPUT"
-          echo "frontend=$frontend" >> "$GITHUB_OUTPUT"
-          echo "egress_webhook=$egress_webhook" >> "$GITHUB_OUTPUT"
+          echo "backend=true" >> "$GITHUB_OUTPUT"
+          echo "frontend=true" >> "$GITHUB_OUTPUT"
+          echo "egress_webhook=true" >> "$GITHUB_OUTPUT"
           echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
           echo "publish=$publish" >> "$GITHUB_OUTPUT"
-          echo "backend=$backend frontend=$frontend tag=$image_tag publish=$publish"
+          echo "backend=true frontend=true tag=$image_tag publish=$publish"
 
   build:
     name: Build ${{ matrix.target }} image
@@ -112,22 +69,18 @@ jobs:
         target: [backend, frontend, egress-webhook]
     steps:
       - uses: actions/checkout@v7
-        if: |
-          (matrix.target == 'backend' && needs.changes.outputs.backend == 'true') ||
-          (matrix.target == 'frontend' && needs.changes.outputs.frontend == 'true') ||
-          (matrix.target == 'egress-webhook' && needs.changes.outputs.egress_webhook == 'true')
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha }}
 
       - uses: astral-sh/setup-uv@v6
-        if: matrix.target == 'backend' && needs.changes.outputs.backend == 'true'
+        if: matrix.target == 'backend'
         with:
           python-version: "3.12"
           enable-cache: true
           prune-cache: false
 
       - name: Generate frozen backend requirements
-        if: matrix.target == 'backend' && needs.changes.outputs.backend == 'true'
+        if: matrix.target == 'backend'
         working-directory: backend
         run: |
           uv export \
@@ -136,21 +89,13 @@ jobs:
             > requirements-frozen.txt
 
       - uses: docker/setup-qemu-action@v3
-        if: |
-          (matrix.target == 'backend' && needs.changes.outputs.backend == 'true') ||
-          (matrix.target == 'frontend' && needs.changes.outputs.frontend == 'true') ||
-          (matrix.target == 'egress-webhook' && needs.changes.outputs.egress_webhook == 'true')
         with:
           platforms: arm64
 
       - uses: docker/setup-buildx-action@v3
-        if: |
-          (matrix.target == 'backend' && needs.changes.outputs.backend == 'true') ||
-          (matrix.target == 'frontend' && needs.changes.outputs.frontend == 'true') ||
-          (matrix.target == 'egress-webhook' && needs.changes.outputs.egress_webhook == 'true')
 
       - name: Log in to GHCR
-        if: needs.changes.outputs.publish == 'true' && ((matrix.target == 'backend' && needs.changes.outputs.backend == 'true') || (matrix.target == 'frontend' && needs.changes.outputs.frontend == 'true') || (matrix.target == 'egress-webhook' && needs.changes.outputs.egress_webhook == 'true'))
+        if: needs.changes.outputs.publish == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -158,10 +103,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker metadata
-        if: |
-          (matrix.target == 'backend' && needs.changes.outputs.backend == 'true') ||
-          (matrix.target == 'frontend' && needs.changes.outputs.frontend == 'true') ||
-          (matrix.target == 'egress-webhook' && needs.changes.outputs.egress_webhook == 'true')
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -169,10 +110,6 @@ jobs:
           tags: type=raw,value=${{ needs.changes.outputs.image_tag }}
 
       - name: Select Dockerfile
-        if: |
-          (matrix.target == 'backend' && needs.changes.outputs.backend == 'true') ||
-          (matrix.target == 'frontend' && needs.changes.outputs.frontend == 'true') ||
-          (matrix.target == 'egress-webhook' && needs.changes.outputs.egress_webhook == 'true')
         id: dockerfile
         run: |
           if [[ "${{ matrix.target }}" == "egress-webhook" ]]; then
@@ -182,10 +119,6 @@ jobs:
           fi
 
       - name: Build image
-        if: |
-          (matrix.target == 'backend' && needs.changes.outputs.backend == 'true') ||
-          (matrix.target == 'frontend' && needs.changes.outputs.frontend == 'true') ||
-          (matrix.target == 'egress-webhook' && needs.changes.outputs.egress_webhook == 'true')
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,31 +53,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Promote SHA images and write manifest
+      - name: Write release manifest
         id: promote
         run: |
           set -euo pipefail
 
           source_commit=$(git rev-parse HEAD)
-          source_tag=$(scripts/image-tag.sh "$source_commit" main)
           sandbox_image="ghcr.io/${IMAGE_OWNER}/cubeplex-sandbox:sandbox-v${{ steps.sandbox.outputs.version }}"
           manifest="release-manifest-${RELEASE_TAG}.yaml"
 
           printf 'release: %s\nsource_commit: %s\nimages:\n' "$RELEASE_TAG" "$source_commit" > "$manifest"
 
+          # images.yml builds and pushes version-tagged images when triggered by
+          # the same tag push; wait for them to appear (up to ~30 min)
           for target in backend frontend; do
-            source="ghcr.io/${IMAGE_OWNER}/cubeplex-${target}:${source_tag}"
             release="ghcr.io/${IMAGE_OWNER}/cubeplex-${target}:${RELEASE_TAG}"
             digest=""
-            for attempt in $(seq 1 60); do
-              if digest=$(docker buildx imagetools inspect "$source" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+            for attempt in $(seq 1 180); do
+              if digest=$(docker buildx imagetools inspect "$release" --format '{{.Manifest.Digest}}' 2>/dev/null); then
                 break
               fi
-              echo "Waiting for $source (attempt $attempt/60)"
+              echo "Waiting for $release (attempt $attempt/180)"
               sleep 10
             done
             [[ "$digest" == sha256:* ]]
-            docker buildx imagetools create --tag "$release" "$source"
             printf '  %s: ghcr.io/%s/cubeplex-%s@%s\n' "$target" "$IMAGE_OWNER" "$target" "$digest" >> "$manifest"
           done
 


### PR DESCRIPTION
## Summary

- Remove PR and main-branch triggers from `images.yml` — no more Docker builds on every PR or merge
- Add `push: tags: v*.*.*` and `workflow_dispatch` (with optional `publish` boolean, default off) as the only triggers
- On a tag push, build all three images and push directly with the version tag (e.g. `v1.0.0`) instead of a SHA-based intermediate
- `release.yml`: drop the SHA-image promote step; poll for the version-tagged images that `images.yml` pushes concurrently (timeout increased to 180 attempts / ~30 min)

## Test plan

- [ ] Verify no image build job fires on a PR after this merges
- [ ] Verify no image build job fires on a push to main
- [ ] Trigger `images.yml` via `workflow_dispatch` with `publish: false` — confirm build runs but does not push
- [ ] On next release tag, confirm `images.yml` pushes `v<semver>` tags and `release.yml` picks them up successfully