### PR TITLE
Sandbox config to agent: design and plan

### DIFF
--- a/backend/cubeplex/middleware/sandbox.py
+++ b/backend/cubeplex/middleware/sandbox.py
@@ -2,8 +2,9 @@
 
 Implements the cubepi ``Middleware`` protocol with two hooks:
 
-- ``tools``: exposes ``execute``, ``write_file``, ``edit_file``, and
-  ``file_read`` as ``cubepi.AgentTool`` instances.
+- ``tools``: exposes ``execute``, ``write_file``, ``edit_file``,
+  ``file_read``, and (when a config loader is provided) ``sandbox_config``
+  as ``cubepi.AgentTool`` instances.
 - ``transform_system_prompt``: appends the sandbox capability section
   (SANDBOX_PROMPT_TEMPLATE) to the system prompt.
 
@@ -21,7 +22,7 @@ import re
 import shlex
 import unicodedata
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from cubepi.agent.types import (
@@ -41,6 +42,11 @@ from cubeplex.parsers import ParseOptions
 from cubeplex.prompts.sandbox import SANDBOX_PROMPT_TEMPLATE
 from cubeplex.sandbox.base import Sandbox
 from cubeplex.sandbox_policy.rules import evaluate_command
+from cubeplex.services.sandbox_runtime_config import POLICY_DENY_NUDGE
+from cubeplex.tools.builtin.sandbox_config import (
+    SandboxConfigLoader,
+    create_sandbox_config_tool,
+)
 
 # ---------------------------------------------------------------------------
 # Per-(workspace_id, conversation_id) ring buffer of commands the sandbox
@@ -607,12 +613,14 @@ class SandboxMiddleware(Middleware):
         workspace_id: str | None = None,
         command_rules: list[dict[str, Any]] | None = None,
         channel: HitlChannel | None = None,
+        config_loader: SandboxConfigLoader | Callable[[], Awaitable[dict[str, Any]]] | None = None,
     ) -> None:
         self.sandbox = sandbox
         self.conversation_id = conversation_id
         self.workspace_id = workspace_id
         self.command_rules = command_rules or []
         self.channel = channel
+        self.config_loader = config_loader
 
         self._tools: list[AgentTool[Any]] = [
             _make_execute_tool(
@@ -624,6 +632,8 @@ class SandboxMiddleware(Middleware):
             _make_edit_file_tool(sandbox),
             _make_file_read_tool(sandbox, conversation_id),
         ]
+        if config_loader is not None:
+            self._tools.append(create_sandbox_config_tool(config_loader))
 
     @property
     def tools(self) -> list[AgentTool[Any]]:
@@ -665,7 +675,7 @@ class SandboxMiddleware(Middleware):
         if action == "deny":
             return BeforeToolCallResult(
                 block=True,
-                reason=f"command blocked by org policy: {pattern}",
+                reason=(f"command blocked by org policy: {pattern}\n{POLICY_DENY_NUDGE}"),
                 deny_reason=pattern,
                 hitl_trace={"decision": "policy_deny", "pattern": pattern},
             )

--- a/backend/cubeplex/services/sandbox_runtime_config.py
+++ b/backend/cubeplex/services/sandbox_runtime_config.py
@@ -18,7 +18,10 @@ from cubeplex.services.sandbox_policy import EffectivePolicy, SandboxPolicyResol
 # Match SandboxEnvResolver precedence (user > workspace > org).
 _SCOPE_RANK = {"user": 3, "workspace": 2, "org": 1}
 
-POLICY_SOURCE = "org_db_current"
+POLICY_SOURCE_ORG_DB = "org_db_current"
+POLICY_SOURCE_BUILT_IN = "built_in_defaults"
+# Back-compat alias used by older call sites / tests.
+POLICY_SOURCE = POLICY_SOURCE_ORG_DB
 SANDBOX_NOTE = "network rules apply at create; recreate sandbox after admin changes"
 GUIDANCE = (
     "Call sandbox_config on network, auth, or missing-env failures. "
@@ -64,6 +67,7 @@ def serialize_network_policy(
     policy: EffectivePolicy,
     *,
     max_rules: int = DEFAULT_MAX_RULES,
+    policy_source: str = POLICY_SOURCE_ORG_DB,
 ) -> dict[str, Any]:
     raw_rules = list(policy.network_rules or [])
     truncated = len(raw_rules) > max_rules
@@ -78,7 +82,7 @@ def serialize_network_policy(
         "default_action": policy.network_default_action,
         "rules": rules,
         "egress_proxy": "set" if policy.egress_proxy else "unset",
-        "policy_source": POLICY_SOURCE,
+        "policy_source": policy_source,
         "sandbox_note": SANDBOX_NOTE,
         "truncated": truncated,
     }
@@ -168,17 +172,22 @@ async def load_agent_view(
 
     Opens no credentials path. Caller owns the session lifecycle.
     """
+    policy_repo = SandboxPolicyRepository(session, org_id=org_id)
+    # Distinguish persisted org policy from built-in defaults (resolver falls
+    # back when the row is missing). One get() here; resolve() may get again.
+    policy_row = await policy_repo.get()
     policy = await SandboxPolicyResolver(
-        SandboxPolicyRepository(session, org_id=org_id),
+        policy_repo,
         default_image=default_image,
     ).resolve()
+    policy_source = POLICY_SOURCE_ORG_DB if policy_row is not None else POLICY_SOURCE_BUILT_IN
     inventory = await resolve_env_inventory(
         session,
         org_id=org_id,
         workspace_id=workspace_id,
         user_id=user_id,
     )
-    network = serialize_network_policy(policy, max_rules=max_rules)
+    network = serialize_network_policy(policy, max_rules=max_rules, policy_source=policy_source)
     env_list, env_truncated = serialize_env_inventory(inventory, max_items=max_env)
     command_rules = serialize_command_rules(policy, max_rules=max_rules)
     cmd_truncated = len(policy.command_rules or []) > max_rules

--- a/backend/cubeplex/services/sandbox_runtime_config.py
+++ b/backend/cubeplex/services/sandbox_runtime_config.py
@@ -1,0 +1,191 @@
+"""Agent-facing sandbox runtime config: network policy + env inventory (no secrets).
+
+Used by the ``sandbox_config`` tool. Always whitelist-serialize; never construct
+``CredentialService`` or pass ``ResolvedEnv.value`` through.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cubeplex.repositories.sandbox_env import SandboxEnvRepository
+from cubeplex.repositories.sandbox_policy import SandboxPolicyRepository
+from cubeplex.services.sandbox_policy import EffectivePolicy, SandboxPolicyResolver
+
+# Match SandboxEnvResolver precedence (user > workspace > org).
+_SCOPE_RANK = {"user": 3, "workspace": 2, "org": 1}
+
+POLICY_SOURCE = "org_db_current"
+SANDBOX_NOTE = "network rules apply at create; recreate sandbox after admin changes"
+GUIDANCE = (
+    "Call sandbox_config on network, auth, or missing-env failures. "
+    "Do not invent credentials or print secret values. "
+    "Prefer this tool over printenv for diagnosis. "
+    "Point the user to admin/workspace sandbox settings for missing allow rules "
+    "or env entries."
+)
+POLICY_DENY_NUDGE = "For network/env inventory call sandbox_config."
+
+DEFAULT_MAX_RULES = 100
+DEFAULT_MAX_ENV = 100
+
+# Keys (or substrings) that must never appear in agent-facing JSON.
+FORBIDDEN_KEY_FRAGMENTS: frozenset[str] = frozenset(
+    {
+        "value",
+        "secret",
+        "credential",
+        "password",
+        "token",
+        "plaintext",
+        "proxy_user",
+        "proxy_pass",
+        "authorization",
+    }
+)
+
+
+@dataclass(frozen=True)
+class EnvInventoryItem:
+    """Non-secret metadata for one winning (injectable) env entry."""
+
+    env_name: str
+    kind: Literal["plain", "secret"]
+    scope: str
+    status: str
+    hosts: list[str] | None
+    header_names: list[str] | None
+
+
+def serialize_network_policy(
+    policy: EffectivePolicy,
+    *,
+    max_rules: int = DEFAULT_MAX_RULES,
+) -> dict[str, Any]:
+    raw_rules = list(policy.network_rules or [])
+    truncated = len(raw_rules) > max_rules
+    rules: list[dict[str, str]] = []
+    for rule in raw_rules[:max_rules]:
+        action = str(rule.get("action", "")).strip()
+        target = str(rule.get("target", "")).strip()
+        if not action or not target:
+            continue
+        rules.append({"action": action, "target": target})
+    return {
+        "default_action": policy.network_default_action,
+        "rules": rules,
+        "egress_proxy": "set" if policy.egress_proxy else "unset",
+        "policy_source": POLICY_SOURCE,
+        "sandbox_note": SANDBOX_NOTE,
+        "truncated": truncated,
+    }
+
+
+def serialize_command_rules(
+    policy: EffectivePolicy,
+    *,
+    max_rules: int = DEFAULT_MAX_RULES,
+) -> list[dict[str, str]]:
+    raw = list(policy.command_rules or [])
+    out: list[dict[str, str]] = []
+    for rule in raw[:max_rules]:
+        action = str(rule.get("action", "")).strip()
+        pattern = str(rule.get("pattern", "")).strip()
+        if not action or not pattern:
+            continue
+        out.append({"action": action, "pattern": pattern})
+    return out
+
+
+def serialize_env_inventory(
+    items: list[EnvInventoryItem],
+    *,
+    max_items: int = DEFAULT_MAX_ENV,
+) -> tuple[list[dict[str, Any]], bool]:
+    truncated = len(items) > max_items
+    out: list[dict[str, Any]] = []
+    for item in items[:max_items]:
+        entry: dict[str, Any] = {
+            "env_name": item.env_name,
+            "kind": item.kind,
+            "scope": item.scope,
+            "status": item.status,
+        }
+        if item.kind == "secret":
+            if item.hosts is not None:
+                entry["hosts"] = list(item.hosts)
+            if item.header_names is not None:
+                entry["header_names"] = list(item.header_names)
+        out.append(entry)
+    return out, truncated
+
+
+async def resolve_env_inventory(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    workspace_id: str,
+    user_id: str,
+) -> list[EnvInventoryItem]:
+    """Winning valid rows only (same inject set as SandboxEnvResolver)."""
+    repo = SandboxEnvRepository(session, org_id=org_id)
+    rows = await repo.list_for_resolution(workspace_id=workspace_id, user_id=user_id)
+    best: dict[str, Any] = {}
+    for row in rows:
+        cur = best.get(row.env_name)
+        if cur is None or _SCOPE_RANK[row.scope] > _SCOPE_RANK[cur.scope]:
+            best[row.env_name] = row
+    items: list[EnvInventoryItem] = []
+    for r in best.values():
+        items.append(
+            EnvInventoryItem(
+                env_name=r.env_name,
+                kind="secret" if r.is_secret else "plain",
+                scope=r.scope,
+                status=getattr(r, "status", None) or "valid",
+                hosts=list(r.hosts) if r.hosts is not None else None,
+                header_names=list(r.header_names) if r.header_names is not None else None,
+            )
+        )
+    items.sort(key=lambda i: i.env_name)
+    return items
+
+
+async def load_agent_view(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    workspace_id: str,
+    user_id: str,
+    default_image: str,
+    max_rules: int = DEFAULT_MAX_RULES,
+    max_env: int = DEFAULT_MAX_ENV,
+) -> dict[str, Any]:
+    """Load and serialize effective policy + env inventory for the agent tool.
+
+    Opens no credentials path. Caller owns the session lifecycle.
+    """
+    policy = await SandboxPolicyResolver(
+        SandboxPolicyRepository(session, org_id=org_id),
+        default_image=default_image,
+    ).resolve()
+    inventory = await resolve_env_inventory(
+        session,
+        org_id=org_id,
+        workspace_id=workspace_id,
+        user_id=user_id,
+    )
+    network = serialize_network_policy(policy, max_rules=max_rules)
+    env_list, env_truncated = serialize_env_inventory(inventory, max_items=max_env)
+    command_rules = serialize_command_rules(policy, max_rules=max_rules)
+    cmd_truncated = len(policy.command_rules or []) > max_rules
+    return {
+        "network": network,
+        "env": env_list,
+        "command_rules": command_rules,
+        "truncated": bool(network["truncated"] or env_truncated or cmd_truncated),
+        "guidance": GUIDANCE,
+    }

--- a/backend/cubeplex/streams/run_manager.py
+++ b/backend/cubeplex/streams/run_manager.py
@@ -2979,12 +2979,24 @@ class RunManager:
                         {"action": "deny", "pattern": "*"},
                     ]
 
+                from cubeplex.config import config as _sb_cfg
+                from cubeplex.tools.builtin.sandbox_config import make_session_loader
+
+                _sb_default_image = str(_sb_cfg.get("sandbox.image", "ubuntu:22.04"))
+                _sb_config_loader = make_session_loader(
+                    session_factory=async_session_maker,
+                    org_id=ctx.org_id,
+                    workspace_id=ctx.workspace_id,
+                    user_id=ctx.user_id,
+                    default_image=_sb_default_image,
+                )
                 sandbox_mw = SandboxMiddleware(
                     sandbox=sandbox,
                     conversation_id=conversation_id,
                     workspace_id=ctx.workspace_id,
                     command_rules=_command_rules,
                     channel=sandbox_hitl_channel,
+                    config_loader=_sb_config_loader,
                 )
                 cubepi_middleware.append(sandbox_mw)
                 # Middleware tools (execute, write_file, edit_file, file_read) collected for

--- a/backend/cubeplex/tools/builtin/sandbox_config.py
+++ b/backend/cubeplex/tools/builtin/sandbox_config.py
@@ -1,0 +1,88 @@
+"""Eager ``sandbox_config`` tool — network policy + env inventory (no secrets)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import TextContent
+from cubepi.types import StructuredValue
+from pydantic import BaseModel
+
+from cubeplex.services.sandbox_runtime_config import load_agent_view
+
+# Loader opens its own session and returns the agent view dict.
+SandboxConfigLoader = Callable[[], Awaitable[dict[str, Any]]]
+
+
+class _SandboxConfigArgs(BaseModel):
+    """No required args in v1."""
+
+
+def create_sandbox_config_tool(
+    loader: SandboxConfigLoader,
+) -> AgentTool[_SandboxConfigArgs]:
+    """Build the diagnosis tool; ``loader`` must not use CredentialService."""
+
+    async def _execute(
+        tool_call_id: str,
+        args: _SandboxConfigArgs,
+        *,
+        signal: asyncio.Event | None = None,
+        on_update: Callable[[StructuredValue], None] | None = None,
+    ) -> AgentToolResult:
+        del tool_call_id, args, signal, on_update
+        try:
+            view = await loader()
+        except Exception as exc:  # noqa: BLE001 — surface to model, don't crash turn
+            return AgentToolResult(
+                content=[TextContent(text=f"sandbox_config failed: {exc}")],
+                is_error=True,
+            )
+        text = json.dumps(view, sort_keys=True, default=str)
+        return AgentToolResult(content=[TextContent(text=text)])
+
+    return AgentTool(
+        name="sandbox_config",
+        description=(
+            "Inspect sandbox network policy and configured env inventory "
+            "(names, kinds, scopes, secret host/header constraints — never values). "
+            "Call on network failures, auth/401 errors, or missing-env diagnosis. "
+            "Do not invent credentials; never print secret values. "
+            "Prefer this tool over printenv for diagnosis. "
+            "Network rules apply at sandbox create; recreate the sandbox after "
+            "admin policy changes."
+        ),
+        parameters=_SandboxConfigArgs,
+        execute=_execute,
+    )
+
+
+def make_session_loader(
+    *,
+    session_factory: Callable[[], Any],
+    org_id: str,
+    workspace_id: str,
+    user_id: str,
+    default_image: str,
+) -> SandboxConfigLoader:
+    """Build a loader that opens a fresh session per call via ``session_factory``.
+
+    ``session_factory`` must return an async context manager yielding AsyncSession
+    (same shape as ``async_session_maker()``).
+    """
+
+    async def _load() -> dict[str, Any]:
+        async with session_factory() as session:
+            return await load_agent_view(
+                session,
+                org_id=org_id,
+                workspace_id=workspace_id,
+                user_id=user_id,
+                default_image=default_image,
+            )
+
+    return _load

--- a/backend/cubeplex/tools/builtin/sandbox_config.py
+++ b/backend/cubeplex/tools/builtin/sandbox_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -14,8 +15,12 @@ from pydantic import BaseModel
 
 from cubeplex.services.sandbox_runtime_config import load_agent_view
 
+logger = logging.getLogger(__name__)
+
 # Loader opens its own session and returns the agent view dict.
 SandboxConfigLoader = Callable[[], Awaitable[dict[str, Any]]]
+
+_SANITIZED_LOADER_ERROR = "sandbox configuration is temporarily unavailable."
 
 
 class _SandboxConfigArgs(BaseModel):
@@ -37,9 +42,11 @@ def create_sandbox_config_tool(
         del tool_call_id, args, signal, on_update
         try:
             view = await loader()
-        except Exception as exc:  # noqa: BLE001 — surface to model, don't crash turn
+        except Exception:
+            # Do not leak driver/DB details into the model transcript.
+            logger.exception("sandbox_config loader failed")
             return AgentToolResult(
-                content=[TextContent(text=f"sandbox_config failed: {exc}")],
+                content=[TextContent(text=_SANITIZED_LOADER_ERROR)],
                 is_error=True,
             )
         text = json.dumps(view, sort_keys=True, default=str)

--- a/backend/tests/unit/test_sandbox_config_tool.py
+++ b/backend/tests/unit/test_sandbox_config_tool.py
@@ -65,12 +65,15 @@ async def test_sandbox_config_tool_returns_loader_json() -> None:
 @pytest.mark.asyncio
 async def test_sandbox_config_tool_surfaces_loader_errors() -> None:
     async def loader() -> dict[str, Any]:
-        raise RuntimeError("db down")
+        raise RuntimeError("db down connection string=secret")
 
     tool = create_sandbox_config_tool(loader)
     result = await tool.execute("id", tool.parameters(), signal=None, on_update=None)
     assert result.is_error is True
-    assert "db down" in result.content[0].text  # type: ignore[union-attr]
+    text = result.content[0].text  # type: ignore[union-attr]
+    assert "temporarily unavailable" in text
+    assert "db down" not in text
+    assert "secret" not in text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_sandbox_config_tool.py
+++ b/backend/tests/unit/test_sandbox_config_tool.py
@@ -1,0 +1,155 @@
+"""Unit tests for the eager sandbox_config tool and middleware registration."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from cubeplex.middleware.sandbox import SandboxMiddleware
+from cubeplex.services.sandbox_runtime_config import POLICY_DENY_NUDGE
+from cubeplex.tools.builtin.sandbox_config import (
+    create_sandbox_config_tool,
+    make_session_loader,
+)
+
+
+class _FakeSandbox:
+    workdir = "/work"
+
+
+class _ToolCall:
+    def __init__(self, name: str, id: str = "call_1") -> None:
+        self.name = name
+        self.id = id
+
+
+class _Ctx:
+    def __init__(self, name: str, command: str) -> None:
+        self.tool_call = _ToolCall(name)
+        self.args = {"command": command}
+
+
+@pytest.mark.asyncio
+async def test_sandbox_config_tool_returns_loader_json() -> None:
+    calls = 0
+
+    async def loader() -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {
+            "network": {"default_action": "deny", "rules": []},
+            "env": [],
+            "command_rules": [],
+            "truncated": False,
+            "guidance": "g",
+        }
+
+    tool = create_sandbox_config_tool(loader)
+    assert tool.name == "sandbox_config"
+    assert "printenv" in tool.description
+    assert "never print secret" in tool.description.lower() or "secret values" in tool.description
+
+    result = await tool.execute("id", tool.parameters(), signal=None, on_update=None)
+    assert result.is_error is not True
+    text = result.content[0].text  # type: ignore[union-attr]
+    data = json.loads(text)
+    assert data["network"]["default_action"] == "deny"
+    assert calls == 1
+
+    await tool.execute("id2", tool.parameters(), signal=None, on_update=None)
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_sandbox_config_tool_surfaces_loader_errors() -> None:
+    async def loader() -> dict[str, Any]:
+        raise RuntimeError("db down")
+
+    tool = create_sandbox_config_tool(loader)
+    result = await tool.execute("id", tool.parameters(), signal=None, on_update=None)
+    assert result.is_error is True
+    assert "db down" in result.content[0].text  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_make_session_loader_opens_fresh_session_per_call() -> None:
+    from contextlib import asynccontextmanager
+
+    sessions_opened = 0
+
+    class _Sess:
+        pass
+
+    @asynccontextmanager
+    async def factory():
+        nonlocal sessions_opened
+        sessions_opened += 1
+        yield _Sess()
+
+    async def fake_view(session: object, **kwargs: object) -> dict[str, Any]:
+        del session, kwargs
+        return {"ok": True}
+
+    import cubeplex.tools.builtin.sandbox_config as mod
+
+    orig = mod.load_agent_view
+    mod.load_agent_view = fake_view  # type: ignore[assignment]
+    try:
+        loader = make_session_loader(
+            session_factory=factory,
+            org_id="o",
+            workspace_id="w",
+            user_id="u",
+            default_image="img",
+        )
+        assert await loader() == {"ok": True}
+        assert await loader() == {"ok": True}
+        assert sessions_opened == 2
+    finally:
+        mod.load_agent_view = orig  # type: ignore[assignment]
+
+
+def test_middleware_registers_sandbox_config_when_loader_present() -> None:
+    async def loader() -> dict[str, Any]:
+        return {}
+
+    mw = SandboxMiddleware(
+        sandbox=_FakeSandbox(),
+        workspace_id="w1",
+        config_loader=loader,
+    )
+    names = {t.name for t in mw.tools}
+    assert "sandbox_config" in names
+    assert "execute" in names
+
+
+def test_middleware_omits_sandbox_config_without_loader() -> None:
+    mw = SandboxMiddleware(sandbox=_FakeSandbox(), workspace_id="w1")
+    names = {t.name for t in mw.tools}
+    assert "sandbox_config" not in names
+
+
+@pytest.mark.asyncio
+async def test_policy_deny_reason_includes_sandbox_config_nudge() -> None:
+    mw = SandboxMiddleware(
+        sandbox=_FakeSandbox(),
+        command_rules=[{"action": "deny", "pattern": "rm *"}],
+    )
+    res = await mw.before_tool_call(_Ctx("execute", "rm -rf /tmp/x"), signal=None)
+    assert res is not None and res.block is True
+    assert res.hitl_trace["decision"] == "policy_deny"
+    assert POLICY_DENY_NUDGE in (res.reason or "")
+    assert "command blocked by org policy" in (res.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_allow_path_has_no_false_host_deny() -> None:
+    """Allow path: no fabricated host-deny claim, no nudge required."""
+    mw = SandboxMiddleware(
+        sandbox=_FakeSandbox(),
+        command_rules=[{"action": "deny", "pattern": "shutdown"}],
+    )
+    res = await mw.before_tool_call(_Ctx("execute", "ls -la"), signal=None)
+    assert res is None

--- a/backend/tests/unit/test_sandbox_confirm_gate.py
+++ b/backend/tests/unit/test_sandbox_confirm_gate.py
@@ -77,12 +77,15 @@ async def test_allow_passes_without_channel_call():
 
 @pytest.mark.asyncio
 async def test_deny_blocks_without_channel_call():
+    from cubeplex.services.sandbox_runtime_config import POLICY_DENY_NUDGE
+
     ch = _StubChannel()
     mw = _mw(ch, [{"action": "deny", "pattern": "rm *"}])
     res = await mw.before_tool_call(_Ctx("execute", "rm -rf /tmp/x"), signal=None)
     assert res is not None and res.block is True
     assert ch.calls == []
     assert res.hitl_trace["decision"] == "policy_deny"
+    assert POLICY_DENY_NUDGE in (res.reason or "")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_sandbox_runtime_config_serialize.py
+++ b/backend/tests/unit/test_sandbox_runtime_config_serialize.py
@@ -1,0 +1,223 @@
+"""Unit tests for agent-facing sandbox runtime config serialization.
+
+Business contract: serializers never emit secret values, credential ids, proxy
+credentials, or unknown keys — only whitelist fields for diagnosis.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cubeplex.services.sandbox_policy import EffectivePolicy
+from cubeplex.services.sandbox_runtime_config import (
+    FORBIDDEN_KEY_FRAGMENTS,
+    GUIDANCE,
+    POLICY_SOURCE,
+    SANDBOX_NOTE,
+    EnvInventoryItem,
+    load_agent_view,
+    serialize_command_rules,
+    serialize_env_inventory,
+    serialize_network_policy,
+)
+
+
+def _forbidden_paths(obj: Any, path: str = "$") -> list[str]:
+    """Recursively collect paths whose keys look secret-bearing or unknown."""
+    hits: list[str] = []
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            key_l = str(key).lower()
+            if any(frag in key_l for frag in FORBIDDEN_KEY_FRAGMENTS):
+                hits.append(f"{path}.{key}")
+            hits.extend(_forbidden_paths(value, f"{path}.{key}"))
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            hits.extend(_forbidden_paths(item, f"{path}[{i}]"))
+    return hits
+
+
+def test_network_policy_whitelist_drops_extra_rule_keys() -> None:
+    policy = EffectivePolicy(
+        default_image="img",
+        network_default_action="deny",
+        network_rules=[
+            {
+                "action": "allow",
+                "target": "pypi.org",
+                "credential_id": "cred-leak",
+                "secret": "should-not-appear",
+                "value": "nope",
+            }
+        ],
+        egress_proxy="http://proxy.example:8080",
+    )
+    out = serialize_network_policy(policy)
+    assert out["default_action"] == "deny"
+    assert out["rules"] == [{"action": "allow", "target": "pypi.org"}]
+    assert out["egress_proxy"] == "set"
+    assert out["policy_source"] == POLICY_SOURCE
+    assert out["sandbox_note"] == SANDBOX_NOTE
+    assert out["truncated"] is False
+    assert _forbidden_paths(out) == []
+
+
+def test_network_policy_egress_unset_when_none() -> None:
+    policy = EffectivePolicy(default_image="img", egress_proxy=None)
+    out = serialize_network_policy(policy)
+    assert out["egress_proxy"] == "unset"
+
+
+def test_network_policy_truncates_rules() -> None:
+    rules = [{"action": "allow", "target": f"h{i}.example"} for i in range(150)]
+    policy = EffectivePolicy(default_image="img", network_rules=rules)
+    out = serialize_network_policy(policy, max_rules=100)
+    assert len(out["rules"]) == 100
+    assert out["truncated"] is True
+
+
+def test_env_inventory_never_emits_values_or_credential_ids() -> None:
+    items = [
+        EnvInventoryItem(
+            env_name="GITHUB_TOKEN",
+            kind="secret",
+            scope="user",
+            status="valid",
+            hosts=["api.github.com"],
+            header_names=["Authorization"],
+        ),
+        EnvInventoryItem(
+            env_name="LOG_LEVEL",
+            kind="plain",
+            scope="org",
+            status="valid",
+            hosts=None,
+            header_names=None,
+        ),
+    ]
+    # Poison: if serializer ever model_dump'd a richer object, these would leak.
+    poisoned = items  # type: ignore[assignment]
+    out, truncated = serialize_env_inventory(poisoned)
+    assert truncated is False
+    assert out == [
+        {
+            "env_name": "GITHUB_TOKEN",
+            "kind": "secret",
+            "scope": "user",
+            "status": "valid",
+            "hosts": ["api.github.com"],
+            "header_names": ["Authorization"],
+        },
+        {
+            "env_name": "LOG_LEVEL",
+            "kind": "plain",
+            "scope": "org",
+            "status": "valid",
+        },
+    ]
+    assert _forbidden_paths(out) == []
+    blob = str(out)
+    assert "cred-" not in blob
+    assert "sk-" not in blob
+    assert "super-secret" not in blob
+
+
+def test_env_inventory_truncates() -> None:
+    items = [
+        EnvInventoryItem(
+            env_name=f"E{i}",
+            kind="plain",
+            scope="org",
+            status="valid",
+            hosts=None,
+            header_names=None,
+        )
+        for i in range(12)
+    ]
+    out, truncated = serialize_env_inventory(items, max_items=10)
+    assert len(out) == 10
+    assert truncated is True
+
+
+def test_command_rules_whitelist() -> None:
+    policy = EffectivePolicy(
+        default_image="img",
+        command_rules=[
+            {"action": "deny", "pattern": "rm *", "extra": "nope", "value": "x"},
+            {"action": "confirm", "pattern": "sudo *"},
+        ],
+    )
+    out = serialize_command_rules(policy)
+    assert out == [
+        {"action": "deny", "pattern": "rm *"},
+        {"action": "confirm", "pattern": "sudo *"},
+    ]
+    assert _forbidden_paths(out) == []
+
+
+def test_command_rules_truncates() -> None:
+    policy = EffectivePolicy(
+        default_image="img",
+        command_rules=[{"action": "deny", "pattern": f"p{i}"} for i in range(5)],
+    )
+    out = serialize_command_rules(policy, max_rules=3)
+    assert len(out) == 3
+
+
+@pytest.mark.asyncio
+async def test_load_agent_view_uses_resolvers_not_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """load_agent_view must assemble via whitelist serializers only."""
+
+    class _FakeSession:
+        pass
+
+    async def fake_policy_resolve(self: object) -> EffectivePolicy:
+        return EffectivePolicy(
+            default_image="img",
+            network_default_action="deny",
+            network_rules=[{"action": "allow", "target": "pypi.org", "value": "leak"}],
+            command_rules=[{"action": "deny", "pattern": "rm *", "credential_id": "c"}],
+            egress_proxy=None,
+        )
+
+    async def fake_inventory(
+        session: object, *, org_id: str, workspace_id: str, user_id: str
+    ) -> list[EnvInventoryItem]:
+        del session, org_id, workspace_id, user_id
+        return [
+            EnvInventoryItem(
+                env_name="API_KEY",
+                kind="secret",
+                scope="org",
+                status="valid",
+                hosts=["api.example.com"],
+                header_names=None,
+            )
+        ]
+
+    monkeypatch.setattr(
+        "cubeplex.services.sandbox_runtime_config.SandboxPolicyResolver.resolve",
+        fake_policy_resolve,
+    )
+    monkeypatch.setattr(
+        "cubeplex.services.sandbox_runtime_config.resolve_env_inventory",
+        fake_inventory,
+    )
+
+    view = await load_agent_view(
+        _FakeSession(),  # type: ignore[arg-type]
+        org_id="org1",
+        workspace_id="ws1",
+        user_id="u1",
+        default_image="ubuntu:22.04",
+    )
+    assert view["guidance"] == GUIDANCE
+    assert view["network"]["rules"] == [{"action": "allow", "target": "pypi.org"}]
+    assert view["command_rules"] == [{"action": "deny", "pattern": "rm *"}]
+    assert view["env"][0]["env_name"] == "API_KEY"
+    assert "value" not in view["env"][0]
+    assert _forbidden_paths(view) == []

--- a/backend/tests/unit/test_sandbox_runtime_config_serialize.py
+++ b/backend/tests/unit/test_sandbox_runtime_config_serialize.py
@@ -15,6 +15,8 @@ from cubeplex.services.sandbox_runtime_config import (
     FORBIDDEN_KEY_FRAGMENTS,
     GUIDANCE,
     POLICY_SOURCE,
+    POLICY_SOURCE_BUILT_IN,
+    POLICY_SOURCE_ORG_DB,
     SANDBOX_NOTE,
     EnvInventoryItem,
     load_agent_view,
@@ -68,6 +70,13 @@ def test_network_policy_egress_unset_when_none() -> None:
     policy = EffectivePolicy(default_image="img", egress_proxy=None)
     out = serialize_network_policy(policy)
     assert out["egress_proxy"] == "unset"
+
+
+def test_network_policy_source_built_in_defaults() -> None:
+    policy = EffectivePolicy(default_image="img")
+    out = serialize_network_policy(policy, policy_source=POLICY_SOURCE_BUILT_IN)
+    assert out["policy_source"] == POLICY_SOURCE_BUILT_IN
+    assert out["policy_source"] != POLICY_SOURCE_ORG_DB
 
 
 def test_network_policy_truncates_rules() -> None:
@@ -175,6 +184,13 @@ async def test_load_agent_view_uses_resolvers_not_values(
     class _FakeSession:
         pass
 
+    class _FakeRepo:
+        def __init__(self, session: object, *, org_id: str) -> None:
+            del session, org_id
+
+        async def get(self) -> object | None:
+            return object()  # pretend org row exists
+
     async def fake_policy_resolve(self: object) -> EffectivePolicy:
         return EffectivePolicy(
             default_image="img",
@@ -200,6 +216,10 @@ async def test_load_agent_view_uses_resolvers_not_values(
         ]
 
     monkeypatch.setattr(
+        "cubeplex.services.sandbox_runtime_config.SandboxPolicyRepository",
+        _FakeRepo,
+    )
+    monkeypatch.setattr(
         "cubeplex.services.sandbox_runtime_config.SandboxPolicyResolver.resolve",
         fake_policy_resolve,
     )
@@ -217,7 +237,54 @@ async def test_load_agent_view_uses_resolvers_not_values(
     )
     assert view["guidance"] == GUIDANCE
     assert view["network"]["rules"] == [{"action": "allow", "target": "pypi.org"}]
+    assert view["network"]["policy_source"] == POLICY_SOURCE_ORG_DB
     assert view["command_rules"] == [{"action": "deny", "pattern": "rm *"}]
     assert view["env"][0]["env_name"] == "API_KEY"
     assert "value" not in view["env"][0]
     assert _forbidden_paths(view) == []
+
+
+@pytest.mark.asyncio
+async def test_load_agent_view_built_in_policy_source_when_no_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeSession:
+        pass
+
+    class _FakeRepo:
+        def __init__(self, session: object, *, org_id: str) -> None:
+            del session, org_id
+
+        async def get(self) -> None:
+            return None
+
+    async def fake_policy_resolve(self: object) -> EffectivePolicy:
+        return EffectivePolicy(default_image="img", network_default_action="deny")
+
+    async def fake_inventory(
+        session: object, *, org_id: str, workspace_id: str, user_id: str
+    ) -> list[EnvInventoryItem]:
+        del session, org_id, workspace_id, user_id
+        return []
+
+    monkeypatch.setattr(
+        "cubeplex.services.sandbox_runtime_config.SandboxPolicyRepository",
+        _FakeRepo,
+    )
+    monkeypatch.setattr(
+        "cubeplex.services.sandbox_runtime_config.SandboxPolicyResolver.resolve",
+        fake_policy_resolve,
+    )
+    monkeypatch.setattr(
+        "cubeplex.services.sandbox_runtime_config.resolve_env_inventory",
+        fake_inventory,
+    )
+
+    view = await load_agent_view(
+        _FakeSession(),  # type: ignore[arg-type]
+        org_id="org1",
+        workspace_id="ws1",
+        user_id="u1",
+        default_image="ubuntu:22.04",
+    )
+    assert view["network"]["policy_source"] == POLICY_SOURCE_BUILT_IN

--- a/docs/dev/plans/2026-07-22-sandbox-config-to-agent.md
+++ b/docs/dev/plans/2026-07-22-sandbox-config-to-agent.md
@@ -24,27 +24,34 @@ cubepi `AgentTool`, sandbox middleware / `run_manager` tool wiring.
 
 ```python
 def serialize_network_policy(policy) -> dict[str, Any]:
-    # default_action, rules[{action, target}], egress_proxy: "set"|"unset"
-    # cap rules; truncated flag
+    # WHITELIST only: default_action, rules[{action, target}],
+    # egress_proxy: "set"|"unset", truncated, policy_source, sandbox_note
+    # Never forward raw rule dicts / model_dump()
 
-def serialize_env_inventory(resolved: list[ResolvedEnv], *, include_scope: ...) -> list[dict]:
-    # env_name, kind, scope if available, status if available, hosts, header_names
-    # NEVER value, credential_id, secret material
+def serialize_env_inventory(meta: list[EnvInventoryItem]) -> list[dict]:
+    # WHITELIST: env_name, kind, scope, status, hosts, header_names
+    # NEVER value, credential_id, secret material, extra keys
 
 def serialize_command_rules(policy) -> list[dict]:
-    # action + pattern only
+    # WHITELIST: action + pattern only
 ```
 
-**Important**: `ResolvedEnv` currently has `value` for injection — serializers
-must not include it. Prefer building from repo rows with scope/status if
-`ResolvedEnv` lacks scope; extend a lightweight DTO if needed **without**
-passing decrypted values into the agent path.
+**DTO**: introduce `EnvInventoryItem` (or equivalent) populated during resolve
+from the **winning** `SandboxEnvVar` row: scope + status + hosts/headers +
+kind, with **no** decrypted value field on the object that serializers see.
+Do not re-query unscoped rows in a way that bypasses effective merge.
+
+**Important**: `ResolvedEnv` currently has `value` for injection — agent path
+must not receive that object unfiltered.
 
 **Tests** (`backend/tests/unit/test_sandbox_runtime_config_serialize.py`):
 - Secret row with fake value never appears in JSON output
 - Plain row value never appears even if present on DTO
 - Caps/truncation marker
 - Hosts and header_names preserved for secrets
+- Fixtures with **extra forbidden keys** on rules/env rows never appear
+- Recursive scan: no `credential_id`, proxy credentials, or value-like fields
+- Scope/status present for winning rows; precedence cases
 
 ---
 
@@ -56,16 +63,19 @@ passing decrypted values into the agent path.
 - Register in sandbox tool list construction (only when sandbox is available)
 
 **Behavior**:
-1. Load org sandbox policy via existing service.
-2. Resolve effective env for `(workspace_id, user_id)` via `SandboxEnvService`.
-3. Return JSON text content with sections: `network`, `env`, optional
-   `command_rules`, `truncated` flags, short `notes` (e.g. sandbox recreate).
+1. Load org sandbox policy via existing service (admin-authored; agent sees
+   diagnosis view, not admin UI parity — see spec Security).
+2. Resolve effective env inventory DTO for `(workspace_id, user_id)`.
+3. Return JSON with sections: `network`, `env`, optional `command_rules`,
+   `truncated` flags, `policy_source`, and `sandbox_note` that network rules
+   apply at sandbox create / may require recreate after admin edits.
 
 **Args**: none required for v1 (optional `section: network|env|all` later).
 
 **Tests**:
 - unit with mocked services
 - e2e optional: member agent tool call returns rules from seeded policy
+- assert tool result never contains secret values / credential ids
 
 ---
 
@@ -129,7 +139,9 @@ Defer unless Phase 1–2 are solid.
 
 | Risk | Mitigation |
 | --- | --- |
-| Accidental value leak via `ResolvedEnv.value` | Explicit serializer tests; never `model_dump()` raw |
+| Accidental value leak via `ResolvedEnv.value` | Separate inventory DTO; whitelist serializers; recursive redaction tests |
+| Extra keys on persisted rule JSON | Whitelist only `action`/`target` (etc.); plant extras in fixtures |
+| Member sees org env names via agent | Document intentional diagnosis visibility; no value disclosure |
 | Tool unused by model | Stable blurb + later error hints |
 | Huge rule lists | Cap + truncated flag |
-| Stale sandbox vs new admin policy | Note in tool result about recreate |
+| Stale sandbox vs new admin policy | `sandbox_note` + policy_source; never claim live re-apply |

--- a/docs/dev/plans/2026-07-22-sandbox-config-to-agent.md
+++ b/docs/dev/plans/2026-07-22-sandbox-config-to-agent.md
@@ -1,0 +1,135 @@
+# Sandbox config visibility for agent — implementation plan
+
+Related: #398 · Spec: `docs/dev/specs/2026-07-22-sandbox-config-to-agent-design.md`
+
+**Goal**: Hybrid delivery of network policy + env inventory (no secrets) to the
+agent via `sandbox_config` tool + short stable prompt guidance.
+
+**Architecture**: Pure serialization helpers over existing policy/env services;
+one DI-backed tool registered when sandbox tools are attached; append a fixed
+paragraph to `SANDBOX_PROMPT_TEMPLATE` (or adjacent fragment).
+
+**Tech stack**: Existing `SandboxPolicyService`, `SandboxEnvService.resolve`,
+cubepi `AgentTool`, sandbox middleware / `run_manager` tool wiring.
+
+---
+
+## Unit 1: Safe serializers (no values)
+
+**Files**:
+- `backend/cubeplex/sandbox_policy/agent_view.py` (new) **or**
+  `backend/cubeplex/services/sandbox_runtime_config.py` (new)
+
+**Functions** (sketch):
+
+```python
+def serialize_network_policy(policy) -> dict[str, Any]:
+    # default_action, rules[{action, target}], egress_proxy: "set"|"unset"
+    # cap rules; truncated flag
+
+def serialize_env_inventory(resolved: list[ResolvedEnv], *, include_scope: ...) -> list[dict]:
+    # env_name, kind, scope if available, status if available, hosts, header_names
+    # NEVER value, credential_id, secret material
+
+def serialize_command_rules(policy) -> list[dict]:
+    # action + pattern only
+```
+
+**Important**: `ResolvedEnv` currently has `value` for injection — serializers
+must not include it. Prefer building from repo rows with scope/status if
+`ResolvedEnv` lacks scope; extend a lightweight DTO if needed **without**
+passing decrypted values into the agent path.
+
+**Tests** (`backend/tests/unit/test_sandbox_runtime_config_serialize.py`):
+- Secret row with fake value never appears in JSON output
+- Plain row value never appears even if present on DTO
+- Caps/truncation marker
+- Hosts and header_names preserved for secrets
+
+---
+
+## Unit 2: `sandbox_config` tool
+
+**Files**:
+- `backend/cubeplex/tools/builtin/sandbox_config.py` (new) **or** factory inside
+  `middleware/sandbox.py` next to execute/write tools
+- Register in sandbox tool list construction (only when sandbox is available)
+
+**Behavior**:
+1. Load org sandbox policy via existing service.
+2. Resolve effective env for `(workspace_id, user_id)` via `SandboxEnvService`.
+3. Return JSON text content with sections: `network`, `env`, optional
+   `command_rules`, `truncated` flags, short `notes` (e.g. sandbox recreate).
+
+**Args**: none required for v1 (optional `section: network|env|all` later).
+
+**Tests**:
+- unit with mocked services
+- e2e optional: member agent tool call returns rules from seeded policy
+
+---
+
+## Unit 3: Prompt guidance (stable)
+
+**Files**:
+- `backend/cubeplex/prompts/sandbox.py` — append fixed diagnosis blurb to
+  `SANDBOX_PROMPT_TEMPLATE` **or** separate constant concatenated in middleware
+
+**Content** (short, static English):
+- Egress and env vars are admin/workspace configured.
+- On network/auth failure call `sandbox_config` before inventing credentials.
+- Never print secret values; secrets are host-scoped placeholders.
+- Point user to settings for missing allow rules / env entries.
+
+**Cache**: text is constant → no extra busts. Do not interpolate live rules.
+
+**Tests**: unit snapshot of template contains key phrases; no dynamic fields.
+
+---
+
+## Unit 4: Wiring + docs
+
+**Files**:
+- `middleware/sandbox.py` / `run_manager` — ensure tool appears with other
+  sandbox tools and has workspace/user/org context
+- `docs/site/docs/admin/sandbox.md` — short “agent troubleshooting metadata”
+  note (implementation PR)
+
+**Tests**: registry/tool-list unit if pattern exists.
+
+---
+
+## Unit 5 (optional Phase 3): Error enrichment
+
+**Files**: execute path / egress error mapping
+
+When a command or network failure is clearly policy deny, append one line:
+`egress_default=deny; host X not in allow rules` (only when detection is
+reliable). Skip if ambiguous.
+
+Defer unless Phase 1–2 are solid.
+
+---
+
+## Delivery order
+
+1. Unit 1 serializers + redaction tests (must land first)
+2. Unit 2 tool
+3. Unit 3 prompt blurb
+4. Unit 4 wiring + admin docs
+5. Unit 5 optional
+
+## Out of scope
+
+- Agent mutating policy/env
+- Putting secret values or placeholders into system prompt
+- Always-on full policy dump in stable prefix (Phase 4 later)
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Accidental value leak via `ResolvedEnv.value` | Explicit serializer tests; never `model_dump()` raw |
+| Tool unused by model | Stable blurb + later error hints |
+| Huge rule lists | Cap + truncated flag |
+| Stale sandbox vs new admin policy | Note in tool result about recreate |

--- a/docs/dev/plans/2026-07-22-sandbox-config-to-agent.md
+++ b/docs/dev/plans/2026-07-22-sandbox-config-to-agent.md
@@ -2,12 +2,14 @@
 
 Related: #398 · Spec: `docs/dev/specs/2026-07-22-sandbox-config-to-agent-design.md`
 
-**Goal**: Hybrid delivery of network policy + env inventory (no secrets) to the
-agent via `sandbox_config` tool + short stable prompt guidance.
+**Goal**: Tool-only delivery of network policy + env inventory (no secrets) to
+the agent via an eager `sandbox_config` tool. No system-prompt diagnosis blurb;
+no `DeferredToolGroup` in v1.
 
 **Architecture**: Pure serialization helpers over existing policy/env services;
-one DI-backed tool registered when sandbox tools are attached; append a fixed
-paragraph to `SANDBOX_PROMPT_TEMPLATE` (or adjacent fragment).
+one DI-backed tool registered when sandbox tools are attached (same place as
+`execute` / `write_file`). Playbook lives in the tool description and optional
+result `guidance` field.
 
 **Tech stack**: Existing `SandboxPolicyService`, `SandboxEnvService.resolve`,
 cubepi `AgentTool`, sandbox middleware / `run_manager` tool wiring.
@@ -55,7 +57,7 @@ must not receive that object unfiltered.
 
 ---
 
-## Unit 2: `sandbox_config` tool
+## Unit 2: `sandbox_config` tool (eager)
 
 **Files**:
 - `backend/cubeplex/tools/builtin/sandbox_config.py` (new) **or** factory inside
@@ -69,35 +71,27 @@ must not receive that object unfiltered.
 3. Return JSON with sections: `network`, `env`, optional `command_rules`,
    `truncated` flags, `policy_source`, and `sandbox_note` that network rules
    apply at sandbox create / may require recreate after admin edits.
+4. Optional short static `guidance` string in the result (when to use, no secret
+   echo, point user to settings) — **not** copied into `SANDBOX_PROMPT_TEMPLATE`.
+
+**Tool description** (static English, in the AgentTool schema): call on
+network / auth / missing-env failures; do not invent credentials; never print
+secret values.
 
 **Args**: none required for v1 (optional `section: network|env|all` later).
+
+**Not in v1**: `DeferredToolGroup` / `load_tools` path; capability registry
+entry under `agents/actions/`.
 
 **Tests**:
 - unit with mocked services
 - e2e optional: member agent tool call returns rules from seeded policy
 - assert tool result never contains secret values / credential ids
+- assert tool is present when sandbox tools are registered
 
 ---
 
-## Unit 3: Prompt guidance (stable)
-
-**Files**:
-- `backend/cubeplex/prompts/sandbox.py` — append fixed diagnosis blurb to
-  `SANDBOX_PROMPT_TEMPLATE` **or** separate constant concatenated in middleware
-
-**Content** (short, static English):
-- Egress and env vars are admin/workspace configured.
-- On network/auth failure call `sandbox_config` before inventing credentials.
-- Never print secret values; secrets are host-scoped placeholders.
-- Point user to settings for missing allow rules / env entries.
-
-**Cache**: text is constant → no extra busts. Do not interpolate live rules.
-
-**Tests**: unit snapshot of template contains key phrases; no dynamic fields.
-
----
-
-## Unit 4: Wiring + docs
+## Unit 3: Wiring + docs
 
 **Files**:
 - `middleware/sandbox.py` / `run_manager` — ensure tool appears with other
@@ -105,17 +99,23 @@ must not receive that object unfiltered.
 - `docs/site/docs/admin/sandbox.md` — short “agent troubleshooting metadata”
   note (implementation PR)
 
-**Tests**: registry/tool-list unit if pattern exists.
+**Explicit non-work**: do **not** edit `prompts/sandbox.py` /
+`SANDBOX_PROMPT_TEMPLATE` for a diagnosis blurb.
+
+**Tests**: registry/tool-list unit if pattern exists; no new system-prompt
+snapshot requirement for this feature.
 
 ---
 
-## Unit 5 (optional Phase 3): Error enrichment
+## Unit 4 (optional Phase 3): Error enrichment
 
 **Files**: execute path / egress error mapping
 
 When a command or network failure is clearly policy deny, append one line:
-`egress_default=deny; host X not in allow rules` (only when detection is
-reliable). Skip if ambiguous.
+`egress_default=deny; host X not in allow rules` and/or `call sandbox_config`
+(only when detection is reliable). Skip if ambiguous.
+
+Prefer this over adding a stable system-prompt blurb if model recall is weak.
 
 Defer unless Phase 1–2 are solid.
 
@@ -124,16 +124,17 @@ Defer unless Phase 1–2 are solid.
 ## Delivery order
 
 1. Unit 1 serializers + redaction tests (must land first)
-2. Unit 2 tool
-3. Unit 3 prompt blurb
-4. Unit 4 wiring + admin docs
-5. Unit 5 optional
+2. Unit 2 eager tool (+ description / optional result guidance)
+3. Unit 3 wiring + admin docs
+4. Unit 4 optional error enrichment
 
 ## Out of scope
 
 - Agent mutating policy/env
 - Putting secret values or placeholders into system prompt
-- Always-on full policy dump in stable prefix (Phase 4 later)
+- Diagnosis playbook or live policy dump in the stable system prefix
+- `DeferredToolGroup` for a single `sandbox_config` tool
+- Always-on full policy dump in stable prefix
 
 ## Risks
 
@@ -142,6 +143,6 @@ Defer unless Phase 1–2 are solid.
 | Accidental value leak via `ResolvedEnv.value` | Separate inventory DTO; whitelist serializers; recursive redaction tests |
 | Extra keys on persisted rule JSON | Whitelist only `action`/`target` (etc.); plant extras in fixtures |
 | Member sees org env names via agent | Document intentional diagnosis visibility; no value disclosure |
-| Tool unused by model | Stable blurb + later error hints |
+| Tool unused by model | Strong tool description + optional result `guidance`; Phase 3 error hints if needed — **not** system-prompt blurb |
 | Huge rule lists | Cap + truncated flag |
 | Stale sandbox vs new admin policy | `sandbox_note` + policy_source; never claim live re-apply |

--- a/docs/dev/plans/2026-07-22-sandbox-config-to-agent.md
+++ b/docs/dev/plans/2026-07-22-sandbox-config-to-agent.md
@@ -4,47 +4,60 @@ Related: #398 · Spec: `docs/dev/specs/2026-07-22-sandbox-config-to-agent-design
 
 **Goal**: Tool-only delivery of network policy + env inventory (no secrets) to
 the agent via an eager `sandbox_config` tool. No system-prompt diagnosis blurb;
-no `DeferredToolGroup` in v1.
+no `DeferredToolGroup` in v1. Reliable policy_deny paths get a short
+deterministic nudge toward the tool.
 
-**Architecture**: Pure serialization helpers over existing policy/env services;
-one DI-backed tool registered when sandbox tools are attached (same place as
-`execute` / `write_file`). Playbook lives in the tool description and optional
-result `guidance` field.
+**Architecture**: Pure serialization helpers over **resolvers** (not CRUD
+services); one tool registered with sandbox tools; per-call session factory
+supplies `org_id` / `workspace_id` / `user_id`. Playbook lives in the tool
+description, optional result `guidance`, and policy_deny error appends.
 
-**Tech stack**: Existing `SandboxPolicyService`, `SandboxEnvService.resolve`,
-cubepi `AgentTool`, sandbox middleware / `run_manager` tool wiring.
+**Tech stack** (use these types — names matter):
+
+| Use | Do not use on agent path |
+| --- | --- |
+| `SandboxPolicyResolver.resolve()` → `EffectivePolicy` | `SandboxPolicyService` alone as “read” without defaults |
+| `SandboxEnvResolver.resolve()` + winning-row metadata | `SandboxEnvService` (CRUD + `CredentialService`) |
+| Fresh `AsyncSession` per tool call | Long-lived session on `SandboxMiddleware` |
+| `EnvInventoryItem` DTO (no value / credential_id) | Raw `ResolvedEnv` with `value` / `credential_id` |
+
+cubepi `AgentTool`; extend `SandboxMiddleware` / `run_manager` wiring.
 
 ---
 
 ## Unit 1: Safe serializers (no values)
 
 **Files**:
-- `backend/cubeplex/sandbox_policy/agent_view.py` (new) **or**
-  `backend/cubeplex/services/sandbox_runtime_config.py` (new)
+- `backend/cubeplex/services/sandbox_runtime_config.py` (new) **or**
+  `backend/cubeplex/sandbox_policy/agent_view.py` (new)
 
 **Functions** (sketch):
 
 ```python
-def serialize_network_policy(policy) -> dict[str, Any]:
+def serialize_network_policy(policy: EffectivePolicy) -> dict[str, Any]:
     # WHITELIST only: default_action, rules[{action, target}],
     # egress_proxy: "set"|"unset", truncated, policy_source, sandbox_note
     # Never forward raw rule dicts / model_dump()
 
 def serialize_env_inventory(meta: list[EnvInventoryItem]) -> list[dict]:
-    # WHITELIST: env_name, kind, scope, status, hosts, header_names
+    # WHITELIST: env_name, kind, scope, status?, hosts, header_names
     # NEVER value, credential_id, secret material, extra keys
 
-def serialize_command_rules(policy) -> list[dict]:
+def serialize_command_rules(policy: EffectivePolicy) -> list[dict]:
     # WHITELIST: action + pattern only
 ```
 
-**DTO**: introduce `EnvInventoryItem` (or equivalent) populated during resolve
-from the **winning** `SandboxEnvVar` row: scope + status + hosts/headers +
-kind, with **no** decrypted value field on the object that serializers see.
-Do not re-query unscoped rows in a way that bypasses effective merge.
+**DTO**: `EnvInventoryItem` populated from the **winning valid** `SandboxEnvVar`
+row during resolve (or a parallel walk of the same resolution order): scope +
+hosts/headers + kind. **No** decrypted value field. Do not re-query unscoped
+rows in a way that bypasses effective merge.
 
-**Important**: `ResolvedEnv` currently has `value` for injection — agent path
-must not receive that object unfiltered.
+**Invalid rows**: `list_for_resolution` already filters `status == "valid"`.
+v1 inventory = inject set only. Do not invent “invalid winner” reporting.
+
+**Important**: `ResolvedEnv` has `value` / `credential_id` for injection —
+agent path must not receive that object unfiltered. Never construct
+`CredentialService` here.
 
 **Tests** (`backend/tests/unit/test_sandbox_runtime_config_serialize.py`):
 - Secret row with fake value never appears in JSON output
@@ -53,30 +66,34 @@ must not receive that object unfiltered.
 - Hosts and header_names preserved for secrets
 - Fixtures with **extra forbidden keys** on rules/env rows never appear
 - Recursive scan: no `credential_id`, proxy credentials, or value-like fields
-- Scope/status present for winning rows; precedence cases
+- Scope present for winning rows; precedence cases
+- Invalid / non-valid rows do not appear (match inject set)
 
 ---
 
-## Unit 2: `sandbox_config` tool (eager)
+## Unit 2: `sandbox_config` tool (eager) + DI
 
 **Files**:
 - `backend/cubeplex/tools/builtin/sandbox_config.py` (new) **or** factory inside
   `middleware/sandbox.py` next to execute/write tools
-- Register in sandbox tool list construction (only when sandbox is available)
+- `middleware/sandbox.py` — extend constructor kwargs for diagnosis context
+- `streams/run_manager.py` — pass `org_id`, `user_id`, session factory (or
+  thin manager) when building `SandboxMiddleware`
 
 **Behavior**:
-1. Load org sandbox policy via existing service (admin-authored; agent sees
-   diagnosis view, not admin UI parity — see spec Security).
-2. Resolve effective env inventory DTO for `(workspace_id, user_id)`.
-3. Return JSON with sections: `network`, `env`, optional `command_rules`,
-   `truncated` flags, `policy_source`, and `sandbox_note` that network rules
-   apply at sandbox create / may require recreate after admin edits.
-4. Optional short static `guidance` string in the result (when to use, no secret
-   echo, point user to settings) — **not** copied into `SANDBOX_PROMPT_TEMPLATE`.
+1. On each call: open session → `SandboxPolicyResolver.resolve()` →
+   `SandboxEnvResolver` / inventory build for `(workspace_id, user_id)` →
+   serialize → close session.
+2. Return JSON: `network`, `env`, optional `command_rules`, `truncated` flags,
+   `policy_source`, `sandbox_note` (rules apply at create; recreate after
+   admin edits).
+3. Optional short static `guidance` string in the result — **not** copied into
+   `SANDBOX_PROMPT_TEMPLATE`.
+4. Explicitly **do not** construct `SandboxEnvService` / decrypt credentials.
 
 **Tool description** (static English, in the AgentTool schema): call on
 network / auth / missing-env failures; do not invent credentials; never print
-secret values.
+secret values; prefer this tool over `printenv` for diagnosis.
 
 **Args**: none required for v1 (optional `section: network|env|all` later).
 
@@ -84,20 +101,39 @@ secret values.
 entry under `agents/actions/`.
 
 **Tests**:
-- unit with mocked services
+- unit with mocked resolvers / session factory
+- assert fresh session opened per call (mock factory call count) if easy
 - e2e optional: member agent tool call returns rules from seeded policy
 - assert tool result never contains secret values / credential ids
 - assert tool is present when sandbox tools are registered
+- assert no CredentialService construction on path
 
 ---
 
-## Unit 3: Wiring + docs
+## Unit 3: Reliable policy_deny hints (v1)
+
+**Files**: execute path / command-rule deny messages already emitted by
+`SandboxMiddleware.before_tool_call` / execute error mapping
+
+When a failure is **already known** to be policy/command deny, append one
+short line, e.g. `For network/env inventory call sandbox_config` (and keep any
+existing pattern-specific deny text). Skip if the failure is ambiguous
+(generic timeout, generic 401 without structured egress reason).
+
+This is **not** a system-prompt blurb and is **not** optional for clear
+policy_deny paths in v1 — it is the deterministic recall path.
+
+**Tests**: unit/e2e that a denied command (or mocked policy_deny) includes the
+nudge; ambiguous errors do not fabricate a false “host X denied” claim.
+
+---
+
+## Unit 4: Wiring + docs
 
 **Files**:
-- `middleware/sandbox.py` / `run_manager` — ensure tool appears with other
-  sandbox tools and has workspace/user/org context
+- finish `middleware` / `run_manager` wiring from Unit 2
 - `docs/site/docs/admin/sandbox.md` — short “agent troubleshooting metadata”
-  note (implementation PR)
+  note (implementation PR); mention expanded visibility of env **names**
 
 **Explicit non-work**: do **not** edit `prompts/sandbox.py` /
 `SANDBOX_PROMPT_TEMPLATE` for a diagnosis blurb.
@@ -107,26 +143,20 @@ snapshot requirement for this feature.
 
 ---
 
-## Unit 4 (optional Phase 3): Error enrichment
+## Unit 5 (optional later): Opaque network enrichment
 
-**Files**: execute path / egress error mapping
-
-When a command or network failure is clearly policy deny, append one line:
-`egress_default=deny; host X not in allow rules` and/or `call sandbox_config`
-(only when detection is reliable). Skip if ambiguous.
-
-Prefer this over adding a stable system-prompt blurb if model recall is weak.
-
-Defer unless Phase 1–2 are solid.
+When egress/sidecar returns a **structured** host deny that is reliable, map
+it to a one-line hint. Do not guess on plain connection refused / timeout.
 
 ---
 
 ## Delivery order
 
-1. Unit 1 serializers + redaction tests (must land first)
-2. Unit 2 eager tool (+ description / optional result guidance)
-3. Unit 3 wiring + admin docs
-4. Unit 4 optional error enrichment
+1. Unit 1 serializers + inventory DTO + redaction tests
+2. Unit 2 eager tool + DI (session factory, resolvers)
+3. Unit 3 policy_deny hints (v1)
+4. Unit 4 admin docs / polish
+5. Unit 5 optional
 
 ## Out of scope
 
@@ -135,14 +165,19 @@ Defer unless Phase 1–2 are solid.
 - Diagnosis playbook or live policy dump in the stable system prefix
 - `DeferredToolGroup` for a single `sandbox_config` tool
 - Always-on full policy dump in stable prefix
+- Reporting invalid non-injectable env winners (separate metadata path)
+- Constructing `CredentialService` for diagnosis
 
 ## Risks
 
 | Risk | Mitigation |
 | --- | --- |
-| Accidental value leak via `ResolvedEnv.value` | Separate inventory DTO; whitelist serializers; recursive redaction tests |
+| Accidental value leak via `ResolvedEnv.value` | Separate inventory DTO; whitelist serializers; recursive redaction tests; ban CredentialService on path |
+| Wrong service (`SandboxEnvService` / raw policy row) | Spec names resolvers; plan tech table; code review gate |
 | Extra keys on persisted rule JSON | Whitelist only `action`/`target` (etc.); plant extras in fixtures |
 | Member sees org env names via agent | Document intentional diagnosis visibility; no value disclosure |
-| Tool unused by model | Strong tool description + optional result `guidance`; Phase 3 error hints if needed — **not** system-prompt blurb |
+| Tool unused by model | Tool description + **v1 policy_deny hints**; optional later opaque enrichment — **not** system-prompt blurb |
+| Long-lived DB session on middleware | Per-call session factory |
 | Huge rule lists | Cap + truncated flag |
 | Stale sandbox vs new admin policy | `sandbox_note` + policy_source; never claim live re-apply |
+| Invalid-status confusion | v1 = inject set only; no invalid-winner promise |

--- a/docs/dev/specs/2026-07-22-sandbox-config-to-agent-design.md
+++ b/docs/dev/specs/2026-07-22-sandbox-config-to-agent-design.md
@@ -28,30 +28,43 @@ user for vague screenshots — **never** exposing secret values.
 - `command_rules`, image, resources
 - Built via `sandbox_policy/rules.py` → egress sidecar
 - Admin API `GET/PUT` sandbox policy
+- **Effective read path today:** `SandboxPolicyResolver.resolve()` →
+  `EffectivePolicy` (org row or built-in defaults). `SandboxPolicyService` is
+  CRUD/validation only — do **not** use it as the agent read path.
 
 **Env** (`SandboxEnvVar`):
 
 - `env_name`, `is_secret`, `scope` (`org` | `workspace` | `user`)
 - Secrets: `hosts`, `header_names`, `status`, `credential_id`
-- Resolution: user > workspace > org (`SandboxEnvService.resolve`)
+- **Effective read path today:** `SandboxEnvResolver.resolve(workspace_id,
+  user_id)` over `SandboxEnvRepository.list_for_resolution`, which filters
+  `status == "valid"` before precedence (user > workspace > org).
+- `SandboxEnvService` is **CRUD only** and holds `CredentialService` — **never**
+  construct it on the agent diagnosis path.
 - Plain values injected for real; secrets become host-scoped placeholders
 - UI/API already list metadata without re-displaying secret values after save
 
 **Agent surface today**:
 
 - `SANDBOX_PROMPT_TEMPLATE` is workdir / file-tools centric only
-- Command deny messages at runtime for some cases
+- Command deny messages at runtime for some cases (HITL / policy_deny on
+  `execute`)
 - No `sandbox_config` / policy tool
 - Agent *can* `printenv` — **discouraged** as primary design (leaks plain
   secrets into transcript or shows useless placeholders)
+- `SandboxMiddleware` today is constructed with
+  `sandbox`, `conversation_id`, `workspace_id`, `command_rules`, `channel` —
+  **no** `org_id`, `user_id`, or session factory. Wiring for the new tool must
+  pass those explicitly (see Delivery → DI).
 
 ## Goals
 
 1. **Effective network policy** visible in compact non-secret form.
 2. **Env inventory**: name + kind + scope + status + secret host/header
-   constraints — **never** plaintext secret values.
-3. Teach diagnosis via **tool description + result guidance** (and optional
-   error-path hints later) — **not** by growing the stable system prompt.
+   constraints for the **injectable** set — **never** plaintext secret values.
+3. Teach diagnosis via **tool description + result guidance** and **v1
+   deterministic hints on reliable policy-deny paths** — **not** by growing
+   the stable system prompt.
 4. Respect **prompt-cache discipline**: full dump only on-demand via tool;
    leave `SANDBOX_PROMPT_TEMPLATE` free of live policy/env and free of a
    diagnosis playbook.
@@ -65,6 +78,9 @@ user for vague screenshots — **never** exposing secret values.
 - Replacing command HITL confirm flows.
 - Injecting live policy/env (or a long diagnosis blurb) into the system prompt.
 - Wrapping `sandbox_config` in a `DeferredToolGroup` in v1 (see Delivery).
+- Guaranteeing the model always calls `sandbox_config` on every opaque
+  timeout/401 (model recall is soft; v1 only hardens **detectable** policy_deny
+  paths).
 
 ## Design
 
@@ -86,50 +102,84 @@ Enough for: “Is `api.github.com` allowed under current policy?”
 Optional one-liner: policy is applied at sandbox creation; admin changes may
 require a new sandbox (align with deploy docs).
 
+Source: `SandboxPolicyResolver.resolve()` → serialize `EffectivePolicy`
+fields only (whitelist). Never `SandboxPolicyService.get()` raw row alone
+without applying the same defaulting as the resolver.
+
 #### B. Env inventory (names + types only)
 
-Per **effective** entry after scope merge for this run’s org/workspace/user
-(same merge as injection).
+Per **effective injectable** entry after scope merge for this run’s
+org/workspace/user — **same set as injection**.
+
+**v1 status semantics (closed decision):**
+
+- Today `list_for_resolution` already filters `status == "valid"`. An invalid
+  row **cannot** be a winning injectable row.
+- v1 inventory therefore matches the **inject set only**: omit non-winning
+  and omit invalid / non-resolvable entries.
+- Do **not** promise “configured but not injectable” for invalid winners in
+  v1 — that requires a separate metadata-resolution path with its own
+  precedence rules (out of scope).
+- `status` on inventory items may still be included for forward compatibility
+  but is expected to be `"valid"` for every returned row under the current
+  resolver.
+- Distinguishing “not configured” vs “configured as secret for hosts […]”
+  is by **presence in the inventory** (and `kind` / `hosts`), not by invalid
+  status.
 
 **DTO requirement:** `ResolvedEnv` today has `env_name`, `is_secret`, `hosts`,
-`header_names`, `credential_id`, optional `value` — **not** `scope` or
-`status`. Implementation must introduce an agent-facing metadata DTO (or extend
-resolution with a parallel non-secret view) that carries the **winning row’s**
-`scope` and `status` without ever attaching decrypted values.
+`header_names`, `credential_id`, optional `value` — **not** `scope`.
+Implementation must introduce an agent-facing metadata DTO (`EnvInventoryItem`)
+built during or parallel to resolve from the **winning valid row**: scope +
+hosts/headers + kind, with **no** decrypted value field and **no**
+`credential_id` on the object serializers see.
 
 | Field | Include? |
 | --- | --- |
 | `env_name` | Yes |
 | `kind` / `is_secret` | Yes (`plain` / `secret`) |
-| `scope` | Yes (from winning row) |
-| `status` | Yes (from winning row; invalid winners reported if present) |
+| `scope` | Yes (from winning valid row) |
+| `status` | Optional; if present, expect `"valid"` under current resolve |
 | `hosts` | Yes for secrets |
 | `header_names` | Yes if set |
 | **value / secret** | **Never** |
 | placeholder string | Prefer **no** |
 | `credential_id` | **Never** |
 
-Invalid / suppressed rows: document v1 choice — **omit non-winning and
-non-resolvable entries** (match inject set) unless a row wins but is invalid
-(then show `status` so the agent can say “configured but not injectable”).
-
 Plain entries: inventory says the name is configured; agent may read the value
 inside the sandbox only when needed for execution — **not** dump into the
-system prompt.
+system prompt. Prefer reading via task-specific commands over blanket
+`printenv`.
 
 #### C. Command policy (v1 optional, recommended if cheap)
 
 Short list of deny/confirm patterns so the agent avoids known-denied commands
 and understands HITL confirms are policy, not random errors.
 
-### Delivery: tool-only (chosen)
+### Delivery: tool-only + reliable failure hints (chosen)
 
 | Layer | Content |
 | --- | --- |
-| **Eager tool `sandbox_config`** | Registered with other sandbox tools (`execute`, `write_file`, …) when the sandbox is available. JSON: network summary + env inventory (+ optional command rules). Read DB at call time. |
-| **Tool description + result guidance** | When to call (network/auth/env failures); never print secrets; point user to settings for missing allow rules / env entries. Optional short `guidance` field in the tool result so the playbook is not system-prompt-resident. |
+| **Eager tool `sandbox_config`** | Registered with other sandbox tools (`execute`, `write_file`, …) when the sandbox is available. JSON: network summary + env inventory (+ optional command rules). Read DB at **tool-call** time. |
+| **Tool description + result guidance** | When to call (network/auth/env failures); never invent credentials; never print secrets; prefer `sandbox_config` over `printenv`; point user to settings for missing allow rules / env entries. Optional short static `guidance` field in the tool result. |
+| **v1 deterministic hints (reliable paths only)** | When `execute` (or egress mapping) already knows the failure is **policy_deny** / command deny, append a short line that points at `sandbox_config` and, when known, the deny reason. **Not** a system-prompt blurb; not required for opaque timeouts/401s. |
 | **System prompt** | **No change** for this feature: keep existing workdir / file-tools sandbox section. Do **not** append a diagnosis blurb; do **not** interpolate live rules or env names. |
-| **Later optional** | Structured one-line hints on blocked egress / policy_deny execute errors (error path, not stable prefix). |
+
+#### DI / session lifecycle (required)
+
+`SandboxMiddleware` today has no org/user/session. Implementation must:
+
+1. Pass run-scoped ids into tool construction: at least `org_id`, `workspace_id`,
+   `user_id` (and whatever is needed for policy repo scoping).
+2. Provide a **session factory** (or equivalent manager) that opens a **fresh
+   `AsyncSession` per tool call**, uses
+   `SandboxPolicyResolver` + `SandboxEnvResolver` (or a thin facade over them),
+   builds `EnvInventoryItem` list without decrypting secrets, serializes, and
+   closes the session. Do **not** hold a long-lived session on the middleware.
+3. **Prohibit** constructing `SandboxEnvService` / `CredentialService` on this
+   path. Never call credential decrypt for diagnosis.
+4. Prefer a single facade e.g. `sandbox_runtime_config.load_agent_view(...)`
+   so middleware/tool code does not reassemble resolvers ad hoc.
 
 #### Why not hybrid prompt blurb
 
@@ -137,6 +187,8 @@ and understands HITL confirms are policy, not random errors.
   discovery via tool surface, data only after the agent calls.
 - Avoids growing the always-on system prompt (#391 / #412 direction).
 - Cache-safe by construction: no new stable-prefix fragment at all.
+- Soft recall gaps are addressed with **deterministic error-path hints** on
+  known policy_deny, not with always-on prose.
 
 #### Why not `DeferredToolGroup` in v1
 
@@ -152,14 +204,16 @@ revisit a `cubeplex:sandbox_runtime` deferred group then.
 
 Why not always-on full dump: token cost and cache busts when admin edits.
 
-### Agent behavior (encoded in tool description / result, not system prompt)
+### Agent behavior (encoded in tool description / result / deny hints)
 
 When network or auth fails:
 
-1. Call `sandbox_config` (or use prior result if still relevant).
+1. Call `sandbox_config` (or use prior result if still relevant). Prefer this
+   over `printenv` / inventing credentials.
 2. Host denied / default deny → tell user which allow rule is missing; point to
    Admin → Sandbox network policy (conceptual path).
-3. Env name missing → ask user to add plain/secret env at correct scope.
+3. Env name missing from inventory → ask user to add plain/secret env at
+   correct scope.
 4. Secret exists but host not allowed → ask to add host to that secret’s
    allowlist (or use an allowed host).
 5. Do not invent API keys; do not ask user to paste secrets into chat if the
@@ -184,7 +238,8 @@ When network or auth fails:
 
 ### Cache / freshness
 
-- Tool path: read **current** org policy + effective env from DB at call time.
+- Tool path: read **current** org policy + effective env from DB at call time
+  via resolvers (fresh session).
 - **Sandbox policy may be stale**: network policy is structural and applied at
   sandbox **create** (manager does not re-apply on reuse). Tool output must
   include a clear note that DB policy is “desired / next create”, and when
@@ -200,24 +255,31 @@ When network or auth fails:
 
 | Phase | Deliverable |
 | --- | --- |
-| **1** | Safe serializers + redaction tests |
-| **2** | Eager `sandbox_config` tool (description + optional result guidance); wiring with other sandbox tools |
-| **3** | Optional: structured hints on blocked egress / policy_deny execute errors |
-| **4** | Optional: deferred multi-op group **only if** more sandbox-diagnosis tools appear; not a v1 goal |
+| **1** | Safe serializers + `EnvInventoryItem` + redaction tests |
+| **2** | Eager `sandbox_config` tool with correct DI (session factory, resolvers); tool description + optional result guidance; wiring |
+| **3** | **v1 required for reliable paths:** append short hints on known policy_deny / command-deny execute results pointing at `sandbox_config` |
+| **4** | Optional: richer egress-timeout mapping when detection is reliable; deferred multi-op group **only if** more diagnosis tools appear |
 
 ## Acceptance criteria
 
 1. Agent can obtain network default action + rules without user screenshots.
-2. Agent can obtain env inventory (name, plain vs secret, scope, status; secrets
-   include hosts and header_names if any); **no secret values** in tool results
-   or system prompt.
-3. Blocked-host diagnosis cites policy (eval or e2e with mocked policy).
-4. Missing vs present env name is distinguishable (“not configured” vs
-   “configured as secret for hosts […]”).
-5. Unit tests ensure secret values never appear in serialization helpers.
+2. Agent can obtain env inventory for the **injectable** set (name, plain vs
+   secret, scope; secrets include hosts and header_names if any); **no secret
+   values** in tool results or system prompt.
+3. Blocked-host diagnosis cites policy (eval or e2e with mocked policy) when
+   the tool is called.
+4. Missing vs present env name is distinguishable by inventory presence
+   (“not configured” vs “configured as secret for hosts […]”).
+5. Unit tests ensure secret values never appear in serialization helpers;
+   no `CredentialService` / decrypt on the agent path.
 6. Docs note: agent can see policy/env **metadata** for troubleshooting.
-7. `SANDBOX_PROMPT_TEMPLATE` (or equivalent always-on sandbox section) does
-   **not** gain a diagnosis blurb or live policy/env dump for this feature.
+7. `SANDBOX_PROMPT_TEMPLATE` does **not** gain a diagnosis blurb or live
+   policy/env dump for this feature.
+8. On a **known** command/policy deny from `execute`, the tool result or
+   error text includes a deterministic nudge toward `sandbox_config` (or
+   already-clear deny reason + inventory pointer).
+9. Tool description (or tests around registration) discourages `printenv` as
+   the first diagnosis step for network/auth failures.
 
 ## Open questions (v1 decisions)
 
@@ -225,19 +287,23 @@ When network or auth fails:
 | --- | --- |
 | Prompt vs tool vs hybrid | **Tool-only** (eager `sandbox_config`; no system-prompt blurb) |
 | DeferredToolGroup | **No** for v1 single tool |
+| Service boundary | **`SandboxPolicyResolver` + `SandboxEnvResolver`** via per-call session factory; never `SandboxEnvService` on this path |
+| Invalid env rows | **Omit** (match inject set); no “invalid winner” reporting in v1 |
 | Command rules in v1 | **Include if present on policy row** (cheap, high value) |
 | Org env visibility | **Effective merge** as injected into the sandbox |
-| Auto error enrichment | **Phase 3** optional (preferred over prompt blurb if recall is weak) |
+| Auto error enrichment | **v1 for reliable policy_deny paths**; optional later for opaque network failures |
 | Egress proxy | Presence only, never credentials |
 
 ## Related code
 
 - `backend/cubeplex/models/sandbox_policy.py`, `sandbox_env.py`
 - `backend/cubeplex/sandbox_policy/rules.py`
-- `backend/cubeplex/services/sandbox_env.py` (`ResolvedEnv`, `resolve`)
-- `backend/cubeplex/services/sandbox_policy.py`
+- `backend/cubeplex/services/sandbox_env.py` (`ResolvedEnv`, `SandboxEnvResolver`)
+- `backend/cubeplex/services/sandbox_policy.py` (`EffectivePolicy`, `SandboxPolicyResolver`)
+- `backend/cubeplex/repositories/sandbox_env.py` (`list_for_resolution`, valid-only filter)
 - `backend/cubeplex/sandbox_env/injector.py`
 - `backend/cubeplex/prompts/sandbox.py`, `middleware/sandbox.py`
+- `backend/cubeplex/streams/run_manager.py` (SandboxMiddleware construction)
 - `backend/cubeplex/agents/actions/registry.py` (deferred capability pattern — **not** used for v1)
 - `docs/site/docs/admin/sandbox.md`
 - `backend/docs/prompt-cache-discipline.md`

--- a/docs/dev/specs/2026-07-22-sandbox-config-to-agent-design.md
+++ b/docs/dev/specs/2026-07-22-sandbox-config-to-agent-design.md
@@ -1,0 +1,190 @@
+# Expose sandbox network policy and env metadata to the agent
+
+Related: #398
+
+## Goal
+
+When network or auth fails in the sandbox, the agent should diagnose from
+**policy and env inventory metadata** instead of trial-and-error or asking the
+user for vague screenshots — **never** exposing secret values.
+
+## Context
+
+### Failure modes today
+
+| What the user sees | What the agent knows | What it should know |
+| --- | --- | --- |
+| Connection refused / timeout | Opaque shell error | Host vs allow/deny + default action |
+| 401 / wrong auth | Placeholder may exist; policy opaque | Env name is **secret**, hosts, header names — **not** value |
+| Env unset | `printenv` useless or dangerous | Configured names + kind + scope |
+| Command blocked | Sometimes a deny pattern | Optional command-policy summary |
+
+### Architecture (existing)
+
+**Network policy** (`SandboxPolicy`):
+
+- `network_default_action` (`allow` | `deny`)
+- `network_rules` JSON `[{action, target}, …]`
+- `command_rules`, image, resources
+- Built via `sandbox_policy/rules.py` → egress sidecar
+- Admin API `GET/PUT` sandbox policy
+
+**Env** (`SandboxEnvVar`):
+
+- `env_name`, `is_secret`, `scope` (`org` | `workspace` | `user`)
+- Secrets: `hosts`, `header_names`, `status`, `credential_id`
+- Resolution: user > workspace > org (`SandboxEnvService.resolve`)
+- Plain values injected for real; secrets become host-scoped placeholders
+- UI/API already list metadata without re-displaying secret values after save
+
+**Agent surface today**:
+
+- `SANDBOX_PROMPT_TEMPLATE` is workdir / file-tools centric only
+- Command deny messages at runtime for some cases
+- No `sandbox_config` / policy tool
+- Agent *can* `printenv` — **discouraged** as primary design (leaks plain
+  secrets into transcript or shows useless placeholders)
+
+## Goals
+
+1. **Effective network policy** visible in compact non-secret form.
+2. **Env inventory**: name + kind + scope + status + secret host/header
+   constraints — **never** plaintext secret values.
+3. Short prompt rules for diagnosis and when to send the user to settings.
+4. Respect **prompt-cache discipline**: prefer on-demand tool for full dump;
+   keep any always-on text tiny and stable.
+5. Prefer DB metadata over scraping the sandbox environment.
+
+## Non-goals
+
+- Exposing secret values, vault ciphertext, or placeholder→secret mapping.
+- Letting the agent **mutate** network policy or env entries from chat.
+- Full packet capture / MITM debug logs.
+- Replacing command HITL confirm flows.
+
+## Design
+
+### What to expose
+
+#### A. Network policy (safe)
+
+```text
+network_default_action: deny
+rules:
+  - allow  pypi.org, files.pythonhosted.org
+  - allow  registry.npmjs.org
+  - deny   *.evil.example
+egress_proxy: set|unset   # presence only, never credentials
+```
+
+Enough for: “Is `api.github.com` allowed under current policy?”
+
+Optional one-liner: policy is applied at sandbox creation; admin changes may
+require a new sandbox (align with deploy docs).
+
+#### B. Env inventory (names + types only)
+
+Per **effective** entry after scope merge for this run’s org/workspace/user
+(same merge as injection):
+
+| Field | Include? |
+| --- | --- |
+| `env_name` | Yes |
+| `kind` / `is_secret` | Yes (`plain` / `secret`) |
+| `scope` | Yes |
+| `status` | Yes |
+| `hosts` | Yes for secrets |
+| `header_names` | Yes if set |
+| **value / secret** | **Never** |
+| placeholder string | Prefer **no** |
+| `credential_id` | Prefer **no** |
+
+Plain entries: inventory says the name is configured; agent may read the value
+inside the sandbox only when needed for execution — **not** dump into the
+system prompt.
+
+#### C. Command policy (v1 optional, recommended if cheap)
+
+Short list of deny/confirm patterns so the agent avoids known-denied commands
+and understands HITL confirms are policy, not random errors.
+
+### Delivery: hybrid (chosen)
+
+| Layer | Content |
+| --- | --- |
+| **Stable prompt blurb** | Fixed short guidance: egress/env are admin-configured; call `sandbox_config` on network/auth failure; never print secrets; secrets use host-scoped placeholders. |
+| **Tool `sandbox_config`** | JSON: network summary + env inventory (+ optional command rules). Read DB at call time. |
+| **Later optional** | Structured one-line hints on blocked egress / policy_deny execute errors |
+
+Why not always-on full dump: token cost and cache busts when admin edits.
+Why not tool-only: agent must remember to call; a short blurb raises recall.
+
+### Prompt playbook (agent behavior)
+
+When network or auth fails:
+
+1. Call `sandbox_config` (or use prior result if still relevant).
+2. Host denied / default deny → tell user which allow rule is missing; point to
+   Admin → Sandbox network policy (conceptual path).
+3. Env name missing → ask user to add plain/secret env at correct scope.
+4. Secret exists but host not allowed → ask to add host to that secret’s
+   allowlist (or use an allowed host).
+5. Do not invent API keys; do not ask user to paste secrets into chat if the
+   settings UI exists.
+6. Never echo secret values or vault material.
+
+### Security
+
+- Same visibility bar as workspace members listing env metadata (no values).
+- Org policy is OK to show to agents running in that org’s sandboxes.
+- Cap rule list and env list (e.g. 100) with a `truncated: true` marker.
+- Treat env **names** as untrusted data (prompt injection); never execute them.
+- Unit tests: serialization helpers never include value/secret fields.
+
+### Cache / freshness
+
+- Tool path: always read DB at call time.
+- Prompt blurb: static; does not include live rules.
+- Optional future inline summary would need deterministic snapshot discipline.
+
+## Phasing
+
+| Phase | Deliverable |
+| --- | --- |
+| **1** | `sandbox_config` tool: network rules + env inventory (no values); redaction tests |
+| **2** | Short sandbox prompt guidance + failure-diagnosis playbook |
+| **3** | Optional: structured hints on blocked egress / policy_deny execute errors |
+| **4** | Optional: compact always-on summary if token budget allows |
+
+## Acceptance criteria
+
+1. Agent can obtain network default action + rules without user screenshots.
+2. Agent can obtain env inventory (name, plain vs secret, scope, status; secrets
+   include hosts and header_names if any); **no secret values** in tool results
+   or system prompt.
+3. Blocked-host diagnosis cites policy (eval or e2e with mocked policy).
+4. Missing vs present env name is distinguishable (“not configured” vs
+   “configured as secret for hosts […]”).
+5. Unit tests ensure secret values never appear in serialization helpers.
+6. Docs note: agent can see policy/env **metadata** for troubleshooting.
+
+## Open questions (v1 decisions)
+
+| Question | Decision |
+| --- | --- |
+| Prompt vs tool vs hybrid | **Hybrid** |
+| Command rules in v1 | **Include if present on policy row** (cheap, high value) |
+| Org env visibility | **Effective merge** as injected into the sandbox |
+| Auto error enrichment | **Phase 3** optional |
+| Egress proxy | Presence only, never credentials |
+
+## Related code
+
+- `backend/cubeplex/models/sandbox_policy.py`, `sandbox_env.py`
+- `backend/cubeplex/sandbox_policy/rules.py`
+- `backend/cubeplex/services/sandbox_env.py` (`ResolvedEnv`, `resolve`)
+- `backend/cubeplex/services/sandbox_policy.py`
+- `backend/cubeplex/sandbox_env/injector.py`
+- `backend/cubeplex/prompts/sandbox.py`, `middleware/sandbox.py`
+- `docs/site/docs/admin/sandbox.md`
+- `backend/docs/prompt-cache-discipline.md`

--- a/docs/dev/specs/2026-07-22-sandbox-config-to-agent-design.md
+++ b/docs/dev/specs/2026-07-22-sandbox-config-to-agent-design.md
@@ -85,19 +85,29 @@ require a new sandbox (align with deploy docs).
 #### B. Env inventory (names + types only)
 
 Per **effective** entry after scope merge for this run’s org/workspace/user
-(same merge as injection):
+(same merge as injection).
+
+**DTO requirement:** `ResolvedEnv` today has `env_name`, `is_secret`, `hosts`,
+`header_names`, `credential_id`, optional `value` — **not** `scope` or
+`status`. Implementation must introduce an agent-facing metadata DTO (or extend
+resolution with a parallel non-secret view) that carries the **winning row’s**
+`scope` and `status` without ever attaching decrypted values.
 
 | Field | Include? |
 | --- | --- |
 | `env_name` | Yes |
 | `kind` / `is_secret` | Yes (`plain` / `secret`) |
-| `scope` | Yes |
-| `status` | Yes |
+| `scope` | Yes (from winning row) |
+| `status` | Yes (from winning row; invalid winners reported if present) |
 | `hosts` | Yes for secrets |
 | `header_names` | Yes if set |
 | **value / secret** | **Never** |
 | placeholder string | Prefer **no** |
-| `credential_id` | Prefer **no** |
+| `credential_id` | **Never** |
+
+Invalid / suppressed rows: document v1 choice — **omit non-winning and
+non-resolvable entries** (match inject set) unless a row wins but is invalid
+(then show `status` so the agent can say “configured but not injectable”).
 
 Plain entries: inventory says the name is configured; agent may read the value
 inside the sandbox only when needed for execution — **not** dump into the
@@ -135,15 +145,31 @@ When network or auth fails:
 
 ### Security
 
-- Same visibility bar as workspace members listing env metadata (no values).
-- Org policy is OK to show to agents running in that org’s sandboxes.
+- **Authz (explicit, not “same as member list”)**: today members may list only
+  **user-scoped** env rows; workspace- and org-scoped env metadata and org
+  network policy require **admin** APIs. The agent tool intentionally exposes
+  the **effective inject set** for this run (names + kinds + secret host/header
+  constraints — never values) so diagnosis matches runtime. That is a deliberate
+  expansion of what a member can see via HTTP for org/workspace env **names**.
+  Document this product decision; do **not** claim parity with list APIs.
 - Cap rule list and env list (e.g. 100) with a `truncated: true` marker.
-- Treat env **names** as untrusted data (prompt injection); never execute them.
-- Unit tests: serialization helpers never include value/secret fields.
+- Treat env **names** and rule **patterns** as untrusted data (prompt injection);
+  never execute them.
+- Serializers must **whitelist fields only** (no `model_dump()` / raw JSON
+  passthrough of rule dicts). Tests must plant forbidden extra keys and assert
+  recursive absence of values, `credential_id`, proxy credentials, and unknown keys.
 
 ### Cache / freshness
 
-- Tool path: always read DB at call time.
+- Tool path: read **current** org policy + effective env from DB at call time.
+- **Sandbox policy may be stale**: network policy is structural and applied at
+  sandbox **create** (manager does not re-apply on reuse). Tool output must
+  include a clear note that DB policy is “desired / next create”, and when
+  possible flag drift if the active sandbox record can expose which policy was
+  applied (image drift already exists as precedent). Prefer wording:
+  `policy_source: "org_db_current"` + `sandbox_note: "network rules apply at
+  create; recreate sandbox after admin changes"`. Do not claim live enforcement
+  of newly edited rules on an old sandbox.
 - Prompt blurb: static; does not include live rules.
 - Optional future inline summary would need deterministic snapshot discipline.
 

--- a/docs/dev/specs/2026-07-22-sandbox-config-to-agent-design.md
+++ b/docs/dev/specs/2026-07-22-sandbox-config-to-agent-design.md
@@ -50,9 +50,11 @@ user for vague screenshots — **never** exposing secret values.
 1. **Effective network policy** visible in compact non-secret form.
 2. **Env inventory**: name + kind + scope + status + secret host/header
    constraints — **never** plaintext secret values.
-3. Short prompt rules for diagnosis and when to send the user to settings.
-4. Respect **prompt-cache discipline**: prefer on-demand tool for full dump;
-   keep any always-on text tiny and stable.
+3. Teach diagnosis via **tool description + result guidance** (and optional
+   error-path hints later) — **not** by growing the stable system prompt.
+4. Respect **prompt-cache discipline**: full dump only on-demand via tool;
+   leave `SANDBOX_PROMPT_TEMPLATE` free of live policy/env and free of a
+   diagnosis playbook.
 5. Prefer DB metadata over scraping the sandbox environment.
 
 ## Non-goals
@@ -61,6 +63,8 @@ user for vague screenshots — **never** exposing secret values.
 - Letting the agent **mutate** network policy or env entries from chat.
 - Full packet capture / MITM debug logs.
 - Replacing command HITL confirm flows.
+- Injecting live policy/env (or a long diagnosis blurb) into the system prompt.
+- Wrapping `sandbox_config` in a `DeferredToolGroup` in v1 (see Delivery).
 
 ## Design
 
@@ -118,18 +122,37 @@ system prompt.
 Short list of deny/confirm patterns so the agent avoids known-denied commands
 and understands HITL confirms are policy, not random errors.
 
-### Delivery: hybrid (chosen)
+### Delivery: tool-only (chosen)
 
 | Layer | Content |
 | --- | --- |
-| **Stable prompt blurb** | Fixed short guidance: egress/env are admin-configured; call `sandbox_config` on network/auth failure; never print secrets; secrets use host-scoped placeholders. |
-| **Tool `sandbox_config`** | JSON: network summary + env inventory (+ optional command rules). Read DB at call time. |
-| **Later optional** | Structured one-line hints on blocked egress / policy_deny execute errors |
+| **Eager tool `sandbox_config`** | Registered with other sandbox tools (`execute`, `write_file`, …) when the sandbox is available. JSON: network summary + env inventory (+ optional command rules). Read DB at call time. |
+| **Tool description + result guidance** | When to call (network/auth/env failures); never print secrets; point user to settings for missing allow rules / env entries. Optional short `guidance` field in the tool result so the playbook is not system-prompt-resident. |
+| **System prompt** | **No change** for this feature: keep existing workdir / file-tools sandbox section. Do **not** append a diagnosis blurb; do **not** interpolate live rules or env names. |
+| **Later optional** | Structured one-line hints on blocked egress / policy_deny execute errors (error path, not stable prefix). |
+
+#### Why not hybrid prompt blurb
+
+- Matches other on-demand capabilities (`conversation_history`, `artifacts`):
+  discovery via tool surface, data only after the agent calls.
+- Avoids growing the always-on system prompt (#391 / #412 direction).
+- Cache-safe by construction: no new stable-prefix fragment at all.
+
+#### Why not `DeferredToolGroup` in v1
+
+Deferred groups (`cubeplex:conversation_history`, MCP servers, …) hide **many
+tool schemas** behind a catalog line + `load_tools`. `sandbox_config` is a
+**single small diagnostic tool** used on the failure path — a deferred group
+still costs catalog text in the system prompt and an extra `load_tools`
+round-trip with almost no schema savings (same reason `generate_image` stays
+eager). Register it eagerly next to other sandbox tools.
+
+If diagnosis later grows into multiple ops (e.g. network check, env lookup),
+revisit a `cubeplex:sandbox_runtime` deferred group then.
 
 Why not always-on full dump: token cost and cache busts when admin edits.
-Why not tool-only: agent must remember to call; a short blurb raises recall.
 
-### Prompt playbook (agent behavior)
+### Agent behavior (encoded in tool description / result, not system prompt)
 
 When network or auth fails:
 
@@ -170,17 +193,17 @@ When network or auth fails:
   `policy_source: "org_db_current"` + `sandbox_note: "network rules apply at
   create; recreate sandbox after admin changes"`. Do not claim live enforcement
   of newly edited rules on an old sandbox.
-- Prompt blurb: static; does not include live rules.
+- No new system-prompt fragment → no extra cache surface for this feature.
 - Optional future inline summary would need deterministic snapshot discipline.
 
 ## Phasing
 
 | Phase | Deliverable |
 | --- | --- |
-| **1** | `sandbox_config` tool: network rules + env inventory (no values); redaction tests |
-| **2** | Short sandbox prompt guidance + failure-diagnosis playbook |
+| **1** | Safe serializers + redaction tests |
+| **2** | Eager `sandbox_config` tool (description + optional result guidance); wiring with other sandbox tools |
 | **3** | Optional: structured hints on blocked egress / policy_deny execute errors |
-| **4** | Optional: compact always-on summary if token budget allows |
+| **4** | Optional: deferred multi-op group **only if** more sandbox-diagnosis tools appear; not a v1 goal |
 
 ## Acceptance criteria
 
@@ -193,15 +216,18 @@ When network or auth fails:
    “configured as secret for hosts […]”).
 5. Unit tests ensure secret values never appear in serialization helpers.
 6. Docs note: agent can see policy/env **metadata** for troubleshooting.
+7. `SANDBOX_PROMPT_TEMPLATE` (or equivalent always-on sandbox section) does
+   **not** gain a diagnosis blurb or live policy/env dump for this feature.
 
 ## Open questions (v1 decisions)
 
 | Question | Decision |
 | --- | --- |
-| Prompt vs tool vs hybrid | **Hybrid** |
+| Prompt vs tool vs hybrid | **Tool-only** (eager `sandbox_config`; no system-prompt blurb) |
+| DeferredToolGroup | **No** for v1 single tool |
 | Command rules in v1 | **Include if present on policy row** (cheap, high value) |
 | Org env visibility | **Effective merge** as injected into the sandbox |
-| Auto error enrichment | **Phase 3** optional |
+| Auto error enrichment | **Phase 3** optional (preferred over prompt blurb if recall is weak) |
 | Egress proxy | Presence only, never credentials |
 
 ## Related code
@@ -212,5 +238,6 @@ When network or auth fails:
 - `backend/cubeplex/services/sandbox_policy.py`
 - `backend/cubeplex/sandbox_env/injector.py`
 - `backend/cubeplex/prompts/sandbox.py`, `middleware/sandbox.py`
+- `backend/cubeplex/agents/actions/registry.py` (deferred capability pattern — **not** used for v1)
 - `docs/site/docs/admin/sandbox.md`
 - `backend/docs/prompt-cache-discipline.md`

--- a/docs/site/docs/admin/sandbox.md
+++ b/docs/site/docs/admin/sandbox.md
@@ -59,6 +59,23 @@ Use **Confirm** for sensitive operations you want a person to sign off on, and *
 Each sandbox run also has an execution timeout: long-running commands are cut off automatically so a stuck process cannot hold a sandbox open indefinitely.
 :::
 
+### Agent troubleshooting metadata
+
+When a sandbox is available for a conversation, the agent can call a
+**`sandbox_config`** tool to read a non-secret diagnosis view of:
+
+- Org **network** default action and host allow/deny rules
+- **Command** deny/confirm patterns (if configured)
+- Effective **env inventory** for the run (name, plain vs secret, scope;
+  for secrets: allowed hosts and header names) — **never secret values**
+
+This is intentional for diagnosis: the agent may see org- and workspace-scoped
+env **names** that a member cannot list via the user-scoped HTTP APIs. Values
+and vault credentials are never included. Network rules apply at sandbox
+**create**; after you change policy, recreate the sandbox for the new rules to
+take effect. On command policy denials, the agent is nudged to call
+`sandbox_config` rather than inventing credentials or dumping `printenv`.
+
 ## Environment variables and secrets
 
 You can inject environment variables and secrets into the sandbox at runtime. This lets the agent's code access API keys, database URLs, or configuration values without hardcoding them.


### PR DESCRIPTION
## Summary

Spec + plan only for exposing sandbox network policy and env metadata to the agent (never secret values), via hybrid tool + short prompt guidance.

Related: #398

Implementation is deferred; this PR freezes the design and phased plan under `docs/dev/`.

## Docs

- `docs/dev/specs/2026-07-22-sandbox-config-to-agent-design.md`
- `docs/dev/plans/2026-07-22-sandbox-config-to-agent.md`

## Test plan

- [ ] Spec/plan review against issue acceptance criteria
- [ ] No code changes expected in this PR