### PR TITLE
Fix invalid claude-code-review.yml workflow (comments inside if: block)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   claude-review:
+    # `/code-review` checks out the PR head and runs Claude with write +
+    # id-token scopes, so restrict it to org members/collaborators.
     if: |
       github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '/code-review') &&
-      # `/code-review` checks out the PR head and runs Claude with write +
-      # id-token scopes, so restrict it to org members/collaborators.
       (github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'COLLABORATOR')


### PR DESCRIPTION
Same bug as the `ci.yml` fix in `5baa7c45`. The `claude-review` job's `if:` is a
YAML literal block scalar (`|`), so the two `#` comment lines inside it were
literal expression text, not comments. GitHub Actions can't parse `#` in
expressions:

```
Invalid workflow file: .github/workflows/claude-code-review.yml
(Line: 15, Col: 9): Unexpected symbol: '#'.
```

So `claude-code-review.yml` was an Invalid workflow file and `/code-review` never
fired. Move the comments above `if:` so they are real YAML comments; the
expression itself is unchanged.

Verified: YAML parses; precise scan confirms no `#` remains inside any `if:|`
block across all workflows (this was the only remaining offender after `ci.yml`
was fixed).