### PR TITLE
Agent update workspace persona

### DIFF
--- a/backend/cubeplex/api/routes/v1/conversations.py
+++ b/backend/cubeplex/api/routes/v1/conversations.py
@@ -77,6 +77,24 @@ router = APIRouter(prefix="/ws/{workspace_id}/conversations", tags=["conversatio
 logger = logging.getLogger(__name__)
 
 
+async def _trigger_for_resume(
+    rds: RedisHandle,
+    *,
+    run_id: str,
+    fallback: str = "interactive",
+) -> str:
+    """Restore the original run trigger for HITL resume / cancel.
+
+    Persona writes and other interactive-only tools key off ``RunContext.trigger``.
+    HTTP resume must not silently default non-interactive (schedule/IM/automated)
+    runs back to interactive.
+    """
+    meta = await get_run_meta(rds.client, prefix=rds.key_prefix, run_id=run_id)
+    if meta is not None and meta.trigger:
+        return meta.trigger
+    return fallback
+
+
 async def _resolve_topic_run_context(
     conversation: Conversation,
     ctx: RequestContext,
@@ -1914,13 +1932,6 @@ async def cancel_active_run(
     from cubeplex.agents.checkpointer import shared_checkpointer
 
     run_manager = raw_request.app.state.run_manager
-    run_ctx = RunContext(
-        user_id=ctx.user.id,
-        org_id=ctx.org_id,
-        workspace_id=ctx.workspace_id,
-        conversation_id=conversation_id,
-        conversation_creator_user_id=conversation.creator_user_id,
-    )
 
     # Cancel-on-paused dispatch — covers both the live paused_hitl case
     # AND the long-pause TTL-expired case where the Redis active-run row
@@ -1938,6 +1949,14 @@ async def cancel_active_run(
             paused_run_id = persisted_run_id
 
     if paused_run_id is not None:
+        run_ctx = RunContext(
+            user_id=ctx.user.id,
+            org_id=ctx.org_id,
+            workspace_id=ctx.workspace_id,
+            conversation_id=conversation_id,
+            conversation_creator_user_id=conversation.creator_user_id,
+            trigger=await _trigger_for_resume(rds, run_id=paused_run_id),
+        )
         try:
             await run_manager.cancel_paused_run(
                 conversation_id=conversation_id,
@@ -2166,6 +2185,7 @@ async def submit_sandbox_confirm(
         sandbox_mode=_sandbox_mode,
         topic_creator_user_id=_topic_creator_user_id,
         conversation_creator_user_id=conversation.creator_user_id,
+        trigger=await _trigger_for_resume(rds, run_id=run_id),
     )
     try:
         new_run_id = await run_manager.resume_run_with_answer(
@@ -2271,6 +2291,7 @@ async def submit_ask_user_answer(
         sandbox_mode=_sandbox_mode,
         topic_creator_user_id=_topic_creator_user_id,
         conversation_creator_user_id=conversation.creator_user_id,
+        trigger=await _trigger_for_resume(rds, run_id=run_id),
     )
     try:
         new_run_id = await run_manager.resume_run_with_answer(

--- a/backend/cubeplex/api/routes/v1/ws_settings.py
+++ b/backend/cubeplex/api/routes/v1/ws_settings.py
@@ -11,9 +11,7 @@ from pathlib import Path
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
 
 from cubeplex.api.schemas.ws_settings import (
     AgentConfigOut,
@@ -27,12 +25,15 @@ from cubeplex.auth.context import RequestContext
 from cubeplex.auth.dependencies import require_member
 from cubeplex.config import config as _config
 from cubeplex.db import get_session
-from cubeplex.models.agent_config import AgentConfig
 from cubeplex.repositories.organization import OrganizationRepository
 from cubeplex.repositories.skill import (
     OrgSkillInstallRepository,
     SkillVersionRepository,
     WorkspaceSkillBindingRepository,
+)
+from cubeplex.services.agent_config import (
+    get_or_create_agent_config,
+    set_system_prompt,
 )
 from cubeplex.skills.cache import SkillCache
 from cubeplex.skills.frontmatter import InvalidFrontmatterError
@@ -47,41 +48,12 @@ from cubeplex.skills.service import (
 router = APIRouter(prefix="/ws/{workspace_id}/settings", tags=["workspace-settings"])
 
 
-async def _get_or_create_agent_config(
-    session: AsyncSession, org_id: str, workspace_id: str
-) -> AgentConfig:
-    result = await session.execute(
-        select(AgentConfig).where(
-            AgentConfig.org_id == org_id,
-            AgentConfig.workspace_id == workspace_id,
-        )
-    )
-    cfg = result.scalar_one_or_none()
-    if cfg is not None:
-        return cfg
-    try:
-        cfg = AgentConfig(org_id=org_id, workspace_id=workspace_id)
-        session.add(cfg)
-        await session.commit()
-        await session.refresh(cfg)
-        return cfg
-    except IntegrityError:
-        await session.rollback()
-        result = await session.execute(
-            select(AgentConfig).where(
-                AgentConfig.org_id == org_id,
-                AgentConfig.workspace_id == workspace_id,
-            )
-        )
-        return result.scalar_one()
-
-
 @router.get("/agent", response_model=AgentConfigOut)
 async def get_agent_config(
     ctx: Annotated[RequestContext, Depends(require_member)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> AgentConfigOut:
-    cfg = await _get_or_create_agent_config(session, ctx.org_id, ctx.workspace_id)
+    cfg = await get_or_create_agent_config(session, ctx.org_id, ctx.workspace_id)
     return AgentConfigOut(system_prompt=cfg.system_prompt)
 
 
@@ -91,11 +63,7 @@ async def update_agent_config(
     ctx: Annotated[RequestContext, Depends(require_member)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> AgentConfigOut:
-    cfg = await _get_or_create_agent_config(session, ctx.org_id, ctx.workspace_id)
-    cfg.system_prompt = body.system_prompt
-    session.add(cfg)
-    await session.commit()
-    await session.refresh(cfg)
+    cfg = await set_system_prompt(session, ctx.org_id, ctx.workspace_id, body.system_prompt)
     return AgentConfigOut(system_prompt=cfg.system_prompt)
 
 

--- a/backend/cubeplex/prompts/persona.py
+++ b/backend/cubeplex/prompts/persona.py
@@ -1,0 +1,24 @@
+"""System prompt fragment for workspace persona tools vs memory."""
+
+PERSONA_AUTHORING_BLOCK: str = """\
+## Workspace Agent Persona
+
+This workspace has an **Agent Persona** (Settings → Agent Persona): standing
+system instructions for every conversation here. Tools:
+
+- `persona_get` — read the current persona text.
+- `persona_update` — full replace of the persona (interactive runs only).
+
+**Use persona when** the user wants a durable role / standing policy for the
+whole workspace agent ("always answer in formal Chinese", "you are a staff
+engineer for this repo", "never deploy without asking", 人设 / system
+instructions).
+
+**Use memory (`memory_save` / `memory_update`) when** the item is a small typed
+fact or preference and the user did not ask to change persona / system
+instructions.
+
+Persona is **workspace-wide** — updates affect all members. Overwriting a
+non-empty persona requires user confirmation. Never put secrets in the persona.
+Max 8000 characters. Changes apply on subsequent turns (not mid-stream).
+"""

--- a/backend/cubeplex/services/agent_config.py
+++ b/backend/cubeplex/services/agent_config.py
@@ -76,20 +76,36 @@ async def set_system_prompt(
 ) -> AgentConfig:
     """Replace workspace persona text.
 
-    ``expected_fingerprint`` — when set, commit only if the current prompt
-    still hashes to this value (optimistic concurrency for HITL overwrite).
+    ``expected_fingerprint`` — when set, the row is locked with
+    ``SELECT … FOR UPDATE`` and the write commits only if the current prompt
+    still hashes to this value (optimistic concurrency for HITL overwrite,
+    safe against concurrent Settings/agent writers).
     """
     if len(text) > PERSONA_MAX_LENGTH:
         raise PersonaTooLongError(
             f"persona exceeds max length {PERSONA_MAX_LENGTH} (got {len(text)})"
         )
-    cfg = await get_or_create_agent_config(session, org_id, workspace_id)
-    current = cfg.system_prompt or ""
+
     if expected_fingerprint is not None:
+        # Ensure the row exists first (may commit once on create).
+        await get_or_create_agent_config(session, org_id, workspace_id)
+        result = await session.execute(
+            select(AgentConfig)
+            .where(
+                AgentConfig.org_id == org_id,
+                AgentConfig.workspace_id == workspace_id,
+            )
+            .with_for_update()
+        )
+        cfg = result.scalar_one()
+        current = cfg.system_prompt or ""
         if persona_fingerprint(current) != expected_fingerprint:
             raise PersonaConflictError(
                 "persona changed since confirmation started; re-read and try again"
             )
+    else:
+        cfg = await get_or_create_agent_config(session, org_id, workspace_id)
+
     cfg.system_prompt = text
     session.add(cfg)
     await session.commit()

--- a/backend/cubeplex/services/agent_config.py
+++ b/backend/cubeplex/services/agent_config.py
@@ -86,25 +86,25 @@ async def set_system_prompt(
             f"persona exceeds max length {PERSONA_MAX_LENGTH} (got {len(text)})"
         )
 
-    if expected_fingerprint is not None:
-        # Ensure the row exists first (may commit once on create).
-        await get_or_create_agent_config(session, org_id, workspace_id)
-        result = await session.execute(
-            select(AgentConfig)
-            .where(
-                AgentConfig.org_id == org_id,
-                AgentConfig.workspace_id == workspace_id,
-            )
-            .with_for_update()
+    # Always lock the row before mutating so concurrent Settings PUT and
+    # agent HITL commits cannot last-write-win over each other on a stale
+    # ORM object. get_or_create may commit once if the row is missing.
+    await get_or_create_agent_config(session, org_id, workspace_id)
+    result = await session.execute(
+        select(AgentConfig)
+        .where(
+            AgentConfig.org_id == org_id,
+            AgentConfig.workspace_id == workspace_id,
         )
-        cfg = result.scalar_one()
-        current = cfg.system_prompt or ""
+        .with_for_update()
+    )
+    cfg = result.scalar_one()
+    current = cfg.system_prompt or ""
+    if expected_fingerprint is not None:
         if persona_fingerprint(current) != expected_fingerprint:
             raise PersonaConflictError(
                 "persona changed since confirmation started; re-read and try again"
             )
-    else:
-        cfg = await get_or_create_agent_config(session, org_id, workspace_id)
 
     cfg.system_prompt = text
     session.add(cfg)

--- a/backend/cubeplex/services/agent_config.py
+++ b/backend/cubeplex/services/agent_config.py
@@ -1,0 +1,97 @@
+"""Shared AgentConfig (workspace persona) service.
+
+Used by ``GET/PUT /settings/agent`` and by ``persona_get`` / ``persona_update``
+tools so validation and get-or-create stay in one place.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from cubeplex.models.agent_config import AgentConfig
+
+PERSONA_MAX_LENGTH = 8000
+
+
+class PersonaTooLongError(ValueError):
+    """Raised when system_prompt exceeds PERSONA_MAX_LENGTH."""
+
+
+class PersonaConflictError(ValueError):
+    """Raised when optimistic concurrency fingerprint does not match."""
+
+
+def persona_fingerprint(text: str) -> str:
+    """Short stable fingerprint of persona text for optimistic concurrency."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+async def get_or_create_agent_config(
+    session: AsyncSession, org_id: str, workspace_id: str
+) -> AgentConfig:
+    """Load workspace AgentConfig, creating an empty row if missing."""
+    result = await session.execute(
+        select(AgentConfig).where(
+            AgentConfig.org_id == org_id,
+            AgentConfig.workspace_id == workspace_id,
+        )
+    )
+    cfg = result.scalar_one_or_none()
+    if cfg is not None:
+        return cfg
+    try:
+        cfg = AgentConfig(org_id=org_id, workspace_id=workspace_id)
+        session.add(cfg)
+        await session.commit()
+        await session.refresh(cfg)
+        return cfg
+    except IntegrityError:
+        await session.rollback()
+        result = await session.execute(
+            select(AgentConfig).where(
+                AgentConfig.org_id == org_id,
+                AgentConfig.workspace_id == workspace_id,
+            )
+        )
+        return result.scalar_one()
+
+
+async def get_system_prompt(session: AsyncSession, org_id: str, workspace_id: str) -> str:
+    """Return current workspace persona text (empty string if none)."""
+    cfg = await get_or_create_agent_config(session, org_id, workspace_id)
+    return cfg.system_prompt or ""
+
+
+async def set_system_prompt(
+    session: AsyncSession,
+    org_id: str,
+    workspace_id: str,
+    text: str,
+    *,
+    expected_fingerprint: str | None = None,
+) -> AgentConfig:
+    """Replace workspace persona text.
+
+    ``expected_fingerprint`` — when set, commit only if the current prompt
+    still hashes to this value (optimistic concurrency for HITL overwrite).
+    """
+    if len(text) > PERSONA_MAX_LENGTH:
+        raise PersonaTooLongError(
+            f"persona exceeds max length {PERSONA_MAX_LENGTH} (got {len(text)})"
+        )
+    cfg = await get_or_create_agent_config(session, org_id, workspace_id)
+    current = cfg.system_prompt or ""
+    if expected_fingerprint is not None:
+        if persona_fingerprint(current) != expected_fingerprint:
+            raise PersonaConflictError(
+                "persona changed since confirmation started; re-read and try again"
+            )
+    cfg.system_prompt = text
+    session.add(cfg)
+    await session.commit()
+    await session.refresh(cfg)
+    return cfg

--- a/backend/cubeplex/streams/run_events.py
+++ b/backend/cubeplex/streams/run_events.py
@@ -55,6 +55,10 @@ class RunMeta:
     error_code: str | None = None
     error_params: str | None = None  # JSON-encoded dict (Redis hash values are strings)
     error_message: str | None = None  # English fallback shown to non-Web clients
+    # Origin of the run (interactive / im / schedule / automated / …).
+    # Persisted so HITL HTTP resume rebuilds RunContext with the same
+    # write-gating as the original turn (e.g. persona_update allow_write).
+    trigger: str | None = None
 
 
 @dataclass(slots=True)
@@ -218,6 +222,7 @@ def _meta_from_hash(raw: dict[str, str]) -> RunMeta | None:
         error_code=raw.get("error_code"),
         error_params=raw.get("error_params"),
         error_message=raw.get("error_message"),
+        trigger=raw.get("trigger"),
     )
 
 
@@ -231,6 +236,7 @@ async def create_run(
     started_at: str,
     user_message: str | None = None,
     ttl_seconds: int,
+    trigger: str | None = None,
 ) -> RunMeta | None:
     """Atomically claim the active-run slot for a conversation.
 
@@ -243,6 +249,7 @@ async def create_run(
         status=status,
         started_at=started_at,
         user_message=user_message,
+        trigger=trigger,
     )
     pairs = _meta_hash_pairs(meta)
 

--- a/backend/cubeplex/streams/run_manager.py
+++ b/backend/cubeplex/streams/run_manager.py
@@ -2946,6 +2946,23 @@ class RunManager:
         )
         _builtin_tools.append(ask_user_tool(sandbox_hitl_channel))
 
+        # persona_get always; persona_update only on interactive member runs
+        # (HITL overwrite requires a human-driven channel.ask). Same channel
+        # as ask_user so pending_request is durable for overwrite confirms.
+        try:
+            from cubeplex.tools.builtin.persona import create_persona_tools
+
+            _builtin_tools.extend(
+                create_persona_tools(
+                    org_id=ctx.org_id,
+                    workspace_id=ctx.workspace_id,
+                    channel=sandbox_hitl_channel,
+                    include_update=(trigger == "interactive"),
+                )
+            )
+        except Exception as _exc:
+            logger.warning("persona tools unavailable for cubepi run: {}", _exc)
+
         # 6b. SandboxMiddleware — needs sandbox. Shares the channel built above
         # so the confirm-gate writes to the same pending row the agent sees.
         if sandbox is not None:
@@ -3613,8 +3630,10 @@ class RunManager:
             # show_widget guidelines — appended unconditionally at a fixed spot
             # so the cache prefix stays deterministic (the tool is always
             # registered). See backend/docs/prompt-cache-discipline.md.
+            from cubeplex.prompts.persona import PERSONA_AUTHORING_BLOCK
             from cubeplex.prompts.widget import WIDGET_GUIDELINES
 
+            effective_system_prompt += "\n\n" + PERSONA_AUTHORING_BLOCK
             effective_system_prompt += "\n\n" + WIDGET_GUIDELINES
 
             final_status = await self._run_cubepi_path(
@@ -4185,8 +4204,10 @@ class RunManager:
             except Exception as exc:
                 logger.warning("Failed to inject available-skills list (respond): {}", exc)
 
+            from cubeplex.prompts.persona import PERSONA_AUTHORING_BLOCK
             from cubeplex.prompts.widget import WIDGET_GUIDELINES
 
+            effective_system_prompt += "\n\n" + PERSONA_AUTHORING_BLOCK
             effective_system_prompt += "\n\n" + WIDGET_GUIDELINES
 
             await self._run_cubepi_respond_path(

--- a/backend/cubeplex/streams/run_manager.py
+++ b/backend/cubeplex/streams/run_manager.py
@@ -2126,6 +2126,9 @@ class RunManager:
                 extra_ref_holder=extra_ref_holder,
                 sse_queue=sse_queue,
                 publish_stream_event=publish_stream_event,
+                # Preserve original run trigger so resume does not re-enable
+                # interactive-only writes (e.g. persona_update) for schedule/IM.
+                trigger=ctx.trigger,
             )
             extra_ref_holder["extra"] = agent._extra
 
@@ -2946,9 +2949,9 @@ class RunManager:
         )
         _builtin_tools.append(ask_user_tool(sandbox_hitl_channel))
 
-        # persona_get always; persona_update only on interactive member runs
-        # (HITL overwrite requires a human-driven channel.ask). Same channel
-        # as ask_user so pending_request is durable for overwrite confirms.
+        # persona tools: always registered (stable tool schema / prompt cache).
+        # Writes gated by trigger at execute time — interactive only.
+        # Same HITL channel as ask_user so overwrite confirms are durable.
         try:
             from cubeplex.tools.builtin.persona import create_persona_tools
 
@@ -2957,7 +2960,7 @@ class RunManager:
                     org_id=ctx.org_id,
                     workspace_id=ctx.workspace_id,
                     channel=sandbox_hitl_channel,
-                    include_update=(trigger == "interactive"),
+                    allow_write=(trigger == "interactive"),
                 )
             )
         except Exception as _exc:

--- a/backend/cubeplex/streams/run_manager.py
+++ b/backend/cubeplex/streams/run_manager.py
@@ -947,6 +947,7 @@ class RunManager:
                 started_at=started_at,
                 user_message=content,
                 ttl_seconds=self._run_event_ttl_seconds,
+                trigger=ctx.trigger,
             )
 
         created_run = await _try_create_run()

--- a/backend/cubeplex/tools/builtin/persona.py
+++ b/backend/cubeplex/tools/builtin/persona.py
@@ -1,0 +1,285 @@
+"""Workspace persona tools as cubepi.AgentTool instances.
+
+``persona_get`` / ``persona_update`` read and write ``AgentConfig.system_prompt``
+— the same field Settings → Agent Persona edits. Overwriting a non-empty
+persona requires HITL confirmation via the run-level CheckpointedChannel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.hitl.binding import HitlBinding
+from cubepi.hitl.channel import CheckpointedChannel, HitlChannel
+from cubepi.hitl.exceptions import HitlCancelled, HitlTimedOut
+from cubepi.hitl.types import Option, Question
+from cubepi.providers.base import TextContent
+from pydantic import BaseModel, Field
+
+from cubeplex.db.engine import async_session_maker
+from cubeplex.services.agent_config import (
+    PERSONA_MAX_LENGTH,
+    PersonaConflictError,
+    PersonaTooLongError,
+    get_system_prompt,
+    persona_fingerprint,
+    set_system_prompt,
+)
+
+_PREVIEW_CHARS = 280
+
+
+class PersonaGetArgs(BaseModel):
+    """No arguments — returns the current workspace persona."""
+
+
+class PersonaUpdateArgs(BaseModel):
+    system_prompt: str = Field(
+        max_length=PERSONA_MAX_LENGTH,
+        description=(
+            "Full replacement text for the workspace Agent Persona "
+            f"(max {PERSONA_MAX_LENGTH} characters). Call persona_get first "
+            "when applying an incremental change so you can compose the full "
+            "new document."
+        ),
+    )
+    reason: str = Field(
+        default="",
+        max_length=500,
+        description="Short reason shown to the user in the confirmation card.",
+    )
+
+
+def _preview(text: str, limit: int = _PREVIEW_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def _tool_result(payload: dict[str, Any], *, is_error: bool = False) -> AgentToolResult:
+    return AgentToolResult(
+        content=[TextContent(text=json.dumps(payload, ensure_ascii=False))],
+        is_error=is_error,
+    )
+
+
+def create_persona_tools(
+    *,
+    org_id: str,
+    workspace_id: str,
+    channel: HitlChannel | None = None,
+    include_update: bool = True,
+) -> list[AgentTool]:  # type: ignore[type-arg]
+    """Build persona_get and optionally persona_update tools.
+
+    ``include_update`` should be True only for interactive member-originated
+    chat runs. Scheduled / IM / automation tool lists omit the write tool.
+    ``channel`` is required when ``include_update`` is True (HITL overwrite).
+    """
+
+    async def _persona_get_execute(
+        tool_call_id: str,
+        args: PersonaGetArgs,
+        *,
+        signal: asyncio.Event | None = None,
+        on_update: object = None,
+    ) -> AgentToolResult:
+        del tool_call_id, args, signal, on_update
+        async with async_session_maker() as session:
+            text = await get_system_prompt(session, org_id, workspace_id)
+        return _tool_result(
+            {
+                "system_prompt": text,
+                "length": len(text),
+                "max_length": PERSONA_MAX_LENGTH,
+                "fingerprint": persona_fingerprint(text),
+            }
+        )
+
+    persona_get = AgentTool(
+        name="persona_get",
+        description=(
+            "Read the current workspace Agent Persona (Settings → Agent Persona / "
+            "system instructions). Returns the full text, length, and max length. "
+            "This is workspace-wide standing instructions for every conversation "
+            "in this workspace — not personal memory items."
+        ),
+        parameters=PersonaGetArgs,
+        execute=_persona_get_execute,
+    )
+
+    tools: list[AgentTool] = [persona_get]  # type: ignore[type-arg]
+
+    if not include_update:
+        return tools
+
+    if channel is None:
+        raise ValueError("persona_update requires a HITL channel")
+
+    async def _persona_update_execute(
+        tool_call_id: str,
+        args: PersonaUpdateArgs,
+        *,
+        signal: asyncio.Event | None = None,
+        on_update: object = None,
+    ) -> AgentToolResult:
+        del tool_call_id, on_update
+        new_text = args.system_prompt
+        if len(new_text) > PERSONA_MAX_LENGTH:
+            return _tool_result(
+                {
+                    "updated": False,
+                    "error": (
+                        f"persona exceeds max length {PERSONA_MAX_LENGTH} (got {len(new_text)})"
+                    ),
+                },
+                is_error=True,
+            )
+
+        async with async_session_maker() as session:
+            current = await get_system_prompt(session, org_id, workspace_id)
+
+        if current == new_text:
+            return _tool_result(
+                {
+                    "updated": False,
+                    "reason": "unchanged",
+                    "length": len(current),
+                    "max_length": PERSONA_MAX_LENGTH,
+                }
+            )
+
+        previous_length = len(current)
+        previous_hash = persona_fingerprint(current)
+        needs_confirm = bool(current.strip())
+
+        if needs_confirm:
+            reason_line = f"\nReason: {args.reason}" if args.reason.strip() else ""
+            prompt = (
+                "Update the workspace Agent Persona for ALL members of this "
+                "workspace?\n\n"
+                f"Current length: {previous_length} characters\n"
+                f"New length: {len(new_text)} characters\n"
+                f"New text preview:\n{_preview(new_text)}"
+                f"{reason_line}\n\n"
+                "This replaces Settings → Agent Persona (system instructions) "
+                "and applies on subsequent turns."
+            )
+            questions = [
+                Question(
+                    key="confirm",
+                    prompt=prompt,
+                    options=[
+                        Option(
+                            label="Approve update",
+                            value="yes",
+                            description="Replace the workspace persona with the new text",
+                        ),
+                        Option(
+                            label="Cancel",
+                            value="no",
+                            description="Keep the current persona unchanged",
+                        ),
+                    ],
+                )
+            ]
+            try:
+                answers = await channel.ask(questions, signal=signal)
+            except HitlCancelled as exc:
+                return _tool_result(
+                    {
+                        "updated": False,
+                        "reason": "cancelled",
+                        "error": str(exc.reason),
+                    }
+                )
+            except HitlTimedOut as exc:
+                return _tool_result(
+                    {
+                        "updated": False,
+                        "reason": "timed_out",
+                        "error": f"timed out after {exc.seconds} seconds",
+                    }
+                )
+
+            decision = answers.get("confirm", "")
+            if isinstance(decision, list):
+                decision = decision[0] if decision else ""
+            if str(decision).lower() not in {"yes", "approve", "approved", "true"}:
+                return _tool_result(
+                    {
+                        "updated": False,
+                        "reason": "denied",
+                        "previous_length": previous_length,
+                    }
+                )
+
+        try:
+            async with async_session_maker() as session:
+                cfg = await set_system_prompt(
+                    session,
+                    org_id,
+                    workspace_id,
+                    new_text,
+                    expected_fingerprint=previous_hash if needs_confirm else None,
+                )
+        except PersonaTooLongError as exc:
+            return _tool_result(
+                {"updated": False, "error": str(exc)},
+                is_error=True,
+            )
+        except PersonaConflictError as exc:
+            return _tool_result(
+                {
+                    "updated": False,
+                    "reason": "conflict",
+                    "error": str(exc),
+                },
+                is_error=True,
+            )
+
+        return _tool_result(
+            {
+                "updated": True,
+                "length": len(cfg.system_prompt or ""),
+                "previous_length": previous_length,
+                "max_length": PERSONA_MAX_LENGTH,
+                "workspace_wide": True,
+                "message": (
+                    "Updated workspace Agent Persona. Applies on the next turn "
+                    "for all members of this workspace."
+                ),
+            }
+        )
+
+    checkpointed = isinstance(channel, CheckpointedChannel)
+    hitl_binding = HitlBinding(
+        checkpointed=checkpointed,
+        run_id=getattr(channel, "_run_id", None) if checkpointed else None,
+    )
+    persona_update = AgentTool(
+        name="persona_update",
+        description=(
+            "Replace the workspace Agent Persona (Settings → Agent Persona — "
+            "standing system instructions for every conversation in this "
+            "workspace). Full document replace only. Affects ALL members. "
+            "Prefer memory_save for small personal preferences; use this when "
+            "the user asks to change persona / system instructions / 人设 / "
+            "workspace-wide standing behavior. Call persona_get first for "
+            "incremental edits. Overwriting a non-empty persona requires user "
+            "confirmation. Never put secrets in the persona. Max "
+            f"{PERSONA_MAX_LENGTH} characters."
+        ),
+        parameters=PersonaUpdateArgs,
+        execute=_persona_update_execute,
+        execution_mode="sequential",
+        hitl=hitl_binding,
+    )
+    # Built-in HITL tool: do not set the custom-tool durability guard so
+    # CheckpointedChannel.ask works from inside this tool body.
+    persona_update.hitl_builtin = True
+    tools.append(persona_update)
+    return tools

--- a/backend/cubeplex/tools/builtin/persona.py
+++ b/backend/cubeplex/tools/builtin/persona.py
@@ -71,13 +71,15 @@ def create_persona_tools(
     org_id: str,
     workspace_id: str,
     channel: HitlChannel | None = None,
-    include_update: bool = True,
+    allow_write: bool = True,
 ) -> list[AgentTool]:  # type: ignore[type-arg]
-    """Build persona_get and optionally persona_update tools.
+    """Build persona_get and persona_update tools.
 
-    ``include_update`` should be True only for interactive member-originated
-    chat runs. Scheduled / IM / automation tool lists omit the write tool.
-    ``channel`` is required when ``include_update`` is True (HITL overwrite).
+    Both tools are always registered so the tool schema stays stable across
+    interactive and automated turns (prompt-cache / replay). Writes are gated
+    by ``allow_write`` (True only for interactive member-originated chat).
+    ``channel`` is required for HITL on non-empty overwrite when writes are
+    allowed; may be None when ``allow_write`` is False.
     """
 
     async def _persona_get_execute(
@@ -111,13 +113,8 @@ def create_persona_tools(
         execute=_persona_get_execute,
     )
 
-    tools: list[AgentTool] = [persona_get]  # type: ignore[type-arg]
-
-    if not include_update:
-        return tools
-
-    if channel is None:
-        raise ValueError("persona_update requires a HITL channel")
+    if allow_write and channel is None:
+        raise ValueError("persona_update requires a HITL channel when allow_write=True")
 
     async def _persona_update_execute(
         tool_call_id: str,
@@ -127,6 +124,19 @@ def create_persona_tools(
         on_update: object = None,
     ) -> AgentToolResult:
         del tool_call_id, on_update
+        if not allow_write:
+            return _tool_result(
+                {
+                    "updated": False,
+                    "reason": "not_allowed",
+                    "error": (
+                        "persona_update is only available on interactive chat runs; "
+                        "scheduled/IM/automation cannot change workspace persona"
+                    ),
+                },
+                is_error=True,
+            )
+        assert channel is not None  # gated above when allow_write
         new_text = args.system_prompt
         if len(new_text) > PERSONA_MAX_LENGTH:
             return _tool_result(
@@ -281,5 +291,4 @@ def create_persona_tools(
     # Built-in HITL tool: do not set the custom-tool durability guard so
     # CheckpointedChannel.ask works from inside this tool body.
     persona_update.hitl_builtin = True
-    tools.append(persona_update)
-    return tools
+    return [persona_get, persona_update]

--- a/backend/tests/e2e/test_persona_tools.py
+++ b/backend/tests/e2e/test_persona_tools.py
@@ -1,0 +1,150 @@
+"""E2E: persona tools write the same AgentConfig row as Settings → Persona."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from cubepi.hitl import ScriptedChannel
+from fastapi.testclient import TestClient
+from sqlmodel import select
+
+import cubeplex.db as cubeplex_db
+from cubeplex.models.workspace import Workspace
+from cubeplex.tools.builtin.persona import PersonaGetArgs, PersonaUpdateArgs, create_persona_tools
+from tests.e2e.conftest import DEFAULT_WS_ID
+
+pytestmark = pytest.mark.e2e
+
+
+def _parse(result: Any) -> dict[str, Any]:
+    return json.loads(result.content[0].text)
+
+
+async def _default_org_id() -> str:
+    async with cubeplex_db.async_session_maker() as session:
+        result = await session.execute(select(Workspace).where(Workspace.id == DEFAULT_WS_ID))
+        return result.scalar_one().org_id
+
+
+class TestPersonaToolsAgainstSettings:
+    @pytest.mark.asyncio
+    async def test_tool_write_visible_via_settings_api(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty → first write via tool; GET /settings/agent returns the new text."""
+        monkeypatch.setattr(
+            "cubeplex.tools.builtin.persona.async_session_maker",
+            cubeplex_db.async_session_maker,
+        )
+
+        put = client.put(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/settings/agent",
+            json={"system_prompt": ""},
+        )
+        assert put.status_code == 200, put.text
+
+        org_id = await _default_org_id()
+        channel = ScriptedChannel([])
+        tools = create_persona_tools(
+            org_id=org_id,
+            workspace_id=DEFAULT_WS_ID,
+            channel=channel,
+            include_update=True,
+        )
+        update = next(t for t in tools if t.name == "persona_update")
+        get_tool = next(t for t in tools if t.name == "persona_get")
+        persona = "E2E persona written by persona_update tool."
+
+        result = await update.execute(
+            "tc-e2e",
+            PersonaUpdateArgs(system_prompt=persona, reason="e2e"),
+            signal=None,
+            on_update=None,
+        )
+        payload = _parse(result)
+        assert payload["updated"] is True, payload
+
+        got = await get_tool.execute("tc-get", PersonaGetArgs(), signal=None, on_update=None)
+        assert _parse(got)["system_prompt"] == persona
+
+        get2 = client.get(f"/api/v1/ws/{DEFAULT_WS_ID}/settings/agent")
+        assert get2.status_code == 200
+        assert get2.json()["system_prompt"] == persona
+
+    @pytest.mark.asyncio
+    async def test_tool_overwrite_denied_leaves_settings_unchanged(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "cubeplex.tools.builtin.persona.async_session_maker",
+            cubeplex_db.async_session_maker,
+        )
+
+        original = "Keep this persona — deny path."
+        put = client.put(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/settings/agent",
+            json={"system_prompt": original},
+        )
+        assert put.status_code == 200, put.text
+
+        org_id = await _default_org_id()
+        channel = ScriptedChannel([{"confirm": "no"}])
+        tools = create_persona_tools(
+            org_id=org_id,
+            workspace_id=DEFAULT_WS_ID,
+            channel=channel,
+            include_update=True,
+        )
+        update = next(t for t in tools if t.name == "persona_update")
+        result = await update.execute(
+            "tc-e2e-deny",
+            PersonaUpdateArgs(system_prompt="Should not land"),
+            signal=None,
+            on_update=None,
+        )
+        payload = _parse(result)
+        assert payload["updated"] is False
+        assert payload["reason"] == "denied"
+
+        get = client.get(f"/api/v1/ws/{DEFAULT_WS_ID}/settings/agent")
+        assert get.json()["system_prompt"] == original
+
+    @pytest.mark.asyncio
+    async def test_tool_overwrite_approve_updates_settings(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "cubeplex.tools.builtin.persona.async_session_maker",
+            cubeplex_db.async_session_maker,
+        )
+
+        put = client.put(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/settings/agent",
+            json={"system_prompt": "Previous persona for approve path."},
+        )
+        assert put.status_code == 200, put.text
+
+        org_id = await _default_org_id()
+        channel = ScriptedChannel([{"confirm": "yes"}])
+        tools = create_persona_tools(
+            org_id=org_id,
+            workspace_id=DEFAULT_WS_ID,
+            channel=channel,
+            include_update=True,
+        )
+        update = next(t for t in tools if t.name == "persona_update")
+        new_text = "Approved replacement persona."
+        result = await update.execute(
+            "tc-e2e-yes",
+            PersonaUpdateArgs(system_prompt=new_text, reason="approve e2e"),
+            signal=None,
+            on_update=None,
+        )
+        payload = _parse(result)
+        assert payload["updated"] is True, payload
+        assert len(channel.history) == 1
+
+        get = client.get(f"/api/v1/ws/{DEFAULT_WS_ID}/settings/agent")
+        assert get.json()["system_prompt"] == new_text

--- a/backend/tests/e2e/test_persona_tools.py
+++ b/backend/tests/e2e/test_persona_tools.py
@@ -51,7 +51,7 @@ class TestPersonaToolsAgainstSettings:
             org_id=org_id,
             workspace_id=DEFAULT_WS_ID,
             channel=channel,
-            include_update=True,
+            allow_write=True,
         )
         update = next(t for t in tools if t.name == "persona_update")
         get_tool = next(t for t in tools if t.name == "persona_get")
@@ -95,7 +95,7 @@ class TestPersonaToolsAgainstSettings:
             org_id=org_id,
             workspace_id=DEFAULT_WS_ID,
             channel=channel,
-            include_update=True,
+            allow_write=True,
         )
         update = next(t for t in tools if t.name == "persona_update")
         result = await update.execute(
@@ -132,7 +132,7 @@ class TestPersonaToolsAgainstSettings:
             org_id=org_id,
             workspace_id=DEFAULT_WS_ID,
             channel=channel,
-            include_update=True,
+            allow_write=True,
         )
         update = next(t for t in tools if t.name == "persona_update")
         new_text = "Approved replacement persona."

--- a/backend/tests/e2e/test_ws_settings.py
+++ b/backend/tests/e2e/test_ws_settings.py
@@ -33,6 +33,13 @@ class TestPersonaRuntime:
         get_resp = client.get(f"/api/v1/ws/{DEFAULT_WS_ID}/settings/agent")
         assert get_resp.json()["system_prompt"] == persona
 
+    def test_persona_rejects_over_max_length(self, client: TestClient) -> None:
+        resp = client.put(
+            f"/api/v1/ws/{DEFAULT_WS_ID}/settings/agent",
+            json={"system_prompt": "x" * 8001},
+        )
+        assert resp.status_code == 422
+
 
 class TestSkillsSettings:
     """Workspace skill binding and private skill management."""

--- a/backend/tests/unit/test_agent_config_service.py
+++ b/backend/tests/unit/test_agent_config_service.py
@@ -1,0 +1,32 @@
+"""Unit tests for agent_config (persona) service helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from cubeplex.services.agent_config import (
+    PERSONA_MAX_LENGTH,
+    PersonaTooLongError,
+    persona_fingerprint,
+    set_system_prompt,
+)
+
+
+def test_persona_fingerprint_stable() -> None:
+    assert persona_fingerprint("abc") == persona_fingerprint("abc")
+    assert persona_fingerprint("abc") != persona_fingerprint("abd")
+    assert len(persona_fingerprint("")) == 16
+
+
+@pytest.mark.asyncio
+async def test_set_system_prompt_rejects_too_long(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Avoid DB: force get_or_create not to be called by raising earlier on length.
+    with pytest.raises(PersonaTooLongError):
+        await set_system_prompt(
+            session=object(),  # type: ignore[arg-type]
+            org_id="o1",
+            workspace_id="w1",
+            text="x" * (PERSONA_MAX_LENGTH + 1),
+        )

--- a/backend/tests/unit/test_persona_authoring_prompt.py
+++ b/backend/tests/unit/test_persona_authoring_prompt.py
@@ -1,0 +1,12 @@
+"""Persona authoring prompt fragment — stable guidance contract."""
+
+from cubeplex.prompts.persona import PERSONA_AUTHORING_BLOCK
+
+
+def test_persona_authoring_mentions_tools_and_memory_boundary() -> None:
+    block = PERSONA_AUTHORING_BLOCK
+    assert "persona_get" in block
+    assert "persona_update" in block
+    assert "memory_save" in block
+    assert "workspace" in block.lower()
+    assert "8000" in block

--- a/backend/tests/unit/test_persona_tools.py
+++ b/backend/tests/unit/test_persona_tools.py
@@ -32,18 +32,19 @@ class _Cfg:
         self.system_prompt = text
 
 
-async def test_create_persona_tools_read_only_omits_update() -> None:
+async def test_create_persona_tools_always_registers_update() -> None:
+    """Tool schema is stable even when writes are disabled."""
     tools = create_persona_tools(
         org_id="o1",
         workspace_id="w1",
-        include_update=False,
+        allow_write=False,
     )
-    assert [t.name for t in tools] == ["persona_get"]
+    assert [t.name for t in tools] == ["persona_get", "persona_update"]
 
 
-async def test_create_persona_tools_with_update_requires_channel() -> None:
+async def test_create_persona_tools_with_write_requires_channel() -> None:
     with pytest.raises(ValueError, match="HITL channel"):
-        create_persona_tools(org_id="o1", workspace_id="w1", include_update=True)
+        create_persona_tools(org_id="o1", workspace_id="w1", allow_write=True)
 
 
 async def test_persona_get_returns_current(
@@ -62,7 +63,7 @@ async def test_persona_get_returns_current(
         MagicMock(return_value=cm),
     )
 
-    tools = create_persona_tools(org_id="o1", workspace_id="w1", include_update=False)
+    tools = create_persona_tools(org_id="o1", workspace_id="w1", allow_write=False)
     get = tools[0]
     result = await get.execute("tc", PersonaGetArgs(), signal=None, on_update=None)
     payload = _parse(result)
@@ -97,7 +98,7 @@ async def test_persona_update_empty_first_write_no_hitl(
         org_id="o1",
         workspace_id="w1",
         channel=channel,
-        include_update=True,
+        allow_write=True,
     )
     update = next(t for t in tools if t.name == "persona_update")
     assert getattr(update, "hitl_builtin", False) is True
@@ -145,7 +146,7 @@ async def test_persona_update_overwrite_requires_confirm_and_commits(
         org_id="o1",
         workspace_id="w1",
         channel=channel,
-        include_update=True,
+        allow_write=True,
     )
     update = next(t for t in tools if t.name == "persona_update")
     result = await update.execute(
@@ -187,7 +188,7 @@ async def test_persona_update_overwrite_denied(
         org_id="o1",
         workspace_id="w1",
         channel=channel,
-        include_update=True,
+        allow_write=True,
     )
     update = next(t for t in tools if t.name == "persona_update")
     result = await update.execute(
@@ -226,7 +227,7 @@ async def test_persona_update_conflict_on_stale_hash(
         org_id="o1",
         workspace_id="w1",
         channel=channel,
-        include_update=True,
+        allow_write=True,
     )
     update = next(t for t in tools if t.name == "persona_update")
     result = await update.execute(
@@ -239,6 +240,33 @@ async def test_persona_update_conflict_on_stale_hash(
     assert payload["updated"] is False
     assert payload["reason"] == "conflict"
     assert result.is_error is True
+
+
+async def test_persona_update_rejects_when_write_disallowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    set_mock = AsyncMock()
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.set_system_prompt",
+        set_mock,
+    )
+    tools = create_persona_tools(
+        org_id="o1",
+        workspace_id="w1",
+        allow_write=False,
+    )
+    update = next(t for t in tools if t.name == "persona_update")
+    result = await update.execute(
+        "tc",
+        PersonaUpdateArgs(system_prompt="Nope"),
+        signal=None,
+        on_update=None,
+    )
+    payload = _parse(result)
+    assert payload["updated"] is False
+    assert payload["reason"] == "not_allowed"
+    assert result.is_error is True
+    set_mock.assert_not_awaited()
 
 
 async def test_persona_update_unchanged_short_circuits(
@@ -266,7 +294,7 @@ async def test_persona_update_unchanged_short_circuits(
         org_id="o1",
         workspace_id="w1",
         channel=channel,
-        include_update=True,
+        allow_write=True,
     )
     update = next(t for t in tools if t.name == "persona_update")
     result = await update.execute(

--- a/backend/tests/unit/test_persona_tools.py
+++ b/backend/tests/unit/test_persona_tools.py
@@ -1,0 +1,281 @@
+"""Unit tests for persona_get / persona_update tools."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cubepi.hitl import ScriptedChannel
+
+from cubeplex.services.agent_config import (
+    PERSONA_MAX_LENGTH,
+    PersonaConflictError,
+    persona_fingerprint,
+)
+from cubeplex.tools.builtin.persona import (
+    PersonaGetArgs,
+    PersonaUpdateArgs,
+    create_persona_tools,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _parse(result: Any) -> dict[str, Any]:
+    return json.loads(result.content[0].text)
+
+
+class _Cfg:
+    def __init__(self, text: str) -> None:
+        self.system_prompt = text
+
+
+async def test_create_persona_tools_read_only_omits_update() -> None:
+    tools = create_persona_tools(
+        org_id="o1",
+        workspace_id="w1",
+        include_update=False,
+    )
+    assert [t.name for t in tools] == ["persona_get"]
+
+
+async def test_create_persona_tools_with_update_requires_channel() -> None:
+    with pytest.raises(ValueError, match="HITL channel"):
+        create_persona_tools(org_id="o1", workspace_id="w1", include_update=True)
+
+
+async def test_persona_get_returns_current(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.get_system_prompt",
+        AsyncMock(return_value="You are a research assistant."),
+    )
+    # session factory is entered; stub it to a no-op async CM
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    cm.__aexit__ = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.async_session_maker",
+        MagicMock(return_value=cm),
+    )
+
+    tools = create_persona_tools(org_id="o1", workspace_id="w1", include_update=False)
+    get = tools[0]
+    result = await get.execute("tc", PersonaGetArgs(), signal=None, on_update=None)
+    payload = _parse(result)
+    assert payload["system_prompt"] == "You are a research assistant."
+    assert payload["length"] == len("You are a research assistant.")
+    assert payload["max_length"] == PERSONA_MAX_LENGTH
+    assert payload["fingerprint"] == persona_fingerprint("You are a research assistant.")
+
+
+async def test_persona_update_empty_first_write_no_hitl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    set_mock = AsyncMock(return_value=_Cfg("New persona"))
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.get_system_prompt",
+        AsyncMock(return_value=""),
+    )
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.set_system_prompt",
+        set_mock,
+    )
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    cm.__aexit__ = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.async_session_maker",
+        MagicMock(return_value=cm),
+    )
+
+    channel = ScriptedChannel([])  # must not be consumed
+    tools = create_persona_tools(
+        org_id="o1",
+        workspace_id="w1",
+        channel=channel,
+        include_update=True,
+    )
+    update = next(t for t in tools if t.name == "persona_update")
+    assert getattr(update, "hitl_builtin", False) is True
+
+    result = await update.execute(
+        "tc",
+        PersonaUpdateArgs(system_prompt="New persona", reason="init"),
+        signal=None,
+        on_update=None,
+    )
+    payload = _parse(result)
+    assert payload["updated"] is True
+    assert payload["previous_length"] == 0
+    assert payload["length"] == len("New persona")
+    set_mock.assert_awaited_once()
+    # empty → first write: no expected_fingerprint
+    kwargs = set_mock.await_args.kwargs
+    assert kwargs.get("expected_fingerprint") is None
+    assert channel.history == []
+
+
+async def test_persona_update_overwrite_requires_confirm_and_commits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = "Old persona text"
+    set_mock = AsyncMock(return_value=_Cfg("Replacement persona"))
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.get_system_prompt",
+        AsyncMock(return_value=current),
+    )
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.set_system_prompt",
+        set_mock,
+    )
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    cm.__aexit__ = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.async_session_maker",
+        MagicMock(return_value=cm),
+    )
+
+    channel = ScriptedChannel([{"confirm": "yes"}])
+    tools = create_persona_tools(
+        org_id="o1",
+        workspace_id="w1",
+        channel=channel,
+        include_update=True,
+    )
+    update = next(t for t in tools if t.name == "persona_update")
+    result = await update.execute(
+        "tc",
+        PersonaUpdateArgs(system_prompt="Replacement persona", reason="user asked"),
+        signal=None,
+        on_update=None,
+    )
+    payload = _parse(result)
+    assert payload["updated"] is True
+    assert payload["previous_length"] == len(current)
+    assert len(channel.history) == 1
+    kwargs = set_mock.await_args.kwargs
+    assert kwargs["expected_fingerprint"] == persona_fingerprint(current)
+
+
+async def test_persona_update_overwrite_denied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    set_mock = AsyncMock()
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.get_system_prompt",
+        AsyncMock(return_value="Existing"),
+    )
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.set_system_prompt",
+        set_mock,
+    )
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    cm.__aexit__ = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.async_session_maker",
+        MagicMock(return_value=cm),
+    )
+
+    channel = ScriptedChannel([{"confirm": "no"}])
+    tools = create_persona_tools(
+        org_id="o1",
+        workspace_id="w1",
+        channel=channel,
+        include_update=True,
+    )
+    update = next(t for t in tools if t.name == "persona_update")
+    result = await update.execute(
+        "tc",
+        PersonaUpdateArgs(system_prompt="Would replace"),
+        signal=None,
+        on_update=None,
+    )
+    payload = _parse(result)
+    assert payload["updated"] is False
+    assert payload["reason"] == "denied"
+    set_mock.assert_not_awaited()
+
+
+async def test_persona_update_conflict_on_stale_hash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.get_system_prompt",
+        AsyncMock(return_value="Existing"),
+    )
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.set_system_prompt",
+        AsyncMock(side_effect=PersonaConflictError("stale")),
+    )
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    cm.__aexit__ = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.async_session_maker",
+        MagicMock(return_value=cm),
+    )
+
+    channel = ScriptedChannel([{"confirm": "yes"}])
+    tools = create_persona_tools(
+        org_id="o1",
+        workspace_id="w1",
+        channel=channel,
+        include_update=True,
+    )
+    update = next(t for t in tools if t.name == "persona_update")
+    result = await update.execute(
+        "tc",
+        PersonaUpdateArgs(system_prompt="Newer"),
+        signal=None,
+        on_update=None,
+    )
+    payload = _parse(result)
+    assert payload["updated"] is False
+    assert payload["reason"] == "conflict"
+    assert result.is_error is True
+
+
+async def test_persona_update_unchanged_short_circuits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    set_mock = AsyncMock()
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.get_system_prompt",
+        AsyncMock(return_value="Same"),
+    )
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.set_system_prompt",
+        set_mock,
+    )
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    cm.__aexit__ = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "cubeplex.tools.builtin.persona.async_session_maker",
+        MagicMock(return_value=cm),
+    )
+
+    channel = ScriptedChannel([])
+    tools = create_persona_tools(
+        org_id="o1",
+        workspace_id="w1",
+        channel=channel,
+        include_update=True,
+    )
+    update = next(t for t in tools if t.name == "persona_update")
+    result = await update.execute(
+        "tc",
+        PersonaUpdateArgs(system_prompt="Same"),
+        signal=None,
+        on_update=None,
+    )
+    payload = _parse(result)
+    assert payload["updated"] is False
+    assert payload["reason"] == "unchanged"
+    set_mock.assert_not_awaited()

--- a/backend/tests/unit/test_run_manager_build_agent.py
+++ b/backend/tests/unit/test_run_manager_build_agent.py
@@ -189,3 +189,101 @@ async def test_build_with_no_sandbox_still_binds_hitl_channel(
     assert isinstance(channel, CheckpointedChannel)
     stored_run_id = getattr(channel, "run_id", None) or getattr(channel, "_run_id", None)
     assert stored_run_id == _RUN_ID
+
+
+async def test_build_registers_persona_tools_for_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interactive runs get persona_get + persona_update; tools bind the HITL channel."""
+    _agent, tools, _channel = await _build(monkeypatch, sandbox=None)
+    names = {getattr(t, "name", None) for t in tools}
+    assert "persona_get" in names
+    assert "persona_update" in names
+
+
+async def test_build_omits_persona_update_for_non_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scheduled / automation runs must not expose persona_update."""
+    mock_agent = MagicMock()
+    mock_agent._extra = {}
+    monkeypatch.setattr(
+        "cubeplex.agents.graph.create_cubeplex_agent",
+        MagicMock(return_value=mock_agent),
+    )
+    from cubeplex.llm.config import ProviderConfig
+    from cubeplex.llm.snapshot import LLMSnapshot, ModelPreset
+
+    snap = LLMSnapshot(
+        providers={
+            "anthropic": ProviderConfig.model_validate(
+                {
+                    "base_url": "https://example.invalid",
+                    "api_key": "k",
+                    "api": "openai-completions",
+                    "models": [
+                        {
+                            "id": "claude-stub",
+                            "name": "claude-stub",
+                            "contextWindow": 128000,
+                            "maxTokens": 32000,
+                        }
+                    ],
+                }
+            ),
+        },
+        model_presets=(
+            ModelPreset(
+                key="default",
+                primary="anthropic/claude-stub",
+                fallbacks=(),
+                kind="tier",
+                is_default=True,
+            ),
+        ),
+        task_routing={},
+    )
+
+    async def _fake_load(*_a: Any, **_kw: Any) -> LLMSnapshot:
+        return snap
+
+    monkeypatch.setattr("cubeplex.llm.snapshot.load_llm_snapshot", _fake_load)
+    mock_bound_model = MagicMock()
+    mock_bound_model.spec.provider_id = "anthropic"
+    mock_bound_model.spec.id = "claude-stub"
+    mock_bound_model.provider = MagicMock()
+    monkeypatch.setattr(
+        "cubeplex.llm.builder.build_chain_model",
+        MagicMock(return_value=mock_bound_model),
+    )
+
+    rm = RunManager(
+        app=_stub_app(),
+        redis=MagicMock(),
+        key_prefix="test_t7",
+        run_event_ttl_seconds=60,
+    )
+    extra_ref_holder: dict[str, Any] = {"extra": None}
+    _agent, tools, _channel = await rm._build_agent_for_conversation(
+        ctx=RunContext(
+            user_id="u1",
+            org_id="o1",
+            workspace_id="w1",
+            conversation_id=_CONV_ID,
+            trigger="schedule",
+        ),
+        conversation_id=_CONV_ID,
+        run_id=_RUN_ID,
+        cp=_stub_cp(),
+        sandbox=None,
+        skill_catalog=None,
+        catalog_session=None,
+        effective_system_prompt="you are a test",
+        extra_ref_holder=extra_ref_holder,
+        sse_queue=MagicMock(),
+        publish_stream_event=MagicMock(),
+        trigger="schedule",
+    )
+    names = {getattr(t, "name", None) for t in tools}
+    assert "persona_get" in names
+    assert "persona_update" not in names

--- a/backend/tests/unit/test_run_manager_build_agent.py
+++ b/backend/tests/unit/test_run_manager_build_agent.py
@@ -201,10 +201,11 @@ async def test_build_registers_persona_tools_for_interactive(
     assert "persona_update" in names
 
 
-async def test_build_omits_persona_update_for_non_interactive(
+async def test_build_keeps_persona_update_schema_for_non_interactive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Scheduled / automation runs must not expose persona_update."""
+    """Scheduled runs still register persona_update (stable tool schema) but
+    gate writes at execute time via allow_write=False."""
     mock_agent = MagicMock()
     mock_agent._extra = {}
     monkeypatch.setattr(
@@ -257,6 +258,17 @@ async def test_build_omits_persona_update_for_non_interactive(
         MagicMock(return_value=mock_bound_model),
     )
 
+    import cubeplex.tools.builtin.persona as persona_mod
+
+    real_create = persona_mod.create_persona_tools
+    captured: dict[str, Any] = {}
+
+    def _capture_create_persona_tools(**kwargs: Any) -> list[Any]:
+        captured.update(kwargs)
+        return real_create(**kwargs)
+
+    monkeypatch.setattr(persona_mod, "create_persona_tools", _capture_create_persona_tools)
+
     rm = RunManager(
         app=_stub_app(),
         redis=MagicMock(),
@@ -286,4 +298,5 @@ async def test_build_omits_persona_update_for_non_interactive(
     )
     names = {getattr(t, "name", None) for t in tools}
     assert "persona_get" in names
-    assert "persona_update" not in names
+    assert "persona_update" in names
+    assert captured.get("allow_write") is False

--- a/backend/tests/unit/test_run_meta_trigger.py
+++ b/backend/tests/unit/test_run_meta_trigger.py
@@ -1,0 +1,51 @@
+"""RunMeta persists trigger for HITL resume write-gating."""
+
+from __future__ import annotations
+
+import fakeredis.aioredis
+import pytest
+
+from cubeplex.streams.run_events import create_run, get_run_meta
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def redis():
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+async def test_create_run_persists_trigger(redis) -> None:
+    meta = await create_run(
+        redis,
+        prefix="test_trigger",
+        run_id="run_sched_1",
+        conversation_id="conv_1",
+        status="running",
+        started_at="2026-07-23T00:00:00+00:00",
+        ttl_seconds=60,
+        trigger="schedule",
+    )
+    assert meta is not None
+    assert meta.trigger == "schedule"
+
+    loaded = await get_run_meta(redis, prefix="test_trigger", run_id="run_sched_1")
+    assert loaded is not None
+    assert loaded.trigger == "schedule"
+
+
+async def test_create_run_without_trigger_leaves_none(redis) -> None:
+    meta = await create_run(
+        redis,
+        prefix="test_trigger",
+        run_id="run_int_1",
+        conversation_id="conv_2",
+        status="running",
+        started_at="2026-07-23T00:00:00+00:00",
+        ttl_seconds=60,
+    )
+    assert meta is not None
+    assert meta.trigger is None
+    loaded = await get_run_meta(redis, prefix="test_trigger", run_id="run_int_1")
+    assert loaded is not None
+    assert loaded.trigger is None

--- a/docs/dev/plans/2026-07-22-agent-update-persona.md
+++ b/docs/dev/plans/2026-07-22-agent-update-persona.md
@@ -53,13 +53,17 @@ class PersonaUpdateArgs(BaseModel):
 - update success: `{ "updated": true, "length", "previous_length", ... }`
 - update error: clear message (too long, not confirmed, etc.)
 
-**Phase note**: Unit 2 can implement update as direct write first only if
-Unit 3 lands in the same PR; prefer not to ship non-empty overwrite without
-HITL.
+**Phase note (hard gate):** Units 2 and 3 **must ship in the same PR**. Do not
+merge a non-empty overwrite path without tool-enforced HITL. If HITL is blocked,
+reject non-empty updates or allow empty→first only.
+
+**Registration:** attach write tool only for interactive member runs (see spec).
+Automated/IM tool lists omit `persona_update`.
 
 **Tests**:
 - e2e: tool write → `GET /settings/agent` returns new text
 - unit: max length rejection
+- unit/e2e: non-interactive trigger does not expose write tool
 
 ---
 
@@ -67,19 +71,31 @@ HITL.
 
 **Files**:
 - `persona.py` update path
-- Reuse sandbox HITL / `ask_user` channel already attached on chat agents
+- Reuse run-level `CheckpointedChannel` from `run_manager` (same channel as
+  `ask_user_tool` / sandbox confirm)
+
+**Cubepi constraints (must design against):**
+- Calling HITL from inside a custom tool requires
+  `allow_inside_custom_tool=True` on that channel **or** an equivalent
+  builtin/middleware path; default channel construction rejects it
+  (`HitlDurabilityNotGuaranteed`).
+- Prefer `channel.ask([...])` → existing `ask_user_request` frontend path
+  (supported by `hitl_resume`). Do not invent a new kind without wiring.
 
 **Logic**:
-1. Load current prompt.
-2. If non-empty and new text differs: pause for confirm with summary
-   (workspace-wide warning, length before/after, reason if provided).
-3. On approve → `set_system_prompt`.
-4. On deny → tool result “not updated”.
+1. Load current prompt; compute `previous_hash`.
+2. If non-empty and new text differs: pause for HITL with summary
+   (workspace-wide warning, length before/after, reason if provided,
+   fingerprint of previous text).
+3. On approve → re-read persona; if hash mismatch → conflict tool result
+   (no write); else `set_system_prompt`.
+4. On deny / cancel / timeout → tool result “not updated”.
 
-Empty previous → write immediately.
+Empty previous → write immediately (no HITL).
 
 **Tests**: e2e or integration with HITL channel mock — confirm path commits;
-deny does not.
+deny does not; double-approve / concurrent UI edit yields conflict; custom-tool
+HITL path does not raise durability error.
 
 ---
 
@@ -135,7 +151,7 @@ contains new text (inspect via trace helper or internal test hook).
 ## Delivery order
 
 1. Unit 1 (service extract)
-2. Units 2+3+4 together (tools + HITL + prompt)
+2. Units 2+3+4 **together** (tools + HITL + prompt) — inseparable release
 3. Unit 5 (assembly proof)
 4. Unit 6 (UI polish)
 5. Unit 7 (docs site)
@@ -146,12 +162,16 @@ contains new text (inspect via trace helper or internal test hook).
 - admin-only policy flag
 - audit columns
 - renaming Persona UI label
+- persona writes from scheduled/IM/automated runs (v1)
 
 ## Risks
 
 | Risk | Mitigation |
 | --- | --- |
-| Agent overwrites long persona silently | Tool-enforced HITL when non-empty |
+| Agent overwrites long persona silently | Tool-enforced HITL when non-empty; no Phase-1-only ship |
+| HITL from custom tool durability | Design against `allow_inside_custom_tool` / ask path |
+| Stale confirm overwrites newer UI edit | previous_hash check at commit |
 | Shared workspace surprise | Confirm + tool description |
+| Automation mutates persona | Omit write tool on non-interactive tool lists |
 | Cache cost after update | Accept; document; rare |
 | Settings page stale | Refetch on focus |

--- a/docs/dev/plans/2026-07-22-agent-update-persona.md
+++ b/docs/dev/plans/2026-07-22-agent-update-persona.md
@@ -1,0 +1,157 @@
+# Agent update workspace persona — implementation plan
+
+Related: #397 · Spec: `docs/dev/specs/2026-07-22-agent-update-persona-design.md`
+
+**Goal**: Built-in agent tools to get/update `AgentConfig.system_prompt` with
+HITL on overwrite, prompt guidance vs memory, and settings UI freshness.
+
+**Architecture**: Factory tools (like memory) call a small shared service used
+by `PUT /settings/agent`. Register tools on the main chat agent tool list in
+`run_manager`. Overwrite path uses existing HITL channel.
+
+**Tech stack**: cubepi `AgentTool`, existing HITL (`ask_user_tool` /
+checkpoint channel), SQLModel `AgentConfig`, React tool-result rendering.
+
+---
+
+## Unit 1: Shared agent-config service
+
+**Files**:
+- `backend/cubeplex/services/agent_config.py` (new) — `get_or_create`,
+  `get_system_prompt`, `set_system_prompt(session, org_id, workspace_id, text)`
+- Refactor `ws_settings.py` to call the service (no behavior change)
+
+**Rules**:
+- Max length 8000 (raise clear validation error).
+- Preserve get-or-create race handling already in the route.
+
+**Tests**: unit with session mock or e2e against existing settings routes
+still green after refactor.
+
+---
+
+## Unit 2: `persona_get` + `persona_update` tools
+
+**Files**:
+- `backend/cubeplex/tools/builtin/persona.py` (new)
+- Wire in `run_manager` next to `create_memory_tools` (per-request DI:
+  org_id, workspace_id, session/service factory)
+
+**Schemas** (sketch):
+
+```python
+class PersonaGetArgs(BaseModel):
+    pass  # no args
+
+class PersonaUpdateArgs(BaseModel):
+    system_prompt: str = Field(max_length=8000)
+    reason: str = Field(default="", max_length=500)
+```
+
+**Results**:
+- get: JSON `{ "system_prompt", "length", "max_length": 8000 }`
+- update success: `{ "updated": true, "length", "previous_length", ... }`
+- update error: clear message (too long, not confirmed, etc.)
+
+**Phase note**: Unit 2 can implement update as direct write first only if
+Unit 3 lands in the same PR; prefer not to ship non-empty overwrite without
+HITL.
+
+**Tests**:
+- e2e: tool write → `GET /settings/agent` returns new text
+- unit: max length rejection
+
+---
+
+## Unit 3: HITL on non-empty overwrite
+
+**Files**:
+- `persona.py` update path
+- Reuse sandbox HITL / `ask_user` channel already attached on chat agents
+
+**Logic**:
+1. Load current prompt.
+2. If non-empty and new text differs: pause for confirm with summary
+   (workspace-wide warning, length before/after, reason if provided).
+3. On approve → `set_system_prompt`.
+4. On deny → tool result “not updated”.
+
+Empty previous → write immediately.
+
+**Tests**: e2e or integration with HITL channel mock — confirm path commits;
+deny does not.
+
+---
+
+## Unit 4: Prompt guidance
+
+**Files**:
+- `backend/cubeplex/prompts/persona.py` (new short fragment) **or** extend
+  memory authoring block carefully (prefer separate small section to avoid
+  bloating memory rules)
+- Inject from `run_manager` or a tiny middleware — **stable prefix**, short
+
+**Copy must cover**:
+- When to use `persona_*` vs `memory_*`
+- Persona is workspace-wide (all members)
+- Confirm before large rewrites (and tool enforces it)
+- Never put secrets in persona
+- Max 8000 characters
+- Change applies on subsequent turns
+
+**Cache note**: document that persona **content** changes bust cache; the
+**guidance fragment** itself should be stable text.
+
+---
+
+## Unit 5: Verify next-turn assembly
+
+**Files**: read-only check of `run_manager` load path; add regression test if
+any caching is found.
+
+**Test**: e2e — set persona via tool → start new run → assembled system prompt
+contains new text (inspect via trace helper or internal test hook).
+
+---
+
+## Unit 6: Frontend tool result + settings refresh
+
+**Files**:
+- Tool result presentation for `persona_update` / `persona_get` (compact card)
+- `PersonaEditor` / `workspaceSettingsStore` — refetch on window focus or
+  explicit invalidate after tool event if already wired for other settings
+
+**Tests**: component smoke if patterns exist; otherwise manual QA note in PR.
+
+---
+
+## Unit 7: User docs (implementation PR)
+
+- Short note under workspace settings / persona guide: ask the agent to update
+  persona; changes affect the whole workspace.
+
+---
+
+## Delivery order
+
+1. Unit 1 (service extract)
+2. Units 2+3+4 together (tools + HITL + prompt)
+3. Unit 5 (assembly proof)
+4. Unit 6 (UI polish)
+5. Unit 7 (docs site)
+
+## Out of scope
+
+- append/search-replace operations
+- admin-only policy flag
+- audit columns
+- renaming Persona UI label
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Agent overwrites long persona silently | Tool-enforced HITL when non-empty |
+| Shared workspace surprise | Confirm + tool description |
+| Cache cost after update | Accept; document; rare |
+| Settings page stale | Refetch on focus |

--- a/docs/dev/specs/2026-07-22-agent-update-persona-design.md
+++ b/docs/dev/specs/2026-07-22-agent-update-persona-design.md
@@ -1,0 +1,180 @@
+# Agent tools to read/update workspace persona
+
+Related: #397
+
+## Goal
+
+Let the agent **read and update** the workspace persona
+(`AgentConfig.system_prompt`) from a normal chat turn, so users can refine
+standing instructions in conversation and have Settings → Persona stay the
+same source of truth.
+
+## Context
+
+### What persona is (and is not)
+
+| User language | Product object | Confusion to avoid |
+| --- | --- | --- |
+| Persona / workspace system instructions | `AgentConfig.system_prompt` (1:1 with workspace) | Default workspace **named** “Personal” |
+| Personal **memory** | Memory items via `memory_save` / `memory_update` | Atomic facts/preferences, not the persona document |
+| Account “Personal info” | User profile | Out of scope |
+
+### Today
+
+| Piece | Location | Agent access |
+| --- | --- | --- |
+| Model | `models/agent_config.py` — `system_prompt` Text | No tool |
+| API | `GET/PUT /api/v1/ws/{ws}/settings/agent` | Settings UI; `require_member`; max **8000** chars |
+| UI | `PersonaEditor.tsx` + workspace settings store | Manual edit |
+| Injection | `run_manager` each run: `BASE_SYSTEM_PROMPT + "\n\n" + agent_cfg.system_prompt` | Re-read at assembly |
+| Memory tools | `tools/builtin/memory.py` | Different layer |
+
+There is no `persona_*` tool. Users who discover style prefs mid-chat must either
+use memory tools (wrong surface for a full role document) or open Settings.
+
+### Prompt cache
+
+Persona sits in the **stable system prefix**. Changing it **invalidates** the
+prompt cache for subsequent turns. That is expected and acceptable — updates
+are rare. Align with `backend/docs/prompt-cache-discipline.md`: do not put
+persona in the unstable tail.
+
+## Goals
+
+1. Agent can **read** current workspace persona text during a conversation.
+2. Agent can **apply** updates to the same DB row Settings uses.
+3. Changes are durable and appear on the **next** model assembly (not mid-stream
+   hot-patch of the current turn).
+4. **HITL confirmation** before overwriting a non-empty persona (high impact in
+   shared workspaces).
+5. Prompt copy teaches **persona vs memory**.
+
+## Non-goals
+
+- Per-conversation instruction overrides that never touch workspace settings.
+- Editing `BASE_SYSTEM_PROMPT` or middleware fragments (sandbox, citations, …).
+- Replacing the memory system.
+- Full persona version history / VCS (optional later).
+
+## Design
+
+### When to use persona vs memory
+
+| Prefer **persona** | Prefer **memory** |
+| --- | --- |
+| User asks to change “persona / system instructions / 人设 / always behave as…” | Small typed fact: preference, correction, project_fact, … |
+| Standing role or policy block for the whole workspace agent | Atomic item that should not rewrite the whole document |
+
+### Tools
+
+| Tool | Behavior |
+| --- | --- |
+| `persona_get` | Return current `system_prompt`, length, and max (8000). |
+| `persona_update` | Full replace of `system_prompt`. Validate max 8000. |
+
+**Authorization (v1):** match settings write — any workspace **member**, same as
+`PUT /settings/agent`. Document shared-workspace impact in tool description.
+
+**Write mode (v1):** full document replace only. Append / search-replace can
+come in a later phase once overwrite UX is solid.
+
+### HITL for overwrite
+
+Recommended v1:
+
+- **Empty → first write:** apply without confirm (still report success clearly).
+- **Non-empty → replace:** require confirmation via existing HITL channel
+  (`ask_user` / confirm card) **before** commit, showing a short summary of the
+  change (length before/after, first ~N chars of new text, note that **all
+  members** of the workspace are affected).
+- Agent should call `persona_get` before proposing a replace when the user
+  intent is incremental (“add X”) so it can compose a full new document.
+
+Implementation options (choose during implementation with cubepi HITL
+patterns already used for sandbox confirm):
+
+1. Tool internally pauses for confirm when previous text non-empty, **or**
+2. Prompt requires agent to `ask_user` first; server still accepts direct
+   writes (weaker).
+
+**Recommendation:** enforce on the tool path (option 1) so confirmation is not
+skippable by a misbehaving model.
+
+### When the new persona takes effect
+
+| Moment | Behavior |
+| --- | --- |
+| Current streaming turn | Already assembled — no mid-turn hot-patch |
+| Next user turn / next run assembly | `run_manager` re-reads `AgentConfig` (already does today) |
+| Prompt cache | Stable prefix changes → cache miss; document as OK |
+
+Verify during implementation that no process-level cache of persona bypasses
+the DB on the next turn.
+
+### Service reuse
+
+Do not duplicate validation. Extract or call the same path as
+`update_agent_config` in `ws_settings.py` (service function that sets
+`system_prompt` with max length 8000).
+
+### Frontend
+
+1. Tool-result card: “Updated workspace persona” + short summary (not a wall of
+   text unless expanded).
+2. `PersonaEditor`: refetch on focus or invalidate settings store so the page
+   does not stay stale after agent write.
+3. User guide line: you can ask the agent to update persona.
+
+### Security / abuse
+
+- Enforce 8000 char cap.
+- Persona is **appended after** base system prompt; base safety authority
+  language stays.
+- Tool cannot change org admin settings, models, or RBAC.
+- Optional later: rate-limit rapid rewrites; audit `source=agent|ui`.
+
+## Phasing
+
+| Phase | Deliverable |
+| --- | --- |
+| **1** | `persona_get` + `persona_update` (full replace) + prompt guidance + e2e |
+| **2** | HITL confirm for overwrite; tool result card; settings stale refresh |
+| **3** | Patch/append helpers; audit metadata; optional admin-only write policy |
+
+Ship Phase 1+2 together if HITL wiring is small enough to avoid a half-safe
+overwrite path in production.
+
+## Acceptance criteria
+
+1. Agent can retrieve current persona via a tool in normal workspace chat.
+2. After a successful update, Settings → Persona shows the new text.
+3. A **new** turn in that workspace uses the updated persona in the effective
+   system prompt.
+4. Memory tools remain; prompt distinguishes persona vs memory.
+5. Empty → first persona and non-empty → replace both work; length over 8000
+   fails cleanly.
+6. Overwrite of non-empty persona requires user confirmation.
+7. Shared-workspace risk is disclosed in tool description and/or confirm copy.
+8. Tests cover write path + authz boundary + confirmation gate.
+
+## Open questions (v1 decisions)
+
+| Question | Decision |
+| --- | --- |
+| Full replace vs patch | **Full replace** in v1 |
+| Always HITL vs only overwrite | **HITL only when previous persona non-empty** |
+| Admin-only agent writes? | **No** — same as UI (member) |
+| Group chats | **Allowed**; confirm copy states workspace-wide effect |
+| Rename UI “Persona” → “Instructions” | Separate copy issue |
+
+## Related code
+
+- `backend/cubeplex/models/agent_config.py`
+- `backend/cubeplex/api/routes/v1/ws_settings.py`
+- `backend/cubeplex/api/schemas/ws_settings.py` (`AgentConfigPatch` max 8000)
+- `backend/cubeplex/tools/builtin/memory.py` (factory pattern to mirror)
+- `backend/cubeplex/streams/run_manager.py` (tool list + prompt assembly)
+- `backend/cubeplex/prompts/memory.py` (authoring guidance pattern)
+- `frontend/.../workspace-settings/PersonaEditor.tsx`
+- `backend/docs/prompt-cache-discipline.md`
+- System prompt optimization: #391

--- a/docs/dev/specs/2026-07-22-agent-update-persona-design.md
+++ b/docs/dev/specs/2026-07-22-agent-update-persona-design.md
@@ -72,8 +72,15 @@ persona in the unstable tail.
 | `persona_get` | Return current `system_prompt`, length, and max (8000). |
 | `persona_update` | Full replace of `system_prompt`. Validate max 8000. |
 
-**Authorization (v1):** match settings write — any workspace **member**, same as
-`PUT /settings/agent`. Document shared-workspace impact in tool description.
+**Authorization (v1):** match settings write for **interactive member-originated
+chat runs** — same as `PUT /settings/agent` (`require_member`). Document
+shared-workspace impact in tool description.
+
+**Non-interactive / automation (v1):** do **not** register `persona_update` on
+scheduled, IM-bot, or other automated trigger tool lists. `persona_get` may
+remain read-only if useful; writes require a human-driven interactive run that
+can answer HITL. Revisit automation ownership only in a later phase with
+explicit confirmer identity.
 
 **Write mode (v1):** full document replace only. Append / search-replace can
 come in a later phase once overwrite UX is solid.
@@ -83,22 +90,46 @@ come in a later phase once overwrite UX is solid.
 Recommended v1:
 
 - **Empty → first write:** apply without confirm (still report success clearly).
-- **Non-empty → replace:** require confirmation via existing HITL channel
-  (`ask_user` / confirm card) **before** commit, showing a short summary of the
-  change (length before/after, first ~N chars of new text, note that **all
-  members** of the workspace are affected).
+- **Non-empty → replace:** require confirmation **before** commit, showing a
+  short summary of the change (length before/after, first ~N chars of new text,
+  note that **all members** of the workspace are affected).
 - Agent should call `persona_get` before proposing a replace when the user
   intent is incremental (“add X”) so it can compose a full new document.
 
-Implementation options (choose during implementation with cubepi HITL
-patterns already used for sandbox confirm):
+**Concrete cubepi design (required — not “choose later”):**
 
-1. Tool internally pauses for confirm when previous text non-empty, **or**
-2. Prompt requires agent to `ask_user` first; server still accepts direct
-   writes (weaker).
+Custom tool bodies cannot call HITL by default: `CheckpointedChannel` raises
+`HitlDurabilityNotGuaranteed` when `_in_custom_tool_var` is set unless
+`allow_inside_custom_tool=True`. Sandbox confirm works because it runs in
+**middleware before** the tool body, via `channel.approve(...)`. Cubeplex
+`hitl_resume` serializes **`ask_user`** and **sandbox `approve`** kinds —
+not a free-form unused `confirm` kind for product tools.
 
-**Recommendation:** enforce on the tool path (option 1) so confirmation is not
-skippable by a misbehaving model.
+**Chosen path for v1 (tool-enforced, durable):**
+
+1. Build `persona_update` as a normal agent tool, but when non-empty overwrite
+   is needed, call `channel.ask([...])` **or** `channel.approve(...)` **only if**
+   the channel used for this agent is constructed with
+   `allow_inside_custom_tool=True` **or** the tool is registered as a cubepi
+   builtin that does not set the custom-tool guard (prefer reusing the existing
+   run-level `CheckpointedChannel` with an explicit
+   `allow_inside_custom_tool=True` **only for this channel instance** after
+   verifying sandbox durability still holds).
+2. Prefer **`ask` with a fixed Yes/No schema** mapped to frontend
+   `ask_user_request` (already supported end-to-end), payload including:
+   `previous_hash` / length, `new_length`, preview of new text, workspace-wide
+   warning.
+3. On deny/cancel/timeout → tool result `updated: false`; **no write**.
+4. On approve → re-load persona and apply **optimistic concurrency** (below)
+   before commit.
+
+Do **not** rely on prompt-only “call `ask_user` first” (skippable). Do **not**
+invent a new HITL kind without `hitl_resume` + frontend event wiring.
+
+**Optimistic concurrency:** store the hash (or exact previous text fingerprint)
+observed when the tool started confirmation. At commit, if current
+`system_prompt` differs → return conflict; require `persona_get` + new confirm.
+Cover double-approve and UI-edit-while-pending in tests.
 
 ### When the new persona takes effect
 
@@ -137,12 +168,12 @@ Do not duplicate validation. Extract or call the same path as
 
 | Phase | Deliverable |
 | --- | --- |
-| **1** | `persona_get` + `persona_update` (full replace) + prompt guidance + e2e |
-| **2** | HITL confirm for overwrite; tool result card; settings stale refresh |
+| **1+2 (inseparable)** | `persona_get` + `persona_update` (full replace) **with** tool-enforced HITL on non-empty overwrite + concurrency check + prompt guidance + e2e. **No production path may write a non-empty overwrite without HITL.** |
+| **UI polish** | Tool result card; settings stale refresh (may land with 1+2 or immediately after) |
 | **3** | Patch/append helpers; audit metadata; optional admin-only write policy |
 
-Ship Phase 1+2 together if HITL wiring is small enough to avoid a half-safe
-overwrite path in production.
+**Release gate:** if HITL wiring is blocked, ship **empty-only** first write or
+block non-empty updates entirely — never a silent overwrite API.
 
 ## Acceptance criteria
 

--- a/docs/site/docs/getting-started/workspace-setup.md
+++ b/docs/site/docs/getting-started/workspace-setup.md
@@ -76,6 +76,12 @@ MCP connectors let the agent interact with external services.
 
 Once enabled and credentialed, the tools are available to the agent in conversations. See the [MCP Tools guide](../guides/mcp/overview.md) for a full walkthrough.
 
+## Agent Persona
+
+**Agent Persona** (Settings → General) sets standing instructions for the AI assistant in every conversation in this workspace — role, tone, and policies that should always apply.
+
+You can edit the persona text on the settings page, or ask the agent in chat to update it (for example: “From now on always answer in formal Chinese in this workspace”). Changes apply on subsequent turns and affect all workspace members. Prefer **Memory** for small personal preferences; use persona when you want a durable workspace-wide role or policy block.
+
 ## Install skills
 
 Skills extend what the agent can do. To add skills to your workspace:

--- a/frontend/packages/web/components/workspace-settings/PersonaEditor.tsx
+++ b/frontend/packages/web/components/workspace-settings/PersonaEditor.tsx
@@ -53,15 +53,17 @@ export function PersonaEditor({ wsId }: PersonaEditorProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wsId])
 
-  // Refetch when the settings page regains focus so agent-driven persona
-  // updates (persona_update tool) don't leave a stale editor open.
+  // Refetch when focus returns so agent-driven persona updates surface.
+  // Skip when the draft is dirty so we never silently discard in-progress edits.
   useEffect(() => {
     const onFocus = (): void => {
+      const saved = agentConfig?.system_prompt ?? ''
+      if (draft !== saved) return
       void loadAll(client())
     }
     window.addEventListener('focus', onFocus)
     return () => window.removeEventListener('focus', onFocus)
-  }, [client, loadAll])
+  }, [agentConfig?.system_prompt, client, draft, loadAll])
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/frontend/packages/web/components/workspace-settings/PersonaEditor.tsx
+++ b/frontend/packages/web/components/workspace-settings/PersonaEditor.tsx
@@ -53,6 +53,16 @@ export function PersonaEditor({ wsId }: PersonaEditorProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wsId])
 
+  // Refetch when the settings page regains focus so agent-driven persona
+  // updates (persona_update tool) don't leave a stale editor open.
+  useEffect(() => {
+    const onFocus = (): void => {
+      void loadAll(client())
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [client, loadAll])
+
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     if (agentConfig) setDraft(agentConfig.system_prompt)


### PR DESCRIPTION
## Summary

Agent tools to read/update workspace **Agent Persona** (`AgentConfig.system_prompt` — Settings → Agent Persona), so chat can maintain the same surface as the settings page.

Related: #397

### What shipped

- **`persona_get` / `persona_update`** tools (interactive runs only for write)
- Shared **`agent_config` service** used by settings API + tools
- **HITL confirm** via run-level `CheckpointedChannel.ask` when overwriting a non-empty persona (optimistic fingerprint concurrency)
- System prompt guidance: persona vs memory
- PersonaEditor refetches on window focus after agent writes
- User docs: workspace setup → Agent Persona

### Docs

- `docs/dev/specs/2026-07-22-agent-update-persona-design.md`
- `docs/dev/plans/2026-07-22-agent-update-persona.md`
- `docs/site/docs/getting-started/workspace-setup.md`

## Test plan

- [x] Unit: persona tools (empty write, confirm, deny, conflict, unchanged)
- [x] Unit: run_manager registers persona tools; omits update for non-interactive
- [x] E2E: tool write → `GET /settings/agent` matches; deny leaves persona unchanged
- [x] E2E: settings max length 422
- [x] Pre-push `check-ci` green