### PR TITLE
Bump cubepi pin to 0.13.4

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -187,7 +187,7 @@ exclude_lines = [
 [tool.uv.sources]
 # Path-linked sibling project; never resolved from an index.
 cubeplex-ee = { path = "ee", editable = true }
-cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "c63c545b16122d2a72cec558851cefe90337bd41" }
+cubepi = { git = "https://github.com/cubeplexai/cubepi.git", rev = "3dfe578592acc79dd56b786b30decabde7537c9e" }
 
 [dependency-groups]
 # Deliberately a group and not an extra: `uv sync --all-extras` (what

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -887,8 +887,8 @@ wheels = [
 
 [[package]]
 name = "cubepi"
-version = "0.13.2"
-source = { git = "https://github.com/cubeplexai/cubepi.git?rev=c63c545b16122d2a72cec558851cefe90337bd41#c63c545b16122d2a72cec558851cefe90337bd41" }
+version = "0.13.4"
+source = { git = "https://github.com/cubeplexai/cubepi.git?rev=3dfe578592acc79dd56b786b30decabde7537c9e#3dfe578592acc79dd56b786b30decabde7537c9e" }
 dependencies = [
     { name = "anthropic" },
     { name = "openai" },
@@ -997,7 +997,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=50.0.0" },
-    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=c63c545b16122d2a72cec558851cefe90337bd41" },
+    { name = "cubepi", extras = ["mcp", "postgres", "trace-cli", "tracing", "tracing-otlp"], git = "https://github.com/cubeplexai/cubepi.git?rev=3dfe578592acc79dd56b786b30decabde7537c9e" },
     { name = "dingtalk-stream", specifier = ">=0.24.3" },
     { name = "discord-py", specifier = ">=2.7.1" },
     { name = "dynaconf", specifier = ">=3.2.11" },


### PR DESCRIPTION
## Summary

- Bump backend git pin of cubepi to `3dfe578` (**v0.13.4**).
- Brings in: span `cubepi.run_id` = agent/host business run id (so chat Info chip / SSE run id matches `cubepi trace`), plus HITL suspension and tracing privacy fixes from the 0.13.4 release.

## Test plan

- [x] `uv lock` resolves cubepi v0.13.4
- [x] Pre-push `check-ci` passed
- [ ] After merge: smoke a chat turn, copy run id from Info chip, confirm `cubepi trace` can find it by that id