### PR TITLE
fix(im/teams): Web Chat replies, wizard paths, and setup docs

### DIFF
--- a/backend/cubeplex/api/routes/v1/im_ingress.py
+++ b/backend/cubeplex/api/routes/v1/im_ingress.py
@@ -41,7 +41,11 @@ from cubeplex.im.feishu.signature import (
 )
 from cubeplex.im.inbound import ingest_inbound_event
 from cubeplex.im.resume import resume_paused_run
-from cubeplex.im.teams.app_manager import get_entry_by_bot_id
+from cubeplex.im.teams.app_manager import (
+    bot_id_candidates,
+    remember_conversation_route,
+    resolve_entry_for_activity,
+)
 from cubeplex.im.teams.commands import parse_link_command as parse_teams_link
 from cubeplex.im.teams.connector import TeamsConnector
 from cubeplex.im.types import BindingMode, lookup_binding_mode
@@ -448,22 +452,25 @@ async def teams_messages(
     if not isinstance(activity, dict):
         return Response(status_code=status.HTTP_400_BAD_REQUEST)
 
-    recipient = activity.get("recipient") or {}
-    bot_id = str(recipient.get("id") or "")
-    if not bot_id:
-        return Response(status_code=status.HTTP_200_OK)
-
-    entry = get_entry_by_bot_id(bot_id)
+    auth_header = request.headers.get("authorization", "")
+    # Web Chat / Direct Line put a channel account id in recipient.id
+    # (``botname@…``), not the Microsoft App ID we cache on. Fall back to
+    # JWT ``aud`` / ``appid`` so those channels still resolve.
+    entry = resolve_entry_for_activity(activity, auth_header)
     if entry is None:
-        logger.debug("[Teams ingress] no app for bot_id={}", bot_id)
+        logger.warning(
+            "[Teams ingress] no app for candidates={}",
+            bot_id_candidates(activity, auth_header),
+        )
         return Response(status_code=status.HTTP_200_OK)
+    # Canonical bot id is the App ID used at connect / external_account_id.
+    bot_id = entry.bot_id
 
     # Validate Azure Bot Framework JWT before any state-changing work.
     token_validator = getattr(entry.app.server, "_token_validator", None)
     if token_validator is None:
         logger.warning("[Teams ingress] no token validator for bot_id={}", bot_id)
         return Response(status_code=status.HTTP_401_UNAUTHORIZED)
-    auth_header = request.headers.get("authorization", "")
     if not auth_header.startswith("Bearer "):
         return Response(status_code=status.HTTP_401_UNAUTHORIZED)
     try:
@@ -512,11 +519,28 @@ async def teams_messages(
 
     event.account_external_id = account.external_account_id
 
+    # Outbound must use this activity's serviceUrl + channelId + recipient.id.
+    # Web Chat bot account is ``name@…``, not the App ID (App ID → connector 403).
+    service_url = str(activity.get("serviceUrl") or "").rstrip("/")
+    bf_channel_id = str(activity.get("channelId") or "msteams")
+    recipient = activity.get("recipient") or {}
+    bot_account_id = str(recipient.get("id") or "") or bot_id
+    if event.channel_id and service_url:
+        remember_conversation_route(
+            event.channel_id,
+            service_url=service_url,
+            channel_id=bf_channel_id,
+            bot_account_id=bot_account_id,
+        )
+
     gate_connector = TeamsConnector(
         bot_id=bot_id,
         app=entry.app,
         channel_id=event.channel_id,
         graph_client=entry.graph_client,
+        service_url=service_url or None,
+        bf_channel_id=bf_channel_id,
+        bot_account_id=bot_account_id,
     )
 
     link_email = parse_teams_link(event.text)

--- a/backend/cubeplex/im/teams/_platform.py
+++ b/backend/cubeplex/im/teams/_platform.py
@@ -29,7 +29,7 @@ class TeamsPlatform:
         **kwargs: Any,
     ) -> Any:
         from cubeplex.im.outbound import OutboundRunTailer
-        from cubeplex.im.teams.app_manager import get_entry_by_bot_id
+        from cubeplex.im.teams.app_manager import get_conversation_route, get_entry_by_bot_id
         from cubeplex.im.teams.connector import TeamsConnector
         from cubeplex.im.teams.graph import TeamsGraphClient
         from cubeplex.im.teams.renderer import TeamsOpDispatcher
@@ -54,6 +54,11 @@ class TeamsPlatform:
 
         channel_id = queue_item.channel_id
         reply_to_id = queue_item.reply_to_id
+        # Prefer route remembered from the inbound webhook activity.
+        route = get_conversation_route(channel_id) if channel_id else None
+        service_url = route[0] if route else None
+        bf_channel_id = route[1] if route else None
+        bot_account_id = route[2] if route else None
 
         connector = TeamsConnector(
             bot_id=bot_id,
@@ -61,6 +66,9 @@ class TeamsPlatform:
             channel_id=channel_id,
             reply_to_id=reply_to_id,
             graph_client=graph_client,
+            service_url=service_url,
+            bf_channel_id=bf_channel_id,
+            bot_account_id=bot_account_id,
         )
 
         bot_name = (account.config or {}).get("bot_app_name") or "CubePlex"

--- a/backend/cubeplex/im/teams/app_manager.py
+++ b/backend/cubeplex/im/teams/app_manager.py
@@ -7,11 +7,18 @@ by bot ID to validate JWT and dispatch activities.
 
 from __future__ import annotations
 
+import base64
+import json
 from typing import Any
 
 from loguru import logger
 
 _app_cache: dict[str, TeamsAppEntry] = {}
+# conversation_id → (service_url, channel_id, bot_account_id) from inbound.
+# Replies must use the activity's serviceUrl AND the channel bot account id
+# (activity.recipient.id) — Web Chat uses ``botname@…``, not the App ID GUID.
+# Using the raw App ID as from.id yields connector 403.
+_conversation_routes: dict[str, tuple[str, str, str]] = {}
 
 
 class TeamsAppEntry:
@@ -95,3 +102,98 @@ def remove_app(bot_id: str) -> None:
 def all_entries() -> list[TeamsAppEntry]:
     """Return all cached App entries."""
     return list(_app_cache.values())
+
+
+def remember_conversation_route(
+    conversation_id: str,
+    *,
+    service_url: str,
+    channel_id: str,
+    bot_account_id: str = "",
+) -> None:
+    """Cache outbound routing for a conversation from an inbound activity."""
+    conv = (conversation_id or "").strip()
+    url = (service_url or "").rstrip("/")
+    ch = (channel_id or "").strip() or "msteams"
+    bot_acc = (bot_account_id or "").strip()
+    if not conv or not url:
+        return
+    _conversation_routes[conv] = (url, ch, bot_acc)
+
+
+def get_conversation_route(conversation_id: str) -> tuple[str, str, str] | None:
+    """Return ``(service_url, channel_id, bot_account_id)`` if known."""
+    return _conversation_routes.get(conversation_id)
+
+
+def _app_ids_from_bearer(auth_header: str) -> list[str]:
+    """Decode (unverified) Bot Framework JWT claims that identify the bot App ID.
+
+    Web Chat / Direct Line put a channel account id in ``activity.recipient.id``
+    (e.g. ``botname@…``), not the Microsoft App ID GUID we cache on. The
+    service token's ``aud`` / ``appid`` is the App ID and is the reliable key.
+    Signature is still verified later by the App's token validator.
+    """
+    if not auth_header.startswith("Bearer "):
+        return []
+    token = auth_header.removeprefix("Bearer ").strip()
+    parts = token.split(".")
+    if len(parts) < 2:
+        return []
+    payload_b64 = parts[1]
+    # urlsafe_b64decode needs padding
+    payload_b64 += "=" * (-len(payload_b64) % 4)
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64.encode("ascii")))
+    except Exception:
+        return []
+    if not isinstance(payload, dict):
+        return []
+    out: list[str] = []
+    aud = payload.get("aud")
+    if isinstance(aud, str) and aud:
+        out.append(aud)
+    elif isinstance(aud, list):
+        out.extend(str(a) for a in aud if a)
+    for key in ("appid", "azp"):
+        val = payload.get(key)
+        if isinstance(val, str) and val:
+            out.append(val)
+    return out
+
+
+def bot_id_candidates(activity: dict[str, Any], auth_header: str) -> list[str]:
+    """Ordered lookup keys for the App cache for one inbound activity."""
+    candidates: list[str] = []
+    recipient = activity.get("recipient") or {}
+    rid = str(recipient.get("id") or "")
+    if rid:
+        candidates.append(rid)
+        # Teams sometimes prefixes the App ID as ``28:<appId>``.
+        if rid.startswith("28:"):
+            candidates.append(rid.removeprefix("28:"))
+    candidates.extend(_app_ids_from_bearer(auth_header))
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for c in candidates:
+        if c and c not in seen:
+            seen.add(c)
+            ordered.append(c)
+    return ordered
+
+
+def resolve_entry_for_activity(
+    activity: dict[str, Any],
+    auth_header: str,
+) -> TeamsAppEntry | None:
+    """Find the cached App for an activity.
+
+    Prefer ``recipient.id`` (Teams channel), fall back to JWT App ID claims
+    (Web Chat / Direct Line, where recipient.id is not the App ID).
+    """
+    for candidate in bot_id_candidates(activity, auth_header):
+        entry = get_entry_by_bot_id(candidate)
+        if entry is not None:
+            return entry
+    return None

--- a/backend/cubeplex/im/teams/connector.py
+++ b/backend/cubeplex/im/teams/connector.py
@@ -7,6 +7,7 @@ from typing import Any
 from loguru import logger
 
 from cubeplex.im.outbound import _FloodSignal
+from cubeplex.im.teams.app_manager import get_conversation_route
 from cubeplex.im.teams.format import normalize_for_teams, strip_mention_tags
 from cubeplex.im.types import (
     DM_SCOPE_KEY,
@@ -17,6 +18,7 @@ from cubeplex.im.types import (
 )
 
 TEAMS_MSG_LIMIT = 25000
+_DEFAULT_SERVICE_URL = "https://smba.trafficmanager.net/teams"
 
 
 class TeamsRateLimitError(_FloodSignal):
@@ -29,7 +31,10 @@ class TeamsConnector:
     Construction:
     - Inbound parsing only needs ``bot_id``.
     - Outbound calls need an ``app`` (microsoft-teams SDK App instance)
-      plus ``channel_id`` and optionally ``reply_to_id``.
+      plus ``channel_id`` (conversation id) and optionally ``reply_to_id``.
+    - ``service_url`` / ``bf_channel_id`` must come from the inbound activity
+      (Web Chat uses a different serviceUrl than Teams; App.send hardcodes
+      msteams + default smba URL and 401s on Web Chat).
     - Identity resolution needs a ``graph_client`` (TeamsGraphClient).
     """
 
@@ -41,12 +46,22 @@ class TeamsConnector:
         channel_id: str | None = None,
         reply_to_id: str | None = None,
         graph_client: Any = None,
+        service_url: str | None = None,
+        bf_channel_id: str | None = None,
+        bot_account_id: str | None = None,
     ) -> None:
         self._bot_id = bot_id
         self._app = app
         self._channel_id = channel_id
         self._reply_to_id = reply_to_id
         self._graph_client = graph_client
+        self._service_url = (service_url or "").rstrip("/") or None
+        self._bf_channel_id = bf_channel_id or None
+        # Channel account id from activity.recipient (not always the App ID).
+        self._bot_account_id = (bot_account_id or "").strip() or None
+        # Web Chat / Direct Line reject PUT updateActivity (405). Cache the
+        # first failure so we stop trying mid-stream.
+        self._edit_supported: bool | None = None
 
     # ------------------------------------------------------------------
     # Inbound
@@ -152,21 +167,115 @@ class TeamsConnector:
     # Outbound
     # ------------------------------------------------------------------
 
+    @property
+    def supports_message_edit(self) -> bool:
+        """Whether this channel supports updating an existing activity.
+
+        Teams does (updateActivity streaming). Web Chat / Direct Line return
+        405 Method Not Allowed on PUT …/activities/{id}.
+        """
+        if self._edit_supported is False:
+            return False
+        if self._edit_supported is True:
+            return True
+        ch = (self._bf_channel_id or "msteams").lower()
+        # Known non-updatable Bot Framework channels.
+        if ch in ("webchat", "directline", "emulator"):
+            return False
+        return True
+
+    def _resolve_route(self, conversation_id: str) -> tuple[str, str, str]:
+        """Pick service_url, channel id, and bot channel account for outbound."""
+        if self._service_url:
+            return (
+                self._service_url,
+                self._bf_channel_id or "msteams",
+                self._bot_account_id or self._bot_id,
+            )
+        cached = get_conversation_route(conversation_id)
+        if cached is not None:
+            url, ch, bot_acc = cached
+            return url, ch, bot_acc or self._bot_account_id or self._bot_id
+        default_url = _DEFAULT_SERVICE_URL
+        if self._app is not None:
+            api = getattr(self._app, "api", None)
+            api_url = getattr(api, "service_url", None) if api is not None else None
+            if isinstance(api_url, str) and api_url.strip():
+                default_url = api_url.rstrip("/")
+        return (
+            default_url,
+            self._bf_channel_id or "msteams",
+            self._bot_account_id or self._bot_id,
+        )
+
+    async def _send_activity(
+        self,
+        conversation_id: str,
+        activity: Any,
+    ) -> Any:
+        """Send via activity_sender with the conversation's real serviceUrl.
+
+        ``App.send`` hardcodes ``channel_id="msteams"``, the default Teams
+        service URL, and ``from.id`` = App ID. Web Chat requires the inbound
+        ``activity.recipient.id`` as from.id or the connector returns 403.
+        """
+        from microsoft_teams.api import (
+            Account,
+            ConversationAccount,
+            ConversationReference,
+            MessageActivityInput,
+        )
+        from microsoft_teams.cards import AdaptiveCard
+
+        if self._app is None:
+            raise RuntimeError("Teams app not bound")
+        if not getattr(self._app, "_initialized", True):
+            raise RuntimeError("Teams app not initialized")
+
+        service_url, bf_channel, bot_account_id = self._resolve_route(conversation_id)
+        if not bot_account_id:
+            bot_account_id = getattr(self._app, "id", None) or self._bot_id
+        if not bot_account_id:
+            raise RuntimeError("Teams bot account id missing")
+
+        if isinstance(activity, str):
+            activity = MessageActivityInput(text=activity)
+        elif isinstance(activity, AdaptiveCard):
+            activity = MessageActivityInput().add_card(activity)
+
+        ref = ConversationReference(
+            channel_id=bf_channel,
+            service_url=service_url,
+            bot=Account(id=str(bot_account_id)),
+            conversation=ConversationAccount(id=conversation_id),
+        )
+        sender = getattr(self._app, "activity_sender", None)
+        if sender is None:
+            # Fallback for older SDK shapes; still better than wrong URL.
+            return await self._app.send(conversation_id, activity)
+        return await sender.send(activity, ref)
+
     async def send_message(self, text: str) -> str | None:
         """Send a Markdown text message. Returns the activity ID."""
         if self._app is None or not self._channel_id:
             return None
         try:
             text = normalize_for_teams(text[:TEAMS_MSG_LIMIT])
-            result = await self._app.send(self._channel_id, text)
+            result = await self._send_activity(self._channel_id, text)
             return str(result.id) if result and hasattr(result, "id") else None
         except Exception:
             logger.opt(exception=True).warning("[Teams] send_message failed")
             return None
 
     async def edit_message(self, activity_id: str, text: str) -> bool:
-        """Update an existing message. Raises TeamsRateLimitError on 429."""
+        """Update an existing message. Raises TeamsRateLimitError on 429.
+
+        Returns False when the channel does not support updates (Web Chat
+        405) so the renderer can fall back to send-new-message.
+        """
         if self._app is None or not self._channel_id:
+            return False
+        if not self.supports_message_edit:
             return False
         try:
             from microsoft_teams.api import MessageActivityInput
@@ -175,11 +284,21 @@ class TeamsConnector:
             msg = MessageActivityInput()
             msg.id = activity_id
             msg.text = text
-            await self._app.send(self._channel_id, msg)
+            await self._send_activity(self._channel_id, msg)
+            self._edit_supported = True
             return True
         except Exception as exc:
             if _is_rate_limit(exc):
                 raise TeamsRateLimitError(f"edit rate limited: {exc}") from exc
+            # Web Chat / some connectors: PUT activities/{id} → 405.
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            if status == 405 or "405" in str(exc):
+                self._edit_supported = False
+                logger.info(
+                    "[Teams] edit not supported on channel={} — using send-only mode",
+                    self._bf_channel_id,
+                )
+                return False
             logger.opt(exception=True).warning("[Teams] edit_message failed")
             return False
 
@@ -191,7 +310,7 @@ class TeamsConnector:
                 TypingActivityInput,
             )
 
-            await self._app.send(self._channel_id, TypingActivityInput())
+            await self._send_activity(self._channel_id, TypingActivityInput())
         except Exception:
             logger.opt(exception=True).debug("[Teams] typing indicator failed")
 
@@ -209,7 +328,7 @@ class TeamsConnector:
                 content=card,
             )
             msg = MessageActivityInput(attachments=[attachment])
-            result = await self._app.send(self._channel_id, msg)
+            result = await self._send_activity(self._channel_id, msg)
             return str(result.id) if result and hasattr(result, "id") else None
         except Exception:
             logger.opt(exception=True).warning("[Teams] send_card failed")
@@ -251,11 +370,16 @@ class TeamsConnector:
     async def send_to_chat(self, chat_id: str, reply_to_id: str | None, text: str) -> str | None:
         if self._app is None:
             return None
+        del reply_to_id  # Bot Framework create-activity path; threading via conv id
         try:
-            result = await self._app.send(chat_id, text)
+            result = await self._send_activity(chat_id, text)
             return str(result.id) if result and hasattr(result, "id") else None
         except Exception:
-            logger.opt(exception=True).warning("[Teams] send_to_chat failed")
+            logger.opt(exception=True).warning(
+                "[Teams] send_to_chat failed chat_id={} route={}",
+                chat_id,
+                self._resolve_route(chat_id),
+            )
             return None
 
 

--- a/backend/cubeplex/im/teams/renderer.py
+++ b/backend/cubeplex/im/teams/renderer.py
@@ -1,4 +1,8 @@
-"""Teams outbound renderer — Markdown messages with updateActivity streaming."""
+"""Teams outbound renderer — Markdown messages with updateActivity streaming.
+
+Web Chat / Direct Line do not support PUT updateActivity (405). For those
+channels we buffer until finalize and send complete message(s).
+"""
 
 from __future__ import annotations
 
@@ -27,8 +31,15 @@ class TeamsOpDispatcher:
         self.sent_char_offset: int = 0
         self._pending_input_sent_id: str | None = None
 
+    def _can_edit(self) -> bool:
+        return bool(getattr(self._connector, "supports_message_edit", True))
+
     async def dispatch_create(self, state: Any) -> bool:
         s = self._state
+        # No updateActivity → don't post a partial first token; finalize will
+        # send the full reply once (avoids a stuck "你好" with no follow-up).
+        if not self._can_edit():
+            return True
         text = s.card_state.streaming_content
         if not text:
             text = "..."
@@ -54,6 +65,9 @@ class TeamsOpDispatcher:
 
     async def dispatch_stream(self, state: Any, text: str) -> bool:
         s = self._state
+        # Buffer only; finalize posts the complete text on non-edit channels.
+        if not self._can_edit():
+            return True
         if s.bot_message_id is None:
             return await self.dispatch_create(state)
         full_content = s.card_state.streaming_content
@@ -62,10 +76,13 @@ class TeamsOpDispatcher:
             split_at = find_split_point(current_segment, _SPLIT_THRESHOLD)
             finalize_text = current_segment[:split_at]
             try:
-                await self._connector.edit_message(s.bot_message_id, finalize_text)
+                ok = await self._connector.edit_message(s.bot_message_id, finalize_text)
             except TeamsRateLimitError:
                 note_flood_strike(s)
                 return False
+            if not ok:
+                # Channel rejected edit mid-stream — fall back to send-only.
+                return True
             self.sent_char_offset += split_at
             remaining = full_content[self.sent_char_offset :]
             if remaining:
@@ -82,7 +99,8 @@ class TeamsOpDispatcher:
             return False
         if ok:
             note_edit_success(s)
-        return bool(ok)
+        # False (e.g. 405) is OK: finalize will send the full buffer.
+        return True
 
     async def dispatch_patch(self, state: Any) -> bool:
         s = self._state
@@ -158,26 +176,29 @@ class TeamsOpDispatcher:
         if not full_content:
             return True
         remaining = full_content[self.sent_char_offset :]
-        if s.bot_message_id is not None and len(remaining) <= TEAMS_MSG_LIMIT:
+        if not remaining:
+            return True
+
+        # Prefer edit when the channel supports it and we already have a msg.
+        if s.bot_message_id is not None and self._can_edit() and len(remaining) <= TEAMS_MSG_LIMIT:
             try:
-                await self._connector.edit_message(s.bot_message_id, remaining)
+                ok = await self._connector.edit_message(s.bot_message_id, remaining)
             except Exception:
                 logger.opt(exception=True).warning("[Teams] finalize edit failed")
-                await self.emergency_text(remaining[:TEAMS_MSG_LIMIT])
-        else:
-            while remaining:
-                chunk = remaining[:TEAMS_MSG_LIMIT]
-                remaining = remaining[TEAMS_MSG_LIMIT:]
-                if s.bot_message_id and not self.sent_char_offset:
-                    try:
-                        await self._connector.edit_message(s.bot_message_id, chunk)
-                    except Exception:
-                        await self._connector.send_message(chunk)
-                else:
-                    msg_id = await self._connector.send_message(chunk)
-                    if msg_id:
-                        s.bot_message_id = msg_id
-                self.sent_char_offset += len(chunk)
+                ok = False
+            if ok:
+                self.sent_char_offset += len(remaining)
+                return True
+            # Fall through to send-new-message path.
+
+        # Send-only (Web Chat / edit failed / oversize): post remaining chunks.
+        while remaining:
+            chunk = remaining[:TEAMS_MSG_LIMIT]
+            remaining = remaining[TEAMS_MSG_LIMIT:]
+            msg_id = await self._connector.send_message(chunk)
+            if msg_id:
+                s.bot_message_id = msg_id
+            self.sent_char_offset += len(chunk)
         return True
 
     async def emergency_text(self, text: str) -> None:

--- a/backend/tests/unit/im/test_teams_app_manager_resolve.py
+++ b/backend/tests/unit/im/test_teams_app_manager_resolve.py
@@ -1,0 +1,98 @@
+"""Web Chat recipient.id is not the App ID — resolve via JWT aud."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import cubeplex.im.teams.app_manager as app_manager
+from cubeplex.im.teams.app_manager import (
+    TeamsAppEntry,
+    bot_id_candidates,
+    resolve_entry_for_activity,
+)
+
+
+def _b64url(data: dict) -> str:
+    raw = json.dumps(data, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _fake_bearer(*, aud: str, appid: str | None = None) -> str:
+    header = _b64url({"alg": "RS256", "typ": "JWT"})
+    payload: dict = {"aud": aud, "iss": "https://api.botframework.com"}
+    if appid is not None:
+        payload["appid"] = appid
+    # signature not validated at candidate-extract time
+    return f"Bearer {header}.{_b64url(payload)}.sig"
+
+
+def setup_function() -> None:
+    app_manager._app_cache.clear()
+
+
+def teardown_function() -> None:
+    app_manager._app_cache.clear()
+
+
+def test_bot_id_candidates_prefer_recipient_then_jwt_aud() -> None:
+    app_id = "11111111-2222-3333-4444-555555555555"
+    # Web Chat style channel account id (not a real secret / app id).
+    webchat_recipient = "test-bot@webchat-channel-account-id"
+    activity = {"recipient": {"id": webchat_recipient}}
+    auth = _fake_bearer(aud=app_id)
+    cands = bot_id_candidates(activity, auth)
+    assert cands[0] == webchat_recipient
+    assert app_id in cands
+
+
+def test_bot_id_candidates_strip_28_prefix() -> None:
+    app_id = "11111111-2222-3333-4444-555555555555"
+    activity = {"recipient": {"id": f"28:{app_id}"}}
+    cands = bot_id_candidates(activity, "")
+    assert cands == [f"28:{app_id}", app_id]
+
+
+def test_resolve_entry_falls_back_to_jwt_aud_for_webchat_recipient() -> None:
+    app_id = "11111111-2222-3333-4444-555555555555"
+    entry = TeamsAppEntry(
+        app=object(),
+        account_id="imac-test",
+        bot_id=app_id,
+        secrets={"app_id": app_id},
+    )
+    app_manager._app_cache[app_id] = entry
+
+    activity = {
+        "type": "message",
+        "recipient": {
+            "id": "test-bot@webchat-channel-account-id",
+            "name": "test-bot",
+        },
+    }
+    auth = _fake_bearer(aud=app_id)
+    resolved = resolve_entry_for_activity(activity, auth)
+    assert resolved is entry
+    assert resolved.bot_id == app_id
+
+
+def test_resolve_entry_none_when_no_cache_match() -> None:
+    activity = {"recipient": {"id": "unknown@channel"}}
+    auth = _fake_bearer(aud="00000000-0000-0000-0000-000000000000")
+    assert resolve_entry_for_activity(activity, auth) is None
+
+
+def test_conversation_route_cache() -> None:
+    app_manager._conversation_routes.clear()
+    app_manager.remember_conversation_route(
+        "conv-webchat-1",
+        service_url="https://webchat.botframework.com/",
+        channel_id="webchat",
+        bot_account_id="cubeplex@abc",
+    )
+    assert app_manager.get_conversation_route("conv-webchat-1") == (
+        "https://webchat.botframework.com",
+        "webchat",
+        "cubeplex@abc",
+    )
+    app_manager._conversation_routes.clear()

--- a/backend/tests/unit/im/test_teams_connector_send_route.py
+++ b/backend/tests/unit/im/test_teams_connector_send_route.py
@@ -1,0 +1,109 @@
+"""Outbound send must use activity serviceUrl, not App.send defaults."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cubeplex.im.teams.app_manager as app_manager
+from cubeplex.im.teams.connector import TeamsConnector
+
+
+@pytest.fixture(autouse=True)
+def _clear_routes() -> Any:
+    app_manager._conversation_routes.clear()
+    yield
+    app_manager._conversation_routes.clear()
+
+
+@pytest.mark.asyncio
+async def test_send_to_chat_uses_activity_service_url_not_default_teams() -> None:
+    sent: dict[str, Any] = {}
+
+    class _Sender:
+        async def send(self, activity: Any, ref: Any) -> SimpleNamespace:
+            sent["activity"] = activity
+            sent["ref"] = ref
+            return SimpleNamespace(id="act-1")
+
+    app = SimpleNamespace(
+        id="11111111-2222-3333-4444-555555555555",
+        _initialized=True,
+        activity_sender=_Sender(),
+        api=SimpleNamespace(service_url="https://smba.trafficmanager.net/teams"),
+    )
+    connector = TeamsConnector(
+        bot_id=app.id,
+        app=app,
+        channel_id="conv-webchat",
+        service_url="https://webchat.botframework.com/",
+        bf_channel_id="webchat",
+        bot_account_id="test-bot@webchat-channel-account-id",
+    )
+    out = await connector.send_to_chat("conv-webchat", None, "hello")
+    assert out == "act-1"
+    assert sent["ref"].service_url == "https://webchat.botframework.com"
+    assert sent["ref"].channel_id == "webchat"
+    assert sent["ref"].conversation.id == "conv-webchat"
+    # from.id must be channel account id, not App ID — raw App ID → 403
+    assert sent["ref"].bot.id == "test-bot@webchat-channel-account-id"
+
+
+@pytest.mark.asyncio
+async def test_send_to_chat_falls_back_to_remembered_route() -> None:
+    sent: dict[str, Any] = {}
+
+    class _Sender:
+        async def send(self, activity: Any, ref: Any) -> SimpleNamespace:
+            sent["ref"] = ref
+            return SimpleNamespace(id="act-2")
+
+    app = SimpleNamespace(
+        id="bot-guid",
+        _initialized=True,
+        activity_sender=_Sender(),
+        api=SimpleNamespace(service_url="https://smba.trafficmanager.net/teams"),
+        send=AsyncMock(),
+    )
+    app_manager.remember_conversation_route(
+        "conv-2",
+        service_url="https://smba.trafficmanager.net/amer/",
+        channel_id="msteams",
+        bot_account_id="28:bot-guid",
+    )
+    connector = TeamsConnector(bot_id="bot-guid", app=app)
+    await connector.send_to_chat("conv-2", None, "hi")
+    assert sent["ref"].service_url == "https://smba.trafficmanager.net/amer"
+    assert sent["ref"].channel_id == "msteams"
+    assert sent["ref"].bot.id == "28:bot-guid"
+    app.send.assert_not_called()
+
+
+def test_webchat_does_not_support_message_edit() -> None:
+    c = TeamsConnector(bf_channel_id="webchat")
+    assert c.supports_message_edit is False
+
+
+def test_msteams_supports_message_edit() -> None:
+    c = TeamsConnector(bf_channel_id="msteams")
+    assert c.supports_message_edit is True
+
+
+@pytest.mark.asyncio
+async def test_edit_message_skips_api_on_webchat() -> None:
+    app = SimpleNamespace(
+        id="bot",
+        _initialized=True,
+        activity_sender=SimpleNamespace(send=AsyncMock()),
+    )
+    c = TeamsConnector(
+        bot_id="bot",
+        app=app,
+        channel_id="conv",
+        bf_channel_id="webchat",
+    )
+    assert await c.edit_message("act-1", "hello") is False
+    app.activity_sender.send.assert_not_called()

--- a/backend/tests/unit/im/test_teams_renderer_send_only.py
+++ b/backend/tests/unit/im/test_teams_renderer_send_only.py
@@ -1,0 +1,70 @@
+"""Web Chat has no updateActivity — stream buffers; finalize sends full text."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from cubeplex.im.teams.renderer import TeamsOpDispatcher
+from cubeplex.im.types import RenderState
+
+
+class _SendOnlyConnector:
+    supports_message_edit = False
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.edits: list[tuple[str, str]] = []
+
+    async def send_message(self, text: str) -> str:
+        self.sent.append(text)
+        return f"msg-{len(self.sent)}"
+
+    async def edit_message(self, activity_id: str, text: str) -> bool:
+        self.edits.append((activity_id, text))
+        return False
+
+
+@pytest.mark.asyncio
+async def test_send_only_channel_finalize_posts_full_reply() -> None:
+    conn = _SendOnlyConnector()
+    state = RenderState(bot_name="bot", run_id="run-1")
+    state.card_state.streaming_content = "你好呀～我是莉莉，见到你很开心。"
+    dispatcher = TeamsOpDispatcher(connector=conn, state=state)
+
+    assert await dispatcher.dispatch_create(SimpleNamespace()) is True
+    assert conn.sent == []  # no partial first token
+    assert await dispatcher.dispatch_stream(SimpleNamespace(), "x") is True
+    assert conn.sent == []
+    assert await dispatcher.dispatch_finalize(SimpleNamespace()) is True
+    assert conn.sent == ["你好呀～我是莉莉，见到你很开心。"]
+    assert conn.edits == []
+
+
+@pytest.mark.asyncio
+async def test_edit_channel_still_streams_via_edit() -> None:
+    class _EditConnector:
+        supports_message_edit = True
+
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+            self.edits: list[tuple[str, str]] = []
+
+        async def send_message(self, text: str) -> str:
+            self.sent.append(text)
+            return "msg-1"
+
+        async def edit_message(self, activity_id: str, text: str) -> bool:
+            self.edits.append((activity_id, text))
+            return True
+
+    conn = _EditConnector()
+    state = RenderState(bot_name="bot", run_id="run-2")
+    state.card_state.streaming_content = "你好"
+    dispatcher = TeamsOpDispatcher(connector=conn, state=state)
+    assert await dispatcher.dispatch_create(SimpleNamespace()) is True
+    assert conn.sent == ["你好"]
+    state.card_state.streaming_content = "你好呀"
+    assert await dispatcher.dispatch_stream(SimpleNamespace(), "呀") is True
+    assert conn.edits == [("msg-1", "你好呀")]

--- a/docs/site/docs/guides/im/teams.md
+++ b/docs/site/docs/guides/im/teams.md
@@ -20,110 +20,210 @@ You need:
 - A **publicly reachable HTTPS URL** for your CubePlex host (see the note above).
 
 :::caution The Azure / Teams console changes often
-The screen names, blade labels, and manifest editor in Azure and the Teams Developer Portal change frequently and differ across tenants. This guide describes each step by **what you are configuring** (register a bot, get an app ID + secret + tenant ID, set the messaging endpoint, enable the Teams channel, build a manifest). Where an exact Azure UI label is given it may have moved or been renamed — follow the capability, not the literal string. The values CubePlex actually consumes — the app ID, app secret, tenant ID, and messaging endpoint path — are the only ones this guide can state with certainty, because they come from CubePlex's own code.
+The screen names, blade labels, and manifest editor in Azure and the Teams Developer Portal change frequently and differ across tenants. This guide describes each step by **what you are configuring** and gives typical portal paths. Where an exact Azure UI label is given it may have moved or been renamed — follow the capability, not the literal string. The values CubePlex actually consumes — the app ID, app secret, tenant ID, and messaging endpoint path — are the only ones this guide can state with certainty, because they come from CubePlex's own code.
 :::
+
+The in-product **Connect Teams** wizard lists the same prerequisites with portal paths; this page is the long form.
 
 ## Step 1 — Register an Azure Bot
 
-In the **Azure portal**, create an **Azure Bot** resource. During creation Azure provisions (or lets you supply) a **Microsoft App** — an Entra / Azure AD application identity for the bot. This is what gives you the credentials CubePlex needs.
+In the **Azure portal**:
 
-Record three values as you go:
+1. **Create a resource** → search **Azure Bot** → **Create**.
+2. Prefer **single-tenant** identity when the portal asks how the bot's Microsoft App is managed (multi-tenant bot creation is deprecated for new bots).
+3. After deployment, open the Azure Bot resource.
 
-- **App ID** (the Microsoft App ID / client ID) — this is the bot's identity. CubePlex stores it as the account's external identifier, and it is the `recipient.id` Microsoft puts on every inbound activity, so it must match exactly.
-- **App secret** (a client secret you generate for the app) — CubePlex uses it to obtain a Bot Framework token. Generate the secret and copy it immediately; Azure shows the secret value only once.
-- **Tenant ID** — the Entra directory (tenant) ID the app lives in.
+Record three values from **Configuration** (and the linked Entra app — see steps 2–3):
+
+| Value | Where to copy it |
+|---|---|
+| **App ID** (Microsoft App ID / Application client ID) | Azure Bot → **Configuration** → **Microsoft App ID** |
+| **Tenant ID** (Directory / App Tenant ID) | Azure Bot → **Configuration** → **App Tenant ID** (or Microsoft Entra ID → **Overview** → **Tenant ID**) |
+| **App secret** | Created in step 2 (Entra app → Certificates & secrets) |
+
+CubePlex stores the App ID as the account's external identifier. It must match the Microsoft App ID you created for this bot.
 
 :::info 📸 Screenshot placeholder
-**Capture:** The Azure portal "Create an Azure Bot" form, and the resulting resource's identity page showing where the Microsoft App ID and the option to create a client secret appear.
+**Capture:** The Azure portal "Create an Azure Bot" form, and the resulting resource's Configuration page showing Microsoft App ID and App Tenant ID.
 **Asset:** `/img/im/teams-azure-bot-create.png`
 :::
+
+## Step 2 — Create a client secret
+
+Secrets and Graph permissions live on the **Microsoft Entra app** behind the bot — not on the Azure Bot blade itself.
+
+1. Azure Bot → **Configuration**.
+2. Next to **Microsoft App ID**, click **Manage**. That opens the Entra **App registration**.
+3. **Certificates & secrets** → **New client secret**.
+4. Copy the secret **Value** immediately (Azure shows it only once). Do **not** paste the Secret ID into CubePlex.
 
 :::info 📸 Screenshot placeholder
 **Capture:** The app's "Certificates & secrets" view at the moment a new client secret is created, with the one-time secret value visible (redact before publishing).
 **Asset:** `/img/im/teams-app-secret.png`
 :::
 
-## Step 2 — Set the messaging endpoint
+## Step 3 — Add Graph permission (identity)
 
-In the Azure Bot resource's **configuration**, set the **messaging endpoint** to the inbound webhook on your CubePlex host:
+CubePlex uses Microsoft Graph (`GET /users/{id}`) to resolve a Teams user's email when possible. That needs an **application** permission with admin consent.
+
+On the **same Entra app** (Azure Bot → Configuration → **Manage**):
+
+1. **API permissions** → **Add a permission**.
+2. **Microsoft Graph** → **Application permissions** (not Delegated).
+3. Search and select **`User.Read.All`** → **Add permissions**.
+4. **Grant admin consent for your tenant** and confirm the status shows granted.
+
+Without admin consent, token acquisition may still work for Bot Framework, but automatic email lookup fails and users must use `/link`.
+
+## Step 4 — Set the messaging endpoint
+
+In the Azure Bot resource → **Configuration**, set **Messaging endpoint** to:
 
 ```
-https://<your-cubeplex-host>/api/v1/im/teams/messages
+https://YOUR_CUBEPLEX_HOST/api/v1/im/teams/messages
 ```
 
-This is the exact path CubePlex listens on. Microsoft's Bot Framework service POSTs each Teams activity to this URL. The host must be internet-reachable over HTTPS (see the intro note) — Microsoft will not deliver to an unreachable or plain-HTTP endpoint.
+Replace `YOUR_CUBEPLEX_HOST` with your public CubePlex host (no trailing slash on the host). Leave **Enable Streaming Endpoint** **off** — CubePlex uses the classic webhook path, not the streaming protocol.
 
-You can set this endpoint before or after you bind in CubePlex, but the bot won't get any answers until both sides are in place: the endpoint must point here **and** the account must be bound and enabled in CubePlex (Step 5). CubePlex rejects activities for an unknown or disabled bot.
+This is the exact path CubePlex listens on. Microsoft's Bot Framework service POSTs each activity here. The host must be internet-reachable over HTTPS — Microsoft will not deliver to an unreachable or plain-HTTP endpoint.
+
+You can set this endpoint before or after you bind in CubePlex, but the bot won't answer until both sides are in place: the endpoint must point here **and** the account must be bound and enabled in CubePlex (Step 7).
 
 :::info 📸 Screenshot placeholder
-**Capture:** The Azure Bot resource configuration page with the messaging endpoint field set to `https://<your-cubeplex-host>/api/v1/im/teams/messages`.
+**Capture:** The Azure Bot Configuration page with the messaging endpoint field set.
 **Asset:** `/img/im/teams-messaging-endpoint.png`
 :::
 
-## Step 3 — Enable the Teams channel
+## Step 5 — Enable the Teams channel
 
-A freshly registered Azure Bot isn't reachable from Teams until you add the **Microsoft Teams channel** to it. In the Azure Bot resource's **Channels** area, add and enable the Teams channel.
+A freshly registered Azure Bot is not reachable from Teams until you add the **Microsoft Teams** channel.
 
-Without this, the bot exists but no Teams message ever reaches it.
+Azure Bot → **Channels** → add **Microsoft Teams** and leave it **Running**.
+
+Without this, the bot exists but no Teams message ever reaches your webhook.
 
 :::info 📸 Screenshot placeholder
-**Capture:** The Azure Bot "Channels" page with the Microsoft Teams channel added and showing as enabled / running.
+**Capture:** The Azure Bot Channels page with Microsoft Teams enabled / running.
 **Asset:** `/img/im/teams-channel-enable.png`
 :::
 
-## Step 4 — Build and upload the Teams app manifest
+## Step 6 — Put the bot into Microsoft Teams
 
-To make the bot installable for users, package it as a **Teams app**. A Teams app is described by a **manifest** (a small JSON document plus icons) that declares, among other things, the **bot ID** — which must be the **App ID from Step 1** — so Teams knows which bot the app installs.
+Enabling the **Teams channel** (Step 5) only tells Azure that Teams is allowed to call your bot. Users still need a **Teams app** installed in their Teams client so they can open a chat with that bot.
 
-You can author the manifest in the **Teams Developer Portal** (or hand-write the manifest JSON and zip it with the icons). Set the bot in the manifest to your App ID, fill in the app name and icons, then upload / install the resulting app into Teams — either by sideloading it for yourself for testing, or publishing it to your organization's app catalog so others can install it.
+Think of three IDs that must be the **same Microsoft App ID** from Step 1:
 
-:::caution Manifest field names are not verifiable from CubePlex
-The exact manifest schema keys and the Developer Portal's field labels live on Microsoft's side and change between schema versions, so this guide can't state them as fixed strings. The one value CubePlex depends on is that the manifest's bot ID equals the **App ID** you bind in CubePlex (Step 5). Get that wrong and inbound activities arrive under a `recipient.id` CubePlex has no account for, and they are silently dropped.
-:::
+| Place | What to set |
+|---|---|
+| Azure Bot | Microsoft App ID (already set when you created the bot) |
+| Teams app package | Bot ID in the app = that same App ID |
+| CubePlex bind (Step 7) | App ID field = that same App ID |
+
+If those three disagree, messages either never reach CubePlex or land on an account you did not bind.
+
+### 6a — Recommended: Teams Developer Portal
+
+1. Open [Teams Developer Portal](https://dev.teams.microsoft.com/) and sign in with the same Microsoft 365 / work account you use in Teams.
+2. **Apps** → **New app**. Give it a display name (this is what people see in Teams, not the Azure Bot resource name).
+3. Fill **Basic information** (short name, long name, developer info, descriptions). The portal will not let you install until required fields are complete.
+4. Under app capabilities / features, add a **Bot** (wording varies: *App features → Bot*, *Bots*, etc.):
+   - Choose **existing bot** / enter bot ID when offered — paste the **Microsoft App ID from Step 1**.
+   - Do **not** create a brand-new bot here unless you intend to abandon the Azure Bot you already set up; a new bot gets a different ID and will not match CubePlex.
+   - Enable scopes you need: at least **Personal** (1:1 chat). Add **Team** / **Group chat** if people will @mention the bot in channels or group chats.
+5. Save. Use **Preview in Teams** if the portal offers it (opens Teams with the app ready to add), **or** download the app package:
+   - **Publish** / **Download app package** (a `.zip` containing `manifest.json` and icons).
+6. Install that package in Teams (pick one path):
+
+   **Sideload for yourself (typical for testing)**  
+   - Desktop or web Teams → **Apps** → **Manage your apps** → **Upload an app** → **Upload a custom app** → choose the `.zip`.  
+   - If you only see “Contact your admin”, your org has turned off custom app upload — ask a Teams admin to allow custom apps for you, or use org catalog upload below.
+
+   **Org catalog (for others in the company)**  
+   - [Teams admin center](https://admin.teams.microsoft.com/) → **Teams apps** → **Manage apps** → **Upload new app** (or equivalent) with the same `.zip`.  
+   - Users then find the app under **Apps** in Teams and install it.
+
+7. After install, open the app → **Chat** (or search the bot by the display name) and send a message. That should hit your messaging endpoint once CubePlex is bound (Step 7).
 
 :::info 📸 Screenshot placeholder
-**Capture:** The Teams Developer Portal manifest editor (or the manifest JSON) showing the bot configured with the App ID, plus the upload / install action.
+**Capture:** Developer Portal bot capability page with the Step 1 App ID filled in, and Teams “Upload a custom app” choosing the package zip.
 **Asset:** `/img/im/teams-manifest.png`
 :::
 
-## Step 5 — Bind the bot in CubePlex
+### 6b — Optional: hand-built package
 
-In your CubePlex workspace, open the **IM connectors** settings and connect a new Teams account. Provide:
+If you prefer not to use the Developer Portal:
+
+1. Create a folder with:
+   - `manifest.json` (schema version and field names follow Microsoft’s current Teams app manifest docs — they change; use their template for the current version).
+   - Two PNGs Microsoft requires (color and outline icons; size rules are in those docs).
+2. In the manifest, set the bot’s id to the **App ID from Step 1**, and enable the chat scopes you need (personal / team / groupChat).
+3. Zip the **contents** of the folder (the zip root should contain `manifest.json` and the icons, not a nested extra folder).
+4. Upload that zip the same way as in step 6a (Teams client sideload or admin center).
+
+CubePlex only cares that the bot id in the package equals the App ID you bind. Icon layout and optional fields are Teams packaging requirements, not CubePlex fields.
+
+### Checklist before you message the bot in Teams
+
+- [ ] Azure Bot **Channels** includes **Microsoft Teams** (Step 5).  
+- [ ] Messaging endpoint points at CubePlex (Step 4).  
+- [ ] Teams app bot id = Azure Microsoft App ID.  
+- [ ] App is installed for your user (sideload or catalog).  
+- [ ] CubePlex Teams account is connected with that App ID (Step 7).  
+- [ ] First-time identity: `/link` if prompted (Step 9).
+
+## Step 7 — Bind the bot in CubePlex
+
+In your CubePlex workspace, open **IM connectors** and connect a new Teams account:
 
 | Field | Required | Notes |
 |---|---|---|
-| **App ID** | Yes | The Microsoft App ID from Step 1. Also serves as the account's external identifier and must match the `recipient.id` on inbound activities. |
-| **App secret** | Yes | The client secret from Step 1. CubePlex uses it to obtain a Bot Framework token. |
-| **Tenant ID** | Yes | The Entra directory (tenant) ID from Step 1. |
-| **Run identity** | Yes | `self` (the bot runs as you) by default. Binding it to run as another user requires the **workspace admin** role. |
+| **App ID** | Yes | Microsoft App ID from Step 1 (Azure Bot → Configuration). |
+| **App secret** | Yes | Client secret **Value** from Step 2 (not the Secret ID). |
+| **Tenant ID** | Yes | Directory (tenant) ID from Step 1. |
+| **Run identity** | Yes | `self` by default. Binding as another user requires **workspace admin**. |
 
-The delivery mode for Teams is always **webhook** — there is no choice to make; CubePlex sets it for you.
+The delivery mode for Teams is always **webhook** — CubePlex sets it for you.
 
-On binding, CubePlex validates the credentials by requesting a client-credentials token from Microsoft (`https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token`). If the App ID, secret, or tenant ID is wrong, the token request fails and binding is rejected with a "could not validate Teams bot credentials" error — fix the values in Azure and retry. The credentials are stored encrypted.
+On binding, CubePlex validates credentials with a client-credentials token request to Microsoft (`https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token`). Wrong App ID, secret, or tenant ID fails with "could not validate Teams bot credentials". Credentials are stored encrypted.
 
 ![CubePlex Teams account connection form](/img/im/teams-cubeplex-connect-form.png)
 
-## Step 6 — Test it
+After a successful connect, the account may show **Disconnected** until Microsoft has delivered at least one activity in the last hour — that is expected for webhook mode. It does not mean the bind failed.
 
-Install the bot in Teams (Step 4) and message it — DM it directly or @-mention it in a channel where it's installed. The first time, CubePlex needs to know who you are.
+## Step 8 — Test with Azure Web Chat
 
-Teams has no email-resolution path, so you link manually. Send the bot:
+Before installing the bot in the Teams client, you can exercise the same webhook from Azure’s **Test in Web Chat**. It uses the messaging endpoint from Step 4 and the CubePlex bind from Step 7 — no separate URL is required.
+
+1. Finish Steps 1–5 and Step 7. The messaging endpoint must point at a running, publicly reachable CubePlex host.
+2. Open the Azure Bot resource → **Test in Web Chat**.
+3. Send a message. CubePlex should receive it at `POST /api/v1/im/teams/messages`.
+4. On first contact, complete identity linking (`/link`, Step 9). Then send a normal question and confirm you get a full agent reply.
+
+Replies in Web Chat appear as a single message when the run finishes (Web Chat does not support mid-reply message edits the way Teams does).
+
+When that works, install the Teams app (Step 6) and message the bot in Teams the same way.
+
+## Step 9 — Link identity (first message)
+
+The first time a given IM identity talks to the bot, CubePlex needs to know who you are.
+
+Teams has no reliable automatic email path for every channel, so you link manually when prompted. Send:
 
 ```
 /link your@email.com
 ```
 
-The bot replies with a confirmation URL of the form `https://<your-cubeplex-host>/im-link?token=...`. Open that link **while logged in to CubePlex**, and confirm. CubePlex checks that your logged-in email matches the claimed email and that you belong to the bot's workspace, then permanently links your Teams identity to your CubePlex account. See [Identity linking](./overview.md#identity-linking).
+The bot replies with a confirmation URL of the form `https://YOUR_CUBEPLEX_HOST/im-link?token=...`. Open that link **while logged in to CubePlex**, and confirm. CubePlex checks that your logged-in email matches the claimed email and that you belong to the bot's workspace, then permanently links your IM identity. See [Identity linking](./overview.md#identity-linking).
 
-The linked email must already belong to a CubePlex account that is a member of the bot's workspace — linking connects an existing account, it doesn't create one or grant membership.
+The linked email must already belong to a CubePlex account that is a member of the bot's workspace — linking connects an existing account; it does not create one or grant membership.
 
-Once linked, your messages run as that user, with the same skills, memory, and tools you have in the web app, and the agent's reply posts back into the chat.
+Once linked, messages run as that user, with the same skills, memory, and tools you have in the web app, and the agent's reply posts back into the chat.
 
 ## Conversation commands
 
 | Command | Effect |
 |---|---|
-| `/link <email>` | Link your Teams identity to your CubePlex account. |
+| `/link <email>` | Link your Teams / Web Chat identity to your CubePlex account. |
 | `/new` | Start a fresh conversation; your next message begins a new one. |
 | `/reset` | Same as `/new`. |
 | `新对话` | Same as `/new` (text form). |
@@ -132,10 +232,10 @@ Once linked, your messages run as that user, with the same skills, memory, and t
 
 ## How inbound messages are authenticated
 
-Every Teams activity arrives at `POST /api/v1/im/teams/messages`. Before CubePlex does any work it:
+Every activity arrives at `POST /api/v1/im/teams/messages`. Before CubePlex does any work it:
 
-1. Reads the bot ID from the activity's `recipient.id` and finds the matching bound account. An unknown bot ID is dropped.
-2. Validates the **Azure Bot Framework JWT** carried in the request's `Authorization: Bearer …` header against the bot's token validator, including the activity's `serviceUrl`. A missing, malformed, or invalid token is rejected with `401`. This is what guarantees the request genuinely came from Microsoft's Bot Framework and not from anyone who guessed your endpoint URL.
+1. Resolves the bound bot for the activity and drops unknown bots.
+2. Validates the **Azure Bot Framework JWT** in the `Authorization: Bearer …` header (including the activity's `serviceUrl`). Missing or invalid tokens return `401`.
 3. Confirms the account is enabled, then resolves identity and runs the agent.
 
 Because the endpoint is public, this JWT check is the security boundary for the Teams connector — there is no separate signing secret you configure, unlike Feishu's encrypt key.

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/im/teams.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/im/teams.md
@@ -5,7 +5,7 @@ title: Microsoft Teams 设置
 
 # Microsoft Teams 设置
 
-Microsoft Teams 连接器让工作区的智能体能够在 Teams 中回复消息。本指南将带你在 Azure 中注册机器人、将其指向 CubePlex 主机、使其可在 Teams 中安装、将其绑定到 CubePlex 工作区，并关联账户以便机器人回复你。
+Microsoft Teams 连接器让工作区的智能体能够在 Teams 中回复消息。本指南将带你在 Azure 中注册机器人、将其指向 CubePlex 主机、使其可在 Teams 中安装、绑定到 CubePlex 工作区，并关联账户以便机器人回复你。
 
 Teams 是 **唯一要求 CubePlex 主机可从公网访问的平台。** 不同于 Feishu 的长连接或 Slack / Discord / DingTalk 网关连接器——其中 CubePlex 打开出站 socket，且你这一侧无需公开任何内容——Teams 通过 **webhook** 传递消息：Microsoft 的 Bot Framework 服务会将每个 activity POST 到主机上的 URL。该 URL 必须能通过 HTTPS 从 Microsoft 服务器访问。如果 CubePlex 主机位于没有入站访问的防火墙后，此连接器将无法工作。
 
@@ -20,110 +20,210 @@ CubePlex 会验证每个入站 activity 的 **Azure Bot Framework JWT**，因此
 - CubePlex 主机的 **可从公网访问的 HTTPS URL**（参阅上方说明）。
 
 :::caution Azure / Teams 控制台经常变更
-Azure 和 Teams Developer Portal 中的页面名称、blade 标签与清单编辑器经常变更，且不同租户间也可能不同。本指南按你要配置的**内容**描述每一步（注册机器人、获取应用 ID + 密钥 + 租户 ID、设置消息端点、启用 Teams 频道、构建清单）。给出的准确 Azure UI 标签可能已移动或更名——请遵循功能，而非字面字符串。由于它们来自 CubePlex 自己的代码，本指南只能确定地说明 CubePlex 实际使用的值：应用 ID、应用密钥、租户 ID 和消息端点路径。
+Azure 和 Teams Developer Portal 中的页面名称、blade 标签与清单编辑器经常变更，且不同租户间也可能不同。本指南按你要配置的**内容**描述每一步，并给出常见门户路径。给出的准确 Azure UI 标签可能已移动或更名——请遵循功能，而非字面字符串。由于它们来自 CubePlex 自己的代码，本指南只能确定地说明 CubePlex 实际使用的值：应用 ID、应用密钥、租户 ID 和消息端点路径。
 :::
+
+产品内 **连接 Teams** 向导与本文列出相同前置条件（含门户路径）；本文是完整版。
 
 ## 步骤 1 — 注册 Azure Bot
 
-在 **Azure 门户**中创建一个 **Azure Bot** 资源。创建期间，Azure 会预配（或让你提供）一个 **Microsoft App**——这是机器人的 Entra / Azure AD 应用身份。它会提供 CubePlex 所需的凭据。
+在 **Azure 门户**：
 
-请在过程中记录三个值：
+1. **创建资源** → 搜索 **Azure Bot** → **创建**。
+2. 当门户询问机器人 Microsoft App 的管理方式时，优先选 **单租户**（新 bot 的多租户创建已弃用）。
+3. 部署完成后打开该 Azure Bot 资源。
 
-- **App ID**（Microsoft App ID / client ID）— 这是机器人的身份。CubePlex 将其存储为账户的外部标识符，Microsoft 也会将其作为每个入站 activity 的 `recipient.id`，因此必须完全匹配。
-- **App secret**（为应用生成的 client secret）— CubePlex 使用它获取 Bot Framework token。生成密钥后立即复制；Azure 仅显示一次密钥值。
-- **Tenant ID** — 应用所在的 Entra 目录（租户）ID。
+从 **配置 / Configuration**（以及步骤 2–3 中的 Entra 应用）记录三个值：
+
+| 值 | 在哪里复制 |
+|---|---|
+| **App ID**（Microsoft App ID / 应用程序客户端 ID） | Azure Bot → **配置** → **Microsoft App ID** |
+| **Tenant ID**（目录 / App Tenant ID） | Azure Bot → **配置** → **App Tenant ID**（或 Microsoft Entra ID → **概述** → **租户 ID**） |
+| **App secret** | 在步骤 2 创建（Entra 应用 → 证书和密码） |
+
+CubePlex 将 App ID 存为账户的外部标识符，必须与该 bot 的 Microsoft App ID 一致。
 
 :::info 📸 截图占位符
-**截图内容：** Azure 门户中的“Create an Azure Bot”表单，以及生成资源的身份页面，显示 Microsoft App ID 和创建 client secret 的位置。
+**截图内容：** Azure 门户中的“Create an Azure Bot”表单，以及资源的配置页，显示 Microsoft App ID 与 App Tenant ID。
 **资源：** `/img/im/teams-azure-bot-create.png`
 :::
 
+## 步骤 2 — 创建客户端密码
+
+密钥与 Graph 权限在 bot 背后的 **Microsoft Entra 应用**上管理，不在 Azure Bot 资源页本身。
+
+1. Azure Bot → **配置**。
+2. 在 **Microsoft App ID** 旁点 **管理 / Manage**，打开 Entra **应用注册**。
+3. **证书和密码** → **新建客户端密码**。
+4. 立即复制密码的 **值 / Value**（Azure 只显示一次）。**不要**把 Secret ID 填进 CubePlex。
+
 :::info 📸 截图占位符
-**截图内容：** 应用的“Certificates & secrets”视图，在创建新 client secret 时显示一次性密钥值（发布前请脱敏）。
+**截图内容：** 应用的“证书和密码”视图，在创建新 client secret 时显示一次性密钥值（发布前请脱敏）。
 **资源：** `/img/im/teams-app-secret.png`
 :::
 
-## 步骤 2 — 设置消息端点
+## 步骤 3 — 添加 Graph 权限（身份解析）
 
-在 Azure Bot 资源的 **配置** 中，将 **消息端点** 设为 CubePlex 主机上的入站 webhook：
+CubePlex 会在可能时通过 Microsoft Graph（`GET /users/{id}`）解析 Teams 用户邮箱。这需要 **应用程序权限** 且已授予管理员同意。
+
+在 **同一 Entra 应用**（Azure Bot → 配置 → **管理**）中：
+
+1. **API 权限** → **添加权限**。
+2. **Microsoft Graph** → **应用程序权限**（不要选委托权限）。
+3. 搜索并勾选 **`User.Read.All`** → **添加权限**。
+4. 点 **为你的租户授予管理员同意**，确认状态为已授予。
+
+未做管理员同意时，Bot Framework token 仍可能成功，但自动邮箱查找会失败，用户必须使用 `/link`。
+
+## 步骤 4 — 设置消息终结点
+
+在 Azure Bot 资源 → **配置** 中，将 **消息终结点 / Messaging endpoint** 设为：
 
 ```
-https://<your-cubeplex-host>/api/v1/im/teams/messages
+https://YOUR_CUBEPLEX_HOST/api/v1/im/teams/messages
 ```
 
-这是 CubePlex 监听的准确路径。Microsoft 的 Bot Framework 服务会将每个 Teams activity POST 到此 URL。主机必须能通过 HTTPS 从互联网访问（参阅简介说明）——Microsoft 不会向无法访问或纯 HTTP 的端点传递消息。
+将 `YOUR_CUBEPLEX_HOST` 换成你的公网 CubePlex 主机（主机后不要多余斜杠）。**流式处理终结点 / Enable Streaming Endpoint** 保持 **关闭**——CubePlex 使用经典 webhook，不是 Streaming Protocol。
 
-你可以在 CubePlex 中绑定之前或之后设置此端点，但在两侧均配置完成前，机器人不会获得任何回复：端点必须指向此处，且账户必须已在 CubePlex 中绑定并启用（步骤 5）。CubePlex 会拒绝未知或已禁用机器人的 activity。
+这是 CubePlex 监听的准确路径。Microsoft 的 Bot Framework 会将每个 activity POST 到此 URL。主机必须可通过 HTTPS 从公网访问——Microsoft 不会向无法访问或纯 HTTP 的端点投递。
+
+你可以在 CubePlex 中绑定之前或之后设置此端点，但在两侧均配置完成前机器人不会回复：端点必须指向此处，且账户必须已在 CubePlex 中绑定并启用（步骤 7）。
 
 :::info 📸 截图占位符
-**截图内容：** Azure Bot 资源配置页面，消息端点字段已设置为 `https://<your-cubeplex-host>/api/v1/im/teams/messages`。
+**截图内容：** Azure Bot 配置页面，消息终结点字段已设置。
 **资源：** `/img/im/teams-messaging-endpoint.png`
 :::
 
-## 步骤 3 — 启用 Teams 频道
+## 步骤 5 — 启用 Teams 频道
 
-新注册的 Azure Bot 在添加 **Microsoft Teams 频道** 前无法从 Teams 访问。在 Azure Bot 资源的 **频道** 区域中，添加并启用 Teams 频道。
+新注册的 Azure Bot 在添加 **Microsoft Teams** 频道前无法从 Teams 访问。
 
-没有此项，机器人虽存在，但永远不会收到任何 Teams 消息。
+Azure Bot → **频道 / Channels** → 添加 **Microsoft Teams**，并保持 **Running**。
+
+没有此项，机器人虽存在，但永远不会有 Teams 消息到达你的 webhook。
 
 :::info 📸 截图占位符
-**截图内容：** Azure Bot 的“Channels”页面，已添加 Microsoft Teams 频道，并显示为已启用/运行中。
+**截图内容：** Azure Bot 的“频道”页面，已添加 Microsoft Teams 并显示为已启用/运行中。
 **资源：** `/img/im/teams-channel-enable.png`
 :::
 
-## 步骤 4 — 构建并上传 Teams 应用清单
+## 步骤 6 — 把 bot 装进 Microsoft Teams
 
-要让用户可以安装机器人，请将它打包为 **Teams 应用**。Teams 应用通过 **清单** 描述（一个小型 JSON 文档及图标）；清单声明的内容包括 **机器人 ID**，其必须是 **步骤 1 中的 App ID**，让 Teams 知道该应用要安装哪个机器人。
+步骤 5 只是在 Azure 上**允许** Teams 调用你的 bot。用户还要在 Teams 客户端里**安装一个 Teams 应用**，才能打开与该 bot 的聊天。
 
-你可以在 **Teams Developer Portal** 中编写清单（或者手写清单 JSON 并与图标一起打包为 zip）。在清单中将机器人设置为你的 App ID，填写应用名称和图标，然后将生成的应用上传/安装到 Teams——可为测试将其旁加载给自己，或将其发布到组织的应用目录，供其他人安装。
+下面三处必须是**同一个**步骤 1 的 Microsoft App ID：
 
-:::caution 清单字段名称无法从 CubePlex 验证
-准确的清单 schema 键和 Developer Portal 字段标签由 Microsoft 定义，并且会随 schema 版本变化，因此本指南无法将它们描述为固定字符串。CubePlex 唯一依赖的值是：清单中的机器人 ID 必须等于你在 CubePlex 中绑定的 **App ID**（步骤 5）。如果填写错误，入站 activity 会以 CubePlex 没有账户对应的 `recipient.id` 到达，并被静默丢弃。
-:::
+| 位置 | 填什么 |
+|---|---|
+| Azure Bot | Microsoft App ID（创建 bot 时已有） |
+| Teams 应用包 | 应用里的 Bot ID = 上述 App ID |
+| CubePlex 绑定（步骤 7） | App ID 字段 = 上述 App ID |
+
+三处不一致时，消息到不了 CubePlex，或落到你没有绑定的账户上。
+
+### 6a — 推荐：Teams Developer Portal
+
+1. 打开 [Teams Developer Portal](https://dev.teams.microsoft.com/)，用你在 Teams 里用的同一 Microsoft 365 / 工作账号登录。
+2. **Apps（应用）** → **New app（新建应用）**。填写显示名称（这是用户在 Teams 里看到的名字，不必与 Azure 资源名相同）。
+3. 补全 **Basic information（基本信息）**（短名称、长名称、开发者信息、描述等）。必填项不全时无法安装。
+4. 在应用能力 / 功能里添加 **Bot（机器人）**（界面文案可能是 *App features → Bot*、*Bots* 等）：
+   - 若可选择 **已有 bot** / 填写 bot ID，粘贴 **步骤 1 的 Microsoft App ID**。
+   - **不要**在这里再「新建一个 bot」，除非你打算弃用已在 Azure 配好的 bot——新建会得到另一个 ID，无法与 CubePlex 对应。
+   - 打开需要的范围：至少 **Personal（个人 / 1:1）**。若要在频道或群聊里 @bot，再勾选 **Team** / **Group chat**。
+5. 保存。若有 **Preview in Teams（在 Teams 中预览）** 可直接打开 Teams 添加；否则下载应用包：
+   - **Publish / Download app package**，得到包含 `manifest.json` 与图标的 `.zip`。
+6. 在 Teams 中安装该包（二选一）：
+
+   **给自己旁加载（测试常用）**  
+   - 桌面或网页版 Teams → **应用** → **管理你的应用** → **上传应用** → **上传自定义应用** → 选择该 `.zip`。  
+   - 若只有「请联系管理员」，说明组织关闭了自定义应用上传——请 Teams 管理员为你开放，或走下方组织目录。
+
+   **组织应用目录（给同事用）**  
+   - [Teams 管理中心](https://admin.teams.microsoft.com/) → **Teams 应用** → **管理应用** → **上传新应用**（或同等入口），上传同一 `.zip`。  
+   - 用户在 Teams **应用** 里找到并安装。
+
+7. 安装后打开应用 → **聊天**（或按显示名搜索 bot）发一条消息。完成步骤 7 绑定后，消息应打到你的 messaging endpoint。
 
 :::info 📸 截图占位符
-**截图内容：** Teams Developer Portal 清单编辑器（或清单 JSON），显示已用 App ID 配置机器人，以及上传/安装操作。
+**截图内容：** Developer Portal 中 Bot 能力页已填入步骤 1 的 App ID，以及 Teams「上传自定义应用」选择 zip 的界面。
 **资源：** `/img/im/teams-manifest.png`
 :::
 
-## 步骤 5 — 在 CubePlex 中绑定机器人
+### 6b — 可选：手写应用包
 
-在 CubePlex 工作区中，打开 **IM 连接器** 设置并连接一个新的 Teams 账户。填写：
+不用 Developer Portal 时：
+
+1. 建一个文件夹，内含：
+   - `manifest.json`（schema 版本与字段名以 Microsoft 当前 Teams 应用清单文档为准，会变；请用官方当前版本模板）。
+   - Microsoft 要求的两张 PNG（彩色与轮廓图标；尺寸见该文档）。
+2. 在清单里把 bot 的 id 设为 **步骤 1 的 App ID**，并打开需要的聊天范围（personal / team / groupChat）。
+3. 打包时 zip **文件夹内的文件**（zip 根目录应直接是 `manifest.json` 和图标，不要多套一层目录）。
+4. 按 6a 的方式在 Teams 客户端或管理中心上传该 zip。
+
+CubePlex 只要求包里的 bot id 与你绑定的 App ID 一致。图标与其它可选字段是 Teams 打包要求，不是 CubePlex 字段。
+
+### 在 Teams 里发消息前的检查清单
+
+- [ ] Azure Bot **频道** 已添加 **Microsoft Teams**（步骤 5）  
+- [ ] 消息终结点已指向 CubePlex（步骤 4）  
+- [ ] Teams 应用的 bot id = Azure Microsoft App ID  
+- [ ] 你的账号已安装该应用（旁加载或组织目录）  
+- [ ] CubePlex 已用同一 App ID 绑定 Teams 账户（步骤 7）  
+- [ ] 首次使用按提示 `/link`（步骤 9）  
+
+## 步骤 7 — 在 CubePlex 中绑定机器人
+
+在 CubePlex 工作区打开 **IM 连接器**，连接新的 Teams 账户：
 
 | 字段 | 是否必需 | 说明 |
 |---|---|---|
-| **App ID** | 是 | 来自步骤 1 的 Microsoft App ID。也用作账户的外部标识符，且必须与入站 activity 中的 `recipient.id` 匹配。 |
-| **App secret** | 是 | 来自步骤 1 的 client secret。CubePlex 使用它获取 Bot Framework token。 |
-| **Tenant ID** | 是 | 来自步骤 1 的 Entra 目录（租户）ID。 |
-| **运行身份** | 是 | 默认值为 `self`（机器人以你的身份运行）。绑定为以其他用户身份运行需要 **工作区管理员** 角色。 |
+| **App ID** | 是 | 步骤 1 的 Microsoft App ID（Azure Bot → 配置）。 |
+| **App secret** | 是 | 步骤 2 的客户端密码 **Value**（不是 Secret ID）。 |
+| **Tenant ID** | 是 | 步骤 1 的目录（租户）ID。 |
+| **运行身份** | 是 | 默认 `self`。以其他用户身份运行需要 **工作区管理员**。 |
 
-Teams 的传递模式始终为 **webhook**——无需选择；CubePlex 会为你设置它。
+Teams 的传递模式始终为 **webhook**——无需选择；CubePlex 会为你设置。
 
-绑定时，CubePlex 会通过向 Microsoft 请求 client-credentials token 来验证凭据（`https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token`）。如果 App ID、密钥或租户 ID 错误，token 请求会失败，并以“could not validate Teams bot credentials”错误拒绝绑定——请在 Azure 中修复值后重试。凭据会加密存储。
+绑定时，CubePlex 会向 Microsoft 请求 client-credentials token 校验凭据（`https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token`）。App ID、密钥或租户 ID 错误会以 “could not validate Teams bot credentials” 拒绝绑定。凭据加密存储。
 
 ![CubePlex Teams 账户连接表单](/img/im/teams-cubeplex-connect-form.png)
 
-## 步骤 6 — 测试
+连接成功后，在 Microsoft 近一小时内尚未投递任何 activity 时，账户可能显示 **未连接 / Disconnected**——对 webhook 模式这是预期行为，不代表绑定失败。
 
-在 Teams 中安装机器人（步骤 4）并向其发送消息——直接向其发送私信，或在已安装它的频道中 @ 提及它。第一次使用时，CubePlex 需要知道你是谁。
+## 步骤 8 — 用 Azure Web Chat 测试
 
-Teams 没有电子邮箱解析路径，因此需要手动关联。向机器人发送：
+在 Teams 客户端安装 bot 之前，可以用 Azure 的 **Test in Web Chat** 走同一条 webhook。它使用步骤 4 的消息终结点和步骤 7 的 CubePlex 绑定——**不需要**单独 URL。
+
+1. 完成步骤 1–5 与步骤 7。消息终结点须指向正在运行且可从公网访问的 CubePlex 主机。
+2. 打开 Azure Bot 资源 → **Test in Web Chat**。
+3. 发送一条消息。CubePlex 应在 `POST /api/v1/im/teams/messages` 收到。
+4. 首次对话完成身份关联（`/link`，见步骤 9）。然后再发正常问题，确认能收到完整智能体回复。
+
+Web Chat 中的回复会在 run 结束后作为一条完整消息出现（Web Chat 不支持像 Teams 那样在回复过程中编辑消息）。
+
+验证通过后，再安装 Teams 应用（步骤 6），在 Teams 里用同样方式与 bot 对话。
+
+## 步骤 9 — 关联身份（首次对话）
+
+某个 IM 身份第一次与 bot 对话时，CubePlex 需要知道你是谁。
+
+Teams 并非在每个频道都能可靠自动解析邮箱，因此在提示时手动关联。发送：
 
 ```
 /link your@email.com
 ```
 
-机器人会回复一个形如 `https://<your-cubeplex-host>/im-link?token=...` 的确认 URL。请在 **已登录 CubePlex** 的状态下打开该链接并确认。CubePlex 会检查已登录电子邮箱是否与声明的电子邮箱匹配，以及你是否属于机器人工作区，然后将 Teams 身份永久关联到 CubePlex 账户。参阅[身份关联](./overview.md#identity-linking)。
+机器人会回复形如 `https://YOUR_CUBEPLEX_HOST/im-link?token=...` 的确认 URL。请在 **已登录 CubePlex** 时打开并确认。CubePlex 会检查已登录邮箱是否与声明一致，以及你是否属于 bot 工作区，然后永久关联 IM 身份。参阅[身份关联](./overview.md#identity-linking)。
 
-关联的电子邮箱必须已属于一个 CubePlex 账户，且该账户是机器人工作区的成员——关联只会连接已有账户，不会创建账户或授予成员资格。
+关联的电子邮箱必须已属于一个 CubePlex 账户，且该账户是 bot 工作区的成员——关联只连接已有账户，不会创建账户或授予成员资格。
 
-关联后，你的消息会以该用户身份运行，拥有你在 Web 应用中相同的技能、记忆和工具，智能体回复会发布回聊天中。
+关联后，消息会以该用户身份运行，拥有你在 Web 应用中相同的技能、记忆和工具，智能体回复会发回聊天。
 
 ## 对话命令
 
 | 命令 | 效果 |
 |---|---|
-| `/link <email>` | 将 Teams 身份关联到 CubePlex 账户。 |
+| `/link <email>` | 将 Teams / Web Chat 身份关联到 CubePlex 账户。 |
 | `/new` | 开始全新对话；下一条消息会开始一个新对话。 |
 | `/reset` | 与 `/new` 相同。 |
 | `新对话` | 与 `/new` 相同（文本形式）。 |
@@ -132,10 +232,10 @@ Teams 没有电子邮箱解析路径，因此需要手动关联。向机器人�
 
 ## 入站消息的认证方式
 
-每个 Teams activity 都会到达 `POST /api/v1/im/teams/messages`。CubePlex 在执行任何操作前会：
+每个 activity 都会到达 `POST /api/v1/im/teams/messages`。CubePlex 在执行任何操作前会：
 
-1. 从 activity 的 `recipient.id` 读取机器人 ID，并查找匹配的已绑定账户。未知机器人 ID 会被丢弃。
-2. 使用机器人的 token 验证器，验证请求 `Authorization: Bearer …` 标头中携带的 **Azure Bot Framework JWT**，包括 activity 的 `serviceUrl`。缺少、格式错误或无效 token 会以 `401` 被拒绝。这确保请求确实来自 Microsoft 的 Bot Framework，而不是猜到端点 URL 的其他人。
+1. 解析这是哪个已绑定 bot，未知 bot 会被丢弃。
+2. 验证请求 `Authorization: Bearer …` 中的 **Azure Bot Framework JWT**（含 activity 的 `serviceUrl`）。缺少或无效 token 返回 `401`。
 3. 确认账户已启用，然后解析身份并运行智能体。
 
 由于端点是公开的，JWT 检查是 Teams 连接器的安全边界——与 Feishu 的加密密钥不同，无需配置单独的签名密钥。

--- a/frontend/packages/web/components/im/ImConnectWizard/platforms/teams.ts
+++ b/frontend/packages/web/components/im/ImConnectWizard/platforms/teams.ts
@@ -12,19 +12,31 @@ export const teamsDescriptor: PlatformDescriptor = {
     {
       key: 'app',
       labelKey: 'im.wizard.teams.prereq.app',
-      helpUrl: () => 'https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps',
-    },
-    {
-      key: 'graphPermission',
-      labelKey: 'im.wizard.teams.prereq.graphPermission',
+      // Create Azure Bot (not bare App registrations). Incomplete
+      // #view/Microsoft_AAD_RegisteredApps dumps users on the portal home.
+      helpUrl: () => 'https://portal.azure.com/#create/Microsoft.AzureBot',
     },
     {
       key: 'clientSecret',
       labelKey: 'im.wizard.teams.prereq.clientSecret',
+      // Secrets live on the Entra app behind the bot.
+      helpUrl: () =>
+        'https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade',
+    },
+    {
+      key: 'graphPermission',
+      labelKey: 'im.wizard.teams.prereq.graphPermission',
+      items: ['User.Read.All'],
+      helpUrl: () =>
+        'https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade',
     },
     {
       key: 'endpoint',
       labelKey: 'im.wizard.teams.prereq.endpoint',
+    },
+    {
+      key: 'teamsChannel',
+      labelKey: 'im.wizard.teams.prereq.teamsChannel',
     },
   ],
   credentialFields: [
@@ -76,5 +88,7 @@ export const teamsDescriptor: PlatformDescriptor = {
     tenant_id: f.tenant_id || '',
     acting_user_id: 'self',
   }),
-  scopeConsoleUrl: () => 'https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps',
+  // Secrets + Graph permissions live on the Entra app registration list.
+  scopeConsoleUrl: () =>
+    'https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade',
 }

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -2486,15 +2486,16 @@
       },
       "teams": {
         "prereq": {
-          "app": "Create a Bot Registration in Azure Portal (or via Teams Toolkit)",
-          "graphPermission": "Add User.Read.All application permission and grant admin consent",
-          "clientSecret": "Create a Client Secret in Certificates & Secrets",
-          "endpoint": "Set Messaging Endpoint to https://<your-domain>/api/v1/im/teams/messages"
+          "app": "Azure Portal → Create a resource → Azure Bot. Prefer single-tenant. Copy Microsoft App ID and Directory (tenant) ID from the bot’s Configuration page.",
+          "clientSecret": "Azure Bot → Configuration → Manage (next to Microsoft App ID) opens the Entra app → Certificates & secrets → New client secret. Copy the secret Value immediately (shown once).",
+          "graphPermission": "Same Entra app (Azure Bot → Configuration → Manage) → API permissions → Add → Microsoft Graph → Application permissions → User.Read.All → Add, then Grant admin consent for your tenant.",
+          "endpoint": "Azure Bot → Configuration → Messaging endpoint = https://YOUR_DOMAIN/api/v1/im/teams/messages (public HTTPS required; leave Streaming endpoint off).",
+          "teamsChannel": "Azure Bot → Channels → add Microsoft Teams and leave it Running. Without this channel, no messages are delivered."
         },
         "field": {
-          "appId": "Application (Client) ID",
-          "appSecret": "Client Secret",
-          "tenantId": "Tenant ID"
+          "appId": "Application (client) ID — Azure Bot → Configuration → Microsoft App ID",
+          "appSecret": "Client secret — Entra app → Certificates & secrets (the Value, not the Secret ID)",
+          "tenantId": "Directory (tenant) ID — Azure Bot → Configuration → App Tenant ID (or Entra ID → Overview)"
         }
       },
       "dingtalk": {

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -2486,15 +2486,16 @@
       },
       "teams": {
         "prereq": {
-          "app": "在 Azure Portal 创建 Bot 注册（或使用 Teams Toolkit）",
-          "graphPermission": "添加 User.Read.All 应用权限并授予管理员同意",
-          "clientSecret": "在「证书和密码」中创建客户端密码",
-          "endpoint": "将消息终结点设为 https://<your-domain>/api/v1/im/teams/messages"
+          "app": "Azure Portal → 创建资源 → Azure Bot。建议选单租户。在 Bot 的「配置 / Configuration」页复制 Microsoft App ID 与 Directory (tenant) ID。",
+          "clientSecret": "Azure Bot → 配置 → Microsoft App ID 旁的「管理 / Manage」进入 Entra 应用 → 证书和密码 → 新建客户端密码。立即复制密码「值 / Value」（只显示一次）。",
+          "graphPermission": "同一 Entra 应用（Azure Bot → 配置 → 管理）→ API 权限 → 添加 → Microsoft Graph → 应用程序权限 → User.Read.All → 添加，再点「为租户授予管理员同意」。",
+          "endpoint": "Azure Bot → 配置 → 消息终结点 / Messaging endpoint 填 https://YOUR_DOMAIN/api/v1/im/teams/messages（须公网 HTTPS；流式处理终结点保持关闭）。",
+          "teamsChannel": "Azure Bot → 频道 / Channels → 添加 Microsoft Teams 并保持 Running。未启用频道则收不到任何消息。"
         },
         "field": {
-          "appId": "应用程序(客户端) ID",
-          "appSecret": "客户端密码",
-          "tenantId": "租户 ID"
+          "appId": "应用程序(客户端) ID — Azure Bot → 配置 → Microsoft App ID",
+          "appSecret": "客户端密码 — Entra 应用 → 证书和密码（填 Value，不是 Secret ID）",
+          "tenantId": "目录(租户) ID — Azure Bot → 配置 → App Tenant ID（或 Entra ID → 概述）"
         }
       },
       "dingtalk": {


### PR DESCRIPTION
## Summary

- **Backend:** Teams inbound resolves bot via JWT `aud` when Web Chat `recipient.id` is a channel account id; outbound uses the activity `serviceUrl` / channel account; skip `updateActivity` on Web Chat (405) and send the full reply on finalize.
- **Wizard:** Clearer Azure portal paths (create Azure Bot, Manage → secret/Graph, messaging endpoint, Teams channel); fix broken App Registrations deep link; avoid next-intl unclosed-tag from angle brackets in copy.
- **Docs:** Expand Teams setup (EN + zh-Hans) with install-into-Teams steps and a short Web Chat test path.

## Test plan

- [x] `uv run pytest tests/unit/im/test_teams_app_manager_resolve.py tests/unit/im/test_teams_connector_send_route.py tests/unit/im/test_teams_renderer_send_only.py tests/unit/im/test_teams_connector.py --no-cov`
- [x] Pre-push `make check-ci` (backend + frontend)
- [ ] Azure Web Chat: bind bot → message → `/link` if needed → full agent reply
- [ ] Teams client after app install: same end-to-end path
- [ ] Connect wizard: open Teams prereqs, external links open Azure Bot create / App registrations list