### PR TITLE
Auto-open artifact preview after save

### DIFF
--- a/docs/site/docs/getting-started/core-concepts.md
+++ b/docs/site/docs/getting-started/core-concepts.md
@@ -96,7 +96,7 @@ Artifacts are deliverables the agent produces during a conversation. They go bey
 Artifacts are:
 
 - **Versioned** — the agent can iterate on an artifact across multiple turns.
-- **Previewable** — rendered inline in the conversation.
+- **Previewable** — when you are on the conversation, the preview panel opens automatically after the agent saves an artifact; you can also open any artifact from its card.
 - **Downloadable** — save artifacts to your local machine.
 
 ## Automation

--- a/docs/site/docs/getting-started/quick-start.md
+++ b/docs/site/docs/getting-started/quick-start.md
@@ -57,7 +57,7 @@ Ask the agent to create something concrete — for example:
 
 > Write a Python script that converts CSV to JSON.
 
-If the agent generates a deliverable, it appears as an **artifact** you can preview, copy, or download.
+If the agent generates a deliverable, it appears as an **artifact**. When you are viewing that conversation, the preview panel opens automatically after the artifact is saved so you can inspect it immediately. You can also open any artifact from its card in the chat.
 
 ## 4. Explore further
 

--- a/frontend/packages/core/src/index.ts
+++ b/frontend/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export {
 export {
   AUTO_OPEN_ARTIFACTS_STORAGE_KEY,
   DEFAULT_AUTO_OPEN_ARTIFACTS,
+  canAutoOpenReplacePanel,
   isAutoOpenArtifactsEnabled,
   parseAutoOpenArtifacts,
   setAutoOpenArtifactsEnabled,

--- a/frontend/packages/core/src/index.ts
+++ b/frontend/packages/core/src/index.ts
@@ -10,6 +10,14 @@ export {
   isMarkdownEditable,
   markdownFilename,
 } from './lib/artifactMarkdown'
+export {
+  AUTO_OPEN_ARTIFACTS_STORAGE_KEY,
+  DEFAULT_AUTO_OPEN_ARTIFACTS,
+  isAutoOpenArtifactsEnabled,
+  parseAutoOpenArtifacts,
+  setAutoOpenArtifactsEnabled,
+  shouldAutoOpenArtifactPreview,
+} from './lib/autoOpenPreview'
 export type * from './types/provider'
 export * from './api/providers'
 export { useProvidersStore } from './stores/providersStore'

--- a/frontend/packages/core/src/lib/autoOpenPreview.test.ts
+++ b/frontend/packages/core/src/lib/autoOpenPreview.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  AUTO_OPEN_ARTIFACTS_STORAGE_KEY,
+  DEFAULT_AUTO_OPEN_ARTIFACTS,
+  isAutoOpenArtifactsEnabled,
+  parseAutoOpenArtifacts,
+  setAutoOpenArtifactsEnabled,
+  shouldAutoOpenArtifactPreview,
+} from './autoOpenPreview'
+
+describe('parseAutoOpenArtifacts', () => {
+  it('defaults on when unset', () => {
+    expect(parseAutoOpenArtifacts(null)).toBe(DEFAULT_AUTO_OPEN_ARTIFACTS)
+    expect(parseAutoOpenArtifacts(undefined)).toBe(DEFAULT_AUTO_OPEN_ARTIFACTS)
+  })
+
+  it('accepts true/false and 0/1', () => {
+    expect(parseAutoOpenArtifacts('true')).toBe(true)
+    expect(parseAutoOpenArtifacts('1')).toBe(true)
+    expect(parseAutoOpenArtifacts('false')).toBe(false)
+    expect(parseAutoOpenArtifacts('0')).toBe(false)
+  })
+
+  it('falls back to default for garbage', () => {
+    expect(parseAutoOpenArtifacts('maybe')).toBe(DEFAULT_AUTO_OPEN_ARTIFACTS)
+  })
+})
+
+describe('isAutoOpenArtifactsEnabled / setAutoOpenArtifactsEnabled', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('reads default when key missing', () => {
+    expect(isAutoOpenArtifactsEnabled()).toBe(DEFAULT_AUTO_OPEN_ARTIFACTS)
+  })
+
+  it('round-trips disable', () => {
+    setAutoOpenArtifactsEnabled(false)
+    expect(localStorage.getItem(AUTO_OPEN_ARTIFACTS_STORAGE_KEY)).toBe('false')
+    expect(isAutoOpenArtifactsEnabled()).toBe(false)
+  })
+
+  it('round-trips enable', () => {
+    setAutoOpenArtifactsEnabled(false)
+    setAutoOpenArtifactsEnabled(true)
+    expect(localStorage.getItem(AUTO_OPEN_ARTIFACTS_STORAGE_KEY)).toBe('true')
+    expect(isAutoOpenArtifactsEnabled()).toBe(true)
+  })
+})
+
+describe('shouldAutoOpenArtifactPreview', () => {
+  it('opens when enabled and conversation is focused', () => {
+    expect(shouldAutoOpenArtifactPreview('conv-1', 'conv-1', true)).toBe(true)
+  })
+
+  it('does not open when preference is off', () => {
+    expect(shouldAutoOpenArtifactPreview('conv-1', 'conv-1', false)).toBe(false)
+  })
+
+  it('does not open for a non-focused conversation', () => {
+    expect(shouldAutoOpenArtifactPreview('conv-1', 'conv-other', true)).toBe(false)
+    expect(shouldAutoOpenArtifactPreview('conv-1', null, true)).toBe(false)
+  })
+})

--- a/frontend/packages/core/src/lib/autoOpenPreview.test.ts
+++ b/frontend/packages/core/src/lib/autoOpenPreview.test.ts
@@ -72,21 +72,46 @@ describe('shouldAutoOpenArtifactPreview', () => {
 
 describe('canAutoOpenReplacePanel', () => {
   it('allows closed panel', () => {
-    expect(canAutoOpenReplacePanel({ type: 'closed' }, 'conv-1')).toBe(true)
+    expect(canAutoOpenReplacePanel({ type: 'closed' }, 'conv-1', 'art-1')).toBe(true)
   })
 
-  it('allows same-conversation artifact panel (refresh / switch artifact)', () => {
-    expect(canAutoOpenReplacePanel({ type: 'artifact', conversationId: 'conv-1' }, 'conv-1')).toBe(
-      true,
-    )
+  it('allows same artifact id (version refresh)', () => {
+    expect(
+      canAutoOpenReplacePanel(
+        { type: 'artifact', conversationId: 'conv-1', artifactId: 'art-1', source: 'user' },
+        'conv-1',
+        'art-1',
+      ),
+    ).toBe(true)
+  })
+
+  it('allows switching artifacts only when current view was auto-opened', () => {
+    expect(
+      canAutoOpenReplacePanel(
+        { type: 'artifact', conversationId: 'conv-1', artifactId: 'art-1', source: 'auto' },
+        'conv-1',
+        'art-2',
+      ),
+    ).toBe(true)
+    expect(
+      canAutoOpenReplacePanel(
+        { type: 'artifact', conversationId: 'conv-1', artifactId: 'art-1', source: 'user' },
+        'conv-1',
+        'art-2',
+      ),
+    ).toBe(false)
   })
 
   it('blocks other conversation artifact and non-artifact surfaces', () => {
-    expect(canAutoOpenReplacePanel({ type: 'artifact', conversationId: 'conv-2' }, 'conv-1')).toBe(
-      false,
-    )
-    expect(canAutoOpenReplacePanel({ type: 'tool' }, 'conv-1')).toBe(false)
-    expect(canAutoOpenReplacePanel({ type: 'sandbox' }, 'conv-1')).toBe(false)
-    expect(canAutoOpenReplacePanel({ type: 'attachment' }, 'conv-1')).toBe(false)
+    expect(
+      canAutoOpenReplacePanel(
+        { type: 'artifact', conversationId: 'conv-2', artifactId: 'art-x', source: 'auto' },
+        'conv-1',
+        'art-1',
+      ),
+    ).toBe(false)
+    expect(canAutoOpenReplacePanel({ type: 'tool' }, 'conv-1', 'art-1')).toBe(false)
+    expect(canAutoOpenReplacePanel({ type: 'sandbox' }, 'conv-1', 'art-1')).toBe(false)
+    expect(canAutoOpenReplacePanel({ type: 'attachment' }, 'conv-1', 'art-1')).toBe(false)
   })
 })

--- a/frontend/packages/core/src/lib/autoOpenPreview.test.ts
+++ b/frontend/packages/core/src/lib/autoOpenPreview.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   AUTO_OPEN_ARTIFACTS_STORAGE_KEY,
   DEFAULT_AUTO_OPEN_ARTIFACTS,
+  canAutoOpenReplacePanel,
   isAutoOpenArtifactsEnabled,
   parseAutoOpenArtifacts,
   setAutoOpenArtifactsEnabled,
@@ -55,7 +56,7 @@ describe('isAutoOpenArtifactsEnabled / setAutoOpenArtifactsEnabled', () => {
 })
 
 describe('shouldAutoOpenArtifactPreview', () => {
-  it('opens when enabled and conversation is focused', () => {
+  it('opens when enabled and chat surface is viewing the conversation', () => {
     expect(shouldAutoOpenArtifactPreview('conv-1', 'conv-1', true)).toBe(true)
   })
 
@@ -63,8 +64,29 @@ describe('shouldAutoOpenArtifactPreview', () => {
     expect(shouldAutoOpenArtifactPreview('conv-1', 'conv-1', false)).toBe(false)
   })
 
-  it('does not open for a non-focused conversation', () => {
+  it('does not open when chat surface is not that conversation', () => {
     expect(shouldAutoOpenArtifactPreview('conv-1', 'conv-other', true)).toBe(false)
     expect(shouldAutoOpenArtifactPreview('conv-1', null, true)).toBe(false)
+  })
+})
+
+describe('canAutoOpenReplacePanel', () => {
+  it('allows closed panel', () => {
+    expect(canAutoOpenReplacePanel({ type: 'closed' }, 'conv-1')).toBe(true)
+  })
+
+  it('allows same-conversation artifact panel (refresh / switch artifact)', () => {
+    expect(canAutoOpenReplacePanel({ type: 'artifact', conversationId: 'conv-1' }, 'conv-1')).toBe(
+      true,
+    )
+  })
+
+  it('blocks other conversation artifact and non-artifact surfaces', () => {
+    expect(canAutoOpenReplacePanel({ type: 'artifact', conversationId: 'conv-2' }, 'conv-1')).toBe(
+      false,
+    )
+    expect(canAutoOpenReplacePanel({ type: 'tool' }, 'conv-1')).toBe(false)
+    expect(canAutoOpenReplacePanel({ type: 'sandbox' }, 'conv-1')).toBe(false)
+    expect(canAutoOpenReplacePanel({ type: 'attachment' }, 'conv-1')).toBe(false)
   })
 })

--- a/frontend/packages/core/src/lib/autoOpenPreview.test.ts
+++ b/frontend/packages/core/src/lib/autoOpenPreview.test.ts
@@ -75,7 +75,7 @@ describe('canAutoOpenReplacePanel', () => {
     expect(canAutoOpenReplacePanel({ type: 'closed' }, 'conv-1', 'art-1')).toBe(true)
   })
 
-  it('allows same artifact id (version refresh)', () => {
+  it('allows same artifact id (caller may no-op open to keep user source)', () => {
     expect(
       canAutoOpenReplacePanel(
         { type: 'artifact', conversationId: 'conv-1', artifactId: 'art-1', source: 'user' },

--- a/frontend/packages/core/src/lib/autoOpenPreview.ts
+++ b/frontend/packages/core/src/lib/autoOpenPreview.ts
@@ -44,13 +44,30 @@ export function setAutoOpenArtifactsEnabled(enabled: boolean): void {
  * Whether a live artifact event should open the preview panel.
  *
  * - Preference must be on.
- * - Conversation must be the focused chat (`activeId`), so background streams
- *   on another conversation don't steal the panel.
+ * - Conversation must be the mounted chat surface (`viewingConversationId`),
+ *   not merely sidebar `activeId` (which can linger on home / draft flows).
  */
 export function shouldAutoOpenArtifactPreview(
   conversationId: string,
-  activeConversationId: string | null,
+  viewingConversationId: string | null,
   enabled: boolean = isAutoOpenArtifactsEnabled(),
 ): boolean {
-  return enabled && activeConversationId === conversationId
+  return enabled && viewingConversationId === conversationId
+}
+
+/**
+ * Whether auto-open may replace the current panel view.
+ *
+ * - Closed → open.
+ * - Already showing an artifact for the same conversation → switch / refresh.
+ * - Any other surface (tool, sandbox, attachment, other conversation's
+ *   artifact) → leave the user's choice alone.
+ */
+export function canAutoOpenReplacePanel(
+  view: { type: string; conversationId?: string },
+  conversationId: string,
+): boolean {
+  if (view.type === 'closed') return true
+  if (view.type === 'artifact' && view.conversationId === conversationId) return true
+  return false
 }

--- a/frontend/packages/core/src/lib/autoOpenPreview.ts
+++ b/frontend/packages/core/src/lib/autoOpenPreview.ts
@@ -59,15 +59,25 @@ export function shouldAutoOpenArtifactPreview(
  * Whether auto-open may replace the current panel view.
  *
  * - Closed → open.
- * - Already showing an artifact for the same conversation → switch / refresh.
- * - Any other surface (tool, sandbox, attachment, other conversation's
- *   artifact) → leave the user's choice alone.
+ * - Same artifact id → refresh (version bump).
+ * - Another artifact for the same conversation only if the current view was
+ *   itself auto-opened (follow the latest deliverable). User-picked artifacts
+ *   are never clobbered by a different artifact.
+ * - Any other surface (tool, sandbox, attachment, other conversation) → leave
+ *   the user's choice alone.
  */
 export function canAutoOpenReplacePanel(
-  view: { type: string; conversationId?: string },
+  view: {
+    type: string
+    conversationId?: string
+    artifactId?: string
+    source?: 'user' | 'auto'
+  },
   conversationId: string,
+  artifactId: string,
 ): boolean {
   if (view.type === 'closed') return true
-  if (view.type === 'artifact' && view.conversationId === conversationId) return true
-  return false
+  if (view.type !== 'artifact' || view.conversationId !== conversationId) return false
+  if (view.artifactId === artifactId) return true
+  return view.source === 'auto'
 }

--- a/frontend/packages/core/src/lib/autoOpenPreview.ts
+++ b/frontend/packages/core/src/lib/autoOpenPreview.ts
@@ -1,0 +1,56 @@
+/**
+ * Preferences that decide whether a preview panel opens automatically when
+ * the corresponding work finishes (e.g. an artifact is saved mid-stream).
+ *
+ * Browser-local only for now — no server-backed user settings. Other panel
+ * types (write_file, file_read, sandbox, …) can share this module later.
+ */
+
+export const AUTO_OPEN_ARTIFACTS_STORAGE_KEY = 'cubeplex.preview.autoOpen.artifacts'
+
+/** Default when the key is unset: auto-open artifacts after save. */
+export const DEFAULT_AUTO_OPEN_ARTIFACTS = true
+
+/**
+ * Parse a storage value. Explicit `'false'` / `'0'` disable; anything else
+ * (including missing) follows the default-on policy.
+ */
+export function parseAutoOpenArtifacts(raw: string | null | undefined): boolean {
+  if (raw === null || raw === undefined) return DEFAULT_AUTO_OPEN_ARTIFACTS
+  if (raw === 'false' || raw === '0') return false
+  if (raw === 'true' || raw === '1') return true
+  return DEFAULT_AUTO_OPEN_ARTIFACTS
+}
+
+export function isAutoOpenArtifactsEnabled(): boolean {
+  if (typeof localStorage === 'undefined') return DEFAULT_AUTO_OPEN_ARTIFACTS
+  try {
+    return parseAutoOpenArtifacts(localStorage.getItem(AUTO_OPEN_ARTIFACTS_STORAGE_KEY))
+  } catch {
+    return DEFAULT_AUTO_OPEN_ARTIFACTS
+  }
+}
+
+export function setAutoOpenArtifactsEnabled(enabled: boolean): void {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(AUTO_OPEN_ARTIFACTS_STORAGE_KEY, enabled ? 'true' : 'false')
+  } catch {
+    // quota / private mode — preference is best-effort
+  }
+}
+
+/**
+ * Whether a live artifact event should open the preview panel.
+ *
+ * - Preference must be on.
+ * - Conversation must be the focused chat (`activeId`), so background streams
+ *   on another conversation don't steal the panel.
+ */
+export function shouldAutoOpenArtifactPreview(
+  conversationId: string,
+  activeConversationId: string | null,
+  enabled: boolean = isAutoOpenArtifactsEnabled(),
+): boolean {
+  return enabled && activeConversationId === conversationId
+}

--- a/frontend/packages/core/src/stores/conversationStore.ts
+++ b/frontend/packages/core/src/stores/conversationStore.ts
@@ -24,6 +24,13 @@ function sortPinnedFirst(list: Conversation[]): Conversation[] {
 export interface ConversationStore {
   conversations: Conversation[]
   activeId: string | null
+  /**
+   * Conversation id of the mounted chat page only. Unlike `activeId` (sidebar
+   * highlight / draft flows), this is set/cleared exclusively by the
+   * conversation route so features like artifact auto-open don't fire on the
+   * home page or artifacts library.
+   */
+  viewingConversationId: string | null
   /** The topic_id of the currently open conversation, or null if it's
    *  topicless / unknown. Lets the sidebar auto-expand the active
    *  conversation's topic even when that conversation falls outside the
@@ -43,6 +50,7 @@ export interface ConversationStore {
   setPin(client: ApiClient, id: string, isPinned: boolean): Promise<void>
   generateTitle(client: ApiClient, id: string, content: string): Promise<void>
   setActive(id: string | null): void
+  setViewingConversation(id: string | null): void
   setActiveTopic(topicId: string | null): void
   inviteToGroup(client: ApiClient, conversationId: string, userIds: string[]): Promise<void>
   fetchConversationParticipants(client: ApiClient, conversationId: string): Promise<void>
@@ -51,6 +59,7 @@ export interface ConversationStore {
 export const useConversationStore = create<ConversationStore>((set, get) => ({
   conversations: [],
   activeId: null,
+  viewingConversationId: null,
   activeTopicId: null,
   isLoading: false,
   isFetchingList: false,
@@ -102,6 +111,7 @@ export const useConversationStore = create<ConversationStore>((set, get) => ({
       set((s) => ({
         conversations: s.conversations.filter((c) => c.id !== id),
         activeId: s.activeId === id ? null : s.activeId,
+        viewingConversationId: s.viewingConversationId === id ? null : s.viewingConversationId,
       }))
     } catch (err) {
       set({ error: (err as Error).message })
@@ -156,6 +166,10 @@ export const useConversationStore = create<ConversationStore>((set, get) => ({
 
   setActive(id: string | null) {
     set({ activeId: id })
+  },
+
+  setViewingConversation(id: string | null) {
+    set({ viewingConversationId: id })
   },
 
   setActiveTopic(topicId: string | null) {

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -269,8 +269,8 @@ function applyArtifactSseEvent(
   const viewingId = useConversationStore.getState().viewingConversationId
   if (!shouldAutoOpenArtifactPreview(conversationId, viewingId)) return
   const panel = usePanelStore.getState()
-  if (!canAutoOpenReplacePanel(panel.view, conversationId)) return
-  panel.openArtifact(conversationId, artifact.id)
+  if (!canAutoOpenReplacePanel(panel.view, conversationId, artifact.id)) return
+  panel.openArtifact(conversationId, artifact.id, 'auto')
 }
 
 /** Dedup map for ``loadMessages``: the page-level effect and ``<MessageList>``'s

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -36,6 +36,7 @@ import {
   streamMessages,
   streamRun,
 } from '../api'
+import { shouldAutoOpenArtifactPreview } from '../lib/autoOpenPreview'
 import { useAuthStore } from './authStore'
 import { useCitationStore } from './citationStore'
 import { useConversationStore } from './conversationStore'
@@ -247,6 +248,24 @@ let activeStreamController: AbortController | null = null
  */
 function ownsStreamingConversation(state: MessageStore, conversationId: string): boolean {
   return state.streamingConversationId === conversationId
+}
+
+/**
+ * Persist an SSE artifact into the artifact store, and optionally open its
+ * preview panel when the preference is on and this conversation is focused.
+ * History/bootstrap never emit these events — only live / reattach streams.
+ */
+async function applyArtifactSseEvent(
+  conversationId: string,
+  artifact: ArtifactEventData['artifact'],
+): Promise<void> {
+  if (!artifact) return
+  const { useArtifactStore } = await import('./artifactStore')
+  useArtifactStore.getState().addOrUpdate(conversationId, artifact)
+  if (shouldAutoOpenArtifactPreview(conversationId, useConversationStore.getState().activeId)) {
+    const { usePanelStore } = await import('./panelStore')
+    usePanelStore.getState().openArtifact(conversationId, artifact.id)
+  }
 }
 
 /** Dedup map for ``loadMessages``: the page-level effect and ``<MessageList>``'s
@@ -1146,10 +1165,7 @@ async function consumeRunStream(
 
       if (event.type === 'artifact') {
         const artifactData = event.data as unknown as ArtifactEventData
-        if (artifactData.artifact) {
-          const { useArtifactStore } = await import('./artifactStore')
-          useArtifactStore.getState().addOrUpdate(conversationId, artifactData.artifact)
-        }
+        await applyArtifactSseEvent(conversationId, artifactData.artifact)
       } else if (event.type === 'citation') {
         const citationData = event.data as unknown as import('../types').CitationData
         useCitationStore.getState().addCitation(conversationId, citationData)
@@ -1795,10 +1811,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
 
           if (event.type === 'artifact') {
             const artifactData = event.data as unknown as ArtifactEventData
-            if (artifactData.artifact) {
-              const { useArtifactStore } = await import('./artifactStore')
-              useArtifactStore.getState().addOrUpdate(conversationId, artifactData.artifact)
-            }
+            await applyArtifactSseEvent(conversationId, artifactData.artifact)
           } else if (event.type === 'citation') {
             const citationData = event.data as unknown as import('../types').CitationData
             useCitationStore.getState().addCitation(conversationId, citationData)

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -36,10 +36,12 @@ import {
   streamMessages,
   streamRun,
 } from '../api'
-import { shouldAutoOpenArtifactPreview } from '../lib/autoOpenPreview'
+import { canAutoOpenReplacePanel, shouldAutoOpenArtifactPreview } from '../lib/autoOpenPreview'
+import { useArtifactStore } from './artifactStore'
 import { useAuthStore } from './authStore'
 import { useCitationStore } from './citationStore'
 import { useConversationStore } from './conversationStore'
+import { usePanelStore } from './panelStore'
 import {
   clearUnreadStorage,
   dropLegacyUnreadStorage,
@@ -252,20 +254,23 @@ function ownsStreamingConversation(state: MessageStore, conversationId: string):
 
 /**
  * Persist an SSE artifact into the artifact store, and optionally open its
- * preview panel when the preference is on and this conversation is focused.
+ * preview panel when the preference is on and the chat surface is focused.
  * History/bootstrap never emit these events — only live / reattach streams.
+ *
+ * Sync (no dynamic import) so focus cannot change between the gate check and
+ * openArtifact. Does not clobber a user-chosen non-artifact panel.
  */
-async function applyArtifactSseEvent(
+function applyArtifactSseEvent(
   conversationId: string,
   artifact: ArtifactEventData['artifact'],
-): Promise<void> {
+): void {
   if (!artifact) return
-  const { useArtifactStore } = await import('./artifactStore')
   useArtifactStore.getState().addOrUpdate(conversationId, artifact)
-  if (shouldAutoOpenArtifactPreview(conversationId, useConversationStore.getState().activeId)) {
-    const { usePanelStore } = await import('./panelStore')
-    usePanelStore.getState().openArtifact(conversationId, artifact.id)
-  }
+  const viewingId = useConversationStore.getState().viewingConversationId
+  if (!shouldAutoOpenArtifactPreview(conversationId, viewingId)) return
+  const panel = usePanelStore.getState()
+  if (!canAutoOpenReplacePanel(panel.view, conversationId)) return
+  panel.openArtifact(conversationId, artifact.id)
 }
 
 /** Dedup map for ``loadMessages``: the page-level effect and ``<MessageList>``'s
@@ -1165,7 +1170,7 @@ async function consumeRunStream(
 
       if (event.type === 'artifact') {
         const artifactData = event.data as unknown as ArtifactEventData
-        await applyArtifactSseEvent(conversationId, artifactData.artifact)
+        applyArtifactSseEvent(conversationId, artifactData.artifact)
       } else if (event.type === 'citation') {
         const citationData = event.data as unknown as import('../types').CitationData
         useCitationStore.getState().addCitation(conversationId, citationData)
@@ -1811,7 +1816,7 @@ export const useMessageStore = create<MessageStore>((set, get) => ({
 
           if (event.type === 'artifact') {
             const artifactData = event.data as unknown as ArtifactEventData
-            await applyArtifactSseEvent(conversationId, artifactData.artifact)
+            applyArtifactSseEvent(conversationId, artifactData.artifact)
           } else if (event.type === 'citation') {
             const citationData = event.data as unknown as import('../types').CitationData
             useCitationStore.getState().addCitation(conversationId, citationData)

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -270,6 +270,16 @@ function applyArtifactSseEvent(
   if (!shouldAutoOpenArtifactPreview(conversationId, viewingId)) return
   const panel = usePanelStore.getState()
   if (!canAutoOpenReplacePanel(panel.view, conversationId, artifact.id)) return
+  // Same artifact already open: store update above is enough. Do not re-open
+  // with source:'auto' — that would downgrade a user selection and let a later
+  // different artifact steal the panel via the auto-chain gate.
+  if (
+    panel.view.type === 'artifact' &&
+    panel.view.conversationId === conversationId &&
+    panel.view.artifactId === artifact.id
+  ) {
+    return
+  }
   panel.openArtifact(conversationId, artifact.id, 'auto')
 }
 

--- a/frontend/packages/core/src/stores/panelStore.ts
+++ b/frontend/packages/core/src/stores/panelStore.ts
@@ -54,6 +54,8 @@ export type PanelView =
       type: 'artifact'
       conversationId: string
       artifactId: string
+      /** Who opened the panel: user click/deep-link vs auto-open on save. */
+      source: 'user' | 'auto'
     }
   | {
       type: 'attachment'
@@ -74,7 +76,7 @@ export interface PanelStore {
     highlightText?: string,
   ) => void
 
-  openArtifact: (conversationId: string, artifactId: string) => void
+  openArtifact: (conversationId: string, artifactId: string, source?: 'user' | 'auto') => void
 
   openAttachment: (info: AttachmentPanelInfo) => void
 
@@ -107,9 +109,9 @@ export const usePanelStore = create<PanelStore>((set) => ({
       },
     }),
 
-  openArtifact: (conversationId, artifactId) =>
+  openArtifact: (conversationId, artifactId, source = 'user') =>
     set({
-      view: { type: 'artifact', conversationId, artifactId },
+      view: { type: 'artifact', conversationId, artifactId, source },
     }),
 
   openAttachment: (info) =>

--- a/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
+++ b/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
@@ -162,6 +162,7 @@ describe('ArtifactPanel expand theater', () => {
       type: 'artifact',
       conversationId: 'conv-1',
       artifactId: 'art-1',
+      source: 'user',
     })
   })
 
@@ -179,6 +180,7 @@ describe('ArtifactPanel expand theater', () => {
       type: 'artifact',
       conversationId: 'conv-1',
       artifactId: 'art-1',
+      source: 'user',
     })
   })
 
@@ -194,6 +196,7 @@ describe('ArtifactPanel expand theater', () => {
       type: 'artifact',
       conversationId: 'conv-1',
       artifactId: 'art-1',
+      source: 'user',
     })
 
     // After exit, rail Close dismisses the whole panel.
@@ -226,6 +229,7 @@ describe('ArtifactPanel expand theater', () => {
       type: 'artifact',
       conversationId: 'conv-1',
       artifactId: 'art-1',
+      source: 'user',
     })
   })
 
@@ -284,6 +288,7 @@ describe('ArtifactPanel expand theater', () => {
       type: 'artifact',
       conversationId: 'conv-1',
       artifactId: 'art-1',
+      source: 'user',
     })
   })
 

--- a/frontend/packages/web/app/(app)/w/[wsId]/conversations/[id]/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/conversations/[id]/page.tsx
@@ -28,6 +28,7 @@ export default function ChatPage({ params }: { params: Promise<{ wsId: string; i
   const t = useTranslations('conversationPage')
   const { wsId, id: conversationId } = use(params)
   const setActive = useConversationStore((s) => s.setActive)
+  const setViewingConversation = useConversationStore((s) => s.setViewingConversation)
   const setActiveTopic = useConversationStore((s) => s.setActiveTopic)
   const conversations = useConversationStore((s) => s.conversations)
   const loadArtifacts = useArtifactStore((s) => s.loadArtifacts)
@@ -51,6 +52,9 @@ export default function ChatPage({ params }: { params: Promise<{ wsId: string; i
   useEffect(() => {
     usePanelStore.getState().close()
     setActive(conversationId)
+    // Chat-surface focus (auto-open previews, etc.). Distinct from activeId,
+    // which also covers sidebar highlight and home draft creation.
+    setViewingConversation(conversationId)
     // Clear unread at the focus boundary (not inside conversationStore.setActive
     // — that would create a messageStore ↔ conversationStore import cycle).
     useMessageStore.getState().clearUnread(conversationId)
@@ -112,8 +116,19 @@ export default function ChatPage({ params }: { params: Promise<{ wsId: string; i
       if (useConversationStore.getState().activeId === conversationId) {
         setActive(null)
       }
+      if (useConversationStore.getState().viewingConversationId === conversationId) {
+        setViewingConversation(null)
+      }
     }
-  }, [conversationId, client, wsId, setActive, setActiveTopic, loadArtifacts])
+  }, [
+    conversationId,
+    client,
+    wsId,
+    setActive,
+    setViewingConversation,
+    setActiveTopic,
+    loadArtifacts,
+  ])
 
   // Arriving from the artifacts library with `?artifact=<id>` auto-opens that
   // artifact's preview. Runs after the reset effect above (declaration order),


### PR DESCRIPTION
## Summary

- After an agent saves an artifact (live SSE `artifact` event), open the right-hand preview panel automatically when the user is viewing that conversation.
- Gate with a browser-local preference (`cubeplex.preview.autoOpen.artifacts`, default **on**) so other panel types can reuse the same pattern later.
- History / bootstrap paths are unchanged — they never emit these SSE events, so they do not spam-open the panel.

Closes #425.

## Changes

- `frontend/packages/core/src/lib/autoOpenPreview.ts` — preference read/write + `shouldAutoOpenArtifactPreview`
- `messageStore` live + reattach stream paths call a shared `applyArtifactSseEvent` that updates the store and optionally opens the panel
- User docs: quick-start + core-concepts note auto-open on save
- Unit tests for preference parsing and focus/enabled gates

## Test plan

- [x] `pnpm exec vitest run src/lib/autoOpenPreview.test.ts` (9 passed)
- [x] Pre-push `check-ci` (backend + frontend) passed
- [ ] Manual: send a turn that creates an artifact while on that conversation → preview panel opens without clicking the card
- [ ] Manual: with `localStorage.setItem('cubeplex.preview.autoOpen.artifacts', 'false')` → panel stays closed until card click
- [ ] Manual: stream in background while viewing another conversation → panel does not open on the wrong chat