### PR TITLE
Sandbox agent runs as cubeplex instead of root

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -136,6 +136,14 @@ default:
     lease_seconds: 300
     resume_timeout: 30
     workdir: "/workspace" # Default working directory for command execution
+    # Agent command identity inside the sandbox (OpenSandbox RunCommandOpts).
+    # Container control plane stays root (browser stack / workspace chown);
+    # agent shell + file writes run as this user. Match the image's cubeplex
+    # user (deploy/images/sandbox/Dockerfile, uid/gid 1000). Set run_uid to
+    # null to keep the previous root default.
+    run_user: "cubeplex"
+    run_uid: 1000
+    run_gid: 1000
     # resource: CPU and memory limits for sandbox containers
     #   cpu: CPU limit (e.g., "100m" = 0.1 core, "1" = 1 core, "2" = 2 cores)
     #   memory: Memory limit (e.g., "100Mi", "512Mi", "2Gi", "4Gi")

--- a/backend/cubeplex/sandbox/base.py
+++ b/backend/cubeplex/sandbox/base.py
@@ -74,6 +74,7 @@ class Sandbox(ABC):
         *,
         timeout: int | None = None,
         envs: dict[str, str] | None = None,
+        as_root: bool = False,
     ) -> ExecuteResult:
         """Execute a shell command. Returns combined stdout+stderr and exit code.
 
@@ -83,6 +84,10 @@ class Sandbox(ABC):
             envs: Per-call env overrides injected into the command process.
                   Merged with any run-level env set via ``set_run_env``; per-call
                   values win on conflict.
+            as_root: When True, run as the container control-plane user (root)
+                  instead of the sandbox agent user. Used for infra helpers
+                  (browser stack, workspace chown). Ignored by drivers that
+                  have no privilege separation.
         """
         ...
 
@@ -143,9 +148,10 @@ class Sandbox(ABC):
         """Start the on-demand Neko browser stack inside the sandbox (idempotent).
 
         Baked into the sandbox image at ``/usr/local/bin/start-browser.sh``; safe
-        to call repeatedly (no-op if already running).
+        to call repeatedly (no-op if already running). Runs as root so
+        supervisord can chown runtime dirs and drop to the sandbox user.
         """
-        result = await self.execute("/usr/local/bin/start-browser.sh", timeout=120)
+        result = await self.execute("/usr/local/bin/start-browser.sh", timeout=120, as_root=True)
         if result.exit_code not in (0, None):
             raise RuntimeError(f"failed to start sandbox browser: {result.output}")
 
@@ -157,6 +163,7 @@ class Sandbox(ABC):
             " --exec /usr/bin/ttyd -- -p 7681 -W -w /workspace bash"
             " && sleep 1",
             timeout=30,
+            as_root=True,
         )
         if result.exit_code not in (0, None):
             raise SandboxError(f"failed to start sandbox terminal: {result.output}")

--- a/backend/cubeplex/sandbox/lazy.py
+++ b/backend/cubeplex/sandbox/lazy.py
@@ -375,10 +375,11 @@ class LazySandbox(Sandbox):
         *,
         timeout: int | None = None,
         envs: dict[str, str] | None = None,
+        as_root: bool = False,
     ) -> ExecuteResult:
         sandbox = await self._ensure_with_retry()
         try:
-            return await sandbox.execute(command, timeout=timeout, envs=envs)
+            return await sandbox.execute(command, timeout=timeout, envs=envs, as_root=as_root)
         except Exception:
             # Sandbox may have died — invalidate and retry once
             async with self._lock:
@@ -388,7 +389,7 @@ class LazySandbox(Sandbox):
             logger.warning("Lazy sandbox: execute failed, recreating sandbox")
             sandbox = await self._ensure()
             await self._ensure_skills_synced(sandbox)
-            return await sandbox.execute(command, timeout=timeout, envs=envs)
+            return await sandbox.execute(command, timeout=timeout, envs=envs, as_root=as_root)
 
     async def upload(self, files: list[tuple[str, bytes]]) -> None:
         sandbox = await self._ensure_with_retry()

--- a/backend/cubeplex/sandbox/local.py
+++ b/backend/cubeplex/sandbox/local.py
@@ -32,10 +32,12 @@ class LocalSandbox(Sandbox):
         *,
         timeout: int | None = None,
         envs: dict[str, str] | None = None,
+        as_root: bool = False,
     ) -> ExecuteResult:
-        # envs is accepted for interface compatibility but not applied: LocalSandbox
-        # runs in the host process environment and is not used in production.
-        del envs
+        # envs/as_root accepted for interface compatibility but not applied:
+        # LocalSandbox runs in the host process environment and is not used
+        # in production.
+        del envs, as_root
         proc = await asyncio.create_subprocess_shell(
             command,
             stdout=asyncio.subprocess.PIPE,

--- a/backend/cubeplex/sandbox/manager.py
+++ b/backend/cubeplex/sandbox/manager.py
@@ -17,7 +17,6 @@ under the workspace PVC so they survive pause/resume and kill+recreate.
 
 import asyncio
 import hashlib
-import inspect
 import re
 import time
 from dataclasses import dataclass
@@ -264,22 +263,6 @@ class SandboxManager:
             run_gid=self._run_gid,
             run_user=self._run_user,
         )
-
-    async def _finalize_backend(self, backend: OpenSandbox) -> OpenSandbox:
-        """Post-attach fixups before handing the backend to callers.
-
-        Reconciles /workspace ownership so agent (uid 1000) can write PVC
-        content left root-owned by prior root-default deployments. Runs on
-        create, healthy reuse, and resume — not only first provision.
-
-        Tolerates non-async stubs (unit tests that return a MagicMock backend).
-        """
-        ensure = getattr(backend, "ensure_workspace_owner", None)
-        if callable(ensure):
-            maybe = ensure()
-            if inspect.isawaitable(maybe):
-                await maybe
-        return backend
 
     async def _renew_provider_ttl(self, sandbox_id: str) -> None:
         """Best-effort extend the provider-side expiration so the OpenSandbox
@@ -766,7 +749,10 @@ class SandboxManager:
             )
             raise SandboxError(f"sandbox {sandbox_id} created but reconnect failed: {exc}") from exc
 
-        backend = await self._finalize_backend(self._wrap_backend(raw_sandbox))
+        backend = self._wrap_backend(raw_sandbox)
+        # Fresh PVC mount is usually root-owned; make the mount point writable
+        # by the agent uid (non-recursive — no migration of prior content).
+        await backend.ensure_workspace_owner()
         # Execute-time egress: set run env on the backend + persist EgressRefs.
         # Env flows via execute (RunCommandOpts), not Sandbox.create.
         if self._exchange_host:
@@ -838,7 +824,7 @@ class SandboxManager:
         if healthy and raw_sandbox is not None:
             await repo.update_activity(record.id)
             logger.info("Reusing healthy sandbox {}", sandbox_id)
-            backend = await self._finalize_backend(self._wrap_backend(raw_sandbox))
+            backend = self._wrap_backend(raw_sandbox)
             if self._exchange_host:
                 await self._apply_egress(
                     session,
@@ -1159,16 +1145,14 @@ class SandboxManager:
                 user_id=user_id,
             )
         try:
-            backend = await self._finalize_backend(
-                await OpenSandbox.connect_or_resume(
-                    record.sandbox_id,
-                    conn_config=conn_config,
-                    resume_timeout=self._resume_timeout,
-                    workdir=self._workdir,
-                    run_uid=self._run_uid,
-                    run_gid=self._run_gid,
-                    run_user=self._run_user,
-                )
+            backend = await OpenSandbox.connect_or_resume(
+                record.sandbox_id,
+                conn_config=conn_config,
+                resume_timeout=self._resume_timeout,
+                workdir=self._workdir,
+                run_uid=self._run_uid,
+                run_gid=self._run_gid,
+                run_user=self._run_user,
             )
         except Exception as exc:
             # Client-side exceptions (resume_timeout, network blip, transient
@@ -1363,7 +1347,7 @@ class SandboxManager:
         assert row.sandbox_id, "running row must have sandbox_id"  # caller invariant
         sandbox_id = row.sandbox_id
         raw = await opensandbox.Sandbox.connect(sandbox_id, connection_config=conn_config)
-        backend = await self._finalize_backend(self._wrap_backend(raw))
+        backend = self._wrap_backend(raw)
         if self._exchange_host:
             async with self._session_factory() as session:
                 try:

--- a/backend/cubeplex/sandbox/manager.py
+++ b/backend/cubeplex/sandbox/manager.py
@@ -17,6 +17,7 @@ under the workspace PVC so they survive pause/resume and kill+recreate.
 
 import asyncio
 import hashlib
+import inspect
 import re
 import time
 from dataclasses import dataclass
@@ -263,6 +264,22 @@ class SandboxManager:
             run_gid=self._run_gid,
             run_user=self._run_user,
         )
+
+    async def _finalize_backend(self, backend: OpenSandbox) -> OpenSandbox:
+        """Post-attach fixups before handing the backend to callers.
+
+        Reconciles /workspace ownership so agent (uid 1000) can write PVC
+        content left root-owned by prior root-default deployments. Runs on
+        create, healthy reuse, and resume — not only first provision.
+
+        Tolerates non-async stubs (unit tests that return a MagicMock backend).
+        """
+        ensure = getattr(backend, "ensure_workspace_owner", None)
+        if callable(ensure):
+            maybe = ensure()
+            if inspect.isawaitable(maybe):
+                await maybe
+        return backend
 
     async def _renew_provider_ttl(self, sandbox_id: str) -> None:
         """Best-effort extend the provider-side expiration so the OpenSandbox
@@ -749,10 +766,7 @@ class SandboxManager:
             )
             raise SandboxError(f"sandbox {sandbox_id} created but reconnect failed: {exc}") from exc
 
-        backend = self._wrap_backend(raw_sandbox)
-        # PVC mounts often arrive root-owned; agent runs as cubeplex and needs
-        # write access under workdir. Best-effort, non-fatal.
-        await backend.ensure_workspace_owner()
+        backend = await self._finalize_backend(self._wrap_backend(raw_sandbox))
         # Execute-time egress: set run env on the backend + persist EgressRefs.
         # Env flows via execute (RunCommandOpts), not Sandbox.create.
         if self._exchange_host:
@@ -824,7 +838,7 @@ class SandboxManager:
         if healthy and raw_sandbox is not None:
             await repo.update_activity(record.id)
             logger.info("Reusing healthy sandbox {}", sandbox_id)
-            backend = self._wrap_backend(raw_sandbox)
+            backend = await self._finalize_backend(self._wrap_backend(raw_sandbox))
             if self._exchange_host:
                 await self._apply_egress(
                     session,
@@ -1145,14 +1159,16 @@ class SandboxManager:
                 user_id=user_id,
             )
         try:
-            backend = await OpenSandbox.connect_or_resume(
-                record.sandbox_id,
-                conn_config=conn_config,
-                resume_timeout=self._resume_timeout,
-                workdir=self._workdir,
-                run_uid=self._run_uid,
-                run_gid=self._run_gid,
-                run_user=self._run_user,
+            backend = await self._finalize_backend(
+                await OpenSandbox.connect_or_resume(
+                    record.sandbox_id,
+                    conn_config=conn_config,
+                    resume_timeout=self._resume_timeout,
+                    workdir=self._workdir,
+                    run_uid=self._run_uid,
+                    run_gid=self._run_gid,
+                    run_user=self._run_user,
+                )
             )
         except Exception as exc:
             # Client-side exceptions (resume_timeout, network blip, transient
@@ -1347,7 +1363,7 @@ class SandboxManager:
         assert row.sandbox_id, "running row must have sandbox_id"  # caller invariant
         sandbox_id = row.sandbox_id
         raw = await opensandbox.Sandbox.connect(sandbox_id, connection_config=conn_config)
-        backend = self._wrap_backend(raw)
+        backend = await self._finalize_backend(self._wrap_backend(raw))
         if self._exchange_host:
             async with self._session_factory() as session:
                 try:

--- a/backend/cubeplex/sandbox/manager.py
+++ b/backend/cubeplex/sandbox/manager.py
@@ -170,6 +170,15 @@ class SandboxManager:
         # Sandbox workdir
         self._workdir: str = config.get("sandbox.workdir", "/workspace")
 
+        # Agent shell identity (OpenSandbox RunCommandOpts.uid/gid). None keeps
+        # the container default (root). Defaults match the cubeplex sandbox image.
+        raw_uid = config.get("sandbox.run_uid", 1000)
+        raw_gid = config.get("sandbox.run_gid", 1000)
+        raw_user = config.get("sandbox.run_user", "cubeplex")
+        self._run_uid: int | None = int(raw_uid) if raw_uid is not None else None
+        self._run_gid: int | None = int(raw_gid) if raw_gid is not None else None
+        self._run_user: str | None = str(raw_user) if raw_user else None
+
         # Resource config
         self._resource_cpu: str = config.get("sandbox.resource.cpu", "100m")
         self._resource_memory: str = config.get("sandbox.resource.memory", "100Mi")
@@ -243,6 +252,16 @@ class SandboxManager:
             api_key=self._api_key,
             request_timeout=timedelta(seconds=request_timeout or self._request_timeout),
             use_server_proxy=self._use_server_proxy,
+        )
+
+    def _wrap_backend(self, raw: opensandbox.Sandbox) -> OpenSandbox:
+        """Attach cubeplex driver defaults (workdir + agent run identity)."""
+        return OpenSandbox(
+            sandbox=raw,
+            workdir=self._workdir,
+            run_uid=self._run_uid,
+            run_gid=self._run_gid,
+            run_user=self._run_user,
         )
 
     async def _renew_provider_ttl(self, sandbox_id: str) -> None:
@@ -730,7 +749,10 @@ class SandboxManager:
             )
             raise SandboxError(f"sandbox {sandbox_id} created but reconnect failed: {exc}") from exc
 
-        backend = OpenSandbox(sandbox=raw_sandbox, workdir=self._workdir)
+        backend = self._wrap_backend(raw_sandbox)
+        # PVC mounts often arrive root-owned; agent runs as cubeplex and needs
+        # write access under workdir. Best-effort, non-fatal.
+        await backend.ensure_workspace_owner()
         # Execute-time egress: set run env on the backend + persist EgressRefs.
         # Env flows via execute (RunCommandOpts), not Sandbox.create.
         if self._exchange_host:
@@ -802,7 +824,7 @@ class SandboxManager:
         if healthy and raw_sandbox is not None:
             await repo.update_activity(record.id)
             logger.info("Reusing healthy sandbox {}", sandbox_id)
-            backend = OpenSandbox(sandbox=raw_sandbox, workdir=self._workdir)
+            backend = self._wrap_backend(raw_sandbox)
             if self._exchange_host:
                 await self._apply_egress(
                     session,
@@ -1128,6 +1150,9 @@ class SandboxManager:
                 conn_config=conn_config,
                 resume_timeout=self._resume_timeout,
                 workdir=self._workdir,
+                run_uid=self._run_uid,
+                run_gid=self._run_gid,
+                run_user=self._run_user,
             )
         except Exception as exc:
             # Client-side exceptions (resume_timeout, network blip, transient
@@ -1322,7 +1347,7 @@ class SandboxManager:
         assert row.sandbox_id, "running row must have sandbox_id"  # caller invariant
         sandbox_id = row.sandbox_id
         raw = await opensandbox.Sandbox.connect(sandbox_id, connection_config=conn_config)
-        backend = OpenSandbox(sandbox=raw, workdir=self._workdir)
+        backend = self._wrap_backend(raw)
         if self._exchange_host:
             async with self._session_factory() as session:
                 try:
@@ -1374,7 +1399,7 @@ class SandboxManager:
                         connection_config=conn_config,
                         skip_health_check=True,
                     )
-                    backend = OpenSandbox(sandbox=raw, workdir=self._workdir)
+                    backend = self._wrap_backend(raw)
                     if not backend.supports_pause():
                         # Driver can't pause natively — go straight to kill
                         # without flipping the row back to `running` first

--- a/backend/cubeplex/sandbox/opensandbox.py
+++ b/backend/cubeplex/sandbox/opensandbox.py
@@ -29,12 +29,30 @@ def _as_sandbox_error() -> Iterator[None]:
 
 
 class OpenSandbox(Sandbox):
-    """Sandbox backed by a remote OpenSandbox container."""
+    """Sandbox backed by a remote OpenSandbox container.
 
-    def __init__(self, *, sandbox: opensandbox.Sandbox, workdir: str = "/workspace") -> None:
+    Agent shell commands run as the configured non-root user (``run_uid`` /
+    ``run_gid``, default cubeplex 1000:1000) via OpenSandbox ``RunCommandOpts``.
+    Infrastructure helpers (browser stack, workspace ownership fixups) call
+    ``execute(..., as_root=True)`` so supervisord can still drop privileges and
+    chown PVC contents.
+    """
+
+    def __init__(
+        self,
+        *,
+        sandbox: opensandbox.Sandbox,
+        workdir: str = "/workspace",
+        run_uid: int | None = 1000,
+        run_gid: int | None = 1000,
+        run_user: str | None = "cubeplex",
+    ) -> None:
         self._sandbox = sandbox
         self._workdir = workdir
         self._run_env: dict[str, str] = {}
+        self._run_uid = run_uid
+        self._run_gid = run_gid
+        self._run_user = run_user
 
     @property
     def id(self) -> str:
@@ -54,13 +72,18 @@ class OpenSandbox(Sandbox):
         *,
         timeout: int | None = None,
         envs: dict[str, str] | None = None,
+        as_root: bool = False,
     ) -> ExecuteResult:
         # Merge: run-level env (set by manager) is the base; per-call envs win.
         merged = {**self._run_env, **(envs or {})}
+        uid: int | None = None if as_root else self._run_uid
+        gid: int | None = None if as_root or uid is None else self._run_gid
         opts = RunCommandOpts(
             working_directory=self._workdir,
             envs=merged if merged else None,
             timeout=timedelta(seconds=timeout) if timeout is not None else None,
+            uid=uid,
+            gid=gid,
         )
         with _as_sandbox_error():
             execution = await self._sandbox.commands.run(command, opts=opts)
@@ -85,7 +108,12 @@ class OpenSandbox(Sandbox):
     async def upload(self, files: list[tuple[str, bytes]]) -> None:
         with _as_sandbox_error():
             for path, content in files:
-                await self._sandbox.files.write_file(path, content)
+                await self._sandbox.files.write_file(
+                    path,
+                    content,
+                    owner=self._run_user,
+                    group=self._run_user,
+                )
 
     async def download(self, paths: list[str]) -> list[tuple[str, bytes]]:
         with _as_sandbox_error():
@@ -132,6 +160,52 @@ class OpenSandbox(Sandbox):
     async def get_terminal_endpoint(self, *, expires_in: int = 3600) -> BrowserEndpoint:
         return self._panel_endpoint(self.TERMINAL_PORT, expires_in)
 
+    async def start_browser(self) -> None:
+        """Start Neko as root so supervisord can chown and drop to cubeplex."""
+        result = await self.execute("/usr/local/bin/start-browser.sh", timeout=120, as_root=True)
+        if result.exit_code not in (0, None):
+            raise RuntimeError(f"failed to start sandbox browser: {result.output}")
+
+    async def start_terminal(self) -> None:
+        """Start ttyd; shell runs as the configured sandbox user when possible."""
+        if self._run_user:
+            # runuser keeps the interactive shell as cubeplex even if ttyd is
+            # launched with root privileges for start-stop-daemon.
+            shell = f"runuser -u {self._run_user} -- bash"
+        else:
+            shell = "bash"
+        result = await self.execute(
+            "start-stop-daemon --start --oknodo --background"
+            " --make-pidfile --pidfile /tmp/ttyd.pid"
+            f" --exec /usr/bin/ttyd -- -p 7681 -W -w /workspace {shell}"
+            " && sleep 1",
+            timeout=30,
+            as_root=True,
+        )
+        if result.exit_code not in (0, None):
+            raise SandboxError(f"failed to start sandbox terminal: {result.output}")
+
+    async def ensure_workspace_owner(self) -> None:
+        """Best-effort chown of the workdir to the sandbox user (root only).
+
+        PVC mounts often arrive as root-owned; agent commands run as cubeplex
+        and need write access. Safe no-op when run_user is unset.
+        """
+        if not self._run_user:
+            return
+        result = await self.execute(
+            f"chown -R {self._run_user}:{self._run_user} {self._workdir} 2>/dev/null || true",
+            timeout=60,
+            as_root=True,
+        )
+        if result.exit_code not in (0, None):
+            logger.warning(
+                "workspace chown for {} failed on sandbox {}: {}",
+                self._workdir,
+                self.id,
+                result.output,
+            )
+
     async def close(self) -> None:
         pass
 
@@ -154,6 +228,9 @@ class OpenSandbox(Sandbox):
         conn_config: ConnectionConfig | None = None,
         resume_timeout: int = 30,
         workdir: str = "/workspace",
+        run_uid: int | None = 1000,
+        run_gid: int | None = 1000,
+        run_user: str | None = "cubeplex",
         **_: object,
     ) -> "OpenSandbox":
         with _as_sandbox_error():
@@ -162,4 +239,10 @@ class OpenSandbox(Sandbox):
                 connection_config=conn_config,
                 resume_timeout=timedelta(seconds=resume_timeout),
             )
-        return cls(sandbox=raw, workdir=workdir)
+        return cls(
+            sandbox=raw,
+            workdir=workdir,
+            run_uid=run_uid,
+            run_gid=run_gid,
+            run_user=run_user,
+        )

--- a/backend/cubeplex/sandbox/opensandbox.py
+++ b/backend/cubeplex/sandbox/opensandbox.py
@@ -189,15 +189,25 @@ class OpenSandbox(Sandbox):
         """Best-effort chown of the workdir to the sandbox user (root only).
 
         PVC mounts often arrive as root-owned; agent commands run as cubeplex
-        and need write access. Safe no-op when run_user is unset.
+        and need write access. Safe no-op when run_user is unset. Never raises:
+        provisioning must not fail solely because chown is unavailable.
         """
         if not self._run_user:
             return
-        result = await self.execute(
-            f"chown -R {self._run_user}:{self._run_user} {self._workdir} 2>/dev/null || true",
-            timeout=60,
-            as_root=True,
-        )
+        try:
+            result = await self.execute(
+                f"chown -R {self._run_user}:{self._run_user} {self._workdir} 2>/dev/null || true",
+                timeout=60,
+                as_root=True,
+            )
+        except Exception as exc:
+            logger.warning(
+                "workspace chown for {} failed on sandbox {}: {}",
+                self._workdir,
+                self.id,
+                exc,
+            )
+            return
         if result.exit_code not in (0, None):
             logger.warning(
                 "workspace chown for {} failed on sandbox {}: {}",

--- a/backend/cubeplex/sandbox/opensandbox.py
+++ b/backend/cubeplex/sandbox/opensandbox.py
@@ -109,8 +109,8 @@ class OpenSandbox(Sandbox):
     async def upload(self, files: list[tuple[str, bytes]]) -> None:
         """Write files then chown by numeric uid so agent can edit them.
 
-        Named owner=cubeplex breaks on older sandbox images that only have
-        ``neko`` at uid 1000. Numeric chown works for both identities.
+        The files API typically writes as root; without a follow-up chown the
+        agent (uid 1000) cannot edit the uploaded path.
         """
         if not files:
             return
@@ -195,8 +195,6 @@ class OpenSandbox(Sandbox):
     async def start_terminal(self) -> None:
         """Start ttyd; shell runs as the configured sandbox uid when possible."""
         if self._run_uid is not None:
-            # setpriv by numeric id works on both old (neko@1000) and new
-            # (cubeplex@1000) images; named runuser would break on mismatch.
             gid = self._run_gid if self._run_gid is not None else self._run_uid
             shell = f"setpriv --reuid={self._run_uid} --regid={gid} --clear-groups -- bash"
         elif self._run_user:
@@ -215,20 +213,22 @@ class OpenSandbox(Sandbox):
             raise SandboxError(f"failed to start sandbox terminal: {result.output}")
 
     async def ensure_workspace_owner(self) -> None:
-        """Best-effort chown of the workdir to the sandbox uid (root only).
+        """Best-effort chown of the workdir mount point (non-recursive).
 
-        PVC mounts often arrive as root-owned; agent commands run as uid 1000
-        and need write access. Uses numeric uid so old images (user named
-        ``neko``) and new images (``cubeplex``) both work. Never raises:
-        attach paths must not fail solely because chown is unavailable.
+        Fresh PVC mounts are usually root-owned and mode 755, so uid 1000
+        cannot create files until the mount point itself is chowned. Only the
+        directory is fixed — not a recursive walk of existing content. Never
+        raises: create must not fail solely because chown is unavailable.
         """
         if self._run_uid is None:
             return
         gid = self._run_gid if self._run_gid is not None else self._run_uid
+        # Non-recursive: only the mount point. Agent-created files already land
+        # as run_uid; uploads are chowned per-path in upload().
         try:
             result = await self.execute(
-                f"chown -R {self._run_uid}:{gid} {shlex.quote(self._workdir)} 2>/dev/null || true",
-                timeout=60,
+                f"chown {self._run_uid}:{gid} {shlex.quote(self._workdir)} 2>/dev/null || true",
+                timeout=30,
                 as_root=True,
             )
         except Exception as exc:

--- a/backend/cubeplex/sandbox/opensandbox.py
+++ b/backend/cubeplex/sandbox/opensandbox.py
@@ -1,5 +1,6 @@
 """OpenSandbox implementation of the Sandbox base class."""
 
+import shlex
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import timedelta
@@ -106,14 +107,17 @@ class OpenSandbox(Sandbox):
             return ExecuteResult(output=output, exit_code=exit_code)
 
     async def upload(self, files: list[tuple[str, bytes]]) -> None:
+        """Write files then chown by numeric uid so agent can edit them.
+
+        Named owner=cubeplex breaks on older sandbox images that only have
+        ``neko`` at uid 1000. Numeric chown works for both identities.
+        """
+        if not files:
+            return
         with _as_sandbox_error():
             for path, content in files:
-                await self._sandbox.files.write_file(
-                    path,
-                    content,
-                    owner=self._run_user,
-                    group=self._run_user,
-                )
+                await self._sandbox.files.write_file(path, content)
+        await self._chown_paths([path for path, _ in files])
 
     async def download(self, paths: list[str]) -> list[tuple[str, bytes]]:
         with _as_sandbox_error():
@@ -127,6 +131,28 @@ class OpenSandbox(Sandbox):
                     raise
                 result.append((path, content))
             return result
+
+    async def _chown_paths(self, paths: list[str]) -> None:
+        """Best-effort chown of paths to run_uid:run_gid (root only)."""
+        if self._run_uid is None or not paths:
+            return
+        gid = self._run_gid if self._run_gid is not None else self._run_uid
+        quoted = " ".join(shlex.quote(p) for p in paths)
+        try:
+            result = await self.execute(
+                f"chown {self._run_uid}:{gid} {quoted} 2>/dev/null || true",
+                timeout=60,
+                as_root=True,
+            )
+        except Exception as exc:
+            logger.warning("chown after upload failed on sandbox {}: {}", self.id, exc)
+            return
+        if result.exit_code not in (0, None):
+            logger.warning(
+                "chown after upload failed on sandbox {}: {}",
+                self.id,
+                result.output,
+            )
 
     def _panel_endpoint(self, port: int, expires_in: int) -> BrowserEndpoint:
         """Build a cubeplex-signed panel-proxy URL for a sandbox port.
@@ -167,10 +193,13 @@ class OpenSandbox(Sandbox):
             raise RuntimeError(f"failed to start sandbox browser: {result.output}")
 
     async def start_terminal(self) -> None:
-        """Start ttyd; shell runs as the configured sandbox user when possible."""
-        if self._run_user:
-            # runuser keeps the interactive shell as cubeplex even if ttyd is
-            # launched with root privileges for start-stop-daemon.
+        """Start ttyd; shell runs as the configured sandbox uid when possible."""
+        if self._run_uid is not None:
+            # setpriv by numeric id works on both old (neko@1000) and new
+            # (cubeplex@1000) images; named runuser would break on mismatch.
+            gid = self._run_gid if self._run_gid is not None else self._run_uid
+            shell = f"setpriv --reuid={self._run_uid} --regid={gid} --clear-groups -- bash"
+        elif self._run_user:
             shell = f"runuser -u {self._run_user} -- bash"
         else:
             shell = "bash"
@@ -186,17 +215,19 @@ class OpenSandbox(Sandbox):
             raise SandboxError(f"failed to start sandbox terminal: {result.output}")
 
     async def ensure_workspace_owner(self) -> None:
-        """Best-effort chown of the workdir to the sandbox user (root only).
+        """Best-effort chown of the workdir to the sandbox uid (root only).
 
-        PVC mounts often arrive as root-owned; agent commands run as cubeplex
-        and need write access. Safe no-op when run_user is unset. Never raises:
-        provisioning must not fail solely because chown is unavailable.
+        PVC mounts often arrive as root-owned; agent commands run as uid 1000
+        and need write access. Uses numeric uid so old images (user named
+        ``neko``) and new images (``cubeplex``) both work. Never raises:
+        attach paths must not fail solely because chown is unavailable.
         """
-        if not self._run_user:
+        if self._run_uid is None:
             return
+        gid = self._run_gid if self._run_gid is not None else self._run_uid
         try:
             result = await self.execute(
-                f"chown -R {self._run_user}:{self._run_user} {self._workdir} 2>/dev/null || true",
+                f"chown -R {self._run_uid}:{gid} {shlex.quote(self._workdir)} 2>/dev/null || true",
                 timeout=60,
                 as_root=True,
             )

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -92,8 +92,9 @@ class MemSandbox(Sandbox):
         *,
         timeout: int | None = None,
         envs: dict[str, str] | None = None,
+        as_root: bool = False,
     ) -> ExecuteResult:
-        del timeout, envs
+        del timeout, envs, as_root
         # Process each ``&&``-separated token in ORDER so that:
         #   mkdir -p ... → rm -rf <old> → tar -xzf ... → rm -f tgz
         # mirrors what the real sandbox shell does.  Extracting the tar first

--- a/backend/tests/e2e/test_generate_image_e2e.py
+++ b/backend/tests/e2e/test_generate_image_e2e.py
@@ -82,7 +82,15 @@ class _TempLocalSandbox(Sandbox):
     def workdir(self) -> str:
         return "/work"
 
-    async def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResult:
+    async def execute(
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,
+        envs: dict[str, str] | None = None,
+        as_root: bool = False,
+    ) -> ExecuteResult:
+        del envs, as_root
         # Remap path arguments in shell commands (base64, test -e, etc.)
         remapped = command
         for keyword in ("/work/",):

--- a/backend/tests/e2e/test_skills_sync_failure_e2e.py
+++ b/backend/tests/e2e/test_skills_sync_failure_e2e.py
@@ -85,11 +85,12 @@ async def test_sync_failure_does_not_write_manifest_and_next_sync_heals(
             *,
             timeout: int | None = None,
             envs: dict[str, str] | None = None,
+            as_root: bool = False,
         ) -> Any:
             if "tar -xzf" in command and not fail_once["done"]:
                 fail_once["done"] = True
                 raise RuntimeError("simulated extract failure")
-            return await original_execute(command, timeout=timeout, envs=envs)
+            return await original_execute(command, timeout=timeout, envs=envs, as_root=as_root)
 
         sandbox.execute = _flaky_execute  # type: ignore[method-assign]
 
@@ -192,11 +193,16 @@ async def test_lazy_sandbox_f4_synced_flag_stays_false_on_failure_then_heals(
         *,
         timeout: int | None = None,
         envs: dict[str, str] | None = None,
+        as_root: bool = False,
     ) -> Any:
+        # Must accept as_root: LazySandbox always forwards it. Dropping the
+        # kwarg raises TypeError after the intentional tar failure; the lazy
+        # retry path then wipes the injected MemSandbox, re-syncs successfully,
+        # and spuriously sets _synced_for_this_run True (F4 false-positive).
         if "tar -xzf" in command and not fail_once["done"]:
             fail_once["done"] = True
             raise RuntimeError("simulated extract failure")
-        return await original_execute(command, timeout=timeout, envs=envs)
+        return await original_execute(command, timeout=timeout, envs=envs, as_root=as_root)
 
     sandbox.execute = _flaky_execute  # type: ignore[method-assign]
 

--- a/backend/tests/parsers/test_sandbox_file_read.py
+++ b/backend/tests/parsers/test_sandbox_file_read.py
@@ -15,7 +15,14 @@ class _FakeSandbox(Sandbox):
     def workdir(self) -> str:
         return "/work"
 
-    async def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResult:
+    async def execute(
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,
+        envs: dict[str, str] | None = None,
+        as_root: bool = False,
+    ) -> ExecuteResult:
         raise NotImplementedError
 
     async def upload(self, files: list[tuple[str, bytes]]) -> None:

--- a/backend/tests/unit/test_opensandbox_execute_env.py
+++ b/backend/tests/unit/test_opensandbox_execute_env.py
@@ -169,8 +169,8 @@ async def test_start_browser_runs_as_root() -> None:
 
 
 @pytest.mark.asyncio
-async def test_upload_chowns_by_uid_not_username() -> None:
-    """Upload writes bytes then chowns by numeric uid (old-image safe)."""
+async def test_upload_chowns_by_uid() -> None:
+    """Upload writes bytes then chowns by numeric uid (files API is root)."""
     backend, raw = _make_backend()
 
     await backend.upload([("/workspace/hello.txt", b"hi")])
@@ -181,8 +181,26 @@ async def test_upload_chowns_by_uid_not_username() -> None:
     cmd, opts = calls[0]
     assert "chown 1000:1000" in cmd
     assert "/workspace/hello.txt" in cmd
+    assert "-R" not in cmd
     assert opts is not None
     assert opts.uid is None  # as_root
+
+
+@pytest.mark.asyncio
+async def test_ensure_workspace_owner_chowns_mount_point_only() -> None:
+    """Create-time fix: chown the workdir, not a recursive tree walk."""
+    backend, _ = _make_backend()
+
+    await backend.ensure_workspace_owner()
+
+    calls = backend._test_run_calls  # type: ignore[attr-defined]
+    assert len(calls) == 1
+    cmd, opts = calls[0]
+    assert cmd.startswith("chown 1000:1000 ")
+    assert "-R" not in cmd
+    assert "/workspace" in cmd
+    assert opts is not None
+    assert opts.uid is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_opensandbox_execute_env.py
+++ b/backend/tests/unit/test_opensandbox_execute_env.py
@@ -4,11 +4,13 @@ Tests:
 - set_run_env stores the env; execute forwards it via opts.envs.
 - Per-call envs (execute(..., envs=...)) merge on top of run-level env (per-call wins).
 - Empty run env + no per-call envs → opts.envs is None (not an empty dict).
+- Default agent commands run as cubeplex uid/gid 1000; as_root clears them.
+- upload stamps owner/group to the sandbox user.
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from opensandbox.models.execd import RunCommandOpts
@@ -16,7 +18,12 @@ from opensandbox.models.execd import RunCommandOpts
 from cubeplex.sandbox.opensandbox import OpenSandbox
 
 
-def _make_backend() -> tuple[OpenSandbox, MagicMock]:
+def _make_backend(
+    *,
+    run_uid: int | None = 1000,
+    run_gid: int | None = 1000,
+    run_user: str | None = "cubeplex",
+) -> tuple[OpenSandbox, MagicMock]:
     """Return an OpenSandbox with a fake _sandbox that records commands.run calls."""
     raw = MagicMock()
     # commands.run is async; capture the opts it receives
@@ -33,9 +40,16 @@ def _make_backend() -> tuple[OpenSandbox, MagicMock]:
         return result
 
     raw.commands.run = fake_run
+    raw.files.write_file = AsyncMock()
     raw.id = "sbx-test"
 
-    backend = OpenSandbox(sandbox=raw, workdir="/workspace")
+    backend = OpenSandbox(
+        sandbox=raw,
+        workdir="/workspace",
+        run_uid=run_uid,
+        run_gid=run_gid,
+        run_user=run_user,
+    )
     # attach run_calls so the test can inspect them
     backend._test_run_calls = run_calls  # type: ignore[attr-defined]
     return backend, raw
@@ -108,3 +122,76 @@ async def test_working_directory_always_set() -> None:
     _, opts = calls[0]
     assert opts is not None
     assert opts.working_directory == "/workspace"
+
+
+@pytest.mark.asyncio
+async def test_default_execute_runs_as_cubeplex_uid() -> None:
+    """Agent commands default to uid/gid 1000 (cubeplex)."""
+    backend, _ = _make_backend()
+
+    await backend.execute("whoami")
+
+    calls = backend._test_run_calls  # type: ignore[attr-defined]
+    _, opts = calls[0]
+    assert opts is not None
+    assert opts.uid == 1000
+    assert opts.gid == 1000
+
+
+@pytest.mark.asyncio
+async def test_as_root_clears_uid_gid() -> None:
+    """as_root=True leaves uid/gid unset so the control plane stays root."""
+    backend, _ = _make_backend()
+
+    await backend.execute("whoami", as_root=True)
+
+    calls = backend._test_run_calls  # type: ignore[attr-defined]
+    _, opts = calls[0]
+    assert opts is not None
+    assert opts.uid is None
+    assert opts.gid is None
+
+
+@pytest.mark.asyncio
+async def test_start_browser_runs_as_root() -> None:
+    """Browser stack needs root for supervisord privilege drop / chown."""
+    backend, _ = _make_backend()
+
+    await backend.start_browser()
+
+    calls = backend._test_run_calls  # type: ignore[attr-defined]
+    assert len(calls) == 1
+    cmd, opts = calls[0]
+    assert cmd == "/usr/local/bin/start-browser.sh"
+    assert opts is not None
+    assert opts.uid is None
+    assert opts.gid is None
+
+
+@pytest.mark.asyncio
+async def test_upload_sets_owner_to_run_user() -> None:
+    """Uploaded files are owned by the sandbox user so agent can edit them."""
+    backend, raw = _make_backend()
+
+    await backend.upload([("/workspace/hello.txt", b"hi")])
+
+    raw.files.write_file.assert_awaited_once_with(
+        "/workspace/hello.txt",
+        b"hi",
+        owner="cubeplex",
+        group="cubeplex",
+    )
+
+
+@pytest.mark.asyncio
+async def test_null_run_uid_skips_privilege_drop() -> None:
+    """run_uid=None keeps prior root-by-default behaviour."""
+    backend, _ = _make_backend(run_uid=None, run_gid=None, run_user=None)
+
+    await backend.execute("whoami")
+
+    calls = backend._test_run_calls  # type: ignore[attr-defined]
+    _, opts = calls[0]
+    assert opts is not None
+    assert opts.uid is None
+    assert opts.gid is None

--- a/backend/tests/unit/test_opensandbox_execute_env.py
+++ b/backend/tests/unit/test_opensandbox_execute_env.py
@@ -169,18 +169,20 @@ async def test_start_browser_runs_as_root() -> None:
 
 
 @pytest.mark.asyncio
-async def test_upload_sets_owner_to_run_user() -> None:
-    """Uploaded files are owned by the sandbox user so agent can edit them."""
+async def test_upload_chowns_by_uid_not_username() -> None:
+    """Upload writes bytes then chowns by numeric uid (old-image safe)."""
     backend, raw = _make_backend()
 
     await backend.upload([("/workspace/hello.txt", b"hi")])
 
-    raw.files.write_file.assert_awaited_once_with(
-        "/workspace/hello.txt",
-        b"hi",
-        owner="cubeplex",
-        group="cubeplex",
-    )
+    raw.files.write_file.assert_awaited_once_with("/workspace/hello.txt", b"hi")
+    calls = backend._test_run_calls  # type: ignore[attr-defined]
+    assert len(calls) == 1
+    cmd, opts = calls[0]
+    assert "chown 1000:1000" in cmd
+    assert "/workspace/hello.txt" in cmd
+    assert opts is not None
+    assert opts.uid is None  # as_root
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_sandbox_browser.py
+++ b/backend/tests/unit/test_sandbox_browser.py
@@ -42,7 +42,15 @@ class _RecordingSandbox(Sandbox):
     def workdir(self) -> str:
         return "/workspace"
 
-    async def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResult:
+    async def execute(
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,
+        envs: dict[str, str] | None = None,
+        as_root: bool = False,
+    ) -> ExecuteResult:
+        del timeout, envs, as_root
         self.commands.append(command)
         return ExecuteResult(output="", exit_code=self._exit_code)
 

--- a/deploy/images/sandbox/Dockerfile
+++ b/deploy/images/sandbox/Dockerfile
@@ -230,19 +230,22 @@ RUN sed -i 's/implicit_hosting: false/implicit_hosting: true/' /etc/neko/neko.ya
 # the now-hidden overlay unnecessary. Keep clipboard + fullscreen.
 RUN sed -i 's#</head>#<style>.video-menu li:has(.fa-external-link-alt){display:none!important}.video-menu li:has(.fa-mouse-pointer),.video-menu li:has(.fa-computer-mouse),.video-menu li:has(.fa-mouse){display:none!important}.logo{display:none!important}.player-overlay{display:none!important}</style><script>setInterval(function(){var v=document.querySelector("video");if(v){try{v.muted=true;if(v.paused)v.play().catch(function(){});}catch(e){}}},250);</script></head>#' /var/www/index.html
 
-# neko user at uid 1000. Remove a pre-existing uid-1000 user conditionally so the
-# build stays deterministic across base-image variants (never hard-fail).
+# Default sandbox user `cubeplex` at uid/gid 1000 (matches backend agent
+# run_uid/run_gid). Also used by the Neko browser stack (ENV USER below).
+# Remove a pre-existing uid-1000 user conditionally so the build stays
+# deterministic across base-image variants (never hard-fail).
 RUN (getent passwd 1000 && userdel -r "$(getent passwd 1000 | cut -d: -f1)" 2>/dev/null || true) \
     && (getent group 1000 && groupdel "$(getent group 1000 | cut -d: -f1)" 2>/dev/null || true) \
-    && groupadd -g 1000 neko \
-    && useradd -u 1000 -g 1000 -m -d /home/neko -s /bin/bash neko \
-    && usermod -aG audio,video neko \
-    && mkdir -p /var/log/neko /tmp/runtime-neko /home/neko/.config/chromium \
-    && chown -R neko:neko /var/log/neko /tmp/runtime-neko /home/neko \
-    && chmod 700 /tmp/runtime-neko
+    && groupadd -g 1000 cubeplex \
+    && useradd -u 1000 -g 1000 -m -d /home/cubeplex -s /bin/bash cubeplex \
+    && usermod -aG audio,video cubeplex \
+    && mkdir -p /var/log/neko /tmp/runtime-neko /home/cubeplex/.config/chromium \
+    && chown -R cubeplex:cubeplex /var/log/neko /tmp/runtime-neko /home/cubeplex \
+    && chmod 700 /tmp/runtime-neko \
+    && chown cubeplex:cubeplex /workspace
 
 # Run Xorg fully rootless (drop the setuid Xorg.wrap) so the neko input socket is
-# owned by the neko user, and load the dummy config from the default path
+# owned by the cubeplex user, and load the dummy config from the default path
 # (Xorg.wrap rejects an absolute -config path).
 RUN rm -f /usr/lib/xorg/Xorg.wrap \
     && cp /etc/neko/xorg.conf /etc/X11/xorg.conf \
@@ -270,7 +273,10 @@ ARG NEKO_TURN_CRED=neko
 
 # First click after cubeplex "Take over" grants control (no in-Neko mouse step).
 # Env wins over /etc/neko/neko.yaml if the image is rebuilt from a newer base.
-ENV USER=neko \
+# USER=cubeplex is for Neko/supervisord child processes (chromium conf uses
+# %(ENV_USER)s). Container control plane stays root; agent commands run as
+# cubeplex via OpenSandbox RunCommandOpts.uid/gid from the backend.
+ENV USER=cubeplex \
     DISPLAY=:99.0 \
     XDG_RUNTIME_DIR=/tmp/runtime-neko \
     NEKO_SERVER_BIND=:8080 \

--- a/deploy/images/sandbox/neko/start-browser.sh
+++ b/deploy/images/sandbox/neko/start-browser.sh
@@ -27,13 +27,13 @@ if [ -S /var/run/supervisor.sock ] && supervisorctl -c "$SUPERVISORD_CONF" pid >
 fi
 
 mkdir -p /var/log/neko /tmp/runtime-neko
-chown neko:neko /var/log/neko /tmp/runtime-neko 2>/dev/null || true
+chown cubeplex:cubeplex /var/log/neko /tmp/runtime-neko 2>/dev/null || true
 
 # The Chromium profile lives on the PVC (/workspace is a runtime mount owned by
-# root), but Chromium runs as the neko user — create + own the dir at runtime so
-# it can write its profile. This is what persists auth state across the session.
+# root), but Chromium runs as the cubeplex user — create + own the dir at runtime
+# so it can write its profile. This is what persists auth state across the session.
 mkdir -p /workspace/.cubeplex-browser-profile
-chown -R neko:neko /workspace/.cubeplex-browser-profile 2>/dev/null || true
+chown -R cubeplex:cubeplex /workspace/.cubeplex-browser-profile 2>/dev/null || true
 
 # Daemonize supervisord; it brings up Xorg, openbox, pulseaudio, neko, chromium.
 # Close the lock fd (9) in the child: otherwise supervisord (and its children)

--- a/docs/site/docs/deployment/backend-config.md
+++ b/docs/site/docs/deployment/backend-config.md
@@ -206,6 +206,9 @@ sandbox:
   secure_access: true     # false for docker-runtime OpenSandbox
   ttl: 1800               # idle seconds before cleanup
   ready_timeout: 300      # wait for a sandbox to become ready (covers a cold pull)
+  run_user: "cubeplex"    # agent shell identity inside the container
+  run_uid: 1000           # OpenSandbox RunCommandOpts.uid (null = root)
+  run_gid: 1000
   resource:
     cpu: "2"
     memory: "4Gi"
@@ -217,6 +220,7 @@ sandbox:
 | `sandbox.use_server_proxy` | `true` | Set `false` for direct pod access; `true` for Docker-bridge / isolated networks. |
 | `sandbox.secure_access` | `true` | Kubernetes ingress-gateway signed URLs. **Must be `false`** on docker-runtime OpenSandbox. |
 | `sandbox.ttl` | `1800` | Idle sandbox is reaped after 30 min. |
+| `sandbox.run_user` / `run_uid` / `run_gid` | `cubeplex` / `1000` / `1000` | Agent commands and uploaded files run as this user. Match the sandbox image. Set `run_uid` to `null` to keep the previous root default. Browser stack still starts as root. |
 | `sandbox.resource.cpu` / `memory` | `2` / `4Gi` | Per-sandbox limits. |
 
 ## Streaming

--- a/docs/site/docs/guides/conversations/sandboxes.md
+++ b/docs/site/docs/guides/conversations/sandboxes.md
@@ -73,6 +73,7 @@ Everything under the sandbox's working directory (`/workspace`) lives on its per
 - **Installed packages persist.** When the agent runs a plain `pip install` or `npm install -g`, the packages land on persistent storage and are still available in later conversations — nothing gets reinstalled on every chat.
 - **Isolated environments work normally.** If a project or skill needs its own Python environment (a conflicting dependency set, a different Python version), the agent can create one with `python -m venv` or `uv`. Environments created under the working directory survive restarts and recreation like any other file.
 - **Everything outside the working directory is temporary.** System locations (`/tmp`, `/opt`, …) are reset when the sandbox is recreated.
+- **Commands run as the non-root `cubeplex` user** (uid 1000), not as root. Prefer installs that write under `/workspace` (the default pip/npm overlays already do). System-wide package managers that need root (for example `apt-get`) will fail unless an operator has arranged elevated access.
 
 ## How the agent organizes files
 


### PR DESCRIPTION
## Summary

- Agent shell commands and file uploads in the sandbox now run as non-root user **`cubeplex`** (uid/gid 1000) via OpenSandbox `RunCommandOpts.uid/gid`.
- Sandbox image renames the uid-1000 user from `neko` → `cubeplex` (browser stack still uses `ENV USER` for Chromium/supervisord children).
- Browser stack, ttyd start, and workspace chown stay **root** (`as_root=True`) so supervisord can drop privileges and PVC mounts become writable.
- Config: `sandbox.run_user` / `run_uid` / `run_gid` (default cubeplex/1000/1000; set `run_uid: null` for previous root default).
- Docs: user-facing sandboxes guide + backend-config reference.

Closes #430

## Deploy note

**Rebuild and roll out the sandbox image** together with this backend change. Uploads set `owner=cubeplex`; old images that only have user `neko` will reject that owner name. uid 1000 itself is unchanged, so execute still works on old images until upload hits the owner field.

## Test plan

- [x] Unit: `test_opensandbox_execute_env` (uid default, as_root, upload owner, null run_uid)
- [x] Unit: manager create / egress injection (chown best-effort)
- [x] Unit: sandbox browser start still invokes start-browser.sh
- [x] Pre-push `make check-ci` green
- [ ] After image rebuild: `whoami` in sandbox → `cubeplex`; write under `/workspace`; browser live view; terminal panel