### PR TITLE
Browser live-view fails on first open with proxy 500

### DIFF
--- a/frontend/docs/auth-and-sse.md
+++ b/frontend/docs/auth-and-sse.md
@@ -67,6 +67,23 @@ scoping rides in the URL path, **not a header**.
 **Gotcha:** Next.js rewrite buffers SSE if `compress` is on. Keep
 `compress: false`.
 
+## Long-running API proxies (browser live-view)
+
+`next.config.ts` rewrites `/api/*` to the backend with a **hardcoded ~30s
+http-proxy timeout**. Anything slower (sandbox browser cold start can be
+30–120s) dies as `socket hang up` / `ECONNRESET` even when the backend later
+returns 200 — the UI then shows a proxy 500.
+
+Long-running endpoints that must wait on the backend use a **filesystem
+route handler** under `app/api/...` so they take precedence over the rewrite
+fallback and are not bound by that 30s ceiling:
+
+- `app/api/v1/ws/[wsId]/browser/live-view/route.ts` — sandbox Neko live-view
+  URL mint (`maxDuration = 180`)
+
+Same pattern as the SSE/messages handlers above. Prefer a dedicated route
+handler over raising a global rewrite timeout.
+
 ## Deployment Mode (M9)
 
 The backend exposes `GET /api/v1/system/info` (public, pre-login)

--- a/frontend/packages/web/__tests__/api/browser-live-view-route.test.ts
+++ b/frontend/packages/web/__tests__/api/browser-live-view-route.test.ts
@@ -114,4 +114,30 @@ describe('browser live-view route proxy', () => {
       detail: expect.stringContaining('proxy failed'),
     })
   })
+
+  it('returns 504 JSON when the response body stalls after headers', async () => {
+    const stalled = {
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: async () => {
+        throw new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+      },
+    }
+    const backendFetch = vi.fn(async () => stalled as unknown as Response)
+    vi.stubGlobal('fetch', backendFetch)
+
+    const request = {
+      url: 'http://localhost/api/v1/ws/ws-42/browser/live-view',
+      headers: new Headers(),
+    } as any
+
+    const response = await GET(request, {
+      params: Promise.resolve({ wsId: 'ws-42' }),
+    })
+
+    expect(response.status).toBe(504)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringContaining('timed out'),
+    })
+  })
 })

--- a/frontend/packages/web/__tests__/api/browser-live-view-route.test.ts
+++ b/frontend/packages/web/__tests__/api/browser-live-view-route.test.ts
@@ -1,0 +1,70 @@
+import { GET } from '../../app/api/v1/ws/[wsId]/browser/live-view/route'
+
+describe('browser live-view route proxy', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('forwards identity headers, wsId, and conversation_id query', async () => {
+    const backendFetch = vi.fn(async () =>
+      Response.json({ url: 'https://neko.example/view?token=abc' }),
+    )
+    vi.stubGlobal('fetch', backendFetch)
+
+    const request = {
+      url: 'http://localhost/api/v1/ws/ws-42/browser/live-view?conversation_id=conv-9',
+      headers: new Headers([
+        ['cookie', 'cubeplex_auth=cookie-val'],
+        ['x-user-id', 'header-user'],
+        ['x-csrf-token', 'csrf-token'],
+      ]),
+    } as any
+
+    const response = await GET(request, {
+      params: Promise.resolve({ wsId: 'ws-42' }),
+    })
+
+    expect(backendFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = backendFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/api/v1/ws/ws-42/browser/live-view?conversation_id=conv-9')
+    expect(init?.headers).toMatchObject({
+      Accept: 'application/json',
+      cookie: 'cubeplex_auth=cookie-val',
+      'x-user-id': 'header-user',
+      'X-CSRF-Token': 'csrf-token',
+    })
+    expect(init).toMatchObject({ cache: 'no-store' })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      url: 'https://neko.example/view?token=abc',
+    })
+  })
+
+  it('passes through backend status and set-cookie', async () => {
+    const backendFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ detail: 'sandbox is starting up' }), {
+          status: 503,
+          headers: {
+            'content-type': 'application/json',
+            'set-cookie': 'cubeplex_auth=refreshed; Path=/; HttpOnly',
+          },
+        }),
+    )
+    vi.stubGlobal('fetch', backendFetch)
+
+    const request = {
+      url: 'http://localhost/api/v1/ws/ws-42/browser/live-view',
+      headers: new Headers(),
+    } as any
+
+    const response = await GET(request, {
+      params: Promise.resolve({ wsId: 'ws-42' }),
+    })
+
+    expect(response.status).toBe(503)
+    expect(response.headers.get('set-cookie')).toContain('cubeplex_auth=refreshed')
+    await expect(response.json()).resolves.toEqual({ detail: 'sandbox is starting up' })
+  })
+})

--- a/frontend/packages/web/__tests__/api/browser-live-view-route.test.ts
+++ b/frontend/packages/web/__tests__/api/browser-live-view-route.test.ts
@@ -1,4 +1,4 @@
-import { GET } from '../../app/api/v1/ws/[wsId]/browser/live-view/route'
+import { GET, UPSTREAM_TIMEOUT_MS } from '../../app/api/v1/ws/[wsId]/browser/live-view/route'
 
 describe('browser live-view route proxy', () => {
   beforeEach(() => {
@@ -34,6 +34,10 @@ describe('browser live-view route proxy', () => {
       'X-CSRF-Token': 'csrf-token',
     })
     expect(init).toMatchObject({ cache: 'no-store' })
+    expect(init?.signal).toBeInstanceOf(AbortSignal)
+    // Bound must sit under maxDuration (180s) and above start_browser (120s).
+    expect(UPSTREAM_TIMEOUT_MS).toBeGreaterThan(120_000)
+    expect(UPSTREAM_TIMEOUT_MS).toBeLessThan(180_000)
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({
@@ -66,5 +70,48 @@ describe('browser live-view route proxy', () => {
     expect(response.status).toBe(503)
     expect(response.headers.get('set-cookie')).toContain('cubeplex_auth=refreshed')
     await expect(response.json()).resolves.toEqual({ detail: 'sandbox is starting up' })
+  })
+
+  it('returns 504 JSON when the upstream wait times out', async () => {
+    const timeoutErr = new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+    const backendFetch = vi.fn(async () => {
+      throw timeoutErr
+    })
+    vi.stubGlobal('fetch', backendFetch)
+
+    const request = {
+      url: 'http://localhost/api/v1/ws/ws-42/browser/live-view',
+      headers: new Headers(),
+    } as any
+
+    const response = await GET(request, {
+      params: Promise.resolve({ wsId: 'ws-42' }),
+    })
+
+    expect(response.status).toBe(504)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringContaining('timed out'),
+    })
+  })
+
+  it('returns 502 JSON when the upstream fetch fails (network)', async () => {
+    const backendFetch = vi.fn(async () => {
+      throw new TypeError('fetch failed')
+    })
+    vi.stubGlobal('fetch', backendFetch)
+
+    const request = {
+      url: 'http://localhost/api/v1/ws/ws-42/browser/live-view',
+      headers: new Headers(),
+    } as any
+
+    const response = await GET(request, {
+      params: Promise.resolve({ wsId: 'ws-42' }),
+    })
+
+    expect(response.status).toBe(502)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringContaining('proxy failed'),
+    })
   })
 })

--- a/frontend/packages/web/app/api/v1/ws/[wsId]/browser/live-view/route.ts
+++ b/frontend/packages/web/app/api/v1/ws/[wsId]/browser/live-view/route.ts
@@ -63,13 +63,22 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   const qs = new URL(request.url).search
   const url = `${BACKEND_URL}/api/v1/ws/${wsId}/browser/live-view${qs}`
 
-  let backendRes: Response
   try {
-    backendRes = await fetch(url, {
+    // Guard both the upstream wait *and* body consumption: headers can arrive
+    // while the body stalls; AbortSignal.timeout aborts the body stream too.
+    const backendRes = await fetch(url, {
       headers: buildProxyHeaders(request),
       // Never cache a signed live-view URL.
       cache: 'no-store',
       signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    })
+    const contentType = backendRes.headers.get('content-type') ?? 'application/json'
+    const body = await backendRes.text()
+    const headers = new Headers({ 'Content-Type': contentType })
+    appendSetCookie(headers, backendRes.headers)
+    return new NextResponse(body, {
+      status: backendRes.status,
+      headers,
     })
   } catch (err) {
     if (isTimeoutError(err)) {
@@ -85,13 +94,4 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       { status: 502 },
     )
   }
-
-  const contentType = backendRes.headers.get('content-type') ?? 'application/json'
-  const body = await backendRes.text()
-  const headers = new Headers({ 'Content-Type': contentType })
-  appendSetCookie(headers, backendRes.headers)
-  return new NextResponse(body, {
-    status: backendRes.status,
-    headers,
-  })
 }

--- a/frontend/packages/web/app/api/v1/ws/[wsId]/browser/live-view/route.ts
+++ b/frontend/packages/web/app/api/v1/ws/[wsId]/browser/live-view/route.ts
@@ -1,0 +1,65 @@
+/**
+ * Browser live-view endpoint — Route Handler proxy.
+ *
+ * Cold-start of the sandbox Neko stack can take 30–120s (start-browser.sh).
+ * Next.js config rewrites use a hardcoded ~30s http-proxy timeout, which
+ * aborts the upstream connection (`socket hang up` / ECONNRESET) while the
+ * backend is still working and eventually returns 200. The browser then
+ * sees a proxy 500 even though the backend succeeded.
+ *
+ * A dedicated route handler takes precedence over the rewrite fallback
+ * (same pattern as the SSE messages proxy) and has no 30s proxy ceiling.
+ * See: https://github.com/cubeplexai/cubeplex/issues/422
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.CUBEPLEX_API_URL ?? 'http://localhost:8000'
+
+// Backend start_browser allows up to 120s for the shell script; leave headroom
+// for get_or_create + endpoint mint. Hosted platforms that honor maxDuration
+// will keep the function alive; local Next dev has no such cap on route handlers.
+export const maxDuration = 180
+export const dynamic = 'force-dynamic'
+
+function buildProxyHeaders(request: NextRequest): HeadersInit {
+  const headers: Record<string, string> = { Accept: 'application/json' }
+  const cookie = request.headers.get('cookie')
+  const userId = request.headers.get('x-user-id')
+  const csrf = request.headers.get('x-csrf-token')
+  if (cookie) headers.cookie = cookie
+  if (userId) headers['x-user-id'] = userId
+  if (csrf) headers['X-CSRF-Token'] = csrf
+  return headers
+}
+
+function appendSetCookie(target: Headers, source: Headers): void {
+  const getSetCookie = (source as Headers & { getSetCookie?: () => string[] }).getSetCookie
+  if (typeof getSetCookie === 'function') {
+    for (const value of getSetCookie.call(source)) {
+      target.append('set-cookie', value)
+    }
+    return
+  }
+  const setCookie = source.get('set-cookie')
+  if (setCookie) target.append('set-cookie', setCookie)
+}
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ wsId: string }> }) {
+  const { wsId } = await params
+  const qs = new URL(request.url).search
+
+  const backendRes = await fetch(`${BACKEND_URL}/api/v1/ws/${wsId}/browser/live-view${qs}`, {
+    headers: buildProxyHeaders(request),
+    // Never cache a signed live-view URL.
+    cache: 'no-store',
+  })
+
+  const contentType = backendRes.headers.get('content-type') ?? 'application/json'
+  const body = await backendRes.text()
+  const headers = new Headers({ 'Content-Type': contentType })
+  appendSetCookie(headers, backendRes.headers)
+  return new NextResponse(body, {
+    status: backendRes.status,
+    headers,
+  })
+}

--- a/frontend/packages/web/app/api/v1/ws/[wsId]/browser/live-view/route.ts
+++ b/frontend/packages/web/app/api/v1/ws/[wsId]/browser/live-view/route.ts
@@ -21,6 +21,11 @@ const BACKEND_URL = process.env.CUBEPLEX_API_URL ?? 'http://localhost:8000'
 export const maxDuration = 180
 export const dynamic = 'force-dynamic'
 
+// Bound the upstream wait below maxDuration so a hung backend still returns a
+// client-visible JSON error (and SWR can retry) instead of spinning forever.
+// 165s = start_browser 120s + get_or_create/endpoint slack, under the 180s cap.
+export const UPSTREAM_TIMEOUT_MS = 165_000
+
 function buildProxyHeaders(request: NextRequest): HeadersInit {
   const headers: Record<string, string> = { Accept: 'application/json' }
   const cookie = request.headers.get('cookie')
@@ -44,15 +49,42 @@ function appendSetCookie(target: Headers, source: Headers): void {
   if (setCookie) target.append('set-cookie', setCookie)
 }
 
+function isTimeoutError(err: unknown): boolean {
+  // AbortSignal.timeout → TimeoutError (DOMException); AbortController → AbortError.
+  // Do not require `instanceof Error` — DOMException identity can differ across
+  // realms / test environments while still exposing `.name`.
+  if (err == null || typeof err !== 'object') return false
+  const name = (err as { name?: string }).name
+  return name === 'TimeoutError' || name === 'AbortError'
+}
+
 export async function GET(request: NextRequest, { params }: { params: Promise<{ wsId: string }> }) {
   const { wsId } = await params
   const qs = new URL(request.url).search
+  const url = `${BACKEND_URL}/api/v1/ws/${wsId}/browser/live-view${qs}`
 
-  const backendRes = await fetch(`${BACKEND_URL}/api/v1/ws/${wsId}/browser/live-view${qs}`, {
-    headers: buildProxyHeaders(request),
-    // Never cache a signed live-view URL.
-    cache: 'no-store',
-  })
+  let backendRes: Response
+  try {
+    backendRes = await fetch(url, {
+      headers: buildProxyHeaders(request),
+      // Never cache a signed live-view URL.
+      cache: 'no-store',
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    })
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return NextResponse.json(
+        {
+          detail: 'sandbox browser live-view timed out waiting for backend; please retry',
+        },
+        { status: 504 },
+      )
+    }
+    return NextResponse.json(
+      { detail: 'sandbox browser live-view proxy failed; please retry' },
+      { status: 502 },
+    )
+  }
 
   const contentType = backendRes.headers.get('content-type') ?? 'application/json'
   const body = await backendRes.text()

--- a/frontend/packages/web/components/panel/BrowserView.tsx
+++ b/frontend/packages/web/components/panel/BrowserView.tsx
@@ -41,7 +41,16 @@ export function BrowserView({
   refreshRef,
   conversationId,
 }: BrowserViewProps) {
-  const { url, loading, error, refresh } = useBrowserLiveView(workspaceId, enabled, conversationId)
+  const { url, loading, error, validating, refresh } = useBrowserLiveView(
+    workspaceId,
+    enabled,
+    conversationId,
+  )
+  // Keep "Connecting…" up while the first request is in flight OR while SWR is
+  // retrying a transient failure (cold-start 503 / brief proxy blip). Only show
+  // the hard error after retries are exhausted and we still have no URL.
+  const showConnecting = !url && (loading || (Boolean(error) && validating))
+  const showError = Boolean(error) && !url && !validating
   const close = usePanelStore((s) => s.close)
   const [takeover, setTakeover] = useState(false)
   const overlayRef = useRef<HTMLDivElement>(null)
@@ -134,12 +143,12 @@ export function BrowserView({
       )}
 
       <div className="relative flex-1 overflow-hidden">
-        {loading && (
+        {showConnecting && (
           <div className="absolute inset-0 grid place-items-center text-sm text-muted-foreground">
             Connecting to the sandbox browser…
           </div>
         )}
-        {error && (
+        {showError && error && (
           <div className="absolute inset-0 grid place-items-center px-4 text-center text-sm text-destructive">
             Could not open the sandbox browser. {error.message}
           </div>

--- a/frontend/packages/web/hooks/useBrowserLiveView.ts
+++ b/frontend/packages/web/hooks/useBrowserLiveView.ts
@@ -12,6 +12,14 @@ async function fetcher(url: string): Promise<BrowserLiveView> {
   return res.json() as Promise<BrowserLiveView>
 }
 
+/** Retry transient cold-start / proxy failures; skip auth and not-found. */
+function shouldRetryOnError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? '')
+  // 401/403/404 are terminal for this endpoint.
+  if (/browser live-view fetch failed: 40[134]\b/.test(msg)) return false
+  return true
+}
+
 /**
  * Fetches the embeddable live-view URL for the workspace's sandbox browser.
  * The backend ensures the Neko stack is running before returning the URL.
@@ -19,6 +27,10 @@ async function fetcher(url: string): Promise<BrowserLiveView> {
  * Pass ``conversationId`` so dedicated-mode topic / standalone group-chat
  * conversations resolve to the shared sandbox's browser instead of the
  * viewer's personal one.
+ *
+ * Cold start can take tens of seconds; the request is served by a dedicated
+ * Next route handler (not the 30s rewrite proxy) so it can wait for the
+ * backend. We still retry transient 5xx/network errors a few times.
  */
 export function useBrowserLiveView(
   workspaceId: string | null,
@@ -27,14 +39,19 @@ export function useBrowserLiveView(
 ) {
   const convQs = conversationId ? `?conversation_id=${encodeURIComponent(conversationId)}` : ''
   const key = workspaceId && enabled ? `/api/v1/ws/${workspaceId}/browser/live-view${convQs}` : null
-  const { data, error, isLoading, mutate } = useSWR<BrowserLiveView>(key, fetcher, {
+  const { data, error, isLoading, isValidating, mutate } = useSWR<BrowserLiveView>(key, fetcher, {
     revalidateOnFocus: false,
     revalidateOnMount: true,
-    shouldRetryOnError: false,
+    shouldRetryOnError,
+    errorRetryCount: 4,
+    // Give cold-start 503s a few seconds before the next attempt.
+    errorRetryInterval: 3000,
   })
   return {
     url: data?.url ?? null,
     loading: isLoading,
+    /** True while SWR is in-flight (first load or error retry). */
+    validating: isValidating,
     error: error as Error | undefined,
     refresh: mutate,
   }


### PR DESCRIPTION
## Summary

Fixes intermittent **Could not open the sandbox browser. browser live-view fetch failed: 500** on first open (refresh usually works).

**Root cause:** cold-start of the sandbox Neko stack can take ~30–120s. Next.js config rewrites hard-timeout the upstream http-proxy at ~30s (`socket hang up` / `ECONNRESET`). Backend still returns **200** after ~48s (observed), but the browser sees a proxy failure.

**Fix:**
- Dedicated App Router handler for `GET /api/v1/ws/{ws}/browser/live-view` (takes precedence over rewrite fallback; `maxDuration = 180`) — same pattern as SSE/messages proxies
- SWR retries transient 5xx/network errors; UI stays on “Connecting…” while retrying instead of flashing a hard error

Closes #422

## Test plan

- [x] Unit: `browser-live-view-route.test.ts` (header/query forwarding, status/set-cookie passthrough)
- [x] `frontend check-ci` (lint, type-check, vitest, next build) via pre-push
- [ ] Manual: open browser preview on a cold sandbox; first open should stay on “Connecting…” and succeed without refresh (can take ~1 min)
- [ ] Manual: open live-view when browser already warm; still loads quickly
- [ ] Confirm Next logs no longer show `Failed to proxy ... socket hang up` for this path