### PR TITLE
System prompt optimization: widget skill (F1) + design

### DIFF
--- a/backend/cubeplex/api/routes/v1/admin_skills.py
+++ b/backend/cubeplex/api/routes/v1/admin_skills.py
@@ -31,7 +31,7 @@ from cubeplex.api.schemas.skill_discovery import (
 from cubeplex.auth.dependencies import require_org_admin, resolve_current_org_id
 from cubeplex.config import config as _config
 from cubeplex.db import get_session
-from cubeplex.models import Skill, User
+from cubeplex.models import OrgPreinstalledTombstone, Skill, User
 from cubeplex.repositories.organization import OrganizationRepository
 from cubeplex.repositories.skill import (
     OrgPreinstalledTombstoneRepository,
@@ -464,12 +464,21 @@ async def uninstall_skill(
         )
         await session.flush()
         await session.delete(install)
-        await session.commit()
 
+    # Tombstone + install delete must land in ONE commit so the boot-time
+    # preinstalled-skill reconciler cannot reinstall between the two.
     if skill.source == "preinstalled":
-        await OrgPreinstalledTombstoneRepository(session).add_tombstone(
-            org_id=org_id, skill_id=skill_id, hidden_by_user_id=user.id
-        )
+        existing_tomb = await OrgPreinstalledTombstoneRepository(session).get(org_id, skill_id)
+        if existing_tomb is None:
+            session.add(
+                OrgPreinstalledTombstone(
+                    org_id=org_id,
+                    skill_id=skill_id,
+                    hidden_by_user_id=user.id,
+                )
+            )
+
+    await session.commit()
 
 
 @router.post("/upload", status_code=201)

--- a/backend/cubeplex/prompts/widget.py
+++ b/backend/cubeplex/prompts/widget.py
@@ -1,8 +1,12 @@
-"""Design guidelines + tool description for the show_widget generative-UI tool.
+"""show_widget tool description + short always-on system stub.
 
-Self-authored (informed by, not copied from, Claude's artifact guidelines).
-Keep this string stable: it is appended to the system prompt and is
-cache-sensitive (see backend/docs/prompt-cache-discipline.md).
+Full design rules and scenario skeletons live in the preinstalled
+``show-widget`` skill (``backend/skills/preinstalled/show-widget/``).
+The always-on system fragment is intentionally small so non-widget turns
+do not pay ~11k chars every request (trace finding F1 / #391).
+
+Keep these strings stable: they sit in the system-prompt cache prefix
+(see backend/docs/prompt-cache-discipline.md).
 """
 
 WIDGET_TOOL_DESCRIPTION = (
@@ -12,240 +16,32 @@ WIDGET_TOOL_DESCRIPTION = (
     "(an HTML fragment — no <html>/<body>) directly here; do NOT first write it to "
     "a file or save it as an artifact. It renders in a sandboxed iframe: no "
     "fetch/XHR/WebSocket, no localStorage, but JS libraries may be loaded from the "
-    "allowed CDNs."
+    "allowed CDNs. For non-trivial widgets, load the `show-widget` skill first."
 )
 
+# Short always-on stub. Hard safety limits stay here so a model that skips
+# load_skill still cannot invent full-page docs / network calls / storage.
+# Skeletons and visual playbooks are on-demand via the show-widget skill.
 WIDGET_GUIDELINES = """\
-## Rendering interactive widgets (show_widget)
+## Interactive widgets (show_widget)
 
-### When to use
+Use `show_widget` when the answer is better seen than read (charts, diagrams,
+dashboards, sliders, comparisons). Stream an HTML fragment — do not
+`write_file` or `save_artifact` first.
 
-`show_widget` is your DEFAULT for any answer the user is better off seeing
-than reading. Trigger words (Chinese + English) that should make you reach
-for it first: 画 / 绘制 / 画一个 / 可视化 / 示意图 / 流程图 / 架构图 / 图表 /
-仪表盘 / 数据图 / 对比 / draw / visualize / chart / diagram / dashboard /
-flowchart / architecture / mockup / sliders / animation / explainer /
-side-by-side / breakdown.
+Hard limits (always):
 
-Use it directly. Do NOT route through `write_file` + `save_artifact` first —
-the widget IS the answer, not an attachment to it.
+- Fragment only: no `<!DOCTYPE>` / `<html>` / `<head>` / `<body>`.
+- Order: short `<style>` → HTML → `<script>` last.
+- No fetch/XHR/WebSocket; no `localStorage`/`sessionStorage`; embed data.
+- CDNs only: cdnjs.cloudflare.com, cdn.jsdelivr.net, unpkg.com, esm.sh.
+- Target ~600×360–480 px; one focus per call; total under ~256 KB.
+- Theme via CSS vars only: `var(--bg)`, `var(--fg)`, `var(--muted)`,
+  `var(--border)`, `var(--accent)` — never hard-code colors.
+- Chart.js: pin canvas CSS height with `!important` (e.g.
+  `height:300px!important`) or the chart grows unbounded.
 
-Skip it for: pure text, code blocks, short factual replies, error messages.
-
-### Size
-
-This is a WIDGET, not a webpage. Keep it compact:
-
-- Target width ~600 px, max 640 px. The host iframe is already centered and
-  capped — do NOT set `width: 100vw` or `min-width:1024px`.
-- Target height ~360-480 px. Avoid scrollbars; if content is long, pick a
-  more compact form (a table instead of cards, a single chart instead of
-  five) rather than letting it grow.
-- One focused thing per widget. If a request implies two unrelated visuals,
-  ship two widget calls.
-
-### Hard rules for `widget_code`
-
-- It is an HTML fragment injected into `<div id="root">`. Do NOT include
-  `<!DOCTYPE>`, `<html>`, `<head>`, or `<body>`.
-- Order for streaming: `<style>` (short) first, then visible HTML, then
-  `<script>` last. Scripts run only after the widget finishes streaming.
-- No data fetching: fetch/XHR/WebSocket are blocked. Embed all data inline.
-  (Loading JS libraries from the CDNs below IS permitted — that is
-  `script-src`, not `connect-src`.)
-- No `localStorage` / `sessionStorage` (they throw). Use in-memory variables.
-- Libraries may be loaded only from: cdnjs.cloudflare.com, cdn.jsdelivr.net,
-  unpkg.com, esm.sh.
-- Total `widget_code` under ~256 KB.
-
-### Visual quality bar
-
-The shell pre-defines these CSS variables on `:root`; values are picked by
-the host for the current light or dark theme:
-
-- `--bg`     page background
-- `--fg`     foreground text
-- `--muted`  card / panel surface
-- `--border` separator
-- `--accent` link / primary
-
-Always reference them via `var(--bg)` etc. **Do NOT hard-code colors** (no
-`#1a1a1a`, no `#fff`, no `rgb()`); the widget must look right in BOTH themes.
-Two font weights max (400, 500). Avoid gradients, drop shadows, blur. Use
-generous whitespace and small radii (4-8 px). Keep typography to one family
-(system-ui is already set).
-
-### Scenario skeletons
-
-Pick the one closest to the request and adapt — keep the overall shape,
-swap the data and labels. These are starting points, not templates to
-echo verbatim.
-
-**Important — theme reactivity.** Anything that reads CSS variables into JS at
-render time (Canvas, WebGL, Chart.js, D3, etc.) freezes those colours. The
-host can repaint the widget when the app's theme toggles by updating `:root`'s
-inline `style` attribute, so add a `MutationObserver` on the root to re-apply
-the new tokens. Inline SVG / HTML that uses `var(--fg)` etc. directly does
-NOT need this — the cascade re-evaluates automatically.
-
-#### A. Single chart (Chart.js)
-
-**Chart.js height rule (mandatory).** With `responsive:true` and
-`maintainAspectRatio:false`, Chart.js reads the canvas's CSS height —
-NOT the HTML `height` attribute. Without an explicit CSS height pinned with
-`!important`, Chart.js reads its parent container's `clientHeight` (which
-includes the canvas itself), computes a slightly larger value, resizes the
-canvas, which makes the container taller, and so on — an unbounded
-height-growth loop that freezes the browser. Always set height in CSS:
-
-- **One chart:** `canvas{width:100%!important;height:300px!important;}`
-- **Multiple charts with different heights:** use per-id rules or inline styles,
-  e.g. `<canvas id="yr" style="width:100%;height:180px;display:block;">`.
-  Never use the HTML `height` attribute as a substitute.
-
-```html
-<style>
-  .card{background:var(--muted);border:1px solid var(--border);border-radius:8px;padding:16px;}
-  .card h3{margin:0 0 8px;font-size:14px;font-weight:500;color:var(--fg);}
-  canvas{width:100%!important;height:300px!important;}
-</style>
-<div class="card">
-  <h3>Title that says what is plotted</h3>
-  <canvas id="c"></canvas>
-</div>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
-<script>
-  const css = (v) => getComputedStyle(document.documentElement).getPropertyValue(v).trim();
-  function tokens(){ return { fg: css('--fg'), acc: css('--accent'), bd: css('--border') }; }
-  let t = tokens();
-  const chart = new Chart(document.getElementById('c'), {
-    type: 'line',
-    data: { labels: ['A','B','C','D','E'], datasets: [{ label: 'Series', data: [3,8,5,12,9], borderColor: t.acc, backgroundColor: t.acc+'33', tension: .3 }] },
-    options: { responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { labels: { color: t.fg } } },
-      scales: { x: { ticks: { color: t.fg }, grid: { color: t.bd } },
-                y: { ticks: { color: t.fg }, grid: { color: t.bd } } } }
-  });
-  // Re-apply theme tokens whenever the host updates :root's inline style.
-  new MutationObserver(() => {
-    t = tokens();
-    chart.options.plugins.legend.labels.color = t.fg;
-    chart.options.scales.x.ticks.color = t.fg;
-    chart.options.scales.x.grid.color = t.bd;
-    chart.options.scales.y.ticks.color = t.fg;
-    chart.options.scales.y.grid.color = t.bd;
-    chart.data.datasets[0].borderColor = t.acc;
-    chart.data.datasets[0].backgroundColor = t.acc + '33';
-    chart.update('none');
-  }).observe(document.documentElement, { attributes: true, attributeFilter: ['style'] });
-</script>
-```
-
-#### B. Architecture / flow diagram (inline SVG)
-
-```html
-<style>
-  .diag{display:block;width:100%;height:auto;}
-  .node{fill:var(--muted);stroke:var(--border);}
-  .label{fill:var(--fg);font:500 12px system-ui;text-anchor:middle;dominant-baseline:central;}
-  .edge{stroke:var(--border);stroke-width:1.5;fill:none;}
-  .edge.hl{stroke:var(--accent);}  /* emphasized edge — arrowhead follows via context-stroke */
-</style>
-<svg class="diag" viewBox="0 0 560 220" xmlns="http://www.w3.org/2000/svg">
-  <!-- One shared marker; fill:context-stroke makes each arrowhead inherit its
-       OWN line's stroke, so a recoloured edge never gets a mismatched head. -->
-  <defs><marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6"
-        orient="auto" markerUnits="userSpaceOnUse">
-    <path d="M0 0 L10 5 L0 10 z" fill="context-stroke"/></marker></defs>
-  <rect class="node" x="20"  y="80" width="120" height="60" rx="6"/>
-  <text class="label" x="80"  y="110">Client</text>
-  <rect class="node" x="220" y="80" width="120" height="60" rx="6"/>
-  <text class="label" x="280" y="110">API</text>
-  <rect class="node" x="420" y="80" width="120" height="60" rx="6"/>
-  <text class="label" x="480" y="110">DB</text>
-  <line class="edge"    x1="140" y1="110" x2="220" y2="110" marker-end="url(#a)"/>
-  <line class="edge hl" x1="340" y1="110" x2="420" y2="110" marker-end="url(#a)"/>
-</svg>
-```
-
-**Arrowheads must match their line.** Use one shared marker with
-`fill="context-stroke"` so every arrowhead inherits its own edge's `stroke` —
-an emphasized edge (`.hl` → `var(--accent)`) then gets a matching coloured head
-automatically. **Never give the arrow a hard-coded `fill`** (a fixed token or
-hex): a recoloured line would keep a mismatched grey head. Add
-`markerUnits="userSpaceOnUse"` so the head stays a constant size regardless of
-the line's `stroke-width`.
-
-#### C. Dashboard (metric cards + small chart)
-
-```html
-<style>
-  .grid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-bottom:12px;}
-  .stat{background:var(--muted);border:1px solid var(--border);border-radius:8px;padding:12px;}
-  .stat .v{font-size:22px;font-weight:500;color:var(--fg);}
-  .stat .l{font-size:11px;color:var(--fg);opacity:.7;margin-top:2px;}
-  .panel{background:var(--muted);border:1px solid var(--border);border-radius:8px;padding:16px;}
-  canvas{width:100%!important;height:200px!important;}
-</style>
-<div class="grid">
-  <div class="stat"><div class="v">1,284</div><div class="l">Active users</div></div>
-  <div class="stat"><div class="v">$42.1k</div><div class="l">Revenue (MTD)</div></div>
-  <div class="stat"><div class="v">98.6%</div><div class="l">Uptime</div></div>
-</div>
-<div class="panel"><canvas id="c"></canvas></div>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
-<script>/* Chart.js init — see scenario A */</script>
-```
-
-#### D. Interactive explainer (slider drives a calculation)
-
-```html
-<style>
-  .row{display:flex;align-items:center;gap:12px;margin:8px 0;}
-  .row label{flex:0 0 110px;color:var(--fg);font-size:13px;}
-  .row input{flex:1;accent-color:var(--accent);}
-  .row .val{flex:0 0 64px;text-align:right;font-variant-numeric:tabular-nums;color:var(--fg);}
-  .out{margin-top:12px;padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--muted);}
-  .out .big{font-size:24px;font-weight:500;color:var(--fg);}
-  .out .lbl{font-size:11px;color:var(--fg);opacity:.7;}
-</style>
-<div class="row"><label>Principal</label><input id="p" type="range" min="1000" max="100000" step="100" value="10000"><div class="val" id="pv">$10,000</div></div>
-<div class="row"><label>Years</label>    <input id="y" type="range" min="1"    max="40"     step="1"   value="10"><div class="val" id="yv">10</div></div>
-<div class="row"><label>Rate (%)</label> <input id="r" type="range" min="0"    max="15"     step="0.1" value="5"><div class="val" id="rv">5%</div></div>
-<div class="out"><div class="big" id="ans">$16,288.95</div><div class="lbl">Future value</div></div>
-<script>
-  const $=(id)=>document.getElementById(id);
-  function recalc(){
-    const P=+$('p').value, y=+$('y').value, r=+$('r').value/100;
-    $('pv').textContent='$'+P.toLocaleString();
-    $('yv').textContent=y; $('rv').textContent=r*100+'%';
-    $('ans').textContent='$'+(P*Math.pow(1+r,y)).toLocaleString(undefined,{maximumFractionDigits:2});
-  }
-  ['p','y','r'].forEach(id=>$(id).addEventListener('input',recalc));
-</script>
-```
-
-#### E. Side-by-side comparison table
-
-```html
-<style>
-  table{width:100%;border-collapse:collapse;font-size:13px;color:var(--fg);}
-  th,td{padding:8px 10px;border-bottom:1px solid var(--border);text-align:left;}
-  th{font-weight:500;color:var(--fg);opacity:.85;background:var(--muted);}
-  .check{color:var(--accent);font-weight:500;}
-  .dash{opacity:.5;}
-</style>
-<table>
-  <thead><tr><th>Feature</th><th>Option A</th><th>Option B</th></tr></thead>
-  <tbody>
-    <tr><td>Streams</td><td class="check">Yes</td><td class="dash">–</td></tr>
-    <tr><td>Offline</td><td class="dash">–</td><td class="check">Yes</td></tr>
-    <tr><td>Free tier</td><td>1k req/mo</td><td>500 req/mo</td></tr>
-  </tbody>
-</table>
-```
-
-If none of the above fits, write something simple in the same style — bordered
-muted cards, accent color sparingly, small radii, no shadows. Better to ship a
-plain card than a sprawling page.
+For scenario skeletons (Chart.js, SVG flow, dashboard, sliders, comparison
+table), theme-repaint patterns, and the visual quality bar — load the
+`show-widget` skill before building non-trivial widgets.
 """

--- a/backend/cubeplex/repositories/skill.py
+++ b/backend/cubeplex/repositories/skill.py
@@ -427,7 +427,7 @@ class OrgPreinstalledTombstoneRepository:
         return result.scalar_one_or_none()
 
     async def add_tombstone(
-        self, *, org_id: str, skill_id: str, hidden_by_user_id: str
+        self, *, org_id: str, skill_id: str, hidden_by_user_id: str | None = None
     ) -> OrgPreinstalledTombstone:
         row = OrgPreinstalledTombstone(
             org_id=org_id,

--- a/backend/cubeplex/seeders/skill_seeder.py
+++ b/backend/cubeplex/seeders/skill_seeder.py
@@ -14,6 +14,7 @@ from loguru import logger
 from redis.asyncio import Redis
 from redis.exceptions import LockNotOwnedError
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubeplex.models import Organization, OrgPreinstalledTombstone, OrgSkillInstall
@@ -25,6 +26,7 @@ from cubeplex.skills.storage_paths import global_skill_prefix, skill_object_key
 
 LOCK_KEY = "cubeplex:lock:skill_seeder"
 # Catalog seed is usually fast; org-install reconcile can touch many orgs.
+# Concurrent inserts are conflict-safe (see _reconcile_preinstalled_installs).
 LOCK_TTL_SECONDS = 120
 
 
@@ -209,15 +211,37 @@ async def _reconcile_preinstalled_installs(db_session: AsyncSession) -> None:
             key = (org_id, skill.id)
             if key in existing_pairs or key in tomb_pairs:
                 continue
-            db_session.add(
-                OrgSkillInstall(
-                    org_id=org_id,
-                    skill_id=skill.id,
-                    installed_version=skill.current_version,
-                    installed_by_user_id=None,
-                    auto_bind=True,
-                )
-            )
+            # SAVEPOINT per row: concurrent seeder / unique-index races must not
+            # abort the whole reconcile batch. Re-check tombstone inside the
+            # nested txn so a concurrent admin uninstall is less likely to be
+            # undone (uninstall itself is a single commit for install+tombstone).
+            try:
+                async with db_session.begin_nested():
+                    still_tomb = (
+                        await db_session.execute(
+                            select(OrgPreinstalledTombstone).where(
+                                OrgPreinstalledTombstone.org_id == org_id,  # type: ignore[arg-type]
+                                OrgPreinstalledTombstone.skill_id == skill.id,  # type: ignore[arg-type]
+                            )
+                        )
+                    ).scalar_one_or_none()
+                    if still_tomb is not None:
+                        tomb_pairs.add(key)
+                        continue
+                    db_session.add(
+                        OrgSkillInstall(
+                            org_id=org_id,
+                            skill_id=skill.id,
+                            installed_version=skill.current_version,
+                            installed_by_user_id=None,
+                            auto_bind=True,
+                        )
+                    )
+                    await db_session.flush()
+            except IntegrityError:
+                # Concurrent insert of the same (org, skill) org-wide install.
+                existing_pairs.add(key)
+                continue
             existing_pairs.add(key)
             created += 1
 

--- a/backend/cubeplex/seeders/skill_seeder.py
+++ b/backend/cubeplex/seeders/skill_seeder.py
@@ -1,6 +1,9 @@
 """Preinstalled-skills seeder: walks preinstalled/ → upserts global skill rows
 and uploads files to skills/_global/<name>/<version>/. Multi-replica safe via
 Redis named lock.
+
+After catalog seed, reconciles org installs so **existing** orgs pick up newly
+shipped preinstalled skills (bootstrap only installs at org-create time).
 """
 
 from __future__ import annotations
@@ -10,8 +13,10 @@ from pathlib import Path
 from loguru import logger
 from redis.asyncio import Redis
 from redis.exceptions import LockNotOwnedError
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from cubeplex.models import Organization, OrgPreinstalledTombstone, OrgSkillInstall
 from cubeplex.objectstore import get_objectstore_client
 from cubeplex.repositories.skill import SkillRepository, SkillVersionRepository
 from cubeplex.skills.content_hash import compute_skill_version_hash
@@ -19,7 +24,8 @@ from cubeplex.skills.frontmatter import parse_skill_md
 from cubeplex.skills.storage_paths import global_skill_prefix, skill_object_key
 
 LOCK_KEY = "cubeplex:lock:skill_seeder"
-LOCK_TTL_SECONDS = 60
+# Catalog seed is usually fast; org-install reconcile can touch many orgs.
+LOCK_TTL_SECONDS = 120
 
 
 async def seed_preinstalled_skills(
@@ -29,6 +35,10 @@ async def seed_preinstalled_skills(
     redis: Redis,
 ) -> None:
     """Idempotently seed preinstalled skills into the global catalog.
+
+    Also auto-installs any missing non-tombstoned preinstalled skills for
+    existing orgs (so skills added after bootstrap become loadable without a
+    manual admin install).
 
     Multi-replica safe: only one process holding the Redis lock runs the seed;
     others log and return.
@@ -45,6 +55,7 @@ async def seed_preinstalled_skills(
 
     try:
         await _do_seed(preinstalled_dir, db_session)
+        await _reconcile_preinstalled_installs(db_session)
     finally:
         try:
             await lock.release()
@@ -145,3 +156,77 @@ async def _do_seed(preinstalled_dir: Path, db_session: AsyncSession) -> None:
         if skill.name not in found_names and skill.deprecated_at is None:
             await skills.deprecate(skill.id)
             logger.info("Deprecated removed preinstalled skill: {}", skill.name)
+
+
+async def _reconcile_preinstalled_installs(db_session: AsyncSession) -> None:
+    """Install missing preinstalled skills for every existing org.
+
+    Mirrors org-bootstrap auto-install (``auto_bind=True``, system actor).
+    Skips skills an org admin already uninstalled (tombstone). Does not change
+    existing installs (version pins stay as-is).
+    """
+    skills_repo = SkillRepository(db_session)
+    active = [s for s in await skills_repo.list_preinstalled() if s.deprecated_at is None]
+    if not active:
+        return
+
+    orgs = list((await db_session.execute(select(Organization))).scalars().all())
+    if not orgs:
+        return
+    org_ids = [org.id for org in orgs]
+
+    skill_ids = [s.id for s in active]
+    existing_rows = (
+        (
+            await db_session.execute(
+                select(OrgSkillInstall).where(
+                    OrgSkillInstall.skill_id.in_(skill_ids),  # type: ignore[attr-defined]
+                    OrgSkillInstall.workspace_id.is_(None),  # type: ignore[union-attr]
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    existing_pairs = {(row.org_id, row.skill_id) for row in existing_rows}
+
+    tomb_rows = (
+        (
+            await db_session.execute(
+                select(OrgPreinstalledTombstone).where(
+                    OrgPreinstalledTombstone.skill_id.in_(skill_ids)  # type: ignore[attr-defined]
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    tomb_pairs = {(row.org_id, row.skill_id) for row in tomb_rows}
+
+    created = 0
+    for org_id in org_ids:
+        for skill in active:
+            key = (org_id, skill.id)
+            if key in existing_pairs or key in tomb_pairs:
+                continue
+            db_session.add(
+                OrgSkillInstall(
+                    org_id=org_id,
+                    skill_id=skill.id,
+                    installed_version=skill.current_version,
+                    installed_by_user_id=None,
+                    auto_bind=True,
+                )
+            )
+            existing_pairs.add(key)
+            created += 1
+
+    if created == 0:
+        return
+
+    await db_session.commit()
+    logger.info(
+        "Reconciled preinstalled skill installs: created {} row(s) for {} org(s)",
+        created,
+        len(org_ids),
+    )

--- a/backend/cubeplex/seeders/skill_seeder.py
+++ b/backend/cubeplex/seeders/skill_seeder.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from loguru import logger
 from redis.asyncio import Redis
 from redis.exceptions import LockNotOwnedError
-from sqlalchemy import select
+from sqlalchemy import delete, exists, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -245,12 +245,28 @@ async def _reconcile_preinstalled_installs(db_session: AsyncSession) -> None:
             existing_pairs.add(key)
             created += 1
 
-    if created == 0:
+    # Tombstone wins: drop any org-wide install that already has a tombstone
+    # (heals dual-state from concurrent uninstall vs uncommitted reconcile).
+    purge = await db_session.execute(
+        delete(OrgSkillInstall).where(
+            OrgSkillInstall.workspace_id.is_(None),  # type: ignore[union-attr]
+            OrgSkillInstall.skill_id.in_(skill_ids),  # type: ignore[attr-defined]
+            exists().where(
+                OrgPreinstalledTombstone.org_id == OrgSkillInstall.org_id,  # type: ignore[arg-type]
+                OrgPreinstalledTombstone.skill_id == OrgSkillInstall.skill_id,  # type: ignore[arg-type]
+            ),
+        )
+    )
+    purged = int(getattr(purge, "rowcount", 0) or 0)
+
+    if created == 0 and purged == 0:
         return
 
     await db_session.commit()
     logger.info(
-        "Reconciled preinstalled skill installs: created {} row(s) for {} org(s)",
+        "Reconciled preinstalled skill installs: created {} row(s), purged {} dual-state "
+        "for {} org(s)",
         created,
+        purged,
         len(org_ids),
     )

--- a/backend/cubeplex/skills/service.py
+++ b/backend/cubeplex/skills/service.py
@@ -13,7 +13,13 @@ from loguru import logger
 from sqlalchemy import exists, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from cubeplex.models import OrgSkillInstall, Skill, SkillVersion, WorkspaceSkillBinding
+from cubeplex.models import (
+    OrgPreinstalledTombstone,
+    OrgSkillInstall,
+    Skill,
+    SkillVersion,
+    WorkspaceSkillBinding,
+)
 from cubeplex.objectstore import get_objectstore_client
 from cubeplex.repositories.artifact import ArtifactRepository
 from cubeplex.repositories.skill import (
@@ -22,12 +28,12 @@ from cubeplex.repositories.skill import (
     SkillVersionRepository,
 )
 from cubeplex.skills.cache import SkillCache
+from cubeplex.skills.content_hash import compute_skill_version_hash
 from cubeplex.skills.frontmatter import (  # noqa: F401
     InvalidFrontmatterError,
     parse_skill_md,
     peek_skill_name,
 )
-from cubeplex.skills.content_hash import compute_skill_version_hash
 from cubeplex.skills.storage_paths import org_skill_prefix, skill_object_key
 
 
@@ -60,6 +66,9 @@ class SkillCatalogService:
         A skill is enabled if:
         - It has an explicit WorkspaceSkillBinding with enabled=True, OR
         - auto_bind=True on the install AND no explicit binding with enabled=False exists.
+
+        Preinstalled skills with an org tombstone are never returned, even if an
+        orphan install row still exists (e.g. boot reconcile race with uninstall).
         """
         explicit_disable = exists().where(
             WorkspaceSkillBinding.org_skill_install_id == OrgSkillInstall.id,  # type: ignore[arg-type]
@@ -73,6 +82,11 @@ class SkillCatalogService:
             WorkspaceSkillBinding.org_id == org_id,  # type: ignore[arg-type]
             WorkspaceSkillBinding.enabled.is_(True),  # type: ignore[attr-defined]
         )
+        # Tombstone wins over install for preinstalled skills (admin uninstall).
+        not_tombstoned = ~exists().where(
+            OrgPreinstalledTombstone.org_id == org_id,  # type: ignore[arg-type]
+            OrgPreinstalledTombstone.skill_id == Skill.id,  # type: ignore[arg-type]
+        )
         stmt = (
             select(Skill, SkillVersion)
             .join(OrgSkillInstall, OrgSkillInstall.skill_id == Skill.id)  # type: ignore[arg-type]
@@ -84,6 +98,7 @@ class SkillCatalogService:
             .where(
                 OrgSkillInstall.org_id == org_id,  # type: ignore[arg-type]
                 OrgSkillInstall.workspace_id.is_(None),  # type: ignore[union-attr]
+                not_tombstoned,
                 or_(
                     explicit_enable,
                     (OrgSkillInstall.auto_bind.is_(True) & ~explicit_disable),  # type: ignore[attr-defined]
@@ -163,9 +178,7 @@ class SkillCatalogService:
         sv = await self.session.get(SkillVersion, skill_version_id)
         if sv is None:
             raise ValueError(f"skill_version_id not found: {skill_version_id}")
-        cache_dir = await self.cache.ensure_extracted(
-            sv.id, storage_prefix=sv.storage_prefix
-        )
+        cache_dir = await self.cache.ensure_extracted(sv.id, storage_prefix=sv.storage_prefix)
         return (cache_dir / sv.entry_file).read_text(encoding="utf-8")
 
     async def list_files_for_sandbox_sync(
@@ -220,14 +233,10 @@ def validate_skill_files(files: dict[str, bytes]) -> None:
         if rel.startswith("/") or ".." in PurePosixPath(rel).parts:
             raise InvalidZipPathError(f"invalid path in skill bundle: {rel!r}")
         if len(data) > MAX_FILE_BYTES:
-            raise FileTooLargeError(
-                f"{rel} is {len(data)} bytes; cap is {MAX_FILE_BYTES}"
-            )
+            raise FileTooLargeError(f"{rel} is {len(data)} bytes; cap is {MAX_FILE_BYTES}")
         total += len(data)
         if total > MAX_TOTAL_BYTES:
-            raise FileTooLargeError(
-                f"bundle exceeds total cap of {MAX_TOTAL_BYTES} bytes"
-            )
+            raise FileTooLargeError(f"bundle exceeds total cap of {MAX_TOTAL_BYTES} bytes")
 
 
 class SkillPublishService:
@@ -261,7 +270,7 @@ class SkillPublishService:
         keys = await store.list_objects(prefix)
         files: dict[str, bytes] = {}
         for key in keys:
-            rel = key[len(prefix):].lstrip("/")
+            rel = key[len(prefix) :].lstrip("/")
             if not rel:
                 continue
             data, _ = await store.download_file(key)
@@ -369,9 +378,7 @@ class SkillPublishService:
                 "frontmatter 'name' must not contain ':'; the org prefix is added by the server"
             )
         if not SKILL_SLUG_RE.match(fm.name):
-            raise InvalidSkillNameError(
-                f"name must match {SKILL_SLUG_RE.pattern}; got {fm.name!r}"
-            )
+            raise InvalidSkillNameError(f"name must match {SKILL_SLUG_RE.pattern}; got {fm.name!r}")
 
         canonical_name = f"{org_slug}:{fm.name}"
         skills = SkillRepository(self.session)
@@ -481,9 +488,7 @@ def _normalize_skill_zip_files(files: dict[str, bytes]) -> dict[str, bytes]:
         return files
 
     top_levels = {
-        PurePosixPath(path).parts[0]
-        for path in files
-        if len(PurePosixPath(path).parts) > 1
+        PurePosixPath(path).parts[0] for path in files if len(PurePosixPath(path).parts) > 1
     }
     if len(top_levels) != 1:
         logger.info(

--- a/backend/cubeplex/streams/run_manager.py
+++ b/backend/cubeplex/streams/run_manager.py
@@ -3643,9 +3643,10 @@ class RunManager:
             except Exception as exc:
                 logger.warning("Failed to inject available-skills list: {}", exc)
 
-            # show_widget guidelines — appended unconditionally at a fixed spot
-            # so the cache prefix stays deterministic (the tool is always
-            # registered). See backend/docs/prompt-cache-discipline.md.
+            # show_widget short stub — always-on at a fixed spot so the cache
+            # prefix stays deterministic (tool is always registered). Full
+            # playbook is the preinstalled `show-widget` skill. See
+            # backend/docs/prompt-cache-discipline.md and prompts/widget.py.
             from cubeplex.prompts.persona import PERSONA_AUTHORING_BLOCK
             from cubeplex.prompts.widget import WIDGET_GUIDELINES
 
@@ -3981,7 +3982,7 @@ class RunManager:
 
         The leading setup (citation counter, subagent/citation drainer,
         sandbox + skill catalog resolution, AgentConfig system-prompt
-        merge, available-skills suffix, widget guidelines suffix) is
+        merge, available-skills suffix, widget stub suffix) is
         identical to ``_execute_run``'s — keeping it byte-stable preserves
         the prompt cache prefix across pause/resume.
         """

--- a/backend/skills/preinstalled/show-widget/SKILL.md
+++ b/backend/skills/preinstalled/show-widget/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: show-widget
+description: >
+  Build inline interactive HTML widgets with show_widget — charts, diagrams,
+  dashboards, sliders, side-by-side comparisons, or any visual explainer.
+  Load before non-trivial widget work for design rules and scenario skeletons.
+version: 1.0.0
+keywords:
+  - widget
+  - show_widget
+  - chart
+  - diagram
+  - dashboard
+  - 图表
+  - 可视化
+  - 流程图
+  - 架构图
+  - 仪表盘
+---
+
+# show-widget — inline interactive HTML
+
+Render with the **`show_widget`** tool. Stream `widget_code` as an HTML
+fragment; do **not** `write_file` + `save_artifact` first — the widget is the
+answer.
+
+## When to use
+
+Prefer `show_widget` when the user is better off *seeing* than reading:
+画 / 绘制 / 可视化 / 示意图 / 流程图 / 架构图 / 图表 / 仪表盘 / 对比 /
+draw / visualize / chart / diagram / dashboard / flowchart / architecture /
+mockup / sliders / animation / explainer / side-by-side / breakdown.
+
+Skip for pure text, code blocks, short facts, or errors.
+
+## Size
+
+This is a widget, not a webpage:
+
+- Target ~600 px wide (max 640). Host iframe is centered/capped — no
+  `width:100vw` or `min-width:1024px`.
+- Target height ~360–480 px. Prefer a denser form over scrollbars.
+- One focus per call; unrelated visuals → multiple `show_widget` calls.
+
+## Hard rules for `widget_code`
+
+1. **HTML fragment** only — inject into `<div id="root">`. No `<!DOCTYPE>`,
+   `<html>`, `<head>`, or `<body>`.
+2. **Stream order:** short `<style>` → visible HTML → `<script>` last.
+   Scripts run only after streaming finishes.
+3. **No network from the widget:** fetch / XHR / WebSocket blocked. Embed all
+   data. Loading libraries from allowed CDNs is fine (`script-src`, not
+   `connect-src`).
+4. **No `localStorage` / `sessionStorage`** (they throw). Use in-memory vars.
+5. **CDN allowlist only:** `cdnjs.cloudflare.com`, `cdn.jsdelivr.net`,
+   `unpkg.com`, `esm.sh`.
+6. Total `widget_code` under ~256 KB.
+
+## Visual quality
+
+Host defines these CSS variables on `:root` (light/dark):
+
+| Token | Use |
+| --- | --- |
+| `--bg` | page background |
+| `--fg` | text |
+| `--muted` | card / panel surface |
+| `--border` | separators |
+| `--accent` | primary / links |
+
+Always use `var(--bg)` etc. **Never hard-code colors** (`#…`, `rgb()`, named
+colors) — widgets must work in both themes. Two font weights max (400, 500).
+No gradients, drop shadows, or blur. Radii 4–8 px. system-ui is already set.
+
+### Theme reactivity (Canvas / Chart.js / D3)
+
+Anything that **reads** CSS vars into JS at render time freezes those colors.
+Observe `:root` `style` changes and re-apply tokens:
+
+```js
+const css = (v) => getComputedStyle(document.documentElement).getPropertyValue(v).trim();
+function tokens() {
+  return { fg: css('--fg'), acc: css('--accent'), bd: css('--border') };
+}
+new MutationObserver(() => { /* re-read tokens + chart.update('none') */ })
+  .observe(document.documentElement, { attributes: true, attributeFilter: ['style'] });
+```
+
+Inline SVG/HTML using `var(--fg)` directly does **not** need this — cascade
+re-evaluates automatically.
+
+## Chart.js height (mandatory)
+
+With `responsive:true` and `maintainAspectRatio:false`, Chart.js reads the
+canvas **CSS** height — not the HTML `height` attribute. Without an explicit
+CSS height pinned with `!important`, the canvas grows unbounded and freezes
+the tab.
+
+- One chart: `canvas{width:100%!important;height:300px!important;}`
+- Multiple heights: per-id CSS or inline `style="width:100%;height:180px;display:block;"`
+
+## Scenario skeletons
+
+Pick the closest and adapt — swap data/labels; do not echo verbatim.
+
+### A. Single chart (Chart.js)
+
+```html
+<style>
+  .card{background:var(--muted);border:1px solid var(--border);border-radius:8px;padding:16px;}
+  .card h3{margin:0 0 8px;font-size:14px;font-weight:500;color:var(--fg);}
+  canvas{width:100%!important;height:300px!important;}
+</style>
+<div class="card">
+  <h3>Title that says what is plotted</h3>
+  <canvas id="c"></canvas>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+<script>
+  const css = (v) => getComputedStyle(document.documentElement).getPropertyValue(v).trim();
+  function tokens(){ return { fg: css('--fg'), acc: css('--accent'), bd: css('--border') }; }
+  let t = tokens();
+  const chart = new Chart(document.getElementById('c'), {
+    type: 'line',
+    data: {
+      labels: ['A','B','C','D','E'],
+      datasets: [{
+        label: 'Series', data: [3,8,5,12,9],
+        borderColor: t.acc, backgroundColor: t.acc+'33', tension: .3
+      }]
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { labels: { color: t.fg } } },
+      scales: {
+        x: { ticks: { color: t.fg }, grid: { color: t.bd } },
+        y: { ticks: { color: t.fg }, grid: { color: t.bd } }
+      }
+    }
+  });
+  new MutationObserver(() => {
+    t = tokens();
+    chart.options.plugins.legend.labels.color = t.fg;
+    chart.options.scales.x.ticks.color = t.fg;
+    chart.options.scales.x.grid.color = t.bd;
+    chart.options.scales.y.ticks.color = t.fg;
+    chart.options.scales.y.grid.color = t.bd;
+    chart.data.datasets[0].borderColor = t.acc;
+    chart.data.datasets[0].backgroundColor = t.acc + '33';
+    chart.update('none');
+  }).observe(document.documentElement, { attributes: true, attributeFilter: ['style'] });
+</script>
+```
+
+### B. Architecture / flow (inline SVG)
+
+```html
+<style>
+  .diag{display:block;width:100%;height:auto;}
+  .node{fill:var(--muted);stroke:var(--border);}
+  .label{fill:var(--fg);font:500 12px system-ui;text-anchor:middle;dominant-baseline:central;}
+  .edge{stroke:var(--border);stroke-width:1.5;fill:none;}
+  .edge.hl{stroke:var(--accent);}
+</style>
+<svg class="diag" viewBox="0 0 560 220" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6"
+      orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0 0 L10 5 L0 10 z" fill="context-stroke"/>
+    </marker>
+  </defs>
+  <rect class="node" x="20"  y="80" width="120" height="60" rx="6"/>
+  <text class="label" x="80"  y="110">Client</text>
+  <rect class="node" x="220" y="80" width="120" height="60" rx="6"/>
+  <text class="label" x="280" y="110">API</text>
+  <rect class="node" x="420" y="80" width="120" height="60" rx="6"/>
+  <text class="label" x="480" y="110">DB</text>
+  <line class="edge"    x1="140" y1="110" x2="220" y2="110" marker-end="url(#a)"/>
+  <line class="edge hl" x1="340" y1="110" x2="420" y2="110" marker-end="url(#a)"/>
+</svg>
+```
+
+One shared marker with `fill="context-stroke"` so each arrowhead inherits its
+edge stroke. Never hard-code marker fill. Use `markerUnits="userSpaceOnUse"`
+for constant head size.
+
+### C. Dashboard (metrics + small chart)
+
+```html
+<style>
+  .grid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-bottom:12px;}
+  .stat{background:var(--muted);border:1px solid var(--border);border-radius:8px;padding:12px;}
+  .stat .v{font-size:22px;font-weight:500;color:var(--fg);}
+  .stat .l{font-size:11px;color:var(--fg);opacity:.7;margin-top:2px;}
+  .panel{background:var(--muted);border:1px solid var(--border);border-radius:8px;padding:16px;}
+  canvas{width:100%!important;height:200px!important;}
+</style>
+<div class="grid">
+  <div class="stat"><div class="v">1,284</div><div class="l">Active users</div></div>
+  <div class="stat"><div class="v">$42.1k</div><div class="l">Revenue (MTD)</div></div>
+  <div class="stat"><div class="v">98.6%</div><div class="l">Uptime</div></div>
+</div>
+<div class="panel"><canvas id="c"></canvas></div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+<script>/* Chart.js init — same token + MutationObserver pattern as A */</script>
+```
+
+### D. Interactive explainer (sliders)
+
+```html
+<style>
+  .row{display:flex;align-items:center;gap:12px;margin:8px 0;}
+  .row label{flex:0 0 110px;color:var(--fg);font-size:13px;}
+  .row input{flex:1;accent-color:var(--accent);}
+  .row .val{flex:0 0 64px;text-align:right;font-variant-numeric:tabular-nums;color:var(--fg);}
+  .out{margin-top:12px;padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--muted);}
+  .out .big{font-size:24px;font-weight:500;color:var(--fg);}
+  .out .lbl{font-size:11px;color:var(--fg);opacity:.7;}
+</style>
+<div class="row"><label>Principal</label><input id="p" type="range" min="1000" max="100000" step="100" value="10000"><div class="val" id="pv">$10,000</div></div>
+<div class="row"><label>Years</label><input id="y" type="range" min="1" max="40" step="1" value="10"><div class="val" id="yv">10</div></div>
+<div class="row"><label>Rate (%)</label><input id="r" type="range" min="0" max="15" step="0.1" value="5"><div class="val" id="rv">5%</div></div>
+<div class="out"><div class="big" id="ans">$16,288.95</div><div class="lbl">Future value</div></div>
+<script>
+  const $ = (id) => document.getElementById(id);
+  function recalc() {
+    const P = +$('p').value, y = +$('y').value, r = +$('r').value / 100;
+    $('pv').textContent = '$' + P.toLocaleString();
+    $('yv').textContent = y;
+    $('rv').textContent = (r * 100) + '%';
+    $('ans').textContent = '$' + (P * Math.pow(1 + r, y)).toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+  ['p', 'y', 'r'].forEach((id) => $(id).addEventListener('input', recalc));
+</script>
+```
+
+### E. Side-by-side comparison
+
+```html
+<style>
+  table{width:100%;border-collapse:collapse;font-size:13px;color:var(--fg);}
+  th,td{padding:8px 10px;border-bottom:1px solid var(--border);text-align:left;}
+  th{font-weight:500;color:var(--fg);opacity:.85;background:var(--muted);}
+  .check{color:var(--accent);font-weight:500;}
+  .dash{opacity:.5;}
+</style>
+<table>
+  <thead><tr><th>Feature</th><th>Option A</th><th>Option B</th></tr></thead>
+  <tbody>
+    <tr><td>Streams</td><td class="check">Yes</td><td class="dash">–</td></tr>
+    <tr><td>Offline</td><td class="dash">–</td><td class="check">Yes</td></tr>
+    <tr><td>Free tier</td><td>1k req/mo</td><td>500 req/mo</td></tr>
+  </tbody>
+</table>
+```
+
+If nothing fits: bordered muted cards, accent sparingly, small radii, no
+shadows. A plain card beats a sprawling page.

--- a/backend/tests/e2e/test_skill_discovery_local.py
+++ b/backend/tests/e2e/test_skill_discovery_local.py
@@ -1,23 +1,56 @@
+import io
+import secrets
 import tempfile
+import zipfile
 from pathlib import Path
 
 import httpx
 import pytest
 
 
+def _zip_skill(name: str, version: str = "1.0.0") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr(
+            "SKILL.md",
+            f"---\nname: {name}\ndescription: d\nversion: {version}\n---\n# {name}\n",
+        )
+    return buf.getvalue()
+
+
+async def _publish_uploaded(
+    client: httpx.AsyncClient, ws_id: str, *, slug: str | None = None
+) -> str:
+    """Publish an org-uploaded skill (not auto-enabled). Returns skill name slug."""
+    name = slug or f"disc-{secrets.token_hex(4)}"
+    resp = await client.post(
+        f"/api/v1/ws/{ws_id}/skills/publish",
+        files={"file": ("a.zip", _zip_skill(name), "application/zip")},
+    )
+    assert resp.status_code == 201, resp.text
+    return name
+
+
 @pytest.mark.asyncio
 async def test_discover_then_install_local_skill_becomes_enabled(
     member_client: tuple[httpx.AsyncClient, str],
 ) -> None:
-    client, ws_id = member_client
+    """Uploaded skills start as in_catalog; install enables them for the workspace.
 
-    disc = await client.get(f"/api/v1/ws/{ws_id}/skills/discover", params={"q": "research"})
+    Preinstalled skills are auto-installed on seed reconcile (auto_bind=True), so
+    they already appear as ``enabled``. The discover→install path is covered with
+    an org-uploaded skill that is not auto-enabled.
+    """
+    client, ws_id = member_client
+    slug = await _publish_uploaded(client, ws_id)
+
+    disc = await client.get(f"/api/v1/ws/{ws_id}/skills/discover", params={"q": slug})
     assert disc.status_code == 200
     cands = disc.json()
-    cand = next(c for c in cands if c["name"] == "deep-research")
+    cand = next(c for c in cands if c["name"].endswith(f":{slug}") or c["name"] == slug)
     assert cand["install_state"] == "in_catalog"
-    assert cand["canonical_name"] == "deep-research"
     assert "candidate_id" in cand and "/" not in cand["candidate_id"]
+    canonical = cand["canonical_name"]
 
     install = await client.post(
         f"/api/v1/ws/{ws_id}/skills/install",
@@ -25,26 +58,34 @@ async def test_discover_then_install_local_skill_becomes_enabled(
     )
     assert install.status_code == 201
     body = install.json()
-    assert body["canonical_name"] == "deep-research"
+    assert body["canonical_name"] == canonical
 
     enabled = await client.get(f"/api/v1/ws/{ws_id}/skills", params={"scope": "workspace"})
-    assert any(s["name"] == "deep-research" for s in enabled.json())
+    assert any(s["name"] == canonical for s in enabled.json())
 
 
 @pytest.mark.asyncio
 async def test_install_is_workspace_private_not_visible_in_other_ws(
     member_client_two_workspaces: tuple[httpx.AsyncClient, str, str],
 ) -> None:
+    """Workspace-private install of an uploaded skill must not bleed to ws_b.
+
+    Preinstalled skills are org-wide auto-bound, so they appear in every
+    workspace; use an uploaded skill for private-install isolation.
+    """
     client, ws_a, ws_b = member_client_two_workspaces
-    disc = await client.get(f"/api/v1/ws/{ws_a}/skills/discover", params={"q": "research"})
-    cand = next(c for c in disc.json() if c["name"] == "deep-research")
+    slug = await _publish_uploaded(client, ws_a)
+
+    disc = await client.get(f"/api/v1/ws/{ws_a}/skills/discover", params={"q": slug})
+    cand = next(c for c in disc.json() if c["name"].endswith(f":{slug}") or c["name"] == slug)
+    canonical = cand["canonical_name"]
     await client.post(
         f"/api/v1/ws/{ws_a}/skills/install", json={"candidate_id": cand["candidate_id"]}
     )
     a = await client.get(f"/api/v1/ws/{ws_a}/skills", params={"scope": "workspace"})
     b = await client.get(f"/api/v1/ws/{ws_b}/skills", params={"scope": "workspace"})
-    assert any(s["name"] == "deep-research" for s in a.json())
-    assert not any(s["name"] == "deep-research" for s in b.json())
+    assert any(s["name"] == canonical for s in a.json())
+    assert not any(s["name"] == canonical for s in b.json())
 
 
 @pytest.mark.asyncio
@@ -58,8 +99,9 @@ async def test_installed_skill_resolves_via_find_enabled_by_name(
     """
     client, ws_id = member_client
 
-    disc = await client.get(f"/api/v1/ws/{ws_id}/skills/discover", params={"q": "research"})
-    cand = next(c for c in disc.json() if c["name"] == "deep-research")
+    slug = await _publish_uploaded(client, ws_id)
+    disc = await client.get(f"/api/v1/ws/{ws_id}/skills/discover", params={"q": slug})
+    cand = next(c for c in disc.json() if c["name"].endswith(f":{slug}") or c["name"] == slug)
     inst = await client.post(
         f"/api/v1/ws/{ws_id}/skills/install",
         json={"candidate_id": cand["candidate_id"]},
@@ -99,6 +141,25 @@ async def test_installed_skill_resolves_via_find_enabled_by_name(
 
 
 @pytest.mark.asyncio
+async def test_preinstalled_skill_is_enabled_after_seed_reconcile(
+    member_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """New preinstalled skills must be loadable without a manual install.
+
+    Seed reconcile auto-installs missing preinstalled skills with auto_bind=True
+    so agents can load_skill('show-widget') / deep-research after deploy.
+    """
+    client, ws_id = member_client
+    disc = await client.get(f"/api/v1/ws/{ws_id}/skills/discover", params={"q": "research"})
+    assert disc.status_code == 200
+    cand = next(c for c in disc.json() if c["name"] == "deep-research")
+    assert cand["install_state"] == "enabled"
+
+    enabled = await client.get(f"/api/v1/ws/{ws_id}/skills", params={"scope": "workspace"})
+    assert any(s["name"] == "deep-research" for s in enabled.json())
+
+
+@pytest.mark.asyncio
 async def test_tombstoned_preinstalled_cannot_be_reinstalled_via_discovery(
     member_client: tuple[httpx.AsyncClient, str],
 ) -> None:
@@ -123,6 +184,7 @@ async def test_tombstoned_preinstalled_cannot_be_reinstalled_via_discovery(
     from cubeplex.db.engine import _build_database_url
     from cubeplex.repositories.skill import (
         OrgPreinstalledTombstoneRepository,
+        OrgSkillInstallRepository,
         SkillRepository,
     )
     from cubeplex.repositories.workspace import WorkspaceRepository
@@ -138,6 +200,8 @@ async def test_tombstoned_preinstalled_cannot_be_reinstalled_via_discovery(
             assert ws is not None
             skill = await SkillRepository(session).get(skill_id)
             assert skill is not None and skill.source == "preinstalled"
+            # Mirror admin uninstall: drop install + tombstone.
+            await OrgSkillInstallRepository(session).delete(ws.org_id, skill_id)
             await OrgPreinstalledTombstoneRepository(session).add_tombstone(
                 org_id=ws.org_id, skill_id=skill_id, hidden_by_user_id=member_user_id
             )

--- a/backend/tests/e2e/test_skills_seeder.py
+++ b/backend/tests/e2e/test_skills_seeder.py
@@ -202,3 +202,49 @@ async def test_seed_skips_tombstoned_org_on_reconcile(
     # Re-seed must not resurrect the install.
     await seed_preinstalled_skills(preinstalled_dir=src, db_session=db_session, redis=redis_client)
     assert await installs.get(org.id, skill.id) is None
+
+
+@pytest.mark.asyncio
+async def test_list_enabled_excludes_tombstoned_even_with_orphan_install(
+    tmp_path: Path, db_session, redis_client: Redis
+) -> None:
+    """Dual-state (install + tombstone) must not make load_skill succeed.
+
+    Catalog list_enabled is what load_skill uses; tombstone wins.
+    """
+    from cubeplex.skills.cache import SkillCache
+    from cubeplex.skills.service import SkillCatalogService
+
+    org = await OrganizationRepository(db_session).create(
+        name=f"dual-org-{uuid.uuid4().hex[:8]}",
+        slug=f"dual-org-{uuid.uuid4().hex[:8]}",
+    )
+    skill_name = _unique_name("dual-state")
+    src = tmp_path / "preinstalled"
+    _write_skill_md(src / skill_name, name=skill_name, version="1.0.0")
+    await seed_preinstalled_skills(preinstalled_dir=src, db_session=db_session, redis=redis_client)
+
+    skill = await SkillRepository(db_session).find_by_name(skill_name)
+    assert skill is not None
+    installs = OrgSkillInstallRepository(db_session)
+    assert await installs.get(org.id, skill.id) is not None
+
+    # Simulate dual-state: tombstone without deleting install.
+    await OrgPreinstalledTombstoneRepository(db_session).add_tombstone(
+        org_id=org.id, skill_id=skill.id, hidden_by_user_id=None
+    )
+    assert await installs.get(org.id, skill.id) is not None
+
+    catalog = SkillCatalogService(
+        session=db_session, cache=SkillCache(cache_root=tmp_path / "cache")
+    )
+    # workspace_id unused for org-wide path matching; any non-empty id works.
+    enabled = await catalog.list_enabled_for_workspace("ws-placeholder", org_id=org.id)
+    assert all(r.skill_id != skill.id for r in enabled)
+    assert (
+        await catalog.find_enabled_by_name("ws-placeholder", org_id=org.id, name=skill_name) is None
+    )
+
+    # Next reconcile should purge the orphan install.
+    await seed_preinstalled_skills(preinstalled_dir=src, db_session=db_session, redis=redis_client)
+    assert await installs.get(org.id, skill.id) is None

--- a/backend/tests/e2e/test_skills_seeder.py
+++ b/backend/tests/e2e/test_skills_seeder.py
@@ -6,7 +6,13 @@ from pathlib import Path
 import pytest
 from redis.asyncio import Redis
 
-from cubeplex.repositories.skill import SkillRepository, SkillVersionRepository
+from cubeplex.repositories.organization import OrganizationRepository
+from cubeplex.repositories.skill import (
+    OrgPreinstalledTombstoneRepository,
+    OrgSkillInstallRepository,
+    SkillRepository,
+    SkillVersionRepository,
+)
 from cubeplex.seeders import seed_preinstalled_skills
 
 
@@ -136,3 +142,63 @@ async def test_seeder_writes_content_hash(tmp_path: Path, db_session, redis_clie
     versions = await SkillVersionRepository(db_session).list_for_skill(skill.id)
     assert len(versions) == 1
     assert versions[0].content_hash.startswith("sha256:")
+
+
+@pytest.mark.asyncio
+async def test_seed_auto_installs_for_existing_org(
+    tmp_path: Path, db_session, redis_client: Redis
+) -> None:
+    """Existing orgs get OrgSkillInstall for newly seeded preinstalled skills.
+
+    Bootstrap only installs at org-create; seeder reconcile closes the gap so
+    agents can load_skill after deploy without a manual admin install.
+    """
+    org = await OrganizationRepository(db_session).create(
+        name=f"seed-org-{uuid.uuid4().hex[:8]}",
+        slug=f"seed-org-{uuid.uuid4().hex[:8]}",
+    )
+    skill_name = _unique_name("show-widget")
+    src = tmp_path / "preinstalled"
+    _write_skill_md(src / skill_name, name=skill_name, version="1.0.0", description="widgets")
+
+    await seed_preinstalled_skills(preinstalled_dir=src, db_session=db_session, redis=redis_client)
+
+    skill = await SkillRepository(db_session).find_by_name(skill_name)
+    assert skill is not None
+    install = await OrgSkillInstallRepository(db_session).get(org.id, skill.id)
+    assert install is not None
+    assert install.installed_version == "1.0.0"
+    assert install.auto_bind is True
+    assert install.workspace_id is None
+
+
+@pytest.mark.asyncio
+async def test_seed_skips_tombstoned_org_on_reconcile(
+    tmp_path: Path, db_session, redis_client: Redis
+) -> None:
+    """Admin uninstall (tombstone) must not be undone by seeder reconcile."""
+    org = await OrganizationRepository(db_session).create(
+        name=f"tomb-org-{uuid.uuid4().hex[:8]}",
+        slug=f"tomb-org-{uuid.uuid4().hex[:8]}",
+    )
+    skill_name = _unique_name("tombstoned")
+    src = tmp_path / "preinstalled"
+    _write_skill_md(src / skill_name, name=skill_name, version="1.0.0")
+
+    # First seed creates catalog + install.
+    await seed_preinstalled_skills(preinstalled_dir=src, db_session=db_session, redis=redis_client)
+    skill = await SkillRepository(db_session).find_by_name(skill_name)
+    assert skill is not None
+    installs = OrgSkillInstallRepository(db_session)
+    assert await installs.get(org.id, skill.id) is not None
+
+    # Org admin uninstalls: delete install + tombstone (mirrors admin route).
+    await installs.delete(org.id, skill.id)
+    await OrgPreinstalledTombstoneRepository(db_session).add_tombstone(
+        org_id=org.id, skill_id=skill.id, hidden_by_user_id=None
+    )
+    assert await installs.get(org.id, skill.id) is None
+
+    # Re-seed must not resurrect the install.
+    await seed_preinstalled_skills(preinstalled_dir=src, db_session=db_session, redis=redis_client)
+    assert await installs.get(org.id, skill.id) is None

--- a/backend/tests/unit/test_show_widget.py
+++ b/backend/tests/unit/test_show_widget.py
@@ -2,19 +2,26 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
-from cubeplex.prompts.widget import WIDGET_GUIDELINES
+from cubeplex.prompts.widget import WIDGET_GUIDELINES, WIDGET_TOOL_DESCRIPTION
+from cubeplex.skills.frontmatter import parse_skill_md
 from cubeplex.streams.run_manager import _subagent_shared_tools
 from cubeplex.tools.builtin.show_widget import _ShowWidgetArgs, make_show_widget_tool
+
+_PREINSTALLED = (
+    Path(__file__).resolve().parents[2] / "skills" / "preinstalled" / "show-widget" / "SKILL.md"
+)
 
 
 def test_tool_metadata() -> None:
     tool = make_show_widget_tool()
     assert tool.name == "show_widget"
     assert tool.parameters is _ShowWidgetArgs
+    assert "show-widget" in tool.description
 
 
 @pytest.mark.asyncio
@@ -30,10 +37,30 @@ async def test_execute_returns_light_ack() -> None:
     assert "rendered" in text.lower()
 
 
-def test_guidelines_mention_tool_and_constraints() -> None:
+def test_always_on_guidelines_are_short_stub() -> None:
+    """F1: bulk playbook moved to skill; system prefix keeps only hard limits."""
     assert "show_widget" in WIDGET_GUIDELINES
-    assert "fetch" in WIDGET_GUIDELINES  # network-blocked note
+    assert "fetch" in WIDGET_GUIDELINES
     assert "localStorage" in WIDGET_GUIDELINES
+    assert "show-widget" in WIDGET_GUIDELINES  # points agents at the skill
+    # Stay well under the old ~11k always-on block.
+    assert len(WIDGET_GUIDELINES) < 1500
+    assert "MutationObserver" not in WIDGET_GUIDELINES  # skeleton detail → skill
+    assert "show-widget" in WIDGET_TOOL_DESCRIPTION
+
+
+def test_preinstalled_show_widget_skill_exists_and_parses() -> None:
+    assert _PREINSTALLED.is_file()
+    text = _PREINSTALLED.read_text(encoding="utf-8")
+    fm = parse_skill_md(text)
+    assert fm.name == "show-widget"
+    assert fm.version
+    assert "show_widget" in fm.description or "widget" in fm.description.lower()
+    # Playbook content lives in the skill body.
+    assert "Chart.js" in text
+    assert "MutationObserver" in text
+    assert "var(--fg)" in text
+    assert "context-stroke" in text
 
 
 def test_subagent_shared_tools_drops_show_widget() -> None:

--- a/docs/dev/notes/2026-07-22-system-prompt-trace-review.md
+++ b/docs/dev/notes/2026-07-22-system-prompt-trace-review.md
@@ -1,0 +1,245 @@
+# System prompt trace review — seed sample (local)
+
+**Date:** 2026-07-23  
+**Related:** #391 · design PR #412  
+**Spec:** [docs/dev/specs/2026-07-22-system-prompt-trace-optimization-design.md](../specs/2026-07-22-system-prompt-trace-optimization-design.md)  
+**Plan:** [docs/dev/plans/2026-07-22-system-prompt-trace-optimization.md](../plans/2026-07-22-system-prompt-trace-optimization.md)  
+**Discipline:** [backend/docs/prompt-cache-discipline.md](../../../backend/docs/prompt-cache-discipline.md)  
+**Trace skill:** `.agents/skills/cubepi-trace/SKILL.md`
+
+**Status:** Phase A seed measurement + Phase B **partial** findings from one
+real local conversation. **Not** a full stratified sample. Phase C (prompt
+edits) still requires human design approval of this note and broader sample
+coverage where claimed.
+
+**Environment:** local main worktree (`backend/cubepi-traces/`), developer
+machine, `record_content` on. **Do not treat as production telemetry.**
+Raw JSONL stays on disk only; this note cites **trace ids** and redacted
+sizes only—no user secrets, full skill bodies, or full memory text.
+
+---
+
+## 1. Sample set
+
+| Field | Value |
+| --- | --- |
+| Conversation | `conv-1m1jE95wSfyYDi` |
+| Focus run (latest) | `fd9890facb3e92805a7a775621000a41` |
+| Prior run (same conv) | `1a078f8b74a8152fbaede423004d5a47` |
+| Date shard | `cubepi-traces/2026-07-23/` |
+| Primary model (latest) | `deepseek-v4-flash` |
+| Prior model | `glm-5.2` (skill load + HITL) |
+| Scenario class | Long multi-turn **sandbox coding + artifact**: PPTX investor deck after `ask_user` (format=pptx, theme=auto, content=refresh) |
+| Outcome rubric | **success** (status ok, no ERROR spans; deck built + `save_artifact`) but **high cost / latency** |
+
+### How to re-open
+
+```bash
+cd backend
+uv run cubepi trace ls --meta conversation_id=conv-1m1jE95wSfyYDi --dir ./cubepi-traces
+uv run cubepi trace view fd9890fa --dir ./cubepi-traces
+uv run cubepi trace convert fd9890fa --dir ./cubepi-traces --span 0xa248bc9e  # first chat
+uv run cubepi trace convert fd9890fa --dir ./cubepi-traces --span 0x2df20720  # last chat
+uv run cubepi trace stats --dir ./cubepi-traces --meta conversation_id=conv-1m1jE95wSfyYDi
+```
+
+First chat span id (tree): `0xa248bc9e`. Last: `0x2df20720`.
+
+---
+
+## 2. Baselines (measured)
+
+### 2.1 Run shape (latest: `fd9890…`)
+
+| Metric | Value |
+| --- | --- |
+| Wall time | ~978 782 ms (~16.3 min) |
+| `cubepi.turn` count | 38 |
+| `chat deepseek-v4-flash` | 37 |
+| Tools | `execute`×24, `write_file`×16, `edit_file`×4, `write_todos`×6, `ask_user`×1, `save_artifact`×1 |
+| Errors | **0** |
+
+### 2.2 Token usage (trace field convention)
+
+Cubepi trace: `gen_ai.usage.input_tokens` is **inclusive total prompt**
+(cache_read is a **subset**). Approximate hit fraction for a call:
+
+```text
+cache_read / input_tokens   # only when both present; not a billing formula
+```
+
+| Scope | Input tokens (sum) | Output | Cache read (sum) |
+| --- | --- | --- | --- |
+| Latest run only (37 chats) | **4 208 037** | **20 966** | **3 194 880** |
+| Conversation (both models, stats CLI) | deepseek 4.2M in / 21k out; glm 422k in / 3.6k out | | deepseek cache_tok ~3.2M; glm ~330k |
+
+Per-call **input_tokens** on latest run:
+
+| Point | input_tokens | cache_read | cache_read/input (if defined) |
+| --- | --- | --- | --- |
+| First chat | 92 182 | 65 536 | ~71% |
+| Mid | ~116 457 | 114 688 | ~98% |
+| Last chat | **126 210** | 114 688 | ~91% |
+
+**Cache cliffs:** multiple turns at **0%** cache_read (observed near ~96k,
+~111k, ~122k, ~124k, ~125k input). Overall run still cache-heavy, but
+cliffs re-bill large prefixes.
+
+### 2.3 First request composition (converted OpenAI-shaped body)
+
+Source: `cubepi trace convert fd9890fa --span 0xa248bc9e`.
+
+| Bucket | Chars (approx) | Notes |
+| --- | --- | --- |
+| **system** | **37 449** | Single system message |
+| **tools** (schemas) | **~25 623** | 21 tools always registered |
+| **tool** role (history) | **~145 196** | Dominated by skill load + file_read of skill refs |
+| **assistant** history | ~1.2k (first) → ~12k (last) | Grows with loop |
+| **user** | small | HITL resume + brief |
+| **Total request JSON** | ~312k chars first chat | |
+
+**Last request** (`0x2df20720`): 119 messages; tool-role history **~184k**
+chars; system still ~37.5k; same ~21 tools.
+
+### 2.4 System message section sizes (first chat)
+
+Split on `## ` headers (and top-level `#` blocks). Approximate character
+counts of the **assembled** system string:
+
+| Section / block | ~chars | Observation |
+| --- | --- | --- |
+| `## Rendering interactive widgets (show_widget)` | **~11 030** | Always present; task is **PPTX**, not widget |
+| `## Memory` (+ pinned items) | **~7 139** | Large personal corrections (ops / social); low relevance to deck |
+| `# Available skills` catalog | **~6 435** | Long skill descriptions (incl. namespaced uploaded skill) |
+| `## File Attachments` + persona tail | **~7 131** | Attachment rules + agent persona overlay |
+| `## Artifacts` | ~1 827 | Relevant near end of run |
+| `## Shell Execution` + workspace org | ~1.5–1.6k each | Useful for sandbox task |
+| `## Saving memory` / todos notes | ~1–1.7k | Always-on |
+| Base core / doing tasks / etc. | smaller | |
+
+Persona overlay observed (redacted intent only): named assistant + “Always
+talk to me with English.”
+
+### 2.5 History bloat drivers (tool results, not system)
+
+Largest tool payloads retained in the transcript (first chat already):
+
+| Kind | ~chars | Example |
+| --- | --- | --- |
+| `load_skill` body | ~33k | `gxf-beta-s-org:huashu-design` full SKILL.md |
+| `file_read` skill reference | ~42k | `…/references/slide-decks.md` (full file, not truncated) |
+| Other skill refs | 10–17k each | `editable-pptx.md`, `design-styles.md`, … |
+| App source read | ~17k | e.g. frontend `globals.css` pulled into tool result |
+
+These remain as **tool** messages for **all subsequent turns** of the run
+(no compaction observed).
+
+### 2.6 Agent loop pattern
+
+- One turn produced **out≈7869** tokens then **11× `write_file`** in the
+  same turn (~223 s wall for that turn).
+- Many small `execute` cycles (fonts, sharp, build) after large skill-driven
+  planning.
+- Ends with `save_artifact` + short final reply.
+
+---
+
+## 3. Findings table
+
+Severity is for **this sample class** (long skill + sandbox artifact). Do
+not generalize to all product surfaces without more stratified runs.
+
+| id | severity | evidence | fragment(s) / layer | proposed change (direction only) | expected metric |
+| --- | --- | --- | --- | --- | --- |
+| **F1** | **high** | `fd9890…`: system always includes ~11k widget block while tools/path are PPTX + sandbox | `WIDGET_GUIDELINES` / `run_manager` always-on append | Conversation-stable gate: inject widget prose only when `show_widget` is in the tool set **for that agent config**, or move bulk to on-demand skill; **never** per-turn task classify mid-conversation | Lower median system chars / first-turn input on non-widget runs; cache e2e still green |
+| **F2** | **high** | First chat tool-role ~145k; skill body + multi-file references stay for 37 turns; input 92k→126k | `load_skill` + `file_read` + history replay; skills middleware | Cap or summarize skill bodies in history; truncate large reference reads; optional “skill unload”; long-run **compaction** | p95 input tokens on multi-turn skill runs; same task success rate |
+| **F3** | **high** | Skills list ~6.4k with long uploaded skill blurb; name `gxf-beta-s-org:huashu-design` | `SKILLS_PROMPT_TEMPLATE` / catalog formatting | Short catalog lines (name + one-line trigger); full text only after `load_skill`; UI/display: #399 | Catalog chars; load_skill still discoverable |
+| **F4** | **medium** | Memory block ~7k, mostly off-task personal corrections | `MemoryMiddleware` + pinned memory render | Tighter ranking / size budget for system memory block; keep authoring rules short | System memory section chars; no regression on in-scope corrections |
+| **F5** | **medium** | 21 tool schemas ~25k always (write_todos, file_read, schedule, …) | Tool registration / deferred groups | Expand deferred tool groups; shorten schema descriptions | tools JSON chars; task success |
+| **F6** | **medium** | Several 0% cache_read turns despite high average cache | Stable prefix + history growth | Keep system/tool prefix stable; avoid mid-run skill **re**-injection into system; measure cliffs after F1–F2 | Count of 0% cache turns / run |
+| **F7** | **low–medium** | 37 turns, 16 write_file, 24 execute for one deck | Skill guidance + agent behavior (not only base system) | Skill-side: fewer full-file dumps; prefer edit over rewrite; optional model/effort policy | Turns per successful artifact; wall time |
+| **F8** | **info** | Run **succeeded** with no ERROR | — | Do not “fix success”; optimize cost path | — |
+
+### Hypotheses from the design doc — status on this sample
+
+| Hypothesis (spec §4.7) | This sample |
+| --- | --- |
+| Widget always-on and oversized | **Confirmed** for this non-widget run (F1) |
+| Loaded skills bloat multi-turn | **Confirmed** strongly (F2) |
+| Memory authoring / block size | **Partially confirmed** as dead weight for this task (F4) |
+| Citation under-follow | **Not exercised** (no web_search path) |
+| Sandbox on pure Q&A | **Not exercised** (sandbox was needed) |
+| Subagent style guidance | **Not exercised** |
+
+---
+
+## 4. Won’t fix (from this sample alone)
+
+| Item | Why |
+| --- | --- |
+| Rewrite base “be concise” without more samples | Success path; style conflict not proven as failure mode here |
+| Delete sandbox workspace-org rules | Task used sandbox; dead-weight claim invalid here |
+| Change model / provider | Out of scope for prompt optimization |
+| Blame deepseek alone for 37 turns | Skill + history design dominate measurable tokens |
+| Commit raw JSONL or full memory/skill text | Privacy / repo hygiene |
+
+---
+
+## 5. Recommended PR split (after note approval + broader sample)
+
+One concern per PR; each cites a finding id and re-measures.
+
+| Order | PR concern | Findings | Notes |
+| --- | --- | --- | --- |
+| 1 | Gate or slim **widget** system prose (conversation-stable) | F1 | Pair with `show_widget` tool presence |
+| 2 | **Skill catalog** line budget + short descriptions | F3 | Coordinates with #399 display only |
+| 3 | **History** policy for large tool results / skill refs | F2 | May touch cubepi/middleware more than `prompts/*.py` |
+| 4 | Memory **system block** size budget / ranking | F4 | Preserve corrections quality |
+| 5 | Deferred tools / schema trim | F5 | Optional after 1–3 |
+
+**Do not** combine 1–5 into one mega-diff.
+
+---
+
+## 6. Open questions
+
+1. Is widget gating allowed when `show_widget` remains registered but unused
+   (tool always on in default agent)? If yes, need another conversation-stable
+   signal (agent profile / capability flag), not per-user-message NLP.
+2. Should large `file_read` of skill `references/*` auto-truncate with
+   “open path in sandbox” guidance?
+3. Compaction: product feature vs prompt-only? Spec currently notes tool
+   result formatting as out of scope unless it interacts with system rules—
+   F2 may force an explicit scope expansion in a follow-up design.
+4. Expand sample: short Q&A, citation search, pure memory chat, multi-subagent
+   (still required before org-wide claims).
+
+---
+
+## 7. Analysis checklist scores (latest run only)
+
+| Checklist item (spec §4.4) | Score (this run) |
+| --- | --- |
+| 1 Instruction adherence | Not primary failure; language/persona followed |
+| 2 Dead weight | **High** — widget + off-task memory + long catalog |
+| 3 Redundancy / conflict | Medium — long skill vs base concise |
+| 4 Cache / cost | **High** volume; cliffs present |
+| 5 Ordering / primacy | Widget/memory before task-specific needs |
+| 6 Tool schema vs prose | Medium — large schemas + long prose for same tools |
+| 7 Subagent / skill load | **High** — skill + refs dominate history |
+| 8 Oneshots | Not the focus of this run |
+
+---
+
+## 8. Gate for Phase C
+
+Per design PR #412:
+
+- [x] Seed note written with methodology, baselines, findings, won’t-fix, PR split  
+- [ ] Stratified sample (≥2 per primary class) for class-level claims  
+- [ ] Human design approval of this note (or successor revision)  
+- [ ] Holdout set reserved for post-fix comparison  
+
+Until the second and third boxes are checked, treat **F1–F3 as high-priority
+hypotheses with strong local evidence**, not as a blank check to rewrite all
+prompts on main.

--- a/docs/dev/plans/2026-07-22-system-prompt-trace-optimization.md
+++ b/docs/dev/plans/2026-07-22-system-prompt-trace-optimization.md
@@ -38,20 +38,21 @@ notes under `docs/dev/notes/`.
 **Core logic:**
 
 1. Confirm tracing records system prompt content on `chat` spans.
-2. Run a **diverse sample** (target ≥10 runs), covering at least:
-   - short Q&A (no tools)
-   - web/search + citations
-   - sandbox coding
-   - artifact creation
-   - widget / generative UI if available
-   - multi-subagent
-   - multi-turn with `load_skill`
-   - Chinese and English user messages
-   - title and reflection oneshots if observable
-3. Record for each: trace id, model, scenario tag, rough outcome
-   (success / loop / miss).
+2. Use **synthetic local or sanitized staging** data only; do not default
+   to production `record_content`. Do not commit raw JSONL.
+3. Run a **stratified sample**:
+   - Scenario classes: short Q&A (no tools); web/search + citations;
+     sandbox coding; artifact creation; widget / generative UI if
+     available; multi-subagent; multi-turn with `load_skill`; Chinese and
+     English; title/reflection oneshots if observable.
+   - Prefer **≥2 runs per primary class** before ranking a class-level
+     finding; overall N often ≥10–20. Record uncertainty when N is small.
+   - Reserve a small **holdout** set for post-fix comparison.
+4. Record for each: trace id, model, scenario tag, outcome under a
+   **fixed scoring rubric** (success / loop / instruction-miss / other) —
+   not free-form only.
 
-**Tests:** N/A (ops). Evidence = list of trace ids in the note.
+**Tests:** N/A (ops). Evidence = list of trace ids + rubric in the note.
 
 ### Unit of work A2 — Section size / composition baseline
 
@@ -72,11 +73,17 @@ presence.
 
 ### Unit of work A3 — Metric baselines (pre-edit)
 
-**Core logic:** From the same sample, compute:
+**Core logic:** From the same sample, record **separate** fields (see
+spec §4.8):
 
 - median / p95 input tokens per turn (by scenario if possible)
-- cache hit proxy (`cache_read / input_tokens` where available)
-- qualitative tallies: citation miss, wrong language, preamble, loops
+- cache_read tokens, cache_creation tokens, uncached input — only with
+  formulas reconciled to cubepi/provider field meanings and
+  `test_prompt_cache` / billing semantics
+- **Do not** report a single “cache hit ratio” unless the denominator is
+  defined in the note
+- qualitative tallies via fixed rubric: citation miss, wrong language,
+  preamble, loops
 
 **Do not** edit prompts until these numbers are written down.
 
@@ -117,15 +124,18 @@ docs/dev/notes/2026-07-22-system-prompt-trace-review.md
 5. Recommended PR split (one concern per PR)
 6. Open questions remaining after analysis
 
-**Success for #391 analysis gate:** note merged (or sitting on this branch
-ready for review) with ≥3 high-severity rows **or** explicit “no high
-severity found” with evidence (unlikely given widget size—still data-driven).
+**Success for #391 analysis gate:** note **merged or explicitly human-
+approved**. Severity is evidence-based — there is no requirement to
+produce three high-severity rows. “No high severity” with evidence is a
+valid outcome.
 
 ---
 
 ## Phase C — Fix (follow-up PRs)
 
-Only after B2. **Do not** land a mega-diff.
+Only after B2 **and** analysis gate approval. **Do not** land prompt
+rewrites on the design-only or unapproved-analysis branch. **Do not** land
+a mega-diff.
 
 ### Unit of work C* — Per-finding PR template
 
@@ -141,10 +151,12 @@ Only after B2. **Do not** land a mega-diff.
 **Core logic rules:**
 
 1. One concern per PR (e.g. “gate widget guidelines” ≠ “rewrite citations”).
-2. Tool availability ↔ prompt consistency.
-3. Stable sort / fixed append order for cache.
-4. Re-measure a small hold-out or re-run scripted scenarios after each fix.
-5. If user-visible agent behavior changes, update `docs/site` in the same
+2. Each PR body references finding `id` + evidence + expected metric.
+3. Tool availability ↔ prompt consistency.
+4. Stable sort / fixed append order for cache; **no mid-conversation
+   system-prefix add/remove** based on user turn classification.
+5. Re-measure holdout or scripted scenarios after each fix; paste metrics.
+6. If user-visible agent behavior changes, update `docs/site` in the same
    PR.
 
 **Example fix candidates (only if findings confirm):**
@@ -203,11 +215,11 @@ way operators must know. User docs only if behavior changes.
 | PR | Content |
 | --- | --- |
 | **This PR (design)** | Spec + this plan only |
-| **Analysis PR** (may be same branch after approval) | Note + optional size script; **no** prompt rewrites required |
-| **Fix PR 1..N** | One high-severity finding each |
+| **Analysis PR** | Note + optional size script; **no** prompt rewrites; human review |
+| **Fix PR 1..N** | Only after analysis approval; one finding each; cite finding id |
 
-Acceptance from the issue: at least 3 high-severity findings **fixed or
-explicitly deferred** with rationale in the note.
+Acceptance: all threshold-meeting findings are **fixed or explicitly
+deferred** with rationale in the note (count is not a goal).
 
 ---
 

--- a/docs/dev/plans/2026-07-22-system-prompt-trace-optimization.md
+++ b/docs/dev/plans/2026-07-22-system-prompt-trace-optimization.md
@@ -21,10 +21,15 @@ under `backend/scripts/dev/`, pytest e2e (`test_prompt_cache.py`), markdown
 notes under `docs/dev/notes/`.
 
 **Spec:** [docs/dev/specs/2026-07-22-system-prompt-trace-optimization-design.md](../specs/2026-07-22-system-prompt-trace-optimization-design.md)  
-**Issue:** #391  
+**Seed note (Phase A/B draft):** [docs/dev/notes/2026-07-22-system-prompt-trace-review.md](../notes/2026-07-22-system-prompt-trace-review.md)  
+**Issue:** #391 · design PR #412  
 **Must read before any prompt edit:**
 [backend/docs/prompt-cache-discipline.md](../../../backend/docs/prompt-cache-discipline.md)  
 **Trace skill:** `.agents/skills/cubepi-trace/SKILL.md`
+
+**Progress:** Seed measurement for `conv-1m1jE95wSfyYDi` / run
+`fd9890facb3e92805a7a775621000a41` is in the note (findings **F1–F8**).
+Still need stratified sample + human approval before Phase C code.
 
 ---
 
@@ -124,10 +129,25 @@ docs/dev/notes/2026-07-22-system-prompt-trace-review.md
 5. Recommended PR split (one concern per PR)
 6. Open questions remaining after analysis
 
+**Done (seed):** [2026-07-22-system-prompt-trace-review.md](../notes/2026-07-22-system-prompt-trace-review.md)
+documents conversation `conv-1m1jE95wSfyYDi`, run `fd9890…`, findings
+**F1–F8**, won’t-fix, and a recommended PR split. Remaining for B2:
+expand N with stratified scenarios; then human approve.
+
 **Success for #391 analysis gate:** note **merged or explicitly human-
 approved**. Severity is evidence-based — there is no requirement to
 produce three high-severity rows. “No high severity” with evidence is a
 valid outcome.
+
+**Example fix candidates after approval (from seed findings, not code):**
+
+| Finding | Candidate follow-up PR |
+| --- | --- |
+| F1 | Gate/slim `WIDGET_GUIDELINES` when conversation-stable |
+| F2 | History / skill-ref truncation or compaction policy |
+| F3 | Short skill catalog lines (+ display work in #399) |
+| F4 | Memory system-block budget |
+| F5 | More deferred tools / shorter schemas |
 
 ---
 

--- a/docs/dev/plans/2026-07-22-system-prompt-trace-optimization.md
+++ b/docs/dev/plans/2026-07-22-system-prompt-trace-optimization.md
@@ -1,0 +1,246 @@
+# System Prompt Trace Optimization — Implementation Plan
+
+**Goal:** Run a measured analysis of real agent system prompts via cubepi
+traces, write an engineering note with ranked findings, then ship only
+high-confidence, surgical prompt fixes—without breaking prompt-cache
+discipline.
+
+**Architecture:** Four phases. **Phase A (Measure)** and **Phase B
+(Diagnose)** are the core of #391. **Phase C (Fix)** and **Phase D
+(Guardrails)** are follow-on, one concern per PR, driven by the note.
+
+```
+traces (content on) → size/token baselines → findings table
+        → docs/dev/notes/…-system-prompt-trace-review.md
+        → PR1 fix / PR2 fix / … (surgical)
+        → cache e2e + spot quality checks
+```
+
+**Tech stack:** Python backend, cubepi tracing CLI, optional small script
+under `backend/scripts/dev/`, pytest e2e (`test_prompt_cache.py`), markdown
+notes under `docs/dev/notes/`.
+
+**Spec:** [docs/dev/specs/2026-07-22-system-prompt-trace-optimization-design.md](../specs/2026-07-22-system-prompt-trace-optimization-design.md)  
+**Issue:** #391  
+**Must read before any prompt edit:**
+[backend/docs/prompt-cache-discipline.md](../../../backend/docs/prompt-cache-discipline.md)  
+**Trace skill:** `.agents/skills/cubepi-trace/SKILL.md`
+
+---
+
+## Phase A — Measure
+
+### Unit of work A1 — Enable content traces + collect sample
+
+**Files / ops:** local or staging config (`tracing.enabled`,
+`tracing.record_content`); no product code required.
+
+**Core logic:**
+
+1. Confirm tracing records system prompt content on `chat` spans.
+2. Run a **diverse sample** (target ≥10 runs), covering at least:
+   - short Q&A (no tools)
+   - web/search + citations
+   - sandbox coding
+   - artifact creation
+   - widget / generative UI if available
+   - multi-subagent
+   - multi-turn with `load_skill`
+   - Chinese and English user messages
+   - title and reflection oneshots if observable
+3. Record for each: trace id, model, scenario tag, rough outcome
+   (success / loop / miss).
+
+**Tests:** N/A (ops). Evidence = list of trace ids in the note.
+
+### Unit of work A2 — Section size / composition baseline
+
+**Files:** optional
+`backend/scripts/dev/dump_system_prompt_sections.py` (create if helpful)
+
+**Core logic:**
+
+- Dump **static** fragment lengths from `cubeplex.prompts.*` (already
+  approximately known: widget ~12KB largest).
+- From traces (`cubepi trace view … --content` or convert), measure
+  **runtime** system message length and note which middleware sections
+  appear.
+- Capture per-turn `input_tokens` and cache read/creation when present.
+
+**Output:** table in the note: fragment → static bytes → typical runtime
+presence.
+
+### Unit of work A3 — Metric baselines (pre-edit)
+
+**Core logic:** From the same sample, compute:
+
+- median / p95 input tokens per turn (by scenario if possible)
+- cache hit proxy (`cache_read / input_tokens` where available)
+- qualitative tallies: citation miss, wrong language, preamble, loops
+
+**Do not** edit prompts until these numbers are written down.
+
+---
+
+## Phase B — Diagnose
+
+### Unit of work B1 — Apply analysis checklist
+
+**Files:** none yet (working notes)
+
+For each trace, score the eight checklist items from the spec
+(adherence, dead weight, redundancy, cache, ordering, schema vs prose,
+skill bloat, oneshots). Validate or discard the hypothesis table
+(widget always-on, etc.).
+
+### Unit of work B2 — Write engineering note
+
+**Files:**
+
+```text
+docs/dev/notes/2026-07-22-system-prompt-trace-review.md
+```
+
+(Use actual write date if different; keep slug
+`system-prompt-trace-review`.)
+
+**Required sections:**
+
+1. Sample set (N, scenarios, models, env)
+2. Baselines (tokens, cache, quality spot-checks)
+3. **Findings table**
+
+   | id | severity | evidence (trace ids) | fragment(s) | proposed change | expected metric |
+   | --- | --- | --- | --- | --- | --- |
+
+4. Won’t-fix list (noise / one-offs)
+5. Recommended PR split (one concern per PR)
+6. Open questions remaining after analysis
+
+**Success for #391 analysis gate:** note merged (or sitting on this branch
+ready for review) with ≥3 high-severity rows **or** explicit “no high
+severity found” with evidence (unlikely given widget size—still data-driven).
+
+---
+
+## Phase C — Fix (follow-up PRs)
+
+Only after B2. **Do not** land a mega-diff.
+
+### Unit of work C* — Per-finding PR template
+
+**Files (typical):**
+
+- `backend/cubeplex/prompts/<fragment>.py`
+- Matching middleware (`middleware/sandbox.py`, `citation.py`,
+  `skills.py`, …) if gating injection
+- `backend/cubeplex/streams/run_manager.py` if assembly order / widget
+  append changes
+- Tests: cache e2e; any unit snapshot of composition if added in D
+
+**Core logic rules:**
+
+1. One concern per PR (e.g. “gate widget guidelines” ≠ “rewrite citations”).
+2. Tool availability ↔ prompt consistency.
+3. Stable sort / fixed append order for cache.
+4. Re-measure a small hold-out or re-run scripted scenarios after each fix.
+5. If user-visible agent behavior changes, update `docs/site` in the same
+   PR.
+
+**Example fix candidates (only if findings confirm):**
+
+| Possible fix | Touch points |
+| --- | --- |
+| Conditional widget guidelines | `run_manager` append site; ensure `show_widget` tool pairing |
+| Tighten citation lead-in | `prompts/citations.py` / `CitationMiddleware` |
+| Trim dead sandbox lines when sandbox off | `SandboxMiddleware.transform_system_prompt` |
+| Shorten oneshot title/reflection | `prompts/title.py`, `reflection_system.py` |
+
+Each is a **hypothesis** until the note says otherwise.
+
+**Tests (intent per fix PR):**
+
+- `uv run pytest tests/e2e/memory/test_prompt_cache.py` (or project’s
+  equivalent path) green
+- Targeted agent e2e if the fragment’s behavior is covered
+- Optional unit: composed prompt contains/omits section under flags
+
+---
+
+## Phase D — Guardrails (optional)
+
+### Unit of work D1 — Composition snapshots / budgets
+
+**Files:** optional unit tests under `backend/tests/unit/` asserting
+section presence and rough size caps; optional log line for section
+lengths (not a public API unless product wants it).
+
+**Core logic:** Fail CI if a fragment exceeds an agreed budget without an
+intentional budget bump in the same PR.
+
+### Unit of work D2 — Doc touch
+
+Update `prompt-cache-discipline.md` only if injection rules change in a
+way operators must know. User docs only if behavior changes.
+
+---
+
+## File structure (expected over full issue lifecycle)
+
+| File | Phase | Action |
+| --- | --- | --- |
+| `docs/dev/notes/2026-07-22-system-prompt-trace-review.md` | B | Create |
+| `backend/scripts/dev/dump_system_prompt_sections.py` | A | Create optional |
+| `backend/cubeplex/prompts/*.py` | C | Modify per finding |
+| `backend/cubeplex/middleware/*.py` | C | Conditional injection |
+| `backend/cubeplex/streams/run_manager.py` | C | Assembly only if needed |
+| `backend/tests/…` | C/D | Cache + optional snapshots |
+
+---
+
+## Ordering and PR strategy
+
+| PR | Content |
+| --- | --- |
+| **This PR (design)** | Spec + this plan only |
+| **Analysis PR** (may be same branch after approval) | Note + optional size script; **no** prompt rewrites required |
+| **Fix PR 1..N** | One high-severity finding each |
+
+Acceptance from the issue: at least 3 high-severity findings **fixed or
+explicitly deferred** with rationale in the note.
+
+---
+
+## Verification
+
+```bash
+# Phase A/B
+cd backend
+uv run cubepi trace ls
+# … view/convert sample …
+
+# After any Phase C edit
+uv run pytest tests/e2e/memory/test_prompt_cache.py --no-cov 2>&1 | tee tmp/prompt-cache.log | tail -20
+```
+
+Paste evidence (trace ids + note path + test tail) before claiming a phase
+done.
+
+---
+
+## Out of scope
+
+- Agent architecture redesign
+- Auto-optimizer product
+- User-message formatting overhaul
+- Drive-by rewrites of every prompt file
+
+---
+
+## Suggested commits (post-approval)
+
+1. `docs(notes): system prompt trace review findings` (Phase B)
+2. `perf(prompts): <single finding>` (each Phase C PR)
+3. `test(prompts): composition size budgets` (optional Phase D)
+
+Implementation of A–B starts after design approval; C waits on the note.

--- a/docs/dev/specs/2026-07-22-system-prompt-trace-optimization-design.md
+++ b/docs/dev/specs/2026-07-22-system-prompt-trace-optimization-design.md
@@ -1,9 +1,10 @@
 # System Prompt Trace Optimization — Design
 
-**Status:** Draft  
-**Date:** 2026-07-22  
-**Related:** #391  
-**Discipline doc:** [backend/docs/prompt-cache-discipline.md](../../../backend/docs/prompt-cache-discipline.md)
+**Status:** Draft (seed analysis landed; Phase C still gated)  
+**Date:** 2026-07-22 · seed note 2026-07-23  
+**Related:** #391 · design PR #412  
+**Discipline doc:** [backend/docs/prompt-cache-discipline.md](../../../backend/docs/prompt-cache-discipline.md)  
+**Seed analysis note:** [docs/dev/notes/2026-07-22-system-prompt-trace-review.md](../notes/2026-07-22-system-prompt-trace-review.md)
 
 ## 1. Goal
 
@@ -15,6 +16,29 @@ unconditional growth—while preserving prompt-cache discipline.
 
 This issue is **analysis-first**. Implementation of prompt edits is
 follow-up work driven by measured evidence.
+
+### 1.1 Seed evidence (2026-07-23)
+
+A **local** conversation was measured end-to-end and written up as the
+first Phase A/B artifact (not a full stratified sample):
+
+| | |
+| --- | --- |
+| Conversation | `conv-1m1jE95wSfyYDi` |
+| Latest run (focus) | `fd9890facb3e92805a7a775621000a41` |
+| Prior run | `1a078f8b74a8152fbaede423004d5a47` |
+| Class | Long multi-turn sandbox + skill + PPTX artifact (HITL → build) |
+| Write-up | [2026-07-22-system-prompt-trace-review.md](../notes/2026-07-22-system-prompt-trace-review.md) |
+
+**Headline numbers (latest run only):** ~16 min wall; **37** `chat` calls;
+input tokens **~92k → ~126k** per call; **~4.2M** input tokens summed over
+the run; system message **~37k chars** (widget block alone **~11k**); tool
+schemas **~25k chars**; tool-role history **~145k → ~184k chars** driven by
+`load_skill` + full skill reference `file_read`s. Run **succeeded** (no
+ERROR)—primary issue is **cost/latency context design**, not crash.
+
+Finding ids in the note (**F1–F8**) are the authoritative list; this spec
+only summarizes and links them.
 
 ## 2. Context
 
@@ -167,6 +191,12 @@ docs/dev/notes/2026-07-22-system-prompt-trace-review.md
 (If the note is written on a later day, use that day’s date in the
 filename; keep the slug `system-prompt-trace-review`.)
 
+**Seed revision (2026-07-23):** the file above **exists** and holds the
+measured baselines + findings table for `conv-1m1jE95wSfyYDi` /
+`fd9890…`. Treat it as **Phase A seed + Phase B draft**. Expand the same
+file (or a dated successor that links back) when the stratified sample
+grows; do not start a second unlinked note.
+
 **Must contain:**
 
 - Sample set description (N traces, scenarios, models, env)
@@ -176,6 +206,19 @@ filename; keep the slug `system-prompt-trace-review`.)
 - Recommended PR split (one concern per PR)
 - Baseline metrics before any edit: median/p95 input tokens, cache hit
   proxy, quality spot-checks from the checklist
+
+**Seed findings (summary — full table in the note):**
+
+| id | severity | One-line |
+| --- | --- | --- |
+| F1 | high | Always-on **widget** system prose (~11k) on a non-widget PPTX run |
+| F2 | high | **Skill body + full reference files** stuck in tool history for 37 turns |
+| F3 | high | **Skills catalog** descriptions too long; long org-prefixed names |
+| F4 | medium | **Memory** system block large and off-task for this run |
+| F5 | medium | **Tool schemas** ~25k always-on |
+| F6 | medium | **Cache cliffs** (0% cache_read) on some turns |
+| F7 | low–med | Agent loop inefficiency (many write/execute turns) partly skill-side |
+| F8 | info | Run succeeded — optimize cost path, not “fix crash” |
 
 ### 4.6 Fix principles (Phase C)
 
@@ -203,16 +246,18 @@ filename; keep the slug `system-prompt-trace-review`.)
 
 ### 4.7 Hypotheses to validate (not conclusions)
 
-| Hypothesis | Why it might matter |
-| --- | --- |
-| `WIDGET_GUIDELINES` always-on and oversized | ~12KB; many turns never build widgets |
-| Citation rules long but under-followed | Adherence vs length |
-| Sandbox rules on pure Q&A | Conditional on sandbox/tools |
-| Base “be concise” vs long playbooks | Style conflict |
-| Memory authoring over/under-save | vs reflection oneshot |
-| Loaded skills bloat multi-turn | Token growth |
-| Subagent style guidance high-token / low-impact | Aesthetic vs success |
-| Title/reflection shorter without quality loss | Oneshot × frequency |
+| Hypothesis | Why it might matter | Seed sample (`fd9890…`) |
+| --- | --- | --- |
+| `WIDGET_GUIDELINES` always-on and oversized | ~12KB; many turns never build widgets | **Supported** — see note **F1** |
+| Citation rules long but under-followed | Adherence vs length | **Not exercised** |
+| Sandbox rules on pure Q&A | Conditional on sandbox/tools | **Not exercised** (sandbox needed) |
+| Base “be concise” vs long playbooks | Style conflict | Possible via skill; not primary |
+| Memory authoring over/under-save | vs reflection oneshot | **Partial** — large off-task block **F4** |
+| Loaded skills bloat multi-turn | Token growth | **Supported** — **F2**, **F3** |
+| Subagent style guidance high-token / low-impact | Aesthetic vs success | **Not exercised** |
+| Title/reflection shorter without quality loss | Oneshot × frequency | **Not exercised** |
+
+Update the note’s hypothesis table when new scenario classes are measured.
 
 ### 4.8 Success metrics
 
@@ -246,7 +291,8 @@ formulas are reproducible.
 
 1. Analysis note exists under `docs/dev/notes/` with methodology, findings
    table, prioritized recommendations — and is **reviewed/approved** before
-   Phase C.
+   Phase C. **Seed note present** ([link](../notes/2026-07-22-system-prompt-trace-review.md));
+   approval + stratified expansion still required.
 2. Every finding that meets predeclared impact/confidence thresholds is
    either fixed in a follow-up PR or **explicitly deferred** with rationale.
    There is **no quota** to invent N high-severity rows; zero or one real

--- a/docs/dev/specs/2026-07-22-system-prompt-trace-optimization-design.md
+++ b/docs/dev/specs/2026-07-22-system-prompt-trace-optimization-design.md
@@ -91,9 +91,14 @@ only** until traces confirm.
 | **D** | **Guardrails** | Optional snapshots / size budgets; cache e2e green |
 
 This design + plan cover **A–B as the primary deliverable of #391**, with
-C–D specified so implementers do not improvise process. Phase C may land
-in the same branch **only** after the note exists and top findings are
-ranked; prefer separate PRs per concern when edits are large.
+C–D specified so implementers do not improvise process.
+
+**Hard gate for Phase C (resolved):** no prompt-code PR (and no prompt
+edits on the analysis branch) until the findings note is **merged or
+explicitly design-approved** (human review). Each fix PR must reference a
+specific finding `id` from that note and include: evidence (trace ids),
+expected metric, and post-change measurement notes. “Note file exists on
+the branch” is **not** sufficient to start rewrites.
 
 ### 4.2 Prerequisites for measurement
 
@@ -103,6 +108,17 @@ ranked; prefer separate PRs per concern when edits are large.
 - Prefer diverse scenarios: short Q&A, tool-heavy research, sandbox coding,
   artifacts, citation-heavy web search, multi-subagent, CN vs EN users,
   long multi-turn, oneshot title/reflection
+
+**Privacy / data boundary (required):**
+
+- Prefer **synthetic local** or **explicitly sanitized staging** traffic.
+- Do **not** enable `record_content` against production by default for this
+  workstream.
+- Do not commit raw traces, user prompts, tool args/results, or secrets into
+  the repo. The engineering note may cite **trace ids** and redacted
+  snippets only.
+- After analysis, delete or retain local JSONL per team retention norms;
+  document env used in the note (`local` / `staging`).
 
 ### 4.3 How to inspect
 
@@ -166,10 +182,20 @@ filename; keep the slug `system-prompt-trace-review`.)
 - Edit strings in `backend/cubeplex/prompts/*.py` and middleware
   conditionals—not hand-edited traces.
 - Prefer **conditional / lazy injection** when evidence shows dead weight
-  (e.g. gate widget text if tool not registered or task class never needs
-  it)—but keep **tool availability and prompt consistent**.
+  (e.g. gate widget text if the **tool is not registered for that agent
+  config**)—but keep **tool availability and prompt consistent**.
+- **Cache-safe gating (non-negotiable):** capability sections that sit in
+  the stable system prefix must be **fixed for the lifetime of a
+  conversation** and decided **before the first model call** of that
+  conversation (or when agent/tool config is fixed). **Forbidden:**
+  per-turn / per-user-message task classification that adds or removes
+  system-prefix fragments mid-conversation (busts byte-identical prefix —
+  see `prompt-cache-discipline.md`). Turn-varying guidance belongs after
+  the cache breakpoint or in a new conversation.
 - Preserve cache discipline: stable ordering, no timestamps, deterministic
-  skill sort (already present).
+  skill sort (already present). After any injection change, require
+  byte-level prompt comparison across ≥2 turns of the same conversation
+  (or the existing cache e2e) to prove prefix stability.
 - No mega-diff of all prompts at once.
 - Re-run cache e2e and relevant agent e2e after each fix PR.
 - User-visible behavior changes → update matching `docs/site` page in the
@@ -190,14 +216,22 @@ filename; keep the slug `system-prompt-trace-review`.)
 
 ### 4.8 Success metrics
 
-Baselines **before** edits, from the same sample methodology:
+Baselines **before** edits, from the same sample methodology. Report
+fields **separately** (do not invent a single ratio without defining
+denominators against provider/cubepi fields):
 
-- Median / p95 **input tokens** per turn; cache read ratio where available
-- Quality proxies: citation presence on search, wrong-language rate,
-  unnecessary preamble, retry/loop, early stop
-- Reflection oneshot: false-positive saves / missed prefs (spot-check)
-- No regression on `tests/e2e/memory/test_prompt_cache.py` and relevant
-  agent e2e
+| Metric | How to record |
+| --- | --- |
+| Input / prompt tokens | `gen_ai.usage.input_tokens` (or provider equivalent) per turn |
+| Cache read tokens | provider `cache_read` / `cache_read_input_tokens` when present |
+| Cache creation tokens | provider `cache_creation` / write tokens when present |
+| Uncached input | derived only with an explicit formula that matches billing semantics used in `test_prompt_cache` / provider docs — never assume `cache_read / input_tokens` is a “hit rate” without checking whether `input_tokens` is total or uncached-only |
+| Quality proxies | citation presence on search, wrong-language, preamble, retry/loop, early stop — tallied with a **fixed rubric** |
+| Reflection oneshot | false-positive saves / missed prefs (spot-check) |
+| Guardrail | `tests/e2e/memory/test_prompt_cache.py` + relevant agent e2e green |
+
+Document the exact field names observed in cubepi spans in the note so
+formulas are reproducible.
 
 ## 5. Out of scope
 
@@ -211,11 +245,16 @@ Baselines **before** edits, from the same sample methodology:
 ## 6. Success criteria
 
 1. Analysis note exists under `docs/dev/notes/` with methodology, findings
-   table, prioritized recommendations.
-2. At least **3 high-severity findings** fixed in follow-up PRs **or**
-   explicitly deferred with rationale.
-3. Any prompt change preserves cache discipline; cache e2e stays green.
-4. Conditional/lazy injection preferred when evidence supports it.
+   table, prioritized recommendations — and is **reviewed/approved** before
+   Phase C.
+2. Every finding that meets predeclared impact/confidence thresholds is
+   either fixed in a follow-up PR or **explicitly deferred** with rationale.
+   There is **no quota** to invent N high-severity rows; zero or one real
+   high-severity finding is acceptable if the evidence says so.
+3. Any prompt change preserves cache discipline; cache e2e stays green;
+   mid-conversation system-prefix gating is not introduced.
+4. Conditional/lazy injection preferred when evidence supports it **and**
+   gating is conversation-stable (or config-stable).
 5. Diffs are surgical (per-fragment / per-concern), not a full rewrite
    without evidence.
 
@@ -223,7 +262,8 @@ Baselines **before** edits, from the same sample methodology:
 
 | Question | Guidance |
 | --- | --- |
-| Minimum sample size? | Target ≥10 diverse traces; more if variance is high. Dev or staging with content recording is fine; note env. |
+| Minimum sample size? | Stratified sample: cover the scenario classes in §4.2 with **≥2 traces per primary class** when claiming a class-level finding (not one anecdote per class). Overall target often ≥10–20 runs; state N and uncertainty in the note. Keep a small **holdout** for post-fix comparison. |
 | Prompt composition debug endpoint? | Optional; offline traces + a small `backend/scripts/dev/` size dump is enough for #391. |
-| Widget/citation/sandbox → skill-triggered? | Only if traces show dead weight **and** tool pairing stays consistent. |
+| Widget/citation/sandbox → skill-triggered? | Only if traces show dead weight **and** tool pairing stays consistent **and** injection is conversation-stable. |
 | Per-model-family prompts? | Only if failure modes clearly differ; default is one prompt. |
+| Production `record_content`? | Default no; synthetic/staging + redaction only. |

--- a/docs/dev/specs/2026-07-22-system-prompt-trace-optimization-design.md
+++ b/docs/dev/specs/2026-07-22-system-prompt-trace-optimization-design.md
@@ -1,0 +1,229 @@
+# System Prompt Trace Optimization — Design
+
+**Status:** Draft  
+**Date:** 2026-07-22  
+**Related:** #391  
+**Discipline doc:** [backend/docs/prompt-cache-discipline.md](../../../backend/docs/prompt-cache-discipline.md)
+
+## 1. Goal
+
+Improve real agent quality and cost by **analyzing production-like traces**
+(not by rewriting prompts from theory alone). Produce an engineering note
+with a findings table, then land **surgical** prompt / injection fixes for
+the highest-impact issues—prefer conditional or smaller fragments over
+unconditional growth—while preserving prompt-cache discipline.
+
+This issue is **analysis-first**. Implementation of prompt edits is
+follow-up work driven by measured evidence.
+
+## 2. Context
+
+### Where system prompts are assembled today
+
+| Source | Path / hook | Role |
+| --- | --- | --- |
+| Base | `backend/cubeplex/prompts/system.py` → `BASE_SYSTEM_PROMPT` | Core behavior, language, datetime tool, attachments |
+| Skills catalog | `prompts/skills.py` via `run_manager` | Available skills list |
+| Widget | `prompts/widget.py` (`WIDGET_GUIDELINES`) | UI widget authoring (~12KB static; **always appended** in `run_manager`) |
+| Sandbox | `prompts/sandbox.py` via `SandboxMiddleware.transform_system_prompt` | Shell / workdir layout |
+| Memory | `prompts/memory.py` via `MemoryMiddleware` | Pinned memory + authoring rules |
+| Citations | `prompts/citations.py` via `CitationMiddleware` | Inline citation rules |
+| Artifacts | `prompts/artifacts.py` via `ArtifactMiddleware` | `save_artifact` workflow |
+| Subagents | `prompts/subagents.py` | Delegation patterns |
+| Reflection | `prompts/reflection_system.py` | Detached memory curation oneshot |
+| Title | `prompts/title.py` | Title generation oneshot |
+| Agent overlay | `agent_cfg.system_prompt` in `run_manager` | Per-agent extra |
+| Loaded skills | `SkillsMiddleware.transform_system_prompt` | Skill bodies after `load_skill` |
+
+Rough static source sizes (bytes on disk for the module files; runtime also
+adds memory/artifact lists and tool schemas):
+
+| Fragment file | ~bytes |
+| --- | --- |
+| `widget.py` | ~12.0K |
+| `sandbox.py` | ~4.5K |
+| `subagents.py` | ~3.1K |
+| `citations.py` | ~3.1K |
+| `system.py` | ~2.7K |
+| `title.py` | ~2.8K |
+| `memory.py` | ~2.2K |
+| `artifacts.py` | ~1.9K |
+| `reflection_system.py` | ~1.6K |
+| `skills.py` | ~0.5K |
+
+Assembly: `run_manager` builds `effective_system_prompt` from base (+ agent
+overlay + skills template + **unconditional** `WIDGET_GUIDELINES`);
+middleware then appends via `transform_system_prompt`.
+
+Cache constraints (non-negotiable): stable prefix byte-identity, no
+timestamps in system prompt, deterministic ordering — see
+`prompt-cache-discipline.md`. Existing gate:
+`tests/e2e/memory/test_prompt_cache.py`.
+
+### Why this work
+
+System prompt is a large, always-on cost and a frequent root cause of
+instruction misses (citations, language, verbosity). Unvalidated edits risk
+cache misses and regressions. Trace-backed prioritization keeps changes
+small and justified.
+
+## 3. Approaches considered
+
+| Approach | Pros | Cons |
+| --- | --- | --- |
+| **A. Measure → diagnose → fix from traces** (recommended) | Evidence-based; surgical PRs; respects cache discipline | Needs diverse sample + tracing with content |
+| **B. Immediate rewrite of largest fragments (e.g. widget)** | Fast token win possible | May break widget quality; may violate “always-on tool ↔ prompt” pairing without analysis |
+| **C. Auto-optimizer / permanent prompt product** | Ongoing | Out of scope; high risk; not this issue |
+
+**Recommendation: A**, matching the issue. Hypotheses (widget always-on,
+citation under-follow, sandbox on pure Q&A, etc.) are **starting hunches
+only** until traces confirm.
+
+## 4. Design
+
+### 4.1 Phased workflow
+
+| Phase | Name | Output |
+| --- | --- | --- |
+| **A** | **Measure** | Sample set of traces + section size baselines + token/cache baselines |
+| **B** | **Diagnose** | Engineering note with findings table + won’t-fix + PR split |
+| **C** | **Fix** | One concern per follow-up PR; only high-confidence items |
+| **D** | **Guardrails** | Optional snapshots / size budgets; cache e2e green |
+
+This design + plan cover **A–B as the primary deliverable of #391**, with
+C–D specified so implementers do not improvise process. Phase C may land
+in the same branch **only** after the note exists and top findings are
+ranked; prefer separate PRs per concern when edits are large.
+
+### 4.2 Prerequisites for measurement
+
+- Tracing: `tracing.enabled: true`, `tracing.record_content: true`
+- CLI: `uv run cubepi trace` from `backend/` (skill:
+  `.agents/skills/cubepi-trace/SKILL.md`)
+- Prefer diverse scenarios: short Q&A, tool-heavy research, sandbox coding,
+  artifacts, citation-heavy web search, multi-subagent, CN vs EN users,
+  long multi-turn, oneshot title/reflection
+
+### 4.3 How to inspect
+
+```bash
+cd backend
+uv run cubepi trace ls
+uv run cubepi trace view <trace_id_prefix> --content
+uv run cubepi trace convert <trace_id> --span 0x…
+uv run cubepi trace stats --by model
+```
+
+Focus on `chat <model>` spans under `cubepi.turn`:
+
+- System content in `gen_ai.input.messages`
+- `gen_ai.usage.input_tokens`, cache read/creation
+- Tool patterns vs instructions; errors; loops
+
+Admin Trace UI (`/admin/traces`) may complement local JSONL.
+
+### 4.4 Analysis checklist (“worth optimizing”)
+
+For each sampled run, score:
+
+1. **Instruction adherence gaps** — model violates explicit rules
+   (citations, language match, no preamble, `ask_user`, datetime tool,
+   artifact versioning, sandbox paths).
+2. **Dead weight** — large irrelevant sections (e.g. full widget guidelines
+   on pure research).
+3. **Redundancy / conflict** — same rule twice; concision vs long playbooks.
+4. **Cache / cost structure** — unstable prefix; sections that change every
+   turn; cache hit rate.
+5. **Ordering / primacy** — critical rules buried under capability docs.
+6. **Tool schema vs prose duplication** — waste or missing structural
+   enforcement.
+7. **Subagent / skill load cost** — skill body growth after load.
+8. **Oneshot agents** — reflection/title precision vs recall.
+
+### 4.5 Required analysis artifact
+
+Path (repo convention):
+
+```text
+docs/dev/notes/2026-07-22-system-prompt-trace-review.md
+```
+
+(If the note is written on a later day, use that day’s date in the
+filename; keep the slug `system-prompt-trace-review`.)
+
+**Must contain:**
+
+- Sample set description (N traces, scenarios, models, env)
+- **Findings table:** id, severity, evidence (trace ids), fragment(s),
+  proposed change, expected metric
+- Explicit **won’t fix** list
+- Recommended PR split (one concern per PR)
+- Baseline metrics before any edit: median/p95 input tokens, cache hit
+  proxy, quality spot-checks from the checklist
+
+### 4.6 Fix principles (Phase C)
+
+- Edit strings in `backend/cubeplex/prompts/*.py` and middleware
+  conditionals—not hand-edited traces.
+- Prefer **conditional / lazy injection** when evidence shows dead weight
+  (e.g. gate widget text if tool not registered or task class never needs
+  it)—but keep **tool availability and prompt consistent**.
+- Preserve cache discipline: stable ordering, no timestamps, deterministic
+  skill sort (already present).
+- No mega-diff of all prompts at once.
+- Re-run cache e2e and relevant agent e2e after each fix PR.
+- User-visible behavior changes → update matching `docs/site` page in the
+  same PR if any.
+
+### 4.7 Hypotheses to validate (not conclusions)
+
+| Hypothesis | Why it might matter |
+| --- | --- |
+| `WIDGET_GUIDELINES` always-on and oversized | ~12KB; many turns never build widgets |
+| Citation rules long but under-followed | Adherence vs length |
+| Sandbox rules on pure Q&A | Conditional on sandbox/tools |
+| Base “be concise” vs long playbooks | Style conflict |
+| Memory authoring over/under-save | vs reflection oneshot |
+| Loaded skills bloat multi-turn | Token growth |
+| Subagent style guidance high-token / low-impact | Aesthetic vs success |
+| Title/reflection shorter without quality loss | Oneshot × frequency |
+
+### 4.8 Success metrics
+
+Baselines **before** edits, from the same sample methodology:
+
+- Median / p95 **input tokens** per turn; cache read ratio where available
+- Quality proxies: citation presence on search, wrong-language rate,
+  unnecessary preamble, retry/loop, early stop
+- Reflection oneshot: false-positive saves / missed prefs (spot-check)
+- No regression on `tests/e2e/memory/test_prompt_cache.py` and relevant
+  agent e2e
+
+## 5. Out of scope
+
+- Redesigning agent architecture or the whole tool set in this issue.
+- Breaking prompt-cache discipline.
+- A permanent auto-optimizer product.
+- Optimizing user messages / tool result formatting except where they
+  interact with system rules (note separately if found).
+- Shipping a large unprompted rewrite without the analysis note.
+
+## 6. Success criteria
+
+1. Analysis note exists under `docs/dev/notes/` with methodology, findings
+   table, prioritized recommendations.
+2. At least **3 high-severity findings** fixed in follow-up PRs **or**
+   explicitly deferred with rationale.
+3. Any prompt change preserves cache discipline; cache e2e stays green.
+4. Conditional/lazy injection preferred when evidence supports it.
+5. Diffs are surgical (per-fragment / per-concern), not a full rewrite
+   without evidence.
+
+## 7. Open questions (guidance for the note)
+
+| Question | Guidance |
+| --- | --- |
+| Minimum sample size? | Target ≥10 diverse traces; more if variance is high. Dev or staging with content recording is fine; note env. |
+| Prompt composition debug endpoint? | Optional; offline traces + a small `backend/scripts/dev/` size dump is enough for #391. |
+| Widget/citation/sandbox → skill-triggered? | Only if traces show dead weight **and** tool pairing stays consistent. |
+| Per-model-family prompts? | Only if failure modes clearly differ; default is one prompt. |


### PR DESCRIPTION
## Summary
Trace-backed system prompt optimization for #391.

- Spec + plan + seed analysis note (Phase A/B)
- **F1 fix:** move always-on widget playbook (~11k) into preinstalled `show-widget` skill; keep a short hard-limits stub in the system prefix

Other findings (F2–F5 history/catalog/memory/schemas) deferred — larger impact surface.

## Linked issue
Implements design for #391 · finding **F1**

## Status
- [x] Spec
- [x] Plan
- [x] Seed analysis note
- [x] F1: widget → preinstalled skill
- [ ] F2–F5 (deferred)

## Test plan
- [x] `uv run pytest tests/unit/test_show_widget.py --no-cov`
- [ ] Local smoke: non-widget run system prompt no longer includes Chart.js skeletons
- [ ] Local smoke: `load_skill("show-widget")` then `show_widget` still renders well