### PR TITLE
Keep cached MCP tools after transient discovery failures

### DIFF
--- a/backend/cubeplex/mcp/cubepi_runtime.py
+++ b/backend/cubeplex/mcp/cubepi_runtime.py
@@ -305,6 +305,8 @@ def _build_tools_from_cache(
 
 
 _cache_refresh_in_flight: set[str] = set()
+_cache_refresh_last_attempt: dict[str, float] = {}
+_CACHE_REFRESH_RETRY_COOLDOWN_SECONDS = 300.0
 
 
 def schedule_tools_cache_refresh(
@@ -320,11 +322,12 @@ def schedule_tools_cache_refresh(
     """Kick detached re-discovery for installs whose ``tools_cache`` is stale.
 
     Never blocks or raises into the send path. Debounced per install via an
-    in-process set; the TTL gate (``mcp.tools_cache_ttl_hours``, default 24)
-    bounds cross-process stampedes to one refresh per process per TTL.
+    in-process set and a five-minute retry cooldown; the TTL gate
+    (``mcp.tools_cache_ttl_hours``, default 24) bounds normal refreshes.
     """
     from datetime import UTC, datetime
     from datetime import timedelta as _td
+    from time import monotonic
 
     from cubeplex.config import config as _cfg
 
@@ -335,6 +338,7 @@ def schedule_tools_cache_refresh(
     if ttl_hours <= 0:
         return
     now = datetime.now(UTC)
+    monotonic_now = monotonic()
 
     async def _refresh_one(spec: MCPRuntimeConnectorSpec) -> None:
         from cubeplex.credentials.dependencies import build_credential_service
@@ -382,7 +386,14 @@ def schedule_tools_cache_refresh(
             continue
         if spec.connector_id in _cache_refresh_in_flight:
             continue
+        last_attempt = _cache_refresh_last_attempt.get(spec.connector_id)
+        if (
+            last_attempt is not None
+            and monotonic_now - last_attempt < _CACHE_REFRESH_RETRY_COOLDOWN_SECONDS
+        ):
+            continue
         _cache_refresh_in_flight.add(spec.connector_id)
+        _cache_refresh_last_attempt[spec.connector_id] = monotonic_now
         task = asyncio.create_task(
             _refresh_one(spec), name=f"mcp-cache-refresh:{spec.connector_id}"
         )

--- a/backend/cubeplex/mcp/effective.py
+++ b/backend/cubeplex/mcp/effective.py
@@ -61,6 +61,7 @@ class MCPEffectiveInput:
     oauth_supported: bool
     discovery_status: str
     discovery_last_error: str | None
+    discovery_error_transient: bool
     has_cached_tools: bool
     credential_policy: CredentialPolicy
     grant: MCPGrantInput | None
@@ -100,13 +101,13 @@ _TRANSIENT_DISCOVERY_ERROR_TYPES = {
 def _cached_tools_survive_discovery_error(value: MCPEffectiveInput) -> bool:
     error = value.discovery_last_error or ""
     error_type = error.partition(":")[0]
-    transient = (
+    legacy_transient = (
         error_type in _TRANSIENT_DISCOVERY_ERROR_TYPES
         or error_type.endswith("Timeout")
         or (error_type == "HTTPStatusError" and "Server error '5" in error)
         or (error_type == "HTTPStatusError" and "Client error '429" in error)
     )
-    return value.has_cached_tools and transient
+    return value.has_cached_tools and (value.discovery_error_transient or legacy_transient)
 
 
 def compute_effective_state(value: MCPEffectiveInput) -> MCPEffectiveResult:
@@ -350,6 +351,9 @@ class MCPEffectiveConnectorService:
                     oauth_supported=oauth_supported,
                     discovery_status=connector.discovery_status,
                     discovery_last_error=connector.last_error,
+                    discovery_error_transient=bool(
+                        connector.discovery_metadata.get("last_error_transient", False)
+                    ),
                     has_cached_tools=bool(connector.tools_cache),
                     credential_policy=_cast_policy(policy),
                     grant=grant_input,

--- a/backend/cubeplex/mcp/effective.py
+++ b/backend/cubeplex/mcp/effective.py
@@ -60,6 +60,8 @@ class MCPEffectiveInput:
     auth_required: bool
     oauth_supported: bool
     discovery_status: str
+    discovery_last_error: str | None
+    has_cached_tools: bool
     credential_policy: CredentialPolicy
     grant: MCPGrantInput | None
     transport: str
@@ -80,6 +82,31 @@ def _missing_grant_reason(policy: CredentialPolicy) -> MCPEffectiveReason:
     if policy == "user":
         return "user_needs_connection"
     return "missing_org_grant"
+
+
+_TRANSIENT_DISCOVERY_ERROR_TYPES = {
+    "BrokenResourceError",
+    "ConnectError",
+    "ConnectionError",
+    "EndOfStream",
+    "NetworkError",
+    "ProtocolError",
+    "ReadError",
+    "RemoteProtocolError",
+    "TimeoutError",
+}
+
+
+def _cached_tools_survive_discovery_error(value: MCPEffectiveInput) -> bool:
+    error = value.discovery_last_error or ""
+    error_type = error.partition(":")[0]
+    transient = (
+        error_type in _TRANSIENT_DISCOVERY_ERROR_TYPES
+        or error_type.endswith("Timeout")
+        or (error_type == "HTTPStatusError" and "Server error '5" in error)
+        or (error_type == "HTTPStatusError" and "Client error '429" in error)
+    )
+    return value.has_cached_tools and transient
 
 
 def compute_effective_state(value: MCPEffectiveInput) -> MCPEffectiveResult:
@@ -103,7 +130,7 @@ def compute_effective_state(value: MCPEffectiveInput) -> MCPEffectiveResult:
         return MCPEffectiveResult(False, "grant_expired", "missing")
     if value.grant.scope != value.credential_policy:
         return MCPEffectiveResult(False, _missing_grant_reason(value.credential_policy), "missing")
-    if value.discovery_status == "error":
+    if value.discovery_status == "error" and not _cached_tools_survive_discovery_error(value):
         return MCPEffectiveResult(False, "discovery_failed", "missing")
     return MCPEffectiveResult(True, "usable", "available")
 
@@ -322,6 +349,8 @@ class MCPEffectiveConnectorService:
                     auth_required=auth_required,
                     oauth_supported=oauth_supported,
                     discovery_status=connector.discovery_status,
+                    discovery_last_error=connector.last_error,
+                    has_cached_tools=bool(connector.tools_cache),
                     credential_policy=_cast_policy(policy),
                     grant=grant_input,
                     transport=connector.transport,

--- a/backend/cubeplex/mcp/effective.py
+++ b/backend/cubeplex/mcp/effective.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from cubeplex.mcp.exceptions import OAuthRefreshFailed
 from cubeplex.mcp.oauth.token_manager import OAuthTokenManager
@@ -61,7 +61,7 @@ class MCPEffectiveInput:
     oauth_supported: bool
     discovery_status: str
     discovery_last_error: str | None
-    discovery_error_transient: bool
+    discovery_error_transient: bool | None
     has_cached_tools: bool
     credential_policy: CredentialPolicy
     grant: MCPGrantInput | None
@@ -107,7 +107,9 @@ def _cached_tools_survive_discovery_error(value: MCPEffectiveInput) -> bool:
         or (error_type == "HTTPStatusError" and "Server error '5" in error)
         or (error_type == "HTTPStatusError" and "Client error '429" in error)
     )
-    return value.has_cached_tools and (value.discovery_error_transient or legacy_transient)
+    if value.discovery_error_transient is not None:
+        return value.has_cached_tools and value.discovery_error_transient
+    return value.has_cached_tools and legacy_transient
 
 
 def compute_effective_state(value: MCPEffectiveInput) -> MCPEffectiveResult:
@@ -351,8 +353,9 @@ class MCPEffectiveConnectorService:
                     oauth_supported=oauth_supported,
                     discovery_status=connector.discovery_status,
                     discovery_last_error=connector.last_error,
-                    discovery_error_transient=bool(
-                        connector.discovery_metadata.get("last_error_transient", False)
+                    discovery_error_transient=cast(
+                        bool | None,
+                        connector.discovery_metadata.get("last_error_transient"),
                     ),
                     has_cached_tools=bool(connector.tools_cache),
                     credential_policy=_cast_policy(policy),

--- a/backend/cubeplex/services/mcp_discovery.py
+++ b/backend/cubeplex/services/mcp_discovery.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, cast
 
+import httpx
 from cubepi.mcp.http_loader import _open_session
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -76,6 +77,20 @@ def _format_discovery_error(exc: BaseException) -> str:
     name = type(inner).__name__
     msg = str(inner) or repr(inner)
     return f"{name}: {msg}"
+
+
+def _is_transient_discovery_error(exc: BaseException) -> bool:
+    """Classify the live exception before formatting erases its hierarchy."""
+    inner = exc
+    while isinstance(inner, BaseExceptionGroup) and inner.exceptions:
+        inner = inner.exceptions[0]
+    if isinstance(inner, (TimeoutError, ConnectionError, httpx.TimeoutException)):
+        return True
+    if isinstance(inner, (httpx.NetworkError, httpx.RemoteProtocolError)):
+        return True
+    if isinstance(inner, httpx.HTTPStatusError):
+        return inner.response.status_code == 429 or inner.response.status_code >= 500
+    return False
 
 
 @dataclass(frozen=True)
@@ -415,9 +430,14 @@ async def discover_tools_for_install(
     except Exception as exc:  # noqa: BLE001
         install.discovery_status = "error"
         install.last_error = f"credential_resolution_failed: {_format_discovery_error(exc)}"[:2048]
+        install.discovery_metadata = {
+            **dict(install.discovery_metadata or {}),
+            "last_error_transient": False,
+        }
         if connector is not None:
             connector.discovery_status = install.discovery_status
             connector.last_error = install.last_error
+            connector.discovery_metadata = install.discovery_metadata
             await connector_repo.update(connector)
         await install_repo.update(install)
         return DiscoveryResult(
@@ -430,9 +450,14 @@ async def discover_tools_for_install(
     if resolved is None:
         install.discovery_status = "error"
         install.last_error = "Auth header resolution failed"
+        install.discovery_metadata = {
+            **dict(install.discovery_metadata or {}),
+            "last_error_transient": False,
+        }
         if connector is not None:
             connector.discovery_status = install.discovery_status
             connector.last_error = install.last_error
+            connector.discovery_metadata = install.discovery_metadata
             await connector_repo.update(connector)
         await install_repo.update(install)
         return DiscoveryResult(
@@ -444,12 +469,17 @@ async def discover_tools_for_install(
         )
     headers, server_url = resolved
 
-    async def _persist_error(message: str) -> DiscoveryResult:
+    async def _persist_error(message: str, *, transient: bool = False) -> DiscoveryResult:
         install.discovery_status = "error"
         install.last_error = message[:2048]
+        install.discovery_metadata = {
+            **dict(install.discovery_metadata or {}),
+            "last_error_transient": transient,
+        }
         if connector is not None:
             connector.discovery_status = install.discovery_status
             connector.last_error = install.last_error
+            connector.discovery_metadata = install.discovery_metadata
             await connector_repo.update(connector)
         await install_repo.update(install)
         return DiscoveryResult(
@@ -488,7 +518,7 @@ async def discover_tools_for_install(
             and token_mgr is not None
         )
         if not refreshable:
-            return await _persist_error(formatted)
+            return await _persist_error(formatted, transient=_is_transient_discovery_error(exc))
         assert grant is not None  # narrowed by `refreshable`
         try:
             fresh_token = await token_mgr.get_access_token_for_grant(
@@ -516,7 +546,10 @@ async def discover_tools_for_install(
                 with suppress(Exception):
                     grant.grant_status = "expired"
                     await grant_repo.update(grant)
-            return await _persist_error(_format_discovery_error(retry_exc))
+            return await _persist_error(
+                _format_discovery_error(retry_exc),
+                transient=_is_transient_discovery_error(retry_exc),
+            )
 
     tools_cache_raw: list[dict[str, Any]] = [_tool_to_dict(t) for t in discovered.tools]
     # Strip orphan citation mapping keys whose tool no longer exists in

--- a/backend/cubeplex/services/mcp_discovery.py
+++ b/backend/cubeplex/services/mcp_discovery.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import suppress
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any, cast
 
 from cubepi.mcp.http_loader import _open_session
@@ -532,11 +533,13 @@ async def discover_tools_for_install(
     install.discovery_metadata = await _build_discovery_metadata(discovered)
     install.discovery_status = "ok"
     install.last_error = None
+    install.last_discovered_at = datetime.now(UTC)
     if connector is not None:
         connector.tools_cache = tools_cache_raw
         connector.discovery_metadata = install.discovery_metadata
         connector.discovery_status = install.discovery_status
         connector.last_error = install.last_error
+        connector.last_discovered_at = install.last_discovered_at
         await connector_repo.update(connector)
     await install_repo.update(install)
     return DiscoveryResult(

--- a/backend/cubeplex/services/mcp_discovery.py
+++ b/backend/cubeplex/services/mcp_discovery.py
@@ -81,15 +81,21 @@ def _format_discovery_error(exc: BaseException) -> str:
 
 def _is_transient_discovery_error(exc: BaseException) -> bool:
     """Classify the live exception before formatting erases its hierarchy."""
-    inner = exc
-    while isinstance(inner, BaseExceptionGroup) and inner.exceptions:
-        inner = inner.exceptions[0]
-    if isinstance(inner, (TimeoutError, ConnectionError, httpx.TimeoutException)):
-        return True
-    if isinstance(inner, (httpx.NetworkError, httpx.RemoteProtocolError)):
-        return True
-    if isinstance(inner, httpx.HTTPStatusError):
-        return inner.response.status_code == 429 or inner.response.status_code >= 500
+    if is_unauthorized_error(exc):
+        return False
+    stack: list[BaseException] = [exc]
+    while stack:
+        inner = stack.pop()
+        if isinstance(inner, BaseExceptionGroup):
+            stack.extend(inner.exceptions)
+            continue
+        if isinstance(inner, (TimeoutError, ConnectionError, httpx.TimeoutException)):
+            return True
+        if isinstance(inner, (httpx.NetworkError, httpx.RemoteProtocolError)):
+            return True
+        if isinstance(inner, httpx.HTTPStatusError):
+            if inner.response.status_code == 429 or inner.response.status_code >= 500:
+                return True
     return False
 
 

--- a/backend/cubeplex/services/mcp_discovery.py
+++ b/backend/cubeplex/services/mcp_discovery.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, cast
 
+import anyio
 import httpx
 from cubepi.mcp.http_loader import _open_session
 from loguru import logger
@@ -84,14 +85,24 @@ def _is_transient_discovery_error(exc: BaseException) -> bool:
     if is_unauthorized_error(exc):
         return False
     stack: list[BaseException] = [exc]
+    leaves: list[BaseException] = []
     while stack:
         inner = stack.pop()
         if isinstance(inner, BaseExceptionGroup):
             stack.extend(inner.exceptions)
             continue
+        leaves.append(inner)
+    for inner in leaves:
+        if isinstance(inner, httpx.HTTPStatusError):
+            status = inner.response.status_code
+            if 400 <= status < 500 and status != 429:
+                return False
+    for inner in leaves:
         if isinstance(inner, (TimeoutError, ConnectionError, httpx.TimeoutException)):
             return True
         if isinstance(inner, (httpx.NetworkError, httpx.RemoteProtocolError)):
+            return True
+        if isinstance(inner, (anyio.EndOfStream, anyio.BrokenResourceError)):
             return True
         if isinstance(inner, httpx.HTTPStatusError):
             if inner.response.status_code == 429 or inner.response.status_code >= 500:

--- a/backend/cubeplex/services/mcp_discovery.py
+++ b/backend/cubeplex/services/mcp_discovery.py
@@ -95,7 +95,7 @@ def _is_transient_discovery_error(exc: BaseException) -> bool:
     for inner in leaves:
         if isinstance(inner, httpx.HTTPStatusError):
             status = inner.response.status_code
-            if 400 <= status < 500 and status != 429:
+            if 400 <= status < 500 and status not in {408, 429}:
                 return False
     for inner in leaves:
         if isinstance(inner, (TimeoutError, ConnectionError, httpx.TimeoutException)):

--- a/backend/tests/e2e/test_mcp_four_layer_runtime.py
+++ b/backend/tests/e2e/test_mcp_four_layer_runtime.py
@@ -29,7 +29,8 @@ from cubeplex.mcp.effective import (
     MCPEffectiveConnectorService,
     MCPRuntimeConnectorSpec,
 )
-from cubeplex.models import Workspace
+from cubeplex.models import Credential, MCPCredentialGrant, Workspace
+from cubeplex.models.mcp import MCPConnector
 from cubeplex.repositories.mcp import (
     MCPConnectorRepository,
     MCPConnectorTemplateRepository,
@@ -130,6 +131,70 @@ async def test_noauth_runtime_spec_returns_install_without_grant_lookup(
     assert spec.refresh_credential_id is None
 
     grant_spy.assert_not_awaited()
+
+
+async def test_active_tools_serves_cache_after_transient_discovery_failure(
+    admin_client: tuple[httpx.AsyncClient, str],
+    db_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A timeout refreshing known tools must not remove them from the agent registry."""
+    client, workspace_id = admin_client
+    suffix = secrets.token_hex(4)
+    tpl_resp = await client.post(
+        "/api/v1/admin/mcp/templates",
+        json={
+            "name": f"Stale Cache {suffix}",
+            "server_url": f"https://stale-cache-{suffix}.example.com/mcp",
+            "transport": "streamable_http",
+            "auth_method": "static",
+            "default_credential_policy": "workspace",
+        },
+    )
+    assert tpl_resp.status_code == 201, tpl_resp.text
+    dist_resp = await client.post(
+        f"/api/v1/admin/mcp/templates/{tpl_resp.json()['template_id']}/distribute",
+        json={"enable_existing": True, "auto_enroll": False},
+    )
+    assert dist_resp.status_code == 200, dist_resp.text
+    connector_id = dist_resp.json()["connector"]["connector_id"]
+
+    async with db_maker() as session:
+        connector = await session.get(MCPConnector, connector_id)
+        assert connector is not None
+        credential = Credential(
+            org_id=connector.org_id,
+            kind="mcp_static_token",
+            name=f"stale-cache-{suffix}",
+            value_encrypted=b"opaque",
+        )
+        session.add(credential)
+        await session.flush()
+        session.add(
+            MCPCredentialGrant(
+                org_id=connector.org_id,
+                connector_id=connector_id,
+                grant_scope="workspace",
+                workspace_id=workspace_id,
+                auth_method="static",
+                credential_id=credential.id,
+                grant_status="valid",
+            )
+        )
+        connector.tools_cache = [
+            {
+                "name": "search",
+                "description": "Search cached content",
+                "input_schema": {"type": "object"},
+            }
+        ]
+        connector.discovery_status = "error"
+        connector.last_error = "TimeoutError: TimeoutError()"
+        await session.commit()
+
+    response = await client.get(f"/api/v1/ws/{workspace_id}/mcp/active-tools")
+    assert response.status_code == 200, response.text
+    matching = [item for item in response.json()["items"] if item["connector_id"] == connector_id]
+    assert [item["bare_name"] for item in matching] == ["search"]
 
 
 async def test_org_connector_only_visible_in_workspace_with_state_row(

--- a/backend/tests/e2e/test_mcp_oauth_401_retry.py
+++ b/backend/tests/e2e/test_mcp_oauth_401_retry.py
@@ -226,6 +226,13 @@ async def test_401_then_success_after_forced_refresh(
     assert token_mgr.force_calls == 1
     assert seen_auth == ["Bearer stale-token", "Bearer fresh-token"]
     assert await _grant_status(db_session_maker, grant_id) == "valid"
+    async with db_session_maker() as session:
+        from cubeplex.models.mcp import MCPConnector
+
+        connector = await session.get(MCPConnector, connector_id)
+        assert connector is not None
+        assert connector.last_discovered_at is not None
+        assert connector.last_discovered_at.tzinfo is not None
 
 
 async def test_401_and_refresh_failure_marks_reauthorization_required(

--- a/backend/tests/unit/mcp/test_runtime_tools_cache.py
+++ b/backend/tests/unit/mcp/test_runtime_tools_cache.py
@@ -15,6 +15,7 @@ trip per send. These tests protect the two invariants that matter:
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from dataclasses import replace
 from types import SimpleNamespace
@@ -23,7 +24,12 @@ from typing import Any
 import httpx
 import pytest
 
-from cubeplex.mcp.cubepi_runtime import _build_tools_from_cache, _make_refresh_auth_callback
+from cubeplex.mcp import cubepi_runtime
+from cubeplex.mcp.cubepi_runtime import (
+    _build_tools_from_cache,
+    _make_refresh_auth_callback,
+    schedule_tools_cache_refresh,
+)
 from cubeplex.mcp.effective import MCPRuntimeConnectorSpec
 
 _WEATHER_SCHEMA: dict[str, Any] = {
@@ -102,6 +108,43 @@ def test_empty_cache_returns_none_for_live_fallback() -> None:
 def test_nameless_entries_are_skipped_and_all_nameless_falls_back() -> None:
     spec = _make_spec([{"description": "no name"}, {"name": ""}])
     assert _build_tools_from_cache(spec=spec, headers={}, server_url=spec.server_url) is None
+
+
+def test_automatic_cache_refresh_has_failure_cooldown(monkeypatch: Any) -> None:
+    """A failed detached refresh must not be retried on every agent message."""
+    created: list[object] = []
+
+    def fake_create_task(coro: object, *, name: str) -> object:
+        assert name.startswith("mcp-cache-refresh:")
+        created.append(coro)
+        assert hasattr(coro, "close")
+        coro.close()  # type: ignore[attr-defined]
+        return object()
+
+    monkeypatch.setattr(asyncio, "create_task", fake_create_task)
+    monkeypatch.setattr(cubepi_runtime, "_cache_refresh_in_flight", set())
+    monkeypatch.setattr(cubepi_runtime, "_cache_refresh_last_attempt", {})
+    spec = replace(
+        _make_spec(_PING_CACHE),
+        org_id="org_test",
+        workspace_id="ws_test",
+        last_discovered_at=None,
+    )
+    kwargs = {
+        "specs": [spec],
+        "actor_user_id": "usr_test",
+        "encryption_backend": object(),
+        "http_client": object(),
+        "metadata_discovery": object(),
+        "redis": object(),
+        "signer": object(),
+    }
+
+    schedule_tools_cache_refresh(**kwargs)  # type: ignore[arg-type]
+    cubepi_runtime._cache_refresh_in_flight.clear()  # first attempt completed
+    schedule_tools_cache_refresh(**kwargs)  # type: ignore[arg-type]
+
+    assert len(created) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_mcp_effective_state.py
+++ b/backend/tests/unit/test_mcp_effective_state.py
@@ -26,6 +26,8 @@ def _input(**overrides: object) -> MCPEffectiveInput:
         "auth_required": True,
         "oauth_supported": False,
         "discovery_status": "ok",
+        "discovery_last_error": None,
+        "has_cached_tools": False,
         "credential_policy": "org",
         "grant": MCPGrantInput(
             scope="org", status="valid", has_refresh=False, auth_method="static"
@@ -191,6 +193,42 @@ def test_cross_scope_grant_treated_as_missing_for_policy_scope() -> None:
 
 def test_discovery_failed_after_auth_gates_pass() -> None:
     result = compute_effective_state(_input(discovery_status="error"))
+    assert result.usable is False
+    assert result.reason == "discovery_failed"
+
+
+def test_transient_discovery_failure_keeps_last_good_cache_usable() -> None:
+    result = compute_effective_state(
+        _input(
+            discovery_status="error",
+            discovery_last_error="TimeoutError: TimeoutError()",
+            has_cached_tools=True,
+        )
+    )
+    assert result.usable is True
+    assert result.reason == "usable"
+    assert result.credential_availability == "available"
+
+
+def test_http_timeout_keeps_last_good_cache_usable() -> None:
+    result = compute_effective_state(
+        _input(
+            discovery_status="error",
+            discovery_last_error="ReadTimeout: timed out",
+            has_cached_tools=True,
+        )
+    )
+    assert result.usable is True
+
+
+def test_credential_discovery_failure_does_not_serve_cached_tools() -> None:
+    result = compute_effective_state(
+        _input(
+            discovery_status="error",
+            discovery_last_error="credential_resolution_failed: missing credential",
+            has_cached_tools=True,
+        )
+    )
     assert result.usable is False
     assert result.reason == "discovery_failed"
 

--- a/backend/tests/unit/test_mcp_effective_state.py
+++ b/backend/tests/unit/test_mcp_effective_state.py
@@ -27,7 +27,7 @@ def _input(**overrides: object) -> MCPEffectiveInput:
         "oauth_supported": False,
         "discovery_status": "ok",
         "discovery_last_error": None,
-        "discovery_error_transient": False,
+        "discovery_error_transient": None,
         "has_cached_tools": False,
         "credential_policy": "org",
         "grant": MCPGrantInput(
@@ -232,6 +232,19 @@ def test_structured_transient_network_error_keeps_last_good_cache_usable() -> No
         )
     )
     assert result.usable is True
+
+
+def test_structured_hard_error_overrides_legacy_transient_message() -> None:
+    result = compute_effective_state(
+        _input(
+            discovery_status="error",
+            discovery_last_error="ReadTimeout: timed out before HTTP 403",
+            discovery_error_transient=False,
+            has_cached_tools=True,
+        )
+    )
+    assert result.usable is False
+    assert result.reason == "discovery_failed"
 
 
 def test_credential_discovery_failure_does_not_serve_cached_tools() -> None:

--- a/backend/tests/unit/test_mcp_effective_state.py
+++ b/backend/tests/unit/test_mcp_effective_state.py
@@ -27,6 +27,7 @@ def _input(**overrides: object) -> MCPEffectiveInput:
         "oauth_supported": False,
         "discovery_status": "ok",
         "discovery_last_error": None,
+        "discovery_error_transient": False,
         "has_cached_tools": False,
         "credential_policy": "org",
         "grant": MCPGrantInput(
@@ -215,6 +216,18 @@ def test_http_timeout_keeps_last_good_cache_usable() -> None:
         _input(
             discovery_status="error",
             discovery_last_error="ReadTimeout: timed out",
+            has_cached_tools=True,
+        )
+    )
+    assert result.usable is True
+
+
+def test_structured_transient_network_error_keeps_last_good_cache_usable() -> None:
+    result = compute_effective_state(
+        _input(
+            discovery_status="error",
+            discovery_last_error="WriteError: connection reset",
+            discovery_error_transient=True,
             has_cached_tools=True,
         )
     )

--- a/backend/tests/unit/test_post_grant_discovery_swallows.py
+++ b/backend/tests/unit/test_post_grant_discovery_swallows.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import anyio
 import httpx
 import pytest
 
@@ -29,6 +30,14 @@ def test_concrete_network_subclasses_are_transient() -> None:
     assert mcp_discovery._is_transient_discovery_error(grouped)
 
 
+def test_anyio_disconnects_are_transient_inside_exception_groups() -> None:
+    grouped = ExceptionGroup(
+        "cleanup then AnyIO disconnects",
+        [RuntimeError("cleanup failed"), anyio.EndOfStream(), anyio.BrokenResourceError()],
+    )
+    assert mcp_discovery._is_transient_discovery_error(grouped)
+
+
 def test_http_auth_error_is_not_transient() -> None:
     request = httpx.Request("POST", "https://mcp.example.com")
     response = httpx.Response(401, request=request)
@@ -39,6 +48,28 @@ def test_http_auth_error_is_not_transient() -> None:
         [httpx.WriteError("reset", request=request), error],
     )
     assert not mcp_discovery._is_transient_discovery_error(grouped)
+
+
+def test_hard_http_4xx_takes_precedence_over_network_noise() -> None:
+    request = httpx.Request("POST", "https://mcp.example.com")
+    response = httpx.Response(403, request=request)
+    error = httpx.HTTPStatusError("forbidden", request=request, response=response)
+    grouped = ExceptionGroup(
+        "hard response and network noise",
+        [httpx.WriteError("reset", request=request), error],
+    )
+    assert not mcp_discovery._is_transient_discovery_error(grouped)
+
+
+def test_http_429_remains_transient_with_network_noise() -> None:
+    request = httpx.Request("POST", "https://mcp.example.com")
+    response = httpx.Response(429, request=request)
+    error = httpx.HTTPStatusError("rate limited", request=request, response=response)
+    grouped = ExceptionGroup(
+        "retryable response and network noise",
+        [httpx.WriteError("reset", request=request), error],
+    )
+    assert mcp_discovery._is_transient_discovery_error(grouped)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_post_grant_discovery_swallows.py
+++ b/backend/tests/unit/test_post_grant_discovery_swallows.py
@@ -61,10 +61,11 @@ def test_hard_http_4xx_takes_precedence_over_network_noise() -> None:
     assert not mcp_discovery._is_transient_discovery_error(grouped)
 
 
-def test_http_429_remains_transient_with_network_noise() -> None:
+@pytest.mark.parametrize("status", [408, 429])
+def test_retryable_http_4xx_remains_transient_with_network_noise(status: int) -> None:
     request = httpx.Request("POST", "https://mcp.example.com")
-    response = httpx.Response(429, request=request)
-    error = httpx.HTTPStatusError("rate limited", request=request, response=response)
+    response = httpx.Response(status, request=request)
+    error = httpx.HTTPStatusError("retryable response", request=request, response=response)
     grouped = ExceptionGroup(
         "retryable response and network noise",
         [httpx.WriteError("reset", request=request), error],

--- a/backend/tests/unit/test_post_grant_discovery_swallows.py
+++ b/backend/tests/unit/test_post_grant_discovery_swallows.py
@@ -22,6 +22,11 @@ def test_concrete_network_subclasses_are_transient() -> None:
     request = httpx.Request("POST", "https://mcp.example.com")
     assert mcp_discovery._is_transient_discovery_error(httpx.WriteError("reset", request=request))
     assert mcp_discovery._is_transient_discovery_error(ConnectionResetError())
+    grouped = ExceptionGroup(
+        "cleanup then network failure",
+        [RuntimeError("cleanup failed"), httpx.WriteError("reset", request=request)],
+    )
+    assert mcp_discovery._is_transient_discovery_error(grouped)
 
 
 def test_http_auth_error_is_not_transient() -> None:
@@ -29,6 +34,11 @@ def test_http_auth_error_is_not_transient() -> None:
     response = httpx.Response(401, request=request)
     error = httpx.HTTPStatusError("unauthorized", request=request, response=response)
     assert not mcp_discovery._is_transient_discovery_error(error)
+    grouped = ExceptionGroup(
+        "network noise and auth failure",
+        [httpx.WriteError("reset", request=request), error],
+    )
+    assert not mcp_discovery._is_transient_discovery_error(grouped)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_post_grant_discovery_swallows.py
+++ b/backend/tests/unit/test_post_grant_discovery_swallows.py
@@ -12,9 +12,23 @@ from __future__ import annotations
 
 from typing import Any
 
+import httpx
 import pytest
 
 from cubeplex.services import mcp_discovery
+
+
+def test_concrete_network_subclasses_are_transient() -> None:
+    request = httpx.Request("POST", "https://mcp.example.com")
+    assert mcp_discovery._is_transient_discovery_error(httpx.WriteError("reset", request=request))
+    assert mcp_discovery._is_transient_discovery_error(ConnectionResetError())
+
+
+def test_http_auth_error_is_not_transient() -> None:
+    request = httpx.Request("POST", "https://mcp.example.com")
+    response = httpx.Response(401, request=request)
+    error = httpx.HTTPStatusError("unauthorized", request=request, response=response)
+    assert not mcp_discovery._is_transient_discovery_error(error)
 
 
 @pytest.mark.asyncio

--- a/docs/site/docs/admin/mcp-connectors.md
+++ b/docs/site/docs/admin/mcp-connectors.md
@@ -126,7 +126,7 @@ A template can carry both OAuth and static credentials at the same time — for 
 
 When a workspace first enables a template (creating the connector row), CubePlex connects to the MCP server, lists its tools, and stores the tool list on the connector row. Agent runs use this cached list — they do not re-contact the server on every message, which keeps chat startup fast even with many connectors active. Actually calling a tool always goes to the live server.
 
-The cache refreshes automatically in the background when it is older than 24 hours (config key `mcp.tools_cache_ttl_hours`; set `0` to disable background refresh). If a server changed its tools and you do not want to wait, use **Retry discovery** on the template's detail page to refresh immediately.
+The cache refreshes automatically in the background when it is older than 24 hours (config key `mcp.tools_cache_ttl_hours`; set `0` to disable background refresh). A transient timeout or disconnect during that refresh keeps the last successful tool list available to agents and retries after a short cooldown on later agent runs. Authentication failures still block the connector until its credential is fixed. If a server changed its tools and you do not want to wait, use **Retry discovery** on the template's detail page to refresh immediately; manual retries do not wait for the automatic-refresh cooldown.
 
 ## Workspace state visibility
 


### PR DESCRIPTION
## What changed

- persist `last_discovered_at` after successful MCP discovery so the 24-hour cache TTL works
- keep last-known-good tool schemas available after transient timeouts, disconnects, HTTP 429s, and HTTP 5xx responses
- continue blocking authentication and credential failures
- add a five-minute automatic-refresh cooldown while leaving manual Retry discovery immediate
- document the cache refresh and recovery behavior

## Why

Successful discovery never updated `last_discovered_at`, so every agent build treated cached MCP schemas as stale and launched another background discovery. A single transient failure then set `discovery_status=error`; the effective connector filter removed the connector from runtime specs even though its last successful tool cache was still present. Once filtered out, later agent runs could not automatically retry it.

This caused enabled, credentialed connectors such as Jina to disappear from the agent tool list after an intermittent timeout.

## Impact

Connectors with a last-known-good cache remain available during transient discovery outages and recover on a later agent run after the cooldown. Initial discovery failures without a cache, expired grants, 401s, and credential-resolution failures still require Retry discovery or reauthentication.

## Validation

- 53 targeted MCP unit and Postgres E2E tests passed
- strict mypy passed for the three changed backend modules
- ruff and formatter checks passed
- full backend and frontend pre-push `check-ci` hooks passed
