### PR TITLE
Auto-label PRs and categorize release notes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,53 @@
+# PR auto-labels for actions/labeler.
+# Matched labels feed `.github/release.yml` changelog categories.
+# Docs: https://github.com/actions/labeler
+
+# ---------------------------------------------------------------------------
+# Type labels (from branch name — cubeplex: feat/ | fix/ | docs/)
+# ---------------------------------------------------------------------------
+
+enhancement:
+  - head-branch: ['^feat/', '^feature/']
+
+bug:
+  - head-branch: ['^fix/', '^bugfix/', '^bug/']
+
+documentation:
+  - any:
+    - head-branch: ['^docs/']
+    - changed-files:
+      - any-glob-to-any-file:
+        - 'docs/**'
+        - '**/*.md'
+        - 'backend/docs/**'
+        - 'frontend/docs/**'
+        - 'deploy/**/*.md'
+
+# ---------------------------------------------------------------------------
+# Area labels (from changed paths)
+# ---------------------------------------------------------------------------
+
+backend:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'backend/**'
+      - 'benchmarks/**'
+
+frontend:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'frontend/**'
+
+deploy:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'deploy/**'
+
+ci:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+      - 'scripts/**'
+      - 'Makefile'
+      - 'backend/Makefile'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+# Configures `gh release create --generate-notes` (see .github/workflows/release.yml).
+# Categories match labels applied by .github/labeler.yml + Dependabot + humans.
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: Features
+      labels:
+        - enhancement
+    - title: Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,26 @@
+# Auto-label PRs via actions/labeler (paths + branch name).
+# Config: .github/labeler.yml
+#
+# Uses pull_request_target so GITHUB_TOKEN can write labels on fork PRs.
+# This job must not checkout or run untrusted PR code.
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  # Create labels listed in .github/labeler.yml if missing in the repo.
+  issues: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          # Only remove labels that are defined in labeler.yml and no longer match.
+          # Manually applied labels (e.g. skip-changelog, breaking) are left alone.
+          sync-labels: true


### PR DESCRIPTION
## Summary

- Add official [`actions/labeler`](https://github.com/marketplace/actions/labeler) to auto-label PRs from **branch name** and **changed paths**
- Add `.github/release.yml` so `gh release create --generate-notes` groups PRs into Features / Fixes / Docs / Dependencies / Breaking / Other
- Create missing area labels (`backend`, `frontend`, `deploy`, `ci`, `breaking`, `skip-changelog`)

## How it works

| Input | Labels |
|-------|--------|
| Branch `feat/…` | `enhancement` |
| Branch `fix/…` | `bug` |
| Branch `docs/…` or `*.md` / docs paths | `documentation` |
| Paths under `backend/`, `frontend/`, `deploy/`, `.github/workflows/` | area labels |
| Dependabot (existing) | `dependencies` |
| Manual | `breaking`, `skip-changelog` |

Release workflow is unchanged (`--generate-notes`); it picks up `release.yml` automatically.

## Note

`pull_request_target` runs from **base** branch, so this workflow only takes effect **after merge**. This PR itself will not be auto-labeled until the workflow is on `main`.