### PR TITLE
Hide deprecated preinstalled skills from slash

### DIFF
--- a/backend/cubeplex/seeders/skill_seeder.py
+++ b/backend/cubeplex/seeders/skill_seeder.py
@@ -17,7 +17,12 @@ from sqlalchemy import delete, exists, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from cubeplex.models import Organization, OrgPreinstalledTombstone, OrgSkillInstall
+from cubeplex.models import (
+    Organization,
+    OrgPreinstalledTombstone,
+    OrgSkillInstall,
+    WorkspaceSkillBinding,
+)
 from cubeplex.objectstore import get_objectstore_client
 from cubeplex.repositories.skill import SkillRepository, SkillVersionRepository
 from cubeplex.skills.content_hash import compute_skill_version_hash
@@ -58,6 +63,7 @@ async def seed_preinstalled_skills(
 
     try:
         await _do_seed(preinstalled_dir, db_session)
+        await _purge_deprecated_preinstalled_installs(db_session)
         await _reconcile_preinstalled_installs(db_session)
     finally:
         try:
@@ -159,6 +165,52 @@ async def _do_seed(preinstalled_dir: Path, db_session: AsyncSession) -> None:
         if skill.name not in found_names and skill.deprecated_at is None:
             await skills.deprecate(skill.id)
             logger.info("Deprecated removed preinstalled skill: {}", skill.name)
+
+
+async def _purge_deprecated_preinstalled_installs(db_session: AsyncSession) -> None:
+    """Drop leftover installs of preinstalled skills removed from disk.
+
+    ``_do_seed`` only sets ``deprecated_at``. Leftover ``OrgSkillInstall``
+    rows would otherwise keep slash / ``load_skill`` serving a skill the
+    Skills page catalog no longer shows. Bindings must be deleted first
+    (FK from ``workspace_skill_bindings`` to ``org_skill_installs``).
+    """
+    deprecated_ids = [
+        s.id
+        for s in await SkillRepository(db_session).list_preinstalled()
+        if s.deprecated_at is not None
+    ]
+    if not deprecated_ids:
+        return
+
+    install_ids = list(
+        (
+            await db_session.execute(
+                select(OrgSkillInstall.id).where(
+                    OrgSkillInstall.skill_id.in_(deprecated_ids),  # type: ignore[attr-defined]
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not install_ids:
+        return
+
+    binding_ids = WorkspaceSkillBinding.org_skill_install_id.in_(install_ids)
+    await db_session.execute(delete(WorkspaceSkillBinding).where(binding_ids))
+    await db_session.flush()
+    result = await db_session.execute(
+        delete(OrgSkillInstall).where(
+            OrgSkillInstall.id.in_(install_ids),  # type: ignore[attr-defined]
+        )
+    )
+    purged = int(getattr(result, "rowcount", 0) or 0)
+    await db_session.commit()
+    logger.info(
+        "Purged leftover installs of deprecated preinstalled skills: {} row(s)",
+        purged,
+    )
 
 
 async def _reconcile_preinstalled_installs(db_session: AsyncSession) -> None:

--- a/backend/cubeplex/seeders/skill_seeder.py
+++ b/backend/cubeplex/seeders/skill_seeder.py
@@ -183,10 +183,10 @@ async def _purge_deprecated_preinstalled_installs(db_session: AsyncSession) -> N
     if not deprecated_ids:
         return
 
-    install_ids = list(
+    install_rows = (
         (
             await db_session.execute(
-                select(OrgSkillInstall.id).where(
+                select(OrgSkillInstall).where(
                     OrgSkillInstall.skill_id.in_(deprecated_ids),  # type: ignore[attr-defined]
                 )
             )
@@ -194,11 +194,16 @@ async def _purge_deprecated_preinstalled_installs(db_session: AsyncSession) -> N
         .scalars()
         .all()
     )
+    install_ids = [row.id for row in install_rows]
     if not install_ids:
         return
 
-    binding_ids = WorkspaceSkillBinding.org_skill_install_id.in_(install_ids)
-    await db_session.execute(delete(WorkspaceSkillBinding).where(binding_ids))
+    binding_col = WorkspaceSkillBinding.org_skill_install_id
+    await db_session.execute(
+        delete(WorkspaceSkillBinding).where(
+            binding_col.in_(install_ids),  # type: ignore[attr-defined]
+        )
+    )
     await db_session.flush()
     result = await db_session.execute(
         delete(OrgSkillInstall).where(

--- a/backend/cubeplex/skills/service.py
+++ b/backend/cubeplex/skills/service.py
@@ -70,6 +70,8 @@ class SkillCatalogService:
 
         Preinstalled skills with an org tombstone are never returned, even if an
         orphan install row still exists (e.g. boot reconcile race with uninstall).
+        Catalog rows with ``deprecated_at`` set (removed from disk) are also
+        excluded so slash / load_skill match the Skills page catalog filter.
         """
         explicit_disable = exists().where(
             WorkspaceSkillBinding.org_skill_install_id == OrgSkillInstall.id,  # type: ignore[arg-type]
@@ -99,6 +101,7 @@ class SkillCatalogService:
             .where(
                 OrgSkillInstall.org_id == org_id,  # type: ignore[arg-type]
                 OrgSkillInstall.workspace_id.is_(None),  # type: ignore[union-attr]
+                Skill.deprecated_at.is_(None),  # type: ignore[union-attr]
                 not_tombstoned,
                 or_(
                     explicit_enable,
@@ -136,6 +139,7 @@ class SkillCatalogService:
             .where(
                 OrgSkillInstall.org_id == org_id,  # type: ignore[arg-type]
                 OrgSkillInstall.workspace_id == workspace_id,  # type: ignore[arg-type]
+                Skill.deprecated_at.is_(None),  # type: ignore[union-attr]
                 not_tombstoned,
             )
         )

--- a/backend/tests/e2e/test_skills_seeder.py
+++ b/backend/tests/e2e/test_skills_seeder.py
@@ -432,3 +432,59 @@ async def test_tombstone_suppresses_workspace_private_preinstalled_install(
     await seed_preinstalled_skills(preinstalled_dir=src, db_session=db_session, redis=redis_client)
     assert await installs.get_workspace_private(org.id, workspace.id, skill.id) is None
     assert await installs.get(org.id, skill.id) is None
+
+
+@pytest.mark.asyncio
+async def test_seed_purges_installs_of_removed_preinstalled_skill(
+    tmp_path: Path, db_session, redis_client: Redis
+) -> None:
+    """Removing a preinstalled directory must drop leftover org installs.
+
+    Deprecating the catalog row alone left slash serving pdf-creator after
+    the Skills page hid it. Reconcile now deletes those install + binding rows.
+    """
+    from cubeplex.repositories.workspace import WorkspaceRepository
+    from cubeplex.skills.cache import SkillCache
+    from cubeplex.skills.service import SkillCatalogService
+
+    org = await OrganizationRepository(db_session).create(
+        name=f"gone-org-{uuid.uuid4().hex[:8]}",
+        slug=f"gone-org-{uuid.uuid4().hex[:8]}",
+    )
+    workspace = await WorkspaceRepository(db_session).create(
+        org_id=org.id, name=f"gone-ws-{uuid.uuid4().hex[:6]}"
+    )
+    keep_name = _unique_name("pdf")
+    gone_name = _unique_name("pdf-creator")
+    src = tmp_path / "preinstalled"
+    _write_skill_md(src / keep_name, name=keep_name, version="1.0.0")
+    _write_skill_md(src / gone_name, name=gone_name, version="1.0.0")
+    await seed_preinstalled_skills(preinstalled_dir=src, db_session=db_session, redis=redis_client)
+
+    skills = SkillRepository(db_session)
+    keep = await skills.find_by_name(keep_name)
+    gone = await skills.find_by_name(gone_name)
+    assert keep is not None
+    assert gone is not None
+    installs = OrgSkillInstallRepository(db_session)
+    assert await installs.get(org.id, keep.id) is not None
+    assert await installs.get(org.id, gone.id) is not None
+
+    # Disk no longer has the removed skill — same as shipping without pdf-creator.
+    for path in (src / gone_name).iterdir():
+        path.unlink()
+    (src / gone_name).rmdir()
+    await seed_preinstalled_skills(preinstalled_dir=src, db_session=db_session, redis=redis_client)
+
+    gone = await skills.find_by_name(gone_name)
+    assert gone is not None
+    assert gone.deprecated_at is not None
+    assert await installs.get(org.id, gone.id) is None
+    assert await installs.get(org.id, keep.id) is not None
+
+    catalog = SkillCatalogService(
+        session=db_session, cache=SkillCache(cache_root=tmp_path / "cache")
+    )
+    enabled = await catalog.list_enabled_for_workspace(workspace.id, org_id=org.id)
+    assert all(r.skill_id != gone.id for r in enabled)
+    assert any(r.skill_id == keep.id for r in enabled)

--- a/backend/tests/e2e/test_skills_service_catalog.py
+++ b/backend/tests/e2e/test_skills_service_catalog.py
@@ -242,9 +242,7 @@ async def test_list_enabled_excludes_deprecated_skill(tmp_path, db_session) -> N
             installed_version="1.0.0",
             installed_by_user_id=user_id,
         )
-        bindings = WorkspaceSkillBindingRepository(
-            db_session, org_id=org_id, workspace_id=ws_id
-        )
+        bindings = WorkspaceSkillBindingRepository(db_session, org_id=org_id, workspace_id=ws_id)
         await bindings.enable(install.id)
 
     await skills.deprecate(gone.id)

--- a/backend/tests/e2e/test_skills_service_catalog.py
+++ b/backend/tests/e2e/test_skills_service_catalog.py
@@ -193,3 +193,66 @@ async def test_find_enabled_by_name(tmp_path, db_session) -> None:
     # Not-found case
     missing = await catalog.find_enabled_by_name(ws_id, org_id=org_id, name="nonexistent")
     assert missing is None
+
+
+@pytest.mark.asyncio
+async def test_list_enabled_excludes_deprecated_skill(tmp_path, db_session) -> None:
+    """Deprecated catalog rows must not stay loadable via leftover installs.
+
+    Skills page catalog hides deprecated_at; slash / load_skill go through
+    list_enabled_for_workspace and must use the same filter.
+    """
+    skills = SkillRepository(db_session)
+    versions = SkillVersionRepository(db_session)
+    installs = OrgSkillInstallRepository(db_session)
+
+    org_id = f"org-{secrets.token_hex(4)}"
+    ws_id = f"ws-{secrets.token_hex(4)}"
+    user_id = "user-1"
+    await _seed_org_ws_user(db_session, org_id, ws_id, user_id)
+    live_name = f"pdf-{secrets.token_hex(4)}"
+    gone_name = f"pdf-creator-{secrets.token_hex(4)}"
+
+    live = await skills.create_preinstalled(
+        name=live_name, description="live", keywords=[], current_version="1.0.0"
+    )
+    gone = await skills.create_preinstalled(
+        name=gone_name, description="gone", keywords=[], current_version="1.0.0"
+    )
+    for skill in (live, gone):
+        prefix = global_skill_prefix(skill.name, "1.0.0")
+        await get_objectstore_client().upload_file(
+            f"{prefix}SKILL.md",
+            f"---\nname: {skill.name}\ndescription: d\nversion: 1.0.0\n---\n# x\n".encode(),
+        )
+        await versions.create(
+            skill_id=skill.id,
+            version="1.0.0",
+            description="d",
+            keywords=[],
+            raw_metadata={},
+            storage_prefix=prefix,
+            entry_file="SKILL.md",
+            uploaded_by_user_id=None,
+            content_hash="",
+        )
+        install = await installs.upsert(
+            org_id=org_id,
+            skill_id=skill.id,
+            installed_version="1.0.0",
+            installed_by_user_id=user_id,
+        )
+        bindings = WorkspaceSkillBindingRepository(
+            db_session, org_id=org_id, workspace_id=ws_id
+        )
+        await bindings.enable(install.id)
+
+    await skills.deprecate(gone.id)
+
+    catalog = SkillCatalogService(
+        session=db_session, cache=SkillCache(cache_root=tmp_path / "cache")
+    )
+    resolved = await catalog.list_enabled_for_workspace(ws_id, org_id=org_id)
+    assert [r.name for r in resolved] == [live_name]
+    assert await catalog.find_enabled_by_name(ws_id, org_id=org_id, name=gone_name) is None
+    assert await catalog.find_enabled_by_name(ws_id, org_id=org_id, name=live_name) is not None


### PR DESCRIPTION
## Summary

- Slash (`/pdf`) and `load_skill` resolve enabled skills via `list_enabled_for_workspace`. That query ignored `Skill.deprecated_at`.
- After `pdf-creator` was removed from `backend/skills/preinstalled/`, the seeder only marked the catalog row deprecated. Leftover `OrgSkillInstall` rows stayed enabled, so `/pdf-creator` still appeared while the Skills page catalog hid it.
- Filter deprecated catalog rows out of the enabled list (org-wide and workspace-private).
- On seed, delete leftover installs of deprecated preinstalled skills (bindings first, because of the FK).

## Test plan

- [x] `test_list_enabled_excludes_deprecated_skill` — leftover install of a deprecated skill is not returned.
- [x] `test_seed_purges_installs_of_removed_preinstalled_skill` — removing the on-disk preinstalled dir deprecates the row and deletes the org install.
- [ ] CI e2e (`backend-check` + `e2e`) — this sandbox has no Postgres, so the new e2e tests were not executed locally.