### PR TITLE
Decouple artifact storage keys from conversations

### DIFF
--- a/backend/cubeplex/api/routes/v1/artifact_share.py
+++ b/backend/cubeplex/api/routes/v1/artifact_share.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from cubeplex.cache import RedisHandle, redis_dep
 from cubeplex.db import get_session
 from cubeplex.objectstore import get_objectstore_client
-from cubeplex.objectstore.artifact_paths import artifact_file_key
+from cubeplex.objectstore.artifact_paths import artifact_file_key_candidates
 from cubeplex.repositories import ArtifactRepository
 from cubeplex.services.artifact_share import resolve_share_token
 
@@ -195,11 +195,21 @@ async def share_file(
     target = file_path
     if not target:
         target = artifact.entry_file or artifact.path.rsplit("/", 1)[-1]
-    key = artifact_file_key(artifact_id, version, target)
-
     try:
         store = get_objectstore_client()
-        data, stored_content_type = await store.download_file(key)
+        for key in artifact_file_key_candidates(
+            artifact_id, version, target, artifact.conversation_id
+        ):
+            try:
+                data, stored_content_type = await store.download_file(key)
+                break
+            except ClientError as exc:
+                if exc.response.get("Error", {}).get("Code", "") not in ("NoSuchKey", "404"):
+                    raise
+        else:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="file not found")
+    except HTTPException:
+        raise
     except ClientError as exc:
         code = exc.response.get("Error", {}).get("Code", "")
         if code in ("NoSuchKey", "404"):

--- a/backend/cubeplex/api/routes/v1/artifact_share.py
+++ b/backend/cubeplex/api/routes/v1/artifact_share.py
@@ -1,7 +1,7 @@
 """Public artifact preview page + file-content endpoint (no auth; nonce-gated).
 
 The nonce IS the auth. Tokens are bound to ``(org_id, workspace_id,
-conversation_id, artifact_id, version)`` and expire after 7 days (see
+artifact_id, version)`` and expire after 7 days (see
 ``services/artifact_share.py``). A leaked link exposes one artifact for
 ≤ 1 week — bounded blast radius.
 """
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from cubeplex.cache import RedisHandle, redis_dep
 from cubeplex.db import get_session
 from cubeplex.objectstore import get_objectstore_client
+from cubeplex.objectstore.artifact_paths import artifact_file_key
 from cubeplex.repositories import ArtifactRepository
 from cubeplex.services.artifact_share import resolve_share_token
 
@@ -54,13 +55,12 @@ async def share_page(
         return HTMLResponse(_expired_html(), status_code=status.HTTP_404_NOT_FOUND)
     org_id = str(payload["org_id"])
     workspace_id = str(payload["workspace_id"])
-    conversation_id = str(payload["conversation_id"])
     artifact_id = str(payload["artifact_id"])
     version = int(str(payload["version"]))
 
     repo = ArtifactRepository(session, org_id=org_id, workspace_id=workspace_id)
     artifact = await repo.get_by_id(artifact_id)
-    if artifact is None or artifact.conversation_id != conversation_id:
+    if artifact is None:
         return HTMLResponse(
             _expired_html("Artifact not found"), status_code=status.HTTP_404_NOT_FOUND
         )
@@ -170,7 +170,7 @@ async def share_file(
 ) -> Response:
     """Serve a single file from the artifact behind ``nonce``.
 
-    Auth is the nonce alone — the bound (org, workspace, conv, artifact,
+    Auth is the nonce alone — the bound (org, workspace, artifact,
     version) is what the request was signed for. Path-traversal is rejected
     inline; only files under the artifact's object-store key prefix are
     reachable, even with a tampered ``file_path``.
@@ -182,13 +182,12 @@ async def share_file(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid file path")
     org_id = str(payload["org_id"])
     workspace_id = str(payload["workspace_id"])
-    conversation_id = str(payload["conversation_id"])
     artifact_id = str(payload["artifact_id"])
     version = int(str(payload["version"]))
 
     repo = ArtifactRepository(session, org_id=org_id, workspace_id=workspace_id)
     artifact = await repo.get_by_id(artifact_id)
-    if artifact is None or artifact.conversation_id != conversation_id:
+    if artifact is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="artifact not found")
 
     # If the caller asked for the entry_file by name, accept that; otherwise
@@ -196,7 +195,7 @@ async def share_file(
     target = file_path
     if not target:
         target = artifact.entry_file or artifact.path.rsplit("/", 1)[-1]
-    key = f"artifacts/{conversation_id}/{artifact_id}/v{version}/{target}"
+    key = artifact_file_key(artifact_id, version, target)
 
     try:
         store = get_objectstore_client()

--- a/backend/cubeplex/api/routes/v1/artifacts.py
+++ b/backend/cubeplex/api/routes/v1/artifacts.py
@@ -23,7 +23,7 @@ from cubeplex.db import get_session
 from cubeplex.objectstore import get_objectstore_client
 from cubeplex.objectstore.artifact_paths import (
     artifact_file_key_candidates,
-    artifact_version_prefix_candidates,
+    list_artifact_version_objects,
 )
 from cubeplex.repositories import (
     ArtifactRepository,
@@ -199,26 +199,21 @@ async def download_artifact(
     target_version = version or artifact.version
     try:
         store = get_objectstore_client()
-        prefix = ""
-        keys: list[str] = []
-        for candidate in artifact_version_prefix_candidates(
-            artifact_id, target_version, artifact.conversation_id
-        ):
-            keys = await store.list_objects(candidate)
-            if keys:
-                prefix = candidate
-                break
+        objects = await list_artifact_version_objects(
+            store, artifact_id, target_version, artifact.conversation_id
+        )
 
-        if not keys:
+        if not objects:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="No files found for this artifact version",
             )
 
-        if len(keys) == 1:
+        if len(objects) == 1:
             # Single file — download and return directly
-            data, content_type = await store.download_file(keys[0])
-            filename = keys[0].rsplit("/", 1)[-1]
+            relative_path, key = objects[0]
+            data, content_type = await store.download_file(key)
+            filename = relative_path.rsplit("/", 1)[-1]
             media_type = artifact.mime_type or content_type or "application/octet-stream"
             return Response(
                 content=data,
@@ -229,10 +224,9 @@ async def download_artifact(
         # Multiple files — create a tar archive in memory
         buf = io.BytesIO()
         with tarfile.open(fileobj=buf, mode="w") as tar:
-            for key in keys:
+            for relative_path, key in objects:
                 data, _ = await store.download_file(key)
-                rel_name = key[len(prefix) :]
-                info = tarfile.TarInfo(name=rel_name)
+                info = tarfile.TarInfo(name=relative_path)
                 info.size = len(data)
                 tar.addfile(info, io.BytesIO(data))
         buf.seek(0)
@@ -286,15 +280,9 @@ async def list_artifact_files(
     target_version = version or artifact.version
     try:
         store = get_objectstore_client()
-        prefix = ""
-        keys: list[str] = []
-        for candidate in artifact_version_prefix_candidates(
-            artifact_id, target_version, artifact.conversation_id
-        ):
-            keys = await store.list_objects(candidate)
-            if keys:
-                prefix = candidate
-                break
+        objects = await list_artifact_version_objects(
+            store, artifact_id, target_version, artifact.conversation_id
+        )
     except Exception as e:
         logger.error("Error listing artifact files: {}", e)
         raise HTTPException(
@@ -302,7 +290,7 @@ async def list_artifact_files(
             detail="Failed to list artifact files",
         ) from None
 
-    rel_files = [k[len(prefix) :] for k in keys]
+    rel_files = [relative_path for relative_path, _ in objects]
     if filter == "image":
         rel_files = [
             f for f in rel_files if "." in f and f.rsplit(".", 1)[-1].lower() in IMAGE_EXTENSIONS

--- a/backend/cubeplex/api/routes/v1/artifacts.py
+++ b/backend/cubeplex/api/routes/v1/artifacts.py
@@ -21,6 +21,7 @@ from cubeplex.cache import RedisHandle, redis_dep
 from cubeplex.config import config
 from cubeplex.db import get_session
 from cubeplex.objectstore import get_objectstore_client
+from cubeplex.objectstore.artifact_paths import artifact_file_key, artifact_version_prefix
 from cubeplex.repositories import (
     ArtifactRepository,
     ArtifactVersionRepository,
@@ -193,7 +194,7 @@ async def download_artifact(
         )
 
     target_version = version or artifact.version
-    prefix = f"artifacts/{conversation_id}/{artifact_id}/v{target_version}/"
+    prefix = artifact_version_prefix(artifact_id, target_version)
 
     try:
         store = get_objectstore_client()
@@ -274,7 +275,7 @@ async def list_artifact_files(
         )
 
     target_version = version or artifact.version
-    prefix = f"artifacts/{conversation_id}/{artifact_id}/v{target_version}/"
+    prefix = artifact_version_prefix(artifact_id, target_version)
 
     try:
         store = get_objectstore_client()
@@ -332,7 +333,6 @@ async def create_share_token(
         key_prefix=rh.key_prefix,
         org_id=ctx.org_id,
         workspace_id=ctx.workspace_id,
-        conversation_id=conversation_id,
         artifact_id=artifact_id,
         version=artifact.version,
         name=artifact.name,
@@ -390,7 +390,6 @@ async def create_preview_token(
     nonce = secrets.token_hex(32)
     payload = orjson.dumps(
         {
-            "conversation_id": conversation_id,
             "artifact_id": artifact_id,
             "version": target_version,
             "filename": filename,
@@ -447,7 +446,7 @@ async def preview_artifact_file(
             detail="Invalid file path",
         )
 
-    key = f"artifacts/{conversation_id}/{artifact_id}/v{version}/{file_path}"
+    key = artifact_file_key(artifact_id, version, file_path)
 
     try:
         store = get_objectstore_client()

--- a/backend/cubeplex/api/routes/v1/artifacts.py
+++ b/backend/cubeplex/api/routes/v1/artifacts.py
@@ -21,7 +21,10 @@ from cubeplex.cache import RedisHandle, redis_dep
 from cubeplex.config import config
 from cubeplex.db import get_session
 from cubeplex.objectstore import get_objectstore_client
-from cubeplex.objectstore.artifact_paths import artifact_file_key, artifact_version_prefix
+from cubeplex.objectstore.artifact_paths import (
+    artifact_file_key_candidates,
+    artifact_version_prefix_candidates,
+)
 from cubeplex.repositories import (
     ArtifactRepository,
     ArtifactVersionRepository,
@@ -194,11 +197,17 @@ async def download_artifact(
         )
 
     target_version = version or artifact.version
-    prefix = artifact_version_prefix(artifact_id, target_version)
-
     try:
         store = get_objectstore_client()
-        keys = await store.list_objects(prefix)
+        prefix = ""
+        keys: list[str] = []
+        for candidate in artifact_version_prefix_candidates(
+            artifact_id, target_version, artifact.conversation_id
+        ):
+            keys = await store.list_objects(candidate)
+            if keys:
+                prefix = candidate
+                break
 
         if not keys:
             raise HTTPException(
@@ -275,11 +284,17 @@ async def list_artifact_files(
         )
 
     target_version = version or artifact.version
-    prefix = artifact_version_prefix(artifact_id, target_version)
-
     try:
         store = get_objectstore_client()
-        keys = await store.list_objects(prefix)
+        prefix = ""
+        keys: list[str] = []
+        for candidate in artifact_version_prefix_candidates(
+            artifact_id, target_version, artifact.conversation_id
+        ):
+            keys = await store.list_objects(candidate)
+            if keys:
+                prefix = candidate
+                break
     except Exception as e:
         logger.error("Error listing artifact files: {}", e)
         raise HTTPException(
@@ -390,6 +405,8 @@ async def create_preview_token(
     nonce = secrets.token_hex(32)
     payload = orjson.dumps(
         {
+            "org_id": ctx.org_id,
+            "workspace_id": ctx.workspace_id,
             "artifact_id": artifact_id,
             "version": target_version,
             "filename": filename,
@@ -446,11 +463,24 @@ async def preview_artifact_file(
             detail="Invalid file path",
         )
 
-    key = artifact_file_key(artifact_id, version, file_path)
-
     try:
         store = get_objectstore_client()
-        data, stored_content_type = await store.download_file(key)
+        for key in artifact_file_key_candidates(
+            artifact_id, version, file_path, artifact.conversation_id
+        ):
+            try:
+                data, stored_content_type = await store.download_file(key)
+                break
+            except ClientError as exc:
+                if exc.response.get("Error", {}).get("Code", "") not in ("NoSuchKey", "404"):
+                    raise
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"File not found: {file_path}",
+            )
+    except HTTPException:
+        raise
     except ClientError as e:
         error_code = e.response.get("Error", {}).get("Code", "")
         if error_code in ("NoSuchKey", "404"):

--- a/backend/cubeplex/api/routes/v1/public_artifacts.py
+++ b/backend/cubeplex/api/routes/v1/public_artifacts.py
@@ -4,13 +4,17 @@ import mimetypes
 from typing import Annotated
 
 import orjson
+from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import Response
 from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubeplex.cache import RedisHandle, redis_dep
+from cubeplex.db import get_session
 from cubeplex.objectstore import get_objectstore_client
-from cubeplex.objectstore.artifact_paths import artifact_file_key
+from cubeplex.objectstore.artifact_paths import artifact_file_key_candidates
+from cubeplex.repositories import ArtifactRepository
 from cubeplex.utils.http import content_disposition
 
 router = APIRouter(prefix="/public/artifacts", tags=["public-artifacts"])
@@ -21,6 +25,7 @@ async def public_download(
     token: str,
     filename: str,
     rh: Annotated[RedisHandle, Depends(redis_dep)],
+    session: Annotated[AsyncSession, Depends(get_session)],
 ) -> Response:
     """Serve an artifact file using a short-lived download token.
 
@@ -46,11 +51,28 @@ async def public_download(
 
     artifact_id: str = payload["artifact_id"]
     version: int = payload["version"]
-    obj_key = artifact_file_key(artifact_id, version, stored_filename)
+    repo = ArtifactRepository(
+        session,
+        org_id=str(payload["org_id"]),
+        workspace_id=str(payload["workspace_id"]),
+    )
+    artifact = await repo.get_by_id(artifact_id)
+    if artifact is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found")
 
     try:
         store = get_objectstore_client()
-        data, stored_content_type = await store.download_file(obj_key)
+        for obj_key in artifact_file_key_candidates(
+            artifact_id, version, stored_filename, artifact.conversation_id
+        ):
+            try:
+                data, stored_content_type = await store.download_file(obj_key)
+                break
+            except ClientError as exc:
+                if exc.response.get("Error", {}).get("Code", "") not in ("NoSuchKey", "404"):
+                    raise
+        else:
+            raise FileNotFoundError(stored_filename)
     except Exception as e:
         logger.error("OTK download failed for {}: {}", obj_key, e)
         raise HTTPException(

--- a/backend/cubeplex/api/routes/v1/public_artifacts.py
+++ b/backend/cubeplex/api/routes/v1/public_artifacts.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from cubeplex.cache import RedisHandle, redis_dep
 from cubeplex.objectstore import get_objectstore_client
+from cubeplex.objectstore.artifact_paths import artifact_file_key
 from cubeplex.utils.http import content_disposition
 
 router = APIRouter(prefix="/public/artifacts", tags=["public-artifacts"])
@@ -43,10 +44,9 @@ async def public_download(
             detail="Filename mismatch",
         )
 
-    conversation_id: str = payload["conversation_id"]
     artifact_id: str = payload["artifact_id"]
     version: int = payload["version"]
-    obj_key = f"artifacts/{conversation_id}/{artifact_id}/v{version}/{stored_filename}"
+    obj_key = artifact_file_key(artifact_id, version, stored_filename)
 
     try:
         store = get_objectstore_client()

--- a/backend/cubeplex/api/routes/v1/shares.py
+++ b/backend/cubeplex/api/routes/v1/shares.py
@@ -193,7 +193,7 @@ async def create_share(
         is_active=False,
     )
 
-    await copy_artifacts_to_share(share.id, body.conversation_id, artifacts_data)
+    await copy_artifacts_to_share(share.id, artifacts_data)
 
     share = await share_repo.activate(share.id)
     return _serialize(share)

--- a/backend/cubeplex/api/routes/v1/ws_artifacts.py
+++ b/backend/cubeplex/api/routes/v1/ws_artifacts.py
@@ -16,6 +16,7 @@ from cubeplex.auth.context import RequestContext
 from cubeplex.auth.dependencies import require_member
 from cubeplex.db import get_session
 from cubeplex.objectstore import get_objectstore_client
+from cubeplex.objectstore.artifact_paths import artifact_root_prefix
 from cubeplex.repositories import ArtifactRepository, ConversationRepository
 
 router = APIRouter(prefix="/ws/{workspace_id}/artifacts", tags=["ws-artifacts"])
@@ -63,14 +64,17 @@ async def delete_workspace_artifact(
     if (await conv_repo.get_by_id(artifact.conversation_id)) is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found")
 
-    conversation_id = artifact.conversation_id
+    prefixes = {
+        artifact_root_prefix(artifact_id),
+        f"artifacts/{artifact.conversation_id}/{artifact_id}/",
+    }
     await art_repo.delete_with_versions(artifact)
 
-    prefix = f"artifacts/{conversation_id}/{artifact_id}/"
     try:
         store = get_objectstore_client()
-        for key in await store.list_objects(prefix):
-            await store.delete_file(key)
+        for prefix in prefixes:
+            for key in await store.list_objects(prefix):
+                await store.delete_file(key)
     except Exception as e:  # storage cleanup is best-effort; rows are already gone
         logger.error("Artifact {} storage cleanup failed: {}", artifact_id, e)
 

--- a/backend/cubeplex/im/artifacts.py
+++ b/backend/cubeplex/im/artifacts.py
@@ -28,7 +28,7 @@ from cubeplex.im.artifact_delivery import artifact_outbound_kind, outbound_size_
 from cubeplex.im.card_model import ArtifactItem, CardState
 from cubeplex.im.types import OutboundConnector
 from cubeplex.objectstore import get_objectstore_client
-from cubeplex.objectstore.artifact_paths import artifact_file_key
+from cubeplex.objectstore.artifact_paths import artifact_file_key_candidates
 from cubeplex.services.artifact_share import mint_share_token as _default_mint
 
 MintShareToken = Callable[..., Awaitable[str]]
@@ -56,18 +56,27 @@ async def download_artifact_to_tempfile(artifact: dict[str, Any]) -> Path | None
         return None
     # Build the key OUTSIDE the try so a key-construction bug propagates rather
     # than masquerading as a benign 'object missing → share-link' fallback.
-    key = artifact_file_key(artifact_id, version, filename)
-    try:
-        store = get_objectstore_client()
-        data, _ctype = await store.download_file(key)
-    except (ClientError, BotoCoreError, OSError, ValueError):
-        # Covers missing object (ClientError) AND transient network/endpoint
-        # errors (BotoCoreError: EndpointConnectionError/ConnectTimeoutError) so
-        # a blip degrades to a share-link instead of stranding the artifact. A
-        # key-construction bug (built above, outside the try) still propagates.
-        logger.opt(exception=True).warning(
-            "[IM artifacts] objectstore download failed for {}", artifact_id
-        )
+    store = get_objectstore_client()
+    for key in artifact_file_key_candidates(
+        artifact_id, version, filename, str(artifact.get("conversation_id") or "") or None
+    ):
+        try:
+            data, _ctype = await store.download_file(key)
+            break
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code", "") in ("NoSuchKey", "404"):
+                continue
+            logger.opt(exception=True).warning(
+                "[IM artifacts] objectstore download failed for {}", artifact_id
+            )
+            return None
+        except (BotoCoreError, OSError, ValueError):
+            logger.opt(exception=True).warning(
+                "[IM artifacts] objectstore download failed for {}", artifact_id
+            )
+            return None
+    else:
+        logger.warning("[IM artifacts] objectstore file missing for {}", artifact_id)
         return None
     suffix = Path(filename).suffix
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
@@ -98,6 +107,10 @@ class IMArtifactDispatcher:
     _file_artifacts: dict[str, dict[str, Any]] = field(default_factory=dict)
 
     async def handle(self, artifact: dict[str, Any]) -> None:
+        artifact = {
+            **artifact,
+            "conversation_id": artifact.get("conversation_id") or self.conversation_id,
+        }
         artifact_id = str(artifact.get("id") or "")
         if not artifact_id:
             return

--- a/backend/cubeplex/im/artifacts.py
+++ b/backend/cubeplex/im/artifacts.py
@@ -28,6 +28,7 @@ from cubeplex.im.artifact_delivery import artifact_outbound_kind, outbound_size_
 from cubeplex.im.card_model import ArtifactItem, CardState
 from cubeplex.im.types import OutboundConnector
 from cubeplex.objectstore import get_objectstore_client
+from cubeplex.objectstore.artifact_paths import artifact_file_key
 from cubeplex.services.artifact_share import mint_share_token as _default_mint
 
 MintShareToken = Callable[..., Awaitable[str]]
@@ -37,9 +38,7 @@ MintShareToken = Callable[..., Awaitable[str]]
 _SEND_TIMEOUT = 60.0
 
 
-async def download_artifact_to_tempfile(
-    conversation_id: str, artifact: dict[str, Any]
-) -> Path | None:
+async def download_artifact_to_tempfile(artifact: dict[str, Any]) -> Path | None:
     """Download an artifact's bytes from the object store to a temp file.
 
     Shared by the inline-image path and the native-file path. Returns the temp
@@ -57,7 +56,7 @@ async def download_artifact_to_tempfile(
         return None
     # Build the key OUTSIDE the try so a key-construction bug propagates rather
     # than masquerading as a benign 'object missing → share-link' fallback.
-    key = f"artifacts/{conversation_id}/{artifact_id}/v{version}/{filename}"
+    key = artifact_file_key(artifact_id, version, filename)
     try:
         store = get_objectstore_client()
         data, _ctype = await store.download_file(key)
@@ -121,7 +120,7 @@ class IMArtifactDispatcher:
         await self._fill_share_url(item, artifact)
 
     async def _fill_image_key(self, item: ArtifactItem, artifact: dict[str, Any]) -> None:
-        tmp_path = await download_artifact_to_tempfile(self.conversation_id, artifact)
+        tmp_path = await download_artifact_to_tempfile(artifact)
         if tmp_path is None:
             await self._fill_share_url(item, artifact)
             return
@@ -148,7 +147,6 @@ class IMArtifactDispatcher:
             key_prefix=self.redis_key_prefix,
             org_id=self.org_id,
             workspace_id=self.workspace_id,
-            conversation_id=self.conversation_id,
             artifact_id=item.id,
             version=version,
             name=item.name,
@@ -215,7 +213,7 @@ class IMArtifactDispatcher:
                 artifact_type=str(artifact.get("artifact_type") or ""),
                 name=str(artifact.get("name") or "file"),
             )
-        tmp_path = await download_artifact_to_tempfile(self.conversation_id, artifact)
+        tmp_path = await download_artifact_to_tempfile(artifact)
         if tmp_path is None:
             return await self._fallback_link(item, artifact)
         ok = False

--- a/backend/cubeplex/objectstore/artifact_paths.py
+++ b/backend/cubeplex/objectstore/artifact_paths.py
@@ -1,5 +1,11 @@
 """Canonical object-store paths for versioned artifacts."""
 
+from typing import Protocol
+
+
+class ObjectLister(Protocol):
+    async def list_objects(self, prefix: str) -> list[str]: ...
+
 
 def artifact_root_prefix(artifact_id: str) -> str:
     return f"artifacts/{artifact_id}/"
@@ -34,6 +40,20 @@ def artifact_file_key_candidates(
             artifact_id, version, legacy_conversation_id
         )
     )
+
+
+async def list_artifact_version_objects(
+    store: ObjectLister,
+    artifact_id: str,
+    version: int,
+    legacy_conversation_id: str | None,
+) -> list[tuple[str, str]]:
+    """Return ``(relative_path, object_key)`` pairs for one version."""
+    objects: dict[str, str] = {}
+    for prefix in artifact_version_prefix_candidates(artifact_id, version, legacy_conversation_id):
+        for key in await store.list_objects(prefix):
+            objects.setdefault(key[len(prefix) :], key)
+    return list(objects.items())
 
 
 def artifact_staging_prefix(artifact_id: str, nonce: str) -> str:

--- a/backend/cubeplex/objectstore/artifact_paths.py
+++ b/backend/cubeplex/objectstore/artifact_paths.py
@@ -13,5 +13,28 @@ def artifact_file_key(artifact_id: str, version: int, file_path: str) -> str:
     return f"{artifact_version_prefix(artifact_id, version)}{file_path}"
 
 
+def artifact_version_prefix_candidates(
+    artifact_id: str, version: int, legacy_conversation_id: str | None
+) -> tuple[str, ...]:
+    canonical = artifact_version_prefix(artifact_id, version)
+    if not legacy_conversation_id:
+        return (canonical,)
+    return (canonical, f"artifacts/{legacy_conversation_id}/{artifact_id}/v{version}/")
+
+
+def artifact_file_key_candidates(
+    artifact_id: str,
+    version: int,
+    file_path: str,
+    legacy_conversation_id: str | None,
+) -> tuple[str, ...]:
+    return tuple(
+        f"{prefix}{file_path}"
+        for prefix in artifact_version_prefix_candidates(
+            artifact_id, version, legacy_conversation_id
+        )
+    )
+
+
 def artifact_staging_prefix(artifact_id: str, nonce: str) -> str:
     return f"{artifact_root_prefix(artifact_id)}staging/{nonce}/"

--- a/backend/cubeplex/objectstore/artifact_paths.py
+++ b/backend/cubeplex/objectstore/artifact_paths.py
@@ -1,0 +1,17 @@
+"""Canonical object-store paths for versioned artifacts."""
+
+
+def artifact_root_prefix(artifact_id: str) -> str:
+    return f"artifacts/{artifact_id}/"
+
+
+def artifact_version_prefix(artifact_id: str, version: int) -> str:
+    return f"{artifact_root_prefix(artifact_id)}v{version}/"
+
+
+def artifact_file_key(artifact_id: str, version: int, file_path: str) -> str:
+    return f"{artifact_version_prefix(artifact_id, version)}{file_path}"
+
+
+def artifact_staging_prefix(artifact_id: str, nonce: str) -> str:
+    return f"{artifact_root_prefix(artifact_id)}staging/{nonce}/"

--- a/backend/cubeplex/services/artifact_content.py
+++ b/backend/cubeplex/services/artifact_content.py
@@ -28,7 +28,7 @@ from cubeplex.objectstore import get_objectstore_client
 from cubeplex.objectstore.artifact_paths import (
     artifact_file_key,
     artifact_staging_prefix,
-    artifact_version_prefix_candidates,
+    list_artifact_version_objects,
 )
 from cubeplex.repositories import ArtifactRepository
 
@@ -161,13 +161,9 @@ async def update_artifact_content(
 
     store = get_objectstore_client()
     try:
-        existing: list[str] = []
-        for current_prefix in artifact_version_prefix_candidates(
-            artifact_id, artifact.version, artifact.conversation_id
-        ):
-            existing = await store.list_objects(current_prefix)
-            if existing:
-                break
+        existing = await list_artifact_version_objects(
+            store, artifact_id, artifact.version, artifact.conversation_id
+        )
     except Exception as exc:
         logger.exception("Failed listing artifact objects for {}", artifact_id)
         raise ArtifactContentError(

--- a/backend/cubeplex/services/artifact_content.py
+++ b/backend/cubeplex/services/artifact_content.py
@@ -25,6 +25,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from cubeplex.models.artifact import Artifact
 from cubeplex.models.artifact_version import ArtifactVersion
 from cubeplex.objectstore import get_objectstore_client
+from cubeplex.objectstore.artifact_paths import (
+    artifact_file_key,
+    artifact_staging_prefix,
+    artifact_version_prefix,
+)
 from cubeplex.repositories import ArtifactRepository
 
 MAX_CONTENT_BYTES = 2_000_000
@@ -155,7 +160,7 @@ async def update_artifact_content(
         )
 
     store = get_objectstore_client()
-    current_prefix = f"artifacts/{conversation_id}/{artifact_id}/v{artifact.version}/"
+    current_prefix = artifact_version_prefix(artifact_id, artifact.version)
     try:
         existing = await store.list_objects(current_prefix)
     except Exception as exc:
@@ -172,10 +177,8 @@ async def update_artifact_content(
         )
 
     next_version = expected_version + 1
-    staging_key = (
-        f"artifacts/{conversation_id}/{artifact_id}/staging/{secrets.token_hex(16)}/{filename}"
-    )
-    final_key = f"artifacts/{conversation_id}/{artifact_id}/v{next_version}/{filename}"
+    staging_key = f"{artifact_staging_prefix(artifact_id, secrets.token_hex(16))}{filename}"
+    final_key = artifact_file_key(artifact_id, next_version, filename)
     mime = artifact.mime_type or mimetypes.guess_type(filename)[0] or "text/markdown"
 
     # Staging first: durable copy until final key is written under the row lock.

--- a/backend/cubeplex/services/artifact_content.py
+++ b/backend/cubeplex/services/artifact_content.py
@@ -28,7 +28,7 @@ from cubeplex.objectstore import get_objectstore_client
 from cubeplex.objectstore.artifact_paths import (
     artifact_file_key,
     artifact_staging_prefix,
-    artifact_version_prefix,
+    artifact_version_prefix_candidates,
 )
 from cubeplex.repositories import ArtifactRepository
 
@@ -160,9 +160,14 @@ async def update_artifact_content(
         )
 
     store = get_objectstore_client()
-    current_prefix = artifact_version_prefix(artifact_id, artifact.version)
     try:
-        existing = await store.list_objects(current_prefix)
+        existing: list[str] = []
+        for current_prefix in artifact_version_prefix_candidates(
+            artifact_id, artifact.version, artifact.conversation_id
+        ):
+            existing = await store.list_objects(current_prefix)
+            if existing:
+                break
     except Exception as exc:
         logger.exception("Failed listing artifact objects for {}", artifact_id)
         raise ArtifactContentError(

--- a/backend/cubeplex/services/artifact_registration.py
+++ b/backend/cubeplex/services/artifact_registration.py
@@ -12,6 +12,7 @@ import shlex
 from loguru import logger
 
 from cubeplex.models.artifact import Artifact
+from cubeplex.objectstore.artifact_paths import artifact_version_prefix
 from cubeplex.sandbox.base import Sandbox
 
 
@@ -96,7 +97,7 @@ async def register_artifact_from_sandbox(
         from cubeplex.objectstore import get_objectstore_client
 
         store = get_objectstore_client()
-        key_prefix = f"artifacts/{conversation_id}/{artifact.id}/v{artifact.version}/"
+        key_prefix = artifact_version_prefix(artifact.id, artifact.version)
         await store.upload_from_sandbox(sandbox, path, key_prefix)
     except Exception:
         logger.exception("Failed to upload artifact {} to object storage (non-fatal)", artifact.id)

--- a/backend/cubeplex/services/artifact_share.py
+++ b/backend/cubeplex/services/artifact_share.py
@@ -25,7 +25,6 @@ async def mint_share_token(
     key_prefix: str,
     org_id: str,
     workspace_id: str,
-    conversation_id: str,
     artifact_id: str,
     version: int,
     name: str | None = None,
@@ -51,7 +50,6 @@ async def mint_share_token(
         {
             "org_id": org_id,
             "workspace_id": workspace_id,
-            "conversation_id": conversation_id,
             "artifact_id": artifact_id,
             "version": version,
             "name": name,

--- a/backend/cubeplex/services/conversation_sharing.py
+++ b/backend/cubeplex/services/conversation_sharing.py
@@ -8,7 +8,7 @@ from typing import Any
 from loguru import logger
 
 from cubeplex.agents.checkpointer import shared_checkpointer
-from cubeplex.objectstore.artifact_paths import artifact_version_prefix_candidates
+from cubeplex.objectstore.artifact_paths import list_artifact_version_objects
 from cubeplex.objectstore.client import get_objectstore_client
 
 _ATTACHMENT_KEEP_KEYS = {"filename", "mime_type", "size"}
@@ -73,24 +73,20 @@ async def copy_artifacts_to_share(
         version = art.get("version", 1)
         dst_prefix = f"shares/{share_id}/artifacts/{art_id}/v{version}/"
 
-        src_prefix = ""
-        keys: list[str] = []
-        for candidate in artifact_version_prefix_candidates(
-            art_id, version, str(art.get("conversation_id") or "") or None
-        ):
-            keys = await store.list_objects(candidate)
-            if keys:
-                src_prefix = candidate
-                break
-        for key in keys:
+        objects = await list_artifact_version_objects(
+            store,
+            art_id,
+            version,
+            str(art.get("conversation_id") or "") or None,
+        )
+        for rel, key in objects:
             data, content_type = await store.download_file(key)
-            rel = key[len(src_prefix) :]
             dst_key = f"{dst_prefix}{rel}"
             await store.upload_file(dst_key, data, content_type)
 
         logger.debug(
             "Copied {} artifact file(s) for {} to share {}",
-            len(keys),
+            len(objects),
             art_id,
             share_id,
         )

--- a/backend/cubeplex/services/conversation_sharing.py
+++ b/backend/cubeplex/services/conversation_sharing.py
@@ -8,7 +8,7 @@ from typing import Any
 from loguru import logger
 
 from cubeplex.agents.checkpointer import shared_checkpointer
-from cubeplex.objectstore.artifact_paths import artifact_version_prefix
+from cubeplex.objectstore.artifact_paths import artifact_version_prefix_candidates
 from cubeplex.objectstore.client import get_objectstore_client
 
 _ATTACHMENT_KEEP_KEYS = {"filename", "mime_type", "size"}
@@ -71,10 +71,17 @@ async def copy_artifacts_to_share(
     for art in artifacts:
         art_id = art["id"]
         version = art.get("version", 1)
-        src_prefix = artifact_version_prefix(art_id, version)
         dst_prefix = f"shares/{share_id}/artifacts/{art_id}/v{version}/"
 
-        keys = await store.list_objects(src_prefix)
+        src_prefix = ""
+        keys: list[str] = []
+        for candidate in artifact_version_prefix_candidates(
+            art_id, version, str(art.get("conversation_id") or "") or None
+        ):
+            keys = await store.list_objects(candidate)
+            if keys:
+                src_prefix = candidate
+                break
         for key in keys:
             data, content_type = await store.download_file(key)
             rel = key[len(src_prefix) :]

--- a/backend/cubeplex/services/conversation_sharing.py
+++ b/backend/cubeplex/services/conversation_sharing.py
@@ -8,6 +8,7 @@ from typing import Any
 from loguru import logger
 
 from cubeplex.agents.checkpointer import shared_checkpointer
+from cubeplex.objectstore.artifact_paths import artifact_version_prefix
 from cubeplex.objectstore.client import get_objectstore_client
 
 _ATTACHMENT_KEEP_KEYS = {"filename", "mime_type", "size"}
@@ -63,7 +64,6 @@ async def build_snapshot(conversation_id: str) -> list[dict[str, Any]]:
 
 async def copy_artifacts_to_share(
     share_id: str,
-    conversation_id: str,
     artifacts: list[dict[str, Any]],
 ) -> None:
     """Copy artifact files from conversation storage to share-scoped storage."""
@@ -71,7 +71,7 @@ async def copy_artifacts_to_share(
     for art in artifacts:
         art_id = art["id"]
         version = art.get("version", 1)
-        src_prefix = f"artifacts/{conversation_id}/{art_id}/v{version}/"
+        src_prefix = artifact_version_prefix(art_id, version)
         dst_prefix = f"shares/{share_id}/artifacts/{art_id}/v{version}/"
 
         keys = await store.list_objects(src_prefix)

--- a/backend/cubeplex/skills/service.py
+++ b/backend/cubeplex/skills/service.py
@@ -21,6 +21,7 @@ from cubeplex.models import (
     WorkspaceSkillBinding,
 )
 from cubeplex.objectstore import get_objectstore_client
+from cubeplex.objectstore.artifact_paths import artifact_version_prefix
 from cubeplex.repositories.artifact import ArtifactRepository
 from cubeplex.repositories.skill import (
     OrgSkillInstallRepository,
@@ -265,7 +266,7 @@ class SkillPublishService:
                 f"artifact {artifact_id!r} has type {artifact.artifact_type!r}, expected 'skill'"
             )
 
-        prefix = f"artifacts/{artifact.conversation_id}/{artifact.id}/v{artifact.version}/"
+        prefix = artifact_version_prefix(artifact.id, artifact.version)
         store = get_objectstore_client()
         keys = await store.list_objects(prefix)
         files: dict[str, bytes] = {}

--- a/backend/cubeplex/skills/service.py
+++ b/backend/cubeplex/skills/service.py
@@ -21,7 +21,7 @@ from cubeplex.models import (
     WorkspaceSkillBinding,
 )
 from cubeplex.objectstore import get_objectstore_client
-from cubeplex.objectstore.artifact_paths import artifact_version_prefix_candidates
+from cubeplex.objectstore.artifact_paths import list_artifact_version_objects
 from cubeplex.repositories.artifact import ArtifactRepository
 from cubeplex.repositories.skill import (
     OrgSkillInstallRepository,
@@ -267,18 +267,12 @@ class SkillPublishService:
             )
 
         store = get_objectstore_client()
-        prefix = ""
-        keys: list[str] = []
-        for candidate in artifact_version_prefix_candidates(
-            artifact.id, artifact.version, artifact.conversation_id
-        ):
-            keys = await store.list_objects(candidate)
-            if keys:
-                prefix = candidate
-                break
+        objects = await list_artifact_version_objects(
+            store, artifact.id, artifact.version, artifact.conversation_id
+        )
         files: dict[str, bytes] = {}
-        for key in keys:
-            rel = key[len(prefix) :].lstrip("/")
+        for rel, key in objects:
+            rel = rel.lstrip("/")
             if not rel:
                 continue
             data, _ = await store.download_file(key)

--- a/backend/cubeplex/skills/service.py
+++ b/backend/cubeplex/skills/service.py
@@ -21,7 +21,7 @@ from cubeplex.models import (
     WorkspaceSkillBinding,
 )
 from cubeplex.objectstore import get_objectstore_client
-from cubeplex.objectstore.artifact_paths import artifact_version_prefix
+from cubeplex.objectstore.artifact_paths import artifact_version_prefix_candidates
 from cubeplex.repositories.artifact import ArtifactRepository
 from cubeplex.repositories.skill import (
     OrgSkillInstallRepository,
@@ -266,9 +266,16 @@ class SkillPublishService:
                 f"artifact {artifact_id!r} has type {artifact.artifact_type!r}, expected 'skill'"
             )
 
-        prefix = artifact_version_prefix(artifact.id, artifact.version)
         store = get_objectstore_client()
-        keys = await store.list_objects(prefix)
+        prefix = ""
+        keys: list[str] = []
+        for candidate in artifact_version_prefix_candidates(
+            artifact.id, artifact.version, artifact.conversation_id
+        ):
+            keys = await store.list_objects(candidate)
+            if keys:
+                prefix = candidate
+                break
         files: dict[str, bytes] = {}
         for key in keys:
             rel = key[len(prefix) :].lstrip("/")

--- a/backend/scripts/dev/migrate_artifact_object_keys.py
+++ b/backend/scripts/dev/migrate_artifact_object_keys.py
@@ -24,6 +24,21 @@ from cubeplex.objectstore import get_objectstore_client
 from cubeplex.objectstore.artifact_paths import artifact_root_prefix
 
 
+def missing_object_copies(
+    source_prefix: str,
+    destination_prefix: str,
+    source_keys: list[str],
+    destination_keys: list[str],
+) -> list[tuple[str, str]]:
+    existing = set(destination_keys)
+    copies: list[tuple[str, str]] = []
+    for source_key in source_keys:
+        destination_key = f"{destination_prefix}{source_key[len(source_prefix) :]}"
+        if destination_key not in existing:
+            copies.append((source_key, destination_key))
+    return copies
+
+
 async def migrate(*, delete_source: bool) -> tuple[int, int]:
     async with async_session_maker() as session:
         artifacts = list((await session.execute(select(Artifact))).scalars().all())
@@ -39,19 +54,26 @@ async def migrate(*, delete_source: bool) -> tuple[int, int]:
             skipped += 1
             continue
 
-        for source_key in source_keys:
-            relative_path = source_key[len(source_prefix) :]
-            destination_key = f"{destination_prefix}{relative_path}"
+        destination_keys = await store.list_objects(destination_prefix)
+        copies = missing_object_copies(
+            source_prefix,
+            destination_prefix,
+            source_keys,
+            destination_keys,
+        )
+        for source_key, destination_key in copies:
             data, content_type = await store.download_file(source_key)
             await store.upload_file(destination_key, data, content_type)
             copied += 1
-            if delete_source:
+        if delete_source:
+            for source_key in source_keys:
                 await store.delete_file(source_key)
 
         logger.info(
-            "Migrated artifact {}: {} object(s){}",
+            "Migrated artifact {}: {} copied, {} already canonical{}",
             artifact.id,
-            len(source_keys),
+            len(copies),
+            len(source_keys) - len(copies),
             " and deleted legacy keys" if delete_source else "",
         )
 

--- a/backend/scripts/dev/migrate_artifact_object_keys.py
+++ b/backend/scripts/dev/migrate_artifact_object_keys.py
@@ -1,0 +1,80 @@
+"""Copy legacy conversation-prefixed artifact objects to canonical keys.
+
+The migration is idempotent. By default it keeps legacy objects; pass
+``--delete-source`` only after every consumer runs the canonical-key code.
+
+Usage:
+    cd backend
+    uv run python scripts/dev/migrate_artifact_object_keys.py
+    uv run python scripts/dev/migrate_artifact_object_keys.py --delete-source
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from loguru import logger
+from sqlalchemy import select
+
+from cubeplex.db.engine import async_session_maker
+from cubeplex.models.artifact import Artifact
+from cubeplex.objectstore import get_objectstore_client
+from cubeplex.objectstore.artifact_paths import artifact_root_prefix
+
+
+async def migrate(*, delete_source: bool) -> tuple[int, int]:
+    async with async_session_maker() as session:
+        artifacts = list((await session.execute(select(Artifact))).scalars().all())
+
+    store = get_objectstore_client()
+    copied = 0
+    skipped = 0
+    for artifact in artifacts:
+        source_prefix = f"artifacts/{artifact.conversation_id}/{artifact.id}/"
+        destination_prefix = artifact_root_prefix(artifact.id)
+        source_keys = await store.list_objects(source_prefix)
+        if not source_keys:
+            skipped += 1
+            continue
+
+        for source_key in source_keys:
+            relative_path = source_key[len(source_prefix) :]
+            destination_key = f"{destination_prefix}{relative_path}"
+            data, content_type = await store.download_file(source_key)
+            await store.upload_file(destination_key, data, content_type)
+            copied += 1
+            if delete_source:
+                await store.delete_file(source_key)
+
+        logger.info(
+            "Migrated artifact {}: {} object(s){}",
+            artifact.id,
+            len(source_keys),
+            " and deleted legacy keys" if delete_source else "",
+        )
+
+    return copied, skipped
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--delete-source",
+        action="store_true",
+        help="delete each legacy object after its canonical copy succeeds",
+    )
+    args = parser.parse_args()
+    copied, skipped = await migrate(delete_source=args.delete_source)
+    logger.info(
+        "Migration complete: {} copied, {} artifacts had no legacy objects",
+        copied,
+        skipped,
+    )
+
+
+if __name__ == "__main__":
+    logger.remove()
+    logger.add(sys.stderr, format="{time:HH:mm:ss} | {level} | {message}", level="INFO")
+    asyncio.run(main())

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -863,7 +863,7 @@ async def _seed_skill_artifact(workspace_id: str, *, skill_md: bytes) -> tuple[s
         await test_engine.dispose()
 
     store = get_objectstore_client()
-    prefix = f"artifacts/{conv_id}/{artifact_id}/v1/"
+    prefix = f"artifacts/{artifact_id}/v1/"
     await store.upload_file(f"{prefix}SKILL.md", skill_md)
     return artifact_id, conv_id
 

--- a/backend/tests/e2e/test_artifact_content.py
+++ b/backend/tests/e2e/test_artifact_content.py
@@ -87,16 +87,16 @@ async def _seed(client: TestClient) -> AsyncIterator[None]:
             await s.commit()
 
         await store.upload_file(
-            f"artifacts/{_CONV}/{_ART}/v1/guide.md",
+            f"artifacts/{_ART}/v1/guide.md",
             b"# Hello\n",
             content_type="text/markdown",
         )
         yield
     finally:
         for key in (
-            f"artifacts/{_CONV}/{_ART}/v1/guide.md",
-            f"artifacts/{_CONV}/{_ART}/v2/guide.md",
-            f"artifacts/{_CONV}/{_ART}/v3/guide.md",
+            f"artifacts/{_ART}/v1/guide.md",
+            f"artifacts/{_ART}/v2/guide.md",
+            f"artifacts/{_ART}/v3/guide.md",
         ):
             try:
                 await store.delete_file(key)

--- a/backend/tests/e2e/test_artifact_files.py
+++ b/backend/tests/e2e/test_artifact_files.py
@@ -1,5 +1,7 @@
 """E2E tests for the artifact file-list endpoint."""
 
+import io
+import tarfile
 from collections.abc import AsyncIterator
 
 import pytest
@@ -78,6 +80,14 @@ async def _seed(client: TestClient) -> AsyncIterator[None]:
             f"artifacts/{_CONV}/{_ART}/v3/legacy.png",
             b"\x89PNG\r\n\x1a\n-legacy",
         )
+        await store.upload_file(
+            f"artifacts/{_CONV}/{_ART}/v3/only-legacy.png",
+            b"\x89PNG\r\n\x1a\n-only-legacy",
+        )
+        await store.upload_file(
+            f"artifacts/{_ART}/v3/legacy.png",
+            b"\x89PNG\r\n\x1a\n-canonical",
+        )
         yield
     finally:
         store = get_objectstore_client()
@@ -92,6 +102,8 @@ async def _seed(client: TestClient) -> AsyncIterator[None]:
             except Exception:
                 pass
         await store.delete_file(f"artifacts/{_CONV}/{_ART}/v3/legacy.png")
+        await store.delete_file(f"artifacts/{_CONV}/{_ART}/v3/only-legacy.png")
+        await store.delete_file(f"artifacts/{_ART}/v3/legacy.png")
         async with maker() as s:
             await s.execute(text("DELETE FROM artifacts WHERE id = :id"), {"id": _ART})
             await s.execute(text("DELETE FROM conversations WHERE id = :id"), {"id": _CONV})
@@ -224,13 +236,25 @@ def test_existing_legacy_version_remains_readable_during_migration(
         params={"version": 3},
     )
     assert files.status_code == 200, files.text
-    assert files.json()["files"] == ["legacy.png"]
+    assert files.json()["files"] == ["legacy.png", "only-legacy.png"]
 
     preview = client.get(
         f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/{_ART}/preview/v3/legacy.png"
     )
     assert preview.status_code == 200, preview.text
-    assert preview.content == b"\x89PNG\r\n\x1a\n-legacy"
+    assert preview.content == b"\x89PNG\r\n\x1a\n-canonical"
+
+    download = client.get(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/{_ART}/download",
+        params={"version": 3},
+    )
+    assert download.status_code == 200, download.text
+    with tarfile.open(fileobj=io.BytesIO(download.content)) as archive:
+        assert archive.getnames() == ["legacy.png", "only-legacy.png"]
+        canonical = archive.extractfile("legacy.png")
+        legacy = archive.extractfile("only-legacy.png")
+        assert canonical is not None and canonical.read().endswith(b"-canonical")
+        assert legacy is not None and legacy.read().endswith(b"-only-legacy")
 
 
 def test_files_filter_image_empty_when_only_non_image(

--- a/backend/tests/e2e/test_artifact_files.py
+++ b/backend/tests/e2e/test_artifact_files.py
@@ -74,6 +74,10 @@ async def _seed(client: TestClient) -> AsyncIterator[None]:
             ("2_v2.png", b"\x89PNG\r\n\x1a\n-v2-second"),
         ):
             await store.upload_file(f"artifacts/{_ART}/v2/{name}", data)
+        await store.upload_file(
+            f"artifacts/{_CONV}/{_ART}/v3/legacy.png",
+            b"\x89PNG\r\n\x1a\n-legacy",
+        )
         yield
     finally:
         store = get_objectstore_client()
@@ -87,6 +91,7 @@ async def _seed(client: TestClient) -> AsyncIterator[None]:
                 await store.delete_file(f"artifacts/{_ART}/v2/{name}")
             except Exception:
                 pass
+        await store.delete_file(f"artifacts/{_CONV}/{_ART}/v3/legacy.png")
         async with maker() as s:
             await s.execute(text("DELETE FROM artifacts WHERE id = :id"), {"id": _ART})
             await s.execute(text("DELETE FROM conversations WHERE id = :id"), {"id": _CONV})
@@ -209,6 +214,23 @@ def test_preview_version_uses_artifact_prefix(_seed: None, client: TestClient) -
     )
     assert res.status_code == 200, res.text
     assert res.content == b"\x89PNG\r\n\x1a\n-v2-first"
+
+
+def test_existing_legacy_version_remains_readable_during_migration(
+    _seed: None, client: TestClient
+) -> None:
+    files = client.get(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/{_ART}/files",
+        params={"version": 3},
+    )
+    assert files.status_code == 200, files.text
+    assert files.json()["files"] == ["legacy.png"]
+
+    preview = client.get(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/{_ART}/preview/v3/legacy.png"
+    )
+    assert preview.status_code == 200, preview.text
+    assert preview.content == b"\x89PNG\r\n\x1a\n-legacy"
 
 
 def test_files_filter_image_empty_when_only_non_image(

--- a/backend/tests/e2e/test_artifact_files.py
+++ b/backend/tests/e2e/test_artifact_files.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 
 _CONV = "conv-artfiles"
 _ART = "art-artfiles"
-_PREFIX = f"artifacts/{_CONV}/{_ART}/v1/"
+_PREFIX = f"artifacts/{_ART}/v1/"
 
 
 @pytest_asyncio.fixture
@@ -73,7 +73,7 @@ async def _seed(client: TestClient) -> AsyncIterator[None]:
             ("1_v2.png", b"\x89PNG\r\n\x1a\n-v2-first"),
             ("2_v2.png", b"\x89PNG\r\n\x1a\n-v2-second"),
         ):
-            await store.upload_file(f"artifacts/{_CONV}/{_ART}/v2/{name}", data)
+            await store.upload_file(f"artifacts/{_ART}/v2/{name}", data)
         yield
     finally:
         store = get_objectstore_client()
@@ -84,7 +84,7 @@ async def _seed(client: TestClient) -> AsyncIterator[None]:
                 pass
         for name in ("1_v2.png", "2_v2.png"):
             try:
-                await store.delete_file(f"artifacts/{_CONV}/{_ART}/v2/{name}")
+                await store.delete_file(f"artifacts/{_ART}/v2/{name}")
             except Exception:
                 pass
         async with maker() as s:
@@ -132,7 +132,7 @@ def test_files_cross_workspace_404(_seed: None, client: TestClient) -> None:
 
 _CONV2 = "conv-nonimg"
 _ART2 = "art-nonimg"
-_PREFIX2 = f"artifacts/{_CONV2}/{_ART2}/v1/"
+_PREFIX2 = f"artifacts/{_ART2}/v1/"
 
 
 @pytest_asyncio.fixture
@@ -190,8 +190,8 @@ async def _seed_non_image(client: TestClient) -> AsyncIterator[None]:
         await engine.dispose()
 
 
-def test_files_version_param(_seed: None, client: TestClient) -> None:
-    """?version=N returns files from that version's prefix."""
+def test_files_version_param_uses_artifact_prefix(_seed: None, client: TestClient) -> None:
+    """?version=N resolves objects using only the artifact id and version."""
     res = client.get(
         f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/{_ART}/files",
         params={"version": 2, "filter": "image"},
@@ -200,6 +200,15 @@ def test_files_version_param(_seed: None, client: TestClient) -> None:
     body = res.json()
     assert body["version"] == 2
     assert body["files"] == ["1_v2.png", "2_v2.png"]
+
+
+def test_preview_version_uses_artifact_prefix(_seed: None, client: TestClient) -> None:
+    """Preview serves a requested version without a conversation storage prefix."""
+    res = client.get(
+        f"/api/v1/ws/{DEFAULT_WS_ID}/conversations/{_CONV}/artifacts/{_ART}/preview/v2/1_v2.png"
+    )
+    assert res.status_code == 200, res.text
+    assert res.content == b"\x89PNG\r\n\x1a\n-v2-first"
 
 
 def test_files_filter_image_empty_when_only_non_image(

--- a/backend/tests/e2e/test_artifact_share_token.py
+++ b/backend/tests/e2e/test_artifact_share_token.py
@@ -175,5 +175,38 @@ async def test_share_file_needs_no_conversation_in_token(
     await _redis.delete(f"{key_prefix}:share:{nonce}")
 
 
+async def test_share_file_reads_owner_conversation_legacy_key_during_migration(
+    _redis: Redis,
+    _seeded_artifact: async_sessionmaker[AsyncSession],
+    client: TestClient,
+) -> None:
+    store = get_objectstore_client()
+    canonical_key = f"artifacts/{_ART_ID}/v1/report.md"
+    legacy_key = f"artifacts/{_CONV_ID}/{_ART_ID}/v1/report.md"
+    await store.delete_file(canonical_key)
+    await store.upload_file(legacy_key, b"legacy shared report")
+    key_prefix = (
+        f"{_cubeplex_config.get('redis.key_prefix', 'cubeplex')}:"
+        f"{os.getenv('ENV_FOR_DYNACONF', 'development')}"
+    )
+    nonce = await mint_share_token(
+        redis=_redis,
+        key_prefix=key_prefix,
+        org_id=_ORG_ID,
+        workspace_id=_WS_ID,
+        artifact_id=_ART_ID,
+        version=1,
+        entry_file="report.md",
+        ttl_seconds=60,
+    )
+    try:
+        response = client.get(f"/api/v1/public/artifacts/share/{nonce}/file/report.md")
+        assert response.status_code == 200, response.text
+        assert response.content == b"legacy shared report"
+    finally:
+        await _redis.delete(f"{key_prefix}:share:{nonce}")
+        await store.delete_file(legacy_key)
+
+
 async def test_default_ttl_constant_is_seven_days() -> None:
     assert SHARE_TTL_SECONDS == 60 * 60 * 24 * 7

--- a/backend/tests/e2e/test_artifact_share_token.py
+++ b/backend/tests/e2e/test_artifact_share_token.py
@@ -1,9 +1,11 @@
 """Integration tests for the public artifact share-token + preview page (Task 11)."""
 
+import os
 from collections.abc import AsyncIterator
 
 import pytest
 import pytest_asyncio
+from fastapi.testclient import TestClient
 from redis.asyncio import Redis
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import (
@@ -14,6 +16,7 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.pool import NullPool
 
 from cubeplex.config import config as _cubeplex_config
+from cubeplex.objectstore import get_objectstore_client
 from cubeplex.services.artifact_share import (
     SHARE_TTL_SECONDS,
     mint_share_token,
@@ -95,9 +98,12 @@ async def _seeded_artifact() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
                 {"id": _ART_ID, "org": _ORG_ID, "ws": _WS_ID, "conv": _CONV_ID},
             )
             await session.commit()
+        store = get_objectstore_client()
+        await store.upload_file(f"artifacts/{_ART_ID}/v1/report.md", b"shared report")
         try:
             yield maker
         finally:
+            await store.delete_file(f"artifacts/{_ART_ID}/v1/report.md")
             async with maker() as session:
                 await session.execute(text("DELETE FROM artifacts WHERE id = :id"), {"id": _ART_ID})
                 await session.execute(
@@ -118,7 +124,6 @@ async def test_mint_and_resolve_roundtrip(
         key_prefix=key_prefix,
         org_id=_ORG_ID,
         workspace_id=_WS_ID,
-        conversation_id=_CONV_ID,
         artifact_id=_ART_ID,
         version=1,
         ttl_seconds=60,
@@ -129,7 +134,7 @@ async def test_mint_and_resolve_roundtrip(
     assert payload is not None
     assert payload["org_id"] == _ORG_ID
     assert payload["workspace_id"] == _WS_ID
-    assert payload["conversation_id"] == _CONV_ID
+    assert "conversation_id" not in payload
     assert payload["artifact_id"] == _ART_ID
     assert payload["version"] == 1
 
@@ -141,6 +146,33 @@ async def test_resolve_returns_none_for_unknown_nonce(_redis: Redis) -> None:
         redis=_redis, key_prefix="share-test-prefix", nonce="does-not-exist"
     )
     assert out is None
+
+
+async def test_share_file_needs_no_conversation_in_token(
+    _redis: Redis,
+    _seeded_artifact: async_sessionmaker[AsyncSession],
+    client: TestClient,
+) -> None:
+    key_prefix = (
+        f"{_cubeplex_config.get('redis.key_prefix', 'cubeplex')}:"
+        f"{os.getenv('ENV_FOR_DYNACONF', 'development')}"
+    )
+    nonce = await mint_share_token(
+        redis=_redis,
+        key_prefix=key_prefix,
+        org_id=_ORG_ID,
+        workspace_id=_WS_ID,
+        artifact_id=_ART_ID,
+        version=1,
+        entry_file="report.md",
+        ttl_seconds=60,
+    )
+
+    response = client.get(f"/api/v1/public/artifacts/share/{nonce}/file/report.md")
+    assert response.status_code == 200, response.text
+    assert response.content == b"shared report"
+
+    await _redis.delete(f"{key_prefix}:share:{nonce}")
 
 
 async def test_default_ttl_constant_is_seven_days() -> None:

--- a/backend/tests/e2e/test_otk_preview.py
+++ b/backend/tests/e2e/test_otk_preview.py
@@ -78,7 +78,7 @@ async def _seed_office_artifact(
         await test_engine.dispose()
 
     store = get_objectstore_client()
-    key = f"artifacts/{conv_id}/{artifact_id}/v1/{filename}"
+    key = f"artifacts/{artifact_id}/v1/{filename}"
     await store.upload_file(key, file_bytes)
     return artifact_id, conv_id
 

--- a/backend/tests/e2e/test_otk_preview.py
+++ b/backend/tests/e2e/test_otk_preview.py
@@ -173,3 +173,26 @@ class TestOTKPublicDownload:
         tampered = path.rsplit("/", 1)[0] + "/evil.docx"
         r2 = await client.get(tampered)
         assert r2.status_code == 404
+
+    async def test_download_reads_owner_conversation_legacy_key_during_migration(
+        self, office_client: tuple[httpx.AsyncClient, str, str, str]
+    ) -> None:
+        client, ws_id, art_id, conv_id = office_client
+        store = get_objectstore_client()
+        canonical_key = f"artifacts/{art_id}/v1/report.docx"
+        legacy_key = f"artifacts/{conv_id}/{art_id}/v1/report.docx"
+        await store.delete_file(canonical_key)
+        await store.upload_file(legacy_key, b"legacy office document")
+        try:
+            token_url = (
+                f"/api/v1/ws/{ws_id}/conversations/{conv_id}/artifacts/{art_id}/preview-token"
+            )
+            token_response = await client.post(token_url)
+            assert token_response.status_code == 200, token_response.text
+            path = token_response.json()["download_url"].replace("http://test", "")
+
+            download = await client.get(path)
+            assert download.status_code == 200, download.text
+            assert download.content == b"legacy office document"
+        finally:
+            await store.delete_file(legacy_key)

--- a/backend/tests/e2e/test_ws_artifacts.py
+++ b/backend/tests/e2e/test_ws_artifacts.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.pool import NullPool
 
 from cubeplex.db.engine import _build_database_url
+from cubeplex.objectstore import get_objectstore_client
 from tests.e2e.conftest import DEFAULT_ORG_ID, DEFAULT_WS_ID
 
 pytestmark = pytest.mark.asyncio
@@ -44,7 +45,10 @@ async def _seed(client: TestClient) -> AsyncIterator[None]:
                 ),
                 {"id": _STRANGER_ID, "email": f"{_STRANGER_ID}@example.com"},
             )
-            for conv_id, uid in ((_MY_CONV, my_user_id), (_OTHER_CONV, _STRANGER_ID)):
+            for conv_id, uid in (
+                (_MY_CONV, my_user_id),
+                (_OTHER_CONV, _STRANGER_ID),
+            ):
                 await s.execute(
                     text(
                         "INSERT INTO conversations (id, org_id, workspace_id,"
@@ -79,8 +83,20 @@ async def _seed(client: TestClient) -> AsyncIterator[None]:
                     },
                 )
             await s.commit()
+        store = get_objectstore_client()
+        await store.upload_file(f"artifacts/{_MY_CONV}/{_MY_ART}/v1/f", b"v1")
+        await store.upload_file(f"artifacts/{_MY_ART}/v2/f", b"v2")
         yield
     finally:
+        store = get_objectstore_client()
+        for key in (
+            f"artifacts/{_MY_CONV}/{_MY_ART}/v1/f",
+            f"artifacts/{_MY_ART}/v2/f",
+        ):
+            try:
+                await store.delete_file(key)
+            except Exception:
+                pass
         async with maker() as s:
             await s.execute(
                 text("DELETE FROM artifacts WHERE id IN (:a, :b)"), {"a": _MY_ART, "b": _OTHER_ART}
@@ -114,11 +130,14 @@ def test_list_name_search(_seed: None, client: TestClient) -> None:
     assert _MY_ART in {a["id"] for a in res.json()["artifacts"]}
 
 
-def test_delete_accessible_artifact(_seed: None, client: TestClient) -> None:
+async def test_delete_accessible_artifact(_seed: None, client: TestClient) -> None:
     res = client.delete(f"/api/v1/ws/{DEFAULT_WS_ID}/artifacts/{_MY_ART}")
     assert res.status_code == 204
     after = client.get(f"/api/v1/ws/{DEFAULT_WS_ID}/artifacts")
     assert _MY_ART not in {a["id"] for a in after.json()["artifacts"]}
+    store = get_objectstore_client()
+    assert await store.list_objects(f"artifacts/{_MY_CONV}/{_MY_ART}/") == []
+    assert await store.list_objects(f"artifacts/{_MY_ART}/") == []
 
 
 def test_delete_inaccessible_artifact_404(_seed: None, client: TestClient) -> None:

--- a/backend/tests/integration/test_im_outbound_files.py
+++ b/backend/tests/integration/test_im_outbound_files.py
@@ -55,7 +55,7 @@ class _FakeConnector:
         return "msg-1" if self.chat_ok else None
 
 
-async def _make_temp(_conv: str, _artifact: dict[str, Any], *, size: int = 100) -> Path:
+async def _make_temp(_artifact: dict[str, Any], *, size: int = 100) -> Path:
     with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as tmp:
         tmp.write(b"x" * size)
         return Path(tmp.name)
@@ -130,8 +130,8 @@ async def test_terminal_delivery_is_idempotent(monkeypatch: pytest.MonkeyPatch) 
 async def test_oversize_file_falls_back_to_share_link(monkeypatch: pytest.MonkeyPatch) -> None:
     """Over the platform cap → no native send, a share-link message instead."""
 
-    async def _big(_c: str, _a: dict[str, Any]) -> Path:
-        return await _make_temp(_c, _a, size=40 * 1024 * 1024)  # > 30MB Feishu cap
+    async def _big(_a: dict[str, Any]) -> Path:
+        return await _make_temp(_a, size=40 * 1024 * 1024)  # > 30MB Feishu cap
 
     monkeypatch.setattr(artifacts_mod, "download_artifact_to_tempfile", _big)
     conn = _FakeConnector(send_ok=True)
@@ -189,7 +189,7 @@ async def test_exception_during_delivery_releases_claim(
     share-link minting leaked the NX claim.
     """
 
-    async def _boom(_c: str, _a: dict[str, Any]) -> Path:
+    async def _boom(_a: dict[str, Any]) -> Path:
         raise RuntimeError("objectstore exploded")
 
     monkeypatch.setattr(artifacts_mod, "download_artifact_to_tempfile", _boom)

--- a/backend/tests/integration/test_im_outbound_files.py
+++ b/backend/tests/integration/test_im_outbound_files.py
@@ -10,12 +10,24 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from botocore.exceptions import ClientError
 
 from cubeplex.im import artifacts as artifacts_mod
 from cubeplex.im.artifacts import IMArtifactDispatcher
 from cubeplex.im.card_model import CardState
 
 pytestmark = pytest.mark.asyncio
+
+
+class _LegacyArtifactStore:
+    def __init__(self) -> None:
+        self.keys: list[str] = []
+
+    async def download_file(self, key: str) -> tuple[bytes, str]:
+        self.keys.append(key)
+        if key.startswith("artifacts/art-"):
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+        return b"legacy", "application/octet-stream"
 
 
 class _FakeRedis:
@@ -86,7 +98,27 @@ def _artifact(atype: str, art_id: str = "art-1") -> dict[str, Any]:
         "name": f"{art_id}.bin",
         "version": 1,
         "entry_file": "out.xlsx",
+        "conversation_id": "conv-1",
     }
+
+
+async def test_native_download_falls_back_to_owner_conversation_legacy_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _LegacyArtifactStore()
+    monkeypatch.setattr(artifacts_mod, "get_objectstore_client", lambda: store)
+
+    path = await artifacts_mod.download_artifact_to_tempfile(_artifact("document"))
+
+    assert path is not None
+    try:
+        assert path.read_bytes() == b"legacy"
+        assert store.keys == [
+            "artifacts/art-1/v1/out.xlsx",
+            "artifacts/conv-1/art-1/v1/out.xlsx",
+        ]
+    finally:
+        path.unlink(missing_ok=True)
 
 
 async def test_file_artifact_sent_natively_and_not_share_linked(

--- a/backend/tests/unit/services/test_artifact_content.py
+++ b/backend/tests/unit/services/test_artifact_content.py
@@ -166,7 +166,7 @@ def _mock_store(*, objects: list[str] | None = None, list_error: Exception | Non
 @pytest.mark.asyncio
 async def test_update_happy_path_no_sandbox(db_session: AsyncSession) -> None:
     art_id = await _seed_md_artifact(db_session)
-    store = _mock_store(objects=[f"artifacts/conv-1/{art_id}/v1/guide.md"])
+    store = _mock_store(objects=[f"artifacts/{art_id}/v1/guide.md"])
     with (
         patch(
             "cubeplex.services.artifact_content.get_objectstore_client",

--- a/backend/tests/unit/services/test_artifact_content.py
+++ b/backend/tests/unit/services/test_artifact_content.py
@@ -157,7 +157,16 @@ def _mock_store(*, objects: list[str] | None = None, list_error: Exception | Non
     if list_error is not None:
         store.list_objects = AsyncMock(side_effect=list_error)
     else:
-        store.list_objects = AsyncMock(return_value=objects if objects is not None else ["a.md"])
+        stored = objects if objects is not None else ["a.md"]
+
+        async def list_objects(prefix: str) -> list[str]:
+            return [
+                key if key.startswith("artifacts/") else f"{prefix}{key}"
+                for key in stored
+                if not key.startswith("artifacts/") or key.startswith(prefix)
+            ]
+
+        store.list_objects = AsyncMock(side_effect=list_objects)
     store.upload_file = AsyncMock()
     store.delete_file = AsyncMock()
     return store

--- a/backend/tests/unit/test_artifact_object_migration.py
+++ b/backend/tests/unit/test_artifact_object_migration.py
@@ -1,0 +1,23 @@
+"""Contracts for migrating legacy artifact object keys."""
+
+from scripts.dev.migrate_artifact_object_keys import missing_object_copies
+
+
+def test_migration_only_copies_relative_paths_missing_from_canonical_storage() -> None:
+    source_prefix = "artifacts/conv-owner/art-123/"
+    destination_prefix = "artifacts/art-123/"
+
+    assert missing_object_copies(
+        source_prefix,
+        destination_prefix,
+        [
+            f"{source_prefix}v1/index.html",
+            f"{source_prefix}v1/style.css",
+        ],
+        [f"{destination_prefix}v1/index.html"],
+    ) == [
+        (
+            f"{source_prefix}v1/style.css",
+            f"{destination_prefix}v1/style.css",
+        )
+    ]

--- a/backend/tests/unit/test_artifact_storage_paths.py
+++ b/backend/tests/unit/test_artifact_storage_paths.py
@@ -1,5 +1,7 @@
 """Contracts for conversation-independent artifact object keys."""
 
+import pytest
+
 from cubeplex.objectstore.artifact_paths import (
     artifact_file_key,
     artifact_file_key_candidates,
@@ -7,6 +9,7 @@ from cubeplex.objectstore.artifact_paths import (
     artifact_staging_prefix,
     artifact_version_prefix,
     artifact_version_prefix_candidates,
+    list_artifact_version_objects,
 )
 
 
@@ -28,3 +31,21 @@ def test_read_candidates_fall_back_to_the_owner_conversation_legacy_key() -> Non
         "artifacts/art-123/v4/slides/index.html",
         "artifacts/conv-owner/art-123/v4/slides/index.html",
     )
+
+
+@pytest.mark.asyncio
+async def test_partial_migration_merges_prefixes_with_canonical_files_winning() -> None:
+    class Store:
+        async def list_objects(self, prefix: str) -> list[str]:
+            return {
+                "artifacts/art-123/v4/": ["artifacts/art-123/v4/index.html"],
+                "artifacts/conv-owner/art-123/v4/": [
+                    "artifacts/conv-owner/art-123/v4/index.html",
+                    "artifacts/conv-owner/art-123/v4/style.css",
+                ],
+            }[prefix]
+
+    assert await list_artifact_version_objects(Store(), "art-123", 4, "conv-owner") == [
+        ("index.html", "artifacts/art-123/v4/index.html"),
+        ("style.css", "artifacts/conv-owner/art-123/v4/style.css"),
+    ]

--- a/backend/tests/unit/test_artifact_storage_paths.py
+++ b/backend/tests/unit/test_artifact_storage_paths.py
@@ -1,0 +1,17 @@
+"""Contracts for conversation-independent artifact object keys."""
+
+from cubeplex.objectstore.artifact_paths import (
+    artifact_file_key,
+    artifact_root_prefix,
+    artifact_staging_prefix,
+    artifact_version_prefix,
+)
+
+
+def test_artifact_paths_depend_only_on_artifact_and_version() -> None:
+    assert artifact_root_prefix("art-123") == "artifacts/art-123/"
+    assert artifact_version_prefix("art-123", 4) == "artifacts/art-123/v4/"
+    assert artifact_file_key("art-123", 4, "slides/index.html") == (
+        "artifacts/art-123/v4/slides/index.html"
+    )
+    assert artifact_staging_prefix("art-123", "nonce") == "artifacts/art-123/staging/nonce/"

--- a/backend/tests/unit/test_artifact_storage_paths.py
+++ b/backend/tests/unit/test_artifact_storage_paths.py
@@ -2,9 +2,11 @@
 
 from cubeplex.objectstore.artifact_paths import (
     artifact_file_key,
+    artifact_file_key_candidates,
     artifact_root_prefix,
     artifact_staging_prefix,
     artifact_version_prefix,
+    artifact_version_prefix_candidates,
 )
 
 
@@ -15,3 +17,14 @@ def test_artifact_paths_depend_only_on_artifact_and_version() -> None:
         "artifacts/art-123/v4/slides/index.html"
     )
     assert artifact_staging_prefix("art-123", "nonce") == "artifacts/art-123/staging/nonce/"
+
+
+def test_read_candidates_fall_back_to_the_owner_conversation_legacy_key() -> None:
+    assert artifact_version_prefix_candidates("art-123", 4, "conv-owner") == (
+        "artifacts/art-123/v4/",
+        "artifacts/conv-owner/art-123/v4/",
+    )
+    assert artifact_file_key_candidates("art-123", 4, "slides/index.html", "conv-owner") == (
+        "artifacts/art-123/v4/slides/index.html",
+        "artifacts/conv-owner/art-123/v4/slides/index.html",
+    )

--- a/docs/site/docs/deployment/overview.md
+++ b/docs/site/docs/deployment/overview.md
@@ -155,6 +155,23 @@ Every deployment needs three auth secrets, regardless of mode:
 
 All three are required — both installers fail fast if any is empty.
 
+## Upgrading artifact object keys
+
+Releases that switch artifact storage from
+`artifacts/{conversation_id}/{artifact_id}/...` to
+`artifacts/{artifact_id}/...` keep reading the owner-conversation legacy key
+while migration is in progress. Use this rollout order:
+
+1. Deploy the new backend so both canonical and legacy reads are available.
+2. Run `python scripts/dev/migrate_artifact_object_keys.py` inside a backend
+   container. The command is idempotent and retains legacy objects by default.
+3. Verify artifact download, preview, sharing, and skill publication.
+4. Optionally rerun the command with `--delete-source` to remove copied legacy
+   objects.
+
+Objects historically written below a conversation other than the artifact's
+owner are not discovered automatically and require manual recovery.
+
 ## Next steps
 
 - [Docker Compose install guide](./docker-compose.md)

--- a/docs/site/docs/guides/conversations/artifacts.md
+++ b/docs/site/docs/guides/conversations/artifacts.md
@@ -74,7 +74,7 @@ At the top of the chat area, a collapsible **Artifacts** bar shows all artifacts
 
 The agent can update an artifact across multiple turns. When you say "make the header blue" or "add a footer to the page," the agent creates a **new version** of the existing artifact rather than a separate artifact.
 
-Versioned artifacts show a version badge (e.g., "v3") on their card. In the artifact panel, click the version badge to open a dropdown listing all versions with timestamps. Select any version to preview it or download that specific version.
+Versioned artifacts show a version badge (e.g., "v3") on their card. In the artifact panel, click the version badge to open a dropdown listing all versions with timestamps. Select any version to preview it or download that specific version. Each version keeps its own stored files, so later updates do not change what an earlier version opens.
 
 ## Downloading artifacts
 


### PR DESCRIPTION
## Summary

- make artifact object keys depend on artifact ID and version instead of conversation ID
- update download, preview, share, Office token, IM, conversation-share, and skill publication paths
- clean canonical and owner-conversation legacy prefixes when deleting artifacts
- add an idempotent migration script for copying legacy objects to canonical keys

## Why

Artifact versions can be created from a conversation other than the artifact's original conversation. The old object key included a conversation ID, so later versions could be recorded successfully but downloaded from the wrong prefix, resulting in `File not found: index.html`.

The canonical key is now `artifacts/{artifact_id}/v{version}/...`. Authenticated API routes remain conversation-scoped for authorization, while storage resolution and public share tokens no longer depend on a conversation.

Historical objects already written under an unrelated conversation prefix are intentionally not discovered automatically. The migration script handles the normal legacy owner-conversation prefix and retains source objects by default.

## Deployment

Before rolling out the new application code, copy existing legacy objects:

```bash
cd backend
uv run python scripts/dev/migrate_artifact_object_keys.py
```

After verifying the rollout, old owner-conversation objects can optionally be removed with `--delete-source`.

## Validation

- pre-push backend check-ci: passed
- pre-push frontend check-ci: passed
- artifact unit/integration tests: 32 passed
- artifact E2E suite: 28 passed
- artifact share-token E2E file: 4 passed
- targeted Ruff, format, mypy, and migration-script syntax checks: passed
