### PR TITLE
Improve browser live-view aspect ratio and expand theater

### DIFF
--- a/deploy/images/sandbox/Dockerfile
+++ b/deploy/images/sandbox/Dockerfile
@@ -268,12 +268,17 @@ ARG NEKO_TURN_URL=turn:192.168.1.208:3478
 ARG NEKO_TURN_USER=neko
 ARG NEKO_TURN_CRED=neko
 
+# Desktop 1280×900 (16:10-ish) instead of Neko's default 1280×720 (16:9).
+# Side-panel live view is tall; a taller virtual desktop fills more of the
+# rail when letterboxed and looks less flat during watch/takeover (#424).
+# Frontend BrowserView fits the iframe host to the same aspect.
 # First click after cubeplex "Take over" grants control (no in-Neko mouse step).
 # Env wins over /etc/neko/neko.yaml if the image is rebuilt from a newer base.
 ENV USER=neko \
     DISPLAY=:99.0 \
     XDG_RUNTIME_DIR=/tmp/runtime-neko \
     NEKO_SERVER_BIND=:8080 \
+    NEKO_DESKTOP_SCREEN=1280x900@30 \
     NEKO_PLUGINS_ENABLED=true \
     NEKO_PLUGINS_DIR=/etc/neko/plugins/ \
     NEKO_SESSION_IMPLICIT_HOSTING=true \

--- a/frontend/packages/web/__tests__/components/BrowserViewExpand.test.tsx
+++ b/frontend/packages/web/__tests__/components/BrowserViewExpand.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePanelStore } from '@cubeplex/core'
+
+vi.mock('@/hooks/useBrowserLiveView', () => ({
+  useBrowserLiveView: () => ({
+    url: 'https://neko.example/live',
+    loading: false,
+    error: undefined,
+    refresh: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/csrf', () => ({
+  csrfHeaders: () => ({}),
+}))
+
+import { BrowserView } from '@/components/panel/BrowserView'
+
+const messages = {
+  panel: {
+    header: {
+      copy: 'Copy',
+      close: 'Close',
+      expand: 'Expand preview',
+      exitExpand: 'Exit expand',
+    },
+  },
+}
+
+function renderView(hideHeader = true) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <div style={{ width: 800, height: 600 }}>
+        <BrowserView workspaceId="ws-1" hideHeader={hideHeader} />
+      </div>
+    </NextIntlClientProvider>,
+  )
+}
+
+describe('BrowserView expand theater', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'matchMedia',
+      (query: string) =>
+        ({
+          matches: query.includes('min-width: 768px'),
+          media: query,
+          onchange: null,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as MediaQueryList,
+    )
+    // ResizeObserver used by aspect-fit frame
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        cb: ResizeObserverCallback
+        constructor(cb: ResizeObserverCallback) {
+          this.cb = cb
+        }
+        observe(el: Element) {
+          const rect = {
+            width: 800,
+            height: 600,
+            top: 0,
+            left: 0,
+            bottom: 600,
+            right: 800,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          }
+          this.cb(
+            [
+              {
+                target: el,
+                contentRect: rect,
+                borderBoxSize: [],
+                contentBoxSize: [],
+                devicePixelContentBoxSize: [],
+              },
+            ],
+            this as unknown as ResizeObserver,
+          )
+        }
+        unobserve() {}
+        disconnect() {}
+      },
+    )
+    usePanelStore.setState({ view: { type: 'sandbox' } })
+  })
+
+  it('opens expand with dialog focus trap and keeps the same Neko iframe', async () => {
+    renderView()
+    expect(screen.getByTestId('browser-rail')).toBeInTheDocument()
+    const iframeBefore = await waitFor(() => screen.getByTitle('Sandbox browser'))
+
+    fireEvent.click(screen.getByTestId('panel-expand'))
+
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+    expect(screen.getByTestId('browser-expand-preview')).toBeInTheDocument()
+    expect(screen.getByTestId('browser-rail-placeholder')).toBeInTheDocument()
+    // Same single iframe — WebRTC peer must not be torn down.
+    expect(screen.getAllByTitle('Sandbox browser')).toHaveLength(1)
+    expect(screen.getByTitle('Sandbox browser')).toBe(iframeBefore)
+    // Host moved into the theater slot.
+    expect(within(screen.getByTestId('browser-expand-preview')).getByTitle('Sandbox browser')).toBe(
+      iframeBefore,
+    )
+  })
+
+  it('exit expand reparents iframe to rail and keeps sandbox panel open', async () => {
+    renderView()
+    await waitFor(() => screen.getByTitle('Sandbox browser'))
+    fireEvent.click(screen.getByTestId('panel-expand'))
+    await screen.findByRole('dialog')
+    const iframe = screen.getByTitle('Sandbox browser')
+
+    fireEvent.click(within(screen.getByRole('dialog')).getByTestId('panel-exit-expand'))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByTestId('browser-rail')).toBeInTheDocument()
+    expect(screen.getByTitle('Sandbox browser')).toBe(iframe)
+    expect(usePanelStore.getState().view.type).toBe('sandbox')
+  })
+
+  it('Esc closes theater and keeps panel', async () => {
+    renderView()
+    await waitFor(() => screen.getByTitle('Sandbox browser'))
+    fireEvent.click(screen.getByTestId('panel-expand'))
+    const dialog = await screen.findByRole('dialog')
+
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+    expect(screen.getByTestId('browser-rail')).toBeInTheDocument()
+    expect(usePanelStore.getState().view.type).toBe('sandbox')
+  })
+
+  it('aspect-fit frame is landscape (not stretched to tall rail)', async () => {
+    renderView()
+    const frame = await waitFor(() => {
+      const iframe = screen.getByTitle('Sandbox browser')
+      const host = iframe.parentElement
+      expect(host).toBeTruthy()
+      return host!
+    })
+    // 800×600 parent → largest 1280:900 box is 800 × 562.5 → rounded
+    expect(frame.style.width).toBe('800px')
+    expect(frame.style.height).toBe('563px')
+  })
+})

--- a/frontend/packages/web/components/layout/AppShell.tsx
+++ b/frontend/packages/web/components/layout/AppShell.tsx
@@ -213,8 +213,10 @@ export function AppShell({ children, headerTitle, conversationId }: AppShellProp
         elementRef={groupRef}
       >
         <ResizablePanel
-          defaultSize={panelOpen ? (isSandboxPanel ? 35 : 50) : 100}
-          minSize={isSandboxPanel ? 25 : 30}
+          // Sandbox browser is landscape; a wider rail reduces the tall/flat
+          // letterbox and makes takeover clicks easier to aim (see #424).
+          defaultSize={panelOpen ? (isSandboxPanel ? 28 : 50) : 100}
+          minSize={isSandboxPanel ? 20 : 30}
         >
           {main}
         </ResizablePanel>
@@ -222,7 +224,10 @@ export function AppShell({ children, headerTitle, conversationId }: AppShellProp
         {panelOpen && (
           <>
             <ResizableHandle withHandle />
-            <ResizablePanel defaultSize={isSandboxPanel ? 65 : 50} minSize={25}>
+            <ResizablePanel
+              defaultSize={isSandboxPanel ? 72 : 50}
+              minSize={isSandboxPanel ? 35 : 25}
+            >
               {panelContent}
             </ResizablePanel>
           </>

--- a/frontend/packages/web/components/panel/BrowserView.tsx
+++ b/frontend/packages/web/components/panel/BrowserView.tsx
@@ -1,17 +1,39 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { Eye, Hand, RefreshCw } from 'lucide-react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
+import { createPortal } from 'react-dom'
+import { Eye, Hand, Maximize2, Minimize2, RefreshCw, X } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 import { usePanelStore } from '@cubeplex/core'
 
 import { PanelHeader } from '@/components/panel/PanelHeader'
+import { ArtifactExpandDialog } from '@/components/panel/artifact/ArtifactExpandDialog'
 import { useBrowserLiveView } from '@/hooks/useBrowserLiveView'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { csrfHeaders } from '@/lib/csrf'
+import { cn } from '@/lib/utils'
 
 // Keep a long takeover session — whose traffic goes straight to Neko — from
 // being TTL-reaped. The backend keepalive force-updates activity (bypasses the
 // touch throttle), so every ping reliably extends the TTL.
 const KEEPALIVE_MS = 30_000
+
+/**
+ * Live-view frame aspect. Matches sandbox `NEKO_DESKTOP_SCREEN` (1280×900).
+ * Fitting the iframe host to this ratio (instead of stretching into a tall
+ * rail) keeps the desktop from looking flat and maps clicks more naturally.
+ */
+const DESKTOP_WIDTH = 1280
+const DESKTOP_HEIGHT = 900
+const DESKTOP_ASPECT = DESKTOP_WIDTH / DESKTOP_HEIGHT
 
 interface BrowserViewProps {
   workspaceId: string | null
@@ -25,6 +47,163 @@ interface BrowserViewProps {
   conversationId?: string | null
 }
 
+interface LiveFrameProps {
+  url: string | null
+  /** True while first load or SWR is retrying a transient failure. */
+  showConnecting: boolean
+  /** Terminal error after retries exhausted and still no URL. */
+  showError: boolean
+  error: Error | undefined
+  takeover: boolean
+  swallow: (e: React.SyntheticEvent) => void
+  testId?: string
+}
+
+/** Largest desktop-aspect box that fits inside the parent. */
+function useContainedSize(aspect: number): {
+  ref: React.RefObject<HTMLDivElement | null>
+  width: number
+  height: number
+} {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [size, setSize] = useState({ width: 0, height: 0 })
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const measure = (w: number, h: number) => {
+      if (w <= 0 || h <= 0) {
+        setSize({ width: 0, height: 0 })
+        return
+      }
+      let width = w
+      let height = width / aspect
+      if (height > h) {
+        height = h
+        width = height * aspect
+      }
+      setSize({ width: Math.round(width), height: Math.round(height) })
+    }
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      const { width, height } = entry.contentRect
+      measure(width, height)
+    })
+    ro.observe(el)
+    // Initial paint before the first RO callback (some envs fire async only).
+    // Do not run this after a sync RO callback has already measured, or a
+    // zero clientWidth/clientHeight in jsdom would clobber the real size.
+    if (el.clientWidth > 0 && el.clientHeight > 0) {
+      measure(el.clientWidth, el.clientHeight)
+    }
+    return () => ro.disconnect()
+  }, [aspect])
+
+  return { ref, width: size.width, height: size.height }
+}
+
+/**
+ * Single host for the Neko iframe + watch-only input lock.
+ * Aspect-boxed so a tall rail does not stretch the desktop into a flat strip.
+ */
+function BrowserLiveFrame({
+  url,
+  showConnecting,
+  showError,
+  error,
+  takeover,
+  swallow,
+  testId,
+}: LiveFrameProps) {
+  const { ref, width, height } = useContainedSize(DESKTOP_ASPECT)
+
+  return (
+    <div
+      ref={ref}
+      className="relative flex h-full min-h-0 w-full items-center justify-center overflow-hidden bg-black"
+      data-testid={testId}
+    >
+      {showConnecting && (
+        <div className="absolute inset-0 z-10 grid place-items-center text-sm text-muted-foreground">
+          Connecting to the sandbox browser…
+        </div>
+      )}
+      {showError && error && (
+        <div className="absolute inset-0 z-10 grid place-items-center px-4 text-center text-sm text-destructive">
+          Could not open the sandbox browser. {error.message}
+        </div>
+      )}
+      {url && width > 0 && height > 0 && (
+        <div className="relative shrink-0" style={{ width, height }}>
+          <iframe
+            title="Sandbox browser"
+            src={url}
+            className="absolute inset-0 h-full w-full border-0"
+            // When watch-only, make the frame non-focusable so keyboard can't
+            // reach it. `inert` removes it from the focus/interaction tree.
+            inert={!takeover}
+            tabIndex={takeover ? undefined : -1}
+            // fullscreen: a cross-origin iframe can't enter fullscreen without
+            // this delegation, so Neko's fullscreen button is otherwise a no-op.
+            allow="fullscreen; clipboard-read; clipboard-write"
+            allowFullScreen
+          />
+          {!takeover && (
+            // Transparent input lock: captures pointer + keyboard so neither
+            // reaches the iframe while the agent is in control.
+            <div
+              className="absolute inset-0 z-10 cursor-not-allowed"
+              tabIndex={0}
+              role="presentation"
+              onKeyDown={swallow}
+              onKeyUp={swallow}
+              onKeyPress={swallow}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const subscribeNoop = (): (() => void) => () => {}
+
+/** True only after client hydration (SSR snapshot is false). */
+function useIsClient(): boolean {
+  return useSyncExternalStore(
+    subscribeNoop,
+    () => true,
+    () => false,
+  )
+}
+
+/**
+ * Imperative portal host for the live frame. React portals into this element;
+ * we reparent the element between rail and theater so the iframe DOM (and Neko
+ * WebRTC peer) is never destroyed on expand/exit.
+ *
+ * Created once on the client (not during SSR). Cleanup removes the node on unmount.
+ */
+function useLiveFrameHost(): HTMLDivElement | null {
+  const isClient = useIsClient()
+  const host = useMemo(() => {
+    if (!isClient) return null
+    const el = document.createElement('div')
+    el.dataset.browserLiveHost = 'true'
+    el.className = 'h-full w-full min-h-0'
+    return el
+  }, [isClient])
+
+  useEffect(() => {
+    return () => {
+      host?.remove()
+    }
+  }, [host])
+
+  return host
+}
+
 /**
  * Live view of the sandbox browser (Neko, embedded via iframe).
  *
@@ -33,6 +212,9 @@ interface BrowserViewProps {
  *   pointer AND keyboard events and the iframe is `inert`/non-focusable — so the
  *   user cannot disrupt the agent while it drives.
  * - takeover: the lock is lifted and the user can click/type (login, OAuth, …).
+ *
+ * Expand uses ArtifactExpandDialog for focus trap / Esc / backdrop, but the
+ * Neko iframe lives in a movable portal host so WebRTC is not torn down.
  */
 export function BrowserView({
   workspaceId,
@@ -52,8 +234,19 @@ export function BrowserView({
   const showConnecting = !url && (loading || (Boolean(error) && validating))
   const showError = Boolean(error) && !url && !validating
   const close = usePanelStore((s) => s.close)
+  const t = useTranslations('panel.header')
   const [takeover, setTakeover] = useState(false)
-  const overlayRef = useRef<HTMLDivElement>(null)
+  // User intent; AND with isDesktop so a narrow viewport never shows theater
+  // (no setState-in-effect to clear).
+  const [expandIntent, setExpandIntent] = useState(false)
+  const expandButtonRef = useRef<HTMLButtonElement | null>(null)
+  const exitExpandButtonRef = useRef<HTMLButtonElement | null>(null)
+  const railSlotRef = useRef<HTMLDivElement | null>(null)
+  const theaterSlotRef = useRef<HTMLDivElement | null>(null)
+  const host = useLiveFrameHost()
+  // Expand is desktop-only.
+  const isDesktop = useMediaQuery('(min-width: 768px)', true)
+  const expanded = expandIntent && isDesktop
 
   useEffect(() => {
     if (refreshRef) refreshRef.current = () => refresh()
@@ -61,6 +254,38 @@ export function BrowserView({
       if (refreshRef) refreshRef.current = null
     }
   }, [refreshRef, refresh])
+
+  /** Move the portal host into `slot` if it is not already there. */
+  const attachHost = useCallback(
+    (slot: HTMLDivElement | null) => {
+      if (!host || !slot || host.parentElement === slot) return
+      slot.appendChild(host)
+    },
+    [host],
+  )
+
+  // Default: keep host in the rail. Theater attach happens via theater slot
+  // callback ref (dialog content mounts in a portal, so a plain layout effect
+  // can race and see a null theaterSlotRef).
+  useLayoutEffect(() => {
+    if (!expanded) attachHost(railSlotRef.current)
+  }, [expanded, host, attachHost])
+
+  const setRailSlot = useCallback(
+    (el: HTMLDivElement | null) => {
+      railSlotRef.current = el
+      if (!expanded) attachHost(el)
+    },
+    [expanded, attachHost],
+  )
+
+  const setTheaterSlot = useCallback(
+    (el: HTMLDivElement | null) => {
+      theaterSlotRef.current = el
+      if (expanded) attachHost(el)
+    },
+    [expanded, attachHost],
+  )
 
   // While watch-only, swallow any keyboard event that reaches the overlay.
   const swallow = useCallback((e: React.SyntheticEvent) => {
@@ -87,6 +312,22 @@ export function BrowserView({
 
   if (!workspaceId) return null
 
+  const openExpand = (): void => {
+    if (isDesktop) setExpandIntent(true)
+  }
+  const closeExpand = (): void => {
+    // Move host out of the dialog tree before React unmounts the dialog.
+    const rail = railSlotRef.current
+    if (host && rail && host.parentElement !== rail) {
+      rail.appendChild(host)
+    }
+    setExpandIntent(false)
+  }
+  const handlePanelClose = (): void => {
+    closeExpand()
+    close()
+  }
+
   const takeoverButton = (
     <button
       type="button"
@@ -97,6 +338,30 @@ export function BrowserView({
     </button>
   )
 
+  const expandControl = (opts: {
+    active: boolean
+    onToggle: () => void
+    buttonRef?: React.RefObject<HTMLButtonElement | null>
+    className?: string
+  }) => (
+    <button
+      type="button"
+      ref={opts.buttonRef}
+      onClick={opts.onToggle}
+      className={cn(
+        'hidden md:inline-flex p-1 rounded-xs text-muted-foreground hover:bg-accent transition-colors duration-fast',
+        opts.className,
+      )}
+      title={t(opts.active ? 'exitExpand' : 'expand')}
+      data-testid={opts.active ? 'panel-exit-expand' : 'panel-expand'}
+      aria-label={t(opts.active ? 'exitExpand' : 'expand')}
+    >
+      {opts.active ? <Minimize2 className="size-3.5" /> : <Maximize2 className="size-3.5" />}
+    </button>
+  )
+
+  // Expand lives on PanelHeader's dedicated expand slot when the full header
+  // is shown — only put refresh + takeover here so the control is not doubled.
   const actionButtons = (
     <>
       <button
@@ -111,79 +376,116 @@ export function BrowserView({
     </>
   )
 
+  const statusIcon = takeover ? (
+    <Hand className="size-3.5 text-warning-fg shrink-0" />
+  ) : (
+    <Eye className="size-3.5 text-muted-foreground shrink-0" />
+  )
+  const statusTitle = takeover ? 'You are in control' : 'Watching agent'
+
+  const livePortal =
+    host &&
+    createPortal(
+      <BrowserLiveFrame
+        url={url}
+        showConnecting={showConnecting}
+        showError={showError}
+        error={error}
+        takeover={takeover}
+        swallow={swallow}
+        testId="browser-live-preview"
+      />,
+      host,
+    )
+
   return (
     <div className="flex h-full w-full flex-col">
       {hideHeader ? (
         <div className="flex items-center gap-2 border-b border-border bg-card px-3 py-1.5 shrink-0">
-          {takeover ? (
-            <Hand className="size-3.5 text-warning-fg shrink-0" />
-          ) : (
-            <Eye className="size-3.5 text-muted-foreground shrink-0" />
-          )}
-          <span className="text-xs font-medium text-muted-foreground">
-            {takeover ? 'You are in control' : 'Watching agent'}
-          </span>
+          {statusIcon}
+          <span className="text-xs font-medium text-muted-foreground">{statusTitle}</span>
           <span className="flex-1" />
+          {expandControl({
+            active: expanded,
+            onToggle: expanded ? closeExpand : openExpand,
+            buttonRef: expandButtonRef,
+          })}
           {takeoverButton}
         </div>
       ) : (
         <PanelHeader
           source={{
             kind: 'plain',
-            icon: takeover ? (
-              <Hand className="size-3.5 text-warning-fg shrink-0" />
-            ) : (
-              <Eye className="size-3.5 text-muted-foreground shrink-0" />
-            ),
-            title: takeover ? 'You are in control' : 'Watching agent',
+            icon: statusIcon,
+            title: statusTitle,
           }}
           actions={actionButtons}
-          onClose={close}
+          expand={{
+            active: expanded,
+            onToggle: expanded ? closeExpand : openExpand,
+          }}
+          expandClassName="hidden md:inline-flex"
+          expandButtonRef={expandButtonRef}
+          onClose={handlePanelClose}
         />
       )}
 
-      <div className="relative flex-1 overflow-hidden">
-        {showConnecting && (
-          <div className="absolute inset-0 grid place-items-center text-sm text-muted-foreground">
-            Connecting to the sandbox browser…
+      <div className="relative flex-1 min-h-0 overflow-hidden">
+        <div
+          ref={setRailSlot}
+          className="h-full w-full min-h-0"
+          data-testid={expanded ? 'browser-rail-placeholder' : 'browser-rail'}
+        />
+        {expanded && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center px-4 text-center text-sm text-muted-foreground">
+            Expanded in preview
           </div>
-        )}
-        {showError && error && (
-          <div className="absolute inset-0 grid place-items-center px-4 text-center text-sm text-destructive">
-            Could not open the sandbox browser. {error.message}
-          </div>
-        )}
-        {url && (
-          <>
-            <iframe
-              title="Sandbox browser"
-              src={url}
-              className="h-full w-full border-0"
-              // When watch-only, make the frame non-focusable so keyboard can't
-              // reach it. `inert` removes it from the focus/interaction tree.
-              inert={!takeover}
-              tabIndex={takeover ? undefined : -1}
-              // fullscreen: a cross-origin iframe can't enter fullscreen without
-              // this delegation, so Neko's fullscreen button is otherwise a no-op.
-              allow="fullscreen; clipboard-read; clipboard-write"
-              allowFullScreen
-            />
-            {!takeover && (
-              // Transparent input lock: captures pointer + keyboard so neither
-              // reaches the iframe while the agent is in control.
-              <div
-                ref={overlayRef}
-                className="absolute inset-0 z-10 cursor-not-allowed"
-                tabIndex={0}
-                role="presentation"
-                onKeyDown={swallow}
-                onKeyUp={swallow}
-                onKeyPress={swallow}
-              />
-            )}
-          </>
         )}
       </div>
+
+      {livePortal}
+
+      {expanded && (
+        <ArtifactExpandDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) closeExpand()
+          }}
+          title={statusTitle}
+          identityKey={`browser:${workspaceId}:${conversationId ?? ''}`}
+          initialFocusRef={exitExpandButtonRef}
+          finalFocusRef={expandButtonRef}
+          header={
+            <div className="flex items-center gap-2 border-b border-border bg-card px-3 py-1.5 shrink-0">
+              {statusIcon}
+              <span className="text-xs font-medium text-muted-foreground">{statusTitle}</span>
+              <span className="flex-1" />
+              {expandControl({
+                active: true,
+                onToggle: closeExpand,
+                buttonRef: exitExpandButtonRef,
+                className: 'inline-flex',
+              })}
+              {takeoverButton}
+              <button
+                type="button"
+                onClick={closeExpand}
+                className="p-1 rounded-xs text-muted-foreground hover:bg-accent transition-colors duration-fast"
+                title={t('close')}
+                aria-label={t('close')}
+              >
+                <X className="size-3.5" />
+              </button>
+            </div>
+          }
+        >
+          <div
+            ref={setTheaterSlot}
+            className="h-full w-full min-h-0"
+            data-testid="browser-expand-preview"
+          />
+        </ArtifactExpandDialog>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Fixes the sandbox browser live preview looking too tall/flat and hard to control during takeover.

- **Aspect-fit frame**: host the Neko iframe in a 1280∶900 box that fits the panel (no stretched tall strip).
- **Wider sandbox rail**: default panel share 65% → 72% so the landscape desktop scales larger.
- **Expand theater**: same pattern as artifact preview — larger surface for login/OAuth takeover.
- **Desktop resolution**: sandbox `NEKO_DESKTOP_SCREEN=1280x900@30` (was default 1280×720) so letterboxing fills more of a tall rail.

Closes #424

## Test plan

- [x] `vitest` `BrowserViewExpand.test.tsx` (expand single-host, Esc exit, aspect-fit size)
- [x] Pre-push `check-ci` (backend + frontend) passed
- [ ] Manual: open Sandbox → Browser — desktop should look less flat; expand → large theater; Take over still works with input lock when watching

## Notes

Sandbox image change (`NEKO_DESKTOP_SCREEN`) takes effect only after the sandbox image is rebuilt/redeployed. Frontend aspect-fit + expand + wider rail work without that rebuild.