### PR TITLE
Conversation running indicator in chat history sidebar

### DIFF
--- a/docs/dev/plans/2026-07-22-conversation-running-indicator.md
+++ b/docs/dev/plans/2026-07-22-conversation-running-indicator.md
@@ -1,0 +1,139 @@
+# Conversation Running Indicator — Implementation Plan
+
+**Goal:** Add a list-level “this conversation is still streaming” spinner next
+to the title in the chat history sidebar, driven by existing
+`useMessageStore` stream flags.
+
+**Architecture:** Pure frontend affordance. `ConversationRow` subscribes to
+`isStreaming` + `streamingConversationId` and renders a small `Loader2` when
+the row’s `convo.id` matches. No backend or conversation-list API changes.
+
+**Tech stack:** React 19, Next.js app router, Zustand (`@cubeplex/core`
+message store), lucide-react, next-intl, Vitest + React Testing Library.
+
+**Spec:** [docs/dev/specs/2026-07-22-conversation-running-indicator-design.md](../specs/2026-07-22-conversation-running-indicator-design.md)  
+**Issue:** #388
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `frontend/packages/web/components/layout/Sidebar.tsx` | Modify | `ConversationRow`: running predicate + spinner after title |
+| `frontend/packages/web/messages/en.json` | Modify | `sidebar.conversationRunning` |
+| `frontend/packages/web/messages/zh.json` | Modify | Chinese copy for the same key |
+| `frontend/packages/web/__tests__/components/ConversationRow.running.test.tsx` (or Sidebar-focused test) | Create | Business-facing: spinner present/absent from store state |
+
+No changes to `messageStore` unless a tiny exported selector is preferred
+for testability; default is inline store read in the row.
+
+---
+
+## Unit of work 1 — i18n keys
+
+**Files:** `messages/en.json`, `messages/zh.json`
+
+**Interfaces:** `useTranslations('sidebar')` → `t('conversationRunning')`
+
+**Core logic:** Add one string key under existing `sidebar` object. No
+namespace restructure.
+
+**Tests:** Covered indirectly by component test that asserts accessible name
+matches the English string under the test intl provider (same pattern as
+other Sidebar tests if present).
+
+---
+
+## Unit of work 2 — ConversationRow spinner
+
+**Files:** `Sidebar.tsx` (`ConversationRow`)
+
+**Interfaces:**
+
+```ts
+// Read-only subscription inside ConversationRow
+const isRunning = useMessageStore(
+  (s) => s.isStreaming && s.streamingConversationId === convo.id,
+)
+```
+
+**Core logic:**
+
+1. Import `Loader2` and `useMessageStore` if not already available in the
+   file (message store is already used elsewhere in the app; wire import
+   from `@cubeplex/core`).
+2. After the title `div`, when `isRunning`, render:
+
+   ```tsx
+   <Loader2
+     className="size-3.5 shrink-0 animate-spin text-muted-foreground"
+     aria-label={tSidebar('conversationRunning')}
+   />
+   ```
+
+   Adjust size/class only to match pin icon scale (~12–14px) and avoid
+   colliding with avatars/menu.
+3. Do not render the spinner in the rename (`isEditing`) branch unless
+   product wants it during rename; default: spinner only on the link row.
+4. Keep pin / group / menu order:  
+   `[pin?] [groupIcon?] [title …] [spinner?] [avatars?] [menu]`
+
+**Tests (intent):**
+
+- Given store `{ isStreaming: true, streamingConversationId: 'c1' }` and a
+  row for `c1` → spinner is in the document with the running accessible
+  name.
+- Given same store and row for `c2` → no spinner.
+- Given `isStreaming: false` → no spinner.
+- Row still exposes rename/pin controls (smoke: menu trigger or pin icon
+  still present) — protect “layout not broken,” not DOM counts for their
+  own sake.
+
+Prefer a focused unit/component test with store state injected (existing
+patterns in `InputBar.test.tsx` / messageStore mocks) over a full Playwright
+suite for this pure client indicator.
+
+---
+
+## Unit of work 3 — Manual / E2E smoke (optional if time)
+
+**Intent:** One Playwright or manual checklist item:
+
+1. Send a message in conversation A.
+2. Navigate to conversation B while A streams.
+3. Assert A’s sidebar row shows the spinner; B does not.
+4. Wait for completion; spinner gone.
+
+Only automate if a cheap existing sidebar E2E harness already mounts the
+shell; do not build a large new E2E surface for a 10-line UI change.
+
+---
+
+## Out of scope in implementation
+
+- Multi-stream `Set` of running conversation ids
+- Server list fields
+- Unread indicator (#389)
+- Docs site page (no route/API surface)
+
+---
+
+## Verification
+
+```bash
+# from worktree frontend package
+cd frontend/packages/web && pnpm exec vitest run __tests__/components/ConversationRow.running.test.tsx
+# or the chosen test path
+```
+
+Paste green vitest output before claiming done.
+
+---
+
+## Suggested commit sequence (implementation phase)
+
+1. `feat(sidebar): show running spinner on streaming conversation row`
+2. (optional) test-only follow-up if split
+
+Implementation waits for design approval of this plan + spec.

--- a/docs/dev/plans/2026-07-22-conversation-running-indicator.md
+++ b/docs/dev/plans/2026-07-22-conversation-running-indicator.md
@@ -85,7 +85,10 @@ const isRunning = useMessageStore(
   row for `c1` → spinner is in the document with the running accessible
   name.
 - Given same store and row for `c2` → no spinner.
-- Given `isStreaming: false` → no spinner.
+- Given `isStreaming: false` → no spinner (covers idle **and** paused HITL
+  where `streamingConversationId` may still be set).
+- Given `{ isStreaming: false, streamingConversationId: 'c1' }` (HITL-paused
+  shape) and row `c1` → **no** spinner.
 - Row still exposes rename/pin controls (smoke: menu trigger or pin icon
   still present) — protect “layout not broken,” not DOM counts for their
   own sake.
@@ -93,6 +96,12 @@ const isRunning = useMessageStore(
 Prefer a focused unit/component test with store state injected (existing
 patterns in `InputBar.test.tsx` / messageStore mocks) over a full Playwright
 suite for this pure client indicator.
+
+**Store ownership (implementation note, not a spinner feature):** If during
+QA a late terminal event from aborted conversation A clears B’s streaming
+flags, fix the owner check inside `messageStore` terminalization (only clear
+when `streamingConversationId === completedId` / current run still owns the
+controller). Do not add a second running set in the sidebar.
 
 ---
 

--- a/docs/dev/specs/2026-07-22-conversation-running-indicator-design.md
+++ b/docs/dev/specs/2026-07-22-conversation-running-indicator-design.md
@@ -74,10 +74,20 @@ Notes:
 - On normal completion, cancel, or error paths that clear
   `isStreaming` / `streamingConversationId`, the spinner disappears with no
   extra sidebar logic.
-- HITL paused states: follow whatever the store already does for
-  `isStreaming` vs paused. If the stream is considered still active
-  (`streamingConversationId` set), keep the spinner; do not invent a
-  separate “waiting” icon in this issue.
+- **HITL paused (resolved):** Today `finalizePausedStream` / bootstrap set
+  `isStreaming: false` while often leaving `streamingConversationId` set so
+  `MessageList` can still gate the AskUser card. MVP **does not** show the
+  running spinner for paused HITL — the predicate requires `isStreaming ===
+  true` (live stream / tool execution). Waiting-on-user is not “running”; a
+  separate HITL icon is out of scope. Do **not** widen the predicate to
+  “any non-null `streamingConversationId`.”
+- **Stream ownership invariant (store, not a second flag):** Spinner is a
+  pure read of the two flags. Correctness requires that only the **current
+  stream owner** may clear `isStreaming` / `streamingConversationId`. If
+  conversation A is aborted because B starts a send, a late terminal
+  handler for A must not wipe B’s flags. That ownership check belongs in
+  `messageStore` terminal paths if missing; this feature must not paper over
+  it with a parallel “running ids” map.
 
 ### 4.2 UX
 
@@ -146,4 +156,4 @@ Add keys under the existing `sidebar` namespace in
 | --- | --- |
 | Multi-conversation background runs? | Out of scope; current store is single-stream. Spinner tracks that one id. |
 | Server `active_run` on list? | Not for MVP. Revisit only if product requires post-reload running state. |
-| Show spinner during HITL wait? | Match store: if `streamingConversationId` still set, show spinner. |
+| Show spinner during HITL wait? | **No.** Paused HITL has `isStreaming: false`; spinner is live-stream only. |

--- a/docs/dev/specs/2026-07-22-conversation-running-indicator-design.md
+++ b/docs/dev/specs/2026-07-22-conversation-running-indicator-design.md
@@ -1,0 +1,149 @@
+# Conversation Running Indicator — Design
+
+**Status:** Draft  
+**Date:** 2026-07-22  
+**Related:** #388 · complements #389 (unread after completion)
+
+## 1. Goal
+
+Show a small spinner next to a conversation’s title in the left chat-history
+sidebar while that conversation has an agent run in progress on the client.
+When the run ends (success, error, or cancel), remove the spinner. Rows that
+are not running show no indicator.
+
+Users who switch threads or only glance at the list should still know which
+conversation is actively streaming or using tools.
+
+## 2. Context
+
+### What exists today
+
+- Sidebar conversation rows are rendered by `ConversationRow` in
+  `frontend/packages/web/components/layout/Sidebar.tsx`. Layout already
+  includes pin icon, truncated title, optional group avatars, and a hover
+  overflow menu. There is no in-flight visual.
+- Agent streaming is tracked in `@cubeplex/core`’s `useMessageStore`
+  (`frontend/packages/core/src/stores/messageStore.ts`):
+  - `isStreaming: boolean`
+  - `streamingConversationId: string | null`
+- The store models **one active stream at a time**. Starting a new send
+  aborts the previous controller. Bootstrap can seed HITL / last-run error
+  state, but there is no multi-conversation “in-flight runs” client map
+  and no list API field for “running now.”
+- `useMessages` already scopes streaming UI to
+  `isStreaming && streamingConversationId === conversationId` for the open
+  chat; the sidebar never reads that state.
+
+### Why change
+
+Without a list-level signal, users assume a backgrounded chat has finished
+or lose track of which row is still working. The open conversation already
+shows stream chrome; the history list does not.
+
+## 3. Approaches considered
+
+| Approach | Pros | Cons |
+| --- | --- | --- |
+| **A. Drive spinner from existing `messageStore` stream flags** (recommended) | No API/schema work; matches real SSE lifecycle; one source of truth with chat chrome | Only covers the single in-tab stream the client holds; no multi-device |
+| **B. Server `last_run_status` / active-run list on conversation list** | Survives reload and multi-tab if backend tracks runs | Larger backend + list payload change; issue marks this non-goal unless client state is insufficient |
+| **C. Per-row poll of conversation bootstrap** | Accurate when opened | Wasteful N+1 traffic; not list-friendly |
+
+**Recommendation: A.** Acceptance criteria in #388 are client-tab stream
+visibility (“without requiring the user to open that conversation” while
+still on the same client session). Document the single-stream / single-tab
+limit; server in-flight sync is a follow-up.
+
+## 4. Design
+
+### 4.1 Running predicate
+
+A conversation row is **running** when:
+
+```text
+messageStore.isStreaming === true
+AND messageStore.streamingConversationId === convo.id
+```
+
+Notes:
+
+- Keep the predicate in the UI layer (or a tiny selector helper). Do **not**
+  invent a second “running” flag that can drift from stream end handlers.
+- When the user switches conversations mid-stream, `streamingConversationId`
+  stays on the conversation that owns the SSE; that row keeps the spinner
+  even when it is not `activeId`.
+- On normal completion, cancel, or error paths that clear
+  `isStreaming` / `streamingConversationId`, the spinner disappears with no
+  extra sidebar logic.
+- HITL paused states: follow whatever the store already does for
+  `isStreaming` vs paused. If the stream is considered still active
+  (`streamingConversationId` set), keep the spinner; do not invent a
+  separate “waiting” icon in this issue.
+
+### 4.2 UX
+
+- **Placement:** Inside `ConversationRow`, immediately after the truncated
+  title (`flex-1 min-w-0 truncate` title node), before group avatars and the
+  overflow menu. Use a shrink-0 spinner so truncation stays on the title.
+- **Visual:** ~12–14px spinner — prefer existing `Loader2` + `animate-spin`
+  from `lucide-react` (already used in the composer). Color:
+  `text-muted-foreground` by default; ensure contrast on the active row
+  (`bg-accent`).
+- **Surfaces:** Same `ConversationRow` is used for pinned, recent, and
+  topic-nested lists — one change covers all three.
+- **a11y:** Spinner (or its wrapper) gets
+  `aria-label={tSidebar('conversationRunning')}` (or equivalent under
+  `sidebar` / `shellLayout`). Decorative motion should not be the only cue;
+  the label is required.
+- **Non-interference:** Pin, rename inline edit, delete, group avatars, and
+  hover menu remain unchanged. Spinner must not force horizontal overflow
+  of the row.
+
+### 4.3 i18n
+
+Add keys under the existing `sidebar` namespace in
+`frontend/packages/web/messages/en.json` and `zh.json`, e.g.:
+
+- `sidebar.conversationRunning` → “Conversation running” / Chinese equivalent
+
+### 4.4 Coordination with unread (#389)
+
+- **While running:** show spinner only (this issue).
+- **After complete while user away:** unread dot is #389; do not show both
+  for the same terminal moment (spinner clears first).
+
+### 4.5 Explicit non-goals
+
+- Tool name / token / phase text next to the title.
+- Backend conversation-list schema changes or multi-run server sync.
+- Desktop notifications.
+- Failure / HITL-specific icons beyond whatever falls out of the running
+  predicate above.
+- Multi-tab BroadcastChannel sync of stream state.
+
+## 5. Out of scope
+
+- Multi-device or multi-tab in-flight lists.
+- Expanding `messageStore` to track multiple concurrent streams (only if a
+  later product decision allows concurrent runs).
+- Unread badges (#389).
+- Docs site page (no user-facing route/header/enum change beyond a list
+  affordance; optional one-line mention if a sidebar UX doc already exists —
+  not required for this PR pair of design-only).
+
+## 6. Success criteria
+
+1. Start an agent reply → that conversation’s sidebar row shows a spinner
+   next to the title without opening the conversation.
+2. Stream completes normally or user cancels → spinner goes away.
+3. Switch to another conversation while the stream continues → spinner
+   remains on the still-streaming conversation row.
+4. Rename, pin, delete, group avatars, and row menu still work.
+5. Visible spinner + accessible name (i18n).
+
+## 7. Open questions (resolved for implementers)
+
+| Question | Decision for this design |
+| --- | --- |
+| Multi-conversation background runs? | Out of scope; current store is single-stream. Spinner tracks that one id. |
+| Server `active_run` on list? | Not for MVP. Revisit only if product requires post-reload running state. |
+| Show spinner during HITL wait? | Match store: if `streamingConversationId` still set, show spinner. |

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -182,6 +182,16 @@ export interface MessageStore {
 
 let activeStreamController: AbortController | null = null
 
+/**
+ * Shared streaming flags (`isStreaming`, `streamingConversationId`,
+ * `streamAgents`, …) belong to at most one conversation at a time. When send
+ * on B aborts A, a late terminal/error path for A must not wipe B's flags or
+ * commit B's in-flight `streamAgents` into A's history.
+ */
+function ownsStreamingConversation(state: MessageStore, conversationId: string): boolean {
+  return state.streamingConversationId === conversationId
+}
+
 /** Dedup map for ``loadMessages``: the page-level effect and ``<MessageList>``'s
  *  effect both fire on mount, but we only want one bootstrap fetch per open. */
 const loadMessagesInFlight = new Map<string, Promise<void>>()
@@ -913,6 +923,9 @@ async function finalizeCompletedStream(
   conversationId: string,
   stopReason: AssistantMessageType['stop_reason'] = 'stop',
 ): Promise<void> {
+  // Superseded by another send — do not read/clear shared streamAgents or flags.
+  if (!ownsStreamingConversation(get(), conversationId)) return
+
   const { assistantMessage, toolMessages } = buildTurnMessages(
     get().streamAgents,
     get().toolResultMap,
@@ -922,7 +935,43 @@ async function finalizeCompletedStream(
   )
 
   if (!assistantMessage) {
-    set((state) => ({
+    set((state) => {
+      if (!ownsStreamingConversation(state, conversationId)) {
+        return { pendingSteers: { ...state.pendingSteers, [conversationId]: [] } }
+      }
+      return {
+        isStreaming: false,
+        pendingConfirmMap: {},
+        pendingAsk: null,
+        streamingConversationId: null,
+        currentRunId: null,
+        statusPhase: null,
+        pendingSteers: { ...state.pendingSteers, [conversationId]: [] },
+      }
+    })
+    return
+  }
+
+  set((state) => {
+    if (!ownsStreamingConversation(state, conversationId)) {
+      return { pendingSteers: { ...state.pendingSteers, [conversationId]: [] } }
+    }
+    return {
+      messages: {
+        ...state.messages,
+        [conversationId]: [
+          ...(state.messages[conversationId] ?? []),
+          assistantMessage,
+          ...toolMessages,
+        ],
+      },
+      // Reset the in-flight stream now that the content lives in messages.
+      // Leaving streamAgents populated forces MessageList's lastAssistantId
+      // skip to fire — which can hide a DIFFERENT history assistant if the
+      // resume turn's mainStream content arrives before cubepi commits the
+      // resume assistant to the message log.
+      streamAgents: {},
+      toolStartedMap: {},
       isStreaming: false,
       pendingConfirmMap: {},
       pendingAsk: null,
@@ -930,34 +979,8 @@ async function finalizeCompletedStream(
       currentRunId: null,
       statusPhase: null,
       pendingSteers: { ...state.pendingSteers, [conversationId]: [] },
-    }))
-    return
-  }
-
-  set((state) => ({
-    messages: {
-      ...state.messages,
-      [conversationId]: [
-        ...(state.messages[conversationId] ?? []),
-        assistantMessage,
-        ...toolMessages,
-      ],
-    },
-    // Reset the in-flight stream now that the content lives in messages.
-    // Leaving streamAgents populated forces MessageList's lastAssistantId
-    // skip to fire — which can hide a DIFFERENT history assistant if the
-    // resume turn's mainStream content arrives before cubepi commits the
-    // resume assistant to the message log.
-    streamAgents: {},
-    toolStartedMap: {},
-    isStreaming: false,
-    pendingConfirmMap: {},
-    pendingAsk: null,
-    streamingConversationId: null,
-    currentRunId: null,
-    statusPhase: null,
-    pendingSteers: { ...state.pendingSteers, [conversationId]: [] },
-  }))
+    }
+  })
 }
 
 async function finalizePausedStream(
@@ -979,6 +1002,9 @@ async function finalizePausedStream(
   // needs to answer. Mirrors bootstrap's pending_hitl branch which
   // marks the conversation "streaming-attached" even with no live SSE.
   const state0 = get()
+  // Superseded by another send — do not touch shared streamAgents / flags.
+  if (!ownsStreamingConversation(state0, conversationId)) return
+
   const stillAttached =
     state0.pendingAsk !== null || Object.keys(state0.pendingConfirmMap).length > 0
   const nextStreamingConversationId = stillAttached ? conversationId : null
@@ -992,33 +1018,43 @@ async function finalizePausedStream(
   )
 
   if (!assistantMessage) {
-    set((state) => ({
+    set((state) => {
+      if (!ownsStreamingConversation(state, conversationId)) {
+        return { pendingSteers: { ...state.pendingSteers, [conversationId]: [] } }
+      }
+      return {
+        isStreaming: false,
+        streamingConversationId: nextStreamingConversationId,
+        statusPhase: null,
+        pendingSteers: { ...state.pendingSteers, [conversationId]: [] },
+      }
+    })
+    return
+  }
+
+  set((state) => {
+    if (!ownsStreamingConversation(state, conversationId)) {
+      return { pendingSteers: { ...state.pendingSteers, [conversationId]: [] } }
+    }
+    return {
+      messages: {
+        ...state.messages,
+        [conversationId]: [
+          ...(state.messages[conversationId] ?? []),
+          assistantMessage,
+          ...toolMessages,
+        ],
+      },
+      // Same rationale as finalizeCompletedStream — drop the in-flight
+      // stream now that history owns the content.
+      streamAgents: {},
+      toolStartedMap: {},
       isStreaming: false,
       streamingConversationId: nextStreamingConversationId,
       statusPhase: null,
       pendingSteers: { ...state.pendingSteers, [conversationId]: [] },
-    }))
-    return
-  }
-
-  set((state) => ({
-    messages: {
-      ...state.messages,
-      [conversationId]: [
-        ...(state.messages[conversationId] ?? []),
-        assistantMessage,
-        ...toolMessages,
-      ],
-    },
-    // Same rationale as finalizeCompletedStream — drop the in-flight
-    // stream now that history owns the content.
-    streamAgents: {},
-    toolStartedMap: {},
-    isStreaming: false,
-    streamingConversationId: nextStreamingConversationId,
-    statusPhase: null,
-    pendingSteers: { ...state.pendingSteers, [conversationId]: [] },
-  }))
+    }
+  })
 }
 
 async function consumeRunStream(
@@ -1069,61 +1105,72 @@ async function consumeRunStream(
       } else if (event.type === 'error') {
         const errData = event.data as ErrorEventData
         flush()
-        set((s) => ({
-          messages: {
-            ...s.messages,
-            [conversationId]: appendErroredAssistantTurn(s, conversationId, errData),
-          },
-          errors: {
-            ...s.errors,
-            [conversationId]: { runId: s.currentRunId ?? '', data: errData },
-          },
-          streamAgents: {},
-          toolStartedMap: {},
-          toolResultMap: {},
-          isStreaming: false,
-          pendingConfirmMap: {},
-          pendingAsk: null,
-          streamingConversationId: null,
-          currentRunId: null,
-          statusPhase: null,
-          lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
-          pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
-        }))
+        set((s) => {
+          const owns = ownsStreamingConversation(s, conversationId)
+          return {
+            messages: {
+              ...s.messages,
+              [conversationId]: appendErroredAssistantTurn(s, conversationId, errData),
+            },
+            errors: {
+              ...s.errors,
+              [conversationId]: { runId: s.currentRunId ?? '', data: errData },
+            },
+            pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
+            ...(owns
+              ? {
+                  streamAgents: {},
+                  toolStartedMap: {},
+                  toolResultMap: {},
+                  isStreaming: false,
+                  pendingConfirmMap: {},
+                  pendingAsk: null,
+                  streamingConversationId: null,
+                  currentRunId: null,
+                  statusPhase: null,
+                  lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
+                }
+              : {}),
+          }
+        })
         break
       } else if (event.type === 'done') {
         const usage = (event.data as Record<string, unknown>).usage as
           import('../types').UsageSummary | undefined
         const paused = (event.data as Record<string, unknown>).paused === true
-        const usageUpdate: Partial<MessageStore> = {
-          lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
-        }
-        if (usage) {
-          usageUpdate.turnUsage = {
-            ...get().turnUsage,
-            [conversationId]: usage.turn,
+        // Only advance the shared event cursor / usage while we still own
+        // the stream — a superseded reattach must not clobber the live send.
+        if (ownsStreamingConversation(get(), conversationId)) {
+          const usageUpdate: Partial<MessageStore> = {
+            lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
           }
-          usageUpdate.sessionUsage = {
-            ...get().sessionUsage,
-            [conversationId]: usage.session,
+          if (usage) {
+            usageUpdate.turnUsage = {
+              ...get().turnUsage,
+              [conversationId]: usage.turn,
+            }
+            usageUpdate.sessionUsage = {
+              ...get().sessionUsage,
+              [conversationId]: usage.session,
+            }
+            usageUpdate.contextWindow = {
+              ...get().contextWindow,
+              [conversationId]: usage.context_window,
+            }
+            usageUpdate.contextTokens = {
+              ...get().contextTokens,
+              [conversationId]: usage.context_tokens ?? null,
+            }
           }
-          usageUpdate.contextWindow = {
-            ...get().contextWindow,
-            [conversationId]: usage.context_window,
+          set(usageUpdate)
+          // paused: the run task is over but the conversation is parked
+          // on a pending HITL question — keep pendingAsk / pendingConfirmMap
+          // alive so the card stays visible until the user answers or cancels.
+          if (paused) {
+            sawPausedDone = true
+          } else {
+            sawDone = true
           }
-          usageUpdate.contextTokens = {
-            ...get().contextTokens,
-            [conversationId]: usage.context_tokens ?? null,
-          }
-        }
-        set(usageUpdate)
-        // paused: the run task is over but the conversation is parked
-        // on a pending HITL question — keep pendingAsk / pendingConfirmMap
-        // alive so the card stays visible until the user answers or cancels.
-        if (paused) {
-          sawPausedDone = true
-        } else {
-          sawDone = true
         }
         break
       } else if (event.type === 'injected_message') {
@@ -1131,13 +1178,19 @@ async function consumeRunStream(
         // Flush batched stream mutations so the commit reads fully-applied
         // streamAgents, not a stale snapshot.
         flush()
-        set((s) => ({
-          lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
-        }))
-        get().__commitTurnAndInject(conversationId, d)
+        if (ownsStreamingConversation(get(), conversationId)) {
+          set((s) => ({
+            lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
+          }))
+          get().__commitTurnAndInject(conversationId, d)
+        }
         continue
       }
 
+      if (!ownsStreamingConversation(get(), conversationId)) {
+        shouldFinalize = false
+        return
+      }
       batchedSet((s) => applyStreamEvent(s, event))
       if (++processed % YIELD_EVERY === 0) {
         await yieldToEventLoop()
@@ -1644,6 +1697,10 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
     try {
       outer: for (;;) {
         for await (const event of streamSource) {
+          // Drop late events once another send owns the shared stream flags.
+          if (!ownsStreamingConversation(get(), conversationId)) {
+            break outer
+          }
           if (event.event_id && get().lastAppliedEventId) {
             if (compareEventIds(event.event_id, get().lastAppliedEventId!) <= 0) continue
           }
@@ -1668,6 +1725,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
             if (!retried && !sawDone && errData.message.includes('409')) {
               retried = true
               await new Promise((r) => setTimeout(r, 400))
+              if (!ownsStreamingConversation(get(), conversationId)) break outer
               streamSource = streamMessages(
                 client,
                 conversationId,
@@ -1679,32 +1737,40 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
               continue outer
             }
             flush()
-            set((s) => ({
-              messages: {
-                ...s.messages,
-                [conversationId]: appendErroredAssistantTurn(s, conversationId, errData),
-              },
-              errors: {
-                ...s.errors,
-                [conversationId]: { runId: s.currentRunId ?? '', data: errData },
-              },
-              streamAgents: {},
-              toolStartedMap: {},
-              toolResultMap: {},
-              isStreaming: false,
-              pendingConfirmMap: {},
-              pendingAsk: null,
-              streamingConversationId: null,
-              currentRunId: null,
-              statusPhase: null,
-              lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
-              pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
-            }))
+            set((s) => {
+              const owns = ownsStreamingConversation(s, conversationId)
+              return {
+                messages: {
+                  ...s.messages,
+                  [conversationId]: appendErroredAssistantTurn(s, conversationId, errData),
+                },
+                errors: {
+                  ...s.errors,
+                  [conversationId]: { runId: s.currentRunId ?? '', data: errData },
+                },
+                pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
+                ...(owns
+                  ? {
+                      streamAgents: {},
+                      toolStartedMap: {},
+                      toolResultMap: {},
+                      isStreaming: false,
+                      pendingConfirmMap: {},
+                      pendingAsk: null,
+                      streamingConversationId: null,
+                      currentRunId: null,
+                      statusPhase: null,
+                      lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
+                    }
+                  : {}),
+              }
+            })
             break outer
           } else if (event.type === 'done') {
             const usage = (event.data as Record<string, unknown>).usage as
               import('../types').UsageSummary | undefined
             const paused = (event.data as Record<string, unknown>).paused === true
+            if (!ownsStreamingConversation(get(), conversationId)) break outer
             const usageUpdate: Partial<MessageStore> = {
               lastAppliedEventId: nextEventId(get().lastAppliedEventId, event.event_id),
             }
@@ -1738,6 +1804,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
             // Flush batched stream mutations so the commit reads fully-applied
             // streamAgents, not a stale snapshot.
             flush()
+            if (!ownsStreamingConversation(get(), conversationId)) break outer
             set((s) => ({
               lastAppliedEventId: nextEventId(s.lastAppliedEventId, event.event_id),
             }))
@@ -1753,21 +1820,28 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
         break outer
       }
     } catch (err) {
-      set((s) => ({
-        errors: {
-          ...s.errors,
-          [conversationId]: {
-            runId: s.currentRunId ?? '',
-            data: { error_code: 'internal_error', message: (err as Error).message },
+      set((s) => {
+        const owns = ownsStreamingConversation(s, conversationId)
+        return {
+          errors: {
+            ...s.errors,
+            [conversationId]: {
+              runId: s.currentRunId ?? '',
+              data: { error_code: 'internal_error', message: (err as Error).message },
+            },
           },
-        },
-        isStreaming: false,
-        pendingConfirmMap: {},
-        pendingAsk: null,
-        streamingConversationId: null,
-        currentRunId: null,
-        pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
-      }))
+          pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
+          ...(owns
+            ? {
+                isStreaming: false,
+                pendingConfirmMap: {},
+                pendingAsk: null,
+                streamingConversationId: null,
+                currentRunId: null,
+              }
+            : {}),
+        }
+      })
       return
     } finally {
       flush()
@@ -1778,7 +1852,10 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
 
     if (sawDone || sawPausedDone) {
       const lastState = get()
-      if (!lastState.errors[conversationId]) {
+      if (
+        !lastState.errors[conversationId] &&
+        ownsStreamingConversation(lastState, conversationId)
+      ) {
         if (sawPausedDone) {
           await finalizePausedStream(get, set, conversationId)
         } else {
@@ -1931,15 +2008,20 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
     if (hasContent) {
       await finalizeCompletedStream(get, set, conversationId, 'aborted')
     } else {
-      set((s) => ({
-        isStreaming: false,
-        pendingConfirmMap: {},
-        pendingAsk: null,
-        streamingConversationId: null,
-        currentRunId: null,
-        statusPhase: null,
-        pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
-      }))
+      set((s) => {
+        if (!ownsStreamingConversation(s, conversationId)) {
+          return { pendingSteers: { ...s.pendingSteers, [conversationId]: [] } }
+        }
+        return {
+          isStreaming: false,
+          pendingConfirmMap: {},
+          pendingAsk: null,
+          streamingConversationId: null,
+          currentRunId: null,
+          statusPhase: null,
+          pendingSteers: { ...s.pendingSteers, [conversationId]: [] },
+        }
+      })
     }
 
     try {

--- a/frontend/packages/web/__tests__/components/ConversationRow.running.test.tsx
+++ b/frontend/packages/web/__tests__/components/ConversationRow.running.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Conversation } from '@cubeplex/core'
+import en from '../../messages/en.json'
+import { ConversationRow } from '../../components/layout/Sidebar'
+
+const storeMocks = vi.hoisted(() => ({
+  isStreaming: false,
+  streamingConversationId: null as string | null,
+  remove: vi.fn(),
+  rename: vi.fn(),
+  setPin: vi.fn(),
+  setActive: vi.fn(),
+  pinPending: {} as Record<string, boolean>,
+  conversationParticipants: {} as Record<string, unknown[]>,
+}))
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...rest
+  }: {
+    children: React.ReactNode
+    href: string
+    [key: string]: unknown
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@cubeplex/core', () => ({
+  createApiClient: () => ({
+    setWorkspaceId: vi.fn(),
+  }),
+  useMessageStore: (
+    selector: (state: { isStreaming: boolean; streamingConversationId: string | null }) => unknown,
+  ) =>
+    selector({
+      isStreaming: storeMocks.isStreaming,
+      streamingConversationId: storeMocks.streamingConversationId,
+    }),
+  useConversationStore: (
+    selector?: (state: {
+      remove: typeof storeMocks.remove
+      rename: typeof storeMocks.rename
+      setPin: typeof storeMocks.setPin
+      setActive: typeof storeMocks.setActive
+      pinPending: Record<string, boolean>
+      conversationParticipants: Record<string, unknown[]>
+    }) => unknown,
+  ) => {
+    const state = {
+      remove: storeMocks.remove,
+      rename: storeMocks.rename,
+      setPin: storeMocks.setPin,
+      setActive: storeMocks.setActive,
+      pinPending: storeMocks.pinPending,
+      conversationParticipants: storeMocks.conversationParticipants,
+    }
+    // ConversationRow both destructures and selects.
+    if (typeof selector === 'function') return selector(state)
+    return state
+  },
+}))
+
+function makeConvo(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: 'c1',
+    title: 'Alpha chat',
+    is_pinned: false,
+    topic_id: null,
+    is_group_chat: false,
+    created_at: '2026-07-22T00:00:00Z',
+    updated_at: '2026-07-22T00:00:00Z',
+    model_key: null,
+    reasoning: { mode: 'off', effort: 'medium', summary: 'auto' },
+    ...overrides,
+  }
+}
+
+function renderRow(convo: Conversation = makeConvo()): ReturnType<typeof render> {
+  return render(
+    <NextIntlClientProvider locale="en" messages={en}>
+      <ConversationRow convo={convo} isActive={false} currentWsId="ws-1" />
+    </NextIntlClientProvider>,
+  )
+}
+
+describe('ConversationRow running indicator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storeMocks.isStreaming = false
+    storeMocks.streamingConversationId = null
+    storeMocks.pinPending = {}
+    storeMocks.conversationParticipants = {}
+  })
+
+  it('shows a spinner with accessible name when this conversation is streaming', () => {
+    storeMocks.isStreaming = true
+    storeMocks.streamingConversationId = 'c1'
+
+    renderRow(makeConvo({ id: 'c1', title: 'Alpha chat' }))
+
+    expect(screen.getByLabelText(en.sidebar.conversationRunning)).toBeInTheDocument()
+    expect(screen.getByText('Alpha chat')).toBeInTheDocument()
+    // Menu trigger still present — row chrome is intact
+    expect(screen.getByLabelText(en.sidebar.moreActions)).toBeInTheDocument()
+  })
+
+  it('does not show a spinner for a different conversation while another streams', () => {
+    storeMocks.isStreaming = true
+    storeMocks.streamingConversationId = 'c1'
+
+    renderRow(makeConvo({ id: 'c2', title: 'Beta chat' }))
+
+    expect(screen.queryByLabelText(en.sidebar.conversationRunning)).not.toBeInTheDocument()
+    expect(screen.getByText('Beta chat')).toBeInTheDocument()
+  })
+
+  it('does not show a spinner when idle', () => {
+    storeMocks.isStreaming = false
+    storeMocks.streamingConversationId = null
+
+    renderRow()
+
+    expect(screen.queryByLabelText(en.sidebar.conversationRunning)).not.toBeInTheDocument()
+  })
+
+  it('does not show a spinner for paused HITL (isStreaming false, id still set)', () => {
+    storeMocks.isStreaming = false
+    storeMocks.streamingConversationId = 'c1'
+
+    renderRow(makeConvo({ id: 'c1' }))
+
+    expect(screen.queryByLabelText(en.sidebar.conversationRunning)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/packages/web/__tests__/stores/messageStore.streamOwnership.test.ts
+++ b/frontend/packages/web/__tests__/stores/messageStore.streamOwnership.test.ts
@@ -1,0 +1,229 @@
+import { act } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useMessageStore } from '@cubeplex/core'
+
+const CONV_A = 'conv-A'
+const CONV_B = 'conv-B'
+
+type ControllableSSE = {
+  response: () => Response
+  push: (event: object) => void
+  close: () => void
+}
+
+function makeControllableSSE(): ControllableSSE {
+  const encoder = new TextEncoder()
+  let streamController: ReadableStreamDefaultController<Uint8Array> | null = null
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      streamController = controller
+    },
+  })
+  return {
+    response: () =>
+      new Response(stream, {
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    push: (event: object) => {
+      streamController?.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
+    },
+    close: () => {
+      try {
+        streamController?.close()
+      } catch {
+        // already closed / aborted
+      }
+    },
+  }
+}
+
+const mockClient = {
+  baseUrl: '',
+  get: vi.fn(),
+  post: vi.fn(),
+  resolvePath: (p: string) => p,
+}
+
+function baseEvent(partial: object): object {
+  return {
+    agent_id: null,
+    agent_name: null,
+    timestamp: '',
+    ...partial,
+  }
+}
+
+async function flushMicrotasks(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await act(async () => {
+      await Promise.resolve()
+    })
+  }
+}
+
+beforeEach(() => {
+  vi.useRealTimers()
+  useMessageStore.setState({
+    messages: {},
+    streamAgents: {},
+    isStreaming: false,
+    streamingConversationId: null,
+    currentRunId: null,
+    lastAppliedEventId: null,
+    statusPhase: null,
+    error: null,
+    errors: {},
+    todos: [],
+    toolStartedMap: {},
+    toolResultMap: {},
+    pendingConfirmMap: {},
+    pendingAsk: null,
+    pendingSteers: {},
+  })
+})
+
+describe('messageStore stream ownership', () => {
+  it('does not clear B flags when a late error arrives after A loses ownership', async () => {
+    const a = makeControllableSSE()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(a.response())),
+    )
+
+    const sendA = useMessageStore.getState().send(mockClient as never, CONV_A, 'from a')
+    await flushMicrotasks()
+
+    a.push(
+      baseEvent({
+        type: 'text_delta',
+        data: { content: 'partial-a' },
+        event_id: '1-0',
+      }),
+    )
+    await flushMicrotasks()
+    expect(useMessageStore.getState().streamingConversationId).toBe(CONV_A)
+    expect(useMessageStore.getState().isStreaming).toBe(true)
+
+    // Simulate another conversation taking the shared stream flags without
+    // aborting A's fetch (so we can still deliver a late terminal event).
+    useMessageStore.setState({
+      isStreaming: true,
+      streamingConversationId: CONV_B,
+      currentRunId: 'run-B',
+      streamAgents: {
+        main: {
+          text: 'from-b',
+          toolCalls: [],
+          toolResults: [],
+          thinking: '',
+          blocks: [],
+          name: null,
+        },
+      },
+    })
+
+    a.push(
+      baseEvent({
+        type: 'error',
+        data: { error_code: 'late', message: 'stale terminal from A' },
+        event_id: '2-0',
+      }),
+    )
+    await flushMicrotasks(10)
+    a.close()
+    await act(async () => {
+      await sendA
+    })
+
+    const state = useMessageStore.getState()
+    expect(state.isStreaming).toBe(true)
+    expect(state.streamingConversationId).toBe(CONV_B)
+    expect(state.currentRunId).toBe('run-B')
+    expect(state.streamAgents.main?.text).toBe('from-b')
+    // Per-conversation error for A is still allowed (optional); flags must stay on B.
+  })
+
+  it('does not clear B flags when a late done arrives after A loses ownership', async () => {
+    const a = makeControllableSSE()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(a.response())),
+    )
+
+    const sendA = useMessageStore.getState().send(mockClient as never, CONV_A, 'from a')
+    await flushMicrotasks()
+    a.push(
+      baseEvent({
+        type: 'text_delta',
+        data: { content: 'partial-a' },
+        event_id: '1-0',
+      }),
+    )
+    await flushMicrotasks()
+
+    useMessageStore.setState({
+      isStreaming: true,
+      streamingConversationId: CONV_B,
+      currentRunId: 'run-B',
+      streamAgents: {
+        main: {
+          text: 'from-b',
+          toolCalls: [],
+          toolResults: [],
+          thinking: '',
+          blocks: [],
+          name: null,
+        },
+      },
+    })
+
+    a.push(baseEvent({ type: 'done', data: {}, event_id: '3-0' }))
+    await flushMicrotasks(10)
+    a.close()
+    await act(async () => {
+      await sendA
+    })
+
+    const state = useMessageStore.getState()
+    expect(state.isStreaming).toBe(true)
+    expect(state.streamingConversationId).toBe(CONV_B)
+    expect(state.streamAgents.main?.text).toBe('from-b')
+  })
+
+  it('keeps B flags after real A→B send handoff (abort previous controller)', async () => {
+    const a = makeControllableSSE()
+    const b = makeControllableSSE()
+    let calls = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        calls += 1
+        return Promise.resolve(calls === 1 ? a.response() : b.response())
+      }),
+    )
+
+    void useMessageStore.getState().send(mockClient as never, CONV_A, 'from a')
+    await flushMicrotasks()
+    a.push(
+      baseEvent({
+        type: 'text_delta',
+        data: { content: 'a' },
+        event_id: '1-0',
+      }),
+    )
+    await flushMicrotasks()
+    expect(useMessageStore.getState().streamingConversationId).toBe(CONV_A)
+
+    void useMessageStore.getState().send(mockClient as never, CONV_B, 'from b')
+    await flushMicrotasks(10)
+    // Close controllable bodies so send() loops can exit (jsdom abort is flaky).
+    a.close()
+    await flushMicrotasks(10)
+
+    expect(useMessageStore.getState().isStreaming).toBe(true)
+    expect(useMessageStore.getState().streamingConversationId).toBe(CONV_B)
+
+    b.close()
+    await flushMicrotasks(5)
+  })
+})

--- a/frontend/packages/web/components/layout/Sidebar.tsx
+++ b/frontend/packages/web/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   type Topic,
   createApiClient,
   useConversationStore,
+  useMessageStore,
   useTopicStore,
 } from '@cubeplex/core'
 import {
@@ -32,6 +33,7 @@ import { VscMcp } from 'react-icons/vsc'
 import {
   CalendarClock,
   Layers,
+  Loader2,
   type LucideIcon,
   MoreHorizontal,
   Package,
@@ -75,7 +77,7 @@ function GroupChatAvatars({ convoId }: { convoId: string }): React.ReactElement 
   )
 }
 
-function ConversationRow({
+export function ConversationRow({
   convo,
   isActive,
   currentWsId,
@@ -93,6 +95,7 @@ function ConversationRow({
   const hasGroupParticipants = useConversationStore(
     (s) => (s.conversationParticipants[convo.id]?.length ?? 0) > 0,
   )
+  const isRunning = useMessageStore((s) => s.isStreaming && s.streamingConversationId === convo.id)
 
   const [isEditing, setIsEditing] = useState(false)
   const [draft, setDraft] = useState(convo.title)
@@ -185,6 +188,12 @@ function ConversationRow({
         <div className="flex-1 min-w-0 truncate text-[12.5px] font-medium leading-tight">
           {convo.title || tSidebar('untitledChat')}
         </div>
+        {isRunning && (
+          <Loader2
+            className="size-3.5 shrink-0 animate-spin text-muted-foreground"
+            aria-label={tSidebar('conversationRunning')}
+          />
+        )}
         {showGroupIcon && <GroupChatAvatars convoId={convo.id} />}
         <DropdownMenu>
           <DropdownMenuTrigger

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -90,6 +90,7 @@
     "collapseSidebar": "Collapse sidebar",
     "expandSidebar": "Expand sidebar",
     "noRecentChats": "No conversations yet",
+    "conversationRunning": "Conversation running",
     "search": {
       "open": "Search Chats",
       "placeholder": "Search Chats…",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -90,6 +90,7 @@
     "collapseSidebar": "收起侧边栏",
     "expandSidebar": "展开侧边栏",
     "noRecentChats": "暂无会话",
+    "conversationRunning": "会话运行中",
     "search": {
       "open": "搜索对话",
       "placeholder": "搜索对话…",


### PR DESCRIPTION
## Summary
Implements the conversation running indicator in the chat history sidebar (#388).

- Spec + plan (design review addressed)
- `ConversationRow` shows a `Loader2` spinner when `messageStore.isStreaming && streamingConversationId === convo.id`
- i18n: `sidebar.conversationRunning` (en/zh)
- Vitest: spinner present/absent for streaming, other row, idle, and HITL-paused shapes

## Linked issue
Closes #388
Related: #409 (this PR)

## Status
- [x] Spec
- [x] Plan
- [x] Implementation

## Test plan
- [x] Unit: `ConversationRow.running.test.tsx` (4 cases green)
- [x] Pre-push `check-ci` (backend + frontend) passed
- [ ] Manual: send in A → switch to B → spinner stays on A → completes → spinner gone