### PR TITLE
Feishu ask_user form for multi-select, multi-question, and free-text

### DIFF
--- a/backend/cubeplex/api/routes/v1/im_ingress.py
+++ b/backend/cubeplex/api/routes/v1/im_ingress.py
@@ -419,6 +419,7 @@ async def _handle_card_action(
             operator_open_id=action.operator_open_id,
             question_id=action.question_id,
             answer_key=action.answer_key,
+            answers=getattr(action, "answers", None),
             run_manager=run_manager,
         )
     except Exception:

--- a/backend/cubeplex/im/card_model.py
+++ b/backend/cubeplex/im/card_model.py
@@ -48,6 +48,23 @@ class ArtifactItem:
 
 
 @dataclass(slots=True)
+class AskFormField:
+    """One cubepi ``ask_user`` question projected for platform form renderers.
+
+    Feishu CardKit can collect every field in one form submit; other IM
+    platforms still only handle the simple single-select button path and
+    ignore this list.
+    """
+
+    key: str
+    prompt: str
+    kind: Literal["single_select", "multi_select", "input"]
+    options: list[tuple[str, str]] = field(default_factory=list)
+    """``(label, value)`` pairs for select kinds; empty for free-text input."""
+    required: bool = True
+
+
+@dataclass(slots=True)
 class PendingInput:
     """An awaiting-user-input prompt rendered as an interactive element."""
 
@@ -68,16 +85,31 @@ class PendingInput:
     machine values like ``yes`` / ``no`` with human-readable labels like
     ``Yes`` / ``No``. Rendering the value as button text would force the
     user to choose between machine tokens.
+
+    Populated only for the simple single-question single-select path that
+    one-click buttons can answer. Multi-question / multi-select / free-text
+    leave this empty; Feishu uses ``fields`` instead.
     """
+    fields: list[AskFormField] = field(default_factory=list)
+    """Full ask_user question list for form-capable platforms (Feishu)."""
     question_id: str | None = None
     """cubepi-side identifier for matching the resume call."""
     answer_key: str | None = None
     """cubepi form schema key (questions[0].key for ask_user). The resume call
     builds the answer dict as {answer_key: choice} — without this, cubepi
-    rejects the answer because our key won't match its schema."""
+    rejects the answer because our key won't match its schema. Unused when
+    the form path submits a full answers dict."""
     resolved_choice: str | None = None
     resolved_by_open_id: str | None = None
     resolved_at_iso: str | None = None
+
+    def needs_form(self) -> bool:
+        """True when one-click buttons cannot submit a complete answer."""
+        if self.kind != "ask_user" or not self.fields:
+            return False
+        if len(self.fields) > 1:
+            return True
+        return self.fields[0].kind in ("multi_select", "input")
 
 
 @dataclass(slots=True)
@@ -136,6 +168,7 @@ class CardState:
 
 __all__ = [
     "ArtifactItem",
+    "AskFormField",
     "CardState",
     "PendingInput",
     "SubAgentRow",

--- a/backend/cubeplex/im/feishu/card_action_router.py
+++ b/backend/cubeplex/im/feishu/card_action_router.py
@@ -30,6 +30,10 @@ class ActionPayload:
     question_id: str = ""
     answer_key: str = ""
     """cubepi form-schema key the resume call uses to build {answer_key: choice}."""
+    answers: dict[str, Any] | None = None
+    """Full answer dict from a form submit (multi-question / multi-select /
+    free-text). When set, resume passes this through as the cubepi answer
+    instead of wrapping ``choice`` under ``answer_key``."""
 
 
 @dataclass(slots=True, frozen=True)
@@ -40,6 +44,28 @@ class ResumeAction:
     operator_open_id: str
     question_id: str = ""
     answer_key: str = ""
+    answers: dict[str, Any] | None = None
+
+
+def _normalize_form_value(form_value: dict[str, Any]) -> dict[str, Any]:
+    """Drop submit-button noise and keep only user-filled field values.
+
+    Feishu form_value keys match each field's ``name`` (we set those to the
+    cubepi question keys). Multi-select returns a list; select/input return
+    scalars. Empty strings for optional fields are kept so cubepi can decide.
+    """
+    answers: dict[str, Any] = {}
+    for key, value in form_value.items():
+        # Skip the submit button's own name if Feishu includes it.
+        if key in ("ask_user_submit", "Button_submit"):
+            continue
+        if value is None:
+            continue
+        if isinstance(value, list):
+            answers[str(key)] = [str(v) for v in value]
+        else:
+            answers[str(key)] = str(value)
+    return answers
 
 
 def parse_action_payload(event: dict[str, Any]) -> ActionPayload:
@@ -49,12 +75,36 @@ def parse_action_payload(event: dict[str, Any]) -> ActionPayload:
         raise InvalidAction("missing operator.open_id")
     action = event.get("action") or {}
     value = action.get("value") or {}
+    if not isinstance(value, dict):
+        value = {}
     kind_raw = str(value.get("action") or "")
     if kind_raw not in ("ask_user", "sandbox_confirm"):
         raise InvalidAction(f"unknown action kind: {kind_raw!r}")
     run_id = str(value.get("run_id") or "")
+    if not run_id:
+        raise InvalidAction("missing run_id")
+
+    # Form submit: action.form_value holds {question_key: answer, ...}.
+    # The submit button's callback value carries action/run_id/question_id
+    # but no single ``choice`` — multi-field answers live only in form_value.
+    form_value = action.get("form_value")
+    answers: dict[str, Any] | None = None
+    if isinstance(form_value, dict) and form_value:
+        answers = _normalize_form_value(form_value)
+        if not answers:
+            raise InvalidAction("empty form_value")
+        return ActionPayload(
+            kind=kind_raw,  # type: ignore[arg-type]
+            run_id=run_id,
+            choice="",
+            operator_open_id=operator_open_id,
+            question_id=str(value.get("question_id") or ""),
+            answer_key="",
+            answers=answers,
+        )
+
     choice = str(value.get("choice") or "")
-    if not run_id or not choice:
+    if not choice:
         raise InvalidAction("missing run_id or choice")
     return ActionPayload(
         kind=kind_raw,  # type: ignore[arg-type]
@@ -89,6 +139,7 @@ def dispatch(
         operator_open_id=payload.operator_open_id,
         question_id=payload.question_id,
         answer_key=payload.answer_key,
+        answers=payload.answers,
     )
 
 

--- a/backend/cubeplex/im/feishu/card_model.py
+++ b/backend/cubeplex/im/feishu/card_model.py
@@ -5,6 +5,7 @@ The canonical definitions now live in ``cubeplex.im.card_model``.
 
 from cubeplex.im.card_model import (
     ArtifactItem,
+    AskFormField,
     CardState,
     PendingInput,
     SubAgentRow,
@@ -13,6 +14,7 @@ from cubeplex.im.card_model import (
 
 __all__ = [
     "ArtifactItem",
+    "AskFormField",
     "CardState",
     "PendingInput",
     "SubAgentRow",

--- a/backend/cubeplex/im/feishu/card_renderer.py
+++ b/backend/cubeplex/im/feishu/card_renderer.py
@@ -412,6 +412,105 @@ def _artifacts_panel(state: CardState) -> dict[str, Any]:
     }
 
 
+def _option_objects(options: list[tuple[str, str]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "text": {"tag": "plain_text", "content": label[:100] or value[:100]},
+            "value": value,
+        }
+        for label, value in options
+        if value
+    ]
+
+
+def _render_form_field(field: Any, *, index: int) -> list[dict[str, Any]]:
+    """Project one AskFormField into Feishu form child elements.
+
+    Select components have no ``label``; put the prompt as a div above.
+    Input supports ``label`` natively.
+    """
+    # element_id: letters/numbers/underscore, start with letter, ≤20 chars.
+    eid = f"ask_f_{index}"
+    name = field.key
+    elements: list[dict[str, Any]] = []
+    if field.kind == "input":
+        elements.append(
+            {
+                "tag": "input",
+                "element_id": eid,
+                "name": name,
+                "required": field.required,
+                "width": "fill",
+                "input_type": "multiline_text",
+                "rows": 2,
+                "placeholder": {"tag": "plain_text", "content": "请输入"},
+                "label": {
+                    "tag": "plain_text",
+                    "content": (field.prompt or name)[:200],
+                },
+            }
+        )
+        return elements
+
+    if field.prompt:
+        elements.append(
+            {
+                "tag": "div",
+                "text": {"tag": "lark_md", "content": field.prompt},
+            }
+        )
+    tag = "multi_select_static" if field.kind == "multi_select" else "select_static"
+    elements.append(
+        {
+            "tag": tag,
+            "element_id": eid,
+            "name": name,
+            "required": field.required,
+            "width": "fill",
+            "placeholder": {"tag": "plain_text", "content": "请选择"},
+            "options": _option_objects(list(field.options)),
+        }
+    )
+    return elements
+
+
+def _render_ask_form(pending: PendingInput) -> dict[str, Any]:
+    """CardKit form: collect every ask_user field, submit once.
+
+    form_value keys are the cubepi question keys, so the resume path can
+    pass the dict straight through as the cubepi answer.
+    """
+    form_elements: list[dict[str, Any]] = []
+    for i, field in enumerate(pending.fields):
+        form_elements.extend(_render_form_field(field, index=i))
+
+    submit_value: dict[str, Any] = {
+        "action": pending.kind,
+        "run_id": pending.run_id,
+        "form": True,
+    }
+    if pending.question_id:
+        submit_value["question_id"] = pending.question_id
+    form_elements.append(
+        {
+            "tag": "button",
+            "element_id": "ask_submit",
+            "name": "ask_user_submit",
+            "text": {"tag": "plain_text", "content": "提交"},
+            "type": "primary",
+            "width": "fill",
+            "form_action_type": "submit",
+            "behaviors": [{"type": "callback", "value": submit_value}],
+        }
+    )
+    return {
+        "tag": "form",
+        "element_id": "pending_input",
+        "name": "ask_user_form",
+        "elements": form_elements,
+    }
+
+
 def _render_pending_input(pending: PendingInput) -> dict[str, Any]:
     if pending.resolved_choice is not None:
         receipt = (
@@ -419,14 +518,26 @@ def _render_pending_input(pending: PendingInput) -> dict[str, Any]:
             + (f" · 由 {pending.resolved_by_open_id} 操作" if pending.resolved_by_open_id else "")
             + (f" · {pending.resolved_at_iso}" if pending.resolved_at_iso else "")
         )
+        # After resolve, show the clean field prompts (not the web-client
+        # notice that non-form platforms bake into pending.question).
+        header = pending.question
+        if pending.fields:
+            header = "\n\n".join(f.prompt for f in pending.fields if f.prompt) or header
         return {
             "tag": "interactive_container",
             "element_id": "pending_input",
             "elements": [
-                {"tag": "div", "text": {"tag": "lark_md", "content": pending.question}},
+                {"tag": "div", "text": {"tag": "lark_md", "content": header}},
                 {"tag": "div", "text": {"tag": "lark_md", "content": receipt}},
             ],
         }
+
+    # Form path: multi-question / multi-select / free-text — one submit
+    # returns the full answers dict. Single-select one-click buttons stay
+    # below for the common yes/no case.
+    if pending.needs_form():
+        return _render_ask_form(pending)
+
     body_elements: list[dict[str, Any]] = [
         {"tag": "div", "text": {"tag": "lark_md", "content": pending.question}},
     ]

--- a/backend/cubeplex/im/outbound.py
+++ b/backend/cubeplex/im/outbound.py
@@ -56,6 +56,20 @@ class OutboundOp:
     final: bool = False
 
 
+def _label_for_option(pending: Any, answer_key: str, value: str) -> str:
+    """Map a machine answer value back to a human label when we have one."""
+    for lbl, val, _ in pending.choices:
+        if val == value:
+            return str(lbl)
+    for field in getattr(pending, "fields", None) or []:
+        if field.key != answer_key:
+            continue
+        for lbl, val in field.options:
+            if val == value:
+                return str(lbl)
+    return value or "answered"
+
+
 def fold_event(event: dict[str, Any], state: RenderState, *, now: float) -> OutboundOp | None:
     """Fold one cubepi run event into ``state.card_state``.
 
@@ -253,64 +267,88 @@ def fold_event(event: dict[str, Any], state: RenderState, *, now: float) -> Outb
         return None
 
     if etype == "ask_user_request":
-        from cubeplex.im.card_model import PendingInput
+        from cubeplex.im.card_model import AskFormField, PendingInput
 
         question_id = str(data.get("question_id") or "")
         questions_list = data.get("questions") or []
-        if questions_list and isinstance(questions_list, list):
-            first = questions_list[0] if isinstance(questions_list[0], dict) else {}
-        else:
-            first = {}
+        if not isinstance(questions_list, list):
+            questions_list = []
+
+        # Project every question into AskFormField so form-capable platforms
+        # (Feishu) can collect multi-select / free-text / multi-question in
+        # one submit. Button-only platforms still use ``choices`` below.
+        fields: list[AskFormField] = []
+        for q in questions_list:
+            if not isinstance(q, dict):
+                continue
+            key = str(q.get("key") or "")
+            if not key:
+                continue
+            q_prompt = str(q.get("prompt") or "")
+            multi_select = bool(q.get("multi_select"))
+            required = bool(q.get("required", True))
+            raw_opts = q.get("options") or []
+            options: list[tuple[str, str]] = []
+            if isinstance(raw_opts, list):
+                for opt in raw_opts:
+                    if isinstance(opt, str) and opt:
+                        options.append((opt, opt))
+                    elif isinstance(opt, dict):
+                        value = str(opt.get("value") or opt.get("key") or opt.get("label") or "")
+                        label = str(opt.get("label") or opt.get("value") or opt.get("key") or "")
+                        if value:
+                            options.append((label, value))
+            if multi_select and options:
+                kind: Literal["single_select", "multi_select", "input"] = "multi_select"
+            elif options:
+                kind = "single_select"
+            else:
+                kind = "input"
+            fields.append(
+                AskFormField(
+                    key=key,
+                    prompt=q_prompt,
+                    kind=kind,
+                    options=options,
+                    required=required,
+                )
+            )
+
+        first = questions_list[0] if questions_list and isinstance(questions_list[0], dict) else {}
         prompt = str(first.get("prompt") or "")
-        more = len(questions_list) - 1 if len(questions_list) > 1 else 0
+        more = len(fields) - 1 if len(fields) > 1 else 0
         if more > 0:
             prompt = f"{prompt}\n\n_(+{more} more question{'s' if more > 1 else ''})_"
-        # cubepi expects the answer dict keyed by `questions[*].key`. v1
-        # captures questions[0].key so the resume path can rebuild the
-        # right shape; multi-question forms fall back to questions[0].
+        # Button path still keys the single-choice resume on questions[0].key.
         answer_key = str(first.get("key") or "") or None
-        raw_options = first.get("options") or []
-        # Each choice is (label, value, button_type):
-        # - label is what the user reads on the button (option's ``label``)
-        # - value is what cubepi receives back in the answer dict (option's
-        #   ``value`` — falling back to ``key`` for legacy fixtures, then
-        #   ``label`` if neither is set)
-        # - button_type is the Feishu styling hint
-        # Keeping label and value separate matters for {label:"Yes", value:"yes"}
-        # — sending "Yes" back would mismatch cubepi's schema.
+
+        # One-click buttons only work for a single single-select question.
+        # multi_select needs a list; free-text needs an input; multi-question
+        # needs every key filled. Those go through the form path (Feishu) or
+        # the web-client notice (other IM platforms).
         choices: list[tuple[str, str, str]] = []
-        # multi_select=True questions need a list answer; a single Feishu card
-        # button can only ship one scalar. The free-form fallback below
-        # already routes to the web client — reuse it by skipping option
-        # parsing so the renderer shows the notice instead of buttons that
-        # would only send one of the N required selections.
-        multi_select = bool(first.get("multi_select"))
-        # Multi-QUESTION forms (questions list has 2+ entries) also can't be
-        # answered via a single button row: the click would submit only
-        # questions[0]'s answer and cubepi would reject or mis-resume the
-        # incomplete form. Treat like free-form / multi-select and route to
-        # the web client.
-        multi_question = len(questions_list) > 1
-        if isinstance(raw_options, list) and not multi_select and not multi_question:
-            for opt in raw_options:
-                if isinstance(opt, str) and opt:
-                    # Bare-string options collapse: the same string is both
-                    # the human label and the schema value.
-                    choices.append((opt, opt, "default"))
-                elif isinstance(opt, dict):
-                    value = str(opt.get("value") or opt.get("key") or opt.get("label") or "")
-                    label = str(opt.get("label") or opt.get("value") or opt.get("key") or "")
-                    btn_type = str(opt.get("type") or "default")
-                    if value:
-                        choices.append((label, value, btn_type))
-        # Free-form (no options) and multi-select questions cannot be answered
-        # via a single card button. The old "OK" fallback was misleading: clicking
-        # it sent ``{key: "ok"}`` which cubepi either rejected as a schema
-        # mismatch or silently treated as the wrong value for a path/filename/date
-        # prompt. v1 doesn't render text input via CardKit; append a notice and
-        # leave ``choices`` empty so the renderer surfaces the "(等待响应)" hint
-        # instead of a bogus button. The user answers through the web client.
+        simple_button = (
+            len(fields) == 1 and fields[0].kind == "single_select" and bool(fields[0].options)
+        )
+        if simple_button:
+            raw_options = first.get("options") or []
+            if isinstance(raw_options, list):
+                for opt in raw_options:
+                    if isinstance(opt, str) and opt:
+                        choices.append((opt, opt, "default"))
+                    elif isinstance(opt, dict):
+                        value = str(opt.get("value") or opt.get("key") or opt.get("label") or "")
+                        label = str(opt.get("label") or opt.get("value") or opt.get("key") or "")
+                        btn_type = str(opt.get("type") or "default")
+                        if value:
+                            choices.append((label, value, btn_type))
+
+        # Non-form platforms still show a web-client notice when buttons
+        # can't complete the form. Feishu's form renderer uses ``fields``
+        # and ignores this notice text.
         if not choices:
+            multi_question = len(fields) > 1
+            multi_select = any(f.kind == "multi_select" for f in fields)
             if multi_question:
                 notice = "_(此问需多题作答，请在 CubePlex 网页端继续。)_"
             elif multi_select:
@@ -318,11 +356,13 @@ def fold_event(event: dict[str, Any], state: RenderState, *, now: float) -> Outb
             else:
                 notice = "_(此问题需要文本输入；请在 CubePlex 网页端继续。)_"
             prompt = f"{prompt}\n\n{notice}" if prompt else notice
+
         state.card_state.pending_input = PendingInput(
             kind="ask_user",
             run_id=state.run_id,
             question=prompt,
             choices=choices,
+            fields=fields,
             question_id=question_id,
             answer_key=answer_key,
         )
@@ -362,15 +402,22 @@ def fold_event(event: dict[str, Any], state: RenderState, *, now: float) -> Outb
         elif etype == "sandbox_confirm_resolved":
             resolved = str(data.get("decision") or "")
         else:
-            # data["answers"] is {answer_key: machine_value} — look up the
-            # human-readable label so the receipt shows what the user chose.
+            # data["answers"] is {answer_key: machine_value} (or multi-key for
+            # form submits). Prefer human labels from choices / fields.
             answers = data.get("answers") or {}
-            chosen_value = next(iter(answers.values()), "") if isinstance(answers, dict) else ""
-            label = next(
-                (lbl for lbl, val, _ in pending.choices if val == chosen_value),
-                chosen_value or "answered",
-            )
-            resolved = label
+            if isinstance(answers, dict) and answers:
+                parts: list[str] = []
+                for akey, aval in answers.items():
+                    if isinstance(aval, list):
+                        labels = [_label_for_option(pending, akey, str(v)) for v in aval]
+                        parts.append(", ".join(labels) if labels else str(aval))
+                    else:
+                        parts.append(_label_for_option(pending, akey, str(aval)))
+                resolved = (
+                    "; ".join(parts) if len(parts) > 1 else (parts[0] if parts else "answered")
+                )
+            else:
+                resolved = "answered"
         pending.resolved_choice = resolved
         state.card_state.hitl_resolved = True
         state.last_patch_monotonic = now

--- a/backend/cubeplex/im/resume.py
+++ b/backend/cubeplex/im/resume.py
@@ -84,6 +84,7 @@ async def resume_paused_run(
     operator_open_id: str,
     question_id: str = "",
     answer_key: str = "",
+    answers: dict[str, Any] | None = None,
     run_manager: Any,
     **_: Any,
 ) -> bool:
@@ -144,15 +145,22 @@ async def resume_paused_run(
             reason=f"via Feishu card (operator={operator_open_id})",
         )
     elif input_kind == "ask_user":
-        # cubepi ask_user expects a dict keyed by the question's `key`
-        # (the form schema). The renderer plumbs questions[0].key through
-        # the button payload → ActionPayload → ResumeAction → here. If
-        # the question carried no key (defensive fallback for malformed
-        # payloads or single-key prompts), drop in "choice" so cubepi
-        # gets a syntactically valid dict; a schema mismatch is then
-        # cubepi's to report, not ours.
-        key = answer_key or "choice"
-        answer = {key: choice}
+        # Form path (Feishu multi-question / multi-select / free-text): the
+        # card action already built the full {key: value} dict from
+        # form_value. Button path still wraps a single choice under
+        # questions[0].key.
+        if answers is not None:
+            answer = answers
+        else:
+            # cubepi ask_user expects a dict keyed by the question's `key`
+            # (the form schema). The renderer plumbs questions[0].key through
+            # the button payload → ActionPayload → ResumeAction → here. If
+            # the question carried no key (defensive fallback for malformed
+            # payloads or single-key prompts), drop in "choice" so cubepi
+            # gets a syntactically valid dict; a schema mismatch is then
+            # cubepi's to report, not ours.
+            key = answer_key or "choice"
+            answer = {key: choice}
     else:
         logger.warning("[resume] unknown input_kind={}", input_kind)
         return False

--- a/backend/tests/im/feishu/test_card_action_router.py
+++ b/backend/tests/im/feishu/test_card_action_router.py
@@ -134,3 +134,57 @@ def test_dispatch_sandbox_confirm_maps_to_sandbox_decision() -> None:
     assert action.input_kind == "sandbox_confirm"
     assert action.choice == "approve"
     assert action.question_id == "qsc_1"
+
+
+def test_parse_payload_form_submit_extracts_answers() -> None:
+    event = {
+        "operator": {"open_id": "ou_user_1"},
+        "action": {
+            "tag": "button",
+            "name": "ask_user_submit",
+            "value": {
+                "action": "ask_user",
+                "run_id": "run_1",
+                "question_id": "q_form",
+                "form": True,
+            },
+            "form_value": {
+                "k1": "yes",
+                "k2": "hello",
+                "tags": ["a", "b"],
+            },
+        },
+    }
+    parsed = parse_action_payload(event)
+    assert parsed.kind == "ask_user"
+    assert parsed.run_id == "run_1"
+    assert parsed.choice == ""
+    assert parsed.question_id == "q_form"
+    assert parsed.answers == {"k1": "yes", "k2": "hello", "tags": ["a", "b"]}
+
+
+def test_parse_payload_form_submit_rejects_empty_form_value() -> None:
+    with pytest.raises(InvalidAction):
+        parse_action_payload(
+            {
+                "operator": {"open_id": "ou_x"},
+                "action": {
+                    "value": {"action": "ask_user", "run_id": "r", "form": True},
+                    "form_value": {"ask_user_submit": "x"},
+                },
+            }
+        )
+
+
+def test_dispatch_form_answers_pass_through() -> None:
+    payload = ActionPayload(
+        kind="ask_user",
+        run_id="run_1",
+        choice="",
+        operator_open_id="ou_x",
+        question_id="q_1",
+        answers={"name": "alice", "tags": ["a"]},
+    )
+    action = dispatch(payload, expected_responder_open_id="ou_x")
+    assert action is not None
+    assert action.answers == {"name": "alice", "tags": ["a"]}

--- a/backend/tests/im/feishu/test_card_renderer_layout.py
+++ b/backend/tests/im/feishu/test_card_renderer_layout.py
@@ -146,6 +146,52 @@ def test_pending_input_renders_buttons_with_payload() -> None:
     assert "approve_deploy" in s
 
 
+def test_pending_input_form_renders_select_input_and_multi() -> None:
+    """Multi-question / multi-select / free-text use a CardKit form so the
+    user can submit every field in one click.
+    """
+    from cubeplex.im.feishu.card_model import AskFormField
+
+    state = _empty_state()
+    state.pending_input = PendingInput(
+        kind="ask_user",
+        run_id="run_form",
+        question="fill me\n\n_(网页端)_",
+        choices=[],
+        fields=[
+            AskFormField(
+                key="pick",
+                prompt="Pick one",
+                kind="single_select",
+                options=[("Yes", "yes"), ("No", "no")],
+            ),
+            AskFormField(
+                key="tags",
+                prompt="Tags",
+                kind="multi_select",
+                options=[("A", "a"), ("B", "b")],
+            ),
+            AskFormField(key="name", prompt="Your name", kind="input"),
+        ],
+        question_id="q_form",
+    )
+    card = render(state)
+    form = next(e for e in card["body"]["elements"] if e.get("element_id") == "pending_input")
+    assert form["tag"] == "form"
+    tags = [el.get("tag") for el in form["elements"]]
+    assert "select_static" in tags
+    assert "multi_select_static" in tags
+    assert "input" in tags
+    assert "button" in tags
+    submit = next(el for el in form["elements"] if el.get("tag") == "button")
+    assert submit.get("form_action_type") == "submit"
+    assert submit["behaviors"][0]["value"]["run_id"] == "run_form"
+    assert submit["behaviors"][0]["value"]["question_id"] == "q_form"
+    # Field names are cubepi keys so form_value maps 1:1 to the answer dict.
+    names = {el.get("name") for el in form["elements"] if el.get("name")}
+    assert {"pick", "tags", "name", "ask_user_submit"} <= names
+
+
 def test_pending_input_button_text_is_label_value_carries_schema_key() -> None:
     """The button TEXT must be the human label; the button VALUE.choice must
     carry the schema value. Otherwise users pick between machine tokens.

--- a/backend/tests/im/feishu/test_im_ingress_card_action.py
+++ b/backend/tests/im/feishu/test_im_ingress_card_action.py
@@ -70,9 +70,70 @@ async def test_card_action_dispatch_calls_resume(monkeypatch: pytest.MonkeyPatch
             "operator_open_id": "ou_user_1",
             "question_id": "q_1",
             "answer_key": "approve_deploy",
+            "answers": None,
             "run_manager": rm,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_card_action_form_submit_passes_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from cubeplex.api.routes.v1 import im_ingress
+
+    resume_calls: list[dict[str, Any]] = []
+
+    async def fake_resume(**kwargs: Any) -> bool:
+        resume_calls.append(kwargs)
+        return True
+
+    monkeypatch.setattr(im_ingress, "resume_paused_run", fake_resume)
+
+    redis_state: dict[str, str] = {
+        "cubeplex-dev:run:run_1:awaiting_responder": "ou_user_1",
+    }
+
+    async def fake_get(key: str) -> str | None:
+        return redis_state.get(key)
+
+    async def fake_setnx(key: str, value: str, ex: int) -> bool:
+        if key in redis_state:
+            return False
+        redis_state[key] = value
+        return True
+
+    monkeypatch.setattr(im_ingress, "_redis_get", fake_get)
+    monkeypatch.setattr(im_ingress, "_redis_setnx", fake_setnx)
+
+    event = {
+        "header": {"event_type": "card.action.trigger"},
+        "event": {
+            "token": "tok_form",
+            "operator": {"open_id": "ou_user_1"},
+            "action": {
+                "value": {
+                    "action": "ask_user",
+                    "run_id": "run_1",
+                    "question_id": "q_form",
+                    "form": True,
+                },
+                "form_value": {"k1": "yes", "name": "alice", "tags": ["a", "b"]},
+            },
+        },
+    }
+    rm = _FakeRunManager()
+    handled, toast = await im_ingress._handle_card_action(
+        event, run_manager=rm, redis_key_prefix="cubeplex-dev"
+    )
+    assert handled is True
+    assert toast is None
+    assert resume_calls[0]["answers"] == {
+        "k1": "yes",
+        "name": "alice",
+        "tags": ["a", "b"],
+    }
+    assert resume_calls[0]["question_id"] == "q_form"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/im/test_fold_event_terminal.py
+++ b/backend/tests/im/test_fold_event_terminal.py
@@ -40,6 +40,9 @@ def test_ask_user_request_populates_pending_input() -> None:
     assert pending.question_id == "q_1"
     assert pending.answer_key == "choice"
     assert pending.choices == [("yes", "yes", "default"), ("no", "no", "default")]
+    assert pending.needs_form() is False
+    assert len(pending.fields) == 1
+    assert pending.fields[0].kind == "single_select"
     assert op is not None and op.kind == "patch_card"
 
 
@@ -115,10 +118,10 @@ def test_ask_user_request_prefers_value_over_label_for_callback() -> None:
     ]
 
 
-def test_ask_user_multi_question_routes_to_web_client_notice() -> None:
-    """Multi-question asks (questions list has 2+ entries) can't be answered
-    with a single button row — the click would only submit questions[0].
-    Route to the web client.
+def test_ask_user_multi_question_populates_fields_and_needs_form() -> None:
+    """Multi-question asks cannot use one-click buttons; fields are populated
+    so Feishu can render a form. Non-form platforms still see a web notice
+    baked into ``question``.
     """
     state = _state_with_card()
     fold_event(
@@ -142,13 +145,16 @@ def test_ask_user_multi_question_routes_to_web_client_notice() -> None:
     pending = state.card_state.pending_input
     assert pending is not None
     assert pending.choices == []
+    assert pending.needs_form() is True
+    assert len(pending.fields) == 2
+    assert pending.fields[0].kind == "single_select"
+    assert pending.fields[1].kind == "input"
     assert "网页端" in pending.question
 
 
-def test_ask_user_multi_select_routes_to_web_client_notice() -> None:
-    """Multi-select questions need a list answer; a single card-button click
-    can only ship one scalar. Treat them like the free-form case — surface
-    a notice pointing to the web client and skip the buttons.
+def test_ask_user_multi_select_populates_fields_and_needs_form() -> None:
+    """Multi-select questions need a list answer; populate fields for the
+    Feishu form path and skip one-click buttons.
     """
     state = _state_with_card()
     fold_event(
@@ -172,14 +178,16 @@ def test_ask_user_multi_select_routes_to_web_client_notice() -> None:
     pending = state.card_state.pending_input
     assert pending is not None
     assert pending.choices == []
+    assert pending.needs_form() is True
+    assert pending.fields[0].kind == "multi_select"
+    assert pending.fields[0].options == [("A", "a"), ("B", "b")]
     assert "多选" in pending.question and "网页端" in pending.question
 
 
-def test_ask_user_request_with_no_options_renders_text_input_notice() -> None:
+def test_ask_user_request_with_no_options_populates_input_field() -> None:
     """Free-form questions (no options) cannot be answered via card buttons.
-    Instead of synthesizing a misleading "OK" button (which would send the
-    string "ok" back to cubepi and fail the schema), the renderer surfaces
-    a notice pointing the user to the web client.
+    Populate an input field for Feishu; non-form platforms still see the
+    web-client notice in ``question``.
     """
     state = _state_with_card()
     fold_event(
@@ -196,6 +204,9 @@ def test_ask_user_request_with_no_options_renders_text_input_notice() -> None:
     pending = state.card_state.pending_input
     assert pending is not None
     assert pending.choices == []
+    assert pending.needs_form() is True
+    assert pending.fields[0].kind == "input"
+    assert pending.fields[0].key == "freeform"
     assert "网页端" in pending.question
 
 

--- a/backend/tests/im/test_resume.py
+++ b/backend/tests/im/test_resume.py
@@ -113,6 +113,37 @@ async def test_resume_paused_run_ask_user_passes_choice_dict(
 
 
 @pytest.mark.asyncio
+async def test_resume_paused_run_ask_user_passes_full_answers_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Form submit path: resume with the full answers dict from form_value."""
+    from cubeplex.im import resume as resume_mod
+
+    seen: list[dict[str, Any]] = []
+
+    class _FakeRunManager:
+        async def resume_run_with_answer(self, **kwargs: Any) -> str:
+            seen.append(kwargs)
+            return "new_run_xyz"
+
+    async def fake_resolve(_: str) -> tuple[str, str, str, str, str | None, bool] | None:
+        return ("conv_1", "user_1", "org_1", "ws_1", None, False)
+
+    monkeypatch.setattr(resume_mod, "_resolve_run_context", fake_resolve)
+    answers = {"k1": "yes", "k2": "hello", "tags": ["a", "b"]}
+    ok = await resume_mod.resume_paused_run(
+        run_id="run_1",
+        input_kind="ask_user",
+        choice="",
+        operator_open_id="ou_x",
+        question_id="q_1",
+        answers=answers,
+        run_manager=_FakeRunManager(),
+    )
+    assert ok is True
+    assert seen[0]["answer"] == answers
+
+
 async def test_resume_paused_run_ask_user_falls_back_to_choice_key_when_no_answer_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Feishu CardKit form now answers multi-question, multi-select, and free-text `ask_user` prompts in-chat (no web redirect for those cases).
- Simple single-select single-question keeps one-click buttons.
- Form `form_value` maps 1:1 to cubepi’s answers dict (`{key: value | list}`) via resume.

Other IM platforms are unchanged: they still surface the web-client notice when buttons cannot complete the form.

## Test plan

- [x] Unit: fold_event fields / needs_form for multi / multi_select / input
- [x] Unit: Feishu form render (select_static, multi_select_static, input, submit)
- [x] Unit: form_value parse → answers; resume_paused_run full dict
- [x] Unit: ingress form submit path
- [x] `make check-ci` (pre-push)
- [x] Manual: trigger multi-question ask_user in Feishu and submit the form
- [x] Manual: multi_select and free-text input still resume the run