### PR TITLE
reframe k8s compatibility as capability requirements

### DIFF
--- a/docs/dev/notes/2026-07-21-oci-k8s-deployment.md
+++ b/docs/dev/notes/2026-07-21-oci-k8s-deployment.md
@@ -35,8 +35,14 @@ Error creating pod: [initContainers are not supported]
 Error creating pod: [unsupported VolumeMount option: subPath: config]
 ```
 
-OCI virtual nodes run a Kata-based runtime that rejects both features outright — not a
-timing/config issue, a hard capability gap. The chart needs `initContainers` for the
+OCI virtual nodes are a Virtual Kubelet provider backed by OCI Container Instances
+(one Container Instance per Pod) — not a regular kubelet on a regular node. The gap is
+almost certainly in that Virtual Kubelet → Container Instances translation layer not
+implementing initContainers/subPath, the same pattern as Azure AKS virtual nodes
+(Virtual Kubelet + ACI, which Microsoft's own docs confirm drops initContainers too).
+It is not a property of Kata Containers as a runtime — Kata is CRI-compatible and
+doesn't itself reject these Pod-spec features on a normal node. Either way it's a hard
+capability gap, not a timing/config issue. The chart needs `initContainers` for the
 `migrate` (alembic) step and `subPath` for mounting individual config files from a
 ConfigMap/Secret. No workaround inside the chart is reasonable; the real fix is
 infrastructure: **add a managed node pool** and keep cubeplex off the virtual nodes.

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -9,19 +9,15 @@ A single `helm upgrade --install` deploys CubePlex (backend + frontend +
 Postgres + Redis + rustfs, optionally the alibaba OpenSandbox umbrella) to
 an existing Kubernetes cluster.
 
-## ⚠️ Known Limitations: OCI Virtual Nodes
-
-**OCI Container Engine for Kubernetes virtual nodes are not supported.**
-
-Virtual nodes in OCI Kubernetes run pods in Kata containers, which do not support:
-- **Init containers** (required for database migrations)
-- **VolumeMount subPath** (required for config file assembly)
-
-These are fundamental requirements of cubeplex — no workaround is possible without
-major architectural changes.
-
-**Solution:** Use OCI managed node pools instead of virtual nodes. See
-[Cloud Provider Compatibility](#9-cloud-provider-compatibility) for details.
+The backend Deployment requires two standard Kubernetes Pod features: **init
+containers** (used for the database migration step) and **subPath volume
+mounts** (used to assemble config files from a ConfigMap/Secret). Standard
+node pools — including managed node pools from any cloud provider, k3s, and
+kubeadm — support both. Serverless or "virtual node" offerings that run pods
+in a lightweight sandbox instead of a full kubelet (for example, OCI virtual
+nodes or Azure AKS virtual nodes) typically do not support one or both. See
+[§9 Cloud Provider Compatibility](#9-cloud-provider-compatibility) if your
+cluster uses one of these.
 
 ## 1. Prerequisites
 
@@ -937,21 +933,39 @@ A fuller annotated template lives at
 
 ## 9. Cloud Provider Compatibility
 
-### Tested & Supported
+cubeplex requires a Kubernetes node pool with a full kubelet, specifically for
+**init container** and **subPath volume mount** support (see above). The
+tables below summarize compatibility by provider and service.
+
+### Verified
 
 | Provider | Service | Status | Notes |
 |---|---|---|---|
-| EKS (AWS) | Elastic Kubernetes Service | ✅ Fully supported | Standard managed K8s; no known issues |
-| GKE (Google) | Google Kubernetes Engine | ✅ Fully supported | Standard managed K8s; no known issues |
-| AKS (Azure) | Azure Kubernetes Service | ✅ Fully supported | Standard managed K8s; no known issues |
-| k3s | Lightweight K8s | ✅ Fully supported | Works great on any infra |
-| kubeadm | Self-hosted | ✅ Fully supported | Full K8s feature support |
+| OCI | Container Engine for Kubernetes — managed node pool | ✅ Supported | Deployed and tested end-to-end, including chat, sandbox, and egress. |
+| OCI | Container Engine for Kubernetes — virtual nodes | ❌ Not supported | Pods fail to start (`Pending` / `CrashLoopBackOff`) — no init container or subPath support. |
 
-### Known Limitations
+### Expected to work
 
-| Provider | Service | Status | Details | Workaround |
-|---|---|---|---|---|
-| OCI | Container Engine for Kubernetes (Virtual Nodes) | ❌ Unsupported | Virtual nodes don't support init containers or VolumeMount subPath | Use managed node pools instead of virtual nodes |
+The following run a full kubelet and implement the standard Pod API, so init
+containers and subPath mounts are expected to work the same way as on OCI's
+managed node pools. These have not been independently verified against a live
+cubeplex deployment.
+
+| Provider | Service |
+|---|---|
+| EKS (AWS) | Elastic Kubernetes Service, EC2-backed node groups |
+| GKE (Google) | Google Kubernetes Engine, Standard or Autopilot |
+| AKS (Azure) | Azure Kubernetes Service, standard (VM-backed) node pools |
+| k3s | Lightweight Kubernetes |
+| kubeadm | Self-managed Kubernetes |
+
+### Not supported
+
+| Provider | Service | Status | Details |
+|---|---|---|---|
+| OCI | Container Engine — virtual nodes | ❌ Not supported | See Verified, above. |
+| Azure | AKS virtual nodes (ACI-backed) | ❌ Not supported | Init containers are listed as unsupported in [Microsoft's virtual-nodes documentation](https://learn.microsoft.com/en-us/azure/aks/virtual-nodes#limitations); PersistentVolumeClaims are also unsupported (only an inline Azure Files mount is available). |
+| AWS | EKS on Fargate | ⚠️ Partial | Fargate supports init containers, but only static PV provisioning, not dynamic (see [Fargate storage](https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html#fargate-storage)). The chart's default StorageClass requires dynamic provisioning, so Fargate would need a manually pre-provisioned PV, which this guide does not cover. Standard EC2-backed EKS node groups do not have this restriction. |
 
 **OCI Virtual Nodes:** If your OCI cluster uses only virtual nodes, you must add a managed
 node pool to run cubeplex. Virtual nodes are optimized for stateless microservices and burst

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/kubernetes.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/kubernetes.md
@@ -9,18 +9,13 @@ title: Kubernetes（Helm）
 Postgres + Redis + rustfs，可选 alibaba OpenSandbox 全家桶）部署到已有的
 Kubernetes 集群中。
 
-## ⚠️ 已知限制：OCI 虚拟节点
-
-**OCI Container Engine for Kubernetes 的虚拟节点不受支持。**
-
-OCI Kubernetes 的虚拟节点用 Kata 容器跑 Pod，不支持：
-- **Init containers**（数据库迁移需要用到）
-- **VolumeMount subPath**（组装配置文件需要用到）
-
-这两个是 cubeplex 的基本运行要求——不做架构级改动的话没有变通办法。
-
-**解决方法：** 用 OCI 的托管节点池代替虚拟节点。详见
-[云厂商兼容性](#9-云厂商兼容性)。
+backend Deployment 需要两个标准 Kubernetes Pod 特性：**init container**
+（用于数据库迁移步骤）和 **subPath volume mount**（用于从 ConfigMap/Secret
+组装配置文件）。标准节点池——包括各云厂商的托管节点池、k3s 和 kubeadm——均
+支持这两个特性。以轻量沙箱代替完整 kubelet 运行 Pod 的 serverless 或
+"虚拟节点"类方案（例如 OCI 虚拟节点、Azure AKS 虚拟节点）通常不支持其中
+一项或两项。如果你的集群使用此类方案，请参阅
+[§9 云厂商兼容性](#9-云厂商兼容性)。
 
 ## 1. 前置依赖
 
@@ -905,21 +900,38 @@ opensandbox:
 
 ## 9. 云厂商兼容性
 
-### 已测试且支持
+cubeplex 需要具备完整 kubelet 的 Kubernetes 节点池，具体来说是为了支持
+**init container** 和 **subPath volume mount**（见上文）。下表按厂商和
+服务类型列出兼容情况。
+
+### 已验证
 
 | 厂商 | 服务 | 状态 | 备注 |
 |---|---|---|---|
-| EKS（AWS） | Elastic Kubernetes Service | ✅ 完全支持 | 标准托管 K8s，无已知问题 |
-| GKE（Google） | Google Kubernetes Engine | ✅ 完全支持 | 标准托管 K8s，无已知问题 |
-| AKS（Azure） | Azure Kubernetes Service | ✅ 完全支持 | 标准托管 K8s，无已知问题 |
-| k3s | 轻量级 K8s | ✅ 完全支持 | 在任何基础设施上都能跑 |
-| kubeadm | 自建 | ✅ 完全支持 | 完整支持所有 K8s 特性 |
+| OCI | Container Engine for Kubernetes — 托管节点池 | ✅ 支持 | 已端到端部署并测试，包括对话、sandbox 与 egress 功能。 |
+| OCI | Container Engine for Kubernetes — 虚拟节点 | ❌ 不支持 | Pod 无法启动（`Pending` / `CrashLoopBackOff`），不支持 init container 或 subPath。 |
 
-### 已知限制
+### 预期可用
 
-| 厂商 | 服务 | 状态 | 详情 | 变通方法 |
-|---|---|---|---|---|
-| OCI | Container Engine for Kubernetes（虚拟节点） | ❌ 不支持 | 虚拟节点不支持 init container 或 VolumeMount subPath | 用托管节点池代替虚拟节点 |
+以下服务均运行完整 kubelet 并实现标准 Pod API，预期 init container 和
+subPath mount 的行为与 OCI 托管节点池一致。尚未针对实际 cubeplex 部署
+逐一验证。
+
+| 厂商 | 服务 |
+|---|---|
+| EKS（AWS） | Elastic Kubernetes Service，EC2 支撑的 node group |
+| GKE（Google） | Google Kubernetes Engine，Standard 或 Autopilot |
+| AKS（Azure） | Azure Kubernetes Service，标准（VM 支撑的）节点池 |
+| k3s | 轻量级 Kubernetes |
+| kubeadm | 自托管 Kubernetes |
+
+### 不支持
+
+| 厂商 | 服务 | 状态 | 详情 |
+|---|---|---|---|
+| OCI | Container Engine — 虚拟节点 | ❌ 不支持 | 见上方"已验证"。 |
+| Azure | AKS 虚拟节点（ACI 支撑） | ❌ 不支持 | [Microsoft 官方虚拟节点文档](https://learn.microsoft.com/en-us/azure/aks/virtual-nodes#limitations)将 init container 列为不支持项；PersistentVolumeClaim 同样不支持（仅支持 inline 的 Azure Files 挂载）。 |
+| AWS | EKS on Fargate | ⚠️ 部分支持 | Fargate 支持 init container，但仅支持静态 PV，不支持动态供给（参见 [Fargate storage](https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html#fargate-storage)）。chart 默认的 StorageClass 需要动态供给，因此 Fargate 需要手动预先创建 PV，本文未涵盖该配置；使用常规 EC2 支撑的 node group 的 EKS 则没有此限制。 |
 
 **OCI 虚拟节点：** 如果你的 OCI 集群只有虚拟节点，必须加一个托管节点池才能跑
 cubeplex。虚拟节点是为无状态微服务和突发负载优化的，不适合 cubeplex 这类


### PR DESCRIPTION
## Summary
- Replaces the OCI-specific "⚠️ Known Limitations" alarm box at the top of the Kubernetes deployment doc with a neutral statement of the two actual Kubernetes Pod features cubeplex needs (init containers, subPath volume mounts). Readers can now check their own cluster against a concrete requirement instead of reading past a vendor-specific warning that may not apply to them.
- Reworks the §9 compatibility tables. The previous version claimed EKS, GKE, AKS, k3s, and kubeadm were "tested & supported" — none of these were actually tested; only OCI was. Splits into:
  - **Verified** — OCI (managed node pool works, virtual nodes fail), the only provider actually deployed to and tested this cycle.
  - **Expected to work** — standard node pools elsewhere, explicitly marked as not independently verified.
  - **Not supported** — serverless/virtual-node offerings, sourced from each provider's own documentation (Azure AKS virtual nodes explicitly list init containers as unsupported; EKS Fargate supports init containers but only static PV provisioning, which the chart's default StorageClass doesn't use).
- Mirrored in the zh-Hans translation, with the same tone pass.

## Test plan
- [x] `pnpm build` in `docs/site` — both `en` and `zh-Hans` locales build cleanly, no broken anchors