### PR TITLE
Unblock backend startup hang and Ctrl-C shutdown

### DIFF
--- a/backend/cubeplex/im/dingtalk/gateway.py
+++ b/backend/cubeplex/im/dingtalk/gateway.py
@@ -4,13 +4,49 @@ from __future__ import annotations
 
 import asyncio
 import json
+from contextlib import suppress
 from typing import Any
+from urllib.parse import quote_plus
 
 import dingtalk_stream
 import httpx
+import websockets
 from loguru import logger
 
 from cubeplex.im.dingtalk.connector import DingtalkConnector
+
+
+async def stream_until_disconnect(client: dingtalk_stream.DingTalkStreamClient) -> None:
+    """Run one DingTalk stream session until disconnect or cancel.
+
+    ``dingtalk_stream.DingTalkStreamClient.start()`` catches
+    ``asyncio.CancelledError`` and reconnects forever, which prevents uvicorn
+    graceful shutdown (Ctrl-C hangs). We reimplement the connection body so
+    cancellation always propagates, and run the sync open-connection HTTP call
+    in a worker thread so it cannot block the event loop.
+    """
+    client.pre_start()
+    connection = await asyncio.to_thread(client.open_connection)
+    if not connection:
+        raise ConnectionError("dingtalk open_connection returned no endpoint")
+
+    logger.info("[DingTalk] stream endpoint ready")
+    uri = f"{connection['endpoint']}?ticket={quote_plus(connection['ticket'])}"
+    async with websockets.connect(uri) as websocket:
+        client.websocket = websocket
+        keepalive = asyncio.create_task(
+            client.keepalive(websocket),
+            name="dingtalk-keepalive",
+        )
+        try:
+            async for raw_message in websocket:
+                json_message = json.loads(raw_message)
+                asyncio.create_task(client.background_task(json_message))
+        finally:
+            keepalive.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await keepalive
+            client.websocket = None
 
 
 class DingtalkGateway:
@@ -77,7 +113,7 @@ class DingtalkGateway:
             backoff = 1.0
             while True:
                 try:
-                    await client.start()
+                    await stream_until_disconnect(client)
                 except asyncio.CancelledError:
                     return
                 except Exception:
@@ -280,22 +316,24 @@ class DingtalkGateway:
             lg.propagate = False
         if self._refresh_task is not None:
             self._refresh_task.cancel()
-            try:
+            with suppress(asyncio.CancelledError, Exception):
                 await self._refresh_task
-            except (asyncio.CancelledError, Exception):
-                pass
         if self._client is not None:
             ws = getattr(self._client, "websocket", None)
             if ws is not None:
-                try:
+                with suppress(Exception):
                     await ws.close()
-                except Exception:
-                    pass
         if self._task is not None:
             self._task.cancel()
             try:
                 await asyncio.wait_for(self._task, timeout=5.0)
-            except (asyncio.CancelledError, TimeoutError, Exception):
+            except TimeoutError:
+                # Should be unreachable with stream_until_disconnect; re-cancel
+                # in case a future SDK path swallows cancellation again.
+                self._task.cancel()
+                with suppress(asyncio.CancelledError, TimeoutError, Exception):
+                    await asyncio.wait_for(self._task, timeout=2.0)
+            except (asyncio.CancelledError, Exception):
                 pass
         await self._shared_http.aclose()
         logger.info("[DingTalk] Gateway stopped for account {}", self._account.id)

--- a/backend/cubeplex/services/conversation_search/chunker.py
+++ b/backend/cubeplex/services/conversation_search/chunker.py
@@ -1,10 +1,22 @@
 """Sliding-window chunker. Token counting via tiktoken cl100k_base."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
+from functools import lru_cache
 
 import tiktoken
 
-_ENC = tiktoken.get_encoding("cl100k_base")
+
+@lru_cache(maxsize=1)
+def _encoding() -> tiktoken.Encoding:
+    """Lazy-load cl100k_base.
+
+    tiktoken may download the BPE file on first use (sync HTTP). Doing that at
+    module import blocks the asyncio event loop during app lifespan and can
+    leave the API port unbound for tens of seconds (or until Ctrl-C fails).
+    """
+    return tiktoken.get_encoding("cl100k_base")
 
 
 @dataclass(frozen=True)
@@ -31,13 +43,14 @@ def chunk_messages(
     """
     if not messages or target_tokens <= 0:
         return []
+    enc = _encoding()
     tokens: list[int] = []
     token_seq: list[int] = []
-    space = _ENC.encode(" ")
+    space = enc.encode(" ")
     for m in messages:
         if not m.text:
             continue
-        encoded = _ENC.encode(m.text)
+        encoded = enc.encode(m.text)
         if not encoded:
             continue
         tokens.extend(encoded)
@@ -52,7 +65,7 @@ def chunk_messages(
     i = 0
     while i < len(tokens):
         j = min(i + target_tokens, len(tokens))
-        text = _ENC.decode(tokens[i:j])
+        text = enc.decode(tokens[i:j])
         seqs = token_seq[i:j]
         out.append(
             Chunk(

--- a/backend/tests/services/conversation_search/test_chunker.py
+++ b/backend/tests/services/conversation_search/test_chunker.py
@@ -1,8 +1,20 @@
+import cubeplex.services.conversation_search.chunker as chunker_mod
 from cubeplex.services.conversation_search.chunker import Chunk, MessageInput, chunk_messages
 
 
 def _msg(seq: int, text: str) -> MessageInput:
     return MessageInput(seq=seq, text=text)
+
+
+def test_import_does_not_eagerly_load_tiktoken_encoding() -> None:
+    """Module import must not call get_encoding (can block on HTTP download)."""
+    # _encoding is an lru_cache; cache_info hits stay 0 until first chunk_messages.
+    chunker_mod._encoding.cache_clear()
+    info = chunker_mod._encoding.cache_info()
+    assert info.hits == 0
+    assert info.misses == 0
+    # Import path already ran; the contract is: no cache fill until use.
+    assert chunker_mod._encoding.cache_info().currsize == 0
 
 
 def test_single_short_message_one_chunk() -> None:

--- a/backend/tests/unit/im/test_dingtalk_stream_cancel.py
+++ b/backend/tests/unit/im/test_dingtalk_stream_cancel.py
@@ -1,0 +1,98 @@
+"""DingTalk stream must respect asyncio cancellation (no Ctrl-C hang)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cubeplex.im.dingtalk.gateway import DingtalkGateway, stream_until_disconnect
+
+
+@pytest.mark.asyncio
+async def test_stream_until_disconnect_propagates_cancelled_error() -> None:
+    """SDK start() swallows CancelledError; our wrapper must not."""
+    client = MagicMock()
+    client.pre_start = MagicMock()
+    client.open_connection = MagicMock(
+        return_value={
+            "endpoint": "wss://example.test/connect",
+            "ticket": "t1",
+        }
+    )
+
+    async def _keepalive(_ws: object) -> None:
+        await asyncio.Event().wait()
+
+    client.keepalive = _keepalive
+    client.websocket = None
+
+    class _FakeWs:
+        def __init__(self) -> None:
+            self._q: asyncio.Queue[str | None] = asyncio.Queue()
+
+        async def __aenter__(self) -> _FakeWs:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        def __aiter__(self) -> _FakeWs:
+            return self
+
+        async def __anext__(self) -> str:
+            item = await self._q.get()
+            if item is None:
+                raise StopAsyncIteration
+            return item
+
+        async def close(self) -> None:
+            await self._q.put(None)
+
+    fake_ws = _FakeWs()
+
+    with patch("cubeplex.im.dingtalk.gateway.websockets.connect", return_value=fake_ws):
+        task = asyncio.create_task(stream_until_disconnect(client))
+        await asyncio.sleep(0)  # let it enter async for
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_gateway_stop_cancels_run_task_quickly() -> None:
+    """stop() must finish without waiting on SDK reconnect sleep."""
+    account = SimpleNamespace(id="acc_1", external_account_id="ext_1", workspace_id="ws_1")
+    gw = DingtalkGateway(
+        account=account,
+        app_key="k",
+        app_secret="s",
+        ingest=AsyncMock(),
+        session_maker=MagicMock(),
+        run_manager=None,
+        redis_key_prefix="test",
+    )
+
+    async def _hang_forever(_client: Any) -> None:
+        await asyncio.Event().wait()
+
+    with (
+        patch("cubeplex.im.dingtalk.gateway.stream_until_disconnect", side_effect=_hang_forever),
+        patch("cubeplex.im.dingtalk.gateway.dingtalk_stream") as mock_sdk,
+    ):
+        mock_sdk.Credential = MagicMock()
+        mock_sdk.DingTalkStreamClient = MagicMock(
+            return_value=MagicMock(
+                register_callback_handler=MagicMock(),
+                websocket=None,
+            )
+        )
+        mock_sdk.ChatbotMessage.TOPIC = "topic"
+        await gw.start()
+        assert gw._task is not None and not gw._task.done()
+
+        await asyncio.wait_for(gw.stop(), timeout=2.0)
+        assert gw._task is None or gw._task.done()


### PR DESCRIPTION
## Summary

- **tiktoken**: `conversation_search.chunker` no longer calls `get_encoding` at import time. A cold BPE download is sync HTTP and was blocking the asyncio event loop during lifespan, so the API never bound until the download finished (or Ctrl-C failed mid-startup).
- **DingTalk**: stop using `dingtalk_stream.DingTalkStreamClient.start()`, which catches `asyncio.CancelledError` and reconnects forever. Replace with `stream_until_disconnect()` that propagates cancellation and runs `open_connection` in a worker thread.

These two bugs explained a local incident: backend sat through lifespan after the egress listener, never listened on the API port, and SIGINT could not exit the process.

## Test plan

- [x] `pytest tests/services/conversation_search/test_chunker.py tests/unit/im/test_dingtalk_stream_cancel.py` (unit)
- [x] Pre-push `check-ci` (backend + frontend)
- [ ] Restart `python main.py` with empty `/tmp/data-gym-cache` (optional): API should bind without multi-tens-of-seconds silence; Ctrl-C should exit promptly with DingTalk enabled