### PR TITLE
Fix invalid ci.yml workflow (comments inside if: block scalar)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   gate:
     name: Gate (automatic, /ci, or workflow_dispatch)
+    # `/ci` checks out the PR head and runs its code with access to repo
+    # secrets, so restrict it to org members/collaborators. Ordinary PR
+    # CI still runs for everyone via the `pull_request` trigger above.
     if: |
       github.event_name == 'pull_request' ||
       github.event_name == 'push' ||
@@ -27,9 +30,6 @@ jobs:
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
        startsWith(github.event.comment.body, '/ci') &&
-       # `/ci` checks out the PR head and runs its code with access to repo
-       # secrets, so restrict it to org members/collaborators. Ordinary PR
-       # CI still runs for everyone via the `pull_request` trigger above.
        (github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR'))


### PR DESCRIPTION
## Problem

`ci.yml` has been an **Invalid workflow file** since `15d5dbe5`, so **no CI jobs
ran on any PR or push** (every run failed with `Invalid workflow file`; only
CodeQL, which lives in `codeql.yml`, kept running).

Root cause: the `gate` job's `if:` is a YAML literal block scalar (`|`). The
three `#` comment lines written *inside* that block are **literal text, not
comments** — they became part of the `${{ }}` expression, and GitHub Actions
can't parse `#` in expressions:

```
Invalid workflow file
(Line: 23, Col: 9): Unexpected symbol: '#'. Located at position 250 within
expression: ... startsWith(github.event.comment.body, '/ci') &&
 # `/ci` checks out the PR head ...
```

Because the file is invalid, GitHub refuses to load the workflow, so `gate` ->
`changes` -> `backend-check` / `frontend-check` / e2e never run.

## Fix

Move the three comment lines from inside the `if: |` block to **above** the
`if:` key, where they are real YAML comments. The expression itself is
unchanged (it was valid before `15d5dbe5`).

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
  -> OK; no `#` remains inside the `if:` block.
- Local pre-push gate (backend-check-ci + frontend-check-ci) passed.
- This PR modifies `ci.yml`, so GitHub runs the **fixed** workflow on the PR —
  the appearance of `backend-check` / `frontend-check` check runs here confirms
  the workflow loads again.