### PR TITLE
Skill name display: design and plan

### DIFF
--- a/docs/dev/plans/2026-07-22-skill-name-display.md
+++ b/docs/dev/plans/2026-07-22-skill-name-display.md
@@ -1,0 +1,145 @@
+# Skill name display — implementation plan
+
+Related: #399 · Spec: `docs/dev/specs/2026-07-22-skill-name-display-design.md`
+
+**Goal**: Show bare skill slug as the primary UI label for uploaded
+(`org:slug`) skills while keeping canonical names for identity and tools.
+
+**Architecture**: Pure frontend display helper (Phase 1). Optional later
+backend resolve for bare `load_skill` (Phase 2) — not required for the first
+shippable PR.
+
+**Tech stack**: TypeScript helper + existing skill card/detail components;
+Jest/Vitest unit tests for the helper.
+
+---
+
+## Unit 1: `formatSkillLabel` helper
+
+**Files**:
+- `frontend/packages/core/src/lib/formatSkillLabel.ts` (preferred if core is
+  shared) **or** `frontend/packages/web/lib/formatSkillLabel.ts`
+- Export from package index if placed in core
+
+**API**:
+
+```ts
+export function formatSkillLabel(name: string): {
+  primary: string
+  canonical: string
+  isNamespaced: boolean
+  namespace: string | null  // segment before last ':'
+}
+```
+
+**Rules**:
+- If `name` contains `:`, `primary` = substring after **last** `:`;
+  `namespace` = before last `:`; `isNamespaced = true`.
+- Else `primary = canonical = name`; `isNamespaced = false`.
+- Empty/edge: safe fallbacks (empty primary → canonical).
+
+**Tests**:
+- `acme-corp:quarterly-report` → primary `quarterly-report`
+- `deep-research` → primary `deep-research`, not namespaced
+- `a:b:c` → primary `c` (last colon) — document intentional behavior
+- empty string
+
+---
+
+## Unit 2: Admin skill list + detail
+
+**Files**:
+- `frontend/packages/web/components/admin/skills/SkillCard.tsx`
+- `frontend/packages/web/components/admin/skills/SkillDetailPanel.tsx`
+
+**Changes**:
+- Card title: `primary`; `title` attribute or Tooltip: `canonical`
+- Detail header: `primary` as main heading; monospace secondary row with full
+  canonical + copy button if not already present
+- Keep `data-testid` stable: prefer still based on canonical `skill.name` so
+  e2e selectors do not break
+
+**Tests**: update any snapshot/e2e that assert visible full org prefix as sole
+label; assert primary slug visible.
+
+---
+
+## Unit 3: Workspace skill list + detail
+
+**Files**:
+- `frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillCard.tsx`
+- `frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillDetail.tsx`
+
+Same display rules as Unit 2.
+
+---
+
+## Unit 4: Other UI surfaces (same helper)
+
+**Files** (audit and apply if they show uploaded `skill.name` raw):
+- Skill install lists, binding tables, any mono headers that truncate badly
+- **Do not** change remote registry candidate cards that already show a
+  short `candidate.name` separate from `canonical_name` unless they dump the
+  long form as primary
+
+**Chat/tool panels**:
+- `SkillView` / load_skill panel may show the name the agent passed (often
+  canonical) — optional: display via helper for friendliness; keep copyable
+  canonical available
+
+---
+
+## Unit 5: Optional badge
+
+If design time allows: small “Uploaded” / source badge on cards when
+`isNamespaced` so users still see origin without the long prefix.
+
+Skip if it requires new i18n/design cycles; Phase 1 is complete without it.
+
+---
+
+## Unit 6 (Phase 2, separate PR): bare `load_skill` + agent list
+
+**Files**:
+- `backend/cubeplex/skills/service.py` / catalog `find_enabled_by_name`
+- `tools/builtin/load_skill.py` description update
+- Skills list assembly for `SKILLS_PROMPT_TEMPLATE`
+- Tests for precedence: preinstalled wins; unique uploaded bare resolves;
+  ambiguous errors
+
+**Not in Phase 1 PR.**
+
+---
+
+## Unit 7: Docs
+
+- If only UI: brief note in skills management guide that uploaded skills show
+  short names; tools still use `org:slug`.
+- If Phase 2: update D18 follow-on note in marketplace design or skills guide.
+
+---
+
+## Delivery order
+
+1. Unit 1 helper + tests  
+2. Units 2–3 cards/details  
+3. Unit 4 audit pass  
+4. Unit 5 optional badge  
+5. Docs with implementation  
+6. Phase 2 later  
+
+## Out of scope (Phase 1)
+
+- Migrating `Skill.name` in DB  
+- Changing sandbox path encoding  
+- Bare `load_skill`  
+- Frontmatter title field  
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Users copy primary and paste into agent | Tooltip/detail show canonical; Phase 2 bare resolve later |
+| E2E selectors break | Keep testids on canonical name |
+| Multi-colon names | Last-colon rule documented |
+| Confusion between two skills same bare slug different orgs | Not visible in single-org UI lists; federation later uses canonical |

--- a/docs/dev/specs/2026-07-22-skill-name-display-design.md
+++ b/docs/dev/specs/2026-07-22-skill-name-display-design.md
@@ -1,0 +1,142 @@
+# Uploaded skill names: shorter display without losing isolation
+
+Related: #399
+
+## Goal
+
+Stop long `org-slug:skill-slug` strings from dominating skill UI (and, later,
+agent skill lists), while keeping **canonical** names for identity, uniqueness,
+and `load_skill`.
+
+## Context
+
+### Why the prefix exists (D18)
+
+Canonical name for uploaded skills:
+
+```text
+<org-slug>:<skill-slug>
+```
+
+Intentional for namespace isolation across orgs, visual distinction from
+**preinstalled** bare slugs (`deep-research`), and future federation without
+rename breakage. Object-store paths use `org_id` + bare skill slug and are
+independent of the display string.
+
+### Current behavior
+
+| Layer | Behavior |
+| --- | --- |
+| Publish | `SkillPublishService`: `canonical_name = f"{org_slug}:{fm.name}"` |
+| DB | `Skill.name` stores full canonical; max 128 |
+| UI | Admin/workspace cards and detail headers render `skill.name` raw |
+| Agent | Available-skills list + `load_skill(name)` use canonical name |
+| Sandbox FS | `:` → `__` via `safe_skill_name` |
+
+There is **no** separate `display_name` field. Org slugs up to 32 chars make
+cards truncate on the **prefix**, hiding the useful skill slug.
+
+## Problem
+
+1. Visual noise — prefix repeats the current org on every uploaded skill in an
+   already org-scoped list.
+2. Truncation cuts the skill slug first.
+3. Agent friction — long tokens in skill lists and `load_skill` args.
+4. Sandbox path length (secondary).
+
+Must not casually break: uniqueness vs preinstalled bare slugs, stable identity
+for installs/versions/`load_skill`, org-rename policy (old prefixes may stick).
+
+## Approaches considered
+
+| Option | Summary | Verdict |
+| --- | --- | --- |
+| **A. Display ≠ canonical** | UI shows bare slug; tooltip/detail show full | **Primary UX fix** |
+| **B. Bare `load_skill` resolve** | Unambiguous bare name → `org:slug` | **Optional later** |
+| **C. Shorter namespace token** | Short org key in canonical | Migration cost; later |
+| **D. Single-tenant bare names** | Divergent modes | Avoid for now |
+| **E. UI layout only** | Two-line / ellipsis prefix | Complements A |
+| **F. Frontmatter title** | Human title field | Later polish |
+
+## Recommended direction
+
+### Phase 1 — UI display (A + E) — **this feature’s default scope**
+
+Shared helper:
+
+```ts
+formatSkillLabel(name: string): { primary: string; canonical: string; isNamespaced: boolean }
+// primary = segment after last ':' if colon present, else whole name
+// canonical = original name
+```
+
+| Surface | Show |
+| --- | --- |
+| List cards, most headers | `primary` (bare slug) |
+| Tooltip on hover | full `canonical` |
+| Detail technical row / copy | full `canonical` |
+| Preinstalled (no colon) | unchanged bare name |
+| Optional | “Uploaded” badge instead of textual prefix |
+
+Truncation: prefer ellipsis on the **prefix** if any secondary line shows
+canonical; primary line should show the full bare slug when possible.
+
+**No DB migration.** `Skill.name` stays canonical. `load_skill` still requires
+the full name unless Phase 2 lands.
+
+### Phase 2 — Agent list / bare resolve (optional follow-up)
+
+- Skills list in prompt: show bare slug with note `id: org:slug`, **or**
+- `load_skill("my-skill")` resolves when exactly one enabled match after
+  applying precedence:
+
+  1. Preinstalled bare name wins if both exist.
+  2. Else unique uploaded bare slug in this org/workspace visibility.
+  3. Else require full canonical / error with candidates.
+
+Keep full canonical always valid.
+
+### Phase 3 — Optional (C/F)
+
+Short org namespace or separate display `title` from frontmatter — only if
+Phase 1–2 still feel noisy.
+
+## Non-goals (Phase 1)
+
+- Rewriting historical `Skill.name` rows.
+- Changing object-store or sandbox path layout.
+- Dropping uniqueness of uploaded vs preinstalled names.
+- Making remote registry candidate cards use a different rule without review
+  (default: same primary/canonical helper when a colon form appears).
+
+## Acceptance criteria
+
+1. In org-scoped skill lists, the **dominant visible label** is the short skill
+   slug (or later title), not a long `org-slug:` prefix.
+2. Full canonical name remains available (tooltip, detail, copy).
+3. `load_skill` continues to work for existing uploaded skills with full name
+   (and bare name only if Phase 2 is implemented).
+4. No undefined collision between preinstalled and uploaded names.
+5. Preinstalled skills unchanged (still bare).
+6. Tests for display helper + (if Phase 2) resolution precedence.
+7. Docs/spec note updated if agent-visible names change.
+
+## Open questions (v1 decisions)
+
+| Question | Decision |
+| --- | --- |
+| UI-only first vs also agent names | **UI-only (Phase 1) in first implementation**; Phase 2 separate |
+| Bare load when preinstalled collides | Require prefix; preinstalled wins |
+| Frontmatter title | Not required for Phase 1 |
+| Org slug rename | Tooltip shows historical canonical forever |
+| Search / remote install cards | Reuse same helper when name is namespaced |
+
+## Related code
+
+- Design D18: `docs/dev/specs/2026-04-26-skills-marketplace-design.md`
+- Publish: `backend/cubeplex/skills/service.py`
+- Model: `backend/cubeplex/models/skill.py`
+- Sandbox path: `backend/cubeplex/skills/sandbox_paths.py`
+- UI: `SkillCard.tsx`, `WorkspaceSkillCard.tsx`, skill detail panels
+- Agent list: `prompts/skills.py` + catalog assembly in run path
+- `load_skill`: `tools/builtin/load_skill.py`


### PR DESCRIPTION
## Summary

Spec + plan only for showing bare skill slugs in UI while preserving canonical `org:slug` identity for isolation and `load_skill`. Optional bare resolve deferred to a later phase.

Related: #399

Implementation is deferred; this PR freezes the design and phased plan under `docs/dev/`.

## Docs

- `docs/dev/specs/2026-07-22-skill-name-display-design.md`
- `docs/dev/plans/2026-07-22-skill-name-display.md`

## Test plan

- [ ] Spec/plan review against issue acceptance criteria
- [ ] No code changes expected in this PR