### PR TITLE
Release v0.3.0

### DIFF
--- a/backend/cubeplex/api/app.py
+++ b/backend/cubeplex/api/app.py
@@ -460,7 +460,7 @@ def create_app(
     app = FastAPI(
         title="cubeplex API",
         description="AI Agent System Backend",
-        version="0.2.0",
+        version="0.3.0",
         lifespan=lifespan,
     )
 

--- a/backend/cubeplex/api/routes/v1/system.py
+++ b/backend/cubeplex/api/routes/v1/system.py
@@ -11,7 +11,7 @@ from cubeplex.db import get_session
 router = APIRouter(prefix="/system", tags=["system"])
 
 # v1 hardcoded; bump on release. Kept in sync with backend/pyproject.toml.
-_CUBEPLEX_VERSION = "0.2.0"
+_CUBEPLEX_VERSION = "0.3.0"
 
 
 @router.get("/info", response_model=SystemInfoResponse)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cubeplex"
-version = "0.2.0"
+version = "0.3.0"
 description = "cubeplex - AI Agent System Backend with cubepi"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -919,7 +919,7 @@ tracing-otlp = [
 
 [[package]]
 name = "cubeplex"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },

--- a/deploy/kubernetes/charts/cubeplex/Chart.yaml
+++ b/deploy/kubernetes/charts/cubeplex/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cubeplex
 description: cubeplex AI agent platform (backend + frontend + bundled infra)
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 
 kubeVersion: ">=1.21.0-0"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubeplex-frontend",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "packageManager": "pnpm@10.23.0",
   "scripts": {

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cubeplex/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/frontend/packages/web/package.json
+++ b/frontend/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps the application version from 0.2.0 to 0.3.0 across all version sources
and the hardcoded code-level version refs:

- `backend/pyproject.toml`
- `backend/cubeplex/api/app.py` (FastAPI app `version`)
- `backend/cubeplex/api/routes/v1/system.py` (`_CUBEPLEX_VERSION`)
- `backend/uv.lock` (cubeplex package version)
- `frontend/package.json`, `frontend/packages/core/package.json`,
  `frontend/packages/web/package.json`
- `deploy/kubernetes/charts/cubeplex/Chart.yaml` (`version` + `appVersion`)

Verified with `scripts/check-version-consistency.sh v0.3.0` and the pre-push
CI-equivalent gate (backend-check-ci + frontend-check-ci).

Sandbox version is unchanged at 0.1.0: `sandbox-v0.1.0` is current (no
Dockerfile or other image-input changes since it was built), so `release.yml`
will promote the existing image to `cubeplex-sandbox:v0.3.0` (tag alias, no
rebuild).

After merge, `v0.3.0` will be tagged on the merged commit, triggering
`images.yml` (backend/frontend/egress-webhook) and `release.yml` (manifest,
sandbox promotion, Helm chart OCI publish, GitHub Release).