### PR TITLE
Replace /admin/traces free-text filters with searchable comboboxes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,11 +297,26 @@ jobs:
         # against the live LLM gateway. Keeping them off the PR path saves
         # ~5-10× wall-clock per push and prevents vendor-rate-limit flakes
         # from blocking unrelated merges.
-        run: make backend-test-e2e
+        #
+        # -ci variant additionally writes coverage-e2e.xml: e2e tests are the
+        # primary test type for business-flow code in this repo (see
+        # docs/testing.md), so without this the Codecov patch-coverage gate
+        # only ever sees the unit-test run and reports business logic as
+        # untested even when it's covered here.
+        run: make backend-test-e2e-ci
 
       - name: Cleanup leftover test sandboxes
         if: always()
         run: make backend-cleanup-sandboxes
+
+      - name: Upload e2e coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v7
+        with:
+          files: backend/coverage-e2e.xml
+          flags: backend-e2e-shard-${{ matrix.shard }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   frontend-e2e:
     name: Frontend E2E (playwright)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install skills-restore backend-install frontend-install backend-check-ci frontend-check-ci check-ci backend-migrate backend-test-e2e backend-test-contracts backend-start backend-cleanup-sandboxes frontend-build-core frontend-install-browsers frontend-test-e2e frontend-test-e2e-ci test-ui-unit test-ui-e2e test-ui test-all clean
+.PHONY: help install skills-restore backend-install frontend-install backend-check-ci frontend-check-ci check-ci backend-migrate backend-test-e2e backend-test-e2e-ci backend-test-contracts backend-start backend-cleanup-sandboxes frontend-build-core frontend-install-browsers frontend-test-e2e frontend-test-e2e-ci test-ui-unit test-ui-e2e test-ui test-all clean
 
 help:
 	@echo "Available commands:"
@@ -11,6 +11,7 @@ help:
 	@echo "  make check-ci                   - Run backend and frontend CI checks"
 	@echo "  make backend-migrate            - Run backend Alembic migrations"
 	@echo "  make backend-test-e2e           - Run backend E2E tests"
+	@echo "  make backend-test-e2e-ci        - Run backend E2E tests, writing coverage-e2e.xml for Codecov"
 	@echo "  make backend-test-contracts     - Run plugin contract tests (EE compat)"
 	@echo "  make backend-start              - Start backend server"
 	@echo "  make backend-cleanup-sandboxes  - Cleanup leftover test sandboxes"
@@ -55,6 +56,9 @@ backend-migrate:
 
 backend-test-e2e:
 	$(MAKE) -C backend test-e2e
+
+backend-test-e2e-ci:
+	$(MAKE) -C backend test-e2e-ci
 
 backend-test-contracts:
 	$(MAKE) -C backend test-contracts

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,6 +2,7 @@
 .test.env
 .coverage
 coverage.xml
+coverage-e2e.xml
 scripts/dev
 skills_cache/
 # cubepi tracing output (default tracing.directory); may contain prompt/tool payloads

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev-install format lint lint-fix type-check test test-real-llm test-cov test-e2e test-contracts migrate start cleanup-sandboxes check check-ci clean pre-commit-install pre-commit-install-all pre-commit-run
+.PHONY: help install dev-install format lint lint-fix type-check test test-real-llm test-cov test-e2e test-e2e-ci test-contracts migrate start cleanup-sandboxes check check-ci clean pre-commit-install pre-commit-install-all pre-commit-run
 
 help:
 	@echo "Available commands:"
@@ -11,6 +11,7 @@ help:
 	@echo "  make test-real-llm     - Run real-LLM injection tests"
 	@echo "  make test-cov          - Run backend tests with coverage report"
 	@echo "  make test-e2e          - Run backend E2E tests"
+	@echo "  make test-e2e-ci       - Run backend E2E tests, writing coverage-e2e.xml for Codecov"
 	@echo "  make test-contracts    - Run plugin contract tests (EE compat)"
 	@echo "  make migrate           - Run Alembic migrations"
 	@echo "  make start             - Start backend server"
@@ -68,6 +69,11 @@ test-cov:
 test-e2e:
 	@echo "Running backend E2E tests (real_llm tests deselected)..."
 	uv run pytest tests/e2e/ -v -m "not real_llm"
+	@echo "✓ Backend E2E tests passed"
+
+test-e2e-ci:
+	@echo "Running backend E2E tests (real_llm tests deselected)..."
+	uv run pytest tests/e2e/ -v -m "not real_llm" --cov-report=xml:coverage-e2e.xml
 	@echo "✓ Backend E2E tests passed"
 
 test-contracts:

--- a/backend/cubeplex/api/routes/v1/admin_traces.py
+++ b/backend/cubeplex/api/routes/v1/admin_traces.py
@@ -9,7 +9,7 @@ parse errors / query strings never reach the frontend.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -78,8 +78,6 @@ async def list_traces(
     model: str | None = Query(default=None),
     start: datetime | None = Query(default=None),
     end: datetime | None = Query(default=None),
-    min_duration_ms: int | None = Query(default=None, ge=0),
-    max_duration_ms: int | None = Query(default=None, ge=0),
     limit: int = Query(default=20, ge=1, le=100),
 ) -> TraceListResponse:
     if start and end and start >= end:
@@ -90,6 +88,26 @@ async def list_traces(
                 status_code=400,
                 detail=f"{label} must be a timezone-aware ISO 8601 timestamp",
             )
+    # Never call Tempo without an explicit range: this deployment's own
+    # default search window is much narrower than useful, which made the
+    # trace list appear empty on first load. Default to the last hour, and
+    # fill in whichever side is missing relative to the other.
+    now = datetime.now(UTC)
+    if start is None and end is None:
+        start, end = now - timedelta(hours=1), now
+    elif end is None:
+        end = now
+    elif start is None:
+        start = end - timedelta(hours=1)
+    assert start is not None and end is not None  # always set by the block above
+    # Tempo hard-caps search ranges at 168h on this deployment; forwarding a
+    # wider one gets a generic 502 from _bad_upstream below, so reject it
+    # here with a message that actually explains the limit.
+    if end - start > timedelta(hours=168):
+        raise HTTPException(
+            status_code=400,
+            detail="Range exceeds the maximum supported window (7 days)",
+        )
     client = await _client_or_503()
     org_id = await resolve_current_org_id(user, session)
     try:
@@ -102,8 +120,6 @@ async def list_traces(
             model=model,
             start=start,
             end=end,
-            min_duration_ms=min_duration_ms,
-            max_duration_ms=max_duration_ms,
             limit=limit,
         )
     except TempoQueryValueError as exc:
@@ -143,6 +159,11 @@ async def get_filter_options(
     session: Annotated[AsyncSession, Depends(get_session)],
     kind: FilterOptionKind = Query(..., description="Entity kind to list."),
     q: str | None = Query(default=None, max_length=100),
+    ids: list[str] | None = Query(
+        default=None,
+        description="Exact-match batch lookup (e.g. resolving IDs already on "
+        "screen to names). Mutually exclusive with q - ids wins if both are given.",
+    ),
     limit: int = Query(default=20, ge=1, le=50),
 ) -> FilterOptionsResponse:
     """Read-only dropdown options for the traces filter bar.
@@ -152,8 +173,13 @@ async def get_filter_options(
     - never trusts a client-supplied org. Has no Tempo dependency, so it works
     even when the trace viewer's Tempo backend is unset.
     """
+    if ids is not None and len(ids) > 200:
+        raise HTTPException(status_code=400, detail="Too many ids requested")
     org_id = await resolve_current_org_id(user, session)
     pattern = f"{_escape_like(q)}%" if q else None
+    # Batch lookups are already bounded by the caller's page size; the normal
+    # prefix limit doesn't apply.
+    row_limit = len(ids) if ids is not None else limit
 
     if kind is FilterOptionKind.WORKSPACE:
         # Coarse / low-cardinality: return all in the org (cap 200) so the
@@ -161,7 +187,9 @@ async def get_filter_options(
         stmt = select(cast(Any, Workspace.id), cast(Any, Workspace.name)).where(
             cast(Any, Workspace.org_id) == org_id
         )
-        if pattern is not None:
+        if ids is not None:
+            stmt = stmt.where(cast(Any, Workspace.id).in_(ids))
+        elif pattern is not None:
             stmt = stmt.where(cast(Any, Workspace.name).ilike(pattern, escape="\\"))
         stmt = stmt.order_by(cast(Any, Workspace.name)).limit(200)
     elif kind is FilterOptionKind.CONVERSATION:
@@ -170,9 +198,11 @@ async def get_filter_options(
             cast(Any, Conversation.org_id) == org_id,
             cast(Any, Conversation.deleted_at).is_(None),
         )
-        if pattern is not None:
+        if ids is not None:
+            stmt = stmt.where(cast(Any, Conversation.id).in_(ids))
+        elif pattern is not None:
             stmt = stmt.where(cast(Any, Conversation.title).ilike(pattern, escape="\\"))
-        stmt = stmt.order_by(cast(Any, Conversation.title)).limit(limit)
+        stmt = stmt.order_by(cast(Any, Conversation.title)).limit(row_limit)
     else:  # FilterOptionKind.USER - users are org-scoped only via membership.
         label = func.coalesce(cast(Any, User.display_name), cast(Any, User.email)).label("label")
         stmt = (
@@ -181,14 +211,16 @@ async def get_filter_options(
             .join(Workspace, cast(Any, Membership.workspace_id) == Workspace.id)
             .where(cast(Any, Workspace.org_id) == org_id)
         )
-        if pattern is not None:
+        if ids is not None:
+            stmt = stmt.where(cast(Any, User.id).in_(ids))
+        elif pattern is not None:
             stmt = stmt.where(
                 or_(
                     cast(Any, User.display_name).ilike(pattern, escape="\\"),
                     cast(Any, User.email).ilike(pattern, escape="\\"),
                 )
             )
-        stmt = stmt.distinct().order_by(label).limit(limit)
+        stmt = stmt.distinct().order_by(label).limit(row_limit)
 
     rows = (await session.execute(stmt)).all()
     options = [FilterOption(id=str(row[0]), name=str(row[1])) for row in rows]

--- a/backend/cubeplex/api/routes/v1/admin_traces.py
+++ b/backend/cubeplex/api/routes/v1/admin_traces.py
@@ -10,13 +10,17 @@ parse errors / query strings never reach the frontend.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from loguru import logger
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubeplex.api.schemas.trace import (
+    FilterOption,
+    FilterOptionKind,
+    FilterOptionsResponse,
     SpanNode,
     TagValuesResponse,
     TraceDetail,
@@ -24,7 +28,7 @@ from cubeplex.api.schemas.trace import (
 )
 from cubeplex.auth.dependencies import require_org_admin, resolve_current_org_id
 from cubeplex.db import get_session
-from cubeplex.models import User
+from cubeplex.models import Conversation, Membership, User, Workspace
 from cubeplex.services.tempo_client import (
     TempoClient,
     TempoQueryError,
@@ -124,6 +128,71 @@ async def get_tag_values(
     except TempoQueryError as exc:
         raise _bad_upstream(exc) from exc
     return TagValuesResponse(values=values)
+
+
+def _escape_like(value: str) -> str:
+    """Escape LIKE/ILIKE wildcards so a prefix search treats them literally."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+# Registered before /{trace_id} (same reason as /tag-values above) so the
+# literal "filter-options" path isn't captured as a trace_id.
+@router.get("/filter-options", response_model=FilterOptionsResponse)
+async def get_filter_options(
+    user: Annotated[User, Depends(require_org_admin)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    kind: FilterOptionKind = Query(..., description="Entity kind to list."),
+    q: str | None = Query(default=None, max_length=100),
+    limit: int = Query(default=20, ge=1, le=50),
+) -> FilterOptionsResponse:
+    """Read-only dropdown options for the traces filter bar.
+
+    Postgres-backed (not Tempo): workspace/user/conversation names live in the
+    app DB, keyed by the IDs the trace spans carry. Org-scoped from the session
+    - never trusts a client-supplied org. Has no Tempo dependency, so it works
+    even when the trace viewer's Tempo backend is unset.
+    """
+    org_id = await resolve_current_org_id(user, session)
+    pattern = f"{_escape_like(q)}%" if q else None
+
+    if kind is FilterOptionKind.WORKSPACE:
+        # Coarse / low-cardinality: return all in the org (cap 200) so the
+        # combobox can filter client-side without a prefix round-trip.
+        stmt = select(cast(Any, Workspace.id), cast(Any, Workspace.name)).where(
+            cast(Any, Workspace.org_id) == org_id
+        )
+        if pattern is not None:
+            stmt = stmt.where(cast(Any, Workspace.name).ilike(pattern, escape="\\"))
+        stmt = stmt.order_by(cast(Any, Workspace.name)).limit(200)
+    elif kind is FilterOptionKind.CONVERSATION:
+        # High-cardinality: server-side prefix typeahead, never materialize all.
+        stmt = select(cast(Any, Conversation.id), cast(Any, Conversation.title)).where(
+            cast(Any, Conversation.org_id) == org_id,
+            cast(Any, Conversation.deleted_at).is_(None),
+        )
+        if pattern is not None:
+            stmt = stmt.where(cast(Any, Conversation.title).ilike(pattern, escape="\\"))
+        stmt = stmt.order_by(cast(Any, Conversation.title)).limit(limit)
+    else:  # FilterOptionKind.USER - users are org-scoped only via membership.
+        label = func.coalesce(cast(Any, User.display_name), cast(Any, User.email)).label("label")
+        stmt = (
+            select(cast(Any, User.id), label)
+            .join(Membership, cast(Any, Membership.user_id) == User.id)
+            .join(Workspace, cast(Any, Membership.workspace_id) == Workspace.id)
+            .where(cast(Any, Workspace.org_id) == org_id)
+        )
+        if pattern is not None:
+            stmt = stmt.where(
+                or_(
+                    cast(Any, User.display_name).ilike(pattern, escape="\\"),
+                    cast(Any, User.email).ilike(pattern, escape="\\"),
+                )
+            )
+        stmt = stmt.distinct().order_by(label).limit(limit)
+
+    rows = (await session.execute(stmt)).all()
+    options = [FilterOption(id=str(row[0]), name=str(row[1])) for row in rows]
+    return FilterOptionsResponse(options=options)
 
 
 def _has_foreign_org_span(node: SpanNode, expected_org_id: str) -> bool:

--- a/backend/cubeplex/api/schemas/trace.py
+++ b/backend/cubeplex/api/schemas/trace.py
@@ -76,6 +76,18 @@ class TurnPayload(BaseModel):
     index: int
     stop_reason: str | None = None
     tool_calls_count: int = 0
+    messages: list[ChatMessage] = Field(default_factory=list)
+    output_messages: list[ChatMessage] = Field(default_factory=list)
+
+
+class AgentPayload(BaseModel):
+    """Detail carried by the `invoke_agent` (run root) span."""
+
+    provider: str | None = None
+    tools: list[str] = Field(default_factory=list)
+    system_instructions: list[ChatMessage] = Field(default_factory=list)
+    messages: list[ChatMessage] = Field(default_factory=list)
+    output_messages: list[ChatMessage] = Field(default_factory=list)
 
 
 class SpanNode(BaseModel):
@@ -90,6 +102,7 @@ class SpanNode(BaseModel):
     llm: LlmCallPayload | None = None
     tool: ToolCallPayload | None = None
     turn: TurnPayload | None = None
+    agent: AgentPayload | None = None
     raw_attributes: dict[str, Any] = Field(default_factory=dict)
     children: list[SpanNode] = Field(default_factory=list)
 

--- a/backend/cubeplex/api/schemas/trace.py
+++ b/backend/cubeplex/api/schemas/trace.py
@@ -123,4 +123,29 @@ class TagValuesResponse(BaseModel):
     values: list[str]
 
 
+class FilterOptionKind(StrEnum):
+    """Entity kinds the traces filter dropdown can list from Postgres.
+
+    `model` is intentionally absent - it is low-cardinality and sourced from
+    Tempo via ``tag-values`` (the value is its own label). These three are
+    Postgres-backed, org-scoped, and (for user/conversation) prefix-narrowed.
+    """
+
+    WORKSPACE = "workspace"
+    USER = "user"
+    CONVERSATION = "conversation"
+
+
+class FilterOption(BaseModel):
+    """One selectable entry: ``id`` is the filter value stored in the URL,
+    ``name`` is the human-readable label shown in the dropdown."""
+
+    id: str
+    name: str
+
+
+class FilterOptionsResponse(BaseModel):
+    options: list[FilterOption]
+
+
 SpanNode.model_rebuild()

--- a/backend/cubeplex/services/tempo_client.py
+++ b/backend/cubeplex/services/tempo_client.py
@@ -16,6 +16,7 @@ from typing import Any
 import httpx
 
 from cubeplex.api.schemas.trace import (
+    AgentPayload,
     ChatMessage,
     LlmCallPayload,
     SpanKind,
@@ -116,6 +117,7 @@ def parse_trace_detail(payload: dict[str, Any]) -> TraceDetail:
             llm=_extract_llm(attrs) if kind == SpanKind.CHAT else None,
             tool=_extract_tool(attrs) if kind == SpanKind.TOOL else None,
             turn=_extract_turn(attrs) if kind == SpanKind.TURN else None,
+            agent=_extract_agent(attrs) if kind == SpanKind.AGENT else None,
             raw_attributes=attrs,
         )
         nodes[node.span_id] = node
@@ -185,6 +187,20 @@ def _extract_turn(attrs: dict[str, Any]) -> TurnPayload:
         index=int(attrs.get("cubepi.turn.index", 0) or 0),
         stop_reason=attrs.get("cubepi.turn.stop_reason"),
         tool_calls_count=int(attrs.get("cubepi.turn.tool_calls.count", 0) or 0),
+        messages=_decode_messages(attrs.get("gen_ai.input.messages")),
+        output_messages=_decode_messages(attrs.get("gen_ai.output.messages")),
+    )
+
+
+def _extract_agent(attrs: dict[str, Any]) -> AgentPayload:
+    tools_raw = attrs.get("cubepi.agent.tools")
+    tools = [str(t) for t in tools_raw] if isinstance(tools_raw, list) else []
+    return AgentPayload(
+        provider=attrs.get("gen_ai.provider.name"),
+        tools=tools,
+        system_instructions=_decode_messages(attrs.get("gen_ai.system_instructions")),
+        messages=_decode_messages(attrs.get("gen_ai.input.messages")),
+        output_messages=_decode_messages(attrs.get("gen_ai.output.messages")),
     )
 
 
@@ -209,7 +225,13 @@ def _decode_messages(raw: Any) -> list[ChatMessage]:
         try:
             data = _json.loads(raw)
         except _json.JSONDecodeError:
-            return []
+            # Long attribute values can get truncated somewhere upstream in
+            # the tracing pipeline (span attribute length limits), leaving
+            # invalid JSON. Silently returning [] would be indistinguishable
+            # from "nothing was sent" - surface the partial raw content
+            # instead via a sentinel role/part-type the frontend renders
+            # distinctly (a truncation warning, not an empty list).
+            return [ChatMessage(role="_truncated", parts=[{"type": "_truncated", "content": raw}])]
     else:
         data = raw
     if not isinstance(data, list):
@@ -246,6 +268,55 @@ def _decode_tools(raw: Any) -> list[ToolDefinition]:
     return out
 
 
+def _derive_output_from_raw_response(raw_response: str | None) -> list[ChatMessage]:
+    """Fallback for `chat` spans: `gen_ai.output.messages` is never set on
+    them in this cubepi version (only on invoke_agent/cubepi.turn spans) -
+    but `cubepi.llm.raw_response` carries the same content in the provider's
+    wire format. Reconstruct a single assistant ChatMessage from it when the
+    response looks like an OpenAI-compatible chat completion (the only shape
+    observed in this deployment - openai.api.type=chat_completions). Any
+    other/unexpected shape just yields [] as before - no regression.
+    """
+    if not raw_response:
+        return []
+    try:
+        data = _json.loads(raw_response)
+    except _json.JSONDecodeError:
+        return []
+    if not isinstance(data, dict):
+        return []
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        return []
+    message = choices[0].get("message")
+    if not isinstance(message, dict):
+        return []
+
+    parts: list[dict[str, Any]] = []
+    content = message.get("content")
+    if isinstance(content, str) and content:
+        parts.append({"type": "text", "content": content})
+
+    for tc in message.get("tool_calls") or []:
+        if not isinstance(tc, dict):
+            continue
+        fn = tc.get("function") or {}
+        args_raw = fn.get("arguments")
+        args: Any = args_raw
+        if isinstance(args_raw, str):
+            try:
+                args = _json.loads(args_raw)
+            except _json.JSONDecodeError:
+                pass  # keep the raw string - still better than dropping it
+        parts.append(
+            {"type": "tool_call", "id": tc.get("id"), "name": fn.get("name"), "arguments": args}
+        )
+
+    if not parts:
+        return []
+    return [ChatMessage(role="assistant", parts=parts)]
+
+
 def _extract_llm(attrs: dict[str, Any]) -> LlmCallPayload:
     finish = attrs.get("gen_ai.response.finish_reasons")
     finish_list = finish if isinstance(finish, list) else ([finish] if finish else [])
@@ -268,7 +339,8 @@ def _extract_llm(attrs: dict[str, Any]) -> LlmCallPayload:
         response_id=attrs.get("gen_ai.response.id"),
         system_instructions=_decode_messages(attrs.get("gen_ai.system_instructions")),
         messages=_decode_messages(attrs.get("gen_ai.input.messages")),
-        output_messages=_decode_messages(attrs.get("gen_ai.output.messages")),
+        output_messages=_decode_messages(attrs.get("gen_ai.output.messages"))
+        or _derive_output_from_raw_response(attrs.get("cubepi.llm.raw_response")),
         tools=_decode_tools(
             attrs.get("gen_ai.tool.definitions")
             or attrs.get("gen_ai.request.tools")

--- a/backend/cubeplex/services/tempo_client.py
+++ b/backend/cubeplex/services/tempo_client.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json as _json
 import re
 import urllib.parse
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
@@ -355,8 +355,6 @@ class TempoClient:
         model: str | None = None,
         start: datetime | None = None,
         end: datetime | None = None,
-        min_duration_ms: int | None = None,
-        max_duration_ms: int | None = None,
         limit: int = 20,
     ) -> list[TraceSummary]:
         # cubepi.metadata.org_id lives on invoke_agent spans; gen_ai.request.model
@@ -379,10 +377,6 @@ class TempoClient:
             )
         if run_id:
             metadata_clauses.append(f"span.cubepi.run_id={_quote_traceql(run_id)}")
-        if min_duration_ms is not None:
-            metadata_clauses.append(f"trace:duration > {int(min_duration_ms)}ms")
-        if max_duration_ms is not None:
-            metadata_clauses.append(f"trace:duration < {int(max_duration_ms)}ms")
 
         model_clauses: list[str] = []
         if model:
@@ -445,13 +439,29 @@ class TempoClient:
         # 2.8.2), which would leak workspace/user/conversation/model identifiers
         # across orgs via autocomplete. v2 honors the org-scoping TraceQL.
         #
+        # Same cross-span pitfall as search() above: cubepi.metadata.org_id
+        # lives on the invoke_agent span, but e.g. gen_ai.request.model lives
+        # on a child chat span. A single {...} selector requires both on the
+        # same span and would silently return zero values. Use sibling
+        # spansets joined at the top level, exactly like search() does, so
+        # the org scope and the requested tag are matched independently.
+        #
+        # Like search(), Tempo defaults to its own (narrow) window when start/
+        # end are omitted. This is a dropdown-population lookup, not a
+        # time-scoped search, so default to a wide window rather than
+        # requiring every caller to pass one. Capped just under 168h (7
+        # days) - this Tempo deployment rejects search/tag-values ranges
+        # wider than that with a 400.
+        now = datetime.now(UTC)
+        params: dict[str, Any] = {
+            "q": '{ resource.service.name="cubeplex" '
+            f'&& span.cubepi.metadata.org_id={_quote_traceql(org_id)} }} && {{ span.{tag} != "" }}',
+            "start": str(int((now - timedelta(hours=167)).timestamp())),
+            "end": str(int(now.timestamp())),
+        }
         # Tempo v2 takes the FULL prefixed tag name (e.g. `span.cubepi.run_id`)
         # as a single path segment — NOT `span/<tag>` as two segments. All tags
         # in _ALLOWED_TAGS live on spans, so we prepend `span.` here.
-        params: dict[str, Any] = {
-            "q": '{ resource.service.name="cubeplex" '
-            f"&& span.cubepi.metadata.org_id={_quote_traceql(org_id)} }}",
-        }
         quoted = urllib.parse.quote(tag, safe=".")
         url = f"{self._endpoint}/api/v2/search/tag/span.{quoted}/values"
         async with httpx.AsyncClient(timeout=self._timeout) as http:
@@ -473,6 +483,22 @@ class TempoClient:
             raise TempoQueryError("Tempo tag values returned malformed payload") from exc
 
 
+def _total_span_count(t: dict[str, Any]) -> int:
+    # `spanSet(s).matched` counts spans that matched the *search selector*
+    # (e.g. 1, since only the invoke_agent span carries cubepi.metadata.org_id)
+    # - not the trace's real span count. `serviceStats.<service>.spanCount`
+    # is Tempo's actual per-trace span total; sum across services in case a
+    # trace ever spans more than one.
+    service_stats = t.get("serviceStats")
+    if not isinstance(service_stats, dict):
+        return 0
+    total = 0
+    for stats in service_stats.values():
+        if isinstance(stats, dict):
+            total += int(stats.get("spanCount") or 0)
+    return total
+
+
 def _search_hit_to_summary(t: dict[str, Any]) -> TraceSummary:
     # Tempo returns one or more spanSets (plural, documented). Legacy versions
     # also emit a singular `spanSet` alias with the same content as spanSets[0].
@@ -486,9 +512,7 @@ def _search_hit_to_summary(t: dict[str, Any]) -> TraceSummary:
         sets.append(t["spanSet"])
 
     attrs_list: list[dict[str, Any]] = []
-    total_matched = 0
     for ss in sets:
-        total_matched += int(ss.get("matched") or 0)
         for span in ss.get("spans") or []:
             if isinstance(span, dict):
                 attrs_list.append(
@@ -507,7 +531,7 @@ def _search_hit_to_summary(t: dict[str, Any]) -> TraceSummary:
         root_name=t.get("rootTraceName", ""),
         start_time=_ns_to_dt(t.get("startTimeUnixNano", "0")),
         duration_ms=int(t.get("durationMs", 0)),
-        span_count=total_matched,
+        span_count=_total_span_count(t),
         workspace_id=first("cubepi.metadata.workspace_id"),
         user_id=first("cubepi.metadata.user_id"),
         conversation_id=first("cubepi.metadata.conversation_id"),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -186,7 +186,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "94d0ca7380502506042390ce73a02de1060387b0" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "454610487014d352cbecb8c0fc50154d69126f4b" }
 
 [dependency-groups]
 dev = [

--- a/backend/tests/e2e/test_admin_traces.py
+++ b/backend/tests/e2e/test_admin_traces.py
@@ -1,7 +1,7 @@
 """E2E for /api/v1/admin/traces routes."""
 
 import secrets
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
 import httpx
@@ -119,6 +119,39 @@ async def test_list_rejects_naive_datetime(admin_client, fake_tempo) -> None:
     assert "timezone" in resp.text.lower()
 
 
+async def test_list_defaults_to_last_hour_when_no_range_given(admin_client, fake_tempo) -> None:
+    """Tempo's own default search window is much narrower than useful (it can
+    return zero traces even when traces exist), so the route must never call
+    Tempo without an explicit range."""
+    client, _ws = admin_client
+    resp = await client.get("/api/v1/admin/traces")
+    assert resp.status_code == 200, resp.text
+    call = fake_tempo.search.await_args
+    start, end = call.kwargs["start"], call.kwargs["end"]
+    assert start is not None and end is not None
+    assert timedelta(minutes=59) < end - start < timedelta(hours=1, minutes=1)
+
+
+async def test_list_fills_missing_side_of_a_partial_range(admin_client, fake_tempo) -> None:
+    client, _ws = admin_client
+    start = datetime.now(UTC) - timedelta(minutes=30)
+    resp = await client.get("/api/v1/admin/traces", params={"start": start.isoformat()})
+    assert resp.status_code == 200, resp.text
+    call = fake_tempo.search.await_args
+    assert call.kwargs["start"] == start
+    assert call.kwargs["end"] is not None
+
+
+async def test_list_rejects_range_over_168h(admin_client, fake_tempo) -> None:
+    client, _ws = admin_client
+    resp = await client.get(
+        "/api/v1/admin/traces?start=2026-06-01T00:00:00%2B00:00&end=2026-07-01T00:00:00%2B00:00"
+    )
+    assert resp.status_code == 400
+    assert "7 days" in resp.text
+    fake_tempo.search.assert_not_awaited()
+
+
 async def test_detail_rejects_foreign_org_in_child_span(
     admin_client, fake_tempo, fake_resolve_org
 ) -> None:
@@ -212,28 +245,28 @@ async def seeded_filter_options(
     foreign_ws = await WorkspaceRepository(db_session).create(
         org_id=foreign_org.id, name="Foreign WS"
     )
-    await WorkspaceRepository(db_session).create(org_id=org_id, name="Alpha WS")
+    alpha_ws = await WorkspaceRepository(db_session).create(org_id=org_id, name="Alpha WS")
 
     # 3 alpha conversations so a `limit` cap is observable.
+    alpha_conv_ids: list[str] = []
     for title in ("Alpha Chat A", "Alpha Chat B", "Alpha Chat C"):
-        db_session.add(
-            Conversation(
-                title=title,
-                org_id=org_id,
-                workspace_id=ws_id,
-                creator_user_id=user_id,
-                has_messages=True,
-            )
-        )
-    db_session.add(
-        Conversation(
-            title="Foreign Chat",
-            org_id=foreign_org.id,
-            workspace_id=foreign_ws.id,
+        conv = Conversation(
+            title=title,
+            org_id=org_id,
+            workspace_id=ws_id,
             creator_user_id=user_id,
             has_messages=True,
         )
+        db_session.add(conv)
+        alpha_conv_ids.append(conv.id)
+    foreign_chat = Conversation(
+        title="Foreign Chat",
+        org_id=foreign_org.id,
+        workspace_id=foreign_ws.id,
+        creator_user_id=user_id,
+        has_messages=True,
     )
+    db_session.add(foreign_chat)
 
     alpha_user = User(
         email=f"alpha-{token}@example.com",
@@ -258,10 +291,16 @@ async def seeded_filter_options(
 
     return client, {
         "alpha_ws": "Alpha WS",
+        "alpha_ws_id": alpha_ws.id,
         "foreign_ws": "Foreign WS",
+        "foreign_ws_id": foreign_ws.id,
         "foreign_chat": "Foreign Chat",
+        "foreign_chat_id": foreign_chat.id,
+        "alpha_conv_id": alpha_conv_ids[0],
         "alpha_user": "Alpha User",
+        "alpha_user_id": alpha_user.id,
         "foreign_user": "Foreign User",
+        "foreign_user_id": foreign_user.id,
     }
 
 
@@ -288,6 +327,43 @@ async def test_filter_options_conversation_limit_caps(seeded_filter_options) -> 
     resp = await client.get("/api/v1/admin/traces/filter-options?kind=conversation&q=Alpha&limit=2")
     assert resp.status_code == 200, resp.text
     assert len(resp.json()["options"]) == 2  # 3 match, capped at limit
+
+
+async def test_filter_options_ids_batch_lookup(seeded_filter_options) -> None:
+    """`ids` resolves exact IDs to names (used to render names in the trace
+    list table) instead of prefix-narrowing - and stays org-scoped like q."""
+    client, labels = seeded_filter_options
+    resp = await client.get(
+        "/api/v1/admin/traces/filter-options",
+        params={"kind": "workspace", "ids": [labels["alpha_ws_id"], labels["foreign_ws_id"]]},
+    )
+    assert resp.status_code == 200, resp.text
+    names = {o["name"] for o in resp.json()["options"]}
+    assert names == {labels["alpha_ws"]}  # foreign org's workspace excluded
+
+
+async def test_filter_options_ids_wins_over_q(seeded_filter_options) -> None:
+    client, labels = seeded_filter_options
+    resp = await client.get(
+        "/api/v1/admin/traces/filter-options",
+        params={
+            "kind": "conversation",
+            "q": "nonexistent-prefix",
+            "ids": [labels["alpha_conv_id"]],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    ids = {o["id"] for o in resp.json()["options"]}
+    assert ids == {labels["alpha_conv_id"]}
+
+
+async def test_filter_options_ids_rejects_oversized_batch(admin_client) -> None:
+    client, _ws = admin_client
+    resp = await client.get(
+        "/api/v1/admin/traces/filter-options",
+        params={"kind": "user", "ids": [f"usr-{i}" for i in range(201)]},
+    )
+    assert resp.status_code == 400
 
 
 async def test_filter_options_user_prefix_and_scoped(seeded_filter_options) -> None:

--- a/backend/tests/e2e/test_admin_traces.py
+++ b/backend/tests/e2e/test_admin_traces.py
@@ -1,12 +1,21 @@
 """E2E for /api/v1/admin/traces routes."""
 
+import secrets
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
+import pytest_asyncio
 
 from cubeplex.api.routes.v1 import admin_traces
 from cubeplex.api.schemas.trace import TraceSummary
+from cubeplex.models import Conversation, Role, User, Workspace
+from cubeplex.repositories import (
+    MembershipRepository,
+    OrganizationRepository,
+    WorkspaceRepository,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -176,3 +185,126 @@ async def test_detail_404_on_org_mismatch(admin_client, fake_tempo, fake_resolve
     client, _ws = admin_client
     resp = await client.get("/api/v1/admin/traces/t1")
     assert resp.status_code == 404
+
+
+# --- filter-options (Postgres-backed dropdown suggestions) --------------------
+
+
+@pytest_asyncio.fixture
+async def seeded_filter_options(
+    admin_client_with_user_id, db_session
+) -> tuple[httpx.AsyncClient, dict[str, str]]:
+    """Seed the admin's org + a foreign org with workspaces/conversations/users
+    so filter-options scoping and prefix tests have something to assert against.
+
+    Returns ``(client, labels)`` where ``labels`` maps a role to the seeded
+    human-readable name the test asserts on.
+    """
+    client, ws_id, user_id = admin_client_with_user_id
+    ws = await db_session.get(Workspace, ws_id)
+    assert ws is not None
+    org_id = ws.org_id
+
+    token = secrets.token_hex(4)
+    foreign_org = await OrganizationRepository(db_session).create(
+        name=f"Foreign Org {token}", slug=f"foreign-{token}"
+    )
+    foreign_ws = await WorkspaceRepository(db_session).create(
+        org_id=foreign_org.id, name="Foreign WS"
+    )
+    await WorkspaceRepository(db_session).create(org_id=org_id, name="Alpha WS")
+
+    # 3 alpha conversations so a `limit` cap is observable.
+    for title in ("Alpha Chat A", "Alpha Chat B", "Alpha Chat C"):
+        db_session.add(
+            Conversation(
+                title=title,
+                org_id=org_id,
+                workspace_id=ws_id,
+                creator_user_id=user_id,
+                has_messages=True,
+            )
+        )
+    db_session.add(
+        Conversation(
+            title="Foreign Chat",
+            org_id=foreign_org.id,
+            workspace_id=foreign_ws.id,
+            creator_user_id=user_id,
+            has_messages=True,
+        )
+    )
+
+    alpha_user = User(
+        email=f"alpha-{token}@example.com",
+        hashed_password="x",
+        display_name="Alpha User",
+    )
+    foreign_user = User(
+        email=f"foreign-{token}@example.com",
+        hashed_password="x",
+        display_name="Foreign User",
+    )
+    db_session.add(alpha_user)
+    db_session.add(foreign_user)
+    await db_session.commit()
+
+    await MembershipRepository(db_session).grant(
+        user_id=alpha_user.id, workspace_id=ws_id, role=Role.MEMBER
+    )
+    await MembershipRepository(db_session).grant(
+        user_id=foreign_user.id, workspace_id=foreign_ws.id, role=Role.MEMBER
+    )
+
+    return client, {
+        "alpha_ws": "Alpha WS",
+        "foreign_ws": "Foreign WS",
+        "foreign_chat": "Foreign Chat",
+        "alpha_user": "Alpha User",
+        "foreign_user": "Foreign User",
+    }
+
+
+async def test_filter_options_workspace_org_scoped(seeded_filter_options) -> None:
+    client, labels = seeded_filter_options
+    resp = await client.get("/api/v1/admin/traces/filter-options?kind=workspace")
+    assert resp.status_code == 200, resp.text
+    names = {o["name"] for o in resp.json()["options"]}
+    assert labels["alpha_ws"] in names
+    assert labels["foreign_ws"] not in names  # foreign org excluded
+
+
+async def test_filter_options_conversation_prefix_and_scoped(seeded_filter_options) -> None:
+    client, labels = seeded_filter_options
+    resp = await client.get("/api/v1/admin/traces/filter-options?kind=conversation&q=Alpha")
+    assert resp.status_code == 200, resp.text
+    titles = {o["name"] for o in resp.json()["options"]}
+    assert "Alpha Chat A" in titles
+    assert labels["foreign_chat"] not in titles  # foreign org excluded
+
+
+async def test_filter_options_conversation_limit_caps(seeded_filter_options) -> None:
+    client, _labels = seeded_filter_options
+    resp = await client.get("/api/v1/admin/traces/filter-options?kind=conversation&q=Alpha&limit=2")
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()["options"]) == 2  # 3 match, capped at limit
+
+
+async def test_filter_options_user_prefix_and_scoped(seeded_filter_options) -> None:
+    client, labels = seeded_filter_options
+    resp = await client.get("/api/v1/admin/traces/filter-options?kind=user&q=Alpha")
+    assert resp.status_code == 200, resp.text
+    names = {o["name"] for o in resp.json()["options"]}
+    assert labels["alpha_user"] in names
+    assert labels["foreign_user"] not in names  # foreign org excluded via membership join
+
+
+async def test_filter_options_rejects_unknown_kind(admin_client) -> None:
+    client, _ws = admin_client
+    resp = await client.get("/api/v1/admin/traces/filter-options?kind=robot")
+    assert resp.status_code == 422  # FastAPI StrEnum query validation
+
+
+async def test_filter_options_requires_admin(non_admin_client) -> None:
+    resp = await non_admin_client.get("/api/v1/admin/traces/filter-options?kind=workspace")
+    assert resp.status_code == 403

--- a/backend/tests/unit/test_tempo_client.py
+++ b/backend/tests/unit/test_tempo_client.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 import respx
 
+from cubeplex.api.schemas.trace import SpanKind
 from cubeplex.services.tempo_client import TempoClient, TempoQueryError, TempoTraceNotFoundError
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "tempo"
@@ -72,6 +73,114 @@ async def test_get_trace_returns_detail() -> None:
     detail = await client.get_trace("abc123")
     assert detail.summary.trace_id == payload["batches"][0]["scopeSpans"][0]["spans"][0]["traceId"]
     assert detail.root.children
+
+
+@respx.mock
+async def test_get_trace_extracts_agent_and_turn_payloads() -> None:
+    """The invoke_agent (root) span and cubepi.turn spans carry their own
+    gen_ai.input.messages/output.messages/system_instructions. This real
+    captured fixture has some of these truncated mid-sentence (an actual
+    tracing-pipeline artifact, not a synthetic edge case) - exercising both
+    the happy path and the truncation sentinel in one fixture.
+    """
+    payload = json.loads((FIXTURES / "sample_trace_multi_turn.json").read_text())
+    client = TempoClient(endpoint="http://tempo.local", timeout_seconds=5)
+    respx.get("http://tempo.local/api/traces/abc123").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+    detail = await client.get_trace("abc123")
+
+    agent = detail.root.agent
+    assert agent is not None
+    assert agent.provider == "unknown:deepseek-anthropic-shape"
+    assert "datetime" in agent.tools
+    # This fixture's agent-level system_instructions/messages are all
+    # truncated (>1400 chars, cut off mid-string) - decode falls back to the
+    # sentinel instead of silently returning [].
+    assert len(agent.system_instructions) == 1
+    assert agent.system_instructions[0].role == "_truncated"
+    assert len(agent.messages) == 1
+    assert agent.messages[0].role == "_truncated"
+
+    turns = {t.turn.index: t.turn for t in detail.root.children if t.kind == SpanKind.TURN}
+    # Turn 1's messages are short enough to be valid JSON - the happy path.
+    assert turns[1].messages and turns[1].messages[0].role != "_truncated"
+    assert turns[1].output_messages and turns[1].output_messages[0].role == "assistant"
+    # Turn 0's are truncated - same sentinel fallback as the agent-level ones.
+    assert turns[0].messages[0].role == "_truncated"
+    assert turns[0].output_messages[0].role == "_truncated"
+
+
+@respx.mock
+async def test_chat_span_derives_output_messages_from_raw_response() -> None:
+    """`gen_ai.output.messages` is never set on `chat` spans in this cubepi
+    version (only on invoke_agent/cubepi.turn) - the chat span's own response
+    content has to come from cubepi.llm.raw_response instead (OpenAI chat
+    completions shape: choices[0].message.{content,tool_calls}).
+    """
+    raw_response = json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "function": {
+                                    "name": "execute",
+                                    "arguments": '{"command": "ls -la /workspace"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+    )
+    payload = {
+        "batches": [
+            {
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {
+                                "traceId": "abc123",
+                                "spanId": "s1",
+                                "name": "chat glm-5.2",
+                                "startTimeUnixNano": "1781164911000000000",
+                                "endTimeUnixNano": "1781164912000000000",
+                                "attributes": [
+                                    {
+                                        "key": "gen_ai.operation.name",
+                                        "value": {"stringValue": "chat"},
+                                    },
+                                    {
+                                        "key": "cubepi.llm.raw_response",
+                                        "value": {"stringValue": raw_response},
+                                    },
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+    }
+    client = TempoClient(endpoint="http://tempo.local", timeout_seconds=5)
+    respx.get("http://tempo.local/api/traces/abc123").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+    detail = await client.get_trace("abc123")
+
+    output = detail.root.llm.output_messages if detail.root.llm else None
+    assert output is not None
+    assert len(output) == 1
+    assert output[0].role == "assistant"
+    assert output[0].parts[0]["type"] == "tool_call"
+    assert output[0].parts[0]["name"] == "execute"
+    assert output[0].parts[0]["arguments"] == {"command": "ls -la /workspace"}
 
 
 @respx.mock

--- a/backend/tests/unit/test_tempo_client.py
+++ b/backend/tests/unit/test_tempo_client.py
@@ -134,14 +134,21 @@ async def test_tag_values_handles_null_values() -> None:
 
 
 @respx.mock
-async def test_search_passes_zero_duration_filter() -> None:
+async def test_tag_values_scopes_org_and_tag_as_sibling_spansets() -> None:
+    """Regression: cubepi.metadata.org_id lives on the invoke_agent span while
+    e.g. gen_ai.request.model lives on a child chat span. A single {...}
+    selector requires both conditions on the same span and silently returns
+    zero values (verified against a live Tempo instance). The org scope and
+    the requested tag must be independent sibling spansets.
+    """
     client = TempoClient(endpoint="http://tempo.local", timeout_seconds=5)
-    route = respx.get("http://tempo.local/api/search").mock(
-        return_value=httpx.Response(200, json={"traces": []})
+    route = respx.get("http://tempo.local/api/v2/search/tag/span.gen_ai.request.model/values").mock(
+        return_value=httpx.Response(200, json={"tagValues": []})
     )
-    await client.search(org_id="org-1", min_duration_ms=0)
+    await client.tag_values(tag="gen_ai.request.model", org_id="org-1")
     q = route.calls.last.request.url.params["q"]
-    assert "trace:duration > 0ms" in q
+    assert '{ resource.service.name="cubeplex" && span.cubepi.metadata.org_id="org-1" }' in q
+    assert '{ span.gen_ai.request.model != "" }' in q
 
 
 async def test_get_trace_rejects_invalid_trace_id() -> None:
@@ -291,6 +298,7 @@ async def test_search_extracts_model_from_sibling_spanset() -> None:
                         ],
                     },
                 ],
+                "serviceStats": {"cubeplex": {"spanCount": 3}},
             }
         ],
     }
@@ -299,7 +307,9 @@ async def test_search_extracts_model_from_sibling_spanset() -> None:
     [summary] = await client.search(org_id="org-1")
     assert summary.workspace_id == "ws-7"
     assert summary.model == "deepseek-v4-flash"
-    assert summary.span_count == 2  # both matched spans counted
+    # From serviceStats, not spanSet `matched` (which only counts spans that
+    # matched the search selector, not the trace's real span total).
+    assert summary.span_count == 3
 
 
 @respx.mock
@@ -348,6 +358,7 @@ async def test_search_reads_spansets_plural() -> None:
                     }
                 ],
                 # NO spanSet (singular)
+                "serviceStats": {"cubeplex": {"spanCount": 4}},
             }
         ],
     }
@@ -355,4 +366,27 @@ async def test_search_reads_spansets_plural() -> None:
     respx.get("http://tempo.local/api/search").mock(return_value=httpx.Response(200, json=payload))
     [summary] = await client.search(org_id="org-1")
     assert summary.workspace_id == "ws-plural"
-    assert summary.span_count == 1
+    assert summary.span_count == 4
+
+
+@respx.mock
+async def test_search_span_count_defaults_to_zero_without_service_stats() -> None:
+    """Older/malformed Tempo responses without serviceStats shouldn't crash -
+    just report an unknown span count as 0 rather than falling back to the
+    misleading `matched` count."""
+    payload = {
+        "traces": [
+            {
+                "traceID": "abc",
+                "rootTraceName": "invoke_agent",
+                "startTimeUnixNano": "1781164911000000000",
+                "durationMs": 8055,
+                "spanSet": {"matched": 1, "spans": []},
+                # NO serviceStats
+            }
+        ],
+    }
+    client = TempoClient(endpoint="http://tempo.local", timeout_seconds=5)
+    respx.get("http://tempo.local/api/search").mock(return_value=httpx.Response(200, json=payload))
+    [summary] = await client.search(org_id="org-1")
+    assert summary.span_count == 0

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -890,8 +890,8 @@ wheels = [
 
 [[package]]
 name = "cubepi"
-version = "0.13.0"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=94d0ca7380502506042390ce73a02de1060387b0#94d0ca7380502506042390ce73a02de1060387b0" }
+version = "0.13.1"
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=454610487014d352cbecb8c0fc50154d69126f4b#454610487014d352cbecb8c0fc50154d69126f4b" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },
@@ -998,7 +998,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=48.0.1" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=94d0ca7380502506042390ce73a02de1060387b0" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=454610487014d352cbecb8c0fc50154d69126f4b" },
     { name = "dingtalk-stream", specifier = ">=0.24.3" },
     { name = "discord-py", specifier = ">=2.7.1" },
     { name = "dynaconf", specifier = ">=3.2.11" },

--- a/docs/dev/plans/2026-07-20-traces-filter-typeahead.md
+++ b/docs/dev/plans/2026-07-20-traces-filter-typeahead.md
@@ -141,9 +141,12 @@ FilterCombobox({
 
 - Writing readable names into Tempo spans (rejected).
 - Resolving names for `run_id` (not in tag-values allowlist; stays free-text).
-- Friendly names in the trace **detail** view or the list table columns (those
-  still show raw IDs; separate concern, not the filter complaint).
-- Pagination/cursor for the trace list itself (unchanged).
+- Friendly names in the trace **detail** view (list table columns are now
+  addressed - see Unit 6 below).
+
+(Duration filter and trace-list pagination were originally scoped out here;
+see Units 3-6 below - a follow-up round addressed both, plus two bugs found
+during a hands-on review of the shipped filter bar.)
 
 ## Success criteria
 
@@ -165,3 +168,108 @@ FilterCombobox({
   helper; model maps `{value:x,label:x}`. ✓
 - Vagueness: cardinality caps (workspace 200, user/conversation 20), the
   user-via-membership join, and the free-text-fallback rule are all named. ✓
+
+---
+
+# Round 2 - time range, pagination, model-filter fix, name rendering
+
+Triggered by a hands-on PM-style review of the shipped filter bar (screenshots
++ direct backend/Tempo probing), which surfaced two live bugs alongside the
+user's next-round asks. Same architecture as Round 1: query-time/UI only, no
+DB migration, no change to what cubepi writes into spans.
+
+## Unit 3 - Backend: fix the Model tag-values TraceQL scoping bug
+
+**Bug found:** `tag-values?tag=gen_ai.request.model` always returned
+`{"values":[]}`, even though traces clearly had `gen_ai.request.model` set on
+their `chat` spans. Root cause, confirmed by querying Tempo directly:
+`TempoClient.tag_values` (`backend/cubeplex/services/tempo_client.py`) scoped
+org + tag in a single `{...}` selector. `cubepi.metadata.org_id` lives on the
+`invoke_agent` span; `gen_ai.request.model` lives on the child `chat` span - a
+single selector requires both on the *same* span, so it silently matched
+nothing. `search()` already had this exact problem documented and solved (see
+its comment) - `tag_values` just never got the same treatment.
+
+**Fix:** sibling spansets, same pattern as `search()`:
+`{ resource.service.name="cubeplex" && span.cubepi.metadata.org_id=... } && { span.<tag> != "" }`.
+Also discovered mid-fix: this Tempo deployment hard-caps every search/tag-values
+query at 168h (7 days) - omitting a time range isn't safe either (Tempo's own
+default window is too narrow). `tag_values` now always sends an explicit
+30-day-intent window, clamped to 167h to stay under the cap.
+
+Tests: `backend/tests/unit/test_tempo_client.py::test_tag_values_scopes_org_and_tag_as_sibling_spansets`
+asserts the emitted `q` string shape directly.
+
+## Unit 4 - Backend: default time range server-side + drop duration filter
+
+**Bug found:** opening `/admin/traces` with no filters showed "No traces match
+these filters" despite traces existing - `list_traces` sent no `start`/`end`
+to Tempo when both were empty, so Tempo used its own (much narrower) default
+window. Setting only "From" (no "To") produced an opaque 502 - Tempo rejects
+an open-ended range with a 400, which `_bad_upstream` masks.
+
+**Fix** (`backend/cubeplex/api/routes/v1/admin_traces.py::list_traces`):
+self-default the range server-side, independent of the client - never call
+Tempo without an explicit range. Both `start`/`end` absent -> last 1h; one
+side absent -> fill it relative to the other. Also reject a >168h range with
+a clear 400 (`"Range exceeds the maximum supported window (7 days)"`) instead
+of forwarding a doomed request to Tempo and letting `_bad_upstream` mask it.
+
+Dropped `min_duration_ms`/`max_duration_ms` end-to-end (route params, the two
+`TempoClient.search` params + TraceQL clauses, and their one unit test) - the
+UI control is gone per user decision, so the plumbing was dead weight.
+
+Tests: `test_list_defaults_to_last_hour_when_no_range_given`,
+`test_list_fills_missing_side_of_a_partial_range`,
+`test_list_rejects_range_over_168h` in `backend/tests/e2e/test_admin_traces.py`.
+
+## Unit 5 - Frontend: time-range presets + limit + load-more pagination
+
+**Presets:** `[1h] [1d] [7d] [Custom]`, default `1h` - plain button row
+(`components/ui/button.tsx`), not a popover, so the active window is always
+visible. **No `1m` preset**: the 168h Tempo cap (discovered in Unit 3/4) can't
+serve a full month in one query; the user chose to drop the option rather than
+build cross-query stitching for a low-value case.
+
+**Pagination:** Tempo's `/api/search` has no cursor. "Load more" is a
+time-keyset shift mirroring the repo's one existing pagination precedent
+(`components/admin/SSOIdentitiesList.tsx`'s offset/`hasMore`/append pattern,
+adapted to a time cursor instead of an offset): fixed `start`, `end` shrinks to
+(last visible trace's `start_time` − 1ms) on each click, results append.
+`limit` select: `25/50/100`, default `50`.
+
+**URL scheme:** `preset` param (default `1h`); `start`/`end` only round-trip
+through the URL in `custom` mode (presets are relative-to-now and would go
+stale as frozen absolute timestamps in a bookmarked URL); `limit` param.
+
+Files: `components/admin/traces/TraceFilterBar.tsx`,
+`app/admin/traces/page.tsx`, `components/admin/traces/types.ts`,
+`messages/{en,zh}.json`.
+
+## Unit 6 - Frontend + backend: render names instead of raw IDs in the trace list table
+
+Extended `GET /admin/traces/filter-options` with an optional repeated `ids`
+param (exact-match `.in_()`, mutually exclusive with `q`, `ids` wins) - same
+org-scoped queries as Round 1's Unit 1, just a different predicate. Capped at
+200 ids per request (400 above that).
+
+Frontend (`app/admin/traces/page.tsx`): after each page of traces loads
+(initial or "load more"), batch-resolves newly-seen `workspace_id`/`user_id`/
+`conversation_id` values via `getAdminFilterOptionsByIds`, merging into three
+`Record<id, name>` caches that persist across pages (never evicted).
+`TraceListTable.tsx` renders the resolved name with the raw id as a `title`
+tooltip, falling back to the raw id if a lookup misses (e.g. a deleted
+workspace/user).
+
+Tests: `test_filter_options_ids_batch_lookup`, `test_filter_options_ids_wins_over_q`,
+`test_filter_options_ids_rejects_oversized_batch` in
+`backend/tests/e2e/test_admin_traces.py`.
+
+## Round 2 verification
+
+- `cd backend && uv run pytest tests/unit/test_tempo_client.py tests/e2e/test_admin_traces.py --no-cov` - 40 passed.
+- `cd frontend && pnpm --filter web run type-check && pnpm --filter web run lint` - clean.
+- Manual: Playwright-driven screenshots against the live dev deployment for
+  every case above (empty-on-load fixed, model dropdown populated, preset
+  switching, custom-range-over-168h shows a real error, load-more appends
+  without duplicates, table cells show names with id tooltips).

--- a/docs/dev/plans/2026-07-20-traces-filter-typeahead.md
+++ b/docs/dev/plans/2026-07-20-traces-filter-typeahead.md
@@ -1,0 +1,167 @@
+# Traces filter typeahead
+
+## Goal
+
+Replace the four free-text filters on `/admin/traces` (workspace, user,
+conversation, model) with searchable select/typeahead controls so admins pick
+entities instead of typing UUIDs.
+
+## Architecture
+
+Query-time only. No write-path changes (we do **not** write names into Tempo
+spans - that was explored and rejected: it can't scale on the high-cardinality
+conversation field because Tempo tag-values has no server-side prefix filter,
+and it taxes the run-start path for a diagnostic tool).
+
+Dropdown cost is driven by **distinct-entity count, not trace count**, so the
+design never materializes full cardinality:
+
+- **model** (low card) - reuse the existing `GET /tag-values?tag=gen_ai.request.model`
+  (Tempo). The value IS the label. Fetch once, filter client-side.
+- **workspace** (low card) - new Postgres-backed endpoint, returns all org
+  workspaces `{id, name}`. Fetch once, filter client-side.
+- **user** / **conversation** (medium/high card) - new Postgres-backed endpoint,
+  **server-side prefix typeahead**, `LIMIT 20`. Never fetch all.
+
+The stored filter value is always the raw ID (or model name) - identical to
+today - so `list_traces` and its TraceQL are **unchanged**. The new endpoint is
+purely read-only suggestions. A free-text fallback lets an admin paste a known
+ID (the "advanced search by ID" the user asked for) and never regresses the
+current capability.
+
+`run_id`, `start`, `end`, `min_duration_ms`, `max_duration_ms` stay as-is.
+
+## Tech stack
+
+FastAPI + SQLModel/SQLAlchemy (backend), Next.js + React 19 + base-ui
+Combobox (frontend). No migration, no DB schema change, no new dependency.
+
+---
+
+## Unit 1 - Backend: `filter-options` endpoint
+
+### Files
+
+- `backend/cubeplex/api/routes/v1/admin_traces.py` - add `GET /filter-options`.
+- `backend/cubeplex/api/schemas/trace.py` - add `FilterOption`, `FilterOptionsResponse`.
+
+### Interfaces
+
+`GET /api/v1/admin/traces/filter-options` (require_org_admin, same auth/CSRF as
+the sibling routes; `org_id` from session, never from a param):
+
+- `kind`: `workspace` | `user` | `conversation` (required, 400 on unknown).
+- `q`: optional prefix string. Used for `user`/`conversation` typeahead.
+  Ignored for `workspace` (returns all).
+- `limit`: int, default 20, max 50.
+
+Response: `{ "options": [ { "id": str, "name": str } ] }`
+
+### Core logic
+
+Org-scoped queries (org_id from `resolve_current_org_id`):
+
+- `workspace`: `SELECT id, name FROM workspaces WHERE org_id = :org_id ORDER BY name` (cap at 200; org workspaces are coarse/low-cardinality).
+- `conversation`: `SELECT id, title FROM conversations WHERE org_id = :org_id AND title ILIKE :q || '%' ORDER BY title LIMIT :limit` (q required to narrow; `conversation` is `OrgScopedMixin`).
+- `user`: users belong to an org only via membership. `SELECT DISTINCT u.id, COALESCE(u.display_name, u.email) FROM users u JOIN memberships m ON u.id = m.user_id JOIN workspaces w ON m.workspace_id = w.id WHERE w.org_id = :org_id AND (u.display_name ILIKE :q || '%' OR u.email ILIKE :q || '%') ORDER BY label LIMIT :limit`.
+
+`name` is the display label; `id` is the filter value the combobox stores. For
+`user`, label falls back to `email` when `display_name` is null (email is
+unique + always present; display_name is nullable).
+
+### Tests (e2e - `backend/tests/e2e/test_admin_traces.py`)
+
+- Each `kind` returns only entities belonging to the session org (seed a second
+  org's workspace/user/conversation, assert absent) - the org-scoping invariant.
+- `conversation`/`user` prefix `q` narrows results and respects `limit`.
+- `workspace` returns all org workspaces regardless of `q`.
+- Unknown `kind` -> 400; non-org-admin -> 403.
+- These touch the app + Postgres -> e2e, full stop.
+
+---
+
+## Unit 2 - Frontend: `FilterCombobox` + TraceFilterBar rewrite
+
+### Files
+
+- `frontend/packages/web/components/admin/traces/FilterCombobox.tsx` - **new**. Reusable searchable combobox built on `components/ui/combobox.tsx` (base-ui; currently unused repo-wide - this wires it up).
+- `frontend/packages/web/components/admin/traces/TraceFilterBar.tsx` - replace the 4 `field()` text inputs with `<FilterCombobox>`; keep `run_id`/time/duration inputs.
+- `frontend/packages/web/lib/api/admin-traces.ts` - add `getAdminFilterOptions(kind, q?, limit?)` -> `{id,name}[]`; keep existing `getAdminTraceTagValues` (used for model).
+- `frontend/packages/web/components/admin/traces/types.ts` - `TraceFilterValues` unchanged (values stay raw IDs / model name).
+- `frontend/packages/web/messages/{en,zh}.json` - `adminTraces.filters`: add placeholder + empty-state keys per field.
+
+### Interfaces
+
+`FilterCombobox` props:
+
+```
+type Option = { value: string; label: string }
+type LoadMode =
+  | { mode: 'list'; load: () => Promise<Option[]> }        // model, workspace
+  | { mode: 'typeahead'; load: (q: string) => Promise<Option[]> }  // user, conversation
+
+FilterCombobox({
+  label, value, onChange, mode, placeholder?
+})
+```
+
+- `value` / `onChange` are the raw filter string (the ID or model name), so
+  `TraceFilterBar`'s state + URL-sync logic is untouched.
+- On selecting an option: `onChange(option.value)`.
+- Free-text fallback: committing typed text that matches no option calls
+  `onChange(typedText)` - this is the paste-an-ID path. (For model, typed text
+  is a model name; for ws/user/conversation, a raw ID.)
+- Clearable (× button sets `onChange(undefined)`).
+
+### Core logic
+
+- `list` mode: fetch once on first open, filter options client-side by the
+  typed string. Used for model (Tempo tag-values, value=label=model) and
+  workspace (filter-options, label=name value=id).
+- `typeahead` mode: debounce (≈200ms) `load(q)` on keystroke; skip queries
+  shorter than 1 char; show top results. Used for user + conversation.
+- Loading / error / empty states inside the popup; a failed fetch leaves the
+  field usable as free-text (degrades to current behavior).
+- All fetches go through the existing `getJson` helper (credentials, 401
+  redirect, 503 -> `AdminTracesDisabledError`). On 503 the page already shows
+  the disabled state from the list call.
+
+### Tests
+
+- Component-level: selecting an option calls `onChange` with `option.value`;
+  typing + committing commits the typed string; clear button clears. (unit,
+  jsdom - no real services.)
+- No existing frontend test covers the filter bar, so nothing breaks. A full
+  Playwright e2e for the dropdown is optional; the backend org-scoping e2e is
+  the load-bearing invariant.
+
+---
+
+## Out of scope
+
+- Writing readable names into Tempo spans (rejected).
+- Resolving names for `run_id` (not in tag-values allowlist; stays free-text).
+- Friendly names in the trace **detail** view or the list table columns (those
+  still show raw IDs; separate concern, not the filter complaint).
+- Pagination/cursor for the trace list itself (unchanged).
+
+## Success criteria
+
+- Admin can pick workspace / user / conversation / model from a searchable list
+  instead of typing a UUID.
+- user/conversation lists are prefix-narrowed server-side and never exceed 20
+  rows per query, so 10k+ conversations don't slow or bloat the dropdown.
+- Selecting an option filters the trace list identically to typing that ID today
+  (filter value semantics unchanged).
+- Pasting a raw ID still works (free-text fallback).
+- Only the session org's entities are ever returned.
+
+## Plan self-review
+
+- Spec coverage: the 4 fields -> Unit 1 (3 Postgres kinds) + existing tag-values
+  (model) -> Unit 2 wires all 4. ✓
+- Interface consistency: `Option {value,label}` is the single combobox contract;
+  backend returns `{id,name}`, mapped to `{value:id,label:name}` in the API
+  helper; model maps `{value:x,label:x}`. ✓
+- Vagueness: cardinality caps (workspace 200, user/conversation 20), the
+  user-via-membership join, and the free-text-fallback rule are all named. ✓

--- a/frontend/packages/web/app/admin/traces/[traceId]/page.tsx
+++ b/frontend/packages/web/app/admin/traces/[traceId]/page.tsx
@@ -2,7 +2,10 @@
 
 import { use, useCallback, useEffect, useMemo, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import { ArrowLeft } from 'lucide-react'
 
+import { Button } from '@/components/ui/button'
 import { SpanDetail } from '@/components/admin/traces/SpanDetail'
 import { SpanTree } from '@/components/admin/traces/SpanTree'
 import type { SpanNode, TraceDetail } from '@/components/admin/traces/types'
@@ -17,8 +20,22 @@ function findSpan(root: SpanNode, id: string): SpanNode | null {
   return null
 }
 
+// Each chat span already carries its own token usage; sum them across the
+// whole tree for a trace-level total instead of adding a backend field.
+function sumTokens(node: SpanNode): { input: number; output: number } {
+  let input = node.llm?.tokens.input ?? 0
+  let output = node.llm?.tokens.output ?? 0
+  for (const c of node.children) {
+    const child = sumTokens(c)
+    input += child.input
+    output += child.output
+  }
+  return { input, output }
+}
+
 export default function AdminTraceDetailPage({ params }: { params: Promise<{ traceId: string }> }) {
   const { traceId } = use(params)
+  const t = useTranslations('adminTraces')
   const router = useRouter()
   const sp = useSearchParams()
   const [detail, setDetail] = useState<TraceDetail | null>(null)
@@ -52,6 +69,7 @@ export default function AdminTraceDetailPage({ params }: { params: Promise<{ tra
     () => (detail && selectedSpanId ? findSpan(detail.root, selectedSpanId) : null),
     [detail, selectedSpanId],
   )
+  const totalTokens = useMemo(() => (detail ? sumTokens(detail.root) : null), [detail])
 
   const onSelect = useCallback(
     (id: string) => {
@@ -63,6 +81,18 @@ export default function AdminTraceDetailPage({ params }: { params: Promise<{ tra
     [router, sp],
   )
 
+  // router.back() returns to the list with whatever filters/preset/page it
+  // had (it's the same history entry, just with a `span=` query update on
+  // top) - falls back to a fresh /admin/traces when there's nothing to go
+  // back to (e.g. this URL was opened directly, not navigated to in-app).
+  const handleBack = useCallback(() => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back()
+    } else {
+      router.push('/admin/traces')
+    }
+  }, [router])
+
   if (error) return <div className="p-6 text-sm text-destructive">{error}</div>
   if (!detail) return <div className="p-6 text-sm text-muted-foreground">…</div>
 
@@ -70,9 +100,22 @@ export default function AdminTraceDetailPage({ params }: { params: Promise<{ tra
     <div className="grid h-full grid-cols-[420px_1fr] overflow-hidden">
       <div className="overflow-y-auto border-r border-border">
         <div className="border-b border-border px-3 py-2 text-xs text-muted-foreground">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="mb-1.5 -ml-2 gap-1.5 px-2"
+            onClick={handleBack}
+          >
+            <ArrowLeft className="size-3.5" />
+            {t('backToList')}
+          </Button>
           <div className="font-mono">{detail.summary.trace_id}</div>
           <div>
             {detail.summary.duration_ms} ms · {detail.summary.span_count} spans
+            {totalTokens && (totalTokens.input > 0 || totalTokens.output > 0)
+              ? ` · ${totalTokens.input.toLocaleString()} in / ${totalTokens.output.toLocaleString()} out`
+              : ''}
           </div>
         </div>
         <SpanTree root={detail.root} selectedSpanId={selectedSpanId} onSelect={onSelect} />

--- a/frontend/packages/web/app/admin/traces/page.tsx
+++ b/frontend/packages/web/app/admin/traces/page.tsx
@@ -6,77 +6,222 @@ import { useTranslations } from 'next-intl'
 
 import { TraceFilterBar } from '@/components/admin/traces/TraceFilterBar'
 import { TraceListTable } from '@/components/admin/traces/TraceListTable'
-import type { TraceFilterValues, TraceSummary } from '@/components/admin/traces/types'
-import { AdminTracesDisabledError, listAdminTraces } from '@/lib/api/admin-traces'
+import { Button } from '@/components/ui/button'
+import {
+  DEFAULT_LIMIT,
+  DEFAULT_TIME_RANGE_PRESET,
+  type FilterOptionKind,
+  type TimeRangePreset,
+  type TraceFilterValues,
+  type TraceSummary,
+} from '@/components/admin/traces/types'
+import {
+  AdminTracesDisabledError,
+  getAdminFilterOptionsByIds,
+  listAdminTraces,
+} from '@/lib/api/admin-traces'
+
+// Tempo hard-caps search ranges at 168h on this deployment (see backend
+// list_traces) - keep every preset comfortably under that.
+const PRESET_MS: Record<'1h' | '1d' | '7d', number> = {
+  '1h': 60 * 60 * 1000,
+  '1d': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+}
+
+function isPreset(v: string | null): v is TimeRangePreset {
+  return v === '1h' || v === '1d' || v === '7d' || v === 'custom'
+}
 
 function valuesFromSearchParams(sp: URLSearchParams): TraceFilterValues {
   const v: TraceFilterValues = {}
-  for (const k of [
-    'workspace_id',
-    'user_id',
-    'conversation_id',
-    'run_id',
-    'model',
-    'start',
-    'end',
-  ] as const) {
+  for (const k of ['workspace_id', 'user_id', 'conversation_id', 'run_id', 'model'] as const) {
     const val = sp.get(k)
     if (val) v[k] = val
   }
-  for (const k of ['min_duration_ms', 'max_duration_ms'] as const) {
-    const val = sp.get(k)
-    if (val && !Number.isNaN(Number(val))) v[k] = Number(val)
+  // Custom start/end only round-trip through the URL in custom mode -
+  // presets are relative-to-now and would go stale as frozen absolute
+  // timestamps in a shared/bookmarked URL.
+  if (isPreset(sp.get('range')) && sp.get('range') === 'custom') {
+    const start = sp.get('start')
+    const end = sp.get('end')
+    if (start) v.start = start
+    if (end) v.end = end
   }
+  const limitParam = sp.get('limit')
+  v.limit = limitParam && !Number.isNaN(Number(limitParam)) ? Number(limitParam) : DEFAULT_LIMIT
   return v
+}
+
+function presetFromSearchParams(sp: URLSearchParams): TimeRangePreset {
+  const p = sp.get('range')
+  return isPreset(p) ? p : DEFAULT_TIME_RANGE_PRESET
+}
+
+// Resolves whichever of `ids` aren't already in `cache`, merging results in.
+// Shared by the trace-list-driven resolution (Unit 4) and the filter-value
+// resolution below (so a deep-linked ?workspace_id=... shows a name in the
+// combobox even when the filtered result set is empty).
+async function resolveMissingNames(
+  kind: FilterOptionKind,
+  ids: (string | null | undefined)[],
+  cache: Record<string, string>,
+  setCache: (updater: (prev: Record<string, string>) => Record<string, string>) => void,
+) {
+  const missing = Array.from(new Set(ids.filter((id): id is string => !!id && !(id in cache))))
+  if (missing.length === 0) return
+  try {
+    const opts = await getAdminFilterOptionsByIds(kind, missing)
+    if (opts.length === 0) return
+    setCache((prev) => {
+      const next = { ...prev }
+      for (const o of opts) next[o.id] = o.name
+      return next
+    })
+  } catch {
+    // Best-effort: the table/combobox fall back to raw ids on failure.
+  }
 }
 
 export default function AdminTracesPage() {
   const t = useTranslations('adminTraces')
   const router = useRouter()
   const sp = useSearchParams()
-  const [filters, setFilters] = useState<TraceFilterValues>(() =>
-    valuesFromSearchParams(new URLSearchParams(sp?.toString() ?? '')),
-  )
+  const initialSp = new URLSearchParams(sp?.toString() ?? '')
+
+  const [filters, setFilters] = useState<TraceFilterValues>(() => valuesFromSearchParams(initialSp))
+  const [preset, setPreset] = useState<TimeRangePreset>(() => presetFromSearchParams(initialSp))
   const [traces, setTraces] = useState<TraceSummary[]>([])
   const [error, setError] = useState<string | null>(null)
   const [disabled, setDisabled] = useState(false)
   const [loading, setLoading] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [hasMore, setHasMore] = useState(false)
+  // id -> name caches for the table, resolved in batches as new traces load.
+  // Never evicted - they only grow across "load more" pages. Falls back to
+  // the raw id when a lookup misses (e.g. a deleted workspace/user).
+  const [workspaceNames, setWorkspaceNames] = useState<Record<string, string>>({})
+  const [userNames, setUserNames] = useState<Record<string, string>>({})
+  const [conversationNames, setConversationNames] = useState<Record<string, string>>({})
   const abortRef = useRef<AbortController | null>(null)
+  const tracesRef = useRef<TraceSummary[]>([])
+  // The range actually sent to the backend for the currently-loaded page(s):
+  // fixed `start`, shrinking `end` on each "load more". Independent of
+  // `filters.start`/`end`, which only reflect user input in `custom` mode.
+  const rangeAnchorRef = useRef<{ start: string; end: string } | null>(null)
 
-  const fetchPage = useCallback(async (f: TraceFilterValues) => {
-    abortRef.current?.abort()
-    const ctrl = new AbortController()
-    abortRef.current = ctrl
-    setLoading(true)
-    setError(null)
-    setDisabled(false)
-    try {
-      const res = await listAdminTraces({ ...f, limit: 50 }, ctrl.signal)
-      if (ctrl.signal.aborted) return
-      setTraces(res.traces)
-    } catch (e: unknown) {
-      if (ctrl.signal.aborted) return
-      if (e instanceof AdminTracesDisabledError) {
-        setDisabled(true)
-      } else {
-        setError(e instanceof Error ? e.message : String(e))
+  const effectiveRange = useCallback(
+    (f: TraceFilterValues): { start: string; end: string } => {
+      if (preset === 'custom') {
+        const end = f.end ? new Date(f.end) : new Date()
+        const start = f.start ? new Date(f.start) : new Date(end.getTime() - PRESET_MS['1h'])
+        return { start: start.toISOString(), end: end.toISOString() }
       }
-    } finally {
-      if (!ctrl.signal.aborted) setLoading(false)
-    }
-  }, [])
+      const end = new Date()
+      const start = new Date(end.getTime() - PRESET_MS[preset])
+      return { start: start.toISOString(), end: end.toISOString() }
+    },
+    [preset],
+  )
+
+  const runFetch = useCallback(
+    async (
+      f: TraceFilterValues,
+      range: { start: string; end: string },
+      mode: 'replace' | 'more',
+    ) => {
+      abortRef.current?.abort()
+      const ctrl = new AbortController()
+      abortRef.current = ctrl
+      rangeAnchorRef.current = range
+      if (mode === 'replace') setLoading(true)
+      else setLoadingMore(true)
+      setError(null)
+      setDisabled(false)
+      try {
+        const res = await listAdminTraces({ ...f, start: range.start, end: range.end }, ctrl.signal)
+        if (ctrl.signal.aborted) return
+        const limit = f.limit ?? DEFAULT_LIMIT
+        setHasMore(res.traces.length === limit)
+        const next = mode === 'replace' ? res.traces : [...tracesRef.current, ...res.traces]
+        tracesRef.current = next
+        setTraces(next)
+      } catch (e: unknown) {
+        if (ctrl.signal.aborted) return
+        if (e instanceof AdminTracesDisabledError) {
+          setDisabled(true)
+        } else {
+          setError(e instanceof Error ? e.message : String(e))
+        }
+      } finally {
+        if (!ctrl.signal.aborted) {
+          setLoading(false)
+          setLoadingMore(false)
+        }
+      }
+    },
+    [],
+  )
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      fetchPage(filters)
+      void runFetch(filters, effectiveRange(filters), 'replace')
     }, 300)
     return () => clearTimeout(timer)
-  }, [filters, fetchPage])
+  }, [filters, preset, effectiveRange, runFetch])
 
-  const handleChange = (next: TraceFilterValues) => {
-    setFilters(next)
+  useEffect(() => {
+    void resolveMissingNames(
+      'workspace',
+      traces.map((tr) => tr.workspace_id),
+      workspaceNames,
+      setWorkspaceNames,
+    )
+    void resolveMissingNames(
+      'user',
+      traces.map((tr) => tr.user_id),
+      userNames,
+      setUserNames,
+    )
+    void resolveMissingNames(
+      'conversation',
+      traces.map((tr) => tr.conversation_id),
+      conversationNames,
+      setConversationNames,
+    )
+    // Intentionally keyed on `traces` only: the caches are read for their
+    // current value but must not retrigger this effect when they grow.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [traces])
+
+  // Independent of the trace-list resolution above: a deep-linked filter
+  // (e.g. ?workspace_id=...) should show a name in the combobox even when
+  // the filtered result set is empty (so the trace-list effect never sees
+  // that id).
+  useEffect(() => {
+    void resolveMissingNames('workspace', [filters.workspace_id], workspaceNames, setWorkspaceNames)
+    void resolveMissingNames('user', [filters.user_id], userNames, setUserNames)
+    void resolveMissingNames(
+      'conversation',
+      [filters.conversation_id],
+      conversationNames,
+      setConversationNames,
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters.workspace_id, filters.user_id, filters.conversation_id])
+
+  const loadMore = () => {
+    const anchor = rangeAnchorRef.current
+    const last = tracesRef.current[tracesRef.current.length - 1]
+    if (!anchor || !last) return
+    const nextEnd = new Date(new Date(last.start_time).getTime() - 1).toISOString()
+    void runFetch(filters, { start: anchor.start, end: nextEnd }, 'more')
+  }
+
+  const syncUrl = (nextFilters: TraceFilterValues, nextPreset: TimeRangePreset) => {
     const usp = new URLSearchParams()
-    for (const [k, v] of Object.entries(next)) {
+    for (const [k, v] of Object.entries(nextFilters)) {
+      if (k === 'start' || k === 'end') continue
       if (
         v !== undefined &&
         v !== null &&
@@ -85,7 +230,22 @@ export default function AdminTracesPage() {
       )
         usp.set(k, String(v))
     }
+    if (nextPreset !== DEFAULT_TIME_RANGE_PRESET) usp.set('range', nextPreset)
+    if (nextPreset === 'custom') {
+      if (nextFilters.start) usp.set('start', nextFilters.start)
+      if (nextFilters.end) usp.set('end', nextFilters.end)
+    }
     router.replace(`/admin/traces${usp.toString() ? `?${usp.toString()}` : ''}`)
+  }
+
+  const handleFiltersChange = (next: TraceFilterValues) => {
+    setFilters(next)
+    syncUrl(next, preset)
+  }
+
+  const handlePresetChange = (next: TimeRangePreset) => {
+    setPreset(next)
+    syncUrl(filters, next)
   }
 
   return (
@@ -94,7 +254,17 @@ export default function AdminTracesPage() {
         <h1 className="text-lg font-semibold">{t('title')}</h1>
         <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
       </div>
-      <TraceFilterBar value={filters} onChange={handleChange} />
+      <TraceFilterBar
+        value={filters}
+        onChange={handleFiltersChange}
+        preset={preset}
+        onPresetChange={handlePresetChange}
+        workspaceLabel={filters.workspace_id ? workspaceNames[filters.workspace_id] : undefined}
+        userLabel={filters.user_id ? userNames[filters.user_id] : undefined}
+        conversationLabel={
+          filters.conversation_id ? conversationNames[filters.conversation_id] : undefined
+        }
+      />
       <div className="flex-1 overflow-auto">
         {disabled && <div className="p-6 text-sm text-muted-foreground">{t('disabled')}</div>}
         {!disabled && loading && (
@@ -104,7 +274,29 @@ export default function AdminTracesPage() {
         {!disabled && !loading && !error && traces.length === 0 && (
           <div className="p-6 text-sm text-muted-foreground">{t('empty')}</div>
         )}
-        {!disabled && !loading && !error && traces.length > 0 && <TraceListTable traces={traces} />}
+        {!disabled && !loading && !error && traces.length > 0 && (
+          <>
+            <TraceListTable
+              traces={traces}
+              workspaceNames={workspaceNames}
+              userNames={userNames}
+              conversationNames={conversationNames}
+            />
+            {hasMore && (
+              <div className="flex justify-center p-4">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={loadMore}
+                  disabled={loadingMore}
+                >
+                  {loadingMore ? t('loadingMore') : t('loadMore')}
+                </Button>
+              </div>
+            )}
+          </>
+        )}
       </div>
     </div>
   )

--- a/frontend/packages/web/components/admin/traces/FilterCombobox.tsx
+++ b/frontend/packages/web/components/admin/traces/FilterCombobox.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { XIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface FilterComboboxOption {
+  /** Filter value stored in the URL (an entity ID, or a model name). */
+  value: string
+  /** Human-readable label shown in the dropdown and input. */
+  label: string
+}
+
+interface Props {
+  label: string
+  value: string | undefined
+  onChange: (next: string | undefined) => void
+  /**
+   * Fetch options for a query string. In `list` mode this is called once with
+   * '' on mount and the result is filtered client-side; in `typeahead` mode it
+   * is called (debounced) on every keystroke so the server narrows by prefix.
+   */
+  loadOptions: (q: string, signal: AbortSignal) => Promise<FilterComboboxOption[]>
+  mode: 'list' | 'typeahead'
+  placeholder?: string
+}
+
+export function FilterCombobox({ label, value, onChange, loadOptions, mode, placeholder }: Props) {
+  const t = useTranslations('adminTraces.filters')
+  // inputValue is the editable text in the input. It is initialized from the
+  // external value (a raw id when deep-linked from the URL) and thereafter
+  // driven only by user actions (type/select/clear) - so a deep-linked id
+  // shows as-is until the user picks an option, which then shows its label.
+  const [inputValue, setInputValue] = useState(value ?? '')
+  const [options, setOptions] = useState<FilterComboboxOption[]>([])
+  const [loading, setLoading] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [highlight, setHighlight] = useState(-1)
+  const abortRef = useRef<AbortController | null>(null)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  const listLoadedRef = useRef(false)
+
+  const runLoad = useCallback(
+    async (q: string) => {
+      abortRef.current?.abort()
+      const ctrl = new AbortController()
+      abortRef.current = ctrl
+      setLoading(true)
+      try {
+        const opts = await loadOptions(q, ctrl.signal)
+        if (!ctrl.signal.aborted) setOptions(opts)
+      } catch {
+        // Leave the previous options in place; a failed fetch keeps the field
+        // usable as free-text (e.g. paste an ID).
+      } finally {
+        if (!ctrl.signal.aborted) setLoading(false)
+      }
+    },
+    [loadOptions],
+  )
+
+  // list mode: fetch once on mount so the dropdown is populated.
+  useEffect(() => {
+    if (mode !== 'list' || listLoadedRef.current) return
+    listLoadedRef.current = true
+    void runLoad('')
+  }, [mode, runLoad])
+
+  // typeahead: debounced server fetch on input change while open.
+  useEffect(() => {
+    if (mode !== 'typeahead' || !open) return
+    const handle = setTimeout(() => {
+      void runLoad(inputValue)
+    }, 200)
+    return () => clearTimeout(handle)
+  }, [inputValue, open, mode, runLoad])
+
+  // click-outside to close
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [open])
+
+  const displayOptions = useMemo(() => {
+    if (mode === 'list') {
+      const q = inputValue.toLowerCase()
+      return q ? options.filter((o) => o.label.toLowerCase().includes(q)) : options
+    }
+    return options
+  }, [options, inputValue, mode])
+
+  // Clamp stale highlight (e.g. after the visible set shrank) at use instead of
+  // resetting via an effect.
+  const safeHighlight = highlight >= 0 && highlight < displayOptions.length ? highlight : -1
+
+  const select = (opt: FilterComboboxOption) => {
+    setInputValue(opt.label)
+    onChange(opt.value)
+    setHighlight(-1)
+    setOpen(false)
+  }
+
+  const clear = () => {
+    setInputValue('')
+    onChange(undefined)
+    setHighlight(-1)
+    setOpen(false)
+  }
+
+  // Enter picks the highlighted item, else the first visible match, else commits
+  // the typed text as the filter value (the paste-an-ID fallback).
+  const commitFreeText = () => {
+    const trimmed = inputValue.trim()
+    onChange(trimmed === '' ? undefined : trimmed)
+    setOpen(false)
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      if (!open) setOpen(true)
+      setHighlight((h) => Math.min(Math.max(h, -1) + 1, displayOptions.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlight((h) => Math.max(h - 1, -1))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      const idx = safeHighlight >= 0 ? safeHighlight : displayOptions.length > 0 ? 0 : -1
+      if (idx >= 0) select(displayOptions[idx])
+      else commitFreeText()
+    } else if (e.key === 'Escape') {
+      setOpen(false)
+    }
+  }
+
+  return (
+    <div ref={rootRef} className="relative flex flex-col gap-1 text-xs text-muted-foreground">
+      <span>{label}</span>
+      <div className="relative">
+        <input
+          type="text"
+          value={inputValue}
+          placeholder={placeholder}
+          onChange={(e) => {
+            setInputValue(e.target.value)
+            if (!open) setOpen(true)
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={onKeyDown}
+          className="h-8 w-44 rounded border border-border bg-card px-2 py-1 pr-7 text-sm text-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+        />
+        {inputValue && (
+          <button
+            type="button"
+            onClick={clear}
+            aria-label={t('clear')}
+            className="absolute right-1 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center text-muted-foreground hover:text-foreground"
+          >
+            <XIcon className="size-3.5" />
+          </button>
+        )}
+      </div>
+      {open && (
+        <div className="absolute top-full left-0 z-50 mt-1 max-h-60 w-44 overflow-auto rounded border border-border bg-popover p-1 text-foreground shadow-md">
+          {loading && (
+            <div className="px-2 py-1 text-xs text-muted-foreground">{t('loadingOptions')}</div>
+          )}
+          {!loading && displayOptions.length === 0 && (
+            <div className="px-2 py-1 text-xs text-muted-foreground">{t('noOptions')}</div>
+          )}
+          {!loading &&
+            displayOptions.map((o, i) => (
+              <button
+                type="button"
+                key={o.value}
+                onClick={() => select(o)}
+                onMouseEnter={() => setHighlight(i)}
+                className={cn(
+                  'block w-full truncate rounded px-2 py-1 text-left text-sm',
+                  i === safeHighlight ? 'bg-accent text-accent-foreground' : 'text-foreground',
+                )}
+                title={o.label}
+              >
+                {o.label}
+              </button>
+            ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/packages/web/components/admin/traces/FilterCombobox.tsx
+++ b/frontend/packages/web/components/admin/traces/FilterCombobox.tsx
@@ -24,15 +24,41 @@ interface Props {
   loadOptions: (q: string, signal: AbortSignal) => Promise<FilterComboboxOption[]>
   mode: 'list' | 'typeahead'
   placeholder?: string
+  /**
+   * Resolved label for a deep-linked `value` (e.g. from a shared/bookmarked
+   * URL), fetched asynchronously by the parent. Swaps the input's display
+   * text from the raw id to this label once it arrives - but only while the
+   * input still shows exactly `value` untouched, so it never clobbers a
+   * selection or in-progress typing that happened in the meantime.
+   */
+  initialLabel?: string
 }
 
-export function FilterCombobox({ label, value, onChange, loadOptions, mode, placeholder }: Props) {
+export function FilterCombobox({
+  label,
+  value,
+  onChange,
+  loadOptions,
+  mode,
+  placeholder,
+  initialLabel,
+}: Props) {
   const t = useTranslations('adminTraces.filters')
   // inputValue is the editable text in the input. It is initialized from the
   // external value (a raw id when deep-linked from the URL) and thereafter
   // driven only by user actions (type/select/clear) - so a deep-linked id
-  // shows as-is until the user picks an option, which then shows its label.
+  // shows as-is until the user picks an option, or `initialLabel` resolves,
+  // whichever comes first.
   const [inputValue, setInputValue] = useState(value ?? '')
+
+  useEffect(() => {
+    if (initialLabel && value !== undefined && inputValue === value) {
+      setInputValue(initialLabel)
+    }
+    // Only re-run when the resolved label itself changes; re-checking on
+    // every inputValue change would fight the user's own typing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialLabel])
   const [options, setOptions] = useState<FilterComboboxOption[]>([])
   const [loading, setLoading] = useState(false)
   const [open, setOpen] = useState(false)

--- a/frontend/packages/web/components/admin/traces/SpanDetail.tsx
+++ b/frontend/packages/web/components/admin/traces/SpanDetail.tsx
@@ -1,18 +1,29 @@
 'use client'
 
 import { useTranslations } from 'next-intl'
-import { RotateCw } from 'lucide-react'
-import { Badge } from '@/components/ui/badge'
-import { Card } from '@/components/ui/card'
 import type { SpanNode } from './types'
+import { AgentCard } from './cards/AgentCard'
 import { JsonBlock } from './cards/JsonBlock'
 import { LlmCard } from './cards/LlmCard'
 import { Section } from './cards/Section'
 import { ToolCard } from './cards/ToolCard'
+import { TurnCard } from './cards/TurnCard'
 import { KIND_BADGE } from './kindStyles'
 
 interface Props {
   node: SpanNode
+}
+
+// Distinct chat models used anywhere under this agent span - an agent run
+// can call more than one model across turns, so this isn't a single value.
+function collectModels(node: SpanNode): string[] {
+  const models = new Set<string>()
+  const walk = (n: SpanNode) => {
+    if (n.llm?.model) models.add(n.llm.model)
+    for (const c of n.children) walk(c)
+  }
+  walk(node)
+  return Array.from(models)
 }
 
 // Matches the formatDuration shape already used in TraceListTable.tsx (repo
@@ -48,21 +59,8 @@ export function SpanDetail({ node }: Props) {
       </div>
       {node.llm && <LlmCard llm={node.llm} />}
       {node.tool && <ToolCard tool={node.tool} />}
-      {node.turn && (
-        <Card className="flex-row items-center gap-3 p-4">
-          <div className="rounded-md bg-warning-surface p-2 text-warning-fg">
-            <RotateCw className="size-4" />
-          </div>
-          <div className="space-y-1 text-xs">
-            <div className="text-sm font-semibold">Turn {node.turn.index}</div>
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <span>stop:</span>
-              <Badge variant="outline">{node.turn.stop_reason ?? '—'}</Badge>
-              <span>tool calls: {node.turn.tool_calls_count}</span>
-            </div>
-          </div>
-        </Card>
-      )}
+      {node.turn && <TurnCard turn={node.turn} />}
+      {node.agent && <AgentCard agent={node.agent} models={collectModels(node)} />}
       <Section title={t('rawAttributes')} defaultOpen={node.kind === 'other'}>
         <JsonBlock value={JSON.stringify(node.raw_attributes, null, 2)} />
       </Section>

--- a/frontend/packages/web/components/admin/traces/SpanDetail.tsx
+++ b/frontend/packages/web/components/admin/traces/SpanDetail.tsx
@@ -1,13 +1,30 @@
 'use client'
 
 import { useTranslations } from 'next-intl'
+import { RotateCw } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
 import type { SpanNode } from './types'
 import { JsonBlock } from './cards/JsonBlock'
 import { LlmCard } from './cards/LlmCard'
+import { Section } from './cards/Section'
 import { ToolCard } from './cards/ToolCard'
+import { KIND_BADGE } from './kindStyles'
 
 interface Props {
   node: SpanNode
+}
+
+// Matches the formatDuration shape already used in TraceListTable.tsx (repo
+// convention: this small helper is duplicated per-file rather than shared).
+function formatDuration(ms: number): string {
+  if (ms < 0) return '0s'
+  if (ms < 1000) return `${ms}ms`
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return s > 0 ? `${m}m${s}s` : `${m}m`
 }
 
 export function SpanDetail({ node }: Props) {
@@ -15,29 +32,40 @@ export function SpanDetail({ node }: Props) {
   return (
     <div className="space-y-4 p-4">
       <div>
-        <h2 className="text-base font-semibold">{node.name}</h2>
-        <p className="text-xs text-muted-foreground">
-          {node.kind} · {node.duration_ms} ms · {new Date(node.start_time).toLocaleString()}
+        <div className="flex items-center gap-2">
+          <h2 className="text-base font-semibold">{node.name}</h2>
+          <span
+            className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+              KIND_BADGE[node.kind] ?? KIND_BADGE.other
+            }`}
+          >
+            {node.kind}
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground" title={`${node.duration_ms} ms`}>
+          {formatDuration(node.duration_ms)} · {new Date(node.start_time).toLocaleString()}
         </p>
       </div>
       {node.llm && <LlmCard llm={node.llm} />}
       {node.tool && <ToolCard tool={node.tool} />}
       {node.turn && (
-        <div className="rounded border border-border bg-card p-3 text-xs">
-          <div className="font-semibold">Turn {node.turn.index}</div>
-          <div className="text-muted-foreground">
-            stop: {node.turn.stop_reason ?? '—'} · tool_calls: {node.turn.tool_calls_count}
+        <Card className="flex-row items-center gap-3 p-4">
+          <div className="rounded-md bg-warning-surface p-2 text-warning-fg">
+            <RotateCw className="size-4" />
           </div>
-        </div>
+          <div className="space-y-1 text-xs">
+            <div className="text-sm font-semibold">Turn {node.turn.index}</div>
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <span>stop:</span>
+              <Badge variant="outline">{node.turn.stop_reason ?? '—'}</Badge>
+              <span>tool calls: {node.turn.tool_calls_count}</span>
+            </div>
+          </div>
+        </Card>
       )}
-      <details className="rounded border border-border bg-card" open={node.kind === 'other'}>
-        <summary className="cursor-pointer px-3 py-2 text-sm font-medium select-none">
-          {t('rawAttributes')}
-        </summary>
-        <div className="border-t border-border px-3 py-3">
-          <JsonBlock value={JSON.stringify(node.raw_attributes, null, 2)} />
-        </div>
-      </details>
+      <Section title={t('rawAttributes')} defaultOpen={node.kind === 'other'}>
+        <JsonBlock value={JSON.stringify(node.raw_attributes, null, 2)} />
+      </Section>
     </div>
   )
 }

--- a/frontend/packages/web/components/admin/traces/SpanTree.tsx
+++ b/frontend/packages/web/components/admin/traces/SpanTree.tsx
@@ -2,29 +2,12 @@
 
 import { useMemo } from 'react'
 import type { SpanNode } from './types'
+import { KIND_BADGE, KIND_BAR } from './kindStyles'
 
 interface Props {
   root: SpanNode
   selectedSpanId: string
   onSelect: (id: string) => void
-}
-
-// Maps span kind → [badge classes, bar fill class].
-// Uses semantic tokens only (no raw palette utilities per spec §1).
-const KIND_BADGE: Record<string, string> = {
-  agent: 'bg-info-surface text-info-fg',
-  turn: 'bg-warning-surface text-warning-fg',
-  chat: 'bg-primary/10 text-primary',
-  tool: 'bg-success-surface text-success-fg',
-  other: 'bg-muted text-muted-foreground',
-}
-
-const KIND_BAR: Record<string, string> = {
-  agent: 'bg-info-solid',
-  turn: 'bg-warning-solid',
-  chat: 'bg-primary',
-  tool: 'bg-success-solid',
-  other: 'bg-muted-foreground',
 }
 
 interface FlatRow {

--- a/frontend/packages/web/components/admin/traces/TraceFilterBar.tsx
+++ b/frontend/packages/web/components/admin/traces/TraceFilterBar.tsx
@@ -1,15 +1,44 @@
 'use client'
 
+import { useCallback } from 'react'
 import { useTranslations } from 'next-intl'
-import type { TraceFilterValues } from './types'
+import { FilterCombobox, type FilterComboboxOption } from './FilterCombobox'
+import type { FilterOptionKind, TraceFilterValues } from './types'
+import { getAdminFilterOptions, getAdminTraceTagValues } from '@/lib/api/admin-traces'
 
 interface Props {
   value: TraceFilterValues
   onChange: (next: TraceFilterValues) => void
 }
 
+// Map a Postgres filter-options kind to a list/typeahead loader returning
+// {value: id, label: name} pairs.
+function useFilterOptionsLoader(kind: FilterOptionKind) {
+  return useCallback(
+    async (_q: string, signal: AbortSignal): Promise<FilterComboboxOption[]> => {
+      const opts = await getAdminFilterOptions(kind, _q || undefined, signal)
+      return opts.map((o) => ({ value: o.id, label: o.name }))
+    },
+    [kind],
+  )
+}
+
+// model is low-cardinality and sourced from Tempo tag-values; the value is its
+// own label.
+function useModelLoader() {
+  return useCallback(async (_q: string, signal: AbortSignal): Promise<FilterComboboxOption[]> => {
+    const values = await getAdminTraceTagValues('gen_ai.request.model', signal)
+    return values.map((v) => ({ value: v, label: v }))
+  }, [])
+}
+
 export function TraceFilterBar({ value, onChange }: Props) {
   const t = useTranslations('adminTraces.filters')
+  const loadWorkspace = useFilterOptionsLoader('workspace')
+  const loadUser = useFilterOptionsLoader('user')
+  const loadConversation = useFilterOptionsLoader('conversation')
+  const loadModel = useModelLoader()
+
   const field = (k: keyof TraceFilterValues, label: string, type = 'text') => (
     <label className="flex flex-col gap-1 text-xs text-muted-foreground">
       <span>{label}</span>
@@ -17,7 +46,7 @@ export function TraceFilterBar({ value, onChange }: Props) {
         type={type}
         value={(value[k] as string | number | undefined) ?? ''}
         onChange={(e) => onChange({ ...value, [k]: e.target.value || undefined })}
-        className="rounded border border-border bg-card px-2 py-1 text-sm text-foreground"
+        className="h-8 w-44 rounded border border-border bg-card px-2 py-1 text-sm text-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
       />
     </label>
   )
@@ -38,18 +67,47 @@ export function TraceFilterBar({ value, onChange }: Props) {
           if (Number.isFinite(n)) {
             onChange({ ...value, [k]: n })
           }
-          // Invalid (NaN/Infinity): ignore — browser type=number already constrains most cases.
+          // Invalid (NaN/Infinity): ignore - browser type=number already constrains most cases.
         }}
-        className="rounded border border-border bg-card px-2 py-1 text-sm text-foreground w-28"
+        className="h-8 w-28 rounded border border-border bg-card px-2 py-1 text-sm text-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
       />
     </label>
   )
+
   return (
     <div className="flex flex-wrap gap-3 border-b border-border bg-card/40 px-4 py-3">
-      {field('workspace_id', t('workspace'))}
-      {field('user_id', t('user'))}
-      {field('conversation_id', t('conversation'))}
-      {field('model', t('model'))}
+      <FilterCombobox
+        label={t('workspace')}
+        value={value.workspace_id}
+        onChange={(v) => onChange({ ...value, workspace_id: v })}
+        loadOptions={loadWorkspace}
+        mode="list"
+        placeholder={t('searchPlaceholder')}
+      />
+      <FilterCombobox
+        label={t('user')}
+        value={value.user_id}
+        onChange={(v) => onChange({ ...value, user_id: v })}
+        loadOptions={loadUser}
+        mode="typeahead"
+        placeholder={t('searchPlaceholder')}
+      />
+      <FilterCombobox
+        label={t('conversation')}
+        value={value.conversation_id}
+        onChange={(v) => onChange({ ...value, conversation_id: v })}
+        loadOptions={loadConversation}
+        mode="typeahead"
+        placeholder={t('searchPlaceholder')}
+      />
+      <FilterCombobox
+        label={t('model')}
+        value={value.model}
+        onChange={(v) => onChange({ ...value, model: v })}
+        loadOptions={loadModel}
+        mode="list"
+        placeholder={t('searchPlaceholder')}
+      />
       {field('run_id', t('runId'))}
       {field('start', t('from'), 'datetime-local')}
       {field('end', t('to'), 'datetime-local')}

--- a/frontend/packages/web/components/admin/traces/TraceFilterBar.tsx
+++ b/frontend/packages/web/components/admin/traces/TraceFilterBar.tsx
@@ -2,14 +2,32 @@
 
 import { useCallback } from 'react'
 import { useTranslations } from 'next-intl'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { FilterCombobox, type FilterComboboxOption } from './FilterCombobox'
-import type { FilterOptionKind, TraceFilterValues } from './types'
+import type { FilterOptionKind, TimeRangePreset, TraceFilterValues } from './types'
 import { getAdminFilterOptions, getAdminTraceTagValues } from '@/lib/api/admin-traces'
 
 interface Props {
   value: TraceFilterValues
   onChange: (next: TraceFilterValues) => void
+  preset: TimeRangePreset
+  onPresetChange: (next: TimeRangePreset) => void
+  // Resolved names for deep-linked workspace_id/user_id/conversation_id (e.g.
+  // from a shared URL), so the combobox shows a name instead of the raw id.
+  workspaceLabel?: string
+  userLabel?: string
+  conversationLabel?: string
 }
+
+const PRESETS: TimeRangePreset[] = ['1h', '1d', '7d', 'custom']
+const LIMIT_OPTIONS = [25, 50, 100]
 
 // Map a Postgres filter-options kind to a list/typeahead loader returning
 // {value: id, label: name} pairs.
@@ -32,7 +50,15 @@ function useModelLoader() {
   }, [])
 }
 
-export function TraceFilterBar({ value, onChange }: Props) {
+export function TraceFilterBar({
+  value,
+  onChange,
+  preset,
+  onPresetChange,
+  workspaceLabel,
+  userLabel,
+  conversationLabel,
+}: Props) {
   const t = useTranslations('adminTraces.filters')
   const loadWorkspace = useFilterOptionsLoader('workspace')
   const loadUser = useFilterOptionsLoader('user')
@@ -50,69 +76,89 @@ export function TraceFilterBar({ value, onChange }: Props) {
       />
     </label>
   )
-  const numField = (k: 'min_duration_ms' | 'max_duration_ms', label: string) => (
-    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-      <span>{label}</span>
-      <input
-        type="number"
-        min={0}
-        value={(value[k] as number | undefined) ?? ''}
-        onChange={(e) => {
-          const raw = e.target.value
-          if (raw === '') {
-            onChange({ ...value, [k]: undefined })
-            return
-          }
-          const n = Number(raw)
-          if (Number.isFinite(n)) {
-            onChange({ ...value, [k]: n })
-          }
-          // Invalid (NaN/Infinity): ignore - browser type=number already constrains most cases.
-        }}
-        className="h-8 w-28 rounded border border-border bg-card px-2 py-1 text-sm text-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
-      />
-    </label>
-  )
 
   return (
-    <div className="flex flex-wrap gap-3 border-b border-border bg-card/40 px-4 py-3">
-      <FilterCombobox
-        label={t('workspace')}
-        value={value.workspace_id}
-        onChange={(v) => onChange({ ...value, workspace_id: v })}
-        loadOptions={loadWorkspace}
-        mode="list"
-        placeholder={t('searchPlaceholder')}
-      />
-      <FilterCombobox
-        label={t('user')}
-        value={value.user_id}
-        onChange={(v) => onChange({ ...value, user_id: v })}
-        loadOptions={loadUser}
-        mode="typeahead"
-        placeholder={t('searchPlaceholder')}
-      />
-      <FilterCombobox
-        label={t('conversation')}
-        value={value.conversation_id}
-        onChange={(v) => onChange({ ...value, conversation_id: v })}
-        loadOptions={loadConversation}
-        mode="typeahead"
-        placeholder={t('searchPlaceholder')}
-      />
-      <FilterCombobox
-        label={t('model')}
-        value={value.model}
-        onChange={(v) => onChange({ ...value, model: v })}
-        loadOptions={loadModel}
-        mode="list"
-        placeholder={t('searchPlaceholder')}
-      />
-      {field('run_id', t('runId'))}
-      {field('start', t('from'), 'datetime-local')}
-      {field('end', t('to'), 'datetime-local')}
-      {numField('min_duration_ms', t('minDurationMs'))}
-      {numField('max_duration_ms', t('maxDurationMs'))}
+    <div className="flex flex-col gap-3 border-b border-border bg-card/40 px-4 py-3">
+      <div className="flex flex-wrap gap-3">
+        <FilterCombobox
+          label={t('workspace')}
+          value={value.workspace_id}
+          onChange={(v) => onChange({ ...value, workspace_id: v })}
+          loadOptions={loadWorkspace}
+          mode="list"
+          placeholder={t('searchPlaceholder')}
+          initialLabel={workspaceLabel}
+        />
+        <FilterCombobox
+          label={t('user')}
+          value={value.user_id}
+          onChange={(v) => onChange({ ...value, user_id: v })}
+          loadOptions={loadUser}
+          mode="typeahead"
+          placeholder={t('searchPlaceholder')}
+          initialLabel={userLabel}
+        />
+        <FilterCombobox
+          label={t('conversation')}
+          value={value.conversation_id}
+          onChange={(v) => onChange({ ...value, conversation_id: v })}
+          loadOptions={loadConversation}
+          mode="typeahead"
+          placeholder={t('searchPlaceholder')}
+          initialLabel={conversationLabel}
+        />
+        <FilterCombobox
+          label={t('model')}
+          value={value.model}
+          onChange={(v) => onChange({ ...value, model: v })}
+          loadOptions={loadModel}
+          mode="list"
+          placeholder={t('searchPlaceholder')}
+        />
+        {field('run_id', t('runId'))}
+      </div>
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+          <span>{t('range')}</span>
+          <div className="flex gap-1">
+            {PRESETS.map((p) => (
+              <Button
+                key={p}
+                type="button"
+                size="sm"
+                variant={preset === p ? 'default' : 'outline'}
+                onClick={() => onPresetChange(p)}
+              >
+                {t(`rangePreset.${p}`)}
+              </Button>
+            ))}
+          </div>
+        </div>
+        {preset === 'custom' && (
+          <>
+            {field('start', t('from'), 'datetime-local')}
+            {field('end', t('to'), 'datetime-local')}
+          </>
+        )}
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          <span>{t('limit')}</span>
+          <Select
+            value={String(value.limit ?? LIMIT_OPTIONS[1])}
+            onValueChange={(v) => onChange({ ...value, limit: Number(v) })}
+          >
+            <SelectTrigger size="sm" className="w-20">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {LIMIT_OPTIONS.map((n) => (
+                <SelectItem key={n} value={String(n)}>
+                  {n}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </label>
+      </div>
     </div>
   )
 }

--- a/frontend/packages/web/components/admin/traces/TraceListTable.tsx
+++ b/frontend/packages/web/components/admin/traces/TraceListTable.tsx
@@ -6,9 +6,46 @@ import type { TraceSummary } from './types'
 
 interface Props {
   traces: TraceSummary[]
+  workspaceNames: Record<string, string>
+  userNames: Record<string, string>
+  conversationNames: Record<string, string>
 }
 
-export function TraceListTable({ traces }: Props) {
+// Renders the resolved name with the raw id as a tooltip; falls back to the
+// raw id itself when the lookup has no entry (e.g. a deleted workspace/user,
+// or the batch resolution for this id hasn't landed yet).
+function EntityCell({
+  id,
+  names,
+}: {
+  id: string | null | undefined
+  names: Record<string, string>
+}) {
+  if (!id) return <span>—</span>
+  const name = names[id]
+  return (
+    <span title={id} className={name ? undefined : 'font-mono text-xs'}>
+      {name ?? id}
+    </span>
+  )
+}
+
+// Matches the formatDuration convention used elsewhere in the app (e.g.
+// components/chat/ToolCallItem.tsx): <60s -> "Ns", >=60s -> "Nm Ss" or "Nm".
+// Extended with a sub-second case (that convention's callers only invoke it
+// for durations already known to be >=1s) - rounding straight to seconds
+// would show a confusing "0s" for the many sub-second trace runs here.
+function formatDuration(ms: number): string {
+  if (ms < 0) return '0s'
+  if (ms < 1000) return `${ms}ms`
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return s > 0 ? `${m}m${s}s` : `${m}m`
+}
+
+export function TraceListTable({ traces, workspaceNames, userNames, conversationNames }: Props) {
   const t = useTranslations('adminTraces.columns')
   return (
     <table className="w-full text-sm">
@@ -34,11 +71,19 @@ export function TraceListTable({ traces }: Props) {
                 {new Date(tr.start_time).toLocaleString()}
               </Link>
             </td>
-            <td className="px-3 py-2">{tr.duration_ms} ms</td>
+            <td className="px-3 py-2" title={`${tr.duration_ms} ms`}>
+              {formatDuration(tr.duration_ms)}
+            </td>
             <td className="px-3 py-2">{tr.model ?? '—'}</td>
-            <td className="px-3 py-2 font-mono text-xs">{tr.workspace_id ?? '—'}</td>
-            <td className="px-3 py-2 font-mono text-xs">{tr.user_id ?? '—'}</td>
-            <td className="px-3 py-2 font-mono text-xs">{tr.conversation_id ?? '—'}</td>
+            <td className="px-3 py-2">
+              <EntityCell id={tr.workspace_id} names={workspaceNames} />
+            </td>
+            <td className="px-3 py-2">
+              <EntityCell id={tr.user_id} names={userNames} />
+            </td>
+            <td className="px-3 py-2">
+              <EntityCell id={tr.conversation_id} names={conversationNames} />
+            </td>
             <td className="px-3 py-2">{tr.span_count}</td>
           </tr>
         ))}

--- a/frontend/packages/web/components/admin/traces/cards/AgentCard.tsx
+++ b/frontend/packages/web/components/admin/traces/cards/AgentCard.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { FileText, MessageSquare, Wrench } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+import { Badge } from '@/components/ui/badge'
+import type { AgentPayload } from '../types'
+import { MessageList } from './MessageList'
+import { Section } from './Section'
+
+interface Props {
+  agent: AgentPayload
+  // Distinct chat models used anywhere in this agent run - a run can call
+  // more than one model across turns, so this is a list, not a single value.
+  models: string[]
+}
+
+// cubepi prefixes a provider name it doesn't canonically recognize with
+// "unknown:" (see cubepi/tracing/schema.py::map_provider_name) - real,
+// intentional signal, not a bug. Show the actual name as the primary text,
+// full value (with the prefix) as a tooltip so the signal isn't lost.
+function formatProvider(provider: string): { label: string; title: string } {
+  const idx = provider.indexOf(':')
+  return idx === -1
+    ? { label: provider, title: provider }
+    : { label: provider.slice(idx + 1), title: provider }
+}
+
+export function AgentCard({ agent, models }: Props) {
+  const t = useTranslations('adminTraces.sections')
+  const provider = agent.provider ? formatProvider(agent.provider) : null
+
+  return (
+    <div className="space-y-3">
+      {(provider || models.length > 0 || agent.tools.length > 0) && (
+        <Section
+          title={t('agentOverview')}
+          icon={<Wrench className="size-4 text-muted-foreground" />}
+        >
+          <div className="space-y-2 text-xs">
+            {(provider || models.length > 0) && (
+              <div>
+                {provider && (
+                  <span>
+                    <span className="text-muted-foreground">{t('provider')}: </span>
+                    <span className="font-mono" title={provider.title}>
+                      {provider.label}
+                    </span>
+                  </span>
+                )}
+                {provider && models.length > 0 && (
+                  <span className="text-muted-foreground"> · </span>
+                )}
+                {models.length > 0 && (
+                  <span>
+                    <span className="text-muted-foreground">{t('model')}: </span>
+                    <span className="font-mono">{models.join(', ')}</span>
+                  </span>
+                )}
+              </div>
+            )}
+            {agent.tools.length > 0 && (
+              <div>
+                <div className="mb-1 text-muted-foreground">{t('tools')}</div>
+                <div className="flex flex-wrap gap-1">
+                  {agent.tools.map((name) => (
+                    <Badge key={name} variant="outline">
+                      {name}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </Section>
+      )}
+      <Section
+        title={t('system')}
+        defaultOpen={false}
+        icon={<FileText className="size-4 text-muted-foreground" />}
+      >
+        <MessageList items={agent.system_instructions} />
+      </Section>
+      <Section
+        title={t('messages')}
+        icon={<MessageSquare className="size-4 text-muted-foreground" />}
+      >
+        <MessageList items={agent.messages} />
+      </Section>
+      <Section
+        title={t('output')}
+        icon={<MessageSquare className="size-4 text-muted-foreground" />}
+      >
+        <MessageList items={agent.output_messages} />
+      </Section>
+    </div>
+  )
+}

--- a/frontend/packages/web/components/admin/traces/cards/JsonBlock.tsx
+++ b/frontend/packages/web/components/admin/traces/cards/JsonBlock.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { Check, Copy } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 
 interface Props {
   value: string | undefined | null
@@ -9,8 +10,13 @@ interface Props {
 }
 
 export function JsonBlock({ value, language = 'json' }: Props) {
+  const t = useTranslations('adminTraces.sections')
   const [copied, setCopied] = useState(false)
-  if (!value) return null
+  // Distinguish "no data at all" (undefined/null - render nothing) from
+  // "the field is present but empty" (e.g. "" or "0") - the latter used to
+  // silently render nothing too, which reads as a bug, not an empty result.
+  if (value == null) return null
+  if (value === '') return <div className="text-xs text-muted-foreground italic">{t('empty')}</div>
   const formatted = (() => {
     if (language !== 'json') return value
     try {

--- a/frontend/packages/web/components/admin/traces/cards/LlmCard.tsx
+++ b/frontend/packages/web/components/admin/traces/cards/LlmCard.tsx
@@ -1,61 +1,44 @@
 'use client'
 
-import { useState } from 'react'
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import { Cpu, FileText, Gauge, Hash, MessageSquare, Wrench } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
-import type { ChatMessage, LlmCallPayload } from '../types'
+import { Badge } from '@/components/ui/badge'
+import type { LlmCallPayload } from '../types'
 import { JsonBlock } from './JsonBlock'
+import { MessageList } from './MessageList'
+import { Section } from './Section'
 
 interface Props {
   llm: LlmCallPayload
 }
 
-function Section({
-  title,
-  defaultOpen = true,
-  children,
-}: {
-  title: string
-  defaultOpen?: boolean
-  children: React.ReactNode
-}) {
-  const [open, setOpen] = useState(defaultOpen)
+function TokenTile({ label, value, tone }: { label: string; value: number; tone: TokenTone }) {
   return (
-    <div className="rounded border border-border bg-card">
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        className="flex w-full items-center justify-between px-3 py-2 text-sm font-medium"
-      >
-        <span>{title}</span>
-        {open ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
-      </button>
-      {open && <div className="border-t border-border px-3 py-3">{children}</div>}
+    <div className={`rounded-lg p-3 text-center ${TOKEN_TONE_CLASSES[tone]}`}>
+      <div className="text-xl font-semibold tabular-nums">{value.toLocaleString()}</div>
+      <div className="text-[11px] tracking-wide uppercase opacity-80">{label}</div>
     </div>
   )
 }
 
-function Messages({ items }: { items: ChatMessage[] }) {
-  if (!items.length) return <div className="text-xs text-muted-foreground">—</div>
-  return (
-    <div className="space-y-3">
-      {items.map((m, i) => (
-        <div key={i} className="rounded border border-border/60 bg-muted/20 p-2">
-          <div className="mb-1 text-xs font-semibold uppercase text-muted-foreground">{m.role}</div>
-          <JsonBlock value={JSON.stringify(m.parts, null, 2)} />
-        </div>
-      ))}
-    </div>
-  )
+type TokenTone = 'info' | 'success' | 'warning' | 'muted'
+
+const TOKEN_TONE_CLASSES: Record<TokenTone, string> = {
+  info: 'bg-info-surface text-info-fg',
+  success: 'bg-success-surface text-success-fg',
+  warning: 'bg-warning-surface text-warning-fg',
+  muted: 'bg-muted text-muted-foreground',
 }
 
 export function LlmCard({ llm }: Props) {
   const t = useTranslations('adminTraces.sections')
+  const hasCache = llm.tokens.cache_read > 0 || llm.tokens.cache_write > 0
+
   return (
     <div className="space-y-3">
-      <Section title={t('model')}>
-        <dl className="grid grid-cols-2 gap-2 text-xs">
+      <Section title={t('model')} icon={<Cpu className="size-4 text-muted-foreground" />}>
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
           <dt className="text-muted-foreground">Model</dt>
           <dd className="font-mono">{llm.model}</dd>
           <dt className="text-muted-foreground">Provider</dt>
@@ -67,33 +50,37 @@ export function LlmCard({ llm }: Props) {
           <dt className="text-muted-foreground">Stream</dt>
           <dd className="font-mono">{String(llm.request_stream ?? '—')}</dd>
           <dt className="text-muted-foreground">Finish</dt>
-          <dd className="font-mono">{llm.finish_reasons.join(', ') || '—'}</dd>
+          <dd className="flex flex-wrap gap-1">
+            {llm.finish_reasons.length > 0
+              ? llm.finish_reasons.map((r) => (
+                  <Badge key={r} variant="outline">
+                    {r}
+                  </Badge>
+                ))
+              : '—'}
+          </dd>
         </dl>
       </Section>
 
-      <Section title={t('tokens')}>
-        <dl className="grid grid-cols-4 gap-2 text-center text-xs">
-          <div>
-            <dt className="text-muted-foreground">input</dt>
-            <dd className="font-mono">{llm.tokens.input}</dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">output</dt>
-            <dd className="font-mono">{llm.tokens.output}</dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">cache read</dt>
-            <dd className="font-mono">{llm.tokens.cache_read}</dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">cache write</dt>
-            <dd className="font-mono">{llm.tokens.cache_write}</dd>
-          </div>
-        </dl>
+      <Section title={t('tokens')} icon={<Hash className="size-4 text-muted-foreground" />}>
+        <div className={`grid gap-2 ${hasCache ? 'grid-cols-4' : 'grid-cols-2'}`}>
+          <TokenTile label={t('tokensInput')} value={llm.tokens.input} tone="info" />
+          <TokenTile label={t('tokensOutput')} value={llm.tokens.output} tone="success" />
+          {llm.tokens.cache_read > 0 && (
+            <TokenTile label={t('tokensCacheRead')} value={llm.tokens.cache_read} tone="warning" />
+          )}
+          {llm.tokens.cache_write > 0 && (
+            <TokenTile label={t('tokensCacheWrite')} value={llm.tokens.cache_write} tone="muted" />
+          )}
+        </div>
       </Section>
 
       {llm.tools.length > 0 && (
-        <Section title={t('tools')} defaultOpen={false}>
+        <Section
+          title={t('tools')}
+          defaultOpen={false}
+          icon={<Wrench className="size-4 text-muted-foreground" />}
+        >
           <ul className="space-y-2 text-xs">
             {llm.tools.map((tool) => (
               <li key={tool.name} className="rounded border border-border/60 p-2">
@@ -107,14 +94,24 @@ export function LlmCard({ llm }: Props) {
         </Section>
       )}
 
-      <Section title={t('system')} defaultOpen={false}>
-        <Messages items={llm.system_instructions} />
+      <Section
+        title={t('system')}
+        defaultOpen={false}
+        icon={<FileText className="size-4 text-muted-foreground" />}
+      >
+        <MessageList items={llm.system_instructions} />
       </Section>
-      <Section title={t('messages')}>
-        <Messages items={llm.messages} />
+      <Section
+        title={t('messages')}
+        icon={<MessageSquare className="size-4 text-muted-foreground" />}
+      >
+        <MessageList items={llm.messages} />
       </Section>
-      <Section title={t('output')}>
-        <Messages items={llm.output_messages} />
+      <Section
+        title={t('output')}
+        icon={<MessageSquare className="size-4 text-muted-foreground" />}
+      >
+        <MessageList items={llm.output_messages} />
       </Section>
       <Section title={t('rawRequest')} defaultOpen={false}>
         <JsonBlock value={llm.raw_request} />
@@ -123,7 +120,11 @@ export function LlmCard({ llm }: Props) {
         <JsonBlock value={llm.raw_response} />
       </Section>
 
-      <Section title={t('performance')} defaultOpen={false}>
+      <Section
+        title={t('performance')}
+        defaultOpen={false}
+        icon={<Gauge className="size-4 text-muted-foreground" />}
+      >
         <dl className="grid grid-cols-2 gap-2 text-xs">
           <dt className="text-muted-foreground">Time to first chunk</dt>
           <dd className="font-mono">

--- a/frontend/packages/web/components/admin/traces/cards/LlmCard.tsx
+++ b/frontend/packages/web/components/admin/traces/cards/LlmCard.tsx
@@ -31,9 +31,21 @@ const TOKEN_TONE_CLASSES: Record<TokenTone, string> = {
   muted: 'bg-muted text-muted-foreground',
 }
 
+// cubepi prefixes a provider name it doesn't canonically recognize with
+// "unknown:" (see cubepi/tracing/schema.py::map_provider_name) - real,
+// intentional signal, not a bug. Show the actual name as the primary text,
+// full value (with the prefix) as a tooltip so the signal isn't lost.
+function formatProvider(provider: string): { label: string; title: string } {
+  const idx = provider.indexOf(':')
+  return idx === -1
+    ? { label: provider, title: provider }
+    : { label: provider.slice(idx + 1), title: provider }
+}
+
 export function LlmCard({ llm }: Props) {
   const t = useTranslations('adminTraces.sections')
   const hasCache = llm.tokens.cache_read > 0 || llm.tokens.cache_write > 0
+  const provider = llm.provider ? formatProvider(llm.provider) : null
 
   return (
     <div className="space-y-3">
@@ -42,7 +54,9 @@ export function LlmCard({ llm }: Props) {
           <dt className="text-muted-foreground">Model</dt>
           <dd className="font-mono">{llm.model}</dd>
           <dt className="text-muted-foreground">Provider</dt>
-          <dd className="font-mono">{llm.provider ?? '—'}</dd>
+          <dd className="font-mono" title={provider?.title}>
+            {provider?.label ?? '—'}
+          </dd>
           <dt className="text-muted-foreground">Max tokens</dt>
           <dd className="font-mono">{llm.request_max_tokens ?? '—'}</dd>
           <dt className="text-muted-foreground">Temperature</dt>

--- a/frontend/packages/web/components/admin/traces/cards/MessageList.tsx
+++ b/frontend/packages/web/components/admin/traces/cards/MessageList.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import {
+  AlertTriangle,
   Bot,
   Brain,
   ChevronDown,
@@ -28,6 +29,9 @@ const ROLE_STYLE: Record<string, { icon: typeof User; accent: string }> = {
   assistant: { icon: Bot, accent: 'border-l-primary' },
   system: { icon: Settings, accent: 'border-l-muted-foreground/40' },
   tool: { icon: Terminal, accent: 'border-l-success-solid' },
+  // _decode_messages' fallback when a span attribute was truncated upstream
+  // (invalid JSON) - not a real conversational role.
+  _truncated: { icon: AlertTriangle, accent: 'border-l-warning-solid' },
 }
 
 function str(v: unknown): string {
@@ -78,6 +82,16 @@ function ToolCallPart({ part }: { part: Record<string, unknown> }) {
   )
 }
 
+function TruncatedPart({ content }: { content: string }) {
+  const t = useTranslations('adminTraces.sections')
+  return (
+    <div className="space-y-1">
+      <p className="text-xs text-warning-fg">{t('truncated')}</p>
+      <JsonBlock value={content} language="text" />
+    </div>
+  )
+}
+
 function ToolResultPart({ part }: { part: Record<string, unknown> }) {
   return (
     <div className="rounded border border-border/60 bg-muted/20 p-2">
@@ -85,7 +99,7 @@ function ToolResultPart({ part }: { part: Record<string, unknown> }) {
         <Terminal className="size-3.5" />
         <span>result</span>
       </div>
-      <JsonBlock value={str(part.result)} language="text" />
+      <JsonBlock value={str(part.result)} />
     </div>
   )
 }
@@ -101,6 +115,8 @@ function MessagePart({ part }: { part: Record<string, unknown> }) {
       return <ToolCallPart part={part} />
     case 'tool_call_response':
       return <ToolResultPart part={part} />
+    case '_truncated':
+      return <TruncatedPart content={str(part.content)} />
     default:
       return <Badge variant="outline">[{type || 'unknown'}]</Badge>
   }
@@ -122,12 +138,14 @@ export function MessageList({ items }: Props) {
             <div className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground">
               <Icon className="size-3.5" />
               <span>
-                {KNOWN_ROLES.has(m.role)
-                  ? t(
-                      `roles.${m.role}` as
-                        'roles.user' | 'roles.assistant' | 'roles.system' | 'roles.tool',
-                    )
-                  : m.role}
+                {m.role === '_truncated'
+                  ? t('truncatedLabel')
+                  : KNOWN_ROLES.has(m.role)
+                    ? t(
+                        `roles.${m.role}` as
+                          'roles.user' | 'roles.assistant' | 'roles.system' | 'roles.tool',
+                      )
+                    : m.role}
               </span>
             </div>
             <div className="space-y-2">

--- a/frontend/packages/web/components/admin/traces/cards/MessageList.tsx
+++ b/frontend/packages/web/components/admin/traces/cards/MessageList.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useState } from 'react'
+import { useTranslations } from 'next-intl'
+import {
+  Bot,
+  Brain,
+  ChevronDown,
+  ChevronRight,
+  Settings,
+  Terminal,
+  User,
+  Wrench,
+} from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import type { ChatMessage } from '../types'
+import { JsonBlock } from './JsonBlock'
+import { MessageText } from './MessageText'
+
+interface Props {
+  items: ChatMessage[]
+}
+
+// Role → icon + left-accent color. Matches the semantic tokens already used
+// elsewhere in this directory (info/success surfaces), not a new palette.
+const ROLE_STYLE: Record<string, { icon: typeof User; accent: string }> = {
+  user: { icon: User, accent: 'border-l-info-solid' },
+  assistant: { icon: Bot, accent: 'border-l-primary' },
+  system: { icon: Settings, accent: 'border-l-muted-foreground/40' },
+  tool: { icon: Terminal, accent: 'border-l-success-solid' },
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : ''
+}
+
+const KNOWN_ROLES = new Set(['user', 'assistant', 'system', 'tool'])
+
+// Matches AssistantMessage.tsx's completed-state ReasoningBlock almost
+// exactly (Brain icon, chevron, italic muted text, left border) so a
+// "reasoning" part here reads as the same concept the live chat UI already
+// shows the user - just without the streaming ticker (traces are historical).
+function ReasoningPart({ content }: { content: string }) {
+  const t = useTranslations('adminTraces.sections')
+  const [open, setOpen] = useState(false)
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+      >
+        {open ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+        <Brain className="size-3 text-muted-foreground/70" />
+        <span>{t('reasoning')}</span>
+      </button>
+      {open && (
+        <div className="mt-1.5 max-h-64 overflow-y-auto border-l-2 border-border/50 pl-4">
+          <p className="text-xs leading-relaxed whitespace-pre-wrap text-muted-foreground/70 italic">
+            {content}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ToolCallPart({ part }: { part: Record<string, unknown> }) {
+  const name = str(part.name) || '?'
+  return (
+    <div className="rounded border border-border/60 bg-muted/20 p-2">
+      <div className="mb-1 flex items-center gap-1.5 text-xs font-semibold">
+        <Wrench className="size-3.5 text-muted-foreground" />
+        <span className="font-mono">{name}</span>
+      </div>
+      <JsonBlock value={JSON.stringify(part.arguments ?? {}, null, 2)} />
+    </div>
+  )
+}
+
+function ToolResultPart({ part }: { part: Record<string, unknown> }) {
+  return (
+    <div className="rounded border border-border/60 bg-muted/20 p-2">
+      <div className="mb-1 flex items-center gap-1.5 text-xs font-semibold text-muted-foreground">
+        <Terminal className="size-3.5" />
+        <span>result</span>
+      </div>
+      <JsonBlock value={str(part.result)} language="text" />
+    </div>
+  )
+}
+
+function MessagePart({ part }: { part: Record<string, unknown> }) {
+  const type = str(part.type)
+  switch (type) {
+    case 'text':
+      return <MessageText>{str(part.content)}</MessageText>
+    case 'reasoning':
+      return <ReasoningPart content={str(part.content)} />
+    case 'tool_call':
+      return <ToolCallPart part={part} />
+    case 'tool_call_response':
+      return <ToolResultPart part={part} />
+    default:
+      return <Badge variant="outline">[{type || 'unknown'}]</Badge>
+  }
+}
+
+export function MessageList({ items }: Props) {
+  const t = useTranslations('adminTraces.sections')
+  if (!items.length) return <div className="text-xs text-muted-foreground">—</div>
+  return (
+    <div className="space-y-3">
+      {items.map((m, i) => {
+        const style = ROLE_STYLE[m.role] ?? ROLE_STYLE.system
+        const Icon = style.icon
+        return (
+          <div
+            key={i}
+            className={`space-y-2 rounded-r-lg border-l-2 bg-muted/10 py-2 pr-3 pl-3 ${style.accent}`}
+          >
+            <div className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground">
+              <Icon className="size-3.5" />
+              <span>
+                {KNOWN_ROLES.has(m.role)
+                  ? t(
+                      `roles.${m.role}` as
+                        'roles.user' | 'roles.assistant' | 'roles.system' | 'roles.tool',
+                    )
+                  : m.role}
+              </span>
+            </div>
+            <div className="space-y-2">
+              {m.parts.map((part, j) => (
+                <MessagePart key={j} part={part} />
+              ))}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/packages/web/components/admin/traces/cards/MessageText.tsx
+++ b/frontend/packages/web/components/admin/traces/cards/MessageText.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import ReactMarkdown from 'react-markdown'
+import type { ComponentProps } from 'react'
+import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
+import rehypeHighlight from 'rehype-highlight'
+import { proseClasses } from '@/lib/utils'
+
+const REMARK_PLUGINS: ComponentProps<typeof ReactMarkdown>['remarkPlugins'] = [
+  remarkGfm,
+  remarkBreaks,
+]
+const REHYPE_PLUGINS: ComponentProps<typeof ReactMarkdown>['rehypePlugins'] = [
+  [rehypeHighlight, { detect: true, ignoreMissing: true }],
+]
+
+interface Props {
+  children: string
+}
+
+// Deliberately not MarkdownWithCitations (components/shared) - that component
+// needs a conversationId from the live chat's Zustand store plus sandbox-link
+// resolution, which don't apply to this read-only historical trace inspector.
+export function MessageText({ children }: Props) {
+  return (
+    <div className={proseClasses}>
+      <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS}>
+        {children}
+      </ReactMarkdown>
+    </div>
+  )
+}

--- a/frontend/packages/web/components/admin/traces/cards/Section.tsx
+++ b/frontend/packages/web/components/admin/traces/cards/Section.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState, type ReactNode } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { Card } from '@/components/ui/card'
+
+interface Props {
+  title: string
+  icon?: ReactNode
+  defaultOpen?: boolean
+  children: ReactNode
+}
+
+// Shared collapsible card shell for the span detail panel (LlmCard, ToolCard,
+// SpanDetail's turn/raw-attributes blocks) so they all look like one system
+// instead of each hand-rolling a border box. Conditional-render collapse
+// (not components/ui/collapsible.tsx, which has no actual show/hide wiring).
+export function Section({ title, icon, defaultOpen = true, children }: Props) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <Card className="gap-0 py-0">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center justify-between gap-2 px-4 py-2.5 text-left"
+      >
+        <span className="flex items-center gap-2 text-sm font-medium">
+          {icon}
+          {title}
+        </span>
+        {open ? (
+          <ChevronDown className="size-4 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="size-4 text-muted-foreground" />
+        )}
+      </button>
+      {open && <div className="border-t border-border/60 px-4 py-3">{children}</div>}
+    </Card>
+  )
+}

--- a/frontend/packages/web/components/admin/traces/cards/ToolCard.tsx
+++ b/frontend/packages/web/components/admin/traces/cards/ToolCard.tsx
@@ -1,9 +1,13 @@
 'use client'
 
+import { Wrench } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
 import type { ToolCallPayload } from '../types'
 import { JsonBlock } from './JsonBlock'
+import { Section } from './Section'
 
 interface Props {
   tool: ToolCallPayload
@@ -13,22 +17,27 @@ export function ToolCard({ tool }: Props) {
   const t = useTranslations('adminTraces.sections')
   return (
     <div className="space-y-3">
-      <div className="rounded border border-border bg-card p-3">
-        <div className="text-xs text-muted-foreground">{t('toolInfo')}</div>
-        <div className="mt-1 font-mono text-sm font-semibold">{tool.name}</div>
-        {tool.description && (
-          <div className="mt-1 text-xs text-muted-foreground">{tool.description}</div>
-        )}
-        {tool.is_error && <div className="mt-2 text-xs font-medium text-destructive">errored</div>}
-      </div>
-      <div>
-        <div className="mb-1 text-xs font-medium text-muted-foreground">{t('arguments')}</div>
+      <Card className="flex-row items-start gap-3 p-4">
+        <div className="rounded-md bg-success-surface p-2 text-success-fg">
+          <Wrench className="size-4" />
+        </div>
+        <div className="flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-sm font-semibold">{tool.name}</span>
+            {tool.is_error && <Badge variant="destructive">error</Badge>}
+          </div>
+          {tool.description && <p className="text-xs text-muted-foreground">{tool.description}</p>}
+          {tool.execution_mode && (
+            <p className="text-[11px] text-muted-foreground">mode: {tool.execution_mode}</p>
+          )}
+        </div>
+      </Card>
+      <Section title={t('arguments')}>
         <JsonBlock value={tool.arguments} />
-      </div>
-      <div>
-        <div className="mb-1 text-xs font-medium text-muted-foreground">{t('result')}</div>
+      </Section>
+      <Section title={t('result')}>
         <JsonBlock value={tool.result} language="text" />
-      </div>
+      </Section>
     </div>
   )
 }

--- a/frontend/packages/web/components/admin/traces/cards/ToolCard.tsx
+++ b/frontend/packages/web/components/admin/traces/cards/ToolCard.tsx
@@ -36,7 +36,7 @@ export function ToolCard({ tool }: Props) {
         <JsonBlock value={tool.arguments} />
       </Section>
       <Section title={t('result')}>
-        <JsonBlock value={tool.result} language="text" />
+        <JsonBlock value={tool.result} />
       </Section>
     </div>
   )

--- a/frontend/packages/web/components/admin/traces/cards/TurnCard.tsx
+++ b/frontend/packages/web/components/admin/traces/cards/TurnCard.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { MessageSquare, RotateCw } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
+import type { TurnPayload } from '../types'
+import { MessageList } from './MessageList'
+import { Section } from './Section'
+
+interface Props {
+  turn: TurnPayload
+}
+
+export function TurnCard({ turn }: Props) {
+  const t = useTranslations('adminTraces.sections')
+  return (
+    <div className="space-y-3">
+      <Card className="flex-row items-center gap-3 p-4">
+        <div className="rounded-md bg-warning-surface p-2 text-warning-fg">
+          <RotateCw className="size-4" />
+        </div>
+        <div className="space-y-1 text-xs">
+          <div className="text-sm font-semibold">Turn {turn.index}</div>
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <span>stop:</span>
+            <Badge variant="outline">{turn.stop_reason ?? '—'}</Badge>
+            <span>tool calls: {turn.tool_calls_count}</span>
+          </div>
+        </div>
+      </Card>
+      {turn.messages.length > 0 && (
+        <Section
+          title={t('messages')}
+          icon={<MessageSquare className="size-4 text-muted-foreground" />}
+        >
+          <MessageList items={turn.messages} />
+        </Section>
+      )}
+      {turn.output_messages.length > 0 && (
+        <Section
+          title={t('output')}
+          icon={<MessageSquare className="size-4 text-muted-foreground" />}
+        >
+          <MessageList items={turn.output_messages} />
+        </Section>
+      )}
+    </div>
+  )
+}

--- a/frontend/packages/web/components/admin/traces/kindStyles.ts
+++ b/frontend/packages/web/components/admin/traces/kindStyles.ts
@@ -1,0 +1,19 @@
+// Shared span-kind → color mapping, used by both SpanTree (row badges + the
+// timeline bar) and SpanDetail (header badge) so the two can't drift apart.
+// Semantic tokens only (no raw palette utilities).
+
+export const KIND_BADGE: Record<string, string> = {
+  agent: 'bg-info-surface text-info-fg',
+  turn: 'bg-warning-surface text-warning-fg',
+  chat: 'bg-primary/10 text-primary',
+  tool: 'bg-success-surface text-success-fg',
+  other: 'bg-muted text-muted-foreground',
+}
+
+export const KIND_BAR: Record<string, string> = {
+  agent: 'bg-info-solid',
+  turn: 'bg-warning-solid',
+  chat: 'bg-primary',
+  tool: 'bg-success-solid',
+  other: 'bg-muted-foreground',
+}

--- a/frontend/packages/web/components/admin/traces/types.ts
+++ b/frontend/packages/web/components/admin/traces/types.ts
@@ -101,10 +101,16 @@ export interface TraceFilterValues {
   model?: string
   start?: string
   end?: string
-  min_duration_ms?: number
-  max_duration_ms?: number
   limit?: number
 }
+
+// Tempo hard-caps search ranges at 168h (7 days) on this deployment, so there
+// is no '1m' option - a full month can't be served by a single query.
+export type TimeRangePreset = '1h' | '1d' | '7d' | 'custom'
+
+export const DEFAULT_TIME_RANGE_PRESET: TimeRangePreset = '1h'
+
+export const DEFAULT_LIMIT = 50
 
 // Postgres-backed dropdown options for the filter bar (see /admin/traces
 // filter-options). `model` is NOT here - it is low-cardinality and sourced

--- a/frontend/packages/web/components/admin/traces/types.ts
+++ b/frontend/packages/web/components/admin/traces/types.ts
@@ -50,6 +50,16 @@ export interface TurnPayload {
   index: number
   stop_reason?: string | null
   tool_calls_count: number
+  messages: ChatMessage[]
+  output_messages: ChatMessage[]
+}
+
+export interface AgentPayload {
+  provider?: string | null
+  tools: string[]
+  system_instructions: ChatMessage[]
+  messages: ChatMessage[]
+  output_messages: ChatMessage[]
 }
 
 export interface SpanNode {
@@ -64,6 +74,7 @@ export interface SpanNode {
   llm?: LlmCallPayload | null
   tool?: ToolCallPayload | null
   turn?: TurnPayload | null
+  agent?: AgentPayload | null
   raw_attributes: Record<string, unknown>
   children: SpanNode[]
 }

--- a/frontend/packages/web/components/admin/traces/types.ts
+++ b/frontend/packages/web/components/admin/traces/types.ts
@@ -105,3 +105,13 @@ export interface TraceFilterValues {
   max_duration_ms?: number
   limit?: number
 }
+
+// Postgres-backed dropdown options for the filter bar (see /admin/traces
+// filter-options). `model` is NOT here - it is low-cardinality and sourced
+// from Tempo tag-values, where the value is its own label.
+export type FilterOptionKind = 'workspace' | 'user' | 'conversation'
+
+export interface FilterOption {
+  id: string
+  name: string
+}

--- a/frontend/packages/web/lib/api/admin-traces.ts
+++ b/frontend/packages/web/lib/api/admin-traces.ts
@@ -89,3 +89,22 @@ export async function getAdminFilterOptions(
   )
   return res.options
 }
+
+// Batch id -> name resolution for rendering the trace list table (raw IDs
+// otherwise). Same endpoint as getAdminFilterOptions, exact-match instead of
+// prefix. Missing ids (e.g. a deleted workspace/user) are simply absent from
+// the response - callers fall back to the raw id.
+export async function getAdminFilterOptionsByIds(
+  kind: FilterOptionKind,
+  ids: string[],
+  signal?: AbortSignal,
+): Promise<FilterOption[]> {
+  if (ids.length === 0) return []
+  const params = new URLSearchParams({ kind })
+  for (const id of ids) params.append('ids', id)
+  const res = await getJson<{ options: FilterOption[] }>(
+    `/api/v1/admin/traces/filter-options?${params.toString()}`,
+    signal,
+  )
+  return res.options
+}

--- a/frontend/packages/web/lib/api/admin-traces.ts
+++ b/frontend/packages/web/lib/api/admin-traces.ts
@@ -1,5 +1,7 @@
 import { readApiError } from '@/lib/csrf'
 import type {
+  FilterOption,
+  FilterOptionKind,
   TraceDetail,
   TraceFilterValues,
   TraceListResponse,
@@ -62,10 +64,28 @@ export async function getAdminTraceDetail(traceId: string): Promise<TraceDetail>
   return getJson<TraceDetail>(`/api/v1/admin/traces/${encodeURIComponent(traceId)}`)
 }
 
-export async function getAdminTraceTagValues(tag: string): Promise<string[]> {
+export async function getAdminTraceTagValues(tag: string, signal?: AbortSignal): Promise<string[]> {
   const params = new URLSearchParams({ tag })
   const res = await getJson<{ values: string[] }>(
     `/api/v1/admin/traces/tag-values?${params.toString()}`,
+    signal,
   )
   return res.values
+}
+
+// Dropdown options for workspace/user/conversation, resolved from Postgres
+// (org-scoped, prefix-narrowed server-side for user/conversation). `model` is
+// NOT served here - use getAdminTraceTagValues for it.
+export async function getAdminFilterOptions(
+  kind: FilterOptionKind,
+  q?: string,
+  signal?: AbortSignal,
+): Promise<FilterOption[]> {
+  const params = new URLSearchParams({ kind })
+  if (q) params.set('q', q)
+  const res = await getJson<{ options: FilterOption[] }>(
+    `/api/v1/admin/traces/filter-options?${params.toString()}`,
+    signal,
+  )
+  return res.options
 }

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -251,7 +251,11 @@
       "from": "From",
       "to": "To",
       "minDurationMs": "Min duration (ms)",
-      "maxDurationMs": "Max duration (ms)"
+      "maxDurationMs": "Max duration (ms)",
+      "searchPlaceholder": "Search…",
+      "loadingOptions": "Loading…",
+      "noOptions": "No matches",
+      "clear": "Clear"
     },
     "columns": {
       "startTime": "Start",

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -277,6 +277,7 @@
     "loading": "Loading traces…",
     "loadingMore": "Loading…",
     "loadMore": "Load more",
+    "backToList": "Back to traces",
     "sections": {
       "model": "Model",
       "tokens": "Token usage",
@@ -297,6 +298,10 @@
       "rawAttributes": "Raw attributes",
       "reasoning": "Reasoning",
       "empty": "empty",
+      "truncated": "Data truncated in the tracing pipeline — showing partial raw content",
+      "truncatedLabel": "Truncated",
+      "agentOverview": "Overview",
+      "provider": "Provider",
       "roles": {
         "user": "User",
         "assistant": "Assistant",

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -250,8 +250,14 @@
       "runId": "Run ID",
       "from": "From",
       "to": "To",
-      "minDurationMs": "Min duration (ms)",
-      "maxDurationMs": "Max duration (ms)",
+      "range": "Time range",
+      "rangePreset": {
+        "1h": "1h",
+        "1d": "1d",
+        "7d": "7d",
+        "custom": "Custom"
+      },
+      "limit": "Limit",
       "searchPlaceholder": "Search…",
       "loadingOptions": "Loading…",
       "noOptions": "No matches",
@@ -269,9 +275,15 @@
     "empty": "No traces match these filters.",
     "disabled": "Trace viewer is not configured for this deployment.",
     "loading": "Loading traces…",
+    "loadingMore": "Loading…",
+    "loadMore": "Load more",
     "sections": {
       "model": "Model",
       "tokens": "Token usage",
+      "tokensInput": "input",
+      "tokensOutput": "output",
+      "tokensCacheRead": "cache read",
+      "tokensCacheWrite": "cache write",
       "messages": "Messages",
       "system": "System instructions",
       "output": "Output messages",
@@ -282,7 +294,15 @@
       "toolInfo": "Tool",
       "arguments": "Arguments",
       "result": "Result",
-      "rawAttributes": "Raw attributes"
+      "rawAttributes": "Raw attributes",
+      "reasoning": "Reasoning",
+      "empty": "empty",
+      "roles": {
+        "user": "User",
+        "assistant": "Assistant",
+        "system": "System",
+        "tool": "Tool"
+      }
     }
   },
   "artifactsPage": {

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -251,7 +251,11 @@
       "from": "开始时间",
       "to": "结束时间",
       "minDurationMs": "最短时长 (ms)",
-      "maxDurationMs": "最长时长 (ms)"
+      "maxDurationMs": "最长时长 (ms)",
+      "searchPlaceholder": "搜索…",
+      "loadingOptions": "加载中…",
+      "noOptions": "无匹配项",
+      "clear": "清除"
     },
     "columns": {
       "startTime": "开始",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -277,6 +277,7 @@
     "loading": "加载中…",
     "loadingMore": "加载中…",
     "loadMore": "加载更多",
+    "backToList": "返回列表",
     "sections": {
       "model": "模型",
       "tokens": "Token 用量",
@@ -297,6 +298,10 @@
       "rawAttributes": "原始属性",
       "reasoning": "推理过程",
       "empty": "空",
+      "truncated": "数据在链路中被截断 — 仅显示部分原始内容",
+      "truncatedLabel": "已截断",
+      "agentOverview": "概览",
+      "provider": "提供方",
       "roles": {
         "user": "用户",
         "assistant": "助手",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -250,8 +250,14 @@
       "runId": "运行 ID",
       "from": "开始时间",
       "to": "结束时间",
-      "minDurationMs": "最短时长 (ms)",
-      "maxDurationMs": "最长时长 (ms)",
+      "range": "时间范围",
+      "rangePreset": {
+        "1h": "1 小时",
+        "1d": "1 天",
+        "7d": "7 天",
+        "custom": "自定义"
+      },
+      "limit": "每页数量",
       "searchPlaceholder": "搜索…",
       "loadingOptions": "加载中…",
       "noOptions": "无匹配项",
@@ -269,9 +275,15 @@
     "empty": "没有符合条件的 Trace。",
     "disabled": "当前部署未配置 Trace 查看器。",
     "loading": "加载中…",
+    "loadingMore": "加载中…",
+    "loadMore": "加载更多",
     "sections": {
       "model": "模型",
       "tokens": "Token 用量",
+      "tokensInput": "输入",
+      "tokensOutput": "输出",
+      "tokensCacheRead": "缓存读取",
+      "tokensCacheWrite": "缓存写入",
       "messages": "消息",
       "system": "系统指令",
       "output": "输出消息",
@@ -282,7 +294,15 @@
       "toolInfo": "工具",
       "arguments": "参数",
       "result": "结果",
-      "rawAttributes": "原始属性"
+      "rawAttributes": "原始属性",
+      "reasoning": "推理过程",
+      "empty": "空",
+      "roles": {
+        "user": "用户",
+        "assistant": "助手",
+        "system": "系统",
+        "tool": "工具"
+      }
     }
   },
   "artifactsPage": {


### PR DESCRIPTION
## What

The `/admin/traces` filter bar forced admins to type raw UUIDs for workspace / user / conversation (and model names). This replaces those four free-text inputs with searchable comboboxes that list real entities by name.

## Why

The tag-values backend + `getAdminTraceTagValues()` helper already existed but were never wired into the UI (dead code). The original trace-viewer spec intended these as autocomplete fields. This finishes that wiring.

## Design (query-time, no write path)

Names are resolved at query time from Postgres — we do **not** write names into Tempo spans. Dropdown cost is driven by distinct-entity count, not trace count, so cardinality is never materialized in full:

| field | source | mode |
|---|---|---|
| model | Tempo `tag-values` (value is its own label) | list — fetch once, filter client-side |
| workspace | Postgres `filter-options` (org workspaces, cap 200) | list |
| user | Postgres `filter-options` (`display_name ?? email`) | typeahead — server prefix, `LIMIT 20` |
| conversation | Postgres `filter-options` (`title`) | typeahead — server prefix, `LIMIT 20` |

`run_id` / time / duration stay as-is. The stored filter value is still the raw ID (or model name), so `list_traces` and its TraceQL are unchanged — the new endpoint is purely read-only suggestions. Each combobox keeps a free-text fallback (Enter commits typed text = paste-an-ID).

Write-time was explored and rejected: Tempo `tag-values` has no server-side prefix filter, so it can't scale on the high-cardinality conversation field, and it taxes the run-start path for a diagnostic tool.

## Changes

- **backend** `admin_traces.py` + `schemas/trace.py`: new `GET /api/v1/admin/traces/filter-options?kind=workspace|user|conversation&q=&limit=` — org-admin gated, org-scoped from session, no Tempo dependency.
- **frontend** new `FilterCombobox.tsx` (list + typeahead modes, clearable, keyboard nav, free-text fallback); `TraceFilterBar.tsx` rewired to use it; `admin-traces.ts` gains `getAdminFilterOptions`; i18n keys in `en/zh`.
- **plan** `docs/dev/plans/2026-07-20-traces-filter-typeahead.md`.

## Tests

- Backend e2e (`test_admin_traces.py`): org-scoping (foreign-org entities excluded) per kind, conversation prefix narrowing + `limit` cap, user prefix via membership join, unknown `kind` → 422, non-admin → 403. All 14 in the file pass.
- Frontend: tsc / eslint / prettier clean; `next build` + vitest green via pre-push `check-ci`.

## Out of scope

Friendly names in the trace detail/list table (still raw IDs there); `run_id` typeahead (not in tag-values allowlist).