### PR TITLE
Restore documentation mobile navigation

### DIFF
--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -105,10 +105,6 @@ html, body { font-feature-settings: 'cv11', 'ss01'; -webkit-font-smoothing: anti
   font-weight: 500;
 }
 
-.navbar__link > svg {
-  display: none;
-}
-
 .header-github-link,
 .navbar__items--right .toggle_Da5Y {
   align-items: center;
@@ -173,6 +169,13 @@ html, body { font-feature-settings: 'cv11', 'ss01'; -webkit-font-smoothing: anti
 }
 
 @media (max-width: 996px) {
+  /* Docusaurus fixes this panel to the viewport; without an explicit height,
+     the shared header styles leave its content clipped to the navbar height. */
+  .navbar-sidebar {
+    height: 100dvh;
+    z-index: 300;
+  }
+
   .navbar__inner {
     width: min(100% - 32px, 1400px);
   }

--- a/docs/site/src/theme/NavbarItem/NavbarNavLink/index.tsx
+++ b/docs/site/src/theme/NavbarItem/NavbarNavLink/index.tsx
@@ -1,0 +1,67 @@
+import React, { type ReactNode } from 'react';
+import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import IconExternalLink from '@theme/Icon/ExternalLink';
+import type { Props } from '@theme/NavbarItem/NavbarNavLink';
+
+function isRegexpStringMatch(regexpString: string, value: string): boolean {
+  return new RegExp(regexpString).test(value);
+}
+
+export default function NavbarNavLink({
+  activeBasePath,
+  activeBaseRegex,
+  to,
+  href,
+  label,
+  html,
+  isDropdownLink,
+  prependBaseUrlToHref,
+  ...props
+}: Props): ReactNode {
+  const toUrl = useBaseUrl(to);
+  const activeBaseUrl = useBaseUrl(activeBasePath);
+  const normalizedHref = useBaseUrl(href, { forcePrependBaseUrl: true });
+  // A same-tab navigation does not need a new-tab announcement or icon.
+  const opensNewTab = props.target === '_blank';
+  const isExternalLink = label && href && !isInternalUrl(href) && opensNewTab;
+
+  const linkContentProps = html
+    ? { dangerouslySetInnerHTML: { __html: html } }
+    : {
+        children: (
+          <>
+            {label}
+            {isExternalLink && (
+              <IconExternalLink {...(isDropdownLink && { width: 12, height: 12 })} />
+            )}
+          </>
+        ),
+      };
+
+  if (href) {
+    return (
+      <Link
+        href={prependBaseUrlToHref ? normalizedHref : href}
+        {...props}
+        {...linkContentProps}
+      />
+    );
+  }
+
+  return (
+    <Link
+      to={toUrl}
+      isNavLink
+      {...((activeBasePath || activeBaseRegex) && {
+        isActive: (_match, location) =>
+          activeBaseRegex
+            ? isRegexpStringMatch(activeBaseRegex, location.pathname)
+            : location.pathname.startsWith(activeBaseUrl),
+      })}
+      {...props}
+      {...linkContentProps}
+    />
+  );
+}


### PR DESCRIPTION
## What changed

- give the mobile documentation drawer an explicit viewport height so its navigation is no longer clipped to the header
- render the external-link marker only for links that actually open a new tab

## Why

The shared header styles left Docusaurus's fixed mobile drawer at the navbar height. Docusaurus also announced same-tab absolute links as opening a new tab.

## Validation

- `pnpm --dir docs/site check`
- verified the generated Chinese documentation navigation has no external-link marker for Products, Docs, or Blog
- verified the local 390px drawer fills the viewport and exposes all navigation links