### PR TITLE
Share deploy verification logic + Kata sandbox VM-isolation note

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -91,12 +91,12 @@ default:
     #   (e.g., Docker bridge deployments, network isolation)
     use_server_proxy: true
     # secure_access: Whether to request OpenSandbox's signed-URL secured
-    #   endpoint mode on create. Required for production-grade Kubernetes
-    #   deployments behind the ingress gateway. Must be set to false when
-    #   using docker-runtime OpenSandbox (the docker backend rejects
-    #   secureAccess=True with HTTP 400 INVALID_PARAMETER). See
-    #   deploy/docker-compose/OPENSANDBOX.md for context.
-    secure_access: true
+    #   endpoint mode on create. Left false: browser/terminal panels no longer
+    #   use OpenSandbox's ingress gateway — they flow through cubeplex's own
+    #   token-authed panel reverse proxy (same path for docker and k8s), and the
+    #   docker backend rejects secureAccess=True outright. See
+    #   docs/dev/specs/2026-07-26-sandbox-panel-proxy-design.md.
+    secure_access: false
     # ready_timeout: Maximum time to wait for sandbox to become ready after creation
     #   Used only during sandbox initialization. If the sandbox doesn't respond to
     #   health checks within this time, creation fails.

--- a/backend/cubeplex/api/app.py
+++ b/backend/cubeplex/api/app.py
@@ -643,10 +643,16 @@ def create_app(
     from cubeplex.config import config as _sandbox_config
 
     if _sandbox_config.get("sandbox.enabled", False):
+        from cubeplex.api.routes import sandbox_panel
         from cubeplex.api.routes.v1 import sandbox_share
 
         app.include_router(ws_browser.router, prefix="/api/v1")
         app.include_router(sandbox_share.router, prefix="/api/v1")
+        # Panel reverse proxy is token-authed and mounted at root (NOT /api/v1):
+        # the panel client's asset/WebSocket sub-resources carry the token in the
+        # path, and it must not sit behind the frontend's /api/* rewrite (which
+        # cannot proxy WebSocket).
+        app.include_router(sandbox_panel.router)
 
     from cubeplex.api.routes.health import router as health_router
 

--- a/backend/cubeplex/api/routes/sandbox_panel.py
+++ b/backend/cubeplex/api/routes/sandbox_panel.py
@@ -1,0 +1,176 @@
+"""Token-authenticated reverse proxy for sandbox browser/terminal panels.
+
+The panel URL embeds a short-lived signed token in its path; this router verifies
+the token and forwards HTTP and WebSocket traffic to the cluster-internal
+opensandbox-server server-proxy (`/sandboxes/{id}/proxy/{port}`), which reaches
+the sandbox Pod (k8s) or container (docker). It is the single panel gateway for
+both runtimes — see docs/dev/specs/2026-07-26-sandbox-panel-proxy-design.md.
+
+The route is intentionally public (no membership dependency): an iframe navigation
+and its WebSocket/asset sub-resources cannot attach auth headers or a session
+cookie to the backend origin, so the signed token in the URL path *is* the
+credential. opensandbox-server itself does not authenticate the proxy route, so it
+must never be exposed publicly — this backend is the only public entry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import websockets
+from fastapi import APIRouter, Request, Response, WebSocket
+from fastapi.responses import StreamingResponse
+from loguru import logger
+from starlette.background import BackgroundTask
+from starlette.status import HTTP_403_FORBIDDEN
+from starlette.websockets import WebSocketDisconnect
+from websockets.asyncio.client import ClientConnection
+from websockets.exceptions import ConnectionClosed
+from websockets.typing import Subprotocol
+
+from cubeplex.sandbox.panel_token import get_panel_secret, verify_panel_token
+
+router = APIRouter()
+
+# Connection-level headers that must not be relayed across a proxy hop.
+_HOP_BY_HOP = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "transfer-encoding",
+        "upgrade",
+        "te",
+        "trailer",
+        "proxy-authorization",
+        "proxy-authenticate",
+        "host",
+        "content-length",
+    }
+)
+
+_WS_POLICY_VIOLATION = 1008
+_WS_INTERNAL_ERROR = 1011
+
+
+def _server_host() -> str:
+    """host:port of the internal opensandbox-server (no scheme)."""
+    from cubeplex.config import config
+
+    domain = str(config.get("sandbox.domain", "localhost:8090")).strip()
+    return domain.split("://", 1)[-1].rstrip("/")
+
+
+def _upstream_path(sandbox_id: str, port: int, full_path: str) -> str:
+    return f"/sandboxes/{sandbox_id}/proxy/{port}/{full_path.lstrip('/')}"
+
+
+@router.api_route(
+    "/sandbox-panel/{token}/{full_path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
+)
+async def panel_http(token: str, request: Request, full_path: str = "") -> Response:
+    try:
+        claims = verify_panel_token(token, secret=get_panel_secret())
+    except ValueError:
+        return Response(status_code=HTTP_403_FORBIDDEN, content=b"invalid or expired panel token")
+
+    target = f"http://{_server_host()}{_upstream_path(claims.sandbox_id, claims.port, full_path)}"
+    if request.url.query:
+        target = f"{target}?{request.url.query}"
+    fwd_headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+    body = await request.body()
+
+    # trust_env=False: opensandbox-server is an internal service — forwarding must
+    # never be routed through an ambient HTTP_PROXY/ALL_PROXY.
+    client = httpx.AsyncClient(timeout=httpx.Timeout(30.0, read=None), trust_env=False)
+    try:
+        upstream = await client.send(
+            client.build_request(request.method, target, headers=fwd_headers, content=body),
+            stream=True,
+        )
+    except httpx.HTTPError as exc:
+        await client.aclose()
+        logger.warning("panel http upstream unreachable ({}): {}", target, exc)
+        return Response(status_code=502, content=b"sandbox panel upstream unavailable")
+
+    resp_headers = {k: v for k, v in upstream.headers.items() if k.lower() not in _HOP_BY_HOP}
+
+    async def _close() -> None:
+        await upstream.aclose()
+        await client.aclose()
+
+    return StreamingResponse(
+        upstream.aiter_raw(),
+        status_code=upstream.status_code,
+        headers=resp_headers,
+        background=BackgroundTask(_close),
+    )
+
+
+@router.websocket("/sandbox-panel/{token}/{full_path:path}")
+async def panel_ws(websocket: WebSocket, token: str, full_path: str = "") -> None:
+    try:
+        claims = verify_panel_token(token, secret=get_panel_secret())
+    except ValueError:
+        await websocket.close(code=_WS_POLICY_VIOLATION)
+        return
+
+    target = f"ws://{_server_host()}{_upstream_path(claims.sandbox_id, claims.port, full_path)}"
+    if websocket.url.query:
+        target = f"{target}?{websocket.url.query}"
+    subprotocols = [Subprotocol(s) for s in (websocket.scope.get("subprotocols") or [])]
+
+    try:
+        upstream = await websockets.connect(
+            target,
+            subprotocols=subprotocols or None,
+            open_timeout=15,
+            max_size=None,
+        )
+    except Exception as exc:  # connect/handshake failure
+        logger.warning("panel ws upstream connect failed ({}): {}", target, exc)
+        await websocket.close(code=_WS_INTERNAL_ERROR)
+        return
+
+    await websocket.accept(subprotocol=upstream.subprotocol)
+    await _relay(websocket, upstream)
+
+
+async def _relay(ws: WebSocket, upstream: ClientConnection) -> None:
+    async def client_to_upstream() -> None:
+        try:
+            while True:
+                msg = await ws.receive()
+                if msg["type"] == "websocket.disconnect":
+                    return
+                if (text := msg.get("text")) is not None:
+                    await upstream.send(text)
+                elif (data := msg.get("bytes")) is not None:
+                    await upstream.send(data)
+        except (WebSocketDisconnect, ConnectionClosed):
+            return
+
+    async def upstream_to_client() -> None:
+        try:
+            async for message in upstream:
+                if isinstance(message, str):
+                    await ws.send_text(message)
+                else:
+                    await ws.send_bytes(message)
+        except ConnectionClosed:
+            return
+
+    tasks = {
+        asyncio.create_task(client_to_upstream()),
+        asyncio.create_task(upstream_to_client()),
+    }
+    _, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+    for task in pending:
+        task.cancel()
+    await upstream.close()
+    try:
+        await ws.close()
+    except RuntimeError:
+        # already closed by the disconnect that ended the relay
+        pass

--- a/backend/cubeplex/sandbox/opensandbox.py
+++ b/backend/cubeplex/sandbox/opensandbox.py
@@ -1,6 +1,5 @@
 """OpenSandbox implementation of the Sandbox base class."""
 
-import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import timedelta
@@ -12,6 +11,11 @@ from opensandbox.exceptions import SandboxException as _ProviderError
 from opensandbox.models.execd import RunCommandOpts
 
 from cubeplex.sandbox.base import BrowserEndpoint, ExecuteResult, Sandbox, SandboxError
+from cubeplex.sandbox.panel_token import (
+    get_panel_base_url,
+    get_panel_secret,
+    sign_panel_token,
+)
 
 
 @contextmanager
@@ -96,57 +100,37 @@ class OpenSandbox(Sandbox):
                 result.append((path, content))
             return result
 
-    # OpenSandbox infrastructure headers that are irrelevant for browser/Neko access.
-    # The signed URL embeds the gateway auth; these headers are only meaningful for
-    # server-to-server calls (egress proxy, secure-access token) and cannot be sent
-    # by an iframe anyway. Strip them so they don't trigger the 501 safeguard in
-    # ws_browser.get_live_view.
-    _BROWSER_IRRELEVANT_HEADERS: frozenset[str] = frozenset(
-        h.lower() for h in ("OPENSANDBOX-EGRESS-AUTH", "OpenSandbox-Secure-Access")
-    )
+    def _panel_endpoint(self, port: int, expires_in: int) -> BrowserEndpoint:
+        """Build a cubeplex-signed panel-proxy URL for a sandbox port.
+
+        The token lives in the URL path so the panel client's relative asset and
+        WebSocket requests all carry the credential (an iframe/WS sub-resource
+        can't attach auth headers). The cubeplex backend reverse-proxy route
+        verifies it and forwards to the cluster-internal opensandbox-server;
+        see docs/dev/specs/2026-07-26-sandbox-panel-proxy-design.md.
+        """
+        base = get_panel_base_url()
+        if not base:
+            raise SandboxError(
+                "sandbox panel is unavailable: backend public URL "
+                "(api.public_url) is not configured"
+            )
+        token = sign_panel_token(
+            sandbox_id=self._sandbox.id,
+            port=port,
+            secret=get_panel_secret(),
+            ttl=timedelta(seconds=expires_in),
+        )
+        # Trailing slash keeps the panel client's relative paths resolving under
+        # the token prefix (drop it and they'd resolve one level up, losing the
+        # token) — the same reason the previous signed-URL path appended one.
+        return BrowserEndpoint(url=f"{base}/sandbox-panel/{token}/", headers={})
 
     async def get_browser_endpoint(self, *, expires_in: int = 3600) -> BrowserEndpoint:
-        with _as_sandbox_error():
-            expires = int(time.time()) + expires_in
-            endpoint = await self._sandbox.get_signed_endpoint(self.BROWSER_PORT, expires)
-            url = endpoint.endpoint
-            # OpenSandbox returns a scheme-less host/path; an iframe needs a full URL.
-            if not url.startswith(("http://", "https://")):
-                protocol = getattr(self._sandbox.connection_config, "protocol", "http")
-                url = f"{protocol}://{url}"
-            # A trailing slash after the .../proxy/<port> path is REQUIRED: the Neko
-            # client uses relative asset/WS paths, so without it they resolve against
-            # .../proxy/ (dropping the port) and the proxy returns 401 — the client JS
-            # never loads and only the static login shell shows.
-            if not url.endswith("/"):
-                url += "/"
-            headers = {
-                k: v
-                for k, v in (endpoint.headers or {}).items()
-                if k.lower() not in self._BROWSER_IRRELEVANT_HEADERS
-            }
-            return BrowserEndpoint(url=url, headers=headers)
+        return self._panel_endpoint(self.BROWSER_PORT, expires_in)
 
     async def get_terminal_endpoint(self, *, expires_in: int = 3600) -> BrowserEndpoint:
-        with _as_sandbox_error():
-            expires = int(time.time()) + expires_in
-            endpoint = await self._sandbox.get_signed_endpoint(self.TERMINAL_PORT, expires)
-            url = endpoint.endpoint
-            if not url.startswith(("http://", "https://")):
-                protocol = getattr(
-                    self._sandbox.connection_config,
-                    "protocol",
-                    "http",
-                )
-                url = f"{protocol}://{url}"
-            if not url.endswith("/"):
-                url += "/"
-            headers = {
-                k: v
-                for k, v in (endpoint.headers or {}).items()
-                if k.lower() not in self._BROWSER_IRRELEVANT_HEADERS
-            }
-            return BrowserEndpoint(url=url, headers=headers)
+        return self._panel_endpoint(self.TERMINAL_PORT, expires_in)
 
     async def close(self) -> None:
         pass

--- a/backend/cubeplex/sandbox/panel_token.py
+++ b/backend/cubeplex/sandbox/panel_token.py
@@ -1,0 +1,73 @@
+"""Signed token for sandbox panel (browser/terminal) reverse-proxy access.
+
+The panel URL embeds this short-lived HS256 JWT in its **path** so every relative
+asset request and the WebSocket handshake the panel client makes carries the
+credential (an iframe navigation and a WS sub-resource cannot attach auth
+headers). The backend reverse-proxy route verifies it and forwards to the
+cluster-internal opensandbox-server; see
+docs/dev/specs/2026-07-26-sandbox-panel-proxy-design.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import jwt
+
+_ISS = "cubeplex:sandbox-panel"
+
+
+@dataclass(frozen=True, slots=True)
+class PanelClaims:
+    sandbox_id: str
+    port: int
+
+
+def sign_panel_token(
+    *,
+    sandbox_id: str,
+    port: int,
+    secret: str,
+    ttl: timedelta,
+) -> str:
+    now = datetime.now(UTC)
+    claims = {
+        "sid": sandbox_id,
+        "port": int(port),
+        "exp": int((now + ttl).timestamp()),
+        "iat": int(now.timestamp()),
+        "iss": _ISS,
+    }
+    return jwt.encode(claims, secret, algorithm="HS256")
+
+
+def verify_panel_token(token: str, *, secret: str) -> PanelClaims:
+    try:
+        payload = jwt.decode(
+            token,
+            secret,
+            algorithms=["HS256"],
+            issuer=_ISS,
+        )
+    except jwt.PyJWTError as exc:
+        raise ValueError("Invalid or expired panel token") from exc
+    return PanelClaims(sandbox_id=str(payload["sid"]), port=int(payload["port"]))
+
+
+def get_panel_secret() -> str:
+    from cubeplex.config import config
+
+    return str(config.get("auth.jwt_secret", "CHANGE_ME"))
+
+
+def get_panel_base_url() -> str:
+    """Public base URL of the cubeplex backend, used as the panel origin.
+
+    Reuses ``api.public_url`` (the backend's own public address). Empty when the
+    operator has not configured a public URL — callers treat that as
+    "panels unavailable" rather than minting an unreachable link.
+    """
+    from cubeplex.config import config
+
+    return str(config.get("api.public_url", "") or "").rstrip("/")

--- a/backend/tests/e2e/test_sandbox_panel_proxy.py
+++ b/backend/tests/e2e/test_sandbox_panel_proxy.py
@@ -2,7 +2,12 @@
 
 Builds a minimal app carrying only the panel router and forwards it at a
 test-double upstream (a uvicorn server standing in for opensandbox-server's
-server-proxy). No DB / real external systems -> integration.
+server-proxy). It hits a FastAPI app over a real socket -> e2e.
+
+The upstream host and the token secret are injected by monkeypatching the panel
+router's module-level helpers, so the test never touches the global dynaconf
+config (whose lazy `@format` `sandbox.domain` caches on first read and can't be
+re-overridden mid-suite).
 """
 
 from __future__ import annotations
@@ -30,6 +35,17 @@ def _free_port() -> int:
     return port
 
 
+def _wait_accepting(port: int, timeout: float = 15.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError(f"upstream on :{port} never started accepting")
+
+
 @pytest.fixture
 def upstream_port():
     """A stand-in opensandbox-server server-proxy: echoes what it received."""
@@ -54,11 +70,7 @@ def upstream_port():
     server = uvicorn.Server(uvicorn.Config(up, host="127.0.0.1", port=port, log_level="warning"))
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
-    for _ in range(200):
-        if server.started:
-            break
-        time.sleep(0.02)
-    assert server.started, "upstream test server failed to start"
+    _wait_accepting(port)
     yield port
     server.should_exit = True
     thread.join(timeout=5)
@@ -66,25 +78,17 @@ def upstream_port():
 
 @pytest.fixture
 def client(upstream_port: int, monkeypatch: pytest.MonkeyPatch):
-    from cubeplex.config import config as cfg
-
-    # sandbox.domain is a lazy `@format {env[CUBEPLEX_SANDBOX__DOMAIN]}` template,
-    # so point it at the upstream via the env var (monkeypatch restores it).
-    monkeypatch.setenv("CUBEPLEX_SANDBOX__DOMAIN", f"127.0.0.1:{upstream_port}")
-    prev_url = cfg.get("api.public_url", "")
-    prev_secret = cfg.get("auth.jwt_secret", "CHANGE_ME")
-    cfg.set("api.public_url", "http://testserver")
-    cfg.set("auth.jwt_secret", _SECRET)
-
     from cubeplex.api.routes import sandbox_panel
+
+    # Inject the upstream + token secret without touching global config, so the
+    # test is immune to whatever `sandbox.domain` other suite tests have cached.
+    monkeypatch.setattr(sandbox_panel, "_server_host", lambda: f"127.0.0.1:{upstream_port}")
+    monkeypatch.setattr(sandbox_panel, "get_panel_secret", lambda: _SECRET)
 
     app = FastAPI()
     app.include_router(sandbox_panel.router)
     with TestClient(app) as test_client:
         yield test_client
-
-    cfg.set("api.public_url", prev_url)
-    cfg.set("auth.jwt_secret", prev_secret)
 
 
 def _token(sid: str = "sbx_1", port: int = 8080) -> str:

--- a/backend/tests/integration/test_sandbox_panel_proxy.py
+++ b/backend/tests/integration/test_sandbox_panel_proxy.py
@@ -1,0 +1,130 @@
+"""Sandbox panel reverse proxy: token gating + HTTP/WebSocket relay.
+
+Builds a minimal app carrying only the panel router and forwards it at a
+test-double upstream (a uvicorn server standing in for opensandbox-server's
+server-proxy). No DB / real external systems -> integration.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from datetime import timedelta
+
+import pytest
+import uvicorn
+from fastapi import FastAPI, Request, WebSocket
+from starlette.testclient import TestClient
+
+from cubeplex.sandbox.panel_token import sign_panel_token
+
+_SECRET = "panel-proxy-test-secret"
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.fixture
+def upstream_port():
+    """A stand-in opensandbox-server server-proxy: echoes what it received."""
+    up = FastAPI()
+
+    @up.api_route("/sandboxes/{sid}/proxy/{port}/{path:path}", methods=["GET", "POST"])
+    async def echo(sid: str, port: int, path: str, request: Request) -> dict:
+        return {"sid": sid, "port": port, "path": path, "query": request.url.query}
+
+    @up.websocket("/sandboxes/{sid}/proxy/{port}/{path:path}")
+    async def ws_echo(websocket: WebSocket, sid: str, port: int, path: str) -> None:
+        await websocket.accept()
+        await websocket.send_text(f"hello:{sid}:{port}:{path}")
+        try:
+            while True:
+                msg = await websocket.receive_text()
+                await websocket.send_text(f"echo:{msg}")
+        except Exception:
+            return
+
+    port = _free_port()
+    server = uvicorn.Server(uvicorn.Config(up, host="127.0.0.1", port=port, log_level="warning"))
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(200):
+        if server.started:
+            break
+        time.sleep(0.02)
+    assert server.started, "upstream test server failed to start"
+    yield port
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+@pytest.fixture
+def client(upstream_port: int, monkeypatch: pytest.MonkeyPatch):
+    from cubeplex.config import config as cfg
+
+    # sandbox.domain is a lazy `@format {env[CUBEPLEX_SANDBOX__DOMAIN]}` template,
+    # so point it at the upstream via the env var (monkeypatch restores it).
+    monkeypatch.setenv("CUBEPLEX_SANDBOX__DOMAIN", f"127.0.0.1:{upstream_port}")
+    prev_url = cfg.get("api.public_url", "")
+    prev_secret = cfg.get("auth.jwt_secret", "CHANGE_ME")
+    cfg.set("api.public_url", "http://testserver")
+    cfg.set("auth.jwt_secret", _SECRET)
+
+    from cubeplex.api.routes import sandbox_panel
+
+    app = FastAPI()
+    app.include_router(sandbox_panel.router)
+    with TestClient(app) as test_client:
+        yield test_client
+
+    cfg.set("api.public_url", prev_url)
+    cfg.set("auth.jwt_secret", prev_secret)
+
+
+def _token(sid: str = "sbx_1", port: int = 8080) -> str:
+    return sign_panel_token(sandbox_id=sid, port=port, secret=_SECRET, ttl=timedelta(hours=1))
+
+
+class TestPanelProxyHttp:
+    def test_valid_token_proxies_to_pod(self, client: TestClient) -> None:
+        r = client.get(f"/sandbox-panel/{_token('sbx_a', 7681)}/foo/bar?x=1")
+        assert r.status_code == 200
+        body = r.json()
+        assert body == {"sid": "sbx_a", "port": 7681, "path": "foo/bar", "query": "x=1"}
+
+    def test_root_path_proxies(self, client: TestClient) -> None:
+        r = client.get(f"/sandbox-panel/{_token('sbx_b', 8080)}/")
+        assert r.status_code == 200
+        assert r.json()["path"] == ""
+
+    def test_bad_token_forbidden(self, client: TestClient) -> None:
+        r = client.get("/sandbox-panel/not-a-real-token/foo")
+        assert r.status_code == 403
+
+    def test_expired_token_forbidden(self, client: TestClient) -> None:
+        expired = sign_panel_token(
+            sandbox_id="sbx_x", port=8080, secret=_SECRET, ttl=timedelta(seconds=-5)
+        )
+        r = client.get(f"/sandbox-panel/{expired}/foo")
+        assert r.status_code == 403
+
+
+class TestPanelProxyWebSocket:
+    def test_valid_token_relays_bidirectional(self, client: TestClient) -> None:
+        with client.websocket_connect(f"/sandbox-panel/{_token('sbx_w', 7681)}/tty") as ws:
+            assert ws.receive_text() == "hello:sbx_w:7681:tty"
+            ws.send_text("ping")
+            assert ws.receive_text() == "echo:ping"
+
+    def test_bad_token_rejected(self, client: TestClient) -> None:
+        from starlette.websockets import WebSocketDisconnect
+
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect("/sandbox-panel/bad-token/tty"):
+                pass

--- a/backend/tests/unit/test_opensandbox_endpoints.py
+++ b/backend/tests/unit/test_opensandbox_endpoints.py
@@ -1,0 +1,56 @@
+"""Browser/terminal endpoint methods build a signed cubeplex panel-proxy URL."""
+
+from __future__ import annotations
+
+import pytest
+
+from cubeplex.sandbox.base import SandboxError
+from cubeplex.sandbox.opensandbox import OpenSandbox
+from cubeplex.sandbox.panel_token import verify_panel_token
+
+
+class _FakeSandbox:
+    def __init__(self, sid: str) -> None:
+        self.id = sid
+
+
+@pytest.fixture(autouse=True)
+def _panel_config():
+    from cubeplex.config import config
+
+    prev_url = config.get("api.public_url", "")
+    prev_secret = config.get("auth.jwt_secret", "CHANGE_ME")
+    config.set("api.public_url", "https://app.example.com")
+    config.set("auth.jwt_secret", "unit-test-secret")
+    yield
+    config.set("api.public_url", prev_url)
+    config.set("auth.jwt_secret", prev_secret)
+
+
+class TestPanelEndpoints:
+    async def test_browser_endpoint_is_signed_panel_url(self) -> None:
+        sb = OpenSandbox(sandbox=_FakeSandbox("sbx_1"))  # type: ignore[arg-type]
+        ep = await sb.get_browser_endpoint()
+        assert ep.headers == {}
+        assert ep.url.startswith("https://app.example.com/sandbox-panel/")
+        assert ep.url.endswith("/")
+        token = ep.url[len("https://app.example.com/sandbox-panel/") :].rstrip("/")
+        claims = verify_panel_token(token, secret="unit-test-secret")
+        assert claims.sandbox_id == "sbx_1"
+        assert claims.port == OpenSandbox.BROWSER_PORT
+
+    async def test_terminal_endpoint_port(self) -> None:
+        sb = OpenSandbox(sandbox=_FakeSandbox("sbx_2"))  # type: ignore[arg-type]
+        ep = await sb.get_terminal_endpoint()
+        token = ep.url[len("https://app.example.com/sandbox-panel/") :].rstrip("/")
+        claims = verify_panel_token(token, secret="unit-test-secret")
+        assert claims.sandbox_id == "sbx_2"
+        assert claims.port == OpenSandbox.TERMINAL_PORT
+
+    async def test_missing_public_url_raises(self) -> None:
+        from cubeplex.config import config
+
+        config.set("api.public_url", "")
+        sb = OpenSandbox(sandbox=_FakeSandbox("sbx_3"))  # type: ignore[arg-type]
+        with pytest.raises(SandboxError, match="public URL"):
+            await sb.get_browser_endpoint()

--- a/backend/tests/unit/test_panel_token.py
+++ b/backend/tests/unit/test_panel_token.py
@@ -1,0 +1,65 @@
+"""Token sign + verify for sandbox panel (browser/terminal) proxy access."""
+
+from __future__ import annotations
+
+import time
+from datetime import timedelta
+
+import pytest
+
+from cubeplex.sandbox.panel_token import (
+    sign_panel_token,
+    verify_panel_token,
+)
+
+_SECRET = "test-secret-for-panel-tokens"
+
+
+class TestPanelToken:
+    def test_roundtrip(self) -> None:
+        token = sign_panel_token(
+            sandbox_id="sbx_abc",
+            port=8080,
+            secret=_SECRET,
+            ttl=timedelta(hours=1),
+        )
+        claims = verify_panel_token(token, secret=_SECRET)
+        assert claims.sandbox_id == "sbx_abc"
+        assert claims.port == 8080
+        assert isinstance(claims.port, int)
+
+    def test_bad_signature_rejected(self) -> None:
+        token = sign_panel_token(
+            sandbox_id="sbx_1", port=7681, secret=_SECRET, ttl=timedelta(hours=1)
+        )
+        with pytest.raises(ValueError, match="Invalid or expired"):
+            verify_panel_token(token, secret="wrong-secret")
+
+    def test_wrong_issuer_rejected(self) -> None:
+        import jwt
+
+        token = jwt.encode(
+            {"sid": "sbx_1", "port": 8080, "iss": "other", "exp": int(time.time()) + 600},
+            _SECRET,
+            algorithm="HS256",
+        )
+        with pytest.raises(ValueError, match="Invalid or expired"):
+            verify_panel_token(token, secret=_SECRET)
+
+    def test_expired_token_rejected(self) -> None:
+        token = sign_panel_token(
+            sandbox_id="sbx_1", port=8080, secret=_SECRET, ttl=timedelta(seconds=-10)
+        )
+        with pytest.raises(ValueError, match="Invalid or expired"):
+            verify_panel_token(token, secret=_SECRET)
+
+    def test_tampered_port_rejected(self) -> None:
+        # A token whose payload is edited without re-signing must fail.
+        token = sign_panel_token(
+            sandbox_id="sbx_1", port=8080, secret=_SECRET, ttl=timedelta(hours=1)
+        )
+        header, payload, sig = token.split(".")
+        # Flip the last char of the signature to simulate tampering.
+        bad_sig = sig[:-1] + ("A" if sig[-1] != "A" else "B")
+        with pytest.raises(ValueError, match="Invalid or expired"):
+            verify_panel_token(f"{header}.{payload}.{bad_sig}", secret=_SECRET)

--- a/backend/tests/unit/test_sandbox_browser.py
+++ b/backend/tests/unit/test_sandbox_browser.py
@@ -73,39 +73,6 @@ async def test_local_sandbox_start_browser_is_noop() -> None:
 
 
 @pytest.mark.asyncio
-async def test_opensandbox_browser_endpoint_uses_signed_endpoint() -> None:
-    """OpenSandbox.get_browser_endpoint signs port 8080 and maps the result."""
-    from cubeplex.sandbox.opensandbox import OpenSandbox
-
-    class _FakeSigned:
-        # OpenSandbox returns a scheme-qualified host/path with no query string.
-        endpoint = "https://signed.example/sandboxes/sb-1/proxy/8080"
-        headers: dict[str, str] = {}
-
-    class _FakeInner:
-        id = "sb-1"
-
-        def __init__(self) -> None:
-            self.calls: list[tuple[int, int]] = []
-
-        async def get_signed_endpoint(self, port: int, expires: int) -> _FakeSigned:
-            self.calls.append((port, expires))
-            return _FakeSigned()
-
-    inner = _FakeInner()
-    sb = OpenSandbox(sandbox=inner)  # type: ignore[arg-type]
-    ep = await sb.get_browser_endpoint(expires_in=1800)
-
-    # A trailing slash is appended so the Neko client's relative asset/WS paths
-    # resolve under .../proxy/8080/ instead of dropping the port segment.
-    assert ep.url == "https://signed.example/sandboxes/sb-1/proxy/8080/"
-    assert ep.headers == {}
-    assert len(inner.calls) == 1
-    port, _expires = inner.calls[0]
-    assert port == 8080
-
-
-@pytest.mark.asyncio
 async def test_opensandbox_translates_provider_error_to_sandbox_error() -> None:
     """The driver must not leak opensandbox's own exception type to callers."""
     from opensandbox.exceptions.sandbox import SandboxInternalException
@@ -116,12 +83,12 @@ async def test_opensandbox_translates_provider_error_to_sandbox_error() -> None:
     class _FailingInner:
         id = "sb-1"
 
-        async def get_signed_endpoint(self, port: int, expires: int):
+        async def pause(self) -> None:
             raise SandboxInternalException("Network connectivity error")
 
     sb = OpenSandbox(sandbox=_FailingInner())  # type: ignore[arg-type]
     with pytest.raises(SandboxError):
-        await sb.get_browser_endpoint()
+        await sb.pause()
 
 
 @pytest.mark.asyncio

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -29,6 +29,10 @@ deploy/
 │   ├── backend/Dockerfile
 │   ├── frontend/Dockerfile
 │   └── sandbox/               # agent sandbox image (Dockerfile + neko browser + fonts)
+├── scripts/lib/               # verification logic shared by both targets
+│   ├── common.sh              # step/fail helpers, proxy handling
+│   ├── http-probes.sh         # smoke probes (health, system info, frontend)
+│   └── e2e-core.sh            # the auth + chat round-trip
 ├── kubernetes/                # Helm chart + scripts + docs
 │   ├── README.md
 │   ├── INSTALL.md             # English install guide
@@ -46,6 +50,12 @@ deploy/
     ├── config/
     └── scripts/
 ```
+
+Each target's `scripts/smoke-test.sh` and `scripts/e2e.sh` only work out how to
+reach that deployment — published host ports for compose, ingress plus
+`--resolve` for kubernetes — then hand off to `deploy/scripts/lib/`. Checks that
+apply to both live in the shared library; the platform-native parts
+(`docker compose ps`, `kubectl rollout status`) stay in the entry points.
 
 The Dockerfiles accept build-time mirror knobs (`APT_MIRROR_HOST`,
 `PIP_INDEX_URL`, `UV_INDEX_URL`, `NPM_REGISTRY`) and `build-and-push.sh`

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -36,7 +36,7 @@ RUSTFS_SECRET_KEY=REPLACE_ME
 
 # ── Optional: OpenSandbox overlay (see compose.opensandbox.yaml) ─────────
 # Only needed if you start the stack with -f compose.opensandbox.yaml.
-# OPENSANDBOX_IMAGE=opensandbox/server:latest
+# OPENSANDBOX_IMAGE=opensandbox/server:v0.2.2
 # OPENSANDBOX_PORT=8090
 
 # ── Optional: docling document-parsing overlay (see compose.docling.yaml) ─

--- a/deploy/docker-compose/compose.opensandbox.yaml
+++ b/deploy/docker-compose/compose.opensandbox.yaml
@@ -10,8 +10,9 @@
 # Pre-requisites:
 #   * `.env` has OPENSANDBOX_*_TAG / image / api_key filled (see .env.example).
 #   * `config/opensandbox.toml` exists (cp from opensandbox.toml.example).
-#   * config/config.production.local.yaml has `sandbox.enabled: true` and
-#     `sandbox.use_server_proxy: true`.
+#   * config/config.production.local.yaml has `sandbox.enabled: true`,
+#     `sandbox.secure_access: false`, and `sandbox.use_server_proxy: false`
+#     (the example config's defaults — both are required for the docker runtime).
 #   * config/config.production.secrets.yaml has `sandbox.domain`,
 #     `sandbox.image`, `sandbox.api_key` matching the server below.
 #

--- a/deploy/docker-compose/compose.opensandbox.yaml
+++ b/deploy/docker-compose/compose.opensandbox.yaml
@@ -26,6 +26,14 @@ services:
     restart: unless-stopped
     environment:
       SANDBOX_CONFIG_PATH: /etc/opensandbox/config.toml
+    # The server reaches the egress sidecar (readiness probe) and the sandbox
+    # containers through the host_ip / eip in opensandbox.toml, which default
+    # to `host.docker.internal`. Linux Docker engines don't resolve that by
+    # default, so wire it to the bridge gateway here too — without it, sandbox
+    # creation fails with "Egress sidecar did not become ready … Name or
+    # service not known" and every tool call errors out.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       # Docker socket — REQUIRED for the docker runtime. Sandbox containers
       # are spawned via the host docker daemon, NOT inside this service.

--- a/deploy/docker-compose/compose.opensandbox.yaml
+++ b/deploy/docker-compose/compose.opensandbox.yaml
@@ -23,7 +23,7 @@
 
 services:
   opensandbox-server:
-    image: ${OPENSANDBOX_IMAGE:-opensandbox/server:latest}
+    image: ${OPENSANDBOX_IMAGE:-opensandbox/server:v0.2.2}
     restart: unless-stopped
     environment:
       SANDBOX_CONFIG_PATH: /etc/opensandbox/config.toml

--- a/deploy/docker-compose/config/config.production.local.yaml.example
+++ b/deploy/docker-compose/config/config.production.local.yaml.example
@@ -8,7 +8,10 @@ production:
     host: "0.0.0.0"
     port: 8000
     # The URL operators / browsers reach the backend at. If you put a
-    # reverse proxy in front, use that URL.
+    # reverse proxy in front, use that URL. This is ALSO the origin for the
+    # sandbox browser/terminal panels: it must be reachable from the end
+    # user's browser AND forward WebSocket (the panels proxy Neko/ttyd over
+    # WS). Leave empty and the panels are unavailable.
     public_url: "http://localhost:8000"
   deployment:
     mode: single_tenant            # single_tenant | multi_tenant

--- a/deploy/docker-compose/config/config.production.secrets.yaml.example
+++ b/deploy/docker-compose/config/config.production.secrets.yaml.example
@@ -36,7 +36,19 @@ production:
     api_key: ""
 
   llm:
-    default_model: "openai/gpt-5.6-terra"
+    # model_presets is REQUIRED — the backend seeds a system default preset
+    # from it at startup. A bare `default_model` does NOT seed a preset: the
+    # backend boots healthy but every chat message fails at runtime with
+    # NoDefaultPresetError (HTTP 500). Each tier's `primary` (and optional
+    # `fallbacks`) is a "<provider>/<model-id>" reference into `providers`
+    # below. Tiers you don't need can stay disabled.
+    model_presets:
+      tiers:
+        lite:  { enabled: true,  primary: "openai/gpt-5.6-terra", fallbacks: [] }
+        flash: { enabled: true,  primary: "openai/gpt-5.6-terra", fallbacks: [] }
+        pro:   { enabled: true,  primary: "openai/gpt-5.6-terra", fallbacks: [] }
+        max:   { enabled: false, primary: null, fallbacks: [] }
+      default_preset: pro
     providers:
       # Any OpenAI-compatible endpoint (OpenAI, Azure, vLLM, LiteLLM, a gateway…).
       openai:

--- a/deploy/docker-compose/config/opensandbox.toml.example
+++ b/deploy/docker-compose/config/opensandbox.toml.example
@@ -25,12 +25,12 @@ type = "docker"
 # inside each sandbox. Must be pullable by the host docker daemon. Defaults to
 # Docker Hub; mainland China can use the
 # sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/ prefix instead.
-execd_image = "opensandbox/execd:v1.0.19"
+execd_image = "opensandbox/execd:v1.0.21"
 
 [egress]
 # Egress sidecar image used when a sandbox is created with networkPolicy.
 # Required for cubeplex (cubeplex always passes a network_policy).
-image = "opensandbox/egress:v1.0.12"
+image = "opensandbox/egress:v1.1.4"
 
 [docker]
 # `bridge` is REQUIRED for cubeplex — host mode disables networkPolicy.

--- a/deploy/docker-compose/config/opensandbox.toml.example
+++ b/deploy/docker-compose/config/opensandbox.toml.example
@@ -25,7 +25,7 @@ type = "docker"
 # inside each sandbox. Must be pullable by the host docker daemon. Defaults to
 # Docker Hub; mainland China can use the
 # sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/ prefix instead.
-execd_image = "opensandbox/execd:v1.0.18"
+execd_image = "opensandbox/execd:v1.0.19"
 
 [egress]
 # Egress sidecar image used when a sandbox is created with networkPolicy.

--- a/deploy/docker-compose/scripts/e2e.sh
+++ b/deploy/docker-compose/scripts/e2e.sh
@@ -1,105 +1,24 @@
 #!/usr/bin/env bash
-# Live e2e against the compose stack. Same logic as the kubernetes
-# variant but talks to the published host ports directly (no ingress
-# Host header dance).
+# Live e2e against the compose stack — talks to the published host ports
+# directly (no ingress Host header dance). Shared logic: deploy/scripts/lib.
+#
+# Usage:
+#   PROMPT="Say the word hello and nothing else." \
+#     deploy/docker-compose/scripts/e2e.sh
+#
+# Requires auth.cookie_secure=false (HTTP only) and a working LLM provider.
 set -euo pipefail
+
+LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../scripts/lib" && pwd)"
+source "$LIB/common.sh"
+source "$LIB/e2e-core.sh"
 
 HOST="${HOST:-localhost}"
 BACKEND_PORT="${BACKEND_PORT:-8000}"
-B="http://$HOST:$BACKEND_PORT"
 PROMPT="${PROMPT:-Say the word \"hello\" and nothing else.}"
 
-unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy 2>/dev/null || true
-export no_proxy='*' NO_PROXY='*'
+BASE="http://$HOST:$BACKEND_PORT"
+CURL_OPTS=(--noproxy '*')
 
-CK=$(mktemp); SSE_OUT=$(mktemp)
-trap 'rm -f "$CK" "$SSE_OUT"' EXIT
-
-EMAIL="e2e-$(date +%s)-$(openssl rand -hex 2)@example.com"
-PASS="correcthorsebatterystaple"
-
-step() { printf '\n==> %s\n' "$*"; }
-fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
-
-step "1. /api/v1/system/info"
-INFO=$(curl -fsS --noproxy '*' "$B/api/v1/system/info")
-echo "  $INFO"
-echo "$INFO" | grep -q '"deployment_mode":"single_tenant"' \
-  || fail "expected single_tenant deployment_mode"
-
-step "2. register $EMAIL"
-REG=$(curl -fsS --noproxy '*' -c "$CK" -H "Content-Type: application/json" \
-  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASS\"}" \
-  "$B/api/v1/auth/register")
-echo "  $REG"
-WS=$(echo "$REG" | python3 -c \
-  'import json,sys; print(json.load(sys.stdin).get("default_workspace_id",""))')
-[[ -n "$WS" ]] || fail "no default_workspace_id from register"
-
-step "3. login (cookie jar)"
-curl -fsS --noproxy '*' -c "$CK" -b "$CK" \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  --data-urlencode "username=$EMAIL" --data-urlencode "password=$PASS" \
-  --data-urlencode "grant_type=password" \
-  "$B/api/v1/auth/login" >/dev/null
-grep -q "cubeplex_auth" "$CK" \
-  || fail "no cubeplex_auth (check auth.cookie_secure=false on HTTP)"
-echo "  ok"
-
-step "4. GET /auth/me — receive csrf cookie"
-curl -fsS --noproxy '*' -c "$CK" -b "$CK" "$B/api/v1/auth/me" >/dev/null
-grep -q "cubeplex_csrf" "$CK" || fail "no cubeplex_csrf in jar"
-CSRF=$(awk -F'\t' '$6=="cubeplex_csrf"{print $7}' "$CK" | tail -1)
-[[ -n "$CSRF" ]] || fail "csrf cookie present but empty"
-echo "  ok"
-
-step "5. create conversation"
-CONV=$(curl -fsS --noproxy '*' -b "$CK" \
-  -H "Content-Type: application/json" \
-  -H "X-CSRF-Token: $CSRF" \
-  -d '{"title":"e2e probe"}' \
-  "$B/api/v1/ws/$WS/conversations")
-CONV_ID=$(echo "$CONV" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
-echo "  conv_id=$CONV_ID"
-
-step "6. POST message → run_id"
-MSG=$(curl -fsS --noproxy '*' -b "$CK" \
-  -H "Content-Type: application/json" \
-  -H "X-CSRF-Token: $CSRF" \
-  -d "$(python3 -c 'import json,os; print(json.dumps({"content": os.environ["PROMPT"]}))')" \
-  "$B/api/v1/ws/$WS/conversations/$CONV_ID/messages")
-RUN_ID=$(echo "$MSG" | python3 -c 'import json,sys; print(json.load(sys.stdin)["run_id"])')
-echo "  run_id=$RUN_ID"
-
-step "7. stream SSE — extract assistant text + usage"
-curl -sN --noproxy '*' -b "$CK" \
-  -H "Accept: text/event-stream" \
-  "$B/api/v1/ws/$WS/conversations/$CONV_ID/runs/$RUN_ID/stream" \
-  --max-time 120 > "$SSE_OUT" || true
-EVENTS=$(grep -c '^data: ' "$SSE_OUT" || true)
-echo "  event types: $(grep -oE '"type":[[:space:]]*"[^"]+"' "$SSE_OUT" | sort -u | tr '\n' ' ')"
-echo "  data lines: $EVENTS"
-[[ "$EVENTS" -gt 0 ]] || fail "no SSE data lines"
-
-TEXT=$(python3 - "$SSE_OUT" <<'PY'
-import json, sys
-text = ""
-for line in open(sys.argv[1]):
-    if not line.startswith("data: "):
-        continue
-    try:
-        obj = json.loads(line[6:])
-    except Exception:
-        continue
-    if obj.get("type") == "text_delta":
-        text += obj.get("data", {}).get("content", "")
-print(text, end="")
-PY
-)
-echo "  ASSISTANT_TEXT: ${TEXT}"
-[[ -n "${TEXT// }" ]] || fail "no text_delta content from LLM"
-
-echo
-echo "==================================================="
-echo "E2E PASSED — LLM round-trip complete."
-echo "==================================================="
+disable_proxies
+run_e2e

--- a/deploy/docker-compose/scripts/smoke-test.sh
+++ b/deploy/docker-compose/scripts/smoke-test.sh
@@ -1,43 +1,40 @@
 #!/usr/bin/env bash
 # Post-up smoke checks for the docker-compose stack. Runs from any host
 # that can reach the published ports (default localhost).
+# Shared HTTP probes: deploy/scripts/lib/http-probes.sh.
 set -euo pipefail
+
+LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../scripts/lib" && pwd)"
+source "$LIB/common.sh"
+source "$LIB/http-probes.sh"
 
 HOST="${HOST:-localhost}"
 BACKEND_PORT="${BACKEND_PORT:-8000}"
 FRONTEND_PORT="${FRONTEND_PORT:-3000}"
-B="http://$HOST:$BACKEND_PORT"
-F="http://$HOST:$FRONTEND_PORT"
 
-unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy 2>/dev/null || true
-export no_proxy='*' NO_PROXY='*'
+# Compose publishes the two services on separate ports; the frontend reaches
+# the backend through the Next.js rewrite.
+BACKEND_BASE="http://$HOST:$BACKEND_PORT"
+FRONTEND_BASE="http://$HOST:$FRONTEND_PORT"
+CURL_OPTS=(--noproxy '*')
 
-step() { printf '\n==> %s\n' "$*"; }
-fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+disable_proxies
 
 step "1. Compose service health"
 ROOT="$(git rev-parse --show-toplevel)"
 ( cd "$ROOT/deploy/docker-compose" && docker compose ps )
 
 step "2. Backend /health/live"
-INFO=$(curl -fsS --noproxy '*' "$B/health/live")
-echo "  $INFO"
-echo "$INFO" | grep -q '"status":"ok"' || fail "backend health check"
+probe_backend_health
 
 step "3. Backend /api/v1/system/info"
-INFO=$(curl -fsS --noproxy '*' "$B/api/v1/system/info")
-echo "  $INFO"
-echo "$INFO" | grep -q '"deployment_mode"' || fail "system info"
+probe_system_info
 
 step "4. Frontend root renders HTML"
-body=$(curl -fsS --noproxy '*' "$F/")
-echo "  $(echo "$body" | head -c 200)..."
-echo "$body" | grep -qiE "<html|<!doctype" || fail "frontend HTML"
+probe_frontend_root
 
 step "5. Frontend → backend rewrite (via Next.js)"
-code=$(curl -s -o /dev/null -w '%{http_code}' --noproxy '*' "$F/api/v1/system/info")
-echo "  /api/v1/system/info via frontend → HTTP $code"
-[[ "$code" =~ ^(200|401|403|404)$ ]] || fail "frontend → backend proxy (got $code)"
+probe_api_via_frontend
 
 echo
 echo "SMOKE TEST PASSED."

--- a/deploy/images/frontend/Dockerfile
+++ b/deploy/images/frontend/Dockerfile
@@ -64,8 +64,14 @@ COPY --from=builder --chown=cubeplex:cubeplex /app/packages/web/.next/standalone
 COPY --from=builder --chown=cubeplex:cubeplex /app/packages/web/.next/static ./packages/web/.next/static
 COPY --from=builder --chown=cubeplex:cubeplex /app/packages/web/public ./packages/web/public
 
+# Rewrites the baked /api/* proxy destination with the runtime CUBEPLEX_API_URL
+# on start (Next bakes rewrites() at build time — see the script).
+COPY --chown=cubeplex:cubeplex deploy/images/frontend/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 USER cubeplex
 
 EXPOSE 3000
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["node", "packages/web/server.js"]

--- a/deploy/images/frontend/entrypoint.sh
+++ b/deploy/images/frontend/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Patch the Next.js API-proxy rewrite destination at container start.
+#
+# next.config.ts proxies /api/* to `${CUBEPLEX_API_URL:-http://localhost:8000}`.
+# Next.js resolves rewrites() at BUILD time and bakes the result into
+# routes-manifest.json — the runtime env var is NOT re-read. The image is
+# built with no backend URL, so the baked destination is the fallback
+# `http://localhost:8000`, which is wrong for every real multi-container
+# deploy (the backend is at `http://backend:8000` under compose, or a Service
+# DNS name under k8s).
+#
+# So we rewrite the baked host here, once, using the runtime CUBEPLEX_API_URL.
+# Left unset, it stays http://localhost:8000 (local/dev default preserved).
+set -e
+
+API_URL="${CUBEPLEX_API_URL:-http://localhost:8000}"
+MANIFEST="/app/packages/web/.next/routes-manifest.json"
+
+if [ "$API_URL" != "http://localhost:8000" ] && [ -f "$MANIFEST" ]; then
+  # `http://localhost:8000` appears only as the /api/* rewrite destination.
+  sed -i "s#http://localhost:8000#${API_URL}#g" "$MANIFEST"
+fi
+
+exec "$@"

--- a/deploy/kubernetes/charts/cubeplex/templates/backend-configmap.yaml
+++ b/deploy/kubernetes/charts/cubeplex/templates/backend-configmap.yaml
@@ -32,7 +32,9 @@ data:
         # Defaults to .Values.opensandbox.enabled for the common case.
         enabled: {{ dig "sandbox" "enabled" .Values.opensandbox.enabled .Values.backend }}
         use_server_proxy: {{ dig "sandbox" "use_server_proxy" false .Values.backend }}
-        secure_access: {{ dig "sandbox" "secure_access" true .Values.backend }}
+        # Panels flow through cubeplex's token-authed panel reverse proxy (not the
+        # OpenSandbox ingress gateway), so signed secured-endpoint mode is off.
+        secure_access: {{ dig "sandbox" "secure_access" false .Values.backend }}
         {{- if .Values.egress.enabled }}
         # Activates egress secret-injection in SandboxManager (every
         # injection call is gated on `if self._exchange_host:`) and is

--- a/deploy/kubernetes/charts/cubeplex/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/cubeplex/templates/ingress.yaml
@@ -35,6 +35,18 @@ spec:
                 name: {{ include "cubeplex.backend.fullname" . }}
                 port:
                   number: {{ .Values.backend.service.port }}
+          # Sandbox browser/terminal panels: the panel URL is rooted at
+          # api.public_url (this ingress host) and reverse-proxies HTTP + WebSocket
+          # to opensandbox-server. It's served by the backend at root (not /api),
+          # so it needs its own path — otherwise it falls through to the frontend
+          # and 404s. ingress-nginx forwards the WS Upgrade on this path by default.
+          - path: /sandbox-panel
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "cubeplex.backend.fullname" . }}
+                port:
+                  number: {{ .Values.backend.service.port }}
           - path: /
             pathType: Prefix
             backend:

--- a/deploy/kubernetes/charts/cubeplex/values.local.yaml.example
+++ b/deploy/kubernetes/charts/cubeplex/values.local.yaml.example
@@ -102,5 +102,5 @@ rustfs:
 #     image:
 #       tag: "v0.2.0"                        # same release version as backend/frontend
 #     # MUST match opensandbox-server's configured egress.image exactly:
-#     # China mirror: sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:v1.0.12
-#     egressImage: "opensandbox/egress:v1.0.12"
+#     # China mirror: sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:v1.1.4
+#     egressImage: "opensandbox/egress:v1.1.4"

--- a/deploy/kubernetes/charts/cubeplex/values.yaml
+++ b/deploy/kubernetes/charts/cubeplex/values.yaml
@@ -53,6 +53,8 @@ backend:
     api:
       host: "0.0.0.0"
       port: 8000
+      # Also the origin for the sandbox browser/terminal panels: it must be
+      # browser-reachable AND forward WebSocket (panels proxy Neko/ttyd over WS).
       public_url: "http://cubeplex.local"
     deployment:
       mode: single_tenant

--- a/deploy/kubernetes/charts/cubeplex/vendor/opensandbox-server/values.yaml
+++ b/deploy/kubernetes/charts/cubeplex/vendor/opensandbox-server/values.yaml
@@ -28,7 +28,7 @@ server:
   # image names and tags) — applies to server, ingress, execd, and egress below.
   image:
     repository: opensandbox/server
-    tag: "v0.1.14"
+    tag: "v0.2.2"
 
   # -- Server Service configuration
   service:
@@ -67,7 +67,7 @@ server:
       nodePort: ""
     image:
       repository: opensandbox/ingress
-      tag: "v1.0.7"
+      tag: "v1.0.10"
     replicaCount: 2
     port: 28888
     dataplaneNamespace: "opensandbox"
@@ -101,7 +101,7 @@ configToml: |
 
   [runtime]
   type = "kubernetes"
-  execd_image = "opensandbox/execd:v1.0.19"
+  execd_image = "opensandbox/execd:v1.0.21"
 
   [kubernetes]
   kubeconfig_path = ""
@@ -114,5 +114,5 @@ configToml: |
   batchsandbox_template_file = "/etc/opensandbox/example.batchsandbox-template.yaml"
   
   [egress]
-  image = "opensandbox/egress:v1.0.12"
+  image = "opensandbox/egress:v1.1.4"
   mode = "dns+nft"

--- a/deploy/kubernetes/charts/cubeplex/vendor/opensandbox-server/values.yaml
+++ b/deploy/kubernetes/charts/cubeplex/vendor/opensandbox-server/values.yaml
@@ -101,7 +101,7 @@ configToml: |
 
   [runtime]
   type = "kubernetes"
-  execd_image = "opensandbox/execd:v1.0.18"
+  execd_image = "opensandbox/execd:v1.0.19"
 
   [kubernetes]
   kubeconfig_path = ""

--- a/deploy/kubernetes/scripts/e2e.sh
+++ b/deploy/kubernetes/scripts/e2e.sh
@@ -1,114 +1,26 @@
 #!/usr/bin/env bash
-# Live e2e test against a deployed cubeplex. Exercises the auth + chat path:
-# register → singleton-org auto-setup (single_tenant) → create conversation
-# → send message → consume SSE → assert assistant text_delta arrived.
+# Live e2e against a deployed cubeplex, reached through the ingress.
+# Shared logic: deploy/scripts/lib.
 #
 # Usage:
-#   HOST=cubeplex.local IP=192.168.1.101 PORT=30019 deploy/scripts/e2e.sh
+#   HOST=cubeplex.local IP=192.168.1.101 PORT=30019 \
+#     deploy/kubernetes/scripts/e2e.sh
 #
 # Requires `auth.cookie_secure: false` in backend.configOverrides (HTTP only)
 # and a working LLM provider configured under backend.secrets.llm.
 set -euo pipefail
 
+LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../scripts/lib" && pwd)"
+source "$LIB/common.sh"
+source "$LIB/e2e-core.sh"
+
 HOST="${HOST:-cubeplex.local}"
 IP="${IP:-192.168.1.101}"
 PORT="${PORT:-30019}"
-BASE="http://${HOST}:${PORT}"
 PROMPT="${PROMPT:-Say the word \"hello\" and nothing else.}"
 
-unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy 2>/dev/null || true
-export no_proxy='*' NO_PROXY='*'
-
+BASE="http://${HOST}:${PORT}"
 CURL_OPTS=(--noproxy '*' --resolve "${HOST}:${PORT}:${IP}")
-CK=$(mktemp); SSE_OUT=$(mktemp)
-trap 'rm -f "$CK" "$SSE_OUT"' EXIT
 
-EMAIL="e2e-$(date +%s)-$(openssl rand -hex 2)@example.com"
-PASS="correcthorsebatterystaple"
-
-step() { printf '\n==> %s\n' "$*"; }
-fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
-
-step "1. /api/v1/system/info"
-INFO=$(curl -fsS "${CURL_OPTS[@]}" "$BASE/api/v1/system/info")
-echo "  $INFO"
-echo "$INFO" | grep -q '"deployment_mode":"single_tenant"' \
-  || fail "expected single_tenant deployment_mode"
-
-step "2. register $EMAIL"
-REG=$(curl -fsS "${CURL_OPTS[@]}" -c "$CK" -H "Content-Type: application/json" \
-  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASS\"}" \
-  "$BASE/api/v1/auth/register")
-echo "  $REG"
-WS=$(echo "$REG" | python3 -c \
-  'import json,sys; print(json.load(sys.stdin).get("default_workspace_id",""))')
-[[ -n "$WS" ]] || fail "no default_workspace_id from register"
-
-step "3. login (cookie jar)"
-curl -fsS "${CURL_OPTS[@]}" -c "$CK" -b "$CK" \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  --data-urlencode "username=$EMAIL" --data-urlencode "password=$PASS" \
-  --data-urlencode "grant_type=password" \
-  "$BASE/api/v1/auth/login" >/dev/null
-grep -q "cubeplex_auth" "$CK" \
-  || fail "no cubeplex_auth in jar (check backend.configOverrides.auth.cookie_secure=false for HTTP)"
-echo "  ok"
-
-step "4. GET /auth/me — receive csrf cookie (issued only on safe methods)"
-curl -fsS "${CURL_OPTS[@]}" -c "$CK" -b "$CK" "$BASE/api/v1/auth/me" >/dev/null
-grep -q "cubeplex_csrf" "$CK" || fail "no cubeplex_csrf in jar"
-# Cookie jar fields: domain TAB tailmatch TAB path TAB secure TAB expires TAB name TAB value
-CSRF=$(awk -F'\t' '$6=="cubeplex_csrf"{print $7}' "$CK" | tail -1)
-[[ -n "$CSRF" ]] || fail "csrf cookie present but empty"
-echo "  ok"
-
-step "5. create conversation"
-CONV=$(curl -fsS "${CURL_OPTS[@]}" -b "$CK" \
-  -H "Content-Type: application/json" \
-  -H "X-CSRF-Token: $CSRF" \
-  -d '{"title":"e2e probe"}' \
-  "$BASE/api/v1/ws/$WS/conversations")
-CONV_ID=$(echo "$CONV" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
-echo "  conv_id=$CONV_ID"
-
-step "6. POST message → run_id"
-MSG=$(curl -fsS "${CURL_OPTS[@]}" -b "$CK" \
-  -H "Content-Type: application/json" \
-  -H "X-CSRF-Token: $CSRF" \
-  -d "$(python3 -c 'import json,sys; print(json.dumps({"content": sys.argv[1]}))' "$PROMPT")" \
-  "$BASE/api/v1/ws/$WS/conversations/$CONV_ID/messages")
-RUN_ID=$(echo "$MSG" | python3 -c 'import json,sys; print(json.load(sys.stdin)["run_id"])')
-echo "  run_id=$RUN_ID"
-
-step "7. stream SSE — extract assistant text + usage"
-curl -sN "${CURL_OPTS[@]}" -b "$CK" \
-  -H "Accept: text/event-stream" \
-  "$BASE/api/v1/ws/$WS/conversations/$CONV_ID/runs/$RUN_ID/stream" \
-  --max-time 120 > "$SSE_OUT" || true
-EVENTS=$(grep -c '^data: ' "$SSE_OUT" || true)
-echo "  event types: $(grep -oE '"type":[[:space:]]*"[^"]+"' "$SSE_OUT" | sort -u | tr '\n' ' ')"
-echo "  data lines: $EVENTS"
-[[ "$EVENTS" -gt 0 ]] || fail "no SSE data lines"
-
-TEXT=$(python3 - "$SSE_OUT" <<'PY'
-import json, sys
-text = ""
-for line in open(sys.argv[1]):
-    if not line.startswith("data: "):
-        continue
-    try:
-        obj = json.loads(line[6:])
-    except Exception:
-        continue
-    if obj.get("type") == "text_delta":
-        text += obj.get("data", {}).get("content", "")
-print(text, end="")
-PY
-)
-echo "  ASSISTANT_TEXT: ${TEXT}"
-[[ -n "${TEXT// }" ]] || fail "no text_delta content from LLM"
-
-echo
-echo "==================================================="
-echo "E2E PASSED — LLM round-trip complete."
-echo "==================================================="
+disable_proxies
+run_e2e

--- a/deploy/kubernetes/scripts/smoke-test.sh
+++ b/deploy/kubernetes/scripts/smoke-test.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
 # Post-install smoke test for cubeplex.
 # Verifies the deployment is correct: rollout, health probes, ingress,
-# Next.js render. Does NOT exercise LLM / sandbox runtime — those have
-# their own test suites.
+# Next.js render. Does NOT exercise LLM / sandbox runtime — that is e2e.sh.
+# Shared HTTP probes: deploy/scripts/lib/http-probes.sh.
 #
 # Usage:
-#   HOST=cubeplex.local NAMESPACE=cubeplex deploy/scripts/smoke-test.sh
+#   HOST=cubeplex.local NAMESPACE=cubeplex INGRESS_IP=<node IP> \
+#     deploy/kubernetes/scripts/smoke-test.sh
 #
 # When HOST is *.local the script expects /etc/hosts to point it at the
-# ingress LB IP. From inside the cluster node we curl ingress-nginx
-# directly with a Host header, no /etc/hosts dance needed.
+# ingress LB IP. --resolve pins it regardless, so no /etc/hosts dance is
+# needed from inside the cluster node.
 set -euo pipefail
+
+LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../scripts/lib" && pwd)"
+source "$LIB/common.sh"
+source "$LIB/http-probes.sh"
 
 NAMESPACE="${NAMESPACE:-cubeplex}"
 RELEASE="${RELEASE:-cubeplex}"
@@ -18,8 +23,12 @@ HOST="${HOST:-cubeplex.local}"
 INGRESS_IP="${INGRESS_IP:-192.168.1.101}"
 INGRESS_PORT="${INGRESS_PORT:-30019}"
 
-step() { echo; echo "==> $*"; }
-fail() { echo "FAIL: $*" >&2; exit 1; }
+# One ingress fronts both services, so the two origins are the same host.
+BACKEND_BASE="http://$HOST:$INGRESS_PORT"
+FRONTEND_BASE="http://$HOST:$INGRESS_PORT"
+CURL_OPTS=(--noproxy '*' --resolve "$HOST:$INGRESS_PORT:$INGRESS_IP")
+
+disable_proxies
 
 step "1. Rollouts"
 kubectl -n "$NAMESPACE" rollout status \
@@ -49,27 +58,18 @@ if [[ -n "$job" ]]; then
 fi
 
 step "4. Backend /health/live via ingress"
-curl -fsS --resolve "$HOST:$INGRESS_PORT:$INGRESS_IP" "http://$HOST:$INGRESS_PORT/health/live" \
-  | tee /tmp/cubeplex-live.json
-grep -q '"status":"ok"' /tmp/cubeplex-live.json \
-  || fail "live probe response unexpected"
+probe_backend_health
 
-step "5. Frontend root page renders"
-body=$(curl -fsS --resolve "$HOST:$INGRESS_PORT:$INGRESS_IP" "http://$HOST:$INGRESS_PORT/")
-echo "$body" | head -c 200
-echo
-echo "$body" | grep -qiE "<title>|<html" \
-  || fail "frontend root did not return HTML"
+step "5. Backend /api/v1/system/info via ingress"
+probe_system_info
 
-step "6. Backend API reachable through /api"
-code=$(curl -s -o /dev/null -w '%{http_code}' \
-  --resolve "$HOST:$INGRESS_PORT:$INGRESS_IP" \
-  "http://$HOST:$INGRESS_PORT/api/v1/system/status" || true)
-echo "  /api/v1/system/status → HTTP $code"
-[[ "$code" =~ ^(200|401|403|404)$ ]] \
-  || fail "backend /api unreachable (got $code)"
+step "6. Frontend root page renders"
+probe_frontend_root
 
-step "7. Summary"
+step "7. Backend API reachable through /api"
+probe_api_via_frontend
+
+step "8. Summary"
 kubectl -n "$NAMESPACE" get pods,svc,ingress
 echo
 echo "SMOKE TEST PASSED."

--- a/deploy/scripts/lib/common.sh
+++ b/deploy/scripts/lib/common.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Shared helpers for the deploy verification scripts. Sourced, never executed.
+#
+# The platform entry points (deploy/docker-compose/scripts/*.sh and
+# deploy/kubernetes/scripts/*.sh) decide *how to reach* the deployment — a
+# published host port for compose, an ingress plus --resolve for kubernetes —
+# and then source the shared pieces, which only see BASE / CURL_OPTS.
+
+step() { printf '\n==> %s\n' "$*"; }
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+# A corporate proxy breaks both the published-port and the --resolve path; the
+# deployment is always reachable directly from wherever these scripts run.
+disable_proxies() {
+  unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy 2>/dev/null || true
+  export no_proxy='*' NO_PROXY='*'
+}

--- a/deploy/scripts/lib/e2e-core.sh
+++ b/deploy/scripts/lib/e2e-core.sh
@@ -28,7 +28,10 @@ run_e2e() {
   local email pass info reg ws csrf slug conv conv_id msg run_id events text
 
   email="e2e-$(date +%s)-$(openssl rand -hex 2)@example.com"
-  pass="correcthorsebatterystaple"
+  # Must satisfy the strictest built-in password policy ("high": upper + lower
+  # + digit + symbol). A plain lowercase passphrase fails register with 400
+  # weak_password on a default deployment.
+  pass="CorrectHorseBatteryStaple7!"
 
   step "1. /api/v1/system/info"
   info=$(curl -fsS "${CURL_OPTS[@]}" "$BASE/api/v1/system/info")

--- a/deploy/scripts/lib/e2e-core.sh
+++ b/deploy/scripts/lib/e2e-core.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Live e2e against a deployed cubeplex, shared by the compose and kubernetes
+# entry points. Sourced, never executed. Requires common.sh first.
+#
+# Exercises the auth + chat path: register → resolve workspace → create
+# conversation → send message → consume SSE → assert assistant text arrived.
+#
+# Caller must set:
+#   BASE       origin the API is reachable on
+#   CURL_OPTS  array of curl flags that make BASE reachable
+#   PROMPT     message to send to the agent
+
+_E2E_CK=""
+_E2E_SSE=""
+_e2e_cleanup() { rm -f "$_E2E_CK" "$_E2E_SSE"; }
+
+# Extract a top-level string field from a JSON body on stdin. Missing key
+# yields an empty string rather than a traceback — callers branch on that.
+_json_get() {
+  python3 -c 'import json,sys; print(json.load(sys.stdin).get(sys.argv[1], ""))' "$1"
+}
+
+run_e2e() {
+  _E2E_CK=$(mktemp)
+  _E2E_SSE=$(mktemp)
+  trap _e2e_cleanup EXIT
+
+  local email pass info reg ws csrf slug conv conv_id msg run_id events text
+
+  email="e2e-$(date +%s)-$(openssl rand -hex 2)@example.com"
+  pass="correcthorsebatterystaple"
+
+  step "1. /api/v1/system/info"
+  info=$(curl -fsS "${CURL_OPTS[@]}" "$BASE/api/v1/system/info")
+  echo "  $info"
+  grep -q '"deployment_mode":"single_tenant"' <<<"$info" \
+    || fail "expected single_tenant deployment_mode"
+
+  step "2. register $email"
+  reg=$(curl -fsS "${CURL_OPTS[@]}" -c "$_E2E_CK" -H "Content-Type: application/json" \
+    -d "$(python3 -c 'import json,sys; print(json.dumps({"email": sys.argv[1], "password": sys.argv[2]}))' "$email" "$pass")" \
+    "$BASE/api/v1/auth/register")
+  echo "  $reg"
+  # Empty on the very first user of a fresh single_tenant deployment: that one
+  # lands in pending-owner state with no org yet and must run onboarding
+  # (step 5). Every later user is attached to the singleton org at register
+  # time and gets a workspace straight away.
+  ws=$(_json_get default_workspace_id <<<"$reg")
+
+  step "3. login (cookie jar)"
+  curl -fsS "${CURL_OPTS[@]}" -c "$_E2E_CK" -b "$_E2E_CK" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "username=$email" --data-urlencode "password=$pass" \
+    --data-urlencode "grant_type=password" \
+    "$BASE/api/v1/auth/login" >/dev/null
+  grep -q "cubeplex_auth" "$_E2E_CK" \
+    || fail "no cubeplex_auth in jar (needs auth.cookie_secure=false over plain HTTP)"
+  echo "  ok"
+
+  step "4. GET /auth/me — receive csrf cookie (issued only on safe methods)"
+  curl -fsS "${CURL_OPTS[@]}" -c "$_E2E_CK" -b "$_E2E_CK" "$BASE/api/v1/auth/me" >/dev/null
+  grep -q "cubeplex_csrf" "$_E2E_CK" || fail "no cubeplex_csrf in jar"
+  # Cookie jar fields: domain TAB tailmatch TAB path TAB secure TAB expires TAB name TAB value
+  csrf=$(awk -F'\t' '$6=="cubeplex_csrf"{print $7}' "$_E2E_CK" | tail -1)
+  [[ -n "$csrf" ]] || fail "csrf cookie present but empty"
+  echo "  ok"
+
+  step "5. resolve workspace"
+  if [[ -n "$ws" ]]; then
+    echo "  from register: $ws"
+  else
+    slug="e2e-$(openssl rand -hex 4)"
+    echo "  first user on this deployment — running onboarding (org slug $slug)"
+    ws=$(curl -fsS "${CURL_OPTS[@]}" -b "$_E2E_CK" \
+      -H "Content-Type: application/json" \
+      -H "X-CSRF-Token: $csrf" \
+      -d "$(python3 -c 'import json,sys; print(json.dumps({"org_name": "E2E Probe", "org_slug": sys.argv[1], "workspace_name": "Personal"}))' "$slug")" \
+      "$BASE/api/v1/onboarding" | _json_get workspace_id)
+    [[ -n "$ws" ]] || fail "onboarding returned no workspace_id"
+    echo "  from onboarding: $ws"
+  fi
+
+  step "6. create conversation"
+  conv=$(curl -fsS "${CURL_OPTS[@]}" -b "$_E2E_CK" \
+    -H "Content-Type: application/json" \
+    -H "X-CSRF-Token: $csrf" \
+    -d '{"title":"e2e probe"}' \
+    "$BASE/api/v1/ws/$ws/conversations")
+  conv_id=$(_json_get id <<<"$conv")
+  [[ -n "$conv_id" ]] || fail "no conversation id: $conv"
+  echo "  conv_id=$conv_id"
+
+  step "7. POST message → run_id"
+  msg=$(curl -fsS "${CURL_OPTS[@]}" -b "$_E2E_CK" \
+    -H "Content-Type: application/json" \
+    -H "X-CSRF-Token: $csrf" \
+    -d "$(python3 -c 'import json,sys; print(json.dumps({"content": sys.argv[1]}))' "$PROMPT")" \
+    "$BASE/api/v1/ws/$ws/conversations/$conv_id/messages")
+  run_id=$(_json_get run_id <<<"$msg")
+  [[ -n "$run_id" ]] || fail "no run_id: $msg"
+  echo "  run_id=$run_id"
+
+  step "8. stream SSE — extract assistant text"
+  curl -sN "${CURL_OPTS[@]}" -b "$_E2E_CK" \
+    -H "Accept: text/event-stream" \
+    "$BASE/api/v1/ws/$ws/conversations/$conv_id/runs/$run_id/stream" \
+    --max-time 120 > "$_E2E_SSE" || true
+  events=$(grep -c '^data: ' "$_E2E_SSE" || true)
+  echo "  event types: $(grep -oE '"type":[[:space:]]*"[^"]+"' "$_E2E_SSE" | sort -u | tr '\n' ' ')"
+  echo "  data lines: $events"
+  [[ "$events" -gt 0 ]] || fail "no SSE data lines"
+
+  text=$(python3 - "$_E2E_SSE" <<'PY'
+import json, sys
+text = ""
+for line in open(sys.argv[1]):
+    if not line.startswith("data: "):
+        continue
+    try:
+        obj = json.loads(line[6:])
+    except Exception:
+        continue
+    if obj.get("type") == "text_delta":
+        text += obj.get("data", {}).get("content", "")
+print(text, end="")
+PY
+)
+  echo "  ASSISTANT_TEXT: ${text}"
+  [[ -n "${text// }" ]] || fail "no text_delta content from LLM"
+
+  echo
+  echo "==================================================="
+  echo "E2E PASSED — LLM round-trip complete."
+  echo "==================================================="
+}

--- a/deploy/scripts/lib/http-probes.sh
+++ b/deploy/scripts/lib/http-probes.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# HTTP-level smoke probes, shared by the compose and kubernetes smoke tests.
+# Sourced, never executed. Requires common.sh to be sourced first.
+#
+# Caller must set:
+#   CURL_OPTS      array of curl flags that make the deployment reachable
+#   BACKEND_BASE   origin serving the backend directly
+#   FRONTEND_BASE  origin serving the Next.js app
+#
+# On compose those two origins are different published ports; behind an
+# ingress they are the same host. Both cases work because every probe names
+# the origin it needs.
+
+probe_backend_health() {
+  local body
+  body=$(curl -fsS "${CURL_OPTS[@]}" "$BACKEND_BASE/health/live") \
+    || fail "backend /health/live unreachable"
+  echo "  $body"
+  grep -q '"status":"ok"' <<<"$body" || fail "unexpected /health/live response"
+}
+
+probe_system_info() {
+  local body
+  body=$(curl -fsS "${CURL_OPTS[@]}" "$BACKEND_BASE/api/v1/system/info") \
+    || fail "backend /api/v1/system/info unreachable"
+  echo "  $body"
+  grep -q '"deployment_mode"' <<<"$body" || fail "unexpected /system/info response"
+}
+
+probe_frontend_root() {
+  local body
+  body=$(curl -fsS "${CURL_OPTS[@]}" "$FRONTEND_BASE/") || fail "frontend root unreachable"
+  echo "  $(head -c 200 <<<"$body")..."
+  grep -qiE '<html|<!doctype' <<<"$body" || fail "frontend root did not return HTML"
+}
+
+# The frontend origin must proxy /api to the backend — a Next.js rewrite on
+# compose, an ingress path rule on kubernetes. /system/info is public, so
+# anything other than 200 means the proxy hop is broken.
+probe_api_via_frontend() {
+  local code
+  code=$(curl -s -o /dev/null -w '%{http_code}' "${CURL_OPTS[@]}" \
+    "$FRONTEND_BASE/api/v1/system/info" || true)
+  echo "  /api/v1/system/info via frontend origin → HTTP $code"
+  [[ "$code" == "200" ]] || fail "frontend → backend proxy broken (got $code)"
+}

--- a/docs/dev/notes/2026-07-24-kata-sandbox-vm-isolation.md
+++ b/docs/dev/notes/2026-07-24-kata-sandbox-vm-isolation.md
@@ -1,0 +1,197 @@
+# Running cubeplex sandboxes as Kata VMs — investigation & working setup
+
+**Date:** 2026-07-23 / 2026-07-24
+**Task:** Find out whether cubeplex's per-conversation OpenSandbox pods can run under
+[Kata Containers](https://katacontainers.io/) (hardware-VM isolation instead of a shared-kernel
+container), and get an agent to prove it from inside the sandbox.
+**Status:** ✅ Working end-to-end on a self-managed kubeadm + containerd cluster. ❌ Not possible
+on OCI OKE managed nodes (their CRI-O build has a blocking bug). Root cause of every failure along
+the way is identified below.
+
+## TL;DR
+
+- **Kata + cubeplex sandboxes works** — but only on **containerd**, not on OKE's **CRI-O**.
+- The one non-obvious config you must set: `privileged_without_host_devices = true` on the
+  containerd Kata runtime. Without it, OpenSandbox's privileged sandbox pods die with
+  `Creating container device /dev/full … EEXIST: File exists`.
+- Proof it's a real VM: an agent ran `uname -a` in its sandbox and got kernel **6.18.35** (Kata's
+  guest kernel) while the host node runs **6.17.0-1018-oracle**. Different kernels ⇒ VM, not a
+  shared-kernel container. A matching `qemu-system-x86_64` process runs on the host.
+
+## Why this needs a VM in the first place
+
+Kata runs each pod inside a lightweight VM (QEMU or Firecracker) with its own guest kernel, so a
+sandboxed agent that breaks out of the container still only lands in a throwaway VM, not on the
+host kernel shared with every other tenant. For an agent platform that executes untrusted
+model-generated shell commands, that is the isolation boundary worth having.
+
+Kata is selected per-pod via a Kubernetes `RuntimeClass` (`runtimeClassName: kata-qemu`). The
+underlying container runtime (containerd or CRI-O) must have a matching runtime handler wired up.
+
+## Finding 1 — OKE managed nodes (CRI-O) cannot run Kata: blocking rootfs bug
+
+OKE managed node pools ship **CRI-O** (`1.36.0-16.81af8589483.el9`, Oracle's build). `oci ce
+node-pool create` has **no** option to pick containerd — CRI-O is fixed. Kata itself installs fine
+(static release under `/opt/kata`, hardware is capable: `/dev/kvm` present, AMD `svm` flag on
+`VM.Standard.E5.Flex`, Oracle Linux 9.7 + UEK kernel), and the QEMU VM genuinely boots. But
+**container creation inside the VM fails** — CRI-O never hands the container rootfs to the Kata
+shim:
+
+```
+# kata-qemu:
+createContainer failed … the file /bin/sh was not found
+# the CRI-O-side share dir is empty:
+/run/kata-containers/shared/sandboxes/<id>/mounts/<cid>/rootfs   # ← empty
+
+# kata-fc (Firecracker), same root cause, fails one step earlier:
+failed to mount /run/kata-containers/shared/containers/<id>/rootfs … ENOENT
+```
+
+Confirmed **not** our config and **not** a Kata-version issue:
+
+- Reproduced on Kata **4.0.0** and **3.32.0** (downgrade didn't help).
+- QEMU and Firecracker VMMs both fail — same rootfs-handoff step, so it's above the VMM layer.
+- Our CRI-O runtime block matches Kata's official CRI-O guide verbatim
+  (`runtime_type = "vm"`, `runtime_root = "/run/vc"`, `privileged_without_host_devices = true`).
+- Tried the common `metacopy=on` → `off` overlay-storage workaround (kata-containers/runtime#1429):
+  no change, even on a brand-new node whose CRI-O never cached an image under the old setting.
+
+The gap is in CRI-O `runtime_type = "vm"` rootfs handoff in this specific Oracle CRI-O build.
+Most Kata users run containerd or upstream CRI-O; the OKE-packaged combo is rarely exercised, which
+is why there's no ready-made issue for it. Not fixable from chart/config side. (Aside: Oracle's
+*other* product, OLCNE, officially supports Kata+CRI-O — but that's a different, self-managed
+distro with a different CRI-O than OKE ships.)
+
+**Also worth recording:** OCI **A1 (Ampere/ARM) shapes do not expose nested virtualization** —
+`/dev/kvm` is absent, so Kata can't run there regardless of runtime. Use an x86 shape
+(`VM.Standard.E5.Flex` worked; it's AMD, and nested virt *is* available despite some docs implying
+AMD can't — verified `/dev/kvm` + `svm` present).
+
+## Finding 2 — Self-managed kubeadm + containerd: Kata works
+
+Provisioned a standalone `VM.Standard.E5.Flex` (8 vCPU / 32 GB, Ubuntu 24.04, x86) and built a
+single-node cluster from scratch: **kubeadm 1.31.14 + containerd 2.2.6 + Flannel**. Basic Kata
+pods came up immediately, **no** rootfs bug — same Kata static release that failed under CRI-O.
+
+Proof it's a VM (not a container): a plain `kata-qemu` pod reports guest kernel `6.18.35` while the
+host is `6.17.0-1018-oracle`.
+
+### Setup steps that mattered
+
+1. **containerd from Docker's repo** (v2.2.6), `containerd config default`, then
+   `SystemdCgroup = true`.
+2. **Kata static release** `/opt/kata` (4.0.0 first, later 3.32.0 — see Finding 3), symlink
+   `/opt/kata/bin/containerd-shim-kata-v2` onto `PATH`.
+3. Register Kata runtime handlers in `/etc/containerd/config.toml` (containerd v2 CRI plugin path
+   is `io.containerd.cri.v1.runtime`):
+
+   ```toml
+   [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.kata-qemu]
+     runtime_type = 'io.containerd.kata.v2'
+     privileged_without_host_devices = true      # ← REQUIRED, see Finding 3
+     sandboxer = 'podsandbox'                     # NOT 'shim' — see gotcha below
+     [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.kata-qemu.options]
+       ConfigPath = '/opt/kata/share/defaults/kata-containers/configuration-qemu.toml'
+   ```
+
+4. `kubectl apply` the matching `RuntimeClass` objects (`handler: kata-qemu` / `kata-fc`).
+
+**Gotcha — `sandboxer`:** the first attempt used `sandboxer = 'shim'` and every sandbox failed
+with `open /run/containerd/io.containerd.sandbox.controller.v1.shim/.../config.json: no such file`.
+Switching to `sandboxer = 'podsandbox'` fixed it. (The newer shim-mode sandbox API isn't what the
+Kata v2 shim expects here.)
+
+### Cluster-networking fixes unrelated to Kata (but needed for cubeplex to run)
+
+The base Ubuntu image had a leftover OS firewall: a blanket `REJECT … icmp-host-prohibited` rule
+sitting at the **end of both the `INPUT` and `FORWARD` iptables chains**, *after* the k8s/Flannel
+rules. It silently dropped pod-to-service traffic — CoreDNS stayed `0/1` looping on
+`dial tcp 10.96.0.1:443: connect: no route to host`, and any pod→ClusterIP call (incl. the
+apiserver) failed. Deleting both REJECT rules fixed cluster DNS and service routing immediately.
+
+Storage: no cloud CSI on a self-managed box, so installed **OpenEBS** (`openebs-localpv-provisioner`)
+and pointed the chart at the hostpath StorageClass (`storageClass.create: true`,
+`basePath: /work/cubeplex`), marked default. Disabled ingress (`ingress.enabled: false`) and
+reached the backend via `kubectl port-forward`.
+
+## Finding 3 — the real blocker for OpenSandbox pods: privileged + `/dev/full` EEXIST
+
+With Kata working for ordinary pods, the actual per-conversation sandbox pods still failed:
+
+```
+Init:StartError …
+Creating container device LinuxDevice { path: "/dev/full", typ: C, major: 1, minor: 7 }
+Caused by: EEXIST: File exists
+```
+
+Isolated the trigger with two controlled pods (this is the key experiment):
+
+| test pod | result |
+|---|---|
+| **privileged**, single container, kata-qemu | ❌ `RunContainerError` — same `/dev/full` EEXIST |
+| **non-privileged**, init + main (2 containers), kata-qemu | ✅ `Running` (guest kernel 6.18.35) |
+
+So the trigger is **`privileged: true`**, *not* the multi-container structure (my earlier guess).
+OpenSandbox's sandbox pods run privileged (the egress side does `nft`/network setup).
+
+**Mechanism** (confirmed via kata-containers/kata-containers#10365 comments): in privileged mode
+Kata passes **every** host `/dev/*` device through into the guest VM. `/dev/full` is one of them —
+but `/dev/full` is *also* in the OCI **default** device set that every container always gets. The
+guest's kata-agent then `mknod`s `/dev/full` twice → `EEXIST`.
+
+**Fix:** set `privileged_without_host_devices = true` on the containerd Kata runtime (shown in
+Finding 2's config). This keeps the privileged *capabilities* but stops the blanket host-device
+passthrough, so the standard `/dev/full` is created exactly once. Upstream, the equivalent knob is
+`--security-opt privileged-without-host-devices` (docker/nerdctl).
+
+> This one line is easy to miss: it had been set for the **CRI-O** Kata runtime during the OKE
+> attempt, but was **absent** from the **containerd** runtime block. Same option, different runtime.
+
+After adding it + `systemctl restart containerd`, the privileged test pod ran immediately, and the
+real OpenSandbox sandbox pod progressed through all init containers
+(`execd-installer` → `egress-mitm-confdir` → `egress-ca-trust` → main sandbox image) to
+`2/2 Running`, BatchSandbox `READY=1`.
+
+**Separate note — Kata 4.0.0 vs 3.32.0:** 4.0.0 *also* hit `/dev/full` EEXIST here; I first tried a
+downgrade to 3.32.0 before finding the config fix. The config fix is what actually resolves it, so
+version choice is not the deciding factor for this bug. (3.32.0 is what's currently installed.)
+
+## End-to-end verification (the thing we were actually after)
+
+Sent a message via the arkplan model asking the agent to run `uname -a` in its sandbox. The agent
+invoked its `execute` shell tool and returned:
+
+```
+# host (physical OCI node):
+Linux kubeadm-kata-experiment 6.17.0-1018-oracle #18~24.04.1-Ubuntu … x86_64 GNU/Linux
+
+# what the AGENT read from inside its sandbox:
+Linux 521bd4bd-…-0 6.18.35 #1 SMP Mon Jun 15 12:55:58 UTC 2026 x86_64 GNU/Linux
+```
+
+Different kernel version ⇒ the agent's sandbox is a **VM**, not a shared-kernel container. Backing
+evidence: sandbox pod `runtimeClassName: kata-qemu`, `2/2 Running`; a `qemu-system-x86_64` VM
+process running on the host. Full chain verified: **cubeplex agent → OpenSandbox → Kata QEMU VM**.
+
+## Recommendations
+
+- **To run cubeplex sandboxes with VM isolation:** use a **containerd**-based cluster, not OKE
+  managed nodes. If OKE is required, its CRI-O `runtime_type=vm` rootfs bug is the blocker to raise
+  with Oracle (or use self-managed OL nodes / OLCNE).
+- **Always** set `privileged_without_host_devices = true` on the Kata runtime — OpenSandbox pods are
+  privileged and will otherwise fail on `/dev/full`.
+- Host must be **x86 with nested virt** (`/dev/kvm` + `vmx`/`svm`). OCI A1/ARM shapes won't work.
+- Chart side needs nothing special for Kata beyond pointing OpenSandbox's BatchSandbox pod template
+  at the RuntimeClass — done here by mounting a ConfigMap over
+  `/etc/opensandbox/example.batchsandbox-template.yaml` with `spec.template.spec.runtimeClassName:
+  kata-qemu`, via `opensandbox.opensandbox-server.server.volumes/volumeMounts` in values.local.yaml.
+
+## Environment reference
+
+- **Experiment host:** OCI `VM.Standard.E5.Flex`, 8 vCPU / 32 GB, Ubuntu 24.04, x86 (AMD EPYC),
+  region `us-phoenix-1`. Kept running for follow-up. SSH alias `kata-kubeadm`.
+- **Cluster:** kubeadm 1.31.14, containerd 2.2.6, Flannel, single node (control-plane untainted),
+  OpenEBS hostpath storage.
+- **Kata:** static release, currently 3.32.0, `/opt/kata`, runtimes `kata-qemu` + `kata-fc`.
+- **cubeplex:** chart 0.3.0, images `ghcr.io/cubeplexai/cubeplex-{backend,frontend,sandbox}:v0.3.0`,
+  egress enabled (EC certs via `gen-egress-certs.sh`), model `arkplan` (Volcengine Ark Agent Plan).

--- a/docs/dev/plans/2026-07-26-sandbox-panel-proxy.md
+++ b/docs/dev/plans/2026-07-26-sandbox-panel-proxy.md
@@ -1,0 +1,127 @@
+# Plan — sandbox panel proxy
+
+**Spec:** [specs/2026-07-26-sandbox-panel-proxy-design.md](../specs/2026-07-26-sandbox-panel-proxy-design.md)
+**Branch:** `fix/2026-07-23-deploy-script-dedup`
+
+**Goal:** one token-authenticated HTTP+WS reverse proxy in the cubeplex backend
+that serves the sandbox browser/terminal panels in both docker and k8s, replacing
+the k8s-only OpenSandbox ingress-gateway.
+
+**Architecture:** the panel URL embeds a short-lived HS256 JWT in its **path**
+(`{api.public_url}/sandbox-panel/{token}/…`) so every relative asset + WS request
+carries the credential. A public backend route verifies the token and reverse-
+proxies to the cluster-internal `opensandbox-server/sandboxes/{id}/proxy/{port}`
+(HTTP via httpx, WS via the `websockets` lib). Endpoint methods mint the URL;
+nothing downstream (opensandbox-server) trusts anything but the network boundary.
+
+**Tech stack:** FastAPI/Starlette (first backend WebSocket route), `httpx` and
+`websockets` (both already direct deps), PyJWT (already used by `im/link.py`).
+
+---
+
+## Unit 1 — panel token sign/verify
+
+- **Files:** `backend/cubeplex/sandbox/panel_token.py` (new). Mirror
+  `cubeplex/im/link.py`.
+- **Interfaces:**
+  - `sign_panel_token(*, sandbox_id: str, port: int, secret: str, ttl: timedelta) -> str`
+  - `verify_panel_token(token: str, *, secret: str) -> PanelClaims`
+    where `PanelClaims` is a frozen dataclass `{sandbox_id: str, port: int}`.
+  - `get_panel_base_url() -> str` (reads `api.public_url`, rstrip `/`)
+    and reuse `get_jwt_secret()` (lift the one in `im/link.py` or import it).
+- **Core logic:** HS256, `iss="cubeplex:sandbox-panel"`, claims `sid`/`port`/
+  `exp`/`iat`. `verify` decodes with issuer check; any `PyJWTError` → `ValueError`.
+  `port` is coerced back to `int`.
+- **Tests** (`backend/tests/unit/test_panel_token.py`): roundtrip; expired token
+  rejected; wrong-secret rejected; wrong-issuer rejected; tampered payload
+  rejected; `port` type preserved. Pure, in-process → **unit**.
+
+## Unit 2 — reverse-proxy route (HTTP + WebSocket)
+
+- **Files:** `backend/cubeplex/api/routes/sandbox_panel.py` (new, router with **no**
+  `/api/v1` prefix); mount in `backend/cubeplex/api/app.py` at root
+  (`app.include_router(sandbox_panel.router)`).
+- **Interfaces / routes:**
+  - `@router.api_route("/sandbox-panel/{token}/{full_path:path}", methods=[...])`
+    and a root variant `"/sandbox-panel/{token}/"`.
+  - `@router.websocket("/sandbox-panel/{token}/{full_path:path}")` (+ root).
+  - Forward target: `{sandbox.domain}/sandboxes/{sid}/proxy/{port}/{full_path}`,
+    query string preserved; ws/http scheme chosen per handler.
+- **Core logic:**
+  - Verify token first (both handlers). HTTP invalid → `403`; WS invalid → accept
+    then close with a policy-violation code (can't send a 403 body pre-accept).
+  - **HTTP:** `httpx.AsyncClient.stream` with the incoming method/body/filtered
+    headers (drop hop-by-hop: connection, keep-alive, transfer-encoding, upgrade,
+    te, trailer, proxy-*). Relay upstream status + filtered headers + streamed
+    body. Upstream connect failure → `502`.
+  - **WS:** `await ws.accept()`, open upstream `websockets.connect(ws_url,
+    subprotocols=…)`, run two tasks relaying `str`/`bytes` frames each way; on
+    either close/`WebSocketDisconnect`, cancel the other and close both. Model on
+    opensandbox `proxy.py` `_relay_client_messages` / `_relay_backend_messages`.
+  - Internal opensandbox-server needs no api_key (proxy route is open) — do not
+    attach one.
+- **Tests** (`backend/tests/e2e/test_sandbox_panel_proxy.py`): stand up a tiny
+  in-test upstream ASGI app (an HTTP echo + a WS echo) bound to a local port; set
+  `sandbox.domain` to it. Assert: valid token proxies HTTP body through; valid
+  token proxies a WS echo round-trip; **bad/expired token → 403 (HTTP) / close
+  (WS)**; upstream-down → 502. Touches the FastAPI app + a real socket → **e2e**.
+
+## Unit 3 — endpoint methods build the panel URL
+
+- **Files:** `backend/cubeplex/sandbox/opensandbox.py`.
+- **Change:** `get_browser_endpoint` / `get_terminal_endpoint` stop calling
+  `self._sandbox.get_signed_endpoint(...)`. They mint a token for
+  `(self._sandbox.id, PORT, exp)` and return
+  `BrowserEndpoint(url=f"{base}/sandbox-panel/{token}/", headers={})`, where `base`
+  = `get_panel_base_url()`. If `base` is empty → raise `SandboxError` (surfaces as
+  the existing 501/503 path). Keep the trailing-slash + `_NEKO_URL_PARAMS`-compat
+  behavior (params still appended by `ws_browser.py`).
+  Remove the now-dead `_BROWSER_IRRELEVANT_HEADERS` handling only if fully orphaned.
+- **Interfaces:** unchanged (`BrowserEndpoint`), so `ws_browser.py` /
+  `ws_sandbox.py` are untouched; their `endpoint.headers` guards still hold
+  (headers now always empty).
+- **Tests** (`backend/tests/unit/test_opensandbox_endpoints.py`): a fake SDK
+  sandbox with a known `id`; assert the returned URL matches
+  `{base}/sandbox-panel/<jwt>/` and that `verify_panel_token` on the embedded JWT
+  yields the right `sandbox_id`/`port`. Pure → **unit**.
+
+## Unit 4 — config + deployment unification
+
+- **Files:**
+  - `deploy/kubernetes/charts/cubeplex/vendor/opensandbox-server/values.yaml`:
+    `gateway.enabled: false` (default); note the OSEP-0011 keys are now optional.
+  - `deploy/kubernetes/charts/cubeplex/values.local.yaml.example` +
+    `deploy/docker-compose/config/config.production.local.yaml.example`: ensure
+    `api.public_url` is documented as the panel base and `sandbox.secure_access:
+    false`.
+- **Core logic:** no signed gateway ⇒ `secure_access` stays false; panels flow
+  through the backend. Keep `opensandbox-server` service internal (ClusterIP /
+  docker network) — do **not** add a public gateway host.
+- **Tests:** none (config); covered by the live verification below.
+
+## Unit 5 — docs (ship with the code)
+
+- **Files:** `docs/site/docs/deployment/docker-compose.md` (+ zh-Hans) capability
+  matrix: browser/terminal **Yes** (was "Broken (signed routes k8s-only, 503)");
+  `docs/site/docs/deployment/kubernetes.md` (+ zh-Hans): panels go through the
+  backend proxy, the ingress-gateway is no longer required. Note `api.public_url`
+  must be set (and be WS-reachable) for panels.
+- No version internals in user docs (per prior guidance).
+
+## Verification (before PR)
+
+1. Backend: `uv run pytest tests/unit/test_panel_token.py
+   tests/unit/test_opensandbox_endpoints.py tests/e2e/test_sandbox_panel_proxy.py`.
+2. Live: on a real deployment, open the browser + terminal panels and confirm the
+   Neko view and ttyd shell render (not 503); confirm a tampered token → 403.
+   (Server-proxy HTTP+WS reachability to the Pod is already measured — see spec.)
+
+## Notes / risks
+
+- **First backend WebSocket route.** Confirm the ASGI server serves WS (uvicorn +
+  `websockets`, already a dep) and that no middleware assumes HTTP-only. Health-
+  check the WS path in the e2e.
+- **Token TTL vs long panel sessions.** TTL 1h + the existing `/keepalive`. If a
+  WS outlives the token it drops and the frontend re-opens (re-mints). Bump TTL if
+  this bites in practice.
+- **Backend carries panel streaming** in both modes now (the accepted trade-off).

--- a/docs/dev/specs/2026-07-26-sandbox-panel-proxy-design.md
+++ b/docs/dev/specs/2026-07-26-sandbox-panel-proxy-design.md
@@ -1,0 +1,162 @@
+# Sandbox panel proxy — unified live-view/terminal gateway
+
+**Status:** design · 2026-07-26
+**Branch:** `fix/2026-07-23-deploy-script-dedup`
+
+## Goal
+
+Make the sandbox **browser (Neko) and terminal (ttyd) panels work in both docker
+and Kubernetes deployments** by routing panel traffic through one authenticated
+reverse proxy inside the cubeplex backend, instead of the k8s-only OpenSandbox
+ingress-gateway.
+
+## Context — why this is changing
+
+Today the endpoint methods in `backend/cubeplex/sandbox/opensandbox.py`
+(`get_browser_endpoint`, `get_terminal_endpoint`) **unconditionally** call the
+OpenSandbox SDK's `get_signed_endpoint(...)`, which returns an OSEP-0011 signed
+URL pointing at the OpenSandbox **ingress-gateway**. That gateway only exists in
+the Kubernetes runtime. In docker-compose there is no gateway, so both panels
+return **503**. The route comment at `ws_browser.py` already flags the gap:
+*"same-origin proxy not yet implemented"*.
+
+The panel URL is handed straight to the frontend and loaded in an **iframe by the
+user's remote browser** (`ws_browser.py`, `ws_sandbox.py`). So the URL must be:
+
+1. **reachable from the user's browser** — not a docker-internal name, and
+2. **authenticated without request headers** — an iframe navigation and a
+   WebSocket sub-resource cannot attach `Authorization`/CSRF headers, and cookies
+   don't cross to the backend's origin.
+
+The k8s gateway satisfies both with a signed token **in the URL path**
+(`gateway.route.mode=uri`): the token is the auth, and because it's in the path,
+every relative asset + WebSocket request the panel client makes carries it.
+
+### What we verified before choosing this design (2026-07-26, live k8s)
+
+OpenSandbox's lifecycle server already exposes an unsigned **server-proxy** route
+(`components proxy.py`) with **both HTTP and WebSocket** handlers:
+`@router.api_route("/sandboxes/{id}/proxy/{port}/{full_path:path}")` and
+`@router.websocket(...)`, port-parameterised, full bidirectional relay. Measured
+against the real k8s dev cluster with a freshly created sandbox:
+
+- **HTTP proxy → Pod** (execd `:44772`) returns real data, **with or without**
+  the server api_key.
+- **WebSocket proxy → Pod** (`:7681`, a stand-in WS echo server) upgrades and
+  relays bidirectionally, **with or without** the server api_key.
+- The proxy route **deliberately skips the server's own api_key auth** (upstream
+  commit "skip auth for proxy-to-sandbox paths"; tenant auth is multi-tenant
+  only). So in cubeplex's single-tenant use it is **open** — which means the
+  security boundary MUST be enforced by cubeplex, and opensandbox-server must
+  never be exposed publicly.
+
+Both runtimes reach the same place: `opensandbox-server/sandboxes/{id}/proxy/{port}`
+→ Pod (k8s) or container (docker). So one cubeplex-side proxy unifies both.
+
+## Approaches considered
+
+- **A — backend reverse proxy, unified (chosen).** cubeplex backend adds one
+  token-authenticated HTTP+WS reverse-proxy route that forwards to
+  opensandbox-server's server-proxy. Endpoint methods mint a cubeplex-signed URL.
+  Both docker and k8s use it; the OpenSandbox gateway is dropped. Cleanest and
+  removes a whole subsystem (gateway deploy, OSEP-0011 signing keys, a separate
+  public NodePort/host). Cost: panel WS/streaming now flows through the backend,
+  and it's the first WebSocket route in the backend.
+- **B — endpoint-selection + graceful degrade.** Branch on `secure_access`: k8s
+  keeps the signed gateway, docker returns a clean 501 "panel only in k8s". No
+  proxy built. Fast and safe, but docker panels stay unavailable and the two
+  runtimes never unify.
+- **C — unified code, gateway kept as optional fallback.** Same proxy as A but
+  keep helm `gateway.enabled` as a togglable bypass. Hedge against backend panel
+  load, at the cost of maintaining two panel paths.
+
+Chosen **A**: the WS/auth/Pod-reach risks are now measured, not assumed, and
+unification simplifies the k8s deployment surface (no separate gateway host).
+
+## Design — what literally happens
+
+### Signed panel token (auth in the URL path)
+
+A short-lived **HS256 JWT** signed with the existing `auth.jwt_secret`, mirroring
+`cubeplex/im/link.py`. Claims: `sid` (sandbox id), `port`, `exp`, `iat`,
+`iss="cubeplex:sandbox-panel"`. TTL matches the endpoint method's `expires_in`
+(default 1h). The token carries the sandbox id and port, so the proxy trusts the
+**token**, never a path/query the client could edit.
+
+### Panel URL shape (token in the path prefix)
+
+```
+{api.public_url}/sandbox-panel/{token}/
+```
+
+The token sits in the path, so the panel client's relative asset requests and its
+WebSocket handshake all resolve under `/sandbox-panel/{token}/…` and carry the
+token automatically (same trick as the k8s gateway's `mode=uri`). The trailing
+slash after the token is required so relative paths resolve correctly (same reason
+the current signed-URL code appends one).
+
+`api.public_url` is the backend's own public base URL (already a config key;
+`http://localhost:8000` in the compose example). If it is empty, panels are
+unavailable and the endpoint methods raise a clean 501 — no silent breakage.
+
+### Backend reverse-proxy route
+
+New router mounted at app **root** (not under `/api/v1`, so it is never caught by
+the frontend's `/api/*` Next rewrite — which cannot proxy WebSocket anyway):
+
+```
+GET/HEAD/…  /sandbox-panel/{token}/{full_path:path}
+WEBSOCKET   /sandbox-panel/{token}/{full_path:path}
+```
+
+Both handlers: verify the token (else **403**) → read `sid`, `port` from claims →
+forward to `{sandbox.domain}/sandboxes/{sid}/proxy/{port}/{full_path}` preserving
+query string:
+
+- **HTTP** — stream via `httpx.AsyncClient`; copy method/body/headers minus
+  hop-by-hop headers; stream the upstream response (status + headers + body) back.
+- **WebSocket** — accept the client WS, open an upstream WS with the `websockets`
+  library to the `ws://…/proxy/{port}/…` URL, and run two relay tasks pumping
+  text+binary frames both ways until either side closes. Mirrors opensandbox's own
+  `proxy.py` relay.
+
+The route is **public** (no `require_member`): the signed token is the credential,
+exactly like the k8s gateway model. This is the only viable auth for iframe
+sub-resources + WS, and it's why opensandbox-server must stay private.
+
+### Endpoint methods (`opensandbox.py`)
+
+`get_browser_endpoint` / `get_terminal_endpoint` stop calling the SDK's
+`get_signed_endpoint`. They mint a panel token for `(self._sandbox.id, PORT, exp)`
+and return `BrowserEndpoint(url=f"{panel_base}/sandbox-panel/{token}/…", headers={})`.
+No headers ⇒ the existing `endpoint.headers` 501 guards in `ws_browser.py` /
+`ws_sandbox.py` pass unchanged. The frontend is **unchanged**: it still receives an
+absolute URL and iframes it (it already does this for the cross-origin k8s
+gateway URL today).
+
+### Deployment / unification
+
+- Sandboxes are created with `secure_access=false` (already the case in the dev
+  values) — the signed gateway is no longer used, so no signed access is required
+  on the sandbox side.
+- Helm: `gateway.enabled` defaults **false**; the OSEP-0011 signing keys and the
+  separate gateway host/NodePort are no longer needed for panels.
+- opensandbox-server stays cluster-internal (ClusterIP / internal docker network)
+  — never public. cubeplex's backend is the only public entry, gated by the token.
+
+## Out of scope
+
+- Rate-limiting / DoS protection on the proxy route (future hardening).
+- Per-request re-authorization beyond the signed token's TTL.
+- Keeping the OpenSandbox gateway as a runtime-selectable fallback (removed; can be
+  re-introduced if backend panel-streaming load proves a problem).
+- Any frontend code change (the response contract `{url}` is unchanged).
+
+## Success criteria
+
+- **docker-compose:** opening the browser panel renders the Neko live view and the
+  terminal panel renders a working ttyd shell — no 503.
+- **k8s:** same panels render through the backend proxy with the gateway removed.
+- A missing / expired / tampered token ⇒ **403**; opensandbox-server needs **no**
+  api_key from the proxy and is not publicly reachable.
+- Existing tool calls and the file-tree panel are unaffected.

--- a/docs/site/docs/deployment/docker-compose.md
+++ b/docs/site/docs/deployment/docker-compose.md
@@ -319,12 +319,13 @@ $EDITOR config/config.production.secrets.yaml
 #     image:   "ghcr.io/cubeplexai/cubeplex-sandbox:v0.2.0"
 #     api_key: "<same as [server].api_key in opensandbox.toml>"
 
-# 3. backend non-secret — enable sandbox + force server proxy
+# 3. backend non-secret — enable sandbox
 $EDITOR config/config.production.local.yaml
 #   sandbox:
 #     enabled: true
-#     use_server_proxy: true     # required: docker bridge endpoints
-#                                # rewrite via the server gateway
+#     secure_access: false       # docker runtime rejects secureAccess=True
+#     use_server_proxy: false    # OpenSandbox v0.1.x drops the port from
+#                                # proxied URLs; use direct host-mapped ports
 
 # 4. up with the overlay
 docker compose \
@@ -358,13 +359,24 @@ call → `tool_result` works end to end.
 
 | Feature | What works | What doesn't |
 |---|---|---|
-| Network policy (egress firewall) | Yes — but only when `[docker].network_mode = "bridge"` | Rejected when `network_mode=host` or a user-defined bridge network |
-| Signed endpoint URLs (`expires=…`) | – | Not implemented for Docker mode; CubePlex doesn't use this today |
-| Server-proxy mode (`use_server_proxy: true`) | – | OpenSandbox v0.1.x drops the port from the proxied endpoint URL. The example config uses `use_server_proxy: false` instead, and the overlay wires `host.docker.internal` via `extra_hosts` so the backend can reach the host-mapped bridge ports of sandbox containers. |
+| Chat → agent tool calls (bash / file read-write in the sandbox) | Yes — chat → sandbox `execute` → `tool_result` works end to end | — |
+| Network policy (egress firewall) | Yes — the egress sidecar is created and enforces the policy in DNS mode, but only when `[docker].network_mode = "bridge"` | Rejected when `network_mode=host` or a user-defined bridge network |
+| **Interactive terminal panel** (chat UI) | – | ❌ Broken. Needs a signed endpoint URL for the ttyd port; the Docker runtime rejects signed routes (`expires` param is Kubernetes-only), so the panel returns 503. |
+| **Live browser panel** (Neko, chat UI) | – | ❌ Broken. Same signed-route requirement as the terminal — returns 503 under the Docker runtime. |
+| **File-tree panel** (chat UI) | – | ❌ Broken today. The execd `list_directory` response fails to parse under the Docker runtime (HTTP 500). Agent-driven file read/write via tool calls still works — only the UI file browser is affected. |
+| Secret injection / env substitution (`cbxref_…` placeholders) | – | ❌ Not available. It needs the backend mTLS credential-exchange listener + egress CA/client certs that the Kubernetes chart deploys (`gen-egress-certs.sh` + the egress webhook). The compose overlay ships none of that, and `sandbox.egress_exchange_host` stays empty, so injection is disabled. |
+| Signed endpoint URLs (`expires=…`) | – | Not implemented for Docker mode. The terminal + browser panels above depend on these, which is why they don't work. |
+| Server-proxy mode (`use_server_proxy: true`) | – | OpenSandbox v0.1.x drops the port from the proxied endpoint URL. Keep `use_server_proxy: false` (the example default), and the overlay wires `host.docker.internal` via `extra_hosts` on both the backend and the opensandbox-server so they can reach the host-mapped bridge ports of sandbox containers. |
 | `pvc.claimName` volumes | Yes — but treated as Docker named volumes | No CSI features, no ReadWriteMany |
 | Pause / resume (`POST /sandboxes/{id}/pause`, etc.) | Calls Docker `pause`/`unpause` (cgroup freezer) | No checkpoint to disk — paused state is lost on host Docker restart. CubePlex defaults `pause_on_idle: false` for this reason. |
 
-The following routes return `501 Not Implemented` on Docker runtime, even
+**In short:** under Docker-mode OpenSandbox, the agent can *run* commands and
+read/write files in the sandbox (tool calls work), and the egress firewall is
+enforced — but the interactive chat-UI panels (terminal, live browser, file
+tree) and secret injection require the Kubernetes runtime. For those, deploy
+via the [Kubernetes guide](./kubernetes.md).
+
+The following routes also return `501 Not Implemented` on Docker runtime, even
 though they exist in the OpenAPI spec (CubePlex doesn't call any of them
 today): `POST /pools` and related pre-warmed pod pools, and the snapshot
 APIs (`POST /sandboxes/{id}/snapshots`, etc.) — both are Kubernetes-only.

--- a/docs/site/docs/deployment/docker-compose.md
+++ b/docs/site/docs/deployment/docker-compose.md
@@ -210,9 +210,13 @@ PROMPT="Say the word hello and nothing else." \
 `e2e.sh` drives:
 
 ```
-register → single-tenant auto-setup → create conversation
+register → login → resolve workspace → create conversation
         → POST message → SSE stream → assert text_delta arrived
 ```
+
+On a fresh deployment the first registered user has no workspace yet, so the
+script runs onboarding to create one; later users already have one from
+registration.
 
 Both scripts default to `localhost`; override with `HOST`, `BACKEND_PORT`,
 `FRONTEND_PORT` to run against a remote host.

--- a/docs/site/docs/deployment/docker-compose.md
+++ b/docs/site/docs/deployment/docker-compose.md
@@ -361,20 +361,20 @@ call → `tool_result` works end to end.
 |---|---|---|
 | Chat → agent tool calls (bash / file read-write in the sandbox) | Yes — chat → sandbox `execute` → `tool_result` works end to end | — |
 | Network policy (egress firewall) | Yes — the egress sidecar is created and enforces the policy in DNS mode, but only when `[docker].network_mode = "bridge"` | Rejected when `network_mode=host` or a user-defined bridge network |
+| **File-tree panel** (chat UI) | Yes — **requires `execd_image` ≥ `v1.0.19`** (the `GET /directories/list` route was added in v1.0.19; the older v1.0.18 returns a plain-text 404 that surfaces as HTTP 500). The example config pins v1.0.19. | — |
 | **Interactive terminal panel** (chat UI) | – | ❌ Broken. Needs a signed endpoint URL for the ttyd port; the Docker runtime rejects signed routes (`expires` param is Kubernetes-only), so the panel returns 503. |
 | **Live browser panel** (Neko, chat UI) | – | ❌ Broken. Same signed-route requirement as the terminal — returns 503 under the Docker runtime. |
-| **File-tree panel** (chat UI) | – | ❌ Broken today. The execd `list_directory` response fails to parse under the Docker runtime (HTTP 500). Agent-driven file read/write via tool calls still works — only the UI file browser is affected. |
 | Secret injection / env substitution (`cbxref_…` placeholders) | – | ❌ Not available. It needs the backend mTLS credential-exchange listener + egress CA/client certs that the Kubernetes chart deploys (`gen-egress-certs.sh` + the egress webhook). The compose overlay ships none of that, and `sandbox.egress_exchange_host` stays empty, so injection is disabled. |
 | Signed endpoint URLs (`expires=…`) | – | Not implemented for Docker mode. The terminal + browser panels above depend on these, which is why they don't work. |
 | Server-proxy mode (`use_server_proxy: true`) | – | OpenSandbox v0.1.x drops the port from the proxied endpoint URL. Keep `use_server_proxy: false` (the example default), and the overlay wires `host.docker.internal` via `extra_hosts` on both the backend and the opensandbox-server so they can reach the host-mapped bridge ports of sandbox containers. |
 | `pvc.claimName` volumes | Yes — but treated as Docker named volumes | No CSI features, no ReadWriteMany |
 | Pause / resume (`POST /sandboxes/{id}/pause`, etc.) | Calls Docker `pause`/`unpause` (cgroup freezer) | No checkpoint to disk — paused state is lost on host Docker restart. CubePlex defaults `pause_on_idle: false` for this reason. |
 
-**In short:** under Docker-mode OpenSandbox, the agent can *run* commands and
-read/write files in the sandbox (tool calls work), and the egress firewall is
-enforced — but the interactive chat-UI panels (terminal, live browser, file
-tree) and secret injection require the Kubernetes runtime. For those, deploy
-via the [Kubernetes guide](./kubernetes.md).
+**In short:** under Docker-mode OpenSandbox, the agent can *run* commands,
+read/write files, and browse the file tree in the sandbox, and the egress
+firewall is enforced — but the interactive **terminal** and **live browser**
+panels and **secret injection** require the Kubernetes runtime. For those,
+deploy via the [Kubernetes guide](./kubernetes.md).
 
 The following routes also return `501 Not Implemented` on Docker runtime, even
 though they exist in the OpenAPI spec (CubePlex doesn't call any of them

--- a/docs/site/docs/deployment/docker-compose.md
+++ b/docs/site/docs/deployment/docker-compose.md
@@ -361,7 +361,7 @@ call → `tool_result` works end to end.
 |---|---|---|
 | Chat → agent tool calls (bash / file read-write in the sandbox) | Yes — chat → sandbox `execute` → `tool_result` works end to end | — |
 | Network policy (egress firewall) | Yes — the egress sidecar is created and enforces the policy in DNS mode, but only when `[docker].network_mode = "bridge"` | Rejected when `network_mode=host` or a user-defined bridge network |
-| **File-tree panel** (chat UI) | Yes — **requires `execd_image` ≥ `v1.0.19`** (the `GET /directories/list` route was added in v1.0.19; the older v1.0.18 returns a plain-text 404 that surfaces as HTTP 500). The example config pins v1.0.19. | — |
+| **File-tree panel** (chat UI) | Yes | — |
 | **Interactive terminal panel** (chat UI) | – | ❌ Broken. Needs a signed endpoint URL for the ttyd port; the Docker runtime rejects signed routes (`expires` param is Kubernetes-only), so the panel returns 503. |
 | **Live browser panel** (Neko, chat UI) | – | ❌ Broken. Same signed-route requirement as the terminal — returns 503 under the Docker runtime. |
 | Secret injection / env substitution (`cbxref_…` placeholders) | – | ❌ Not available. It needs the backend mTLS credential-exchange listener + egress CA/client certs that the Kubernetes chart deploys (`gen-egress-certs.sh` + the egress webhook). The compose overlay ships none of that, and `sandbox.egress_exchange_host` stays empty, so injection is disabled. |

--- a/docs/site/docs/deployment/docker-compose.md
+++ b/docs/site/docs/deployment/docker-compose.md
@@ -362,19 +362,19 @@ call → `tool_result` works end to end.
 | Chat → agent tool calls (bash / file read-write in the sandbox) | Yes — chat → sandbox `execute` → `tool_result` works end to end | — |
 | Network policy (egress firewall) | Yes — the egress sidecar is created and enforces the policy in DNS mode, but only when `[docker].network_mode = "bridge"` | Rejected when `network_mode=host` or a user-defined bridge network |
 | **File-tree panel** (chat UI) | Yes | — |
-| **Interactive terminal panel** (chat UI) | – | ❌ Broken. Needs a signed endpoint URL for the ttyd port; the Docker runtime rejects signed routes (`expires` param is Kubernetes-only), so the panel returns 503. |
-| **Live browser panel** (Neko, chat UI) | – | ❌ Broken. Same signed-route requirement as the terminal — returns 503 under the Docker runtime. |
+| **Interactive terminal panel** (chat UI) | Yes — proxied through the backend's panel route | Requires `api.public_url` set to a URL the user's browser can reach that also forwards WebSocket |
+| **Live browser panel** (Neko, chat UI) | Yes — same panel route as the terminal | Same `api.public_url` requirement |
 | Secret injection / env substitution (`cbxref_…` placeholders) | – | ❌ Not available. It needs the backend mTLS credential-exchange listener + egress CA/client certs that the Kubernetes chart deploys (`gen-egress-certs.sh` + the egress webhook). The compose overlay ships none of that, and `sandbox.egress_exchange_host` stays empty, so injection is disabled. |
-| Signed endpoint URLs (`expires=…`) | – | Not implemented for Docker mode. The terminal + browser panels above depend on these, which is why they don't work. |
 | Server-proxy mode (`use_server_proxy: true`) | – | OpenSandbox v0.1.x drops the port from the proxied endpoint URL. Keep `use_server_proxy: false` (the example default), and the overlay wires `host.docker.internal` via `extra_hosts` on both the backend and the opensandbox-server so they can reach the host-mapped bridge ports of sandbox containers. |
 | `pvc.claimName` volumes | Yes — but treated as Docker named volumes | No CSI features, no ReadWriteMany |
 | Pause / resume (`POST /sandboxes/{id}/pause`, etc.) | Calls Docker `pause`/`unpause` (cgroup freezer) | No checkpoint to disk — paused state is lost on host Docker restart. CubePlex defaults `pause_on_idle: false` for this reason. |
 
 **In short:** under Docker-mode OpenSandbox, the agent can *run* commands,
-read/write files, and browse the file tree in the sandbox, and the egress
-firewall is enforced — but the interactive **terminal** and **live browser**
-panels and **secret injection** require the Kubernetes runtime. For those,
-deploy via the [Kubernetes guide](./kubernetes.md).
+read/write files, browse the file tree, and open the interactive **terminal**
+and **live browser** panels — all through the backend's panel reverse proxy, so
+set `api.public_url` to a browser-reachable, WebSocket-forwarding backend URL.
+Only **secret injection** still requires the Kubernetes runtime; for that, deploy
+via the [Kubernetes guide](./kubernetes.md).
 
 The following routes also return `501 Not Implemented` on Docker runtime, even
 though they exist in the OpenAPI spec (CubePlex doesn't call any of them

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -714,10 +714,15 @@ GET  /api/v1/system/info     — confirm deployment_mode
 POST /api/v1/auth/register   — single-tenant auto-setup
 POST /api/v1/auth/login      — cookie jar
 GET  /api/v1/auth/me         — receive CSRF cookie (safe methods only)
+POST /api/v1/onboarding      — only if this is the deployment's first user
 POST /ws/{ws}/conversations  — conv_id
 POST .../conversations/{conv}/messages — run_id
 GET  .../runs/{run}/stream   — SSE; assert text_delta arrives
 ```
+
+The first user registered on a fresh deployment lands in pending-owner state
+with no workspace, so the script runs onboarding to create one. Every later
+user is attached to the singleton org at registration and skips that step.
 
 To exercise the sandbox path too:
 

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -338,7 +338,7 @@ opensandbox:
       level = "INFO"
       [runtime]
       type = "kubernetes"
-      execd_image = "docker.io/opensandbox/execd:v1.0.18"
+      execd_image = "docker.io/opensandbox/execd:v1.0.19"
       [kubernetes]
       namespace = "opensandbox"
       informer_enabled = true

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -305,17 +305,13 @@ Three typical layouts:
 | External OpenSandbox | `opensandbox.enabled: false`; `backend.sandbox.enabled: true`; `backend.secrets.sandbox.domain` points at the external host |
 | No sandbox (chat-only) | `opensandbox.enabled: false`; leave `backend.sandbox.enabled` unset (it follows `opensandbox.enabled` → false) |
 
-The backend defaults to `sandbox.secure_access: true` — it expects sandbox
-access to go through a signed route token, which requires the OpenSandbox
-`gateway`/`ingress` component to be deployed
-(`opensandbox.opensandbox-server.server.gateway.enabled: true`, not covered
-here). If you're not deploying that gateway, disable the requirement or the
-backend can't create sandboxes at all:
-```yaml
-backend:
-  sandbox:
-    secure_access: false
-```
+The backend defaults to `sandbox.secure_access: false`. Browser and terminal
+panels do **not** go through the OpenSandbox `gateway`/`ingress` component —
+they flow through cubeplex's own token-authenticated panel reverse proxy (the
+same path used in docker mode), so you don't need to deploy the gateway or
+manage OSEP-0011 signing keys. The panels' origin is `api.public_url`, which
+must be **browser-reachable and forward WebSocket** (the panels proxy Neko/ttyd
+over WS) — the same URL you already set for the backend.
 
 If your node pool runs CRI-O (see the [image-name troubleshooting
 entry](#imageinspecterror--short-name-mode-is-enforcing-returns-ambiguous-list)),

--- a/docs/site/docs/deployment/overview.md
+++ b/docs/site/docs/deployment/overview.md
@@ -48,10 +48,18 @@ OpenAI, most cloud vendors, and self-hosted gateways (vLLM, LiteLLM, Ollama,
 
 ```yaml
 llm:
-  # "<provider_name>/<model_id>" — provider_name must appear under providers.
-  default_model: "openai/gpt-5.6-terra"
-  fallback_models:
-    - "anthropic/claude-opus-4.8"
+  # A default preset is REQUIRED. The backend seeds it from model_presets at
+  # startup and resolves every chat message through it — without one the backend
+  # still boots but chat fails at runtime with NoDefaultPresetError (HTTP 500).
+  # Each tier's primary / fallbacks is "<provider_name>/<model_id>"; the
+  # provider_name must appear under providers below.
+  model_presets:
+    tiers:
+      lite:  { enabled: true,  primary: "openai/gpt-5.6-terra", fallbacks: ["anthropic/claude-opus-4.8"] }
+      flash: { enabled: true,  primary: "openai/gpt-5.6-terra", fallbacks: ["anthropic/claude-opus-4.8"] }
+      pro:   { enabled: true,  primary: "openai/gpt-5.6-terra", fallbacks: ["anthropic/claude-opus-4.8"] }
+      max:   { enabled: false, primary: null, fallbacks: [] }
+    default_preset: pro
   providers:
     # Any OpenAI-compatible chat-completions endpoint.
     openai:
@@ -79,9 +87,12 @@ llm:
           max_tokens: 64000
 ```
 
-- `default_model` / `fallback_models` use `"<provider_name>/<model_id>"`; the
-  `provider_name` must appear under `providers`, and fallbacks are tried in
-  order if `default_model` fails.
+- `model_presets.tiers` defines the selectable model tiers (`lite` / `flash` /
+  `pro` / `max`); `default_preset` picks which tier serves requests that don't
+  ask for a specific one. At least one tier must be enabled. Each `primary` /
+  `fallbacks` entry is `"<provider_name>/<model_id>"`; the `provider_name` must
+  appear under `providers`, and fallbacks are tried in order if `primary` fails.
+  Tiers you don't need can stay `enabled: false`.
 - Each provider declares `base_url`, `api_key`, `api`
   (`openai-completions` | `anthropic-messages` | `openai-responses`), and at
   least one entry in `models`. `base_url` follows each SDK's convention —
@@ -93,7 +104,10 @@ Minimal viable configuration (one provider, one model):
 
 ```yaml
 llm:
-  default_model: "openai/gpt-5.6-terra"
+  model_presets:
+    tiers:
+      pro: { enabled: true, primary: "openai/gpt-5.6-terra", fallbacks: [] }
+    default_preset: pro
   providers:
     openai:
       base_url: "https://api.openai.com/v1"
@@ -114,7 +128,10 @@ built-in `preset` instead — it fills in the endpoint and model list for you:
 
 ```yaml
 llm:
-  default_model: "deepseek/deepseek-v4-flash"
+  model_presets:
+    tiers:
+      pro: { enabled: true, primary: "deepseek/deepseek-v4-flash", fallbacks: [] }
+    default_preset: pro
   providers:
     deepseek:
       preset: "deepseek/cn/anthropic-messages"

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/docker-compose.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/docker-compose.md
@@ -308,12 +308,13 @@ $EDITOR config/config.production.secrets.yaml
 #     image:   "ghcr.io/cubeplexai/cubeplex-sandbox:v0.2.0"
 #     api_key: "<与 opensandbox.toml 中 [server].api_key 相同>"
 
-# 3. backend 非密钥配置 —— 启用 sandbox 并强制走 server 代理
+# 3. backend 非密钥配置 —— 启用 sandbox
 $EDITOR config/config.production.local.yaml
 #   sandbox:
 #     enabled: true
-#     use_server_proxy: true     # 必需：docker bridge 端点
-#                                # 要经过 server 网关重写
+#     secure_access: false       # docker runtime 会拒绝 secureAccess=True
+#     use_server_proxy: false    # OpenSandbox v0.1.x 会丢失代理 URL 的端口号，
+#                                # 改用直连主机映射端口
 
 # 4. 带着 overlay 启动
 docker compose \
@@ -346,13 +347,23 @@ CubePlex 会发送 `secureAccess: false`，Docker runtime 就会接受请求。
 
 | 功能 | 可以工作 | 不能工作 |
 |---|---|---|
-| 网络策略（egress 防火墙） | 可以——但仅当 `[docker].network_mode = "bridge"` | 当 `network_mode=host` 或使用自定义 bridge 网络时会被拒绝 |
-| 签名端点 URL（`expires=…`） | – | Docker 模式未实现；CubePlex 目前也不使用它 |
-| server-proxy 模式（`use_server_proxy: true`） | – | OpenSandbox v0.1.x 在代理端点 URL 中会丢失端口号。示例配置改用 `use_server_proxy: false`，overlay 通过 `extra_hosts` 配置 `host.docker.internal`，让 backend 能访问沙箱容器在主机上映射的 bridge 端口。 |
+| 聊天 → agent 工具调用（在沙箱里执行 bash / 读写文件） | 可以——聊天 → 沙箱 `execute` → `tool_result` 全链路可用 | — |
+| 网络策略（egress 防火墙） | 可以——egress sidecar 会被创建并以 DNS 模式执行策略，但仅当 `[docker].network_mode = "bridge"` | 当 `network_mode=host` 或使用自定义 bridge 网络时会被拒绝 |
+| **交互式终端面板**（聊天界面） | – | ❌ 不可用。它需要 ttyd 端口的签名端点 URL，而 Docker runtime 拒绝签名路由（`expires` 参数是 Kubernetes 专属），面板返回 503。 |
+| **实时浏览器面板**（Neko，聊天界面） | – | ❌ 不可用。与终端一样依赖签名路由——在 Docker runtime 下返回 503。 |
+| **文件树面板**（聊天界面） | – | ❌ 目前不可用。execd 的 `list_directory` 响应在 Docker runtime 下解析失败（HTTP 500）。通过工具调用让 agent 读写文件仍然可用——只有 UI 文件浏览器受影响。 |
+| 密钥注入 / env 替换（`cbxref_…` 占位符） | – | ❌ 不可用。它需要后端的 mTLS 凭证交换监听器 + egress CA/客户端证书，这些由 Kubernetes chart 部署（`gen-egress-certs.sh` + egress webhook）。compose overlay 不包含这些，`sandbox.egress_exchange_host` 保持为空，所以注入被禁用。 |
+| 签名端点 URL（`expires=…`） | – | Docker 模式未实现。上面的终端 + 浏览器面板依赖它，所以它们无法工作。 |
+| server-proxy 模式（`use_server_proxy: true`） | – | OpenSandbox v0.1.x 在代理端点 URL 中会丢失端口号。保持 `use_server_proxy: false`（示例默认值），overlay 通过 `extra_hosts` 在 backend 和 opensandbox-server 上都配置 `host.docker.internal`，让它们能访问沙箱容器在主机上映射的 bridge 端口。 |
 | `pvc.claimName` 数据卷 | 可以——但被当作 Docker 命名卷处理 | 没有 CSI 特性，不支持 ReadWriteMany |
 | 暂停 / 恢复（`POST /sandboxes/{id}/pause` 等） | 调用 Docker 的 `pause`/`unpause`（cgroup freezer） | 没有落盘的 checkpoint——主机 Docker 重启后暂停状态会丢失。因此 CubePlex 默认 `pause_on_idle: false`。 |
 
-以下路由在 Docker runtime 上会返回 `501 Not Implemented`，尽管它们出现
+**一句话总结：** 在 Docker 模式的 OpenSandbox 下，agent 可以在沙箱里*执行*
+命令、读写文件（工具调用可用），egress 防火墙也会生效——但聊天界面里的
+交互式面板（终端、实时浏览器、文件树）和密钥注入都需要 Kubernetes runtime。
+这些功能请改用 [Kubernetes 部署指南](./kubernetes.md)。
+
+以下路由在 Docker runtime 上也会返回 `501 Not Implemented`，尽管它们出现
 在 OpenAPI 规范中（CubePlex 目前都没有调用）：`POST /pools` 及相关的
 预热 pod 池接口，以及快照相关接口（`POST /sandboxes/{id}/snapshots` 等）
 ——两者都是 Kubernetes 专属能力。

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/docker-compose.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/docker-compose.md
@@ -203,9 +203,12 @@ PROMPT="Say the word hello and nothing else." \
 `e2e.sh` 执行流程：
 
 ```
-注册 → 单租户自动初始化 → 创建对话
+注册 → 登录 → 确定 workspace → 创建对话
      → 发送消息 → SSE 流 → 断言收到 text_delta
 ```
+
+全新部署上注册的第一个用户还没有 workspace，脚本会调用 onboarding 创建一个；
+之后注册的用户在注册时就已经拿到 workspace，跳过该步。
 
 两个脚本默认针对 `localhost`；用 `HOST`、`BACKEND_PORT`、`FRONTEND_PORT`
 覆盖以针对远程主机运行。

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/docker-compose.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/docker-compose.md
@@ -349,9 +349,9 @@ CubePlex 会发送 `secureAccess: false`，Docker runtime 就会接受请求。
 |---|---|---|
 | 聊天 → agent 工具调用（在沙箱里执行 bash / 读写文件） | 可以——聊天 → 沙箱 `execute` → `tool_result` 全链路可用 | — |
 | 网络策略（egress 防火墙） | 可以——egress sidecar 会被创建并以 DNS 模式执行策略，但仅当 `[docker].network_mode = "bridge"` | 当 `network_mode=host` 或使用自定义 bridge 网络时会被拒绝 |
+| **文件树面板**（聊天界面） | 可以——**需要 `execd_image` ≥ `v1.0.19`**（`GET /directories/list` 路由在 v1.0.19 才加入；旧的 v1.0.18 返回纯文本 404，会表现为 HTTP 500）。示例配置已 pin 到 v1.0.19。 | — |
 | **交互式终端面板**（聊天界面） | – | ❌ 不可用。它需要 ttyd 端口的签名端点 URL，而 Docker runtime 拒绝签名路由（`expires` 参数是 Kubernetes 专属），面板返回 503。 |
 | **实时浏览器面板**（Neko，聊天界面） | – | ❌ 不可用。与终端一样依赖签名路由——在 Docker runtime 下返回 503。 |
-| **文件树面板**（聊天界面） | – | ❌ 目前不可用。execd 的 `list_directory` 响应在 Docker runtime 下解析失败（HTTP 500）。通过工具调用让 agent 读写文件仍然可用——只有 UI 文件浏览器受影响。 |
 | 密钥注入 / env 替换（`cbxref_…` 占位符） | – | ❌ 不可用。它需要后端的 mTLS 凭证交换监听器 + egress CA/客户端证书，这些由 Kubernetes chart 部署（`gen-egress-certs.sh` + egress webhook）。compose overlay 不包含这些，`sandbox.egress_exchange_host` 保持为空，所以注入被禁用。 |
 | 签名端点 URL（`expires=…`） | – | Docker 模式未实现。上面的终端 + 浏览器面板依赖它，所以它们无法工作。 |
 | server-proxy 模式（`use_server_proxy: true`） | – | OpenSandbox v0.1.x 在代理端点 URL 中会丢失端口号。保持 `use_server_proxy: false`（示例默认值），overlay 通过 `extra_hosts` 在 backend 和 opensandbox-server 上都配置 `host.docker.internal`，让它们能访问沙箱容器在主机上映射的 bridge 端口。 |
@@ -359,9 +359,9 @@ CubePlex 会发送 `secureAccess: false`，Docker runtime 就会接受请求。
 | 暂停 / 恢复（`POST /sandboxes/{id}/pause` 等） | 调用 Docker 的 `pause`/`unpause`（cgroup freezer） | 没有落盘的 checkpoint——主机 Docker 重启后暂停状态会丢失。因此 CubePlex 默认 `pause_on_idle: false`。 |
 
 **一句话总结：** 在 Docker 模式的 OpenSandbox 下，agent 可以在沙箱里*执行*
-命令、读写文件（工具调用可用），egress 防火墙也会生效——但聊天界面里的
-交互式面板（终端、实时浏览器、文件树）和密钥注入都需要 Kubernetes runtime。
-这些功能请改用 [Kubernetes 部署指南](./kubernetes.md)。
+命令、读写文件、浏览文件树，egress 防火墙也会生效——但聊天界面里的
+交互式**终端**和**实时浏览器**面板、以及**密钥注入**都需要 Kubernetes
+runtime。这些功能请改用 [Kubernetes 部署指南](./kubernetes.md)。
 
 以下路由在 Docker runtime 上也会返回 `501 Not Implemented`，尽管它们出现
 在 OpenAPI 规范中（CubePlex 目前都没有调用）：`POST /pools` 及相关的

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/docker-compose.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/docker-compose.md
@@ -349,7 +349,7 @@ CubePlex 会发送 `secureAccess: false`，Docker runtime 就会接受请求。
 |---|---|---|
 | 聊天 → agent 工具调用（在沙箱里执行 bash / 读写文件） | 可以——聊天 → 沙箱 `execute` → `tool_result` 全链路可用 | — |
 | 网络策略（egress 防火墙） | 可以——egress sidecar 会被创建并以 DNS 模式执行策略，但仅当 `[docker].network_mode = "bridge"` | 当 `network_mode=host` 或使用自定义 bridge 网络时会被拒绝 |
-| **文件树面板**（聊天界面） | 可以——**需要 `execd_image` ≥ `v1.0.19`**（`GET /directories/list` 路由在 v1.0.19 才加入；旧的 v1.0.18 返回纯文本 404，会表现为 HTTP 500）。示例配置已 pin 到 v1.0.19。 | — |
+| **文件树面板**（聊天界面） | 可以 | — |
 | **交互式终端面板**（聊天界面） | – | ❌ 不可用。它需要 ttyd 端口的签名端点 URL，而 Docker runtime 拒绝签名路由（`expires` 参数是 Kubernetes 专属），面板返回 503。 |
 | **实时浏览器面板**（Neko，聊天界面） | – | ❌ 不可用。与终端一样依赖签名路由——在 Docker runtime 下返回 503。 |
 | 密钥注入 / env 替换（`cbxref_…` 占位符） | – | ❌ 不可用。它需要后端的 mTLS 凭证交换监听器 + egress CA/客户端证书，这些由 Kubernetes chart 部署（`gen-egress-certs.sh` + egress webhook）。compose overlay 不包含这些，`sandbox.egress_exchange_host` 保持为空，所以注入被禁用。 |

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/docker-compose.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/docker-compose.md
@@ -350,18 +350,18 @@ CubePlex 会发送 `secureAccess: false`，Docker runtime 就会接受请求。
 | 聊天 → agent 工具调用（在沙箱里执行 bash / 读写文件） | 可以——聊天 → 沙箱 `execute` → `tool_result` 全链路可用 | — |
 | 网络策略（egress 防火墙） | 可以——egress sidecar 会被创建并以 DNS 模式执行策略，但仅当 `[docker].network_mode = "bridge"` | 当 `network_mode=host` 或使用自定义 bridge 网络时会被拒绝 |
 | **文件树面板**（聊天界面） | 可以 | — |
-| **交互式终端面板**（聊天界面） | – | ❌ 不可用。它需要 ttyd 端口的签名端点 URL，而 Docker runtime 拒绝签名路由（`expires` 参数是 Kubernetes 专属），面板返回 503。 |
-| **实时浏览器面板**（Neko，聊天界面） | – | ❌ 不可用。与终端一样依赖签名路由——在 Docker runtime 下返回 503。 |
+| **交互式终端面板**（聊天界面） | 可以——通过后端的面板反向代理转发 | 需要把 `api.public_url` 设成用户浏览器可达、且能转发 WebSocket 的后端 URL |
+| **实时浏览器面板**（Neko，聊天界面） | 可以——与终端走同一条面板代理 | 同样需要 `api.public_url` |
 | 密钥注入 / env 替换（`cbxref_…` 占位符） | – | ❌ 不可用。它需要后端的 mTLS 凭证交换监听器 + egress CA/客户端证书，这些由 Kubernetes chart 部署（`gen-egress-certs.sh` + egress webhook）。compose overlay 不包含这些，`sandbox.egress_exchange_host` 保持为空，所以注入被禁用。 |
-| 签名端点 URL（`expires=…`） | – | Docker 模式未实现。上面的终端 + 浏览器面板依赖它，所以它们无法工作。 |
 | server-proxy 模式（`use_server_proxy: true`） | – | OpenSandbox v0.1.x 在代理端点 URL 中会丢失端口号。保持 `use_server_proxy: false`（示例默认值），overlay 通过 `extra_hosts` 在 backend 和 opensandbox-server 上都配置 `host.docker.internal`，让它们能访问沙箱容器在主机上映射的 bridge 端口。 |
 | `pvc.claimName` 数据卷 | 可以——但被当作 Docker 命名卷处理 | 没有 CSI 特性，不支持 ReadWriteMany |
 | 暂停 / 恢复（`POST /sandboxes/{id}/pause` 等） | 调用 Docker 的 `pause`/`unpause`（cgroup freezer） | 没有落盘的 checkpoint——主机 Docker 重启后暂停状态会丢失。因此 CubePlex 默认 `pause_on_idle: false`。 |
 
 **一句话总结：** 在 Docker 模式的 OpenSandbox 下，agent 可以在沙箱里*执行*
-命令、读写文件、浏览文件树，egress 防火墙也会生效——但聊天界面里的
-交互式**终端**和**实时浏览器**面板、以及**密钥注入**都需要 Kubernetes
-runtime。这些功能请改用 [Kubernetes 部署指南](./kubernetes.md)。
+命令、读写文件、浏览文件树，还能打开交互式**终端**和**实时浏览器**面板——
+这些都通过后端的面板反向代理转发，所以要把 `api.public_url` 设成浏览器可达、
+能转发 WebSocket 的后端 URL。只有**密钥注入**仍然需要 Kubernetes runtime；那项
+请改用 [Kubernetes 部署指南](./kubernetes.md)。
 
 以下路由在 Docker runtime 上也会返回 `501 Not Implemented`，尽管它们出现
 在 OpenAPI 规范中（CubePlex 目前都没有调用）：`POST /pools` 及相关的

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/kubernetes.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/kubernetes.md
@@ -683,10 +683,14 @@ GET  /api/v1/system/info     — 确认 deployment_mode
 POST /api/v1/auth/register   — 单租户自动初始化
 POST /api/v1/auth/login      — 建立 cookie
 GET  /api/v1/auth/me         — 获取 CSRF cookie（仅安全方法）
+POST /api/v1/onboarding      — 仅当该用户是本部署的第一个用户
 POST /ws/{ws}/conversations  — 得到 conv_id
 POST .../conversations/{conv}/messages — 得到 run_id
 GET  .../runs/{run}/stream   — SSE；断言 text_delta 到达
 ```
+
+全新部署上注册的第一个用户处于 pending-owner 状态、还没有 workspace，脚本会
+调用 onboarding 创建一个。之后注册的用户在注册时就被挂进单例 org，跳过该步。
 
 顺带验证 sandbox 路径：
 

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/kubernetes.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/kubernetes.md
@@ -288,16 +288,12 @@ backend:
 | 使用外部已有 OpenSandbox | `opensandbox.enabled: false`；`backend.sandbox.enabled: true`；`backend.secrets.sandbox.domain` 填外部地址 |
 | 不使用 sandbox（仅对话） | `opensandbox.enabled: false`；`backend.sandbox.enabled` 留空（跟随 `opensandbox.enabled` → false） |
 
-backend 默认要求 `sandbox.secure_access: true`——它要求 sandbox 访问走一个
-签过名的路由令牌，这需要部署 OpenSandbox 的 `gateway`/`ingress` 组件
-（`opensandbox.opensandbox-server.server.gateway.enabled: true`，本文档
-未涉及）。如果你不打算部署这个 gateway，就得把这个要求关掉，否则 backend
-根本创建不了 sandbox：
-```yaml
-backend:
-  sandbox:
-    secure_access: false
-```
+backend 默认 `sandbox.secure_access: false`。浏览器和终端面板**不再**走
+OpenSandbox 的 `gateway`/`ingress` 组件——它们通过 cubeplex 自己的、带 token
+鉴权的面板反向代理转发（和 docker 模式同一条路径），所以你无需部署 gateway、
+也无需管理 OSEP-0011 签名密钥。面板的来源地址是 `api.public_url`，它必须
+**浏览器可达且能转发 WebSocket**（面板通过 WS 代理 Neko/ttyd）——就是你给
+backend 配的那个 URL。
 
 如果你的节点池跑的是 CRI-O（参见[镜像名相关的故障排查条目](#imageinspecterror--short-name-mode-is-enforcing-returns-ambiguous-list)），
 OpenSandbox subchart 自己的镜像也需要同样加上 `docker.io/` 前缀，而且它的

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/kubernetes.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/kubernetes.md
@@ -319,7 +319,7 @@ opensandbox:
       level = "INFO"
       [runtime]
       type = "kubernetes"
-      execd_image = "docker.io/opensandbox/execd:v1.0.18"
+      execd_image = "docker.io/opensandbox/execd:v1.0.19"
       [kubernetes]
       namespace = "opensandbox"
       informer_enabled = true

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/overview.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/overview.md
@@ -44,10 +44,17 @@ Azure OpenAI、大多数云厂商，以及自托管网关（vLLM、LiteLLM、Oll
 
 ```yaml
 llm:
-  # "<provider_name>/<model_id>"——provider_name 必须出现在 providers 下。
-  default_model: "openai/gpt-5.6-terra"
-  fallback_models:
-    - "anthropic/claude-opus-4.8"
+  # 必须配置一个默认 preset。后端在启动时从 model_presets 生成它，聊天路径
+  # 也通过它解析模型——没有默认 preset 时后端仍能启动，但每条消息都会在运行
+  # 时报 NoDefaultPresetError（HTTP 500）。每个 tier 的 primary / fallbacks
+  # 都是 "<provider_name>/<model_id>"，provider_name 必须出现在下方 providers 下。
+  model_presets:
+    tiers:
+      lite:  { enabled: true,  primary: "openai/gpt-5.6-terra", fallbacks: ["anthropic/claude-opus-4.8"] }
+      flash: { enabled: true,  primary: "openai/gpt-5.6-terra", fallbacks: ["anthropic/claude-opus-4.8"] }
+      pro:   { enabled: true,  primary: "openai/gpt-5.6-terra", fallbacks: ["anthropic/claude-opus-4.8"] }
+      max:   { enabled: false, primary: null, fallbacks: [] }
+    default_preset: pro
   providers:
     # 任意 OpenAI 兼容的 chat-completions 端点。
     openai:
@@ -75,9 +82,11 @@ llm:
           max_tokens: 64000
 ```
 
-- `default_model` / `fallback_models` 都用 `"<provider_name>/<model_id>"`；
-  `provider_name` 必须出现在 `providers` 下，fallback 会在 `default_model`
-  失败时按顺序尝试。
+- `model_presets.tiers` 定义可选的模型档位（`lite` / `flash` / `pro` /
+  `max`），`default_preset` 指定未显式指定时用哪个档位。至少要启用一个 tier。
+  每个 `primary` / `fallbacks` 都是 `"<provider_name>/<model_id>"`，
+  `provider_name` 必须出现在 `providers` 下，fallback 会在 `primary` 失败时
+  按顺序尝试。用不到的 tier 可以保持 `enabled: false`。
 - 每个 provider 声明 `base_url`、`api_key`、`api`
   （`openai-completions` | `anthropic-messages` | `openai-responses`），以及
   至少一个 `models` 条目。`base_url` 遵循各 SDK 约定——OpenAI 风格带 `/v1`，
@@ -89,7 +98,10 @@ llm:
 
 ```yaml
 llm:
-  default_model: "openai/gpt-5.6-terra"
+  model_presets:
+    tiers:
+      pro: { enabled: true, primary: "openai/gpt-5.6-terra", fallbacks: [] }
+    default_preset: pro
   providers:
     openai:
       base_url: "https://api.openai.com/v1"
@@ -110,7 +122,10 @@ llm:
 
 ```yaml
 llm:
-  default_model: "deepseek/deepseek-v4-flash"
+  model_presets:
+    tiers:
+      pro: { enabled: true, primary: "deepseek/deepseek-v4-flash", fallbacks: [] }
+    default_preset: pro
   providers:
     deepseek:
       preset: "deepseek/cn/anthropic-messages"


### PR DESCRIPTION
Two related deployment-tooling changes on one branch.

## 1. `refactor(deploy)`: share verification logic between compose and k8s scripts
Extracts the duplicated smoke-test / e2e verification logic from the docker-compose and
kubernetes deploy scripts into shared libraries under `deploy/scripts/lib/`
(`common.sh`, `e2e-core.sh`, `http-probes.sh`). The per-target `e2e.sh` / `smoke-test.sh`
scripts now source these instead of each carrying their own copy. Net ~240 lines removed.
Deployment docs (compose + k8s, en + zh-Hans) updated to match.

## 2. `docs(notes)`: Kata sandbox VM-isolation investigation
New engineering note `docs/dev/notes/2026-07-24-kata-sandbox-vm-isolation.md` documenting
the full investigation into running cubeplex's OpenSandbox pods under Kata Containers
(hardware-VM isolation instead of shared-kernel containers):

- **OKE managed nodes (CRI-O) can't run Kata** — blocking rootfs-handoff bug in Oracle's
  CRI-O `runtime_type=vm`; reproduced on Kata 4.0.0 and 3.32.0, QEMU and Firecracker both.
- **kubeadm + containerd 2.2.6 works** — full setup steps, including the `sandboxer =
  'podsandbox'` gotcha and unrelated OS-firewall/CoreDNS fixes.
- **Key fix:** `privileged_without_host_devices = true` on the containerd Kata runtime —
  without it, OpenSandbox's privileged sandbox pods die on `/dev/full … EEXIST`. Root cause
  traced to Kata passing all host devices through in privileged mode, colliding with the OCI
  default device set.
- **End-to-end proof:** an agent (arkplan model) ran `uname -a` in its sandbox and read guest
  kernel `6.18.35` vs host `6.17.0-1018-oracle` — different kernel ⇒ real VM, not a container.

## Test plan
- [x] Kata setup verified end-to-end on a live self-managed cluster (agent → OpenSandbox →
      Kata QEMU VM); evidence captured in the note.
- [ ] Deploy-script refactor: shell-only consolidation; exercised via the existing
      `deploy/*/scripts/{e2e,smoke-test}.sh` entrypoints.