### PR TITLE
Fix Feishu form submit: forward form_value on long connection

### DIFF
--- a/backend/cubeplex/im/feishu/long_connection.py
+++ b/backend/cubeplex/im/feishu/long_connection.py
@@ -92,6 +92,60 @@ def _install_graceful_shutdown_receiver(
     client._receive_message_loop = MethodType(_receive_message_loop, client)
 
 
+def _as_plain_dict(raw: Any) -> dict[str, Any]:
+    """Coerce an SDK object / Mapping into a plain dict of JSON-ish values."""
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return dict(raw)
+    # lark_oapi models sometimes expose a to_dict / __dict__ of fields.
+    to_dict = getattr(raw, "to_dict", None)
+    if callable(to_dict):
+        try:
+            out = to_dict()
+            if isinstance(out, dict):
+                return dict(out)
+        except Exception:
+            pass
+    items = getattr(raw, "items", None)
+    if callable(items):
+        try:
+            return {str(k): v for k, v in items()}
+        except Exception:
+            pass
+    as_dict = getattr(raw, "__dict__", None)
+    if isinstance(as_dict, dict) and as_dict:
+        return {
+            str(k): v for k, v in as_dict.items() if not str(k).startswith("_") and v is not None
+        }
+    return {}
+
+
+def _action_to_dict(action: Any) -> dict[str, Any]:
+    """Project the SDK action object into the webhook-shaped action dict.
+
+    Button clicks only need ``value``. Form submits also carry
+    ``form_value`` (the filled fields keyed by form item ``name``). The
+    previous shim only forwarded ``value``, so multi-question / input
+    submits hit parse_action_payload as ``missing run_id or choice``
+    (run_id present, choice empty, form_value dropped).
+    """
+    out: dict[str, Any] = {"value": _as_plain_dict(getattr(action, "value", None))}
+    form_value = getattr(action, "form_value", None)
+    if form_value is None and isinstance(action, dict):
+        form_value = action.get("form_value")
+    fv = _as_plain_dict(form_value) if form_value is not None else {}
+    if fv:
+        out["form_value"] = fv
+    for attr in ("tag", "name"):
+        val = getattr(action, attr, None)
+        if val is None and isinstance(action, dict):
+            val = action.get(attr)
+        if val is not None and val != "":
+            out[attr] = str(val)
+    return out
+
+
 async def _lc_handle_card_action(event: Any, *, run_manager: Any, redis_key_prefix: str) -> Any:
     """Glue: convert the SDK's P2CardActionTrigger event into the dict
     envelope that ``_handle_card_action`` (the webhook ingress) accepts,
@@ -132,11 +186,7 @@ async def _lc_handle_card_action(event: Any, *, run_manager: Any, redis_key_pref
                     if operator is not None
                     else {}
                 ),
-                "action": (
-                    {"value": dict(getattr(action, "value", {}) or {})}
-                    if action is not None
-                    else {}
-                ),
+                "action": _action_to_dict(action) if action is not None else {},
             },
         }
 

--- a/backend/tests/im/feishu/test_long_connection_card_action.py
+++ b/backend/tests/im/feishu/test_long_connection_card_action.py
@@ -83,6 +83,58 @@ async def test_lc_handler_builds_envelope_and_calls_ingress(
 
 
 @pytest.mark.asyncio
+async def test_lc_handler_forwards_form_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Form submit callbacks put answers in action.form_value, not choice.
+
+    The LC shim must forward form_value or parse_action_payload rejects the
+    submit as ``missing run_id or choice`` (value has run_id + form marker
+    but no choice).
+    """
+    from cubeplex.im.feishu import long_connection as lc
+
+    seen: list[dict[str, Any]] = []
+
+    async def fake_handler(
+        envelope: dict[str, Any], *, run_manager: Any = None, redis_key_prefix: str = ""
+    ) -> tuple[bool, str | None]:
+        seen.append(envelope)
+        return True, None
+
+    monkeypatch.setattr(lc, "_handle_card_action", fake_handler)
+
+    class _Op:
+        open_id = "ou_user_1"
+
+    class _Action:
+        value = {
+            "action": "ask_user",
+            "run_id": "run_1",
+            "question_id": "q_form",
+            "form": True,
+        }
+        form_value = {"name": "alice", "tags": ["a", "b"]}
+        name = "ask_user_submit"
+        tag = "button"
+
+    class _Data:
+        operator = _Op()
+        token = "tok_form"
+        action = _Action()
+
+    class _Event:
+        event = _Data()
+
+    await lc._lc_handle_card_action(_Event(), run_manager=None, redis_key_prefix="cubeplex-dev")
+    action = seen[0]["event"]["action"]
+    assert action["value"]["run_id"] == "run_1"
+    assert action["form_value"] == {"name": "alice", "tags": ["a", "b"]}
+    assert action["name"] == "ask_user_submit"
+    assert "choice" not in action["value"]
+
+
+@pytest.mark.asyncio
 async def test_lc_handler_carries_toast_when_set(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Long-connection card-action shim only forwarded `action.value`, dropping `form_value`.
- CardKit form submits (multi-question / multi-select / free-text) therefore hit `parse_action_payload` as `missing run_id or choice` → toast「未知操作」.
- Forward `form_value` (and `name`/`tag`) so resume gets the full answers dict.

## Root cause

Default Feishu ingress is long connection. Webhook path already receives the full event body; LC rebuilt a partial envelope:

```python
{"value": dict(action.value)}  # form_value dropped
```

## Test plan

- [x] Unit: LC shim forwards `form_value` for form submits
- [x] Existing card_action / ingress form tests still pass
- [x] pre-push check-ci
- [ ] Manual: submit multi/input ask_user form in Feishu after deploy; run resumes without「未知操作」