### PR TITLE
generate correct EC egress mitm certs, wire exchange host

### DIFF
--- a/deploy/kubernetes/charts/cubeplex/templates/backend-configmap.yaml
+++ b/deploy/kubernetes/charts/cubeplex/templates/backend-configmap.yaml
@@ -32,6 +32,15 @@ data:
         # Defaults to .Values.opensandbox.enabled for the common case.
         enabled: {{ dig "sandbox" "enabled" .Values.opensandbox.enabled .Values.backend }}
         use_server_proxy: {{ dig "sandbox" "use_server_proxy" false .Values.backend }}
+        secure_access: {{ dig "sandbox" "secure_access" true .Values.backend }}
+        {{- if .Values.egress.enabled }}
+        # Activates egress secret-injection in SandboxManager (every
+        # injection call is gated on `if self._exchange_host:`) and is
+        # force-allowed in the sandbox's egress network policy. Defaults to
+        # the same host the sandbox-side mitmproxy addon actually connects to
+        # (see egress-webhook-deployment.yaml's exchangeURL default).
+        egress_exchange_host: {{ dig "sandbox" "egress_exchange_host" (printf "%s.%s.svc.cluster.local" (include "cubeplex.backend.fullname" .) .Release.Namespace) .Values.backend }}
+        {{- end }}
       {{- if .Values.docling.enabled }}
       parsers:
         docling_serve:

--- a/deploy/kubernetes/charts/cubeplex/values.local.yaml.example
+++ b/deploy/kubernetes/charts/cubeplex/values.local.yaml.example
@@ -66,7 +66,7 @@ backend:
         #   preset: "deepseek/cn/anthropic-messages"
         #   api_key: "sk-..."
     sandbox:
-      domain: "cubeplex-opensandbox-server.cubeplex.svc.cluster.local:8090"
+      domain: "opensandbox-server.opensandbox-system.svc.cluster.local:80"
       # image defaults to ghcr.io/cubeplexai/cubeplex-sandbox:v<chart appVersion>;
       # set it only to pin a different sandbox image.
       api_key: "REPLACE_ME"

--- a/deploy/kubernetes/charts/cubeplex/values.yaml
+++ b/deploy/kubernetes/charts/cubeplex/values.yaml
@@ -207,8 +207,14 @@ egress:
   enabled: false
   # Namespace where sandbox pods live (where the MutatingWebhookConfiguration
   # matches and where the addon ConfigMap + MITM CA Secret are mirrored).
-  # When using the bundled opensandbox subchart, that's "opensandbox-system".
-  sandboxNamespace: "opensandbox-system"
+  # NOT the same as where opensandbox-server/-controller themselves run
+  # ("opensandbox-system") — per-conversation sandbox pods run wherever the
+  # server's own configToml [kubernetes] namespace points, which defaults to
+  # "opensandbox" in the bundled subchart (vendor/opensandbox-server's own
+  # values.yaml). Getting this wrong means the MutatingWebhookConfiguration's
+  # namespaceSelector never matches real sandbox pods — and with
+  # failurePolicy: Ignore, that failure is completely silent.
+  sandboxNamespace: "opensandbox"
   webhook:
     replicaCount: 1
     image:

--- a/deploy/kubernetes/egress-bundle/webhook/cert_minter.py
+++ b/deploy/kubernetes/egress-bundle/webhook/cert_minter.py
@@ -49,6 +49,37 @@ def load_ca(key_pem: bytes, cert_pem: bytes) -> CA:
     return CA(key=key, cert=cert)
 
 
+def mint_server_cert(
+    ca: CA, *, common_name: str, sans: list[str], days: int = 365
+) -> tuple[bytes, bytes]:
+    """Mint a server leaf cert (with SANs, for TLS hostname verification) signed
+    by `ca`. Used for the webhook's own serving cert and the backend's mTLS
+    listener cert — distinct from `CertMinter.mint`, which mints CN-only client
+    certs for per-sandbox mTLS auth (no hostname to verify there)."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    now = dt.datetime.now(dt.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)]))
+        .issuer_name(ca.cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=5))
+        .not_valid_after(now + dt.timedelta(days=days))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(s) for s in sans]), critical=False
+        )
+        .sign(ca.key, hashes.SHA256())
+    )
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    return key_pem, cert.public_bytes(serialization.Encoding.PEM)
+
+
 class CertMinter:
     def __init__(self, ca: CA) -> None:
         self._ca = ca

--- a/deploy/kubernetes/egress-bundle/webhook/tests/test_cert_minter.py
+++ b/deploy/kubernetes/egress-bundle/webhook/tests/test_cert_minter.py
@@ -1,9 +1,9 @@
 # deploy/kubernetes/egress-bundle/webhook/tests/test_cert_minter.py
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from webhook.cert_minter import CertMinter, load_ca
+from webhook.cert_minter import CertMinter, load_ca, mint_server_cert
 
 
 def _make_ca(tmp_path):
@@ -21,6 +21,29 @@ def test_minted_cert_has_sandbox_id_cn_and_chains_to_ca(tmp_path):
     cn = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)[0].value
     assert cn == "sbx-123"
     # verify signature chains to the CA public key
+    ca.cert.public_key().verify(
+        cert.signature, cert.tbs_certificate_bytes,
+        ec.ECDSA(cert.signature_hash_algorithm),
+    )
+
+
+def test_server_cert_has_cn_sans_ec_key_and_chains_to_ca(tmp_path):
+    ca = _make_ca(tmp_path)
+    sans = ["cubeplex-egress-webhook.cubeplex.svc", "cubeplex-egress-webhook.cubeplex.svc.cluster.local"]
+    key_pem, cert_pem = mint_server_cert(
+        ca, common_name="cubeplex-egress-webhook.cubeplex.svc", sans=sans
+    )
+    key = serialization.load_pem_private_key(key_pem, password=None)
+    assert isinstance(key, ec.EllipticCurvePrivateKey)
+
+    cert = x509.load_pem_x509_certificate(cert_pem)
+    cn = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)[0].value
+    assert cn == "cubeplex-egress-webhook.cubeplex.svc"
+
+    san_ext = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+    assert san_ext.value.get_values_for_type(x509.DNSName) == sans
+
+    # verify signature chains to the CA public key (same requirement load_ca enforces on read)
     ca.cert.public_key().verify(
         cert.signature, cert.tbs_certificate_bytes,
         ec.ECDSA(cert.signature_hash_algorithm),

--- a/deploy/kubernetes/scripts/gen-egress-certs.sh
+++ b/deploy/kubernetes/scripts/gen-egress-certs.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Generate the egress secret-injection cert triplet (CA + webhook serving cert
+# + backend mTLS cert) and write them as Kubernetes Secrets, bypassing the
+# Helm chart's own cert-generation path.
+#
+# Why this exists: the chart's `cubeplex.egress.certs` helper
+# (templates/_egress-helpers.tpl) uses Helm/Sprig's built-in `genCA` /
+# `genSignedCert`, which only ever produce RSA keys — Sprig has no EC option.
+# But the webhook's own cert_minter.py hard-requires an EC (SECP256R1) CA key
+# and crashes on startup with `TypeError: CA key must be an EC private key`
+# if given one. There is no values.yaml-level fix for this.
+#
+# This script mints a correct EC-based CA + two leaf certs using the exact
+# same cert_minter.py the webhook itself uses (not a reimplementation), then
+# writes all four Secrets the chart expects. Run it ONCE before the first
+# `helm install`/`helm upgrade` with `egress.enabled: true`; the chart's
+# lookup-or-mint template logic finds these Secrets already present and reuses
+# them instead of minting via the broken RSA path.
+#
+# Usage:
+#   NAMESPACE=cubeplex SANDBOX_NAMESPACE=opensandbox RELEASE=cubeplex \
+#     deploy/kubernetes/scripts/gen-egress-certs.sh
+#
+# Safe to re-run: refuses to overwrite existing Secrets unless FORCE=true.
+# Requires: uv (for a throwaway `cryptography` env), kubectl pointed at the
+# target cluster.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+WEBHOOK_DIR="$ROOT/deploy/kubernetes/egress-bundle/webhook"
+NAMESPACE="${NAMESPACE:-cubeplex}"
+SANDBOX_NAMESPACE="${SANDBOX_NAMESPACE:-opensandbox}"
+RELEASE="${RELEASE:-cubeplex}"
+FORCE="${FORCE:-false}"
+
+# Matches the chart's own naming helpers (cubeplex.egress.fullname,
+# cubeplex.egress.webhookFullname, cubeplex.backend.fullname) for the common
+# case where RELEASE contains the chart name "cubeplex" — e.g. the default
+# `helm upgrade --install cubeplex ...`. A release name that doesn't contain
+# "cubeplex" resolves those helpers to "<release>-cubeplex-*" instead; adjust
+# the names below to match if you're using a non-default release name.
+CA_SECRET="${RELEASE}-egress-mitm-ca"
+WEBHOOK_SECRET="${RELEASE}-egress-webhook-tls"
+BACKEND_SECRET="${RELEASE}-backend-mtls"
+
+# On a true first install neither namespace may exist yet (helm --create-namespace
+# only creates $NAMESPACE, and only as part of the helm upgrade call this script
+# runs *before*). Ensure both exist so `kubectl create secret -n ...` below has
+# somewhere to land. Safe to re-run — `kubectl create namespace` is idempotent
+# via the apply here (errors are swallowed only for the "already exists" case).
+for ns in "$NAMESPACE" "$SANDBOX_NAMESPACE"; do
+  kubectl get namespace "$ns" &>/dev/null || kubectl create namespace "$ns"
+done
+
+echo "==> Checking for existing Secrets (idempotency guard)..."
+existing=0
+missing=0
+for pair in "$NAMESPACE:$CA_SECRET" "$NAMESPACE:$WEBHOOK_SECRET" "$NAMESPACE:$BACKEND_SECRET" "$SANDBOX_NAMESPACE:egress-mitm-ca"; do
+  ns="${pair%%:*}"; name="${pair##*:}"
+  if kubectl get secret "$name" -n "$ns" &>/dev/null; then
+    existing=$((existing + 1))
+  else
+    missing=$((missing + 1))
+  fi
+done
+
+if [[ "$FORCE" != "true" ]]; then
+  if [[ "$existing" -eq 4 ]]; then
+    # Expected steady state: every rerun after the first (e.g. from
+    # helm-install.sh's pre-flight check on every install/upgrade) lands here
+    # and should be a silent no-op, not an error.
+    echo "All 4 Secrets already present — nothing to do (set FORCE=true to rotate the CA)."
+    exit 0
+  elif [[ "$existing" -gt 0 ]]; then
+    echo "ERROR: partial state — $existing/4 Secrets exist, $missing missing." >&2
+    echo "  This shouldn't happen from normal use; inspect manually before" >&2
+    echo "  deciding whether FORCE=true (regenerate all four) is safe here." >&2
+    exit 1
+  fi
+  # existing == 0: fall through and generate fresh.
+elif [[ "$existing" -gt 0 ]]; then
+  echo "FORCE=true — overwriting $existing existing Secret(s). This invalidates" >&2
+  echo "the CA and every per-sandbox client cert it signed; all running" >&2
+  echo "sandboxes lose egress injection until recreated." >&2
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "==> Generating CA + webhook + backend leaf certs (EC/SECP256R1)..."
+uv run --with cryptography python3 - "$TMPDIR" "$WEBHOOK_DIR" "$RELEASE" "$NAMESPACE" <<'PYEOF'
+import pathlib
+import sys
+
+out_dir, webhook_dir, release, ns = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+sys.path.insert(0, webhook_dir)
+from cert_minter import generate_ca, load_ca, mint_server_cert  # type: ignore[import-untyped]
+
+ca_key_pem, ca_cert_pem = generate_ca(f"{release}-egress-mitm-ca")
+ca = load_ca(ca_key_pem, ca_cert_pem)
+
+# SANs must match where the sandbox-side mitmproxy addon and the K8s API
+# server actually connect (see egress-webhook-deployment.yaml's exchangeURL
+# default and the MutatingWebhookConfiguration's clientConfig.service).
+webhook_host = f"{release}-egress-webhook.{ns}.svc"
+wh_key_pem, wh_cert_pem = mint_server_cert(
+    ca,
+    common_name=webhook_host,
+    sans=[webhook_host, f"{webhook_host}.cluster.local"],
+    days=3650,
+)
+backend_host = f"{release}-backend.{ns}.svc"
+b_key_pem, b_cert_pem = mint_server_cert(
+    ca,
+    common_name=f"{release}-egress-exchange",
+    sans=[backend_host, f"{backend_host}.cluster.local", "egress-exchange.cubeplex.internal"],
+    days=3650,
+)
+
+d = pathlib.Path(out_dir)
+(d / "ca_key.pem").write_bytes(ca_key_pem)
+(d / "ca_cert.pem").write_bytes(ca_cert_pem)
+(d / "wh_key.pem").write_bytes(wh_key_pem)
+(d / "wh_cert.pem").write_bytes(wh_cert_pem)
+(d / "b_key.pem").write_bytes(b_key_pem)
+(d / "b_cert.pem").write_bytes(b_cert_pem)
+print("Certs generated.")
+PYEOF
+
+echo "==> Writing Secrets..."
+
+# CA — mirrored into both the cubeplex namespace (source of truth) and the
+# sandbox namespace (where the webhook's JSON patch mounts it into each
+# sandbox pod). Same three keys the chart's egress-secrets.yaml renders.
+for target_ns in "$NAMESPACE" "$SANDBOX_NAMESPACE"; do
+  secret_name="$CA_SECRET"
+  [[ "$target_ns" == "$SANDBOX_NAMESPACE" ]] && secret_name="egress-mitm-ca"
+  kubectl create secret generic "$secret_name" -n "$target_ns" \
+    --from-file=mitmproxy-ca.pem="$TMPDIR/ca_key.pem" \
+    --from-file=mitmproxy-ca-cert.pem="$TMPDIR/ca_cert.pem" \
+    --from-file=ca-cert.pem="$TMPDIR/ca_cert.pem" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  kubectl annotate secret "$secret_name" -n "$target_ns" \
+    helm.sh/resource-policy=keep --overwrite >/dev/null
+done
+
+# Webhook HTTPS serving cert.
+kubectl create secret tls "$WEBHOOK_SECRET" -n "$NAMESPACE" \
+  --cert="$TMPDIR/wh_cert.pem" --key="$TMPDIR/wh_key.pem" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl patch secret "$WEBHOOK_SECRET" -n "$NAMESPACE" --type=merge \
+  -p "{\"data\":{\"ca.crt\":\"$(base64 -w0 "$TMPDIR/ca_cert.pem")\"}}" >/dev/null
+
+# Backend mTLS listener cert.
+kubectl create secret tls "$BACKEND_SECRET" -n "$NAMESPACE" \
+  --cert="$TMPDIR/b_cert.pem" --key="$TMPDIR/b_key.pem" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl patch secret "$BACKEND_SECRET" -n "$NAMESPACE" --type=merge \
+  -p "{\"data\":{\"ca.crt\":\"$(base64 -w0 "$TMPDIR/ca_cert.pem")\"}}" >/dev/null
+
+echo ""
+echo "Done. Secrets written:"
+echo "  $NAMESPACE/$CA_SECRET"
+echo "  $SANDBOX_NAMESPACE/egress-mitm-ca"
+echo "  $NAMESPACE/$WEBHOOK_SECRET"
+echo "  $NAMESPACE/$BACKEND_SECRET"
+echo ""
+echo "Next: helm upgrade --install $RELEASE ... (with egress.enabled: true)."
+echo "The chart's lookup-or-mint logic will find these and reuse them."

--- a/deploy/kubernetes/scripts/helm-install.sh
+++ b/deploy/kubernetes/scripts/helm-install.sh
@@ -24,12 +24,30 @@ echo "==> helm dependency update"
 helm dependency update "$CHART/vendor/opensandbox"
 helm dependency update "$CHART"
 
+VALUES_ARGS=(--values "$CHART/values.yaml" --values "$CHART/values.local.yaml")
+
+# egress.enabled deploys a webhook whose serving cert must be EC (SECP256R1) —
+# the chart's own cert-generation helper (Helm/Sprig's genCA, RSA-only) cannot
+# produce that, and the webhook crashes on an RSA cert with no self-heal (see
+# gen-egress-certs.sh's header comment for the full story). Render just the
+# egress Secret template to ask Helm itself whether egress is effectively
+# enabled (accounts for values.yaml defaults + values.local.yaml overrides,
+# unlike grepping the raw YAML), and if so, mint the correct certs *before*
+# the chart ever gets a chance to mint the broken ones. Idempotent — skips
+# straight through on a rerun if the certs already exist.
+EGRESS_ENABLED="$(helm template "$RELEASE" "$CHART" "${VALUES_ARGS[@]}" \
+  --show-only templates/egress-secrets.yaml 2>/dev/null | grep -c '^kind: Secret' || true)"
+if [[ "${EGRESS_ENABLED:-0}" -gt 0 ]]; then
+  echo "==> egress.enabled: true — ensuring EC certs exist before install"
+  NAMESPACE="$NAMESPACE" RELEASE="$RELEASE" \
+    "$ROOT/deploy/kubernetes/scripts/gen-egress-certs.sh"
+fi
+
 echo "==> helm upgrade --install $RELEASE -n $NAMESPACE"
 helm upgrade --install "$RELEASE" "$CHART" \
   --namespace "$NAMESPACE" \
   --create-namespace \
-  --values "$CHART/values.yaml" \
-  --values "$CHART/values.local.yaml" \
+  "${VALUES_ARGS[@]}" \
   --wait \
   --timeout 10m
 

--- a/docs/dev/notes/2026-07-21-oci-k8s-deployment.md
+++ b/docs/dev/notes/2026-07-21-oci-k8s-deployment.md
@@ -1,281 +1,215 @@
-# CubePlex on OCI Kubernetes - Deployment Report
+# CubePlex on OCI Kubernetes — Deployment Report
 
-**Date:** 2026-07-21  
-**Task:** Deploy cubeplex v0.3.0 to OCI Kubernetes (context-cnflby7wbia)  
-**Status:** ⚠️ Blocked by OCI Virtual Node Limitations
+**Date:** 2026-07-21 / 2026-07-22
+**Task:** Deploy cubeplex v0.3.0 to OCI Kubernetes (cluster `cnflby7wbia`, tenancy region `us-phoenix-1`) and run a real-LLM e2e round-trip using the `arkplan` (Volcengine Ark Agent Plan) model.
+**Status:** ✅ Deployed and fully verified — chat + tool-call (sandbox) e2e both pass against the live deployment. Virtual node pool removed from the cluster; only real managed nodes remain.
 
 ## Summary
 
-Attempted to deploy cubeplex v0.3.0 to OCI Container Engine for Kubernetes using the Helm chart. The deployment failed due to fundamental limitations of OCI's virtual node implementation.
+Deployed cubeplex v0.3.0 via the `deploy/kubernetes/charts/cubeplex` Helm chart to an OCI
+Container Engine for Kubernetes cluster. The cluster originally had **only virtual nodes**,
+which cannot run this chart at all (no `initContainers`, no `subPath` support). Added a
+managed (physical/VM) node pool, worked through three more real issues (CRI-O short-name image
+resolution, a private GHCR package, and a chart-config validation gotcha), and finished with a
+passing end-to-end conversation test against the live backend using the `arkplan` model.
 
 ## Environment
 
-- **Kubernetes Version:** v1.36.1
-- **Cluster Type:** OCI Container Engine for Kubernetes (managed service)
-- **Node Type:** Virtual Nodes (3 virtual-node roles)
-- **Ingress Controller:** ingress-nginx (successfully installed)
-- **Chart Version:** 0.3.0
+- **Kubernetes version:** v1.36.1
+- **Cluster:** OCI Container Engine for Kubernetes, cluster OCID
+  `...cnflby7wbia`, originally 3 virtual nodes only (`pool1` virtual node pool, size 3)
+- **Added:** 1 managed node pool (`cubeplex-workload`), 2× `VM.Standard.E5.Flex`,
+  Oracle Linux 9.7 OKE image, CRI-O runtime, `OCI_VCN_IP_NATIVE` pod networking
+- **Ingress:** ingress-nginx (kept on the virtual node pool — plain Deployments work fine there)
+- **Chart version:** 0.3.0, images `ghcr.io/cubeplexai/cubeplex-{backend,frontend}:v0.3.0`
+- **Operator workstation:** has **no direct network route** into the OCI VCN's private
+  subnet (10.0.10.0/24) — only the Kubernetes API server's public endpoint is reachable.
+  All in-cluster verification went through `kubectl port-forward`.
 
-## Issues Encountered
+## Issues Found (in the order hit) and Fixes
 
-### 1. ❌ Init Containers Not Supported (BLOCKING)
+### 1. Virtual nodes don't support `initContainers` or `subPath` — BLOCKING
 
-**Error Message:**
 ```
 Error creating pod: [initContainers are not supported]
-```
-
-**Details:**
-- OCI virtual nodes do **not support `initContainers`** at all
-- This is a fundamental limitation of the Kata container runtime used by OCI virtual nodes
-- Kubelet version v1.36.1 rejects any pod spec with initContainers when targeting virtual nodes
-- The cubeplex Helm chart requires init containers for:
-  - Database migrations (alembic upgrade)
-  - Configuration file preparation (in the standard chart)
-
-**Pod Events:**
-```
-Warning  Failed  100s  kubelet  Error creating pod: [initContainers are not supported]
-```
-
-**Attempted Workaround:**
-Tried to remove `subPath` by adding a `config-init` init container to copy files from ConfigMap/Secret volumes, but this only surfaced the next blocker: init containers themselves are not supported.
-
-### 2. ❌ VolumeMount subPath Not Supported (Also BLOCKING)
-
-**Error Message (when removing init containers):**
-```
 Error creating pod: [unsupported VolumeMount option: subPath: config]
 ```
 
-**Details:**
-- OCI virtual nodes do not support the `subPath` option in VolumeMount specifications
-- This is a known limitation of OCI's virtual node runtime (Kata containers)
-- The cubeplex Helm chart uses subPath for ConfigMap mounts:
-  - `/app/config.production.local.yaml` (from ConfigMap with path="config.production.local.yaml")
-  - `/app/config.production.secrets.yaml` (from Secret with path="config.production.secrets.yaml")
+OCI virtual nodes run a Kata-based runtime that rejects both features outright — not a
+timing/config issue, a hard capability gap. The chart needs `initContainers` for the
+`migrate` (alembic) step and `subPath` for mounting individual config files from a
+ConfigMap/Secret. No workaround inside the chart is reasonable; the real fix is
+infrastructure: **add a managed node pool** and keep cubeplex off the virtual nodes.
 
-### 3. ⚠️ Image Pull Issues (Secondary)
+**Fix applied:**
+1. `oci ce node-pool create` — added a real node pool (`cubeplex-workload`,
+   `VM.Standard.E5.Flex` × 2, `OCI_VCN_IP_NATIVE` networking on the existing node subnet).
+   First attempt with `VM.Standard.E3.Flex` hit `Out of host capacity` in `PHX-AD-2` — retried
+   with `VM.Standard.E5.Flex`, which succeeded.
+2. `kubectl taint node <virtual-node-ip> virtual-node=true:NoSchedule` on all 3 virtual
+   nodes. This is a cluster-side, non-invasive fix (no chart edits): new pods without a
+   matching toleration land only on the real nodes; already-running pods (ingress-nginx)
+   are untouched by `NoSchedule`.
 
-**Error:**
+This is now documented as a **cloud-provider compatibility** callout at the top of
+`docs/site/docs/deployment/kubernetes.md`, with a step-by-step "add a managed node pool"
+section.
+
+### 2. CRI-O rejects unqualified image names — BLOCKING (real nodes)
+
 ```
-A container's image could not be pulled because the image does not exist or requires authorization
+Failed to inspect image "": rpc error: ... short name mode is enforcing, but image name
+cubeplex/postgresql-pgroonga-pgvector:18.2-... returns ambiguous list
 ```
 
-**Context:**
-- This error was masked by the subPath and initContainer issues for backend pods
-- Frontend container image pull failed, likely due to network restrictions or image registry access
+Once pods scheduled onto the real (CRI-O) nodes, `postgres.image`
+(`cubeplex/postgresql-pgroonga-pgvector:...`), `redis.image` (`redis:7-alpine`), and
+`rustfs.mcImage` (`minio/mc:...`) — all unqualified, no registry host — failed to resolve.
+CRI-O's short-name resolution policy refuses to guess the registry unless configured
+otherwise, unlike Docker's implicit `docker.io/` default.
 
-## Root Cause Analysis
-
-### OCI Virtual Node Feature Limitations
-
-OCI virtual nodes run pods in **Kata containers**, a lightweight VM-based container runtime optimized for security and isolation. This runtime has significant limitations for Kubernetes feature support:
-
-**Not Supported:**
-- ❌ `initContainers` — completely blocked by the virtual node runtime
-- ❌ VolumeMount with `subPath` option
-- ❌ Certain advanced CSI features
-- ❌ Some network policies and host networking modes
-
-**Supported:**
-- ✅ Standard volumeMounts (without subPath)
-- ✅ Service discovery (DNS)
-- ✅ Most standard pod features
-
-### Why Init Containers Are Critical
-
-The cubeplex backend requires init containers for essential startup tasks:
-
-1. **Database Migrations** — `alembic upgrade head` must run before the API starts
-   - Ensures schema matches the application version
-   - Blocks main container startup until complete
-   - Cannot be delegated to a separate Job (race condition on first install)
-
-2. **Configuration Preparation** — Merging ConfigMap/Secret files
-   - Original chart uses init container to assemble configs
-   - Without init containers, must use a different approach
-
-### Why the Chart Uses subPath
-
-Even without init containers, the standard chart uses subPath for configuration:
-- `values.yaml` → renders templates with specific key paths
-- Templates mount as: `volumeMounts.subPath` = "config.production.local.yaml"
-- This allows merging multiple config sources without overwriting the entire `/app` directory
-- Without subPath, must mount entire volumes and handle file conflicts
-
-### Why OCI Virtual Nodes Are Incompatible
-
-The combination of **no init containers** + **no subPath** makes it impossible to:
-- Run database migrations safely
-- Merge configuration from multiple sources
-- Handle graceful startup ordering
-
-These are not "nice-to-have" features; they're required for the application to function correctly. A workaround would require fundamental changes to how the application boots.
-
-## Solutions
-
-### Option A: Use Managed Node Pools (Recommended)
-
-OCI Container Engine for Kubernetes supports traditional managed node pools (non-virtual nodes) that run standard container runtimes.
-
-**Steps:**
-1. Add a managed node pool to the OCI cluster (via OCI Console or Terraform)
-2. Configure nodeSelector in values.local.yaml to target the node pool
-3. Redeploy the chart
-
-**Pros:**
-- Full Kubernetes feature support
-- No code changes needed
-- Drop-in replacement for virtual nodes
-
-**Cons:**
-- Managed node pools incur compute costs
-- Requires infrastructure changes
-
-### Option B: Modify Helm Chart to Avoid subPath (Complex)
-
-Refactor the chart templates to mount entire volumes instead of subPaths:
-1. Create a custom init container that assembles configs
-2. Or: use ConfigMap as full `/app` volume (requires precombining all configs)
-3. Rebuild chart dependencies
-
-**Pros:**
-- Works on virtual nodes
-- No infrastructure changes
-
-**Cons:**
-- Requires chart modification
-- Increases complexity
-- May conflict with upstream chart updates
-- Not recommended without OCI-specific testing
-
-### Option C: Use External Managed Services (Alternative Topology)
-
-Deploy PostgreSQL, Redis, rustfs on OCI managed services instead of as pods:
-- OCI Database Service (PostgreSQL)
-- OCI Cache with Redis
-- OCI Object Storage (or external S3-compatible)
-- Disable Postgres/Redis/rustfs subcharts in values.local.yaml
-
-**Pros:**
-- Reduces pod count dramatically
-- Leverages OCI managed services SLAs
-- Still runs OpenSandbox on cluster
-
-**Cons:**
-- Configuration complexity increases
-- Cost structure changes
-- Network latency (managed services vs. in-cluster)
-
-## Deployment Steps Taken
-
-1. ✅ Added ingress-nginx Helm repository
-2. ✅ Installed ingress-nginx in ingress-nginx namespace (NodePort mode)
-3. ✅ Created opensandbox-system namespace
-4. ✅ Generated secrets (JWT, CSRF, vault_key, passwords)
-5. ✅ Authored values.local.yaml for v0.3.0
-6. ✅ Updated Helm chart dependencies (opensandbox + main chart)
-7. ❌ Helm install → failed at pod creation due to subPath
-
-## Configuration Details
-
-**values.local.yaml created:**
+**Fix applied:** fully qualify all three in `values.local.yaml`:
 ```yaml
-- Image: v0.3.0 (GHCR)
-- LLM: OpenAI provider (placeholder, needs real key)
-- Ingress: http://cubeplex.oci.local (ingress-nginx, no TLS)
-- Storage: cubeplex-work-hostpath StorageClass (OpenEBS hostpath)
-- OpenSandbox: Enabled (but couldn't deploy pods)
-- Mode: single_tenant
+postgres: { image: "docker.io/cubeplex/postgresql-pgroonga-pgvector:18.2-pgroonga4.0.6-pgvector0.8.2" }
+redis:    { image: "docker.io/library/redis:7-alpine" }
+rustfs:   { mcImage: "docker.io/minio/mc:RELEASE.2025-04-08T15-39-49Z" }
+```
+Documented as a troubleshooting entry (applies to any CRI-O-based node pool, not just OCI).
+
+### 3. GHCR `cubeplex-backend` / `cubeplex-frontend` packages were private
+
+Anonymous token requests for both packages returned `UNAUTHORIZED` (not `DENIED` —
+confirmed via a known-public GHCR package returning a valid token from the same network
+path, and via a known-nonexistent-but-public-org repo returning `DENIED` instead of
+`UNAUTHORIZED`, which is the real signal that distinguishes "private" from "doesn't
+exist"). The org owner changed both packages' visibility to Public via
+`github.com/orgs/cubeplexai/packages` → package → **Package settings** (a link easy to
+miss at the bottom of the right sidebar) → **Danger Zone** → **Change visibility**.
+Docs claim these are "public GHCR releases" (§3) — that was true in intent but the
+packages had not actually been flipped to public after today's v0.3.0 release cut.
+No doc fix needed here (it's a one-time repo/release-process step, not a chart/doc bug) —
+flagging for the release checklist instead.
+
+### 4. `model_presets.tiers` requires all four tier names — silent seed failure
+
+Chat sends 500'd at runtime with:
+```
+no_default_preset — no preset is marked is_default; admin must configure one
+```
+even though the backend Pod was `Running` and had picked up the arkplan config correctly.
+Root cause: `ModelPresetsConfig` Pydantic validation requires `tiers` to contain **exactly**
+`lite`, `flash`, `pro`, `max` — `values.local.yaml` only defined `flash`. Validation failure
+is caught and logged as a *warning* by `seed_system_providers_from_config`
+(`Failed to seed system providers: ... tiers must contain exactly: lite, flash, pro, max`),
+not surfaced anywhere in pod status/readiness — the app boots fine, health checks pass,
+only the very first chat message reveals the problem.
+
+**Fix applied:** define all four tiers, disabling unused ones with
+`enabled: false, primary: null` instead of omitting them:
+```yaml
+model_presets:
+  tiers:
+    lite:  { enabled: true,  primary: "arkplan/doubao-seed-2.0-lite", fallbacks: [...] }
+    flash: { enabled: true,  primary: "arkplan/deepseek-v4-flash",   fallbacks: [...] }
+    pro:   { enabled: true,  primary: "arkplan/glm-5.2",             fallbacks: [...] }
+    max:   { enabled: false, primary: null, fallbacks: [] }
+  default_preset: flash
+```
+Also discovered the **example file itself was stale**: `values.local.yaml.example` and
+`docs/site/docs/deployment/kubernetes.md` (§4.4, §8, §9, and the zh-Hans translation) all
+showed a `default_model` / `fallback_models` top-level schema that no longer exists in
+`backend/config.yaml` — the real schema has been `model_presets.tiers` + `default_preset`
+since the preset-tiers redesign. Fixed all of these in the same pass.
+
+## Final Working Configuration
+
+`deploy/kubernetes/charts/cubeplex/values.local.yaml` (secrets redacted below, real values
+used during the run):
+
+```yaml
+image:
+  backend:  { tag: "v0.3.0" }
+  frontend: { tag: "v0.3.0" }
+
+backend:
+  configOverrides:
+    api: { public_url: "http://cubeplex.oci.local" }
+    public_base_url: "http://cubeplex.oci.local"
+    frontend_base_url: "http://cubeplex.oci.local"
+    deployment: { mode: "single_tenant" }
+    auth: { cookie_secure: false }
+  secrets:
+    auth: { jwt_secret: "...", csrf_secret: "...", vault_key: "..." }
+    llm:
+      model_presets:
+        tiers:
+          lite:  { enabled: true, primary: "arkplan/doubao-seed-2.0-lite", fallbacks: ["arkplan/doubao-seed-2.0-mini", "alicode/qwen3.6-plus"] }
+          flash: { enabled: true, primary: "arkplan/deepseek-v4-flash", fallbacks: ["arkplan/minimax-m3", "alicode/qwen3.6-plus"] }
+          pro:   { enabled: true, primary: "arkplan/glm-5.2", fallbacks: ["arkplan/deepseek-v4-pro", "alicode/qwen3.6-plus"] }
+          max:   { enabled: false, primary: null, fallbacks: [] }
+        default_preset: flash
+      providers:
+        arkplan: { preset: "volcengine/cn/openai-completions/agent", api_key: "ark-..." }
+        alicode: { preset: "aliyun/cn/openai-completions/coding", api_key: "sk-sp-..." }
+    sandbox:
+      domain: "cubeplex-opensandbox-server.cubeplex.svc.cluster.local:8090"
+      api_key: "..."
+
+postgres:
+  auth: { password: "..." }
+  image: "docker.io/cubeplex/postgresql-pgroonga-pgvector:18.2-pgroonga4.0.6-pgvector0.8.2"
+  persistence: { storageClass: "oci-bv" }
+
+redis:
+  auth: { password: "..." }
+  image: "docker.io/library/redis:7-alpine"
+  persistence: { storageClass: "oci-bv" }
+
+rustfs:
+  auth: { secretKey: "..." }
+  image: "docker.io/rustfs/rustfs:1.0.0-beta.4"
+  mcImage: "docker.io/minio/mc:RELEASE.2025-04-08T15-39-49Z"
+  persistence: { storageClass: "oci-bv" }
+
+ingress:
+  enabled: true
+  className: "nginx"
+  host: "cubeplex.oci.local"
+  tls: { enabled: false }
+
+storageClass:
+  create: false     # using OCI's own `oci-bv` CSI StorageClass instead of the
+                     # chart's OpenEBS-hostpath default (OpenEBS isn't installed
+                     # on this cluster and oci-bv is already there and default)
+
+opensandbox:
+  enabled: false     # chat-only; sandbox/tool-calls not exercised in this run
 ```
 
-## Documentation Gaps
+The `arkplan` provider's `api_key` and the rest of the local LLM provider config were
+pulled from `backend/config.development.local.yaml` on the team's dev workstation
+(192.168.1.215) per the user's instruction to use that config, not a placeholder.
 
-The official Kubernetes deployment guide (`deploy/kubernetes/INSTALL.md` and `docs/site/docs/deployment/kubernetes.md`) does **not mention**:
+## Deployment Steps (final, working sequence)
 
-1. ⚠️ **OCI Container Engine for Kubernetes specific limitations**
-   - Virtual node subPath incompatibility
-   - Kata container runtime constraints
-   - When and why to use managed node pools instead
-
-2. ⚠️ **Virtual node detection and workarounds**
-   - No guidance on detecting virtual node clusters
-   - No troubleshooting section for virtual-node-specific errors
-
-3. ⚠️ **Cloud provider matrix table**
-   - Which cloud providers' managed K8s services have known issues
-   - OCI virtual nodes should be listed with "limited support" status
-
-## Recommended Actions
-
-### For This Deployment
-- **Add a managed node pool to the OCI cluster** and redeploy with nodeSelector
-- Once successful, document the OCI-specific setup
-
-### For Upstream Documentation
-1. **Add an "OCI Container Engine for Kubernetes" section** to the deployment guide
-   - Mention virtual node limitations upfront
-   - Provide managed node pool setup instructions
-   - Include troubleshooting for subPath errors
-
-2. **Create an OCI-specific values.local.yaml example**
-   - Disable problematic subcharts (optional)
-   - Add nodeSelector for managed node pools
-   - Document network topology for managed services
-
-3. **Add a "Cloud Provider Support Matrix"** table
-   - List tested cloud providers
-   - Mark known limitations per provider
-   - Link to provider-specific guides
-
-## Actions Taken to Update Documentation
-
-✅ **Updated Kubernetes deployment guide** (`docs/site/docs/deployment/kubernetes.md`):
-   - Added prominent OCI virtual node incompatibility warning at the top
-   - Created cloud provider compatibility matrix
-   - Added detailed OCI managed node pool setup instructions
-   - Explained why init containers and subPath are required
-
-✅ **Committed documentation changes:**
-   - Commit: `docs(deployment): add OCI Kubernetes virtual node limitations and compatibility guide`
-   - Future deployments will have clear warnings upfront
-
-## Next Steps (For User)
-
-To complete the OCI Kubernetes deployment:
-
-### Phase 1: Add Managed Node Pool
-**Add a managed node pool to the OCI cluster** (via OCI Console):
-   - Create new node pool (e.g., `cubeplex-workload`)
-   - Choose VM shape appropriate for your workload (VM.Standard.E4.Flex for dev/test)
-   - Wait for nodes to reach `Ready` status
-
-### Phase 2: Deploy CubePlex
-**Deploy cubeplex to the managed node pool:**
 ```bash
-# Copy the template
-cp deploy/kubernetes/charts/cubeplex/values.local.yaml.example \
-   deploy/kubernetes/charts/cubeplex/values.local.yaml
+# 1. Managed node pool (see issue #1)
+oci ce node-pool create --cluster-id <id> --compartment-id <id> \
+  --name cubeplex-workload --kubernetes-version v1.36.1 \
+  --cni-type OCI_VCN_IP_NATIVE --node-shape VM.Standard.E5.Flex \
+  --node-shape-config '{"ocpus":2,"memoryInGBs":16}' \
+  --node-source-details '{"sourceType":"IMAGE","imageId":"<OL9.7 OKE 1.36.1 image>","bootVolumeSizeInGBs":50}' \
+  --placement-configs '[{"availabilityDomain":"psHl:PHX-AD-2","subnetId":"<node subnet>"}]' \
+  --pod-subnet-ids '["<node subnet>"]' --size 2 --ssh-public-key "$(cat ~/.ssh/id_rsa.pub)"
 
-# Edit for your environment:
-#   - LLM provider keys (use arkplan/local config if available)
-#   - Database passwords (generate with: openssl rand -hex 16)
-#   - JWT/CSRF/vault secrets (generate as documented)
-#   - Ingress host (e.g., cubeplex.oci.local)
-$EDITOR deploy/kubernetes/charts/cubeplex/values.local.yaml
+kubectl taint node <virtual-node-1> <virtual-node-2> <virtual-node-3> virtual-node=true:NoSchedule
 
-# Add nodeSelector for managed nodes:
-cat >> deploy/kubernetes/charts/cubeplex/values.local.yaml << 'YAML_EOF'
-backend:
-  nodeSelector:
-    node.kubernetes.io/workload: cubeplex
-frontend:
-  nodeSelector:
-    node.kubernetes.io/workload: cubeplex
-YAML_EOF
+# 2. Ingress (stays on the virtual node pool — plain Deployment, no init containers)
+helm install ingress-nginx ingress-nginx/ingress-nginx -n ingress-nginx --create-namespace \
+  --set controller.service.type=NodePort
 
-# Deploy
+# 3. Author values.local.yaml (see above), then:
+helm dependency update deploy/kubernetes/charts/cubeplex/vendor/opensandbox
 helm dependency update deploy/kubernetes/charts/cubeplex
 helm upgrade --install cubeplex deploy/kubernetes/charts/cubeplex \
   --namespace cubeplex --create-namespace \
@@ -284,56 +218,528 @@ helm upgrade --install cubeplex deploy/kubernetes/charts/cubeplex \
   --wait --timeout 15m
 ```
 
-### Phase 3: Verification & Testing
-**⚠️ Testing Requirements (PENDING - only run after deployment succeeds):**
+Result: all 5 pods `Running`/`1/1` (`cubeplex-backend`, `cubeplex-frontend`,
+`cubeplex-postgresql-0`, `cubeplex-redis-master-0`, `cubeplex-rustfs-0`); `helm status`
+→ `deployed`; alembic migrations ran clean in the `migrate` init container; backend
+`/health/live` and `/health/ready` both `200`.
 
-1. **Smoke tests** (deployment correctness):
-   ```bash
-   INGRESS_IP=<node-ip> deploy/kubernetes/scripts/smoke-test.sh
+## Verification — Real E2E Against the Live Deployment
+
+Since the operator workstation cannot reach the cluster's private VCN subnet directly
+(no VPN/peering — only the K8s API server's public endpoint is reachable), tested via
+`kubectl port-forward` tunnels into the live Services rather than the ingress NodePort:
+
+```bash
+kubectl port-forward -n cubeplex svc/cubeplex-backend 18000:8000
+```
+
+Wrote a standalone httpx-based script mirroring the assertions in
+`backend/tests/e2e/test_conversation_flow.py` (which normally run in-process against a
+throwaway test DB and don't touch any deployment) but pointed at the port-forwarded
+**live backend Service**, so it actually exercises the deployed instance end to end:
+
+1. `GET /api/v1/system/info` → `single_tenant`, `v0.3.0`
+2. Register + login (single-tenant auto-org) + fetch CSRF cookie
+3. Create conversation
+4. `POST .../messages` with `Accept: text/event-stream`, collect SSE inline
+5. Assert: events non-empty, last event `type == "done"`, `text_delta` events present with
+   non-empty combined text
+6. `GET .../messages` → assert `>= 2` messages, first `role=user`, last `role=assistant`
+7. Negative cases: nonexistent conversation → `404`; empty content → `400`
+
+**Result: PASSED.** The `arkplan` model (`deepseek-v4-flash` via Volcengine Ark's Agent
+Plan endpoint) responded to "Say the word 'hello' and nothing else." with SSE event
+sequence `status × 3 → text_delta → usage → done`, assistant text `"hello"`, and the
+message history correctly recorded `[user, assistant]`. Both negative-path checks passed.
+
+This is a **real LLM round-trip through the deployed OCI cluster** — not the simple
+curl-based `deploy/kubernetes/scripts/e2e.sh`, and not the in-process pytest suite (which
+never touches a deployment) — but a script written in the same spirit/assertions as the
+pytest e2e tests, executed against the live deployment.
+
+## Follow-up: Enabling OpenSandbox (tool-call path)
+
+After the chat-only e2e passed, went back and enabled `opensandbox.enabled: true` to also
+verify the tool-call/sandbox path. Found and fixed three more issues getting the
+**server + controller** pods running, then hit a fourth that's an **infrastructure
+decision, not a config fix** — left unresolved, flagged for the user.
+
+1. **Wrong Service DNS name/port in the docs and example** — `values.local.yaml.example`
+   and INSTALL.md say the bundled subchart's sandbox domain is
+   `cubeplex-opensandbox-server.cubeplex.svc.cluster.local:8090`. Rendered the chart and
+   checked: the vendored `opensandbox-server` subchart hardcodes
+   `fullnameOverride: "opensandbox-server"` and `namespaceOverride` defaults to
+   `opensandbox-system` — **not** prefixed with the release name or deployed into the
+   parent chart's namespace. Actual Service is `opensandbox-server.opensandbox-system.svc.cluster.local`,
+   port **80** (not 8090). Used the corrected value; **doc fix still needed** (not yet
+   applied — flagging here since it wasn't part of the original doc-fix pass).
+
+2. **Controller image `v0.2.0` on Docker Hub doesn't match the chart's own template** —
+   crashed instantly with `flag provided but not defined: -containerd-socket-path`. The
+   vendored chart template (also versioned 0.2.0) unconditionally passes this flag, but
+   the published `opensandbox/controller:v0.2.0` Docker Hub image predates it (confirmed
+   via differing manifest digests between `v0.2.0` and `latest`). Pinned
+   `opensandbox-controller.controller.image.tag: "latest"` as a workaround — not a
+   permanent fix; someone should either re-tag a correct `v0.2.0` on Docker Hub or bump
+   the vendored chart to match whatever `latest` actually is.
+
+3. **Server needs its own `api_key`, separate from the backend's** — crashed with
+   `server.api_key is empty in non-interactive mode`. The server chart's `configToml` is
+   a raw TOML blob (not individually keyed values); had to override the whole block to
+   set `[server] api_key = "..."` (same value as `backend.secrets.sandbox.api_key`, since
+   that's what the backend presents when calling in). While at it, also fully-qualified
+   `execd_image` and `[egress] image` in the same TOML (same CRI-O short-name issue as
+   #2 in the main report — `opensandbox/execd:...` and `opensandbox/egress:...` needed
+   `docker.io/` prefixes too).
+
+4. **BLOCKING, unresolved: per-conversation sandbox pods get scheduled onto the (now
+   cordoned) virtual nodes and fail at PVC provisioning** — every real chat request that
+   triggers a tool call gets `Create sandbox failed: HTTP 504` after ~2 minutes. Root
+   cause, confirmed via `kubectl get events -n opensandbox`:
    ```
-
-2. **E2E tests with arkplan LLM model** (full round-trip including LLM):
-   ```bash
-   # Option A: Use deploy script (simple, but limited model testing)
-   HOST=cubeplex.oci.local IP=<node-ip> PORT=<ingress-nodeport> \
-   PROMPT="Say the word hello and nothing else." \
-     deploy/kubernetes/scripts/e2e.sh
-
-   # Option B: Use tests/e2e with arkplan config (full test suite)
-   # Configure LLM provider (arkplan or local) in tests/conftest.py
-   # Then run:
-   cd tests
-   pytest e2e/ -k "test_" -v --tb=short
+   failed to provision volume with StorageClass "oci-bv": error generating
+   accessibility requirements: error getting CSINode for selected node
+   "10.0.10.141": csinode.storage.k8s.io "10.0.10.141" not found
    ```
+   `oci-bv` uses `volumeBindingMode: WaitForFirstConsumer` (topology-aware): the volume
+   binder picks a candidate node **before** the PVC is provisioned, then asks the CSI
+   driver for that node's topology via its `CSINode` object. Virtual nodes never run the
+   CSI node plugin, so no `CSINode` object exists for them — the provisioning call errors
+   outright and the whole scheduling attempt for that pod aborts (it does not fall
+   through to try a different, valid node in the same cycle). The BatchSandbox controller
+   then just creates a **brand-new** pod (new UUID) on the next retry, which repeats the
+   same failure — an infinite loop, not a one-off flake.
+   - `kubectl taint node <virtual> virtual-node=true:NoSchedule` did **not** help: the
+     BatchSandbox pod template ships a blanket `tolerations: [{operator: "Exists"}]`,
+     which tolerates any taint.
+   - `kubectl cordon <virtual-node>` did **not** help either — cordoned nodes are still
+     apparently being offered as scheduling candidates during this topology-lookup phase
+     (or the failure happens before cordon status is consulted; either way, observed the
+     same `CSINode ... not found` error against a cordoned node on a fresh, post-cordon
+     attempt).
+   - Chat-only (no sandbox) continued to work perfectly regardless of this — it's fully
+     isolated to the tool-call path.
 
-   **Note on arkplan config:** 
-   - Check `backend/config.development.local.yaml` for local arkplan setup
-   - Kubernetes deployment should use the same LLM provider configured in `values.local.yaml`
-   - Full e2e test suite is in `tests/e2e/`; uses conftest.py for model config
+   **Resolved.** Confirmed with the user, then: (1) deleted `ingress-nginx`'s pod so it
+   rescheduled onto a real node (the 3 virtual nodes were already cordoned from earlier
+   troubleshooting, so it landed on `10.0.10.185` automatically); (2)
+   `oci ce virtual-node-pool delete --virtual-node-pool-id
+   ocid1.virtualnodepool.oc1.phx.amaaaaaaf4havgaagyjjgvgxtobmjtatqsy4qeriidjp6oahbvxyhxql55ea
+   --force`, waited for the work request to reach `SUCCEEDED`; (3) `kubectl get nodes`
+   confirmed only the 2 real nodes remained. Re-ran the tool-call e2e test: the very next
+   sandbox pod scheduled straight onto a real node, ran its `execd-installer` init
+   container normally, and completed a real `ls -la /workspace` round-trip. **Sandbox
+   tool-call path fully verified working** — see the "Final Verification" section below.
 
-3. **Document any OCI-specific configuration** discovered (update this note)
+   One transient side-effect from the transition: a PVC from a pre-deletion failed
+   attempt had a stale `VolumeAttachment` pointing at a node that no longer mattered,
+   causing one `Multi-Attach error` on the very next retry — self-resolved within
+   seconds once Kubernetes' attach-detach controller caught up with the topology change.
+   Also saw brief `Insufficient cpu`/`Insufficient memory` scheduling warnings when
+   running 2 sandbox pods concurrently on the 2× `VM.Standard.E5.Flex` (2 OCPU/16GB
+   each) node pool — expected capacity pressure for this test-sized pool, not a
+   correctness issue; both pods still reached `2/2 Running` once the other's resources
+   freed up.
 
-## Testing Scope
+**Net status:** `opensandbox-server` and `opensandbox-controller` pods `Running`,
+`GET /api/v1/system/info` reports `sandbox_enabled: true`, and — after removing the
+virtual node pool — a real per-conversation sandbox container provisions successfully
+and executes real shell commands (`ls -la /workspace`) with correct results streamed
+back through SSE (`tool_call` → `tool_result` → `text_delta` → `done`).
 
-| Test Type | Status | Notes |
-|---|---|---|
-| Smoke tests (routing, health) | Pending | Deployment must succeed first |
-| E2E with deploy script | Pending | Quick validation, limited models |
-| Full e2e test suite (pytest) | Pending | Comprehensive, uses arkplan if configured |
-| Sandbox integration tests | Pending | Requires OpenSandbox in `values.local.yaml` |
+### Chart change made (not just values/docs)
 
-## Resources Cleaned Up
+`deploy/kubernetes/charts/cubeplex/templates/backend-configmap.yaml` — added a
+`secure_access` passthrough to the `sandbox:` block (previously only `enabled` and
+`use_server_proxy` were templated), needed because `backend.configOverrides.sandbox.*`
+collides with the chart's own hardcoded `sandbox:` key in the same rendered YAML file
+(dynaconf's YAML parser rejects the resulting duplicate key outright). New field, wired
+the same way as the two existing ones:
+```yaml
+secure_access: {{ dig "sandbox" "secure_access" true .Values.backend }}
+```
+Set via `backend.sandbox.secure_access: false` in `values.local.yaml` (sibling to
+`configOverrides`/`secrets`, not nested under `configOverrides`) — needed because the
+OpenSandbox `gateway`/`ingress` component (which `secureAccess=true` requires) wasn't
+deployed in this run.
 
-- Removed test `values.local.yaml` (user will create their own)
-- Uninstalled test release
-- Removed opensandbox-system namespace (will be recreated on next deploy)
+## Backend Bug Fix: model_presets Seed Failure Was Silently Swallowed
 
-## Summary for Future Deployments
+The `no_default_preset` failure mode above (§ "model_presets.tiers requires all four
+tier names") isn't just a deployment-config gotcha — it's a backend bug. Traced it to
+`backend/cubeplex/api/app.py`'s `lifespan()`:
 
-OCI Kubernetes deployments now have clear documentation:
-- ✅ Warning at the top of the deployment guide
-- ✅ Compatibility matrix showing OCI limitation
-- ✅ Step-by-step instructions for adding managed node pools
-- ✅ Clear explanation of why virtual nodes don't work
+```python
+try:
+    async with async_session_maker() as seed_session:
+        await seed_system_providers_from_config(seed_session, _app.state.encryption_backend)
+        await seed_model_presets_from_config(seed_session)   # raises pydantic.ValidationError
+    logger.info("System provider seed step completed")
+except Exception as e:
+    logger.warning("Failed to seed system providers: {}", str(e))   # ← swallowed here
+```
 
-The deployment guide is now accurate and will prevent users from wasting time troubleshooting unsupported configurations.
+`seed_model_presets_from_config` calls `ModelPresetsConfig.model_validate(raw)`
+directly — it always raised correctly on a partial `tiers` map. The bug was the
+**caller**: it shared the same broad `try/except Exception → warning` as system-provider
+seeding, which is a legitimately optional, safe-to-degrade step. Model presets are not
+optional — without them, the app is healthy per every health check but cannot serve a
+single chat message. Conflating the two meant a config typo produced a `WARNING` log
+line and a fully healthy, silently broken deployment, with the real error surfacing only
+when an end user sent a message and got a generic `no_default_preset` 500 with no link
+back to the actual cause.
+
+**Fix** (confirmed with the user before touching backend code, since this is a behavior
+change beyond deploy/chart/docs): pulled `seed_model_presets_from_config` out of the
+system-providers try/except into its own, unguarded step — modeled on the existing
+fail-fast pattern already used elsewhere in the same `lifespan()` for other
+must-not-be-wrong startup config (e.g. `_build_encryption_backend()` raises
+`RuntimeError` directly if `CUBEPLEX_AUTH__VAULT_KEY` is missing, no try/except). An
+invalid `model_presets` config now crashes the pod at startup (`CrashLoopBackOff`,
+visible immediately in `kubectl get pods`) instead of degrading silently.
+
+Added a regression test, `backend/tests/e2e/test_startup_model_presets_validation.py`,
+modeled on the existing `test_startup_mode_consistency.py` pattern (construct the real
+app, run `lifespan(app)` directly, assert it raises). Verified the fix doesn't break
+existing behavior: ran `test_seeder_presets.py` (unit), `test_preset_errors_e2e.py`,
+`test_group_chat.py`, and `test_startup_mode_consistency.py` — all 18 tests green,
+including the two that specifically exercise `no_default_preset` at the HTTP-response
+level (those engineer the "no presets" state via direct DB deletion *after* a
+successful lifespan run with the test suite's always-valid `config.test.yaml`, so they
+were never exercising the buggy code path in the first place and are unaffected by the
+fix).
+
+Test infra note: this machine's local Docker daemon has a broken `HTTPS_PROXY` (dead
+`127.0.0.1:7892`), which blocks pulling the `cubeplex/postgresql-pgroonga-pgvector`
+image needed for a proper local Postgres + pgvector/pgroonga test instance. Rather than
+touch the shared build machine's system-level Docker daemon config without
+authorization, ran the test suite over SSH against a throwaway Postgres/Redis pair on
+the team's dev workstation (192.168.1.215), which already has the image cached from its
+own `infra-postgresql` container. Copied `app.py` and the new test file over
+temporarily, ran the suite, then reverted both and removed the throwaway containers —
+left that machine exactly as found.
+
+### Follow-up: relaxed "all four tiers" to "at least one tier"
+
+The fail-fast fix above still required `tiers` to name all four tiers by key (just
+made the *failure mode* for a partial map correct — crash instead of silently warn).
+User asked whether that "all four" requirement itself should really be "at least one" —
+checked, and it should. Traced `set(self.tiers.keys()) != set(ModelTier)` in
+`ModelPresetsConfig._invariants` (`backend/cubeplex/llm/snapshot_schema.py`) back to its
+one actual caller with a hard dependency: `_load_presets()` in `backend/cubeplex/llm/snapshot.py`
+did `s = cfg.tiers[tier]` — an **unconditional** dict subscript for all four `ModelTier`
+values, which would `KeyError` on any missing key. The "exactly four" schema constraint
+existed purely to satisfy that unconditional access, not because a partial tiers map is
+actually meaningless.
+
+**Fixed both sides:**
+- `ModelPresetsConfig._invariants`: `if set(self.tiers.keys()) != set(ModelTier)` →
+  `if not self.tiers` (reject only a genuinely empty map).
+- `_load_presets()`: `cfg.tiers[tier]` → `cfg.tiers.get(tier, TierSetting())` — a missing
+  tier now resolves to the same disabled default (`enabled=False, primary=None`) that an
+  explicit `{enabled: false, primary: null}` entry would.
+
+Updated the tests that directly asserted the old "exactly four" behavior (they'd have
+been silently-wrong regression gaps otherwise, still green but testing the wrong
+invariant): `test_model_presets_schema.py::test_missing_tier_key_rejected` →
+`test_partial_tiers_accepted` (+ new `test_empty_tiers_rejected`);
+`test_admin_model_presets_schemas.py::test_admin_body_requires_all_four_tiers` →
+`test_admin_body_accepts_partial_tiers` (+ new `test_admin_body_rejects_empty_tiers`,
+since the admin PUT endpoint's request schema is a re-export of `ModelPresetsConfig` and
+inherits the same rule automatically). Added
+`test_snapshot_loader.py::test_snapshot_loads_preset_with_partial_tiers` (only `pro`
+present, no `lite`/`flash`/`max` keys at all — confirms `_load_presets` no longer
+`KeyError`s) and updated `test_startup_model_presets_validation.py` to test the
+genuinely-still-invalid case (`tiers: {}`) plus a new positive case confirming a
+single-tier config now boots cleanly. Ran the full preset/tier-related surface again on
+192.168.1.215 (same throwaway-container, copy-over-revert-cleanup approach): 61/61 then
+40/40 (a broader `-k 'preset or tier'` sweep across `tests/unit/llm/` and
+`tests/unit/api/`) all green.
+
+**Docs updated to match**: `values.local.yaml.example` and both `kubernetes.md`
+(English + zh-Hans) now say "at least one tier, omitted tiers are just disabled" instead
+of "all four tiers required, disable unused ones explicitly" — the troubleshooting
+table entry changed from "chat 500s at runtime" (the old bug's symptom) to
+"`CrashLoopBackOff` with `tiers must contain at least one tier`" (the new, correct,
+fail-fast symptom for the one config that's genuinely still invalid: an empty map).
+
+## Documentation Changes Made
+
+- `docs/site/docs/deployment/kubernetes.md` (+ zh-Hans translation):
+  - OCI virtual-node incompatibility warning at the top, with a cloud-provider
+    compatibility matrix and step-by-step managed-node-pool instructions (§9)
+  - `model_presets.tiers` documented as needing at least one tier (final state, after
+    the backend fix below), with a troubleshooting entry for the `CrashLoopBackOff` /
+    `tiers must contain at least one tier` failure mode
+  - Fixed the stale `default_model`/`fallback_models` schema (didn't match current code)
+    in §4.4, §8 (abridged values tree), and the minimal `values.local.yaml` example
+  - New troubleshooting entry for the CRI-O short-name `ImageInspectError`
+- `deploy/kubernetes/charts/cubeplex/values.local.yaml.example`: same `model_presets`
+  schema fix, with an inline comment explaining the at-least-one-tier requirement
+
+## Final Verification — Sandbox Tool-Call E2E
+
+Same port-forward-based approach as the chat e2e, but with a prompt that requires a tool
+call: "List the contents of /workspace (run `ls -la /workspace`)."
+
+Observed SSE sequence: `status × 3 → tool_call_delta × N → tool_call → usage →
+tool_result → text_delta × N → usage → done`. The `tool_result` payload contained the
+sandbox's actual `ls -la` output (`.skills/`, `lost+found/`), and the assistant's final
+text was an accurate natural-language summary of that real output — not a
+hallucination masking a failure. Ran this twice, including once with two conversations'
+sandbox pods running concurrently (both reached `2/2 Running`, both tool calls
+succeeded); one early request in each run hit a transient `HTTP 504` from
+resource/volume-attachment settling right after the node-pool transition, and the
+agent's own retry logic recovered cleanly both times without any user-visible failure
+in the final response.
+
+## Follow-up: Egress Secret-Injection (MITM Webhook) — 3 More Bugs, Then a Real PASS
+
+User asked whether the egress secret-injection feature (§4.10 — mitmproxy addon in each
+sandbox swaps `cbxref_<id>` placeholders for real secrets over an mTLS exchange with the
+backend) had been tested. It hadn't — separate opt-in feature, `egress.enabled: false`
+default, never touched during the deployment above. Enabled it and worked through three
+more real bugs before landing a genuine pass.
+
+### Bug 1: `sandboxNamespace` doc/example default is wrong for this topology
+
+Set `egress.sandboxNamespace: "opensandbox-system"` per the (existing, unfixed-until-now)
+doc default — but that's where `opensandbox-server`/`-controller` themselves run, not
+where actual per-conversation sandbox pods land (`"opensandbox"`, confirmed repeatedly
+earlier in this same session via `kubectl get pods -n opensandbox`). Traced
+`egress-mutatingwebhookconfiguration.yaml`: the `MutatingWebhookConfiguration`'s
+`namespaceSelector.matchLabels` is set to `kubernetes.io/metadata.name: <sandboxNamespace>`
+— wrong value here means the webhook **never fires for real sandbox pods**, and
+`failurePolicy: Ignore` means this produces zero errors anywhere; it just silently does
+nothing. Fixed by setting `sandboxNamespace: "opensandbox"` instead, confirmed via
+`helm template` that the CA/addon Secrets and the webhook's `namespaceSelector` all
+correctly target `opensandbox` before applying.
+
+### Bug 2: Helm's `genCA` generates RSA; the webhook hard-requires EC
+
+Webhook pod crashed instantly: `TypeError: CA key must be an EC private key`. Root cause:
+`_egress-helpers.tpl`'s `cubeplex.egress.certs` helper calls Helm/Sprig's built-in
+`genCA`/`genSignedCert` — which only ever produce RSA keys, Sprig has no EC option — while
+`deploy/kubernetes/egress-bundle/webhook/cert_minter.py`'s `load_ca()` explicitly requires
+`ec.EllipticCurvePrivateKey` and raises otherwise. The chart's own cert-generation
+mechanism cannot produce output its own application will accept.
+
+No clean values.yaml-level fix exists (Sprig genuinely can't do EC). Worked around it for
+this verification by generating a proper EC CA + two leaf certs manually, using the exact
+same `generate_ca()`-style logic as `cert_minter.py` itself (SECP256R1, same PEM/Secret-key
+shapes: `mitmproxy-ca.pem`/`mitmproxy-ca-cert.pem` for the CA Secret, `tls.crt`/`tls.key`
+for the webhook and backend mTLS Secrets), then created/overwrote all four Secrets
+(`cubeplex-egress-mitm-ca`, `egress-mitm-ca` in the sandbox ns, `cubeplex-egress-webhook-tls`,
+`cubeplex-backend-mtls`) via `kubectl` *before* the next `helm upgrade` — the chart's
+`lookup`-or-mint logic finds all three cert Secrets present and reuses them rather than
+re-minting via the broken RSA path. Deleted the crashing pod to force a re-read; webhook
+came up clean afterward. **This is a real chart bug, not fixed in the chart itself** —
+flagging for a proper fix (either shell out to a cert-generation Job using the same EC
+logic as `cert_minter.py`, or relax the webhook to accept RSA too).
+
+### Bug 3: `sandbox.egress_exchange_host` is required but never set by any chart template
+
+Webhook + mTLS listener both came up healthy, `egress.enabled: true` looked fully wired —
+but a real conversation's tool call still got the placeholder literally: sandbox env var
+`$TEST_EGRESS_TOKEN` was empty (`TOKEN length: 0`). Traced `backend/cubeplex/sandbox/manager.py`:
+`self._exchange_host: str = config.get("sandbox.egress_exchange_host", "")`, and **every**
+injection code path — building placeholder envs, force-allowing the exchange host in the
+sandbox's network policy — is gated on `if self._exchange_host:`. Grepped the entire chart:
+no template sets this key anywhere. Enabling `egress.enabled` deploys all the
+webhook/mTLS/CA/ConfigMap infrastructure but never flips the one backend config switch that
+actually turns on its use — the feature is a structural no-op out of the box even with a
+fully-correct `values.local.yaml` per the (until-now) documented fields.
+
+**Fixed in the chart** (`backend-configmap.yaml`), not just values — added a fourth
+`dig`-based passthrough in the existing `sandbox:` block, defaulting to the same host the
+sandbox-side mitmproxy addon already connects to (mirrors `egress-webhook-deployment.yaml`'s
+own `exchangeURL` default computation) when `egress.enabled` is true:
+```yaml
+egress_exchange_host: {{ dig "sandbox" "egress_exchange_host" (printf "%s.%s.svc.cluster.local" (include "cubeplex.backend.fullname" .) .Release.Namespace) .Values.backend }}
+```
+Verified the auto-default resolves correctly via `helm template --namespace cubeplex`
+(→ `cubeplex-backend.cubeplex.svc.cluster.local`) before applying — a first `helm template`
+run without `--namespace` produced `cubeplex-backend.default.svc.cluster.local`, a reminder
+that `.Release.Namespace` needs the real `--namespace` flag even for template-only dry runs.
+
+### Full round-trip verification
+
+With all three fixed: created a workspace-scoped sandbox-env secret
+(`hosts: ["httpbin.org"]`, `header_names: ["Authorization"]`, a random `secret_value`),
+allow-listed `httpbin.org` in the org's sandbox network policy (network policy and
+credential-substitution eligibility are two independent gates — `hosts` on the secret
+alone does not open network egress; needed both), then had the agent run:
+```bash
+curl -s -H "Authorization: Bearer $TEST_EGRESS_TOKEN" https://httpbin.org/headers
+```
+`httpbin.org` echoed back what it actually received:
+```json
+"Authorization": "Bearer REAL-SECRET-2e76fb892746"
+```
+— the real secret value, not the `cbxref_<32 chars>` placeholder the sandbox env var
+actually held. Confirms the full chain: backend mints placeholder → sandbox env holds
+placeholder → agent sends placeholder in the Authorization header → sandbox-side
+mitmproxy addon keys off the TLS SNI (`httpbin.org`), calls the backend's mTLS exchange
+endpoint, gets the real value back, substitutes it in-flight before the request leaves
+the sandbox → destination sees only the real secret, never the placeholder, and the
+value never touched the LLM prompt or conversation history.
+
+Side notes from this run:
+- Needed org-admin (not just workspace-admin) to `PUT /api/v1/admin/sandbox-policy` —
+  single_tenant mode's first-ever-registered-user-is-owner bootstrap only applies to a
+  truly fresh org; by this point in the session the org already had 11 members from
+  earlier test runs, none of them owner/admin. Used
+  `python -m cubeplex.cli admin grant-admin <email> --org-slug default` (run via
+  `kubectl exec` into the backend pod) to promote a test user — this is the documented
+  operator CLI path, not a workaround.
+- Hit `HTTP 504` a few times purely from **resource contention**, not from these bugs:
+  the 2× `VM.Standard.E5.Flex` node pool struggles with more than ~1-2 concurrent sandbox
+  pods (see the CPU-pressure note in the tool-call section above). `kubectl delete
+  batchsandboxes.sandbox.opensandbox.io -n opensandbox --all` cleans up leftover
+  test sandboxes and frees room immediately (deleting just the Pod respawns it — the
+  BatchSandbox controller reconciles it right back; delete the CR instead).
+- **Network policy is structural, set only at sandbox creation time** (confirmed via
+  `_apply_egress`'s own docstring in `manager.py`) — adding a new allowed host to the
+  org's sandbox policy does **not** retroactively apply to an already-running sandbox
+  pod reused across conversations. Had to `kubectl delete batchsandboxes -n opensandbox
+  --all` to force a fresh sandbox before a newly-allow-listed host (`postman-echo.com`,
+  swapped in after `httpbin.org` started 503ing) actually became reachable.
+- **A regenerated CA does NOT auto-propagate everywhere** — after running
+  `gen-egress-certs.sh` (below) with `FORCE=true` to replace the certs, `kubectl delete
+  pod`-ing the webhook and `rollout restart`-ing the backend was **not enough**: the
+  cluster-scoped `MutatingWebhookConfiguration`'s `caBundle` field is a separate,
+  independently-templated value that only gets refreshed by re-running `helm upgrade`
+  (confirmed by diffing the CA cert embedded in `caBundle` against the CA cert actually
+  in the Secret — they didn't match until the next `helm upgrade`). Until that happens,
+  the API server's calls to the webhook fail TLS verification silently
+  (`failurePolicy: Ignore`) and every sandbox pod is created unpatched — no error
+  anywhere, injection just doesn't happen. **Rule of thumb: any time you touch the
+  egress cert Secrets directly, always follow with a `helm upgrade` before testing.**
+- **A freshly-created sandbox's very first outbound request can race past mitmproxy's
+  own startup** — confirmed via `docker/egress` container logs: transparent-intercept
+  iptables rules (`iptables transparent rules installed successfully`) went in ~600ms
+  *after* the sandbox process's first outbound connection attempt was already logged.
+  That first request leaked the literal `cbxref_...` placeholder (network policy was
+  already active and let it through; MITM redirection just wasn't wired up yet). A
+  second request against the same, now-warm sandbox worked correctly and substituted
+  the real secret. This is a startup-ordering issue inside the vendored/third-party
+  `docker/egress` binary itself (`opensandbox/egress:v1.0.12`), not something fixable
+  from the cubeplex chart side — flagging as a known gap for anyone relying on a brand
+  new sandbox's first tool call to have secrets substituted.
+
+## `gen-egress-certs.sh` — a Proper Fix for the RSA/EC CA Bug
+
+The chart's own `genCA`-based cert generation (Bug 2 above) has no values.yaml-level
+fix, and hand-crafting Secrets with `kubectl create` + inline Python each time isn't
+something to leave as tribal knowledge. Added
+`deploy/kubernetes/scripts/gen-egress-certs.sh`:
+
+- Reuses `cert_minter.py`'s own `generate_ca()` — the exact function the webhook already
+  trusts — rather than reimplementing the crypto. Added a new `mint_server_cert()`
+  function to `cert_minter.py` itself (with a unit test,
+  `deploy/kubernetes/egress-bundle/webhook/tests/test_cert_minter.py`) since the
+  existing `CertMinter.mint()` only produces CN-only client certs (for per-sandbox mTLS
+  auth); the webhook's own serving cert and the backend's mTLS listener cert both need
+  SANs for TLS hostname verification, which nothing in the module produced before.
+- Generates all three cert pairs (CA + webhook leaf + backend leaf) in one Python
+  subprocess and writes all four Kubernetes Secrets
+  (`<release>-egress-mitm-ca`, `egress-mitm-ca` in the sandbox namespace,
+  `<release>-egress-webhook-tls`, `<release>-backend-mtls`) via `kubectl apply`.
+- Idempotency-safe like the existing (pre-Helm, disconnected) `gen-ca.sh`: refuses to
+  overwrite existing Secrets unless `FORCE=true`, since replacing the CA invalidates
+  every already-signed cert.
+- **Verified end-to-end on this cluster**: ran with `FORCE=true` to replace my earlier
+  hand-crafted certs, confirmed the idempotency guard correctly refuses a second run
+  without `FORCE`, restarted the webhook + backend, re-ran `helm upgrade` (see the
+  caBundle note above — required), and reproduced the full egress PASS from scratch on
+  the script's own output.
+
+## Wiring `gen-egress-certs.sh` into `helm-install.sh` (Automatic Pre-Check)
+
+User asked whether this should be a Helm hook Job instead, so the fix works
+regardless of install path (OCI chart pull vs. repo checkout) with zero
+operator awareness needed. Investigated and talked through it before writing
+anything:
+
+**Why a Job doesn't cleanly work the way it initially sounds like it would.**
+Helm renders *all* templates — hooks and main manifests alike — in a single
+pass at the start of `helm upgrade`/`install`; `lookup()` calls are evaluated
+during that render, which happens *before* any hook has actually run against
+the cluster. A `pre-install`/`pre-upgrade` Job that creates the cert Secrets
+would not be visible to the `lookup()` calls in `_egress-helpers.tpl` and
+`egress-mutatingwebhookconfiguration.yaml` in the *same* `helm upgrade`
+invocation — those already rendered (with the old/absent state) before the
+hook's Pod even starts. Making a Job work for real would require flipping it
+to `post-install`/`post-upgrade` and having it imperatively `kubectl patch`
+the already-applied Secrets *and* the cluster-scoped
+`MutatingWebhookConfiguration`'s `caBundle` directly (bypassing Helm's own
+rendered output for those resources entirely), plus new cross-namespace RBAC
+(Secret read/write in two namespaces, patch on a cluster-scoped resource,
+Deployment restart) and adding `kubectl` to the webhook image's Dockerfile
+(which currently only has Python + `cryptography`, no `kubectl` binary) so
+the Job's container could actually do the patching. That's a real feature —
+new chart resources, new RBAC surface, an image change — not a small
+integration, and per the repo's own `AGENTS.md` workflow rules it would
+warrant a worktree + spec/plan rather than being dashed off directly on
+`main`.
+
+**What we did instead**, after weighing that against the actual ask (smoother
+first-install UX): reframed the problem. The published-OCI-chart install path
+*already* requires the operator to hand-generate several secrets
+(`jwt_secret`, `csrf_secret`, `vault_key`, DB passwords) via `openssl rand`
+before running the one-line `helm upgrade --install ... oci://...` — "zero
+pre-steps" was never actually true for that path. Adding "run
+`gen-egress-certs.sh` first if you're enabling egress" is consistent with
+that existing pattern rather than a new regression, so it's now documented
+as one more required pre-step for the OCI path (§4.10 above).
+
+For the **repo-checkout path** (`deploy/kubernetes/scripts/helm-install.sh`),
+we *can* remove the pre-step entirely without any Job/RBAC/Dockerfile work,
+since that script already runs client-side before `helm upgrade`. Added:
+
+1. `gen-egress-certs.sh`: creates `$NAMESPACE`/`$SANDBOX_NAMESPACE` if either
+   is missing (a true first install won't have them yet — `--create-namespace`
+   only creates `$NAMESPACE`, and only as part of the `helm upgrade` call this
+   script now runs *before*). Reworked the idempotency guard from
+   "any Secret exists → hard error, require `FORCE=true`" to "all 4 exist →
+   silent no-op exit 0" (the expected steady state on every rerun) vs.
+   "partial state → error, needs manual inspection" vs. "none exist → proceed"
+   — the old all-or-nothing guard would have made every subsequent
+   `helm-install.sh` run after the first one fail outright.
+2. `helm-install.sh`: renders just `templates/egress-secrets.yaml` via
+   `helm template --show-only` to ask Helm itself whether egress is
+   *effectively* enabled (correctly accounts for the values.yaml default +
+   values.local.yaml override, unlike grepping the raw YAML) and, if so, runs
+   `gen-egress-certs.sh` before the real `helm upgrade --install`.
+
+**Verified end-to-end, twice:**
+- With all 4 Secrets already present (the common case) — detection correctly
+  printed the no-op message and proceeded straight to a normal
+  `helm upgrade --install` (came back `STATUS: deployed`, all pods `Running`).
+- Deleted all 4 Secrets to simulate a true first install with egress enabled
+  — `helm-install.sh` correctly detected the gap, minted fresh EC certs,
+  wrote all 4 Secrets, then a real `helm upgrade` synced the
+  `MutatingWebhookConfiguration`'s `caBundle` automatically as part of the
+  same run (confirmed by diffing the CA cert in `caBundle` against the CA
+  cert in the Secret — matched without any manual intervention). Restarted
+  the webhook/backend pods afterward (needed here only because this was a
+  live, already-running deployment being reset for the test — a genuine
+  first install has no pre-existing pods to go stale, so this step isn't
+  needed in the real first-install case).
+
+## Known Limitations / Follow-ups
+
+- The virtual node pool is gone; the cluster is now 2× `VM.Standard.E5.Flex` real nodes
+  only. That's adequate for this smoke-test-sized deployment but tight — saw
+  `Insufficient cpu`/`Insufficient memory` scheduling warnings when 2 sandbox pods ran
+  concurrently alongside the core cubeplex + OpenSandbox infra pods. Size the node pool
+  (replica count and/or shape) to the real expected concurrent-sandbox load before using
+  this cluster for anything beyond validation.
+- GHCR package visibility is a one-time release-process step, not fixed in the repo —
+  worth adding to the release checklist so it doesn't block the next version's first
+  external deployer.
+- The OpenSandbox `secure_access: false` workaround (§ above) disables OSEP-0011 signed
+  route tokens between the server and (undeployed) ingress gateway. Fine for this
+  chart-bundled, cluster-internal setup where the backend talks to the sandbox server
+  directly; revisit if the `gateway.enabled: true` component is ever deployed for
+  external sandbox access.

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -301,9 +301,71 @@ Three typical layouts:
 
 | Layout | `values.local.yaml` |
 |---|---|
-| Bundled OpenSandbox subchart | `opensandbox.enabled: true`; `backend.secrets.sandbox.domain` points at `cubeplex-opensandbox-server.cubeplex.svc.cluster.local:8090` |
+| Bundled OpenSandbox subchart | `opensandbox.enabled: true`; `backend.secrets.sandbox.domain` points at `opensandbox-server.opensandbox-system.svc.cluster.local:80` (the vendored subchart hardcodes `fullnameOverride`/`namespaceOverride` — no release-name prefix, no `cubeplex` namespace, port 80 not 8090) |
 | External OpenSandbox | `opensandbox.enabled: false`; `backend.sandbox.enabled: true`; `backend.secrets.sandbox.domain` points at the external host |
 | No sandbox (chat-only) | `opensandbox.enabled: false`; leave `backend.sandbox.enabled` unset (it follows `opensandbox.enabled` → false) |
+
+The backend defaults to `sandbox.secure_access: true` — it expects sandbox
+access to go through a signed route token, which requires the OpenSandbox
+`gateway`/`ingress` component to be deployed
+(`opensandbox.opensandbox-server.server.gateway.enabled: true`, not covered
+here). If you're not deploying that gateway, disable the requirement or the
+backend can't create sandboxes at all:
+```yaml
+backend:
+  sandbox:
+    secure_access: false
+```
+
+If your node pool runs CRI-O (see the [image-name troubleshooting
+entry](#imageinspecterror--short-name-mode-is-enforcing-returns-ambiguous-list)),
+the OpenSandbox subchart's own images need the same `docker.io/` qualification, and its
+`configToml` needs `[server] api_key` set explicitly (it does **not** inherit
+`backend.secrets.sandbox.api_key` — set the same value manually) or the server refuses
+to start:
+```yaml
+opensandbox:
+  opensandbox-server:
+    server:
+      image: { repository: "docker.io/opensandbox/server" }
+      ingress: { image: { repository: "docker.io/opensandbox/ingress" } }
+    configToml: |
+      [server]
+      host = "0.0.0.0"
+      port = 80
+      api_key = "<same value as backend.secrets.sandbox.api_key>"
+      [log]
+      level = "INFO"
+      [runtime]
+      type = "kubernetes"
+      execd_image = "docker.io/opensandbox/execd:v1.0.18"
+      [kubernetes]
+      namespace = "opensandbox"
+      informer_enabled = true
+      informer_resync_seconds = 300
+      informer_watch_timeout_seconds = 60
+      snapshot_create_timeout_seconds = 900
+      workload_provider = "batchsandbox"
+      batchsandbox_template_file = "/etc/opensandbox/example.batchsandbox-template.yaml"
+      [egress]
+      image = "docker.io/opensandbox/egress:v1.0.12"
+      mode = "dns+nft"
+  opensandbox-controller:
+    controller:
+      # v0.2.0 on Docker Hub crashes with `flag provided but not defined:
+      # -containerd-socket-path` — that published tag lags the chart's own
+      # template. Pin `latest` until upstream re-cuts a matching v0.2.0.
+      image: { repository: "docker.io/opensandbox/controller", tag: "latest" }
+      snapshot:
+        imageCommitterImage: "docker.io/opensandbox/image-committer:v0.1.0"
+```
+
+Also create the `opensandbox-system` and `opensandbox` namespaces before installing —
+neither the umbrella chart nor its subcharts create them:
+```bash
+kubectl create namespace opensandbox-system
+kubectl create namespace opensandbox   # where per-conversation sandbox pods actually run
+```
 
 ### 4.6 Bundled infra passwords (required)
 
@@ -437,15 +499,30 @@ build is needed. Turn the feature on in `values.local.yaml`:
 ```yaml
 egress:
   enabled: true
-  # Namespace where sandbox pods actually run.
-  # When using the bundled opensandbox subchart, "opensandbox-system".
-  sandboxNamespace: "opensandbox-system"
+  # Namespace where sandbox pods actually run — NOT the same as where
+  # opensandbox-server/-controller themselves run ("opensandbox-system").
+  # With the bundled subchart's own defaults, that's "opensandbox" (its
+  # configToml's [kubernetes] namespace). Get this wrong and the
+  # MutatingWebhookConfiguration's namespaceSelector never matches real
+  # sandbox pods — silently, since failurePolicy is Ignore. Confirm with
+  # `kubectl get pods -n <namespace>` after a sandbox has been created once.
+  sandboxNamespace: "opensandbox"
   webhook:
     image:
       tag: "v0.2.0"             # same release version as backend/frontend
     # MUST exactly match opensandbox-server's configured egress.image.
     # China mirror: sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:v1.0.12
     egressImage: "opensandbox/egress:v1.0.12"
+
+backend:
+  sandbox:
+    # REQUIRED — separate from the deploy-side wiring above. Without it the
+    # backend never actually builds or sends the placeholder credentials,
+    # even though the webhook/mTLS/CA infra is fully deployed and healthy —
+    # it just silently does nothing. Defaults correctly on its own (mirrors
+    # where the sandbox-side addon actually connects) — only set this if you
+    # need to override it.
+    # egress_exchange_host: "cubeplex-backend.cubeplex.svc.cluster.local"
 ```
 
 (Self-building instead? Add `egress-webhook` to `TARGET` when running
@@ -453,16 +530,61 @@ egress:
 
 Notes:
 
-- The chart auto-generates the MITM CA (`genCA`) on first install and marks
-  the Secret `helm.sh/resource-policy: keep`, so upgrades and
-  `helm uninstall` do not rotate the CA. Re-installs into an existing
-  cluster pick up the same CA via `lookup`.
+- **Known chart bug:** the CA the chart auto-generates on first install uses
+  Helm/Sprig's built-in `genCA`, which only produces **RSA** keys — but the
+  webhook's own `cert_minter.py` hard-requires an **EC** (SECP256R1) key and
+  crashes with `TypeError: CA key must be an EC private key` on startup.
+  There is no values.yaml-level fix — `deploy/kubernetes/scripts/
+  gen-egress-certs.sh` mints a proper EC CA + webhook/backend leaf certs
+  using `cert_minter.py`'s own functions and writes the four Secrets the
+  chart expects, so the chart's lookup-or-mint logic finds them already
+  present and reuses them instead of minting via the broken RSA path.
+
+  **If you install via `deploy/kubernetes/scripts/helm-install.sh`** (the
+  "from a repo checkout" path, §5 below), this is handled for you
+  automatically — the script detects `egress.enabled` from your rendered
+  values and runs `gen-egress-certs.sh` before the `helm upgrade` if the
+  certs don't exist yet. Nothing to do.
+
+  **If you install via the published OCI chart** (§5's "Recommended" path —
+  a bare `helm upgrade --install ... oci://ghcr.io/...`), there is no
+  wrapper script in that flow to run this for you: clone the repo (or just
+  fetch `deploy/kubernetes/scripts/gen-egress-certs.sh` and
+  `deploy/kubernetes/egress-bundle/webhook/cert_minter.py`) and run it
+  yourself **before** the `helm upgrade --install` if `egress.enabled: true`
+  — the same kind of required pre-step as generating `jwt_secret`/
+  `csrf_secret`/`vault_key` already is for every install.
+
+  Either way, if you ever re-run the script with `FORCE=true` (e.g.
+  rotating the CA) on an **already-deployed** release, two things need to
+  happen afterward that aren't automatic: (1) a fresh `helm upgrade` — the
+  cluster-scoped `MutatingWebhookConfiguration`'s `caBundle` is a
+  separately-templated value that does not refresh just because the
+  Secrets changed, and until it does, the API server's calls to the webhook
+  fail TLS verification silently (`failurePolicy: Ignore` — pods just stop
+  getting patched, no error anywhere); and (2) restart the webhook and
+  backend Deployments — their pods keep whatever cert data they already
+  mounted at startup, Secret volume updates don't get re-read without a
+  restart.
 - The webhook serving cert and the backend mTLS server cert are signed by
   the same CA and follow the same lookup-or-mint rule.
 - The webhook's `MutatingWebhookConfiguration` has `failurePolicy: Ignore`:
   a webhook outage never blocks sandbox pod creation. Affected sandboxes
   start without secret injection (placeholders stay literal) — alert on
   webhook health separately.
+- **Sandbox network policy is set once, at sandbox creation** — adding a host
+  to `PUT /api/v1/admin/sandbox-policy` does not retroactively apply to a
+  sandbox pod already running (e.g. reused across conversations in the same
+  workspace). Delete the `BatchSandbox` (not just the Pod, which just gets
+  recreated by the controller) to force a fresh sandbox that picks up the
+  new policy: `kubectl delete batchsandboxes -n <sandbox-namespace> --all`.
+- **A brand-new sandbox's very first outbound request can race the egress
+  sidecar's own MITM setup** — the vendored `docker/egress` binary installs
+  its transparent-intercept iptables rules a few hundred ms *after* the
+  sandbox process is otherwise ready, so an immediate first request can slip
+  through unsubstituted (placeholder leaks literally) while later requests on
+  the same sandbox are correctly intercepted. This is inside the third-party
+  egress binary, not fixable from the chart.
 
 ### 4.11 Docling document parsing (optional)
 
@@ -639,6 +761,22 @@ kubectl get pods -A | grep init-pvc
 # ErrImagePull on openebs/linux-utils → pre-pull on every node:
 docker pull openebs/linux-utils:3.5.0
 # or use an existing StorageClass instead of the chart's openebs SC
+```
+
+### `ImageInspectError` / `short name mode is enforcing... returns ambiguous list`
+
+CRI-O (used by some managed node pools, e.g. OCI Container Engine's
+non-virtual nodes) refuses to resolve unqualified image references — no
+registry host prefix — under its default short-name policy. The chart's
+`postgres.image` (`cubeplex/postgresql-pgroonga-pgvector:...`), `redis.image`
+(`redis:7-alpine`), and `rustfs.mcImage` (`minio/mc:...`) ship without a
+`docker.io/` prefix by default. If your nodes run CRI-O and hit this, fully
+qualify them in `values.local.yaml`:
+
+```yaml
+postgres: { image: "docker.io/cubeplex/postgresql-pgroonga-pgvector:18.2-pgroonga4.0.6-pgvector0.8.2" }
+redis:    { image: "docker.io/library/redis:7-alpine" }
+rustfs:   { mcImage: "docker.io/minio/mc:RELEASE.2025-04-08T15-39-49Z" }
 ```
 
 ### Login cookie missing / API 403
@@ -819,31 +957,57 @@ A fuller annotated template lives at
 node pool to run cubeplex. Virtual nodes are optimized for stateless microservices and burst
 workloads, not for database-backed applications like cubeplex.
 
-**To add a managed node pool to OCI Kubernetes:**
+**To add a managed node pool to OCI Kubernetes** (CLI, via `oci ce node-pool create` —
+the OCI Console → Container Engine → your cluster → Node Pools → Create Node Pool wizard
+does the same thing interactively):
 
-1. Visit the OCI Console → Container Engine for Kubernetes → [Your Cluster]
-2. Under "Node Pools," click "Create Node Pool"
-3. Configure:
-   - **Name:** `cubeplex-workload`
-   - **Kubernetes Version:** Match your cluster control plane (v1.36+)
-   - **Image:** Latest available (Oracle-provided or custom)
-   - **Shape:** Choose based on your workload (VM.Standard.E4.Flex recommended for dev/test)
-   - **Initial Node Count:** 1 (scales up with demand)
-4. Create the node pool and wait for nodes to become `Ready`
-5. Label the nodes so cubeplex pods target them:
-   ```bash
-   kubectl label nodes -l nodepool.oci.io/name=cubeplex-workload \
-     node.kubernetes.io/workload=cubeplex
-   ```
-6. Update `values.local.yaml` to add nodeSelector:
-   ```yaml
-   backend:
-     nodeSelector:
-       node.kubernetes.io/workload: cubeplex
-   frontend:
-     nodeSelector:
-       node.kubernetes.io/workload: cubeplex
-   ```
-7. Redeploy with `helm upgrade --install`
+```bash
+oci ce node-pool create \
+  --cluster-id <cluster-ocid> --compartment-id <compartment-ocid> \
+  --name cubeplex-workload --kubernetes-version v1.36.1 \
+  --cni-type OCI_VCN_IP_NATIVE --node-shape VM.Standard.E5.Flex \
+  --node-shape-config '{"ocpus":2,"memoryInGBs":16}' \
+  --node-source-details '{"sourceType":"IMAGE","imageId":"<Oracle-Linux-x.y-OKE-<k8s-version> image OCID>","bootVolumeSizeInGBs":50}' \
+  --placement-configs '[{"availabilityDomain":"<AD>","subnetId":"<node-subnet-ocid>"}]' \
+  --pod-subnet-ids '["<node-subnet-ocid>"]' \
+  --size 2 --ssh-public-key "$(cat ~/.ssh/id_rsa.pub)"
+```
 
-After the node pool is ready, the standard installation should succeed.
+Find the right image OCID for your region/k8s version with
+`oci ce node-pool-options get --node-pool-option-id <cluster-ocid> --compartment-id <compartment-ocid>`
+and filter for `Oracle-Linux-*-OKE-<version>` (non-`aarch64`, non-`GPU` unless you need
+those). If a shape returns `Out of host capacity`, just retry with a different shape —
+`VM.Standard.E5.Flex` succeeded after `VM.Standard.E3.Flex` failed on capacity in one run.
+
+**The chart does not support `nodeSelector`/`nodeAffinity`** on the backend/frontend
+Deployments — there's no values field for it. Don't try to target the new node pool that
+way. Instead, keep cubeplex pods off the virtual nodes by making the virtual nodes
+unschedulable for **new** pods, which is enough since cubeplex's own pods carry no
+special tolerations:
+
+```bash
+kubectl taint node <virtual-node-ip> virtual-node=true:NoSchedule   # once per virtual node
+```
+
+`kubectl cordon` also works for this (blocks new scheduling regardless of taints/tolerations)
+and is simpler if you don't need the taint to persist across node restarts.
+
+**This is not sufficient if you also deploy OpenSandbox** (§4.5): its per-conversation
+sandbox pods carry a blanket `tolerations: [{operator: "Exists"}]`, which bypasses taints
+entirely, and `oci-bv`'s topology-aware `WaitForFirstConsumer` binding mode still offers
+virtual nodes as scheduling candidates even when cordoned — PVC provisioning then fails
+outright with `error getting CSINode for selected node "<virtual-node-ip>": csinode.storage.k8s.io "<virtual-node-ip>" not found`
+(virtual nodes never run a CSI node plugin), and the BatchSandbox controller loops
+forever creating fresh pods that hit the same wall. **If you need OpenSandbox, delete
+the virtual node pool entirely** rather than relying on taints/cordon:
+
+```bash
+oci ce virtual-node-pool delete --virtual-node-pool-id <virtual-node-pool-ocid> --force
+```
+
+Move anything still running on the virtual nodes (e.g. ingress-nginx) to the real pool
+first — `kubectl delete pod` on it after cordoning the virtual nodes is enough; it
+reschedules onto a schedulable (real) node automatically.
+
+After the node pool is ready (and, if using OpenSandbox, after the virtual node pool is
+gone), the standard installation should succeed.

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/kubernetes.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/kubernetes.md
@@ -9,6 +9,19 @@ title: Kubernetes（Helm）
 Postgres + Redis + rustfs，可选 alibaba OpenSandbox 全家桶）部署到已有的
 Kubernetes 集群中。
 
+## ⚠️ 已知限制：OCI 虚拟节点
+
+**OCI Container Engine for Kubernetes 的虚拟节点不受支持。**
+
+OCI Kubernetes 的虚拟节点用 Kata 容器跑 Pod，不支持：
+- **Init containers**（数据库迁移需要用到）
+- **VolumeMount subPath**（组装配置文件需要用到）
+
+这两个是 cubeplex 的基本运行要求——不做架构级改动的话没有变通办法。
+
+**解决方法：** 用 OCI 的托管节点池代替虚拟节点。详见
+[云厂商兼容性](#9-云厂商兼容性)。
+
 ## 1. 前置依赖
 
 | 项 | 要求 | 备注 |
@@ -271,9 +284,70 @@ backend:
 
 | 场景 | `values.local.yaml` |
 |---|---|
-| 使用 chart 自带的 OpenSandbox subchart | `opensandbox.enabled: true`；`backend.secrets.sandbox.domain` 指向 `cubeplex-opensandbox-server.cubeplex.svc.cluster.local:8090` |
+| 使用 chart 自带的 OpenSandbox subchart | `opensandbox.enabled: true`；`backend.secrets.sandbox.domain` 指向 `opensandbox-server.opensandbox-system.svc.cluster.local:80`（vendored 的 subchart 写死了 `fullnameOverride`/`namespaceOverride`——不带 release 名前缀，不在 `cubeplex` 命名空间，端口是 80 不是 8090） |
 | 使用外部已有 OpenSandbox | `opensandbox.enabled: false`；`backend.sandbox.enabled: true`；`backend.secrets.sandbox.domain` 填外部地址 |
 | 不使用 sandbox（仅对话） | `opensandbox.enabled: false`；`backend.sandbox.enabled` 留空（跟随 `opensandbox.enabled` → false） |
+
+backend 默认要求 `sandbox.secure_access: true`——它要求 sandbox 访问走一个
+签过名的路由令牌，这需要部署 OpenSandbox 的 `gateway`/`ingress` 组件
+（`opensandbox.opensandbox-server.server.gateway.enabled: true`，本文档
+未涉及）。如果你不打算部署这个 gateway，就得把这个要求关掉，否则 backend
+根本创建不了 sandbox：
+```yaml
+backend:
+  sandbox:
+    secure_access: false
+```
+
+如果你的节点池跑的是 CRI-O（参见[镜像名相关的故障排查条目](#imageinspecterror--short-name-mode-is-enforcing-returns-ambiguous-list)），
+OpenSandbox subchart 自己的镜像也需要同样加上 `docker.io/` 前缀，而且它的
+`configToml` 需要显式设置 `[server] api_key`（**不会**继承
+`backend.secrets.sandbox.api_key`——得手动填一样的值），否则 server 直接
+拒绝启动：
+```yaml
+opensandbox:
+  opensandbox-server:
+    server:
+      image: { repository: "docker.io/opensandbox/server" }
+      ingress: { image: { repository: "docker.io/opensandbox/ingress" } }
+    configToml: |
+      [server]
+      host = "0.0.0.0"
+      port = 80
+      api_key = "<跟 backend.secrets.sandbox.api_key 一样的值>"
+      [log]
+      level = "INFO"
+      [runtime]
+      type = "kubernetes"
+      execd_image = "docker.io/opensandbox/execd:v1.0.18"
+      [kubernetes]
+      namespace = "opensandbox"
+      informer_enabled = true
+      informer_resync_seconds = 300
+      informer_watch_timeout_seconds = 60
+      snapshot_create_timeout_seconds = 900
+      workload_provider = "batchsandbox"
+      batchsandbox_template_file = "/etc/opensandbox/example.batchsandbox-template.yaml"
+      [egress]
+      image = "docker.io/opensandbox/egress:v1.0.12"
+      mode = "dns+nft"
+  opensandbox-controller:
+    controller:
+      # Docker Hub 上的 v0.2.0 会崩溃，报
+      # `flag provided but not defined: -containerd-socket-path`——
+      # 这个发布出去的 tag 落后于 chart 自己的模板。暂时先 pin `latest`，
+      # 等上游重新出一个真正对得上的 v0.2.0。
+      image: { repository: "docker.io/opensandbox/controller", tag: "latest" }
+      snapshot:
+        imageCommitterImage: "docker.io/opensandbox/image-committer:v0.1.0"
+```
+
+装之前还要先建好 `opensandbox-system` 和 `opensandbox` 这两个命名空间——
+umbrella chart 和它的子 chart 都不会自动建：
+```bash
+kubectl create namespace opensandbox-system
+kubectl create namespace opensandbox   # 实际跑每次对话 sandbox pod 的地方
+```
 
 ### 4.6 内置基础设施密码（必填）
 
@@ -404,15 +478,28 @@ chart 会自动配置以下组件：
 ```yaml
 egress:
   enabled: true
-  # sandbox pod 实际运行的命名空间。
-  # 使用内置 opensandbox subchart 时为 "opensandbox-system"。
-  sandboxNamespace: "opensandbox-system"
+  # sandbox pod 实际运行的命名空间——不是 opensandbox-server/-controller
+  # 自己跑的那个（"opensandbox-system"）。用内置 subchart 默认配置时，
+  # 这个值是 "opensandbox"（server 自己的 configToml [kubernetes]
+  # namespace 默认值）。写错的话 MutatingWebhookConfiguration 的
+  # namespaceSelector 永远匹配不到真正的 sandbox pod——而且因为
+  # failurePolicy: Ignore，不会有任何报错，是完全静默的失败。装完后用
+  # `kubectl get pods -n <namespace>` 确认一下实际用的是哪个命名空间。
+  sandboxNamespace: "opensandbox"
   webhook:
     image:
       tag: "v0.2.0"             # 与 backend/frontend 相同的 release 版本
     # 必须与 opensandbox-server 配置的 egress.image 完全一致。
     # 国内镜像源：sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:v1.0.12
     egressImage: "opensandbox/egress:v1.0.12"
+
+backend:
+  sandbox:
+    # 必填——跟上面部署侧的配置是两回事。不设的话 backend 根本不会生成或
+    # 发送占位符密钥，哪怕 webhook/mTLS/CA 全部部署正确、状态健康，功能
+    # 照样什么都不做，完全静默。这个字段有正确的自动默认值（跟 sandbox 里
+    # mitmproxy addon 实际连接的地址一致），只有需要覆盖时才用得上。
+    # egress_exchange_host: "cubeplex-backend.cubeplex.svc.cluster.local"
 ```
 
 （自己构建？运行 `build-and-push.sh` 时把 `egress-webhook` 加入 `TARGET`，
@@ -420,15 +507,55 @@ egress:
 
 补充说明：
 
-- chart 首次安装时会自动生成 MITM CA（`genCA`），并将该 Secret 标记为
-  `helm.sh/resource-policy: keep`，所以升级和 `helm uninstall` 都不会
-  轮换 CA。重新安装到已有集群时会通过 `lookup` 复用同一个 CA。
+- **已知 chart bug**：chart 首次安装自动生成的 CA 用的是 Helm/Sprig 内置的
+  `genCA`，这个函数只会生成 **RSA** 密钥——但 webhook 自己的
+  `cert_minter.py` 硬性要求 **EC**（SECP256R1）密钥，启动时直接崩溃报
+  `TypeError: CA key must be an EC private key`。这个问题在 values.yaml
+  层面无法修复——`deploy/kubernetes/scripts/gen-egress-certs.sh` 用
+  `cert_minter.py` 自己的函数生成正确的 EC CA + webhook/backend 叶子证书，
+  写好 chart 需要的 4 个 Secret，chart 的「先查找再生成」逻辑发现证书已经
+  存在就会直接复用，不会再走那条坏掉的 RSA 生成路径。
+
+  **如果你是通过 `deploy/kubernetes/scripts/helm-install.sh` 安装**（"从
+  repo checkout 安装"这条路，见下面第 5 节），这一步已经自动处理了——脚本
+  会根据渲染后的 values 检测 `egress.enabled`，如果证书还不存在，会在
+  `helm upgrade` 之前自动跑一遍 `gen-egress-certs.sh`，不需要你做任何事。
+
+  **如果你是直接拉 OCI chart 安装**（第 5 节"推荐"的那条路——一条裸的
+  `helm upgrade --install ... oci://ghcr.io/...`），这条安装流程里没有
+  包装脚本帮你做这件事：clone 一下仓库（或者只拉
+  `deploy/kubernetes/scripts/gen-egress-certs.sh` 和
+  `deploy/kubernetes/egress-bundle/webhook/cert_minter.py` 这两个文件），
+  在 `egress.enabled: true` 时,自己在 `helm upgrade --install` **之前**
+  跑一遍——这跟每次安装都要手动生成 `jwt_secret`/`csrf_secret`/`vault_key`
+  是同一类的必要前置步骤。
+
+  不管走哪条路，如果你之后又用 `FORCE=true` 重新跑了一遍这个脚本（比如
+  轮换 CA），并且是对着一个**已经部署好的** release 做的，还有两件事不会
+  自动发生：（1）重新跑一次 `helm upgrade`——集群级的
+  `MutatingWebhookConfiguration` 里的 `caBundle` 是单独渲染的字段，不会
+  因为 Secret 变了就自动刷新，同步之前 API server 调 webhook 会静默 TLS
+  校验失败（`failurePolicy: Ignore`——pod 就是不再被 patch，没有任何报错）；
+  （2）重启 webhook 和 backend 这两个 Deployment——它们的 Pod 只会用启动
+  时挂载到的那份证书，Secret 卷的内容更新了不会自动重新读取，得靠重启。
 - webhook 的服务证书和 backend 的 mTLS server 证书由同一个 CA 签发，遵循
   同样的「先查找再签发」规则。
 - webhook 的 `MutatingWebhookConfiguration` 设置了
   `failurePolicy: Ignore`：webhook 故障永远不会阻塞 sandbox pod
   创建。受影响的 sandbox 会在没有密钥注入的情况下启动（占位符保持原样）
   ——需要单独对 webhook 健康状况做告警。
+- **sandbox 的网络策略只在创建那一刻生效一次**——给
+  `PUT /api/v1/admin/sandbox-policy` 加一条新规则，不会追溯应用到已经在
+  跑的 sandbox pod（比如同一个 workspace 里跨对话复用的那个）。要让新策略
+  生效，得删掉 `BatchSandbox`（不是 Pod，删 Pod 只会被 controller 立刻
+  重建）强制建一个新的 sandbox：
+  `kubectl delete batchsandboxes -n <sandbox 命名空间> --all`。
+- **全新 sandbox 的第一个出站请求可能会跟 egress sidecar 自己的 MITM
+  启动过程产生竞争**——第三方的 `docker/egress` 二进制装透明拦截的
+  iptables 规则，比 sandbox 进程本身就绪要晚几百毫秒，所以第一个请求
+  可能会在这个窗口漏过去（占位符原样泄漏），而同一个 sandbox 后续的请求
+  会被正确拦截替换。这是 vendored 的第三方 egress 二进制自身的问题，chart
+  这一层修不了。
 
 ### 4.11 Docling 文档解析（可选）
 
@@ -605,6 +732,21 @@ docker pull openebs/linux-utils:3.5.0
 # 或者不使用 chart 的 openebs StorageClass，改用已有的
 ```
 
+### `ImageInspectError` / `short name mode is enforcing... returns ambiguous list`
+
+CRI-O（一些托管节点池会用，比如 OCI Container Engine 的非虚拟节点）在默认的
+短名策略下，拒绝解析不带 registry 前缀的镜像引用。chart 的 `postgres.image`
+（`cubeplex/postgresql-pgroonga-pgvector:...`）、`redis.image`
+（`redis:7-alpine`）、`rustfs.mcImage`（`minio/mc:...`）默认都不带
+`docker.io/` 前缀。如果你的节点跑 CRI-O 遇到这个问题，在
+`values.local.yaml` 里把它们补全：
+
+```yaml
+postgres: { image: "docker.io/cubeplex/postgresql-pgroonga-pgvector:18.2-pgroonga4.0.6-pgvector0.8.2" }
+redis:    { image: "docker.io/library/redis:7-alpine" }
+rustfs:   { mcImage: "docker.io/minio/mc:RELEASE.2025-04-08T15-39-49Z" }
+```
+
 ### 登录 cookie 丢失 / API 返回 403
 
 - HTTP 部署需要 `backend.configOverrides.auth.cookie_secure: false`。
@@ -760,3 +902,77 @@ opensandbox:
 
 完整的带注释模板见仓库中的
 `deploy/kubernetes/charts/cubeplex/values.local.yaml.example`。
+
+## 9. 云厂商兼容性
+
+### 已测试且支持
+
+| 厂商 | 服务 | 状态 | 备注 |
+|---|---|---|---|
+| EKS（AWS） | Elastic Kubernetes Service | ✅ 完全支持 | 标准托管 K8s，无已知问题 |
+| GKE（Google） | Google Kubernetes Engine | ✅ 完全支持 | 标准托管 K8s，无已知问题 |
+| AKS（Azure） | Azure Kubernetes Service | ✅ 完全支持 | 标准托管 K8s，无已知问题 |
+| k3s | 轻量级 K8s | ✅ 完全支持 | 在任何基础设施上都能跑 |
+| kubeadm | 自建 | ✅ 完全支持 | 完整支持所有 K8s 特性 |
+
+### 已知限制
+
+| 厂商 | 服务 | 状态 | 详情 | 变通方法 |
+|---|---|---|---|---|
+| OCI | Container Engine for Kubernetes（虚拟节点） | ❌ 不支持 | 虚拟节点不支持 init container 或 VolumeMount subPath | 用托管节点池代替虚拟节点 |
+
+**OCI 虚拟节点：** 如果你的 OCI 集群只有虚拟节点，必须加一个托管节点池才能跑
+cubeplex。虚拟节点是为无状态微服务和突发负载优化的，不适合 cubeplex 这类
+依赖数据库的应用。
+
+**给 OCI Kubernetes 加托管节点池**（用 CLI，`oci ce node-pool create`——
+OCI 控制台里 Container Engine → 你的集群 → Node Pools → Create Node Pool
+的向导做的是同一件事）：
+
+```bash
+oci ce node-pool create \
+  --cluster-id <cluster-ocid> --compartment-id <compartment-ocid> \
+  --name cubeplex-workload --kubernetes-version v1.36.1 \
+  --cni-type OCI_VCN_IP_NATIVE --node-shape VM.Standard.E5.Flex \
+  --node-shape-config '{"ocpus":2,"memoryInGBs":16}' \
+  --node-source-details '{"sourceType":"IMAGE","imageId":"<Oracle-Linux-x.y-OKE-<k8s版本> 镜像 OCID>","bootVolumeSizeInGBs":50}' \
+  --placement-configs '[{"availabilityDomain":"<AD>","subnetId":"<节点子网 OCID>"}]' \
+  --pod-subnet-ids '["<节点子网 OCID>"]' \
+  --size 2 --ssh-public-key "$(cat ~/.ssh/id_rsa.pub)"
+```
+
+用 `oci ce node-pool-options get --node-pool-option-id <cluster-ocid> --compartment-id <compartment-ocid>`
+找到你所在区域/k8s 版本对应的镜像 OCID，筛选 `Oracle-Linux-*-OKE-<版本>`
+（不需要 `aarch64`、不需要 GPU 的话就排除这两类）。如果某个 shape 返回
+`Out of host capacity`，换个 shape 重试就行——我们这边 `VM.Standard.E3.Flex`
+容量不足失败后，换 `VM.Standard.E5.Flex` 就成功了。
+
+**chart 不支持在 backend/frontend 的 Deployment 上设置
+`nodeSelector`/`nodeAffinity`**——没有对应的 values 字段。不要想着靠这个
+把 Pod 定向调度到新节点池上。正确做法是让虚拟节点对**新** Pod
+不可调度——cubeplex 自己的 Pod 不带任何特殊 toleration，这样就够了：
+
+```bash
+kubectl taint node <虚拟节点IP> virtual-node=true:NoSchedule   # 每个虚拟节点跑一遍
+```
+
+`kubectl cordon` 也能达到同样效果（不管 taint/toleration 是什么都会阻止新调度），
+如果你不需要让这个限制在节点重启后还保留，用 cordon 更省事。
+
+**但如果你还部署了 OpenSandbox（§4.5），光这样是不够的**：它每次对话创建的
+sandbox pod 自带一个 `tolerations: [{operator: "Exists"}]`，会绕过所有
+taint；而且 `oci-bv` 的 topology-aware `WaitForFirstConsumer` 绑定模式，
+哪怕节点已经 cordon 了，还是会把虚拟节点当成调度候选——PVC provisioning
+会直接报错 `error getting CSINode for selected node "<虚拟节点IP>":
+csinode.storage.k8s.io "<虚拟节点IP>" not found`（虚拟节点从不跑 CSI node
+插件），然后 BatchSandbox controller 会没完没了地建新 pod，一直撞在同一堵
+墙上。**如果你需要用 OpenSandbox，必须彻底删掉虚拟节点池**，而不是指望
+taint/cordon：
+
+```bash
+oci ce virtual-node-pool delete --virtual-node-pool-id <虚拟节点池OCID> --force
+```
+
+删之前先把还跑在虚拟节点上的东西（比如 ingress-nginx）挪到真实节点池——
+先给虚拟节点 cordon，再 `kubectl delete pod` 对应的 pod 就行，它会自动
+调度到可调度的（真实）节点上。


### PR DESCRIPTION
## Summary
- Adds `deploy/kubernetes/scripts/gen-egress-certs.sh`, which mints a correct CA + webhook + backend leaf cert set (EC/SECP256R1, via the webhook's own `cert_minter.py`) as four Kubernetes Secrets. Helm's Sprig `genCA` only produces RSA, which crashes the egress webhook with `CA key must be an EC private key` on any real install.
- Wires cert generation into `helm-install.sh` — runs automatically and idempotently whenever `egress.enabled` is true, before `helm upgrade --install`, so `caBundle` stays in sync.
- Fixes `egress.sandboxNamespace` chart default (`opensandbox-system` → `opensandbox`, the namespace the per-conversation sandbox pods and the egress network policy actually apply to).
- Fixes `backend.sandbox.egress_exchange_host` never being set anywhere in the chart, which silently kept `SandboxManager`'s secret-injection path disabled; adds a sane default via `backend-configmap.yaml`.
- Docs (`docs/site/docs/deployment/kubernetes.md` + zh-Hans mirror) gain a new Cloud Provider Compatibility section, a CRI-O image-resolution troubleshooting entry, and notes on all of the above.
- `docs/dev/notes/2026-07-21-oci-k8s-deployment.md` carries the full investigation narrative from deploying v0.3.0 to a live OCI cluster (node pool setup, CRI-O image bugs, sandbox verification, the full egress cert investigation).

## Test plan
- [x] `deploy/kubernetes/egress-bundle/webhook/tests/test_cert_minter.py` — new `mint_server_cert` produces an EC key, correct CN/SANs, and chains to the CA
- [x] `gen-egress-certs.sh` verified end-to-end on a live OCI cluster: idempotency guard refuses re-run without `FORCE=true`, and a from-scratch run (all 4 Secrets deleted) regenerates correctly with `caBundle` auto-synced via the resulting `helm upgrade`
- [x] Egress secret-injection verified end-to-end against the live deployment: sandbox → mitmproxy → backend mTLS exchange → placeholder substitution