### PR TITLE
Browser take over: no second Neko mouse click

### DIFF
--- a/backend/cubeplex/api/routes/v1/ws_browser.py
+++ b/backend/cubeplex/api/routes/v1/ws_browser.py
@@ -27,9 +27,10 @@ router = APIRouter(prefix="/ws/{workspace_id}/browser", tags=["ws-browser"])
 
 # Neko HTML5 client URL params, read client-side:
 # - usr/pwd: auto-login (stripped after read). The password is the sandbox
-#   image's fixed Neko user password; with session.implicit_hosting the member
-#   auto-gets control, so the frontend "take over" works without an extra
-#   in-Neko step. The endpoint is per-sandbox access-controlled, so this isn't a
+#   image's fixed Neko user password. The sandbox image enables
+#   session.implicit_hosting (see deploy/images/sandbox/Dockerfile) so the first
+#   click after cubeplex "Take over" grants control — no second in-Neko mouse
+#   toggle. The endpoint is per-sandbox access-controlled, so this isn't a
 #   meaningful secret.
 # - embed/show_side/volume: strip Neko's own chrome (logo bar, side/chat panel)
 #   and mute (muted autoplay avoids the "click to enable audio" overlay) so the

--- a/backend/tests/unit/test_sandbox_browser.py
+++ b/backend/tests/unit/test_sandbox_browser.py
@@ -2,10 +2,29 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from cubeplex.sandbox.base import BrowserEndpoint, ExecuteResult, Sandbox
 from cubeplex.sandbox.local import LocalSandbox
+
+# backend/tests/unit → repo root
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SANDBOX_DOCKERFILE = _REPO_ROOT / "deploy" / "images" / "sandbox" / "Dockerfile"
+
+
+def test_sandbox_image_enables_neko_implicit_hosting() -> None:
+    """Take over must not require a second in-Neko mouse/control click (#423).
+
+    Upstream Neko defaults to ``implicit_hosting: false``. The sandbox image must
+    flip that so the first click after cubeplex "Take over" grants control, and
+    must hide Neko's redundant mouse control chrome in the embed.
+    """
+    text = _SANDBOX_DOCKERFILE.read_text(encoding="utf-8")
+    assert "NEKO_SESSION_IMPLICIT_HOSTING=true" in text
+    assert "implicit_hosting: false/implicit_hosting: true" in text
+    assert "fa-mouse-pointer" in text
 
 
 class _RecordingSandbox(Sandbox):

--- a/deploy/images/sandbox/Dockerfile
+++ b/deploy/images/sandbox/Dockerfile
@@ -214,14 +214,21 @@ COPY --from=neko /etc/neko /etc/neko
 COPY --from=neko /var/www /var/www
 COPY --from=neko /usr/lib/xorg/modules/drivers/dummy_drv.so /usr/lib/xorg/modules/drivers/dummy_drv.so
 COPY --from=neko /usr/lib/xorg/modules/input/neko_drv.so /usr/lib/xorg/modules/input/neko_drv.so
+# Upstream neko.yaml sets implicit_hosting: false (legacy multi-viewer default).
+# Cubeplex owns watch/takeover at the panel layer (BrowserView overlay), so the
+# member must get input on the first click after "Take over" without a second
+# in-Neko mouse/control toggle. See issue #423.
+RUN sed -i 's/implicit_hosting: false/implicit_hosting: true/' /etc/neko/neko.yaml
 # Trim the embedded Neko client UI:
 # - hide the "open in new window" (popout) control — useless in the panel;
 # - hide every n.eko logo (connect + loading splashes) so none flashes;
-# - hide the player-overlay (the "click to play / unmute" prompt).
+# - hide the player-overlay (the "click to play / unmute" prompt);
+# - hide Neko's host/control mouse chrome (redundant with cubeplex Take over;
+#   with implicit_hosting the interactive toggle is already a no-op status icon).
 # The script forces the <video> muted so it autoplays (browser autoplay policy
 # only allows muted autoplay; volume=0 alone still triggers the prompt), making
 # the now-hidden overlay unnecessary. Keep clipboard + fullscreen.
-RUN sed -i 's#</head>#<style>.video-menu li:has(.fa-external-link-alt){display:none!important}.logo{display:none!important}.player-overlay{display:none!important}</style><script>setInterval(function(){var v=document.querySelector("video");if(v){try{v.muted=true;if(v.paused)v.play().catch(function(){});}catch(e){}}},250);</script></head>#' /var/www/index.html
+RUN sed -i 's#</head>#<style>.video-menu li:has(.fa-external-link-alt){display:none!important}.video-menu li:has(.fa-mouse-pointer),.video-menu li:has(.fa-computer-mouse),.video-menu li:has(.fa-mouse){display:none!important}.logo{display:none!important}.player-overlay{display:none!important}</style><script>setInterval(function(){var v=document.querySelector("video");if(v){try{v.muted=true;if(v.paused)v.play().catch(function(){});}catch(e){}}},250);</script></head>#' /var/www/index.html
 
 # neko user at uid 1000. Remove a pre-existing uid-1000 user conditionally so the
 # build stays deterministic across base-image variants (never hard-fail).
@@ -261,12 +268,15 @@ ARG NEKO_TURN_URL=turn:192.168.1.208:3478
 ARG NEKO_TURN_USER=neko
 ARG NEKO_TURN_CRED=neko
 
+# First click after cubeplex "Take over" grants control (no in-Neko mouse step).
+# Env wins over /etc/neko/neko.yaml if the image is rebuilt from a newer base.
 ENV USER=neko \
     DISPLAY=:99.0 \
     XDG_RUNTIME_DIR=/tmp/runtime-neko \
     NEKO_SERVER_BIND=:8080 \
     NEKO_PLUGINS_ENABLED=true \
     NEKO_PLUGINS_DIR=/etc/neko/plugins/ \
+    NEKO_SESSION_IMPLICIT_HOSTING=true \
     NEKO_WEBRTC_ICELITE=false \
     NEKO_WEBRTC_ICESERVERS_FRONTEND="[{\"urls\":[\"${NEKO_TURN_URL}\"],\"username\":\"${NEKO_TURN_USER}\",\"credential\":\"${NEKO_TURN_CRED}\"}]" \
     NEKO_WEBRTC_ICESERVERS_BACKEND="[{\"urls\":[\"${NEKO_TURN_URL}\"],\"username\":\"${NEKO_TURN_USER}\",\"credential\":\"${NEKO_TURN_CRED}\"}]"


### PR DESCRIPTION
## Summary

- Enable Neko `session.implicit_hosting` in the sandbox image so the first click after cubeplex **Take over** grants control (upstream default is `false`).
- Hide Neko's redundant in-iframe mouse/control chrome in the embed (product control stays on cubeplex Take over / Hand back).
- Contract unit test so the image does not regress to the double-gate UX.

Closes #423

## Why

Users had to click **both** cubeplex **Take over** and Neko's top-right mouse button before mouse/keyboard worked. Design already assumed `implicit_hosting`; the image still shipped upstream's `false`.

## Changes

| Area | Change |
|---|---|
| `deploy/images/sandbox/Dockerfile` | Patch `neko.yaml` → `implicit_hosting: true`; `NEKO_SESSION_IMPLICIT_HOSTING=true`; hide `fa-mouse*` control icons |
| `ws_browser.py` | Comment points at the image config that makes one-click take over work |
| `test_sandbox_browser.py` | Assert Dockerfile keeps implicit hosting + mouse chrome hide |

## Test plan

- [x] `uv run pytest tests/unit/test_sandbox_browser.py --no-cov` (9 passed)
- [x] pre-push `check-ci` passed
- [ ] Rebuild/redeploy sandbox image, open browser panel → **Take over** once → click/type without Neko mouse button
- [ ] Watch-only still blocks input; **Hand back to agent** restores watch-only

**Note:** Needs a new sandbox image build/rollout to take effect in running environments.