### PR TITLE
Fix Feishu blockquote rendering and streaming 300309 fallback

### DIFF
--- a/backend/cubeplex/im/feishu/card_renderer.py
+++ b/backend/cubeplex/im/feishu/card_renderer.py
@@ -48,19 +48,25 @@ _VALID_IMAGE_KEY_RE = re.compile(r"^img_[A-Za-z0-9_-]+$")
 _ASCII_CITATION_RE = re.compile(r"\[(\d+(?:-\d+)?)\](?!\()")
 _CN_CITATION_RE = re.compile(r"【(\d+(?:-\d+)?)】")
 
-# Markdown blockquote line: optional indent, one or more `>`, optional
-# whitespace, then body. Feishu CardKit renders top-level `> quote` fine,
-# but list-nested / indented blockquotes (common agent output under
-# "- **建议回复:**") often drop the quote body entirely in the client.
-_BLOCKQUOTE_LINE_RE = re.compile(r"^(\s*)(>+)(?:[ \t]+(.*)|())$")
+# Markdown blockquote line: 0–3 spaces of indent (CommonMark), one or more
+# `>`, optional whitespace, then body. Feishu CardKit renders top-level
+# `> quote` fine, but list-nested blockquotes (common agent output under
+# "- **建议回复:**" with two-space indent) often drop the quote body.
+# Four+ spaces before `>` is indented code — leave it alone.
+_BLOCKQUOTE_LINE_RE = re.compile(r"^(\s{0,3})(>+)(?:[ \t]+(.*)|())$")
+# After hoisting a quote, do not insert a blank line before the next list
+# item so multi-item lists are not split harder than the quote break requires.
+_LIST_ITEM_LINE_RE = re.compile(r"^\s*(?:[-*+]|\d+\.)\s")
 
 
 def _normalize_blockquotes(text: str) -> str:
     """Hoist blockquotes to column-0 CommonMark form Feishu renders reliably.
 
     Keeps quote semantics (`>` markers). Consecutive quote lines stay one
-    block; blank lines are inserted so a preceding list item does not
-    swallow the quote as nested content.
+    block; a blank line is inserted before the quote so a preceding list
+    item does not swallow it as nested content. A trailing blank is only
+    added when the next line is not a list item (avoids splitting
+    multi-item lists more than necessary).
     """
     lines = text.split("\n")
     out: list[str] = []
@@ -90,7 +96,7 @@ def _normalize_blockquotes(text: str) -> str:
         if out and out[-1].strip() != "":
             out.append("")
         out.extend(block)
-        if i < n and lines[i].strip() != "":
+        if i < n and lines[i].strip() != "" and not _LIST_ITEM_LINE_RE.match(lines[i]):
             out.append("")
 
     return "\n".join(out)

--- a/backend/cubeplex/im/feishu/card_renderer.py
+++ b/backend/cubeplex/im/feishu/card_renderer.py
@@ -48,6 +48,53 @@ _VALID_IMAGE_KEY_RE = re.compile(r"^img_[A-Za-z0-9_-]+$")
 _ASCII_CITATION_RE = re.compile(r"\[(\d+(?:-\d+)?)\](?!\()")
 _CN_CITATION_RE = re.compile(r"【(\d+(?:-\d+)?)】")
 
+# Markdown blockquote line: optional indent, one or more `>`, optional
+# whitespace, then body. Feishu CardKit renders top-level `> quote` fine,
+# but list-nested / indented blockquotes (common agent output under
+# "- **建议回复:**") often drop the quote body entirely in the client.
+_BLOCKQUOTE_LINE_RE = re.compile(r"^(\s*)(>+)(?:[ \t]+(.*)|())$")
+
+
+def _normalize_blockquotes(text: str) -> str:
+    """Hoist blockquotes to column-0 CommonMark form Feishu renders reliably.
+
+    Keeps quote semantics (`>` markers). Consecutive quote lines stay one
+    block; blank lines are inserted so a preceding list item does not
+    swallow the quote as nested content.
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        match = _BLOCKQUOTE_LINE_RE.match(lines[i])
+        if match is None:
+            out.append(lines[i])
+            i += 1
+            continue
+
+        block: list[str] = []
+        while i < n:
+            match = _BLOCKQUOTE_LINE_RE.match(lines[i])
+            if match is None:
+                break
+            markers = match.group(2)
+            body = (match.group(3) or "").rstrip()
+            if body:
+                # Feishu docs: keep a space after `>`.
+                block.append(f"{markers} {body.lstrip()}")
+            else:
+                block.append(markers)
+            i += 1
+
+        if out and out[-1].strip() != "":
+            out.append("")
+        out.extend(block)
+        if i < n and lines[i].strip() != "":
+            out.append("")
+
+    return "\n".join(out)
+
 
 def optimize_markdown_style(
     text: str,
@@ -56,9 +103,10 @@ def optimize_markdown_style(
 ) -> str:
     """Sanitize cubepi markdown for Feishu CardKit's markdown element.
 
-    Demotes headings, spaces tables, strips invalid image refs, and
-    rewrites citation markers to inline links. Code blocks are protected
-    from all rewrites.
+    Demotes headings, spaces tables, strips invalid image refs, rewrites
+    citation markers to inline links, and normalizes blockquotes so
+    list-nested quotes still render. Code blocks are protected from all
+    rewrites.
     """
     citations = citation_index or {}
 
@@ -104,6 +152,10 @@ def optimize_markdown_style(
 
     body = _ASCII_CITATION_RE.sub(_rewrite_ascii_citation, body)
     body = _CN_CITATION_RE.sub(_rewrite_cn_citation, body)
+
+    # After other rewrites: lift indented / list-nested `>` to top-level so
+    # CardKit actually paints the quote body (see _normalize_blockquotes).
+    body = _normalize_blockquotes(body)
 
     # Restore code blocks verbatim.
     for i, fence in enumerate(fences):

--- a/backend/cubeplex/im/feishu/cardkit_client.py
+++ b/backend/cubeplex/im/feishu/cardkit_client.py
@@ -23,6 +23,10 @@ _CREATE_RETRY_DELAYS = (0.2, 1.0, 3.0)
 _FINALIZE_RETRY_DELAYS = (0.2, 0.5, 1.0, 3.0, 10.0, 30.0, 30.0, 30.0, 30.0)
 # CardKit rate-limit response code (same as IM patch rate limit).
 _FLOOD_CODE = 230020
+# Streaming element content rejected because streaming_mode is off.
+# Feishu auto-closes streaming ~10 minutes after it was enabled; also set
+# when a prior finalize/settings call already ended the stream window.
+_STREAMING_CLOSED_CODE = 300309
 
 
 class CardKitError(Exception):
@@ -35,6 +39,14 @@ class CardKitCreateError(CardKitError):
 
 class CardKitRateLimit(_FloodSignal):
     """CardKit returned the 230020 throttle response."""
+
+
+class CardKitStreamingClosed(CardKitError):
+    """CardKit returned 300309 — streaming_mode is closed for this card.
+
+    Further ``stream_text`` calls will keep failing; callers should fall
+    back to full-card ``patch_card`` / ``finalize``.
+    """
 
 
 class CardKitClient:
@@ -168,6 +180,8 @@ class CardKitClient:
         code = int(body.get("code", -1))
         if code == _FLOOD_CODE:
             raise CardKitRateLimit(f"stream_text flood (code={code})")
+        if code == _STREAMING_CLOSED_CODE:
+            raise CardKitStreamingClosed(f"stream_text code={code} msg={body.get('msg')}")
         if code != 0:
             raise CardKitError(f"stream_text code={code} msg={body.get('msg')}")
 
@@ -248,4 +262,5 @@ __all__ = [
     "CardKitCreateError",
     "CardKitError",
     "CardKitRateLimit",
+    "CardKitStreamingClosed",
 ]

--- a/backend/cubeplex/im/feishu/op_dispatcher.py
+++ b/backend/cubeplex/im/feishu/op_dispatcher.py
@@ -6,10 +6,12 @@ hard-codes Feishu rendering logic.
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from loguru import logger
 
+from cubeplex.im.feishu.cardkit_client import CardKitStreamingClosed
 from cubeplex.im.outbound import _FloodSignal, note_edit_success, note_flood_strike
 from cubeplex.im.types import RenderState
 
@@ -70,12 +72,24 @@ class FeishuOpDispatcher:
         return True
 
     async def dispatch_stream(self, state: RenderState, text: str) -> bool:
-        """Push a streaming text update to CardKit."""
+        """Push a streaming text update to CardKit.
+
+        When Feishu has closed streaming_mode (300309, typically after the
+        ~10 minute auto-timeout), further ``stream_text`` calls fail forever.
+        Fall back to throttled ``patch_card`` so progressive content still
+        lands; ``finalize`` remains the terminal full replace.
+        """
         cardkit = self._cardkit
         if cardkit is None:
             return False
         if state.card_id is None or state.card_unavailable:
             return False
+
+        # Already know streaming is dead — never call stream_text again.
+        if state.streaming_closed:
+            state.stream_closed_skip_count += 1
+            return await self._throttled_patch_after_stream_closed(state, force=False)
+
         seq = state.card_state.advance_seq()
         from cubeplex.im.feishu.card_renderer import (
             optimize_markdown_style as _optimize,
@@ -92,6 +106,17 @@ class FeishuOpDispatcher:
             )
             note_edit_success(state)
             return True
+        except CardKitStreamingClosed:
+            # First 300309 for this run: one warning, no traceback. Later
+            # stream ops take the streaming_closed branch above (count only).
+            state.streaming_closed = True
+            state.stream_closed_skip_count += 1
+            logger.warning(
+                "[outbound] CardKit streaming mode closed (code=300309) for "
+                "card_id={}; falling back to patch_card until finalize",
+                state.card_id,
+            )
+            return await self._throttled_patch_after_stream_closed(state, force=True)
         except _FloodSignal:
             note_flood_strike(state)
             return False
@@ -136,6 +161,13 @@ class FeishuOpDispatcher:
         cardkit = self._cardkit
         if cardkit is None:
             return False
+        if state.stream_closed_skip_count > 0:
+            logger.info(
+                "[outbound] CardKit streaming was closed; redirected/skipped "
+                "{} stream_text op(s) for card_id={}",
+                state.stream_closed_skip_count,
+                state.card_id,
+            )
         if state.card_id is None or state.card_unavailable:
             if state.card_state.error:
                 await self.emergency_text(f"⚠️ {state.card_state.error}")
@@ -209,6 +241,24 @@ class FeishuOpDispatcher:
                 logger.opt(exception=True).warning("[outbound] cardkit.aclose() raised")
 
     # -- private helpers --
+
+    async def _throttled_patch_after_stream_closed(
+        self,
+        state: RenderState,
+        *,
+        force: bool,
+    ) -> bool:
+        """Full-card patch when stream_text is no longer available.
+
+        ``force=True`` on the first 300309 so the latest cumulative text
+        lands immediately; later redirects respect ``patch_interval`` so a
+        burst of text_deltas does not trip 230020 flood control.
+        """
+        now = time.monotonic()
+        if not force and now - state.last_patch_monotonic < state.patch_interval:
+            return False
+        state.last_patch_monotonic = now
+        return await self.dispatch_patch(state)
 
     async def _maybe_surface_pending_via_emergency(self, state: RenderState) -> None:
         """Surface the HITL prompt via emergency text when patch_card cannot

--- a/backend/cubeplex/im/types.py
+++ b/backend/cubeplex/im/types.py
@@ -216,6 +216,12 @@ class RenderState:
     patch_interval: float = 1.5
     consecutive_flood_strikes: int = 0
     edits_disabled: bool = False
+    # Feishu CardKit auto-closes streaming_mode ~10 minutes after open
+    # (error 300309). Once set, stop stream_text and fall back to patch_card.
+    streaming_closed: bool = False
+    # How many stream_text ops were redirected/skipped after streaming_closed.
+    # Logged once at finalize so the run is not a traceback storm.
+    stream_closed_skip_count: int = 0
     reaction_in_progress_id: str | None = None
     # Bound at tailer start from IMRunQueueItem fields.
     reply_to_id: str | None = None

--- a/backend/tests/im/feishu/test_card_renderer_markdown.py
+++ b/backend/tests/im/feishu/test_card_renderer_markdown.py
@@ -107,3 +107,21 @@ def test_blockquote_inside_code_fence_untouched() -> None:
 def test_nested_blockquote_markers_preserved() -> None:
     out = optimize_markdown_style("  >> nested quote")
     assert out.strip() == ">> nested quote"
+
+
+def test_four_space_indented_gt_not_hoisted_as_blockquote() -> None:
+    """CommonMark: 4+ spaces before `>` is indented code, not a quote."""
+    md = "para\n    > not a quote\nmore"
+    out = optimize_markdown_style(md)
+    assert "    > not a quote" in out
+    assert not any(ln.startswith(">") and "not a quote" in ln for ln in out.splitlines())
+
+
+def test_hoist_does_not_insert_blank_before_following_list_item() -> None:
+    md = "- item one\n  > quote body\n- item two"
+    out = optimize_markdown_style(md)
+    lines = out.splitlines()
+    idx_quote = next(i for i, ln in enumerate(lines) if ln.startswith(">"))
+    assert lines[idx_quote] == "> quote body"
+    # Next non-empty line should be the following list item without an extra blank.
+    assert lines[idx_quote + 1] == "- item two"

--- a/backend/tests/im/feishu/test_card_renderer_markdown.py
+++ b/backend/tests/im/feishu/test_card_renderer_markdown.py
@@ -66,3 +66,44 @@ def test_chinese_bracket_citation_replaced() -> None:
     # The full "【1-3】" span gets one link to the FIRST cited URL with the
     # full label preserved.
     assert "[1-3](https://a)" in out
+
+
+def test_list_nested_blockquote_hoisted_to_top_level() -> None:
+    """Agent often nests suggested replies under a list item; Feishu drops those."""
+    md = (
+        "- **建议回复:**  \n"
+        '  > "Full-stack" usually means moving across the system.\n'
+        "  >   \n"
+        "  > 仅供参考，不会自动发布。"
+    )
+    out = optimize_markdown_style(md)
+    lines = out.splitlines()
+    # Quote markers must be at column 0 (not indented under the list).
+    quote_lines = [ln for ln in lines if ln.startswith(">")]
+    assert quote_lines == [
+        '> "Full-stack" usually means moving across the system.',
+        ">",
+        "> 仅供参考，不会自动发布。",
+    ]
+    # Blank line separates list item from quote so the list does not nest it.
+    assert "- **建议回复:**" in out
+    idx_label = next(i for i, ln in enumerate(lines) if "建议回复" in ln)
+    idx_quote = next(i for i, ln in enumerate(lines) if ln.startswith(">"))
+    assert idx_quote > idx_label
+    assert any(lines[i].strip() == "" for i in range(idx_label + 1, idx_quote))
+
+
+def test_top_level_blockquote_keeps_quote_markers() -> None:
+    out = optimize_markdown_style("> already top-level\n> second line")
+    assert out.splitlines()[:2] == ["> already top-level", "> second line"]
+
+
+def test_blockquote_inside_code_fence_untouched() -> None:
+    md = "```md\n> this is a literal quote marker in code\n```"
+    out = optimize_markdown_style(md)
+    assert "```md\n> this is a literal quote marker in code\n```" in out
+
+
+def test_nested_blockquote_markers_preserved() -> None:
+    out = optimize_markdown_style("  >> nested quote")
+    assert out.strip() == ">> nested quote"

--- a/backend/tests/im/feishu/test_cardkit_client.py
+++ b/backend/tests/im/feishu/test_cardkit_client.py
@@ -114,6 +114,26 @@ async def test_stream_text_raises_ratelimit_on_230020() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_text_raises_streaming_closed_on_300309() -> None:
+    def handler(_: Request) -> Response:
+        return Response(
+            200,
+            json={"code": 300309, "msg": "ErrMsg: streaming mode is closed; "},
+        )
+
+    client = _build_client(MockTransport(handler))
+    from cubeplex.im.feishu.cardkit_client import CardKitStreamingClosed
+
+    with pytest.raises(CardKitStreamingClosed):
+        await client.stream_text(
+            card_id="AAQA",
+            element_id="streaming_content",
+            content="x",
+            sequence=1,
+        )
+
+
+@pytest.mark.asyncio
 async def test_patch_card_sends_full_json() -> None:
     captured: dict[str, object] = {}
 

--- a/backend/tests/im/feishu/test_op_dispatcher_streaming_closed.py
+++ b/backend/tests/im/feishu/test_op_dispatcher_streaming_closed.py
@@ -1,0 +1,175 @@
+"""FeishuOpDispatcher: 300309 streaming-closed → patch fallback + quiet logs."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cubeplex.im.feishu.cardkit_client import CardKitStreamingClosed
+from cubeplex.im.feishu.op_dispatcher import FeishuOpDispatcher
+from cubeplex.im.types import RenderState
+
+
+class _FakeCardKit:
+    def __init__(self) -> None:
+        self.stream_calls = 0
+        self.patch_calls = 0
+        self.finalize_calls = 0
+        self.fail_stream_with: Exception | None = CardKitStreamingClosed(
+            "stream_text code=300309 msg=ErrMsg: streaming mode is closed; "
+        )
+
+    async def stream_text(self, **_: Any) -> None:
+        self.stream_calls += 1
+        if self.fail_stream_with is not None:
+            raise self.fail_stream_with
+
+    async def patch_card(self, **_: Any) -> None:
+        self.patch_calls += 1
+
+    async def finalize(self, **_: Any) -> bool:
+        self.finalize_calls += 1
+        return True
+
+    async def create_entity(self, *_: Any, **__: Any) -> str:
+        return "card-1"
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _state(*, card_id: str = "card-1") -> RenderState:
+    state = RenderState(bot_name="bot", run_id="run-1")
+    state.card_id = card_id
+    state.card_state.streaming_content = "hello world"
+    # Make throttle easy to force/skip in tests.
+    state.patch_interval = 1.5
+    state.last_patch_monotonic = 0.0
+    return state
+
+
+def _dispatcher(cardkit: _FakeCardKit, state: RenderState) -> FeishuOpDispatcher:
+    connector = AsyncMock()
+    return FeishuOpDispatcher(connector=connector, state=state, cardkit=cardkit)
+
+
+@pytest.mark.asyncio
+async def test_first_300309_falls_back_to_patch_and_sets_flag() -> None:
+    cardkit = _FakeCardKit()
+    state = _state()
+    d = _dispatcher(cardkit, state)
+
+    ok = await d.dispatch_stream(state, "hello world")
+
+    assert ok is True
+    assert state.streaming_closed is True
+    assert state.stream_closed_skip_count == 1
+    assert cardkit.stream_calls == 1
+    assert cardkit.patch_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_subsequent_stream_skips_stream_text_and_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cardkit = _FakeCardKit()
+    state = _state()
+    state.streaming_closed = True
+    state.stream_closed_skip_count = 1
+    # First redirected patch should go through (last_patch is 0).
+    d = _dispatcher(cardkit, state)
+
+    ok1 = await d.dispatch_stream(state, "hello world")
+    assert ok1 is True
+    assert cardkit.stream_calls == 0
+    assert cardkit.patch_calls == 1
+    assert state.stream_closed_skip_count == 2
+
+    # Immediate second stream: throttled, still counted, no extra patch.
+    ok2 = await d.dispatch_stream(state, "hello world more")
+    assert ok2 is False
+    assert cardkit.stream_calls == 0
+    assert cardkit.patch_calls == 1
+    assert state.stream_closed_skip_count == 3
+
+    # Advance past patch_interval → another patch.
+    monkeypatch.setattr(
+        "cubeplex.im.feishu.op_dispatcher.time.monotonic",
+        lambda: state.last_patch_monotonic + state.patch_interval + 0.01,
+    )
+    ok3 = await d.dispatch_stream(state, "hello world more still")
+    assert ok3 is True
+    assert cardkit.patch_calls == 2
+    assert state.stream_closed_skip_count == 4
+
+
+@pytest.mark.asyncio
+async def test_300309_logs_warning_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    cardkit = _FakeCardKit()
+    state = _state()
+    d = _dispatcher(cardkit, state)
+    warnings: list[str] = []
+
+    def _capture(msg: str, *args: Any, **__: Any) -> None:
+        warnings.append(msg.format(*args) if args else msg)
+
+    monkeypatch.setattr(
+        "cubeplex.im.feishu.op_dispatcher.logger.warning",
+        _capture,
+    )
+
+    await d.dispatch_stream(state, "a")
+    # Already closed — must not warn again.
+    await d.dispatch_stream(state, "ab")
+    await d.dispatch_stream(state, "abc")
+
+    closed_warnings = [w for w in warnings if "300309" in w or "streaming mode closed" in w]
+    assert len(closed_warnings) == 1
+    assert state.stream_closed_skip_count == 3
+
+
+@pytest.mark.asyncio
+async def test_finalize_still_works_after_streaming_closed() -> None:
+    cardkit = _FakeCardKit()
+    state = _state()
+    state.streaming_closed = True
+    state.stream_closed_skip_count = 12
+    state.card_state.finalized = True
+    d = _dispatcher(cardkit, state)
+
+    ok = await d.dispatch_finalize(state)
+    assert ok is True
+    assert cardkit.finalize_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_other_stream_errors_still_log_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cardkit = _FakeCardKit()
+    cardkit.fail_stream_with = RuntimeError("boom")
+    state = _state()
+    d = _dispatcher(cardkit, state)
+
+    opt_calls: list[bool] = []
+
+    class _Opt:
+        def warning(self, *_: Any, **__: Any) -> None:
+            return None
+
+    def _opt(*, exception: bool = False) -> _Opt:
+        opt_calls.append(exception)
+        return _Opt()
+
+    monkeypatch.setattr(
+        "cubeplex.im.feishu.op_dispatcher.logger.opt",
+        _opt,
+    )
+
+    ok = await d.dispatch_stream(state, "x")
+    assert ok is False
+    assert state.streaming_closed is False
+    assert cardkit.patch_calls == 0
+    assert opt_calls == [True]


### PR DESCRIPTION
## Summary

- Normalize list-nested markdown blockquotes (`  > …`) to top-level `>` so CardKit shows suggested-reply quote bodies instead of dropping them.
- On CardKit `300309` (streaming mode closed after ~10 min), stop calling `stream_text`, fall back to throttled `patch_card`, log once per run, and keep `finalize` as the terminal path.

## Test plan

- [x] `uv run pytest tests/im/feishu/test_card_renderer_markdown.py tests/im/feishu/test_op_dispatcher_streaming_closed.py tests/im/feishu/test_cardkit_client.py --no-cov`
- [x] Pre-push `check-ci` passed
- [ ] Smoke on a long Feishu IM run: nested “建议回复” quotes visible; after ~10 min no 300309 traceback storm and card still updates via patch/finalize