### PR TITLE
Artifact preview: in-app theater expand

### DIFF
--- a/docs/dev/plans/2026-07-22-artifact-preview-expand.md
+++ b/docs/dev/plans/2026-07-22-artifact-preview-expand.md
@@ -56,10 +56,13 @@ interface ArtifactExpandDialogProps {
 **Core logic**:
 
 - Dialog content: header chrome (title, version, download, minimize) +
-  flex body with `PreviewContent`.
+  flex body with `PreviewContent` (only host while expanded).
 - Size: ~`w-[min(90vw,1400px)] h-[90vh]` or equivalent Tailwind.
 - Esc / overlay click → `onOpenChange(false)`.
-- Focus trap via Dialog primitive defaults.
+- Focus trap via Dialog primitive defaults; nested version popover /
+  skill dialogs must stack above (see spec).
+- Key dialog by artifact identity so a prop swap cannot flash wrong
+  content while open.
 
 **Tests intent**: open/close with React Testing Library; Esc closes;
 does not call panel `close` on expand exit.
@@ -78,24 +81,37 @@ does not call panel `close` on expand exit.
    `expanded` boolean state.
 2. Header maximize toggles `setExpanded(true/false)`.
 3. Render `ArtifactExpandDialog` when `expanded`.
-4. On `panelStore` view change away from this artifact: set `expanded`
-   false (effect).
-5. Mobile: do not show expand control below `md` if sheet already fills
+4. While expanded: **do not** mount rail `PreviewContent` (placeholder
+   only). Only the dialog hosts the preview.
+5. On `panelStore` view change away from this artifact **or** artifact id
+   change: set `expanded` false on the same update path (not only a
+   post-paint effect that can flash stale content).
+6. Mobile: do not show expand control below `md` if sheet already fills
    screen (match existing responsive panel behavior).
-6. Keep side panel mounted; expand is overlay.
+7. Keep side **panel shell** mounted; expand is overlay.
 
 **Core logic**:
 
 ```
-Maximize click → expanded=true
-Esc/minimize/backdrop → expanded=false (selection kept)
-Panel X → close() panel store (existing)
+Maximize click → expanded=true (rail preview unmounts; dialog hosts preview)
+Esc/minimize/backdrop/theater X → expanded=false (panelStore selection kept)
+panelStore switch artifact / non-artifact / panel close → expanded=false first
+Panel X → close() panel store (existing) and clear expanded
 ```
 
 **Tests intent**:
 
-- Unit/component: expand opens dialog; exit leaves artifact selected.
-- Manual: html/pdf/image/code in large stage; version switch; download.
+- Component contract (mock or real `panelStore` as used by the panel):
+  open artifact → expand → exit via **Esc, backdrop, minimize, theater X**
+  → assert same `panelStore.view`, artifact id, and selected version remain.
+- Panel header X still closes the whole panel.
+- Navigate-away: while expanded, switch to another artifact or panel type
+  → theater closes; no assertion that old artifact stays selected if the
+  store intentionally changed.
+- Prefer asserting a single `PreviewContent`/iframe host while expanded
+  (no dual iframe) if practical in unit tests.
+- Manual: html/pdf/image/code in large stage; version switch; download;
+  version popover Esc vs theater Esc.
 
 ---
 

--- a/docs/dev/plans/2026-07-22-artifact-preview-expand.md
+++ b/docs/dev/plans/2026-07-22-artifact-preview-expand.md
@@ -1,0 +1,137 @@
+# Artifact preview in-app expand — implementation plan
+
+**Goal**: Replace (primary) browser fullscreen on the artifact panel with a
+large in-app theater expand dialog.
+
+**Architecture**: Frontend-only. Local expand state on `ArtifactPanel`;
+portal dialog reusing `PreviewContent` + header actions. No backend.
+
+**Tech stack**: React, existing `Dialog` UI, lucide Maximize2/Minimize2,
+next-intl panel header strings.
+
+---
+
+## Unit 1: i18n + PanelHeader affordance
+
+**Files**:
+
+- `frontend/packages/web/messages/en.json`, `zh.json`
+  (`panel.header` / artifact header keys)
+- `frontend/packages/web/components/panel/PanelHeader.tsx` (if prop names
+  change from `fullscreen` to `expand`)
+
+**What changes**:
+
+- Strings: expand / exit expand tooltips (clearer than “Fullscreen”).
+- Optionally rename prop `fullscreen` → `expand` for honesty, or keep prop
+  shape and only change behavior + titles at call site.
+
+**Tests intent**: none beyond string usage typecheck.
+
+---
+
+## Unit 2: `ArtifactExpandDialog` host
+
+**Files**:
+
+- New: `frontend/packages/web/components/panel/artifact/ArtifactExpandDialog.tsx`
+  (or colocated in `ArtifactPanel.tsx` if small)
+- `frontend/packages/web/components/ui/dialog.tsx` (reuse)
+
+**Interfaces**:
+
+```tsx
+interface ArtifactExpandDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  artifact: Artifact
+  versions: ...
+  selectedVersion: number | null
+  onSelectVersion: (v: number | null) => void
+  workspaceId: string
+  // header actions: download url, etc.
+}
+```
+
+**Core logic**:
+
+- Dialog content: header chrome (title, version, download, minimize) +
+  flex body with `PreviewContent`.
+- Size: ~`w-[min(90vw,1400px)] h-[90vh]` or equivalent Tailwind.
+- Esc / overlay click → `onOpenChange(false)`.
+- Focus trap via Dialog primitive defaults.
+
+**Tests intent**: open/close with React Testing Library; Esc closes;
+does not call panel `close` on expand exit.
+
+---
+
+## Unit 3: Wire `ArtifactPanel`
+
+**Files**:
+
+- `frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx`
+
+**What changes**:
+
+1. Replace `isFullscreen` + `requestFullscreen` / `fullscreenchange` with
+   `expanded` boolean state.
+2. Header maximize toggles `setExpanded(true/false)`.
+3. Render `ArtifactExpandDialog` when `expanded`.
+4. On `panelStore` view change away from this artifact: set `expanded`
+   false (effect).
+5. Mobile: do not show expand control below `md` if sheet already fills
+   screen (match existing responsive panel behavior).
+6. Keep side panel mounted; expand is overlay.
+
+**Core logic**:
+
+```
+Maximize click → expanded=true
+Esc/minimize/backdrop → expanded=false (selection kept)
+Panel X → close() panel store (existing)
+```
+
+**Tests intent**:
+
+- Unit/component: expand opens dialog; exit leaves artifact selected.
+- Manual: html/pdf/image/code in large stage; version switch; download.
+
+---
+
+## Unit 4: Cleanup fullscreen-only paths
+
+**Files**:
+
+- `ArtifactPanel.tsx` (remove Fullscreen API listeners)
+- Any tests mocking `requestFullscreen`
+
+**What changes**: delete dead fullscreen code from artifact panel primary
+path. Leave BrowserView / sandbox iframe `allow="fullscreen"` alone
+(those are for embedded remote desktops, unrelated).
+
+---
+
+## Unit 5: Docs (implementation PR)
+
+- If site docs describe artifact panel controls, mention **Expand preview**
+  in-app (not browser fullscreen).
+- Prefer update over new page.
+
+---
+
+## Unit 6: Verification
+
+- Component tests for expand open/close.
+- Manual desktop: theater size, Esc, version, download, all major artifact
+  types.
+- Manual mobile: no broken double-fullscreen.
+
+---
+
+## Non-goals
+
+- Pop-out windows
+- Expand for browser/sandbox tool panels
+- Backend changes
+- Permanent layout maximize without dialog (optional later)

--- a/docs/dev/specs/2026-07-22-artifact-preview-expand-design.md
+++ b/docs/dev/specs/2026-07-22-artifact-preview-expand-design.md
@@ -1,0 +1,151 @@
+# Artifact preview: in-app theater expand
+
+## Goal
+
+Let users view an artifact **large in the center of the product UI** (theater
+/ expand mode) instead of being limited to the narrow right rail or forced
+into **browser Fullscreen API**.
+
+## Context
+
+The right-hand artifact panel is useful but often too narrow for websites,
+docs, PDFs, and wide tables.
+
+| Capability | Status |
+| --- | --- |
+| Right panel preview | `ArtifactPanel` in AppShell / library |
+| Resizable rail | Desktop `ResizablePanel` (default ~50%, min 25%) |
+| Header maximize | **Already present** — toggles `element.requestFullscreen()` on the panel container |
+| Mobile | Near full-viewport sheet (`fixed inset-0`) |
+
+Code:
+
+- `frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx` —
+  `toggleFullscreen`, `containerRef`, header wiring
+- `frontend/packages/web/components/panel/PanelHeader.tsx` — Maximize2 /
+  Minimize2 + `fullscreen` / `exitFullscreen` i18n
+- Preview renderers under `components/panel/artifact/*Preview.tsx`
+
+Browser fullscreen:
+
+- Takes over the entire display (OS chrome “press Esc to exit”)
+- Is not a centered stage inside the app
+- May be restricted in some browsers / embeds
+- Does not match the user ask for “large in the middle of the product”
+
+## Approaches considered
+
+**A. In-app theater / center dialog (recommended primary)**  
+Fixed overlay or Dialog: dimmed backdrop, large centered panel (~90vw ×
+90vh or near full within app), same `PreviewContent` + header actions.
+No Fullscreen API required.
+
+**B. Keep browser fullscreen as primary**  
+Already shipped; wrong mental model for this issue.
+
+**C. Layout maximize only**  
+Widen `ResizablePanel` to ~90% without modal. Helps width but not a true
+center stage; optional later.
+
+**D. Pop-out `window.open`**  
+Auth/CSP complexity; later multi-monitor phase.
+
+**Chosen: A as primary control.** Demote or remove browser fullscreen so
+users are not offered two competing “expand” buttons. Prefer **replace**
+the header Maximize control with in-app expand; do not require both in
+MVP. (Optional: overflow menu “Browser fullscreen” later if needed.)
+
+## Design
+
+### Interaction
+
+| Action | Behavior |
+| --- | --- |
+| Click **Expand** (Maximize2 icon, tooltip “Expand preview”) | Open in-app theater with current artifact + selected version |
+| Esc / Minimize / backdrop click | Close theater; **keep** side panel selection open |
+| Close (X) on theater header | Close theater only (same as Esc) — side panel X still closes the whole preview |
+| Version switch while expanded | Stay expanded; reload preview content |
+| Download while expanded | Same download URL as side panel |
+| Navigate away / open another panel type | Close theater; follow existing `panelStore` rules |
+| Mobile (`md` breakpoint) | Expand control **hidden or no-op** — sheet already fills the viewport |
+
+### Layout
+
+- Portal to `document.body` (avoid clipping by resizable panel overflow).
+- Backdrop: dimmed, click closes expand.
+- Stage: large card, approximately **90vw × 90vh** max, centered, with
+  border/shadow consistent with app dialogs.
+- Chat may be fully covered by backdrop (simpler focus model). Not a
+  permanent split layout.
+- `z-index` above chat and side rail.
+- a11y: `role="dialog"`, `aria-modal="true"`, labelled by artifact name;
+  focus trap; restore focus to Expand button on close.
+
+### Header control
+
+- Primary header button becomes **Expand / Exit expand** (in-app).
+- i18n: `panel.header.expand` / `exitExpand` (or reuse expand wording
+  distinct from old “Fullscreen” if strings still used elsewhere).
+- Tooltips must say expand/preview language, not “Fullscreen”, once
+  browser API is no longer the primary action.
+- Version popover + download remain available in theater header (reuse
+  `ArtifactPanelHeader` or shared chrome).
+
+### Implementation sketch
+
+1. Local state `expanded: boolean` on `ArtifactPanel` (MVP). No global
+   store unless other panels need the same pattern later.
+2. Extract/reuse `PreviewContent` inside `ArtifactExpandDialog` (Dialog
+   from `components/ui/dialog` or fixed layer + portal).
+3. When expanded, side rail can keep showing the same preview underneath
+   (simple) or a muted “Expanded” placeholder — either is fine if state
+   stays consistent; prefer **keep mounted underneath** to avoid remount
+   thrash of iframes when possible, or accept remount if iframe focus
+   fights the dialog (pick simplest stable option in implementation).
+4. Remove or stop wiring `requestFullscreen` / `fullscreenchange` from
+   the primary button path.
+5. Works for conversation rail and any host that mounts `ArtifactPanel`
+   (artifacts library).
+
+### Previews
+
+- No redesign of individual `*Preview.tsx` components beyond filling the
+  larger flex container (`h-full` / `min-h-0` as already used).
+- Verify HTML iframe, PDF, image gallery, code, office previews scale in
+  the large container.
+
+## Out of scope
+
+- Permanent center layout replacing the right rail
+- Redesigning all preview renderers beyond host layout
+- Multi-window pop-out
+- Artifact generation / storage changes
+- Expanding browser/sandbox tool panels (possible follow-up pattern)
+- Default wider rail by artifact type (optional later)
+
+## Success criteria
+
+1. Header control opens a **large in-app** view using most of the viewport.
+2. Expanded view shows the same artifact types/content as the side panel.
+3. Exit expand returns to side panel **without** losing selection.
+4. Esc exits expand; focus management is reasonable.
+5. Desktop primary path does **not** require browser Fullscreen API.
+6. Clear i18n + tooltips (“Expand preview” / exit).
+7. No major regression to download, version switch, or mobile sheet.
+
+## Resolved product choices
+
+| Question | Decision |
+| --- | --- |
+| Primary expand | In-app theater (A) |
+| Browser fullscreen | Not primary; remove from primary button in MVP |
+| Size | ~90vw × 90vh centered card |
+| Theater X | Closes theater only |
+| Backdrop | Covers chat (modal) |
+| Mobile | Hide/no-op expand |
+
+## Related
+
+- Issue #395
+- `ArtifactPanel`, `PanelHeader`, `AppShell` resizable panel
+- Preview components under `components/panel/artifact/`

--- a/docs/dev/specs/2026-07-22-artifact-preview-expand-design.md
+++ b/docs/dev/specs/2026-07-22-artifact-preview-expand-design.md
@@ -77,9 +77,23 @@ MVP. (Optional: overflow menu “Browser fullscreen” later if needed.)
   border/shadow consistent with app dialogs.
 - Chat may be fully covered by backdrop (simpler focus model). Not a
   permanent split layout.
-- `z-index` above chat and side rail.
+- `z-index` above chat and side rail; **above** the artifact rail shell.
+  Nested UI inside the theater (version popover, skill confirm dialogs)
+  must stack **above** the theater content using the same Dialog/Popover
+  primitives’ nested modal support (Base UI / Radix-style nesting). Do not
+  invent a second portal root without verifying z-index vs theater.
 - a11y: `role="dialog"`, `aria-modal="true"`, labelled by artifact name;
-  focus trap; restore focus to Expand button on close.
+  focus trap; restore focus to Expand button on close when still mounted.
+
+### Nested overlays + Esc
+
+- Version popover / dropdown inside theater: open as nested layer; Esc
+  closes the **innermost** overlay first (popover), then a second Esc
+  closes the theater — match existing Dialog + Popover stacking behavior.
+- Skill (or other) confirmation dialogs opened from a preview: must appear
+  above the theater; Esc dismisses the confirm before the theater.
+- Document the intended stack in implementation notes if primitives need
+  `modal` / container props set explicitly.
 
 ### Header control
 
@@ -97,15 +111,34 @@ MVP. (Optional: overflow menu “Browser fullscreen” later if needed.)
    store unless other panels need the same pattern later.
 2. Extract/reuse `PreviewContent` inside `ArtifactExpandDialog` (Dialog
    from `components/ui/dialog` or fixed layer + portal).
-3. When expanded, side rail can keep showing the same preview underneath
-   (simple) or a muted “Expanded” placeholder — either is fine if state
-   stays consistent; prefer **keep mounted underneath** to avoid remount
-   thrash of iframes when possible, or accept remount if iframe focus
-   fights the dialog (pick simplest stable option in implementation).
+3. **Single preview host (required decision):** Do **not** dual-mount
+   heavy previews (HTML iframe, PDF worker, Office) in both the rail and
+   the theater. Choose one of:
+   - **A (preferred):** While `expanded`, rail body shows a lightweight
+     placeholder (“Expanded in preview”) and **only the dialog** mounts
+     `PreviewContent`. Closing expand remounts rail preview (accept
+     remount cost).
+   - **B:** Single `PreviewContent` instance reparented via portal into
+     the dialog body when expanded (harder; only if remount breaks a
+     critical type).
+   Dual-mount is rejected for MVP because of duplicate network/memory,
+   focus fighting, and version desync risk.
 4. Remove or stop wiring `requestFullscreen` / `fullscreenchange` from
    the primary button path.
 5. Works for conversation rail and any host that mounts `ArtifactPanel`
    (artifacts library).
+6. **Navigate-away / selection change (synchronous):** Close expand when
+   any of these become true — do not wait only on a lagging effect after
+   paint of wrong content:
+   - `panelStore` view is no longer this artifact (other panel type, panel
+     close, different artifact id).
+   - Derive close from identity: key dialog by
+     `(conversationId, artifactId)` and set `expanded=false` in the same
+     event path that changes the panel view, **or**
+     `useLayoutEffect`/`useEffect` that clears expand before rendering
+     mismatched props (prefer event-path close).
+   - Focus restore targets Expand only if that button is still mounted;
+     otherwise let Dialog default restore safely.
 
 ### Previews
 
@@ -143,6 +176,8 @@ MVP. (Optional: overflow menu “Browser fullscreen” later if needed.)
 | Theater X | Closes theater only |
 | Backdrop | Covers chat (modal) |
 | Mobile | Hide/no-op expand |
+| Preview mounting | Single host: unmount rail PreviewContent while expanded (A) |
+| Navigate-away | Sync close expand; no stale theater flash |
 
 ## Related
 

--- a/docs/site/docs/guides/conversations/artifacts.md
+++ b/docs/site/docs/guides/conversations/artifacts.md
@@ -47,7 +47,9 @@ When the agent creates an artifact, an **artifact card** appears inline in the c
 
 Clicking the card (or the preview button) opens the **artifact panel** on the right side of the screen. The panel renders a live preview based on the artifact type — websites run in a sandboxed iframe, images display at full resolution, code gets syntax highlighting, and so on.
 
-On desktop, use **Expand preview** in the panel header to open a large centered in-app view (most of the viewport). Press Esc, click the backdrop, or use **Exit expand** to return to the side panel without losing the selected artifact. The side panel **Close** control still closes the whole preview.
+On desktop, use **Expand preview** in the panel header to open a large centered in-app view (most of the viewport). Press Esc, click the backdrop, or use **Exit expand** / the theater header **Close** control to return to the side panel without losing the selected artifact.
+
+While expanded, the theater is a modal overlay — the side panel underneath is not interactive. Exit expand first, then use the side panel **Close** control if you want to dismiss the preview entirely. If you are interacting inside an embedded preview (website or Office document), Esc may stay inside that document; use **Exit expand** in the theater header instead.
 
 ![Artifact card with the right-side preview panel open](/img/conversations/artifact-panel.png)
 

--- a/docs/site/docs/guides/conversations/artifacts.md
+++ b/docs/site/docs/guides/conversations/artifacts.md
@@ -47,6 +47,8 @@ When the agent creates an artifact, an **artifact card** appears inline in the c
 
 Clicking the card (or the preview button) opens the **artifact panel** on the right side of the screen. The panel renders a live preview based on the artifact type — websites run in a sandboxed iframe, images display at full resolution, code gets syntax highlighting, and so on.
 
+On desktop, use **Expand preview** in the panel header to open a large centered in-app view (most of the viewport). Press Esc, click the backdrop, or use **Exit expand** to return to the side panel without losing the selected artifact. The side panel **Close** control still closes the whole preview.
+
 ![Artifact card with the right-side preview panel open](/img/conversations/artifact-panel.png)
 
 ### Artifact gallery

--- a/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
+++ b/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
@@ -1,0 +1,216 @@
+import { render, screen, fireEvent, within, act } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Artifact } from '@cubeplex/core'
+import { useArtifactStore, usePanelStore } from '@cubeplex/core'
+import { WorkspaceContext } from '@/hooks/useWorkspaceContext'
+
+vi.mock('@cubeplex/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@cubeplex/core')>()
+  return {
+    ...actual,
+    createApiClient: () => ({ setWorkspaceId: vi.fn() }),
+  }
+})
+
+vi.mock('@/components/panel/artifact/FallbackPreview', () => ({
+  FallbackPreview: () => <div data-testid="preview-host">preview-body</div>,
+}))
+
+vi.mock('next/dynamic', () => ({
+  default: () => () => null,
+}))
+
+import { ArtifactPanel } from '@/components/panel/artifact/ArtifactPanel'
+
+const messages = {
+  panel: {
+    header: {
+      copy: 'Copy',
+      close: 'Close',
+      expand: 'Expand preview',
+      exitExpand: 'Exit expand',
+    },
+    artifactPanel: {
+      download: 'Download',
+      close: 'Close',
+      expand: 'Expand preview',
+      exitExpand: 'Exit expand',
+      expandedPlaceholder: 'Expanded in preview',
+      unknownType: 'Unknown type',
+      justNow: 'just now',
+      minutesAgo: '{n}m ago',
+      hoursAgo: '{n}h ago',
+      daysAgo: '{n}d ago',
+    },
+  },
+}
+
+const artifact: Artifact = {
+  id: 'art-1',
+  conversation_id: 'conv-1',
+  name: 'report.bin',
+  artifact_type: 'file',
+  path: '/workspace/report.bin',
+  entry_file: null,
+  mime_type: 'application/octet-stream',
+  description: null,
+  created_at: '2026-07-22T00:00:00Z',
+  updated_at: '2026-07-22T00:00:00Z',
+  version: 1,
+}
+
+const otherArtifact: Artifact = {
+  ...artifact,
+  id: 'art-2',
+  name: 'other.bin',
+  path: '/workspace/other.bin',
+}
+
+function seedArtifact(a: Artifact = artifact): void {
+  useArtifactStore.setState({
+    artifacts: { [a.conversation_id]: { [a.id]: a } },
+    versions: {},
+    selectedVersion: {},
+    loading: {},
+    deletedIds: {},
+  })
+  usePanelStore.getState().openArtifact(a.conversation_id, a.id)
+}
+
+function renderPanel() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <WorkspaceContext.Provider value={{ workspaceId: 'ws-1' }}>
+        <ArtifactPanel />
+      </WorkspaceContext.Provider>
+    </NextIntlClientProvider>,
+  )
+}
+
+describe('ArtifactPanel expand theater', () => {
+  beforeEach(() => {
+    usePanelStore.setState({ view: { type: 'closed' } })
+    useArtifactStore.setState({
+      artifacts: {},
+      versions: {},
+      selectedVersion: {},
+      loading: {},
+      deletedIds: {},
+    })
+    seedArtifact()
+  })
+
+  it('opens in-app expand and unmounts rail preview (single host)', () => {
+    renderPanel()
+    expect(screen.getByTestId('artifact-rail-preview')).toBeInTheDocument()
+    expect(screen.getAllByTestId('preview-host')).toHaveLength(1)
+
+    fireEvent.click(screen.getByTitle('Expand preview'))
+
+    expect(screen.getByTestId('artifact-rail-placeholder')).toBeInTheDocument()
+    expect(screen.queryByTestId('artifact-rail-preview')).not.toBeInTheDocument()
+    expect(screen.getByTestId('artifact-expand-preview')).toBeInTheDocument()
+    // Only the theater hosts the preview while expanded.
+    expect(screen.getAllByTestId('preview-host')).toHaveLength(1)
+    expect(
+      within(screen.getByTestId('artifact-expand-preview')).getByTestId('preview-host'),
+    ).toBeInTheDocument()
+  })
+
+  it.each([
+    {
+      name: 'minimize',
+      exit: () => {
+        // Theater header minimize (active expand)
+        fireEvent.click(screen.getAllByTitle('Exit expand')[0]!)
+      },
+    },
+    {
+      name: 'theater X',
+      exit: () => {
+        // Theater has Close; rail also has Close — use the expand dialog's close.
+        const dialog = screen.getByRole('dialog')
+        fireEvent.click(within(dialog).getByTitle('Close'))
+      },
+    },
+  ])('exit via $name keeps panelStore selection', ({ exit }) => {
+    renderPanel()
+    fireEvent.click(screen.getByTitle('Expand preview'))
+    expect(screen.getByTestId('artifact-expand-preview')).toBeInTheDocument()
+
+    exit()
+
+    expect(screen.queryByTestId('artifact-expand-preview')).not.toBeInTheDocument()
+    expect(screen.getByTestId('artifact-rail-preview')).toBeInTheDocument()
+    expect(usePanelStore.getState().view).toEqual({
+      type: 'artifact',
+      conversationId: 'conv-1',
+      artifactId: 'art-1',
+    })
+  })
+
+  it('Esc closes theater and keeps selection', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTitle('Expand preview'))
+    const popup = document.querySelector('[data-slot="dialog-content"]')
+    expect(popup).toBeTruthy()
+
+    fireEvent.keyDown(popup!, { key: 'Escape' })
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByTestId('artifact-rail-preview')).toBeInTheDocument()
+    expect(usePanelStore.getState().view).toEqual({
+      type: 'artifact',
+      conversationId: 'conv-1',
+      artifactId: 'art-1',
+    })
+  })
+
+  it('panel rail Close closes the whole panel', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTitle('Expand preview'))
+
+    // Rail header Close is outside the dialog
+    const rail = screen.getByTestId('artifact-rail-placeholder').parentElement!
+    const railHeaderClose = within(rail.parentElement!).getAllByTitle('Close')[0]!
+    fireEvent.click(railHeaderClose)
+
+    expect(usePanelStore.getState().view).toEqual({ type: 'closed' })
+    expect(screen.queryByTestId('artifact-expand-preview')).not.toBeInTheDocument()
+  })
+
+  it('navigate-away to another artifact closes theater without dual host', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTitle('Expand preview'))
+    expect(screen.getByTestId('artifact-expand-preview')).toBeInTheDocument()
+
+    act(() => {
+      useArtifactStore.setState({
+        artifacts: {
+          'conv-1': { 'art-1': artifact, 'art-2': otherArtifact },
+        },
+      })
+      usePanelStore.getState().openArtifact('conv-1', 'art-2')
+    })
+
+    // Identity-keyed expand: theater closes when artifact id changes.
+    expect(screen.queryByTestId('artifact-expand-preview')).not.toBeInTheDocument()
+    expect(screen.getByTestId('artifact-rail-preview')).toBeInTheDocument()
+    expect(screen.getAllByTestId('preview-host')).toHaveLength(1)
+    expect(screen.getByText('other.bin')).toBeInTheDocument()
+  })
+
+  it('navigate-away to non-artifact panel unmounts expand', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTitle('Expand preview'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    act(() => {
+      usePanelStore.getState().openSandbox()
+    })
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(usePanelStore.getState().view.type).toBe('sandbox')
+  })
+})

--- a/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
+++ b/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, within, act } from '@testing-library/react'
+import { render, screen, fireEvent, within, act, waitFor } from '@testing-library/react'
 import { NextIntlClientProvider } from 'next-intl'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Artifact } from '@cubeplex/core'
@@ -167,17 +167,34 @@ describe('ArtifactPanel expand theater', () => {
     })
   })
 
-  it('panel rail Close closes the whole panel', () => {
+  it('theater Close exits expand only; rail Close after exit dismisses panel', () => {
     renderPanel()
-    fireEvent.click(screen.getByTitle('Expand preview'))
+    fireEvent.click(screen.getByTestId('panel-expand'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
 
-    // Rail header Close is outside the dialog
-    const rail = screen.getByTestId('artifact-rail-placeholder').parentElement!
-    const railHeaderClose = within(rail.parentElement!).getAllByTitle('Close')[0]!
-    fireEvent.click(railHeaderClose)
+    // Theater X closes expand only (modal keeps rail inert while open).
+    fireEvent.click(within(screen.getByRole('dialog')).getByTitle('Close'))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(usePanelStore.getState().view).toEqual({
+      type: 'artifact',
+      conversationId: 'conv-1',
+      artifactId: 'art-1',
+    })
 
+    // After exit, rail Close dismisses the whole panel.
+    fireEvent.click(screen.getByTitle('Close'))
     expect(usePanelStore.getState().view).toEqual({ type: 'closed' })
-    expect(screen.queryByTestId('artifact-expand-preview')).not.toBeInTheDocument()
+  })
+
+  it('opens with focus on theater Exit expand (outside embedded preview)', async () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId('panel-expand'))
+    const dialog = await screen.findByRole('dialog')
+    const exitBtn = within(dialog).getByTestId('panel-exit-expand')
+    // Base UI initialFocus moves focus to the exit control after open.
+    await waitFor(() => {
+      expect(document.activeElement).toBe(exitBtn)
+    })
   })
 
   it('navigate-away to another artifact closes theater without dual host', () => {

--- a/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
+++ b/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
@@ -90,6 +90,21 @@ function renderPanel() {
 
 describe('ArtifactPanel expand theater', () => {
   beforeEach(() => {
+    // Desktop viewport for expand control + theater (useMediaQuery min-width 768px).
+    vi.stubGlobal(
+      'matchMedia',
+      (query: string) =>
+        ({
+          matches: query.includes('min-width: 768px'),
+          media: query,
+          onchange: null,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as MediaQueryList,
+    )
     usePanelStore.setState({ view: { type: 'closed' } })
     useArtifactStore.setState({
       artifacts: {},
@@ -194,6 +209,81 @@ describe('ArtifactPanel expand theater', () => {
     // Base UI initialFocus moves focus to the exit control after open.
     await waitFor(() => {
       expect(document.activeElement).toBe(exitBtn)
+    })
+  })
+
+  it('backdrop click closes theater and keeps selection', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId('panel-expand'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    const overlay = document.querySelector('[data-slot="dialog-overlay"]')
+    expect(overlay).toBeTruthy()
+    fireEvent.click(overlay!)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(usePanelStore.getState().view).toEqual({
+      type: 'artifact',
+      conversationId: 'conv-1',
+      artifactId: 'art-1',
+    })
+  })
+
+  it('version selection while expanded survives exit', () => {
+    const multi: Artifact = { ...artifact, version: 3, name: 'report-v3.bin' }
+    useArtifactStore.setState({
+      artifacts: { 'conv-1': { 'art-1': multi } },
+      versions: {
+        'art-1': [
+          {
+            id: 'v1',
+            artifact_id: 'art-1',
+            version: 1,
+            name: 'report-v1.bin',
+            path: '/workspace/v1',
+            created_at: '2026-07-20T00:00:00Z',
+          },
+          {
+            id: 'v2',
+            artifact_id: 'art-1',
+            version: 2,
+            name: 'report-v2.bin',
+            path: '/workspace/v2',
+            created_at: '2026-07-21T00:00:00Z',
+          },
+          {
+            id: 'v3',
+            artifact_id: 'art-1',
+            version: 3,
+            name: 'report-v3.bin',
+            path: '/workspace/v3',
+            created_at: '2026-07-22T00:00:00Z',
+          },
+        ],
+      },
+      selectedVersion: {},
+      loading: {},
+      deletedIds: {},
+    })
+    usePanelStore.getState().openArtifact('conv-1', 'art-1')
+
+    renderPanel()
+    fireEvent.click(screen.getByTestId('panel-expand'))
+    const dialog = screen.getByRole('dialog')
+    // Open version popover in theater and pick v1 (not latest).
+    fireEvent.click(within(dialog).getByText('v3'))
+    fireEvent.click(within(dialog).getByText('v1'))
+
+    expect(useArtifactStore.getState().selectedVersion['art-1']).toBe(1)
+
+    fireEvent.click(within(dialog).getByTestId('panel-exit-expand'))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    // Selection remains after exit expand.
+    expect(useArtifactStore.getState().selectedVersion['art-1']).toBe(1)
+    expect(usePanelStore.getState().view).toEqual({
+      type: 'artifact',
+      conversationId: 'conv-1',
+      artifactId: 'art-1',
     })
   })
 

--- a/frontend/packages/web/__tests__/components/PanelHeader.test.tsx
+++ b/frontend/packages/web/__tests__/components/PanelHeader.test.tsx
@@ -8,8 +8,8 @@ const messages = {
     header: {
       copy: 'Copy',
       close: 'Close',
-      fullscreen: 'Fullscreen',
-      exitFullscreen: 'Exit fullscreen',
+      expand: 'Expand preview',
+      exitExpand: 'Exit expand',
     },
   },
 }
@@ -63,16 +63,27 @@ describe('PanelHeader', () => {
     expect(screen.queryByTitle('Copy')).not.toBeInTheDocument()
   })
 
-  it('fullscreen toggle fires and flips its label', () => {
+  it('expand toggle fires with expand tooltip', () => {
     const onToggle = vi.fn()
     renderHeader(
       <PanelHeader
         source={{ kind: 'plain', icon: null, title: 'Browser' }}
-        fullscreen={{ active: false, onToggle }}
+        expand={{ active: false, onToggle }}
         onClose={() => {}}
       />,
     )
-    fireEvent.click(screen.getByTitle('Fullscreen'))
+    fireEvent.click(screen.getByTitle('Expand preview'))
     expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('expand active shows exit expand tooltip', () => {
+    renderHeader(
+      <PanelHeader
+        source={{ kind: 'plain', icon: null, title: 'Browser' }}
+        expand={{ active: true, onToggle: () => {} }}
+        onClose={() => {}}
+      />,
+    )
+    expect(screen.getByTitle('Exit expand')).toBeInTheDocument()
   })
 })

--- a/frontend/packages/web/components/panel/PanelHeader.tsx
+++ b/frontend/packages/web/components/panel/PanelHeader.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, type ReactNode } from 'react'
+import { useState, type ReactNode, type Ref } from 'react'
 import { X, Copy, Check, Plug, Maximize2, Minimize2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
@@ -37,6 +37,8 @@ interface PanelHeaderProps {
    * on mobile where the panel already fills the viewport).
    */
   expandClassName?: string
+  /** Ref to the expand/exit-expand button (dialog initial/final focus). */
+  expandButtonRef?: Ref<HTMLButtonElement>
   onClose: () => void
 }
 
@@ -45,6 +47,7 @@ export function PanelHeader({
   actions,
   expand,
   expandClassName,
+  expandButtonRef,
   onClose,
 }: PanelHeaderProps) {
   const t = useTranslations('panel.header')
@@ -129,12 +132,15 @@ export function PanelHeader({
         )}
         {expand && (
           <button
+            ref={expandButtonRef}
+            type="button"
             onClick={expand.onToggle}
             className={cn(
               'p-1 rounded-xs hover:bg-accent transition-colors duration-fast',
               expandClassName,
             )}
             title={t(expand.active ? 'exitExpand' : 'expand')}
+            data-testid={expand.active ? 'panel-exit-expand' : 'panel-expand'}
           >
             {expand.active ? (
               <Minimize2 className="size-3.5 text-muted-foreground" />

--- a/frontend/packages/web/components/panel/PanelHeader.tsx
+++ b/frontend/packages/web/components/panel/PanelHeader.tsx
@@ -5,6 +5,7 @@ import { X, Copy, Check, Plug, Maximize2, Minimize2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
 import { getToolIcon, getParamSummary } from '@/lib/toolIcons'
+import { cn } from '@/lib/utils'
 import { useMcpToolRegistryStore } from '@cubeplex/core'
 
 interface ToolHeaderSource {
@@ -29,11 +30,23 @@ interface PanelHeaderProps {
   source: PanelHeaderSource
   /** per-adapter extras (version popover, download, take-over…) rendered before the standard actions */
   actions?: ReactNode
-  fullscreen?: { active: boolean; onToggle: () => void }
+  /** In-app expand (theater). Prefer this over browser Fullscreen API. */
+  expand?: { active: boolean; onToggle: () => void }
+  /**
+   * Extra class for the expand control (e.g. `hidden md:inline-flex` to hide
+   * on mobile where the panel already fills the viewport).
+   */
+  expandClassName?: string
   onClose: () => void
 }
 
-export function PanelHeader({ source, actions, fullscreen, onClose }: PanelHeaderProps) {
+export function PanelHeader({
+  source,
+  actions,
+  expand,
+  expandClassName,
+  onClose,
+}: PanelHeaderProps) {
   const t = useTranslations('panel.header')
   const [copied, setCopied] = useState(false)
   const mcpEntry = useMcpToolRegistryStore((s) =>
@@ -114,13 +127,16 @@ export function PanelHeader({ source, actions, fullscreen, onClose }: PanelHeade
             )}
           </button>
         )}
-        {fullscreen && (
+        {expand && (
           <button
-            onClick={fullscreen.onToggle}
-            className="p-1 rounded-xs hover:bg-accent transition-colors duration-fast"
-            title={t(fullscreen.active ? 'exitFullscreen' : 'fullscreen')}
+            onClick={expand.onToggle}
+            className={cn(
+              'p-1 rounded-xs hover:bg-accent transition-colors duration-fast',
+              expandClassName,
+            )}
+            title={t(expand.active ? 'exitExpand' : 'expand')}
           >
-            {fullscreen.active ? (
+            {expand.active ? (
               <Minimize2 className="size-3.5 text-muted-foreground" />
             ) : (
               <Maximize2 className="size-3.5 text-muted-foreground" />

--- a/frontend/packages/web/components/panel/artifact/ArtifactExpandDialog.tsx
+++ b/frontend/packages/web/components/panel/artifact/ArtifactExpandDialog.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+
+interface ArtifactExpandDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Artifact name for a11y labelling */
+  title: string
+  /** Stable identity so React remounts if selection swaps while open */
+  identityKey: string
+  header: ReactNode
+  children: ReactNode
+}
+
+/**
+ * In-app theater for artifact preview: large centered dialog (~90vw × 90vh).
+ * Esc / backdrop / controlled onOpenChange(false) close expand only — callers
+ * decide whether panelStore selection is kept.
+ */
+export function ArtifactExpandDialog({
+  open,
+  onOpenChange,
+  title,
+  identityKey,
+  header,
+  children,
+}: ArtifactExpandDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        key={identityKey}
+        showCloseButton={false}
+        className="flex h-[90vh] w-[min(90vw,1400px)] max-w-none flex-col gap-0 overflow-hidden
+          p-0 sm:max-w-none"
+        aria-describedby={undefined}
+      >
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        {header}
+        <div className="min-h-0 flex-1 overflow-hidden" data-testid="artifact-expand-preview">
+          {children}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/packages/web/components/panel/artifact/ArtifactExpandDialog.tsx
+++ b/frontend/packages/web/components/panel/artifact/ArtifactExpandDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ReactNode } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 
 interface ArtifactExpandDialogProps {
@@ -12,12 +12,22 @@ interface ArtifactExpandDialogProps {
   identityKey: string
   header: ReactNode
   children: ReactNode
+  /**
+   * Prefer the Exit expand control so keyboard users start outside embedded
+   * iframes (HTML/Office), where Esc would not reach the dialog.
+   */
+  initialFocusRef?: RefObject<HTMLElement | null>
+  /** Restore focus to the rail Expand control when still mounted. */
+  finalFocusRef?: RefObject<HTMLElement | null>
 }
 
 /**
  * In-app theater for artifact preview: large centered dialog (~90vw × 90vh).
  * Esc / backdrop / controlled onOpenChange(false) close expand only — callers
  * decide whether panelStore selection is kept.
+ *
+ * Modal by design: the rail under the backdrop is inert while open. Exit expand
+ * first, then use the rail Close control to dismiss the whole panel.
  */
 export function ArtifactExpandDialog({
   open,
@@ -26,6 +36,8 @@ export function ArtifactExpandDialog({
   identityKey,
   header,
   children,
+  initialFocusRef,
+  finalFocusRef,
 }: ArtifactExpandDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -35,6 +47,8 @@ export function ArtifactExpandDialog({
         className="flex h-[90vh] w-[min(90vw,1400px)] max-w-none flex-col gap-0 overflow-hidden
           p-0 sm:max-w-none"
         aria-describedby={undefined}
+        initialFocus={initialFocusRef}
+        finalFocus={finalFocusRef}
       >
         <DialogTitle className="sr-only">{title}</DialogTitle>
         {header}

--- a/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
+++ b/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from 'next-intl'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { PanelHeader } from '@/components/panel/PanelHeader'
 import { useWorkspaceContext } from '@/hooks/useWorkspaceContext'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { getArtifactIcon } from './artifactIcons'
 import { PreviewLoading } from './PreviewLoading'
 import { HtmlPreview } from './HtmlPreview'
@@ -252,6 +253,13 @@ export function ArtifactPanel() {
   const exitExpandButtonRef = useRef<HTMLButtonElement | null>(null)
   // Restore focus to rail Expand when the theater closes (if still mounted).
   const expandButtonRef = useRef<HTMLButtonElement | null>(null)
+  // Expand is desktop-only; clear theater if the viewport drops below md so
+  // finalFocus does not target a display:none control.
+  const isDesktop = useMediaQuery('(min-width: 768px)', true)
+
+  useEffect(() => {
+    if (!isDesktop) setExpandedKey(null)
+  }, [isDesktop])
 
   useEffect(() => {
     if (!artifact || artifact.version <= 1 || !conversationId || !artifactId) return

--- a/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
+++ b/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import { useArtifactStore, usePanelStore, createApiClient } from '@cubeplex/core'
 import type { Artifact, ArtifactVersion } from '@cubeplex/core'
@@ -21,6 +21,7 @@ import { FallbackPreview } from './FallbackPreview'
 import { SkillArtifactPreview } from './SkillArtifactPreview'
 import { OfficePreview } from './OfficePreview'
 import { buildDownloadUrl, buildPreviewUrl } from './previewUtils'
+import { ArtifactExpandDialog } from './ArtifactExpandDialog'
 
 const PdfPreview = dynamic(() => import('./PdfPreview').then((m) => m.PdfPreview), {
   ssr: false,
@@ -123,8 +124,7 @@ function ArtifactPanelHeader({
   selectedVersion,
   onSelectVersion,
   onClose,
-  onToggleFullscreen,
-  isFullscreen,
+  expand,
   workspaceId,
   portalContainer,
 }: {
@@ -133,8 +133,7 @@ function ArtifactPanelHeader({
   selectedVersion: number | null
   onSelectVersion: (version: number | null) => void
   onClose: () => void
-  onToggleFullscreen: () => void
-  isFullscreen: boolean
+  expand: { active: boolean; onToggle: () => void }
   workspaceId: string
   portalContainer: HTMLElement | null
 }) {
@@ -168,13 +167,15 @@ function ArtifactPanelHeader({
           </a>
         </>
       }
-      fullscreen={{ active: isFullscreen, onToggle: onToggleFullscreen }}
+      expand={expand}
+      // Mobile sheet already fills the viewport — hide expand control below md.
+      expandClassName="hidden md:inline-flex"
       onClose={onClose}
     />
   )
 }
 
-function PreviewContent({
+export function PreviewContent({
   artifact,
   version,
   workspaceId,
@@ -227,8 +228,23 @@ export function ArtifactPanel() {
   const artifact = conversationId && artifactId ? artifacts[conversationId]?.[artifactId] : null
 
   const { workspaceId } = useWorkspaceContext()
-  const containerRef = useRef<HTMLDivElement | null>(null)
-  const [isFullscreen, setIsFullscreen] = useState(false)
+  const t = useTranslations('panel.artifactPanel')
+
+  // Identity-keyed expand: when the selected artifact (or panel view) changes,
+  // expanded becomes false without a post-paint effect — no stale theater flash.
+  const identityKey = conversationId && artifactId ? `${conversationId}:${artifactId}` : null
+  const [expandedKey, setExpandedKey] = useState<string | null>(null)
+  const expanded = expandedKey !== null && expandedKey === identityKey
+
+  const openExpand = (): void => {
+    if (identityKey) setExpandedKey(identityKey)
+  }
+  const closeExpand = (): void => {
+    setExpandedKey(null)
+  }
+
+  const [railPortalEl, setRailPortalEl] = useState<HTMLElement | null>(null)
+  const [theaterPortalEl, setTheaterPortalEl] = useState<HTMLElement | null>(null)
 
   useEffect(() => {
     if (!artifact || artifact.version <= 1 || !conversationId || !artifactId) return
@@ -237,50 +253,86 @@ export function ArtifactPanel() {
     loadVersions(client, conversationId, artifactId)
   }, [artifact, conversationId, artifactId, loadVersions, workspaceId])
 
-  useEffect(() => {
-    const handleChange = (): void => {
-      setIsFullscreen(document.fullscreenElement === containerRef.current)
-    }
-    document.addEventListener('fullscreenchange', handleChange)
-    return () => document.removeEventListener('fullscreenchange', handleChange)
-  }, [])
-
-  const toggleFullscreen = (): void => {
-    const el = containerRef.current
-    if (!el) return
-    if (document.fullscreenElement === el) {
-      void document.exitFullscreen()
-    } else {
-      void el.requestFullscreen()
-    }
-  }
-
-  if (view.type !== 'artifact' || !artifact || !workspaceId) return null
+  if (view.type !== 'artifact' || !artifact || !workspaceId || !identityKey) return null
 
   const artifactVersions = versions[artifact.id] ?? []
   const currentSelectedVersion = selectedVersion[artifact.id] ?? null
 
+  const handleSelectVersion = (v: number | null): void => {
+    selectVersion(artifact.id, v)
+  }
+
+  const handlePanelClose = (): void => {
+    closeExpand()
+    close()
+  }
+
+  const headerProps = {
+    artifact,
+    versions: artifactVersions,
+    selectedVersion: currentSelectedVersion,
+    onSelectVersion: handleSelectVersion,
+    workspaceId,
+  }
+
   return (
-    <div ref={containerRef} className="flex flex-col h-full bg-background">
+    <div ref={setRailPortalEl} className="flex flex-col h-full bg-background">
       <ArtifactPanelHeader
-        artifact={artifact}
-        versions={artifactVersions}
-        selectedVersion={currentSelectedVersion}
-        onSelectVersion={(v) => selectVersion(artifact.id, v)}
-        onClose={close}
-        onToggleFullscreen={toggleFullscreen}
-        isFullscreen={isFullscreen}
-        workspaceId={workspaceId}
-        // eslint-disable-next-line react-hooks/refs
-        portalContainer={isFullscreen ? containerRef.current : null}
+        {...headerProps}
+        onClose={handlePanelClose}
+        expand={{
+          active: expanded,
+          onToggle: expanded ? closeExpand : openExpand,
+        }}
+        portalContainer={railPortalEl}
       />
       <div className="flex-1 overflow-hidden">
-        <PreviewContent
-          artifact={artifact}
-          version={currentSelectedVersion}
-          workspaceId={workspaceId}
-        />
+        {expanded ? (
+          <div
+            className="flex h-full items-center justify-center text-sm text-muted-foreground px-4
+              text-center"
+            data-testid="artifact-rail-placeholder"
+          >
+            {t('expandedPlaceholder')}
+          </div>
+        ) : (
+          <div data-testid="artifact-rail-preview">
+            <PreviewContent
+              artifact={artifact}
+              version={currentSelectedVersion}
+              workspaceId={workspaceId}
+            />
+          </div>
+        )}
       </div>
+
+      {/* Mount theater only while expanded so PreviewContent has a single host. */}
+      {expanded && (
+        <ArtifactExpandDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) closeExpand()
+          }}
+          title={artifact.name}
+          identityKey={identityKey}
+          header={
+            <div ref={setTheaterPortalEl}>
+              <ArtifactPanelHeader
+                {...headerProps}
+                onClose={closeExpand}
+                expand={{ active: true, onToggle: closeExpand }}
+                portalContainer={theaterPortalEl}
+              />
+            </div>
+          }
+        >
+          <PreviewContent
+            artifact={artifact}
+            version={currentSelectedVersion}
+            workspaceId={workspaceId}
+          />
+        </ArtifactExpandDialog>
+      )}
     </div>
   )
 }

--- a/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
+++ b/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef, type Ref } from 'react'
 import dynamic from 'next/dynamic'
 import { useArtifactStore, usePanelStore, createApiClient } from '@cubeplex/core'
 import type { Artifact, ArtifactVersion } from '@cubeplex/core'
@@ -125,6 +125,7 @@ function ArtifactPanelHeader({
   onSelectVersion,
   onClose,
   expand,
+  expandButtonRef,
   workspaceId,
   portalContainer,
 }: {
@@ -134,6 +135,7 @@ function ArtifactPanelHeader({
   onSelectVersion: (version: number | null) => void
   onClose: () => void
   expand: { active: boolean; onToggle: () => void }
+  expandButtonRef?: Ref<HTMLButtonElement>
   workspaceId: string
   portalContainer: HTMLElement | null
 }) {
@@ -168,6 +170,7 @@ function ArtifactPanelHeader({
         </>
       }
       expand={expand}
+      expandButtonRef={expandButtonRef}
       // Mobile sheet already fills the viewport — hide expand control below md.
       expandClassName="hidden md:inline-flex"
       onClose={onClose}
@@ -245,6 +248,10 @@ export function ArtifactPanel() {
 
   const [railPortalEl, setRailPortalEl] = useState<HTMLElement | null>(null)
   const [theaterPortalEl, setTheaterPortalEl] = useState<HTMLElement | null>(null)
+  // Focus exit-expand on open so Esc works before the user tabs into an iframe.
+  const exitExpandButtonRef = useRef<HTMLButtonElement | null>(null)
+  // Restore focus to rail Expand when the theater closes (if still mounted).
+  const expandButtonRef = useRef<HTMLButtonElement | null>(null)
 
   useEffect(() => {
     if (!artifact || artifact.version <= 1 || !conversationId || !artifactId) return
@@ -284,6 +291,7 @@ export function ArtifactPanel() {
           active: expanded,
           onToggle: expanded ? closeExpand : openExpand,
         }}
+        expandButtonRef={expandButtonRef}
         portalContainer={railPortalEl}
       />
       <div className="flex-1 overflow-hidden">
@@ -306,7 +314,8 @@ export function ArtifactPanel() {
         )}
       </div>
 
-      {/* Mount theater only while expanded so PreviewContent has a single host. */}
+      {/* Mount theater only while expanded so PreviewContent has a single host.
+          Modal backdrop makes the rail inert — exit expand, then rail Close. */}
       {expanded && (
         <ArtifactExpandDialog
           open
@@ -315,12 +324,15 @@ export function ArtifactPanel() {
           }}
           title={artifact.name}
           identityKey={identityKey}
+          initialFocusRef={exitExpandButtonRef}
+          finalFocusRef={expandButtonRef}
           header={
             <div ref={setTheaterPortalEl}>
               <ArtifactPanelHeader
                 {...headerProps}
                 onClose={closeExpand}
                 expand={{ active: true, onToggle: closeExpand }}
+                expandButtonRef={exitExpandButtonRef}
                 portalContainer={theaterPortalEl}
               />
             </div>

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -1455,6 +1455,8 @@
     "header": {
       "copy": "Copy",
       "close": "Close",
+      "expand": "Expand preview",
+      "exitExpand": "Exit expand",
       "fullscreen": "Fullscreen",
       "exitFullscreen": "Exit fullscreen"
     },
@@ -1500,8 +1502,9 @@
     "artifactPanel": {
       "download": "Download",
       "close": "Close",
-      "fullscreen": "Fullscreen",
-      "exitFullscreen": "Exit fullscreen",
+      "expand": "Expand preview",
+      "exitExpand": "Exit expand",
+      "expandedPlaceholder": "Expanded in preview",
       "unknownType": "Unknown type",
       "justNow": "just now",
       "minutesAgo": "{n}m ago",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -1455,6 +1455,8 @@
     "header": {
       "copy": "复制",
       "close": "关闭",
+      "expand": "展开预览",
+      "exitExpand": "退出展开",
       "fullscreen": "全屏",
       "exitFullscreen": "退出全屏"
     },
@@ -1500,8 +1502,9 @@
     "artifactPanel": {
       "download": "下载",
       "close": "关闭",
-      "fullscreen": "全屏",
-      "exitFullscreen": "退出全屏",
+      "expand": "展开预览",
+      "exitExpand": "退出展开",
+      "expandedPlaceholder": "已在大图预览中展开",
       "unknownType": "未知类型",
       "justNow": "刚刚",
       "minutesAgo": "{n} 分钟前",


### PR DESCRIPTION
## Summary

In-app theater expand for artifact preview (#395).

- Spec + plan (docs)
- Implementation: replace browser Fullscreen API with a large centered dialog
- Single `PreviewContent` host while expanded (rail shows placeholder)
- Esc / backdrop / minimize / theater X keep `panelStore` selection
- Navigate-away closes theater via identity-keyed expand state
- Desktop-only expand control (`hidden md:inline-flex`)

Related: #395

## Status

- [x] Spec done
- [x] Plan done
- [x] Implementation

## Docs

- `docs/dev/specs/2026-07-22-artifact-preview-expand-design.md`
- `docs/dev/plans/2026-07-22-artifact-preview-expand.md`
- `docs/site/docs/guides/conversations/artifacts.md` (Expand preview)

## Test plan

- [x] Unit: expand open/close, selection kept, single host, navigate-away
- [x] PanelHeader expand tooltips
- [ ] Manual: html/pdf/image/code/office in theater; version switch; download
- [ ] Manual mobile: expand hidden; sheet still works