### PR TITLE
Timeout hung execute and heartbeat long-running tools

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -102,9 +102,9 @@ default:
     #   health checks within this time, creation fails.
     ready_timeout: 300 # 5 minutes — must cover a cold image pull
     # request_timeout: HTTP request timeout for sandbox API calls
-    #   Must exceed the agent execute-tool cap (120s) so the command timeout
+    #   Must exceed max execute timeout_seconds (600) so the command timeout
     #   fires first and returns `[timeout]` instead of an HTTP client error.
-    request_timeout: 150 # 150 seconds
+    request_timeout: 660 # 660 seconds
     # create_timeout: HTTP timeout for the synchronous create call only. The server
     #   holds POST /sandboxes open until the pod is ready, so a cold image pull
     #   (minutes) blows past request_timeout. Kept separate so ordinary commands

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -102,9 +102,9 @@ default:
     #   health checks within this time, creation fails.
     ready_timeout: 300 # 5 minutes — must cover a cold image pull
     # request_timeout: HTTP request timeout for sandbox API calls
-    #   Must exceed max execute timeout_seconds (600) so the command timeout
+    #   Must exceed max execute timeout_seconds (1800) so the command timeout
     #   fires first and returns `[timeout]` instead of an HTTP client error.
-    request_timeout: 660 # 660 seconds
+    request_timeout: 1860 # 1860 seconds
     # create_timeout: HTTP timeout for the synchronous create call only. The server
     #   holds POST /sandboxes open until the pod is ready, so a cold image pull
     #   (minutes) blows past request_timeout. Kept separate so ordinary commands

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -102,8 +102,9 @@ default:
     #   health checks within this time, creation fails.
     ready_timeout: 300 # 5 minutes — must cover a cold image pull
     # request_timeout: HTTP request timeout for sandbox API calls
-    #   Timeout for individual commands (execute, upload, download, etc.)
-    request_timeout: 60 # 60 seconds
+    #   Must exceed the agent execute-tool cap (120s) so the command timeout
+    #   fires first and returns `[timeout]` instead of an HTTP client error.
+    request_timeout: 150 # 150 seconds
     # create_timeout: HTTP timeout for the synchronous create call only. The server
     #   holds POST /sandboxes open until the pod is ready, so a cold image pull
     #   (minutes) blows past request_timeout. Kept separate so ordinary commands
@@ -346,7 +347,9 @@ default:
   lifecycle:
     graceful_drain_timeout_seconds: 3600
     dev_double_signal_force_exit: true
-    stale_run_threshold_seconds: 120
+    # Above the 120s execute-tool cap so a still-running command is not
+    # declared dead on refresh. Heartbeat of last_event_at is a later change.
+    stale_run_threshold_seconds: 180
 
   # Conversation context compaction (default on; threshold = model.context_window * ratio)
   # cubepi 0.x+: ``keep_tail_tokens`` (token budget) replaces the older

--- a/backend/cubeplex/api/routes/v1/conversations.py
+++ b/backend/cubeplex/api/routes/v1/conversations.py
@@ -1685,14 +1685,16 @@ async def get_conversation_bootstrap(
     if active_run is not None:
         threshold = int(_config.get("lifecycle.stale_run_threshold_seconds", 180))
         if is_stale_meta(active_run, threshold_seconds=threshold):
-            await mark_run_stale(
+            marked = await mark_run_stale(
                 rds.client,
                 prefix=rds.key_prefix,
                 run_id=active_run.run_id,
                 conversation_id=conversation_id,
+                observed_last_event_at=active_run.last_event_at or active_run.started_at,
             )
-            active_run = None
-            last_run_status = "stale"
+            if marked:
+                active_run = None
+                last_run_status = "stale"
 
     active_run_payload: dict[str, Any] | None = None
     if active_run is not None:
@@ -1856,12 +1858,20 @@ async def stream_run(
 
     threshold = int(_cfg.get("lifecycle.stale_run_threshold_seconds", 180))
     if is_stale_meta(run_meta, threshold_seconds=threshold):
-        await mark_run_stale(
+        marked = await mark_run_stale(
             rds.client,
             prefix=rds.key_prefix,
             run_id=run_id,
             conversation_id=conversation_id,
+            observed_last_event_at=run_meta.last_event_at or run_meta.started_at,
         )
+        if not marked:
+            return _build_run_streaming_response(
+                raw_request=raw_request,
+                conversation_id=conversation_id,
+                run_id=run_id,
+                redis_handle=rds,
+            )
 
         async def _stale_stream() -> AsyncIterator[bytes]:
             from datetime import UTC, datetime

--- a/backend/cubeplex/api/routes/v1/conversations.py
+++ b/backend/cubeplex/api/routes/v1/conversations.py
@@ -1311,7 +1311,7 @@ async def send_message(
     _install_cmd = request_obj.content and not request_obj.attachments
     if _install_cmd and _INSTALL_RE.match(request_obj.content.strip()):
         fallback_run_id = f"install-fallback-{secrets.token_hex(6)}"
-        ttl = int(_config.get("lifecycle.stale_run_threshold_seconds", 120))
+        ttl = int(_config.get("lifecycle.stale_run_threshold_seconds", 180))
         claimed = await create_run(
             rds.client,
             prefix=rds.key_prefix,
@@ -1683,7 +1683,7 @@ async def get_conversation_bootstrap(
 
     last_run_status: str | None = None
     if active_run is not None:
-        threshold = int(_config.get("lifecycle.stale_run_threshold_seconds", 120))
+        threshold = int(_config.get("lifecycle.stale_run_threshold_seconds", 180))
         if is_stale_meta(active_run, threshold_seconds=threshold):
             await mark_run_stale(
                 rds.client,
@@ -1728,7 +1728,7 @@ async def get_conversation_bootstrap(
             # Apply the same staleness gate stage-A does: a row that's already
             # past the heartbeat threshold would point pending_hitl at a dead
             # run, and every approve/decline from the client would 404.
-            threshold = int(_config.get("lifecycle.stale_run_threshold_seconds", 120))
+            threshold = int(_config.get("lifecycle.stale_run_threshold_seconds", 180))
             if fresh is not None and not is_stale_meta(fresh, threshold_seconds=threshold):
                 run_id_for_pending = fresh.run_id
             else:
@@ -1854,7 +1854,7 @@ async def stream_run(
 
     from cubeplex.config import config as _cfg
 
-    threshold = int(_cfg.get("lifecycle.stale_run_threshold_seconds", 120))
+    threshold = int(_cfg.get("lifecycle.stale_run_threshold_seconds", 180))
     if is_stale_meta(run_meta, threshold_seconds=threshold):
         await mark_run_stale(
             rds.client,

--- a/backend/cubeplex/middleware/sandbox.py
+++ b/backend/cubeplex/middleware/sandbox.py
@@ -110,7 +110,7 @@ def reset_executed_commands() -> None:
 # Agent-facing default. Drivers must honor this so a hung `gh` / network
 # call becomes a tool result the model can retry from, not a silent stall.
 DEFAULT_EXECUTE_TIMEOUT_SECONDS = 120
-MAX_EXECUTE_TIMEOUT_SECONDS = 600
+MAX_EXECUTE_TIMEOUT_SECONDS = 1800
 
 
 class _ExecuteArgs(BaseModel):
@@ -121,7 +121,7 @@ class _ExecuteArgs(BaseModel):
         le=MAX_EXECUTE_TIMEOUT_SECONDS,
         description=(
             "Seconds before the command is killed. Default 120. "
-            "Raise this for installs, downloads, or builds (max 600)."
+            "Raise this for installs, downloads, or builds (max 1800)."
         ),
     )
 
@@ -250,7 +250,7 @@ def _make_execute_tool(
         description=(
             "Execute a shell command in the sandbox environment. "
             "Default timeout is 120 seconds. For installs, downloads, or "
-            "builds, pass timeout_seconds (max 600). If you hit the limit, "
+            "builds, pass timeout_seconds (max 1800). If you hit the limit, "
             "raise timeout_seconds or split the work and retry."
         ),
         parameters=_ExecuteArgs,

--- a/backend/cubeplex/middleware/sandbox.py
+++ b/backend/cubeplex/middleware/sandbox.py
@@ -110,10 +110,20 @@ def reset_executed_commands() -> None:
 # Agent-facing default. Drivers must honor this so a hung `gh` / network
 # call becomes a tool result the model can retry from, not a silent stall.
 DEFAULT_EXECUTE_TIMEOUT_SECONDS = 120
+MAX_EXECUTE_TIMEOUT_SECONDS = 600
 
 
 class _ExecuteArgs(BaseModel):
     command: str
+    timeout_seconds: int | None = Field(
+        default=None,
+        ge=1,
+        le=MAX_EXECUTE_TIMEOUT_SECONDS,
+        description=(
+            "Seconds before the command is killed. Default 120. "
+            "Raise this for installs, downloads, or builds (max 600)."
+        ),
+    )
 
 
 class _WriteFileArgs(BaseModel):
@@ -203,7 +213,11 @@ def _make_execute_tool(
     ) -> AgentToolResult:
         del tool_call_id, signal, on_update
 
-        timeout = DEFAULT_EXECUTE_TIMEOUT_SECONDS
+        timeout = (
+            args.timeout_seconds
+            if args.timeout_seconds is not None
+            else DEFAULT_EXECUTE_TIMEOUT_SECONDS
+        )
         try:
             result = await sandbox.execute(args.command, timeout=timeout)
         except TimeoutError:
@@ -235,8 +249,9 @@ def _make_execute_tool(
         name="execute",
         description=(
             "Execute a shell command in the sandbox environment. "
-            "Killed after 120 seconds — if that happens, split the work "
-            "or pick a faster command and retry."
+            "Default timeout is 120 seconds. For installs, downloads, or "
+            "builds, pass timeout_seconds (max 600). If you hit the limit, "
+            "raise timeout_seconds or split the work and retry."
         ),
         parameters=_ExecuteArgs,
         execute=_execute,

--- a/backend/cubeplex/middleware/sandbox.py
+++ b/backend/cubeplex/middleware/sandbox.py
@@ -107,6 +107,11 @@ def reset_executed_commands() -> None:
 # ---------------------------------------------------------------------------
 
 
+# Agent-facing default. Drivers must honor this so a hung `gh` / network
+# call becomes a tool result the model can retry from, not a silent stall.
+DEFAULT_EXECUTE_TIMEOUT_SECONDS = 120
+
+
 class _ExecuteArgs(BaseModel):
     command: str
 
@@ -160,6 +165,22 @@ def _shquote(path: str) -> str:
     return shlex.quote(path)
 
 
+def _timeout_tool_message(seconds: int) -> str:
+    return (
+        f"[timeout] Command exceeded {seconds}s and was killed. "
+        "Split the work or use a faster command, then retry."
+    )
+
+
+def _is_timeout_result(output: str, exit_code: int | None) -> bool:
+    return exit_code == -1 and output.strip().startswith("[timeout]")
+
+
+def _is_timeout_error(exc: BaseException) -> bool:
+    text = str(exc).lower()
+    return "timeout" in text or "timed out" in text
+
+
 def _make_execute_tool(
     sandbox: Sandbox,
     *,
@@ -182,7 +203,27 @@ def _make_execute_tool(
     ) -> AgentToolResult:
         del tool_call_id, signal, on_update
 
-        result = await sandbox.execute(args.command)
+        timeout = DEFAULT_EXECUTE_TIMEOUT_SECONDS
+        try:
+            result = await sandbox.execute(args.command, timeout=timeout)
+        except TimeoutError:
+            return AgentToolResult(
+                content=[TextContent(text=_timeout_tool_message(timeout))],
+                is_error=True,
+            )
+        except Exception as exc:
+            if _is_timeout_error(exc):
+                return AgentToolResult(
+                    content=[TextContent(text=_timeout_tool_message(timeout))],
+                    is_error=True,
+                )
+            raise
+
+        if _is_timeout_result(result.output, result.exit_code):
+            return AgentToolResult(
+                content=[TextContent(text=_timeout_tool_message(timeout))],
+                is_error=True,
+            )
         if workspace_id is not None and conversation_id is not None and result.exit_code == 0:
             _record_executed(workspace_id, conversation_id, args.command)
         output = result.output
@@ -192,7 +233,11 @@ def _make_execute_tool(
 
     return AgentTool(
         name="execute",
-        description="Execute a shell command in the sandbox environment.",
+        description=(
+            "Execute a shell command in the sandbox environment. "
+            "Killed after 120 seconds — if that happens, split the work "
+            "or pick a faster command and retry."
+        ),
         parameters=_ExecuteArgs,
         execute=_execute,
     )

--- a/backend/cubeplex/prompts/sandbox.py
+++ b/backend/cubeplex/prompts/sandbox.py
@@ -79,4 +79,6 @@ old_string must appear exactly once. Prefer this over `sed`/`awk`.
 **Error handling:**
 - Non-zero exit codes are appended to output as `[exit code: N]`
 - Check exit codes for command success/failure
+- Commands are killed after 120 seconds and return `[timeout]`. Split the \
+work or pick a faster command, then retry.
 - Commands run in an isolated sandbox — safe to experiment"""

--- a/backend/cubeplex/prompts/sandbox.py
+++ b/backend/cubeplex/prompts/sandbox.py
@@ -79,6 +79,7 @@ old_string must appear exactly once. Prefer this over `sed`/`awk`.
 **Error handling:**
 - Non-zero exit codes are appended to output as `[exit code: N]`
 - Check exit codes for command success/failure
-- Commands are killed after 120 seconds and return `[timeout]`. Split the \
-work or pick a faster command, then retry.
+- Commands are killed after 120 seconds by default and return `[timeout]`. \
+For installs, downloads, or builds, pass `timeout_seconds` (max 600). \
+If you still time out, split the work or raise `timeout_seconds` and retry.
 - Commands run in an isolated sandbox — safe to experiment"""

--- a/backend/cubeplex/prompts/sandbox.py
+++ b/backend/cubeplex/prompts/sandbox.py
@@ -80,6 +80,6 @@ old_string must appear exactly once. Prefer this over `sed`/`awk`.
 - Non-zero exit codes are appended to output as `[exit code: N]`
 - Check exit codes for command success/failure
 - Commands are killed after 120 seconds by default and return `[timeout]`. \
-For installs, downloads, or builds, pass `timeout_seconds` (max 600). \
+For installs, downloads, or builds, pass `timeout_seconds` (max 1800). \
 If you still time out, split the work or raise `timeout_seconds` and retry.
 - Commands run in an isolated sandbox — safe to experiment"""

--- a/backend/cubeplex/sandbox/lazy.py
+++ b/backend/cubeplex/sandbox/lazy.py
@@ -314,7 +314,7 @@ class LazySandbox(Sandbox):
                 self._synced_for_this_run = True
             # status == "failed" → flag stays False (F4 invariant)
 
-    async def _ensure_with_retry(self, *, lease_seconds: int | None = None) -> Sandbox:
+    async def _ensure_with_retry(self) -> Sandbox:
         """Ensure sandbox, retrying once if the existing one is broken."""
         try:
             sandbox = await self._ensure()
@@ -345,16 +345,15 @@ class LazySandbox(Sandbox):
             logger.exception("Lazy sandbox: touch failed (non-fatal)")
 
         # Renew the in-use lease so the idle-pause reaper skips this sandbox
-        # while a tool call is in flight. Sized to op timeout when known;
-        # otherwise the manager falls back to its default lease window.
+        # while a tool call is in flight. Window is the default lease
+        # (``sandbox.lease_seconds``, 300s) unless the caller set
+        # ``op_timeout_seconds`` at construction — never the command timeout.
         try:
             await self._manager.renew_lease(
                 sandbox.id,
                 org_id=self._org_id,
                 workspace_id=self._workspace_id,
-                lease_seconds=lease_seconds
-                if lease_seconds is not None
-                else self._op_timeout_seconds,
+                lease_seconds=self._op_timeout_seconds,
             )
         except Exception:
             logger.exception("Lazy sandbox: lease renew failed (non-fatal)")
@@ -378,17 +377,11 @@ class LazySandbox(Sandbox):
     def supports_pause(self) -> bool:
         return self._sandbox.supports_pause() if self._sandbox is not None else False
 
-    async def _run_with_keepalive(
-        self,
-        awaitable: Awaitable[T],
-        *,
-        lease_seconds: int | None,
-    ) -> T:
+    async def _run_with_keepalive(self, awaitable: Awaitable[T]) -> T:
         """Keep last_activity and the in-use lease fresh while ``awaitable`` runs.
 
-        A single touch at start is enough for the 1800s TTL when the command
-        is short. Long installs (up to 600s) outlive the default 300s lease,
-        so the idle-pause reaper would otherwise see an expired lease mid-op.
+        Each beat extends the default lease window (300s), not the command
+        timeout. A 10s install must not pin the sandbox as in-use for 600s.
         """
 
         async def _beat() -> None:
@@ -409,9 +402,7 @@ class LazySandbox(Sandbox):
                         self._sandbox.id,
                         org_id=self._org_id,
                         workspace_id=self._workspace_id,
-                        lease_seconds=lease_seconds
-                        if lease_seconds is not None
-                        else self._op_timeout_seconds,
+                        lease_seconds=self._op_timeout_seconds,
                     )
                 except Exception:
                     logger.exception("Lazy sandbox: keepalive lease failed (non-fatal)")
@@ -432,11 +423,10 @@ class LazySandbox(Sandbox):
         envs: dict[str, str] | None = None,
         as_root: bool = False,
     ) -> ExecuteResult:
-        sandbox = await self._ensure_with_retry(lease_seconds=timeout)
+        sandbox = await self._ensure_with_retry()
         try:
             return await self._run_with_keepalive(
                 sandbox.execute(command, timeout=timeout, envs=envs, as_root=as_root),
-                lease_seconds=timeout,
             )
         except Exception:
             # Sandbox may have died — invalidate and retry once
@@ -449,7 +439,6 @@ class LazySandbox(Sandbox):
             await self._ensure_skills_synced(sandbox)
             return await self._run_with_keepalive(
                 sandbox.execute(command, timeout=timeout, envs=envs, as_root=as_root),
-                lease_seconds=timeout,
             )
 
     async def upload(self, files: list[tuple[str, bytes]]) -> None:

--- a/backend/cubeplex/sandbox/lazy.py
+++ b/backend/cubeplex/sandbox/lazy.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Sequence
+from collections.abc import Awaitable, Sequence
+from contextlib import suppress
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from loguru import logger
 
@@ -38,6 +39,8 @@ from cubeplex.skills.sync_tar import (
 if TYPE_CHECKING:
     from cubeplex.sandbox.manager import SandboxManager
     from cubeplex.skills.service import SkillCatalogService
+
+T = TypeVar("T")
 
 
 async def _collect_files_for_push(
@@ -210,6 +213,10 @@ class LazySandbox(Sandbox):
         # Sizes the in-use lease window passed to ``manager.renew_lease``. None
         # falls back to the manager's default (``sandbox.lease_seconds``).
         self._op_timeout_seconds = op_timeout_seconds
+        # How often to refresh last_activity / lease while a command is running.
+        # Must stay below both ``sandbox.lease_seconds`` and the run stale
+        # threshold so a single long execute cannot look idle.
+        self._keepalive_interval_seconds = 30.0
         self._event_service = event_service
         self._sandbox: Sandbox | None = None
         self._user_sandbox_id: str | None = None
@@ -307,7 +314,7 @@ class LazySandbox(Sandbox):
                 self._synced_for_this_run = True
             # status == "failed" → flag stays False (F4 invariant)
 
-    async def _ensure_with_retry(self) -> Sandbox:
+    async def _ensure_with_retry(self, *, lease_seconds: int | None = None) -> Sandbox:
         """Ensure sandbox, retrying once if the existing one is broken."""
         try:
             sandbox = await self._ensure()
@@ -345,7 +352,9 @@ class LazySandbox(Sandbox):
                 sandbox.id,
                 org_id=self._org_id,
                 workspace_id=self._workspace_id,
-                lease_seconds=self._op_timeout_seconds,
+                lease_seconds=lease_seconds
+                if lease_seconds is not None
+                else self._op_timeout_seconds,
             )
         except Exception:
             logger.exception("Lazy sandbox: lease renew failed (non-fatal)")
@@ -369,6 +378,52 @@ class LazySandbox(Sandbox):
     def supports_pause(self) -> bool:
         return self._sandbox.supports_pause() if self._sandbox is not None else False
 
+    async def _run_with_keepalive(
+        self,
+        awaitable: Awaitable[T],
+        *,
+        lease_seconds: int | None,
+    ) -> T:
+        """Keep last_activity and the in-use lease fresh while ``awaitable`` runs.
+
+        A single touch at start is enough for the 1800s TTL when the command
+        is short. Long installs (up to 600s) outlive the default 300s lease,
+        so the idle-pause reaper would otherwise see an expired lease mid-op.
+        """
+
+        async def _beat() -> None:
+            while True:
+                await asyncio.sleep(self._keepalive_interval_seconds)
+                if self._sandbox is None:
+                    continue
+                try:
+                    await self._manager.touch(
+                        self._sandbox.id,
+                        org_id=self._org_id,
+                        workspace_id=self._workspace_id,
+                    )
+                except Exception:
+                    logger.exception("Lazy sandbox: keepalive touch failed (non-fatal)")
+                try:
+                    await self._manager.renew_lease(
+                        self._sandbox.id,
+                        org_id=self._org_id,
+                        workspace_id=self._workspace_id,
+                        lease_seconds=lease_seconds
+                        if lease_seconds is not None
+                        else self._op_timeout_seconds,
+                    )
+                except Exception:
+                    logger.exception("Lazy sandbox: keepalive lease failed (non-fatal)")
+
+        task = asyncio.create_task(_beat())
+        try:
+            return await awaitable
+        finally:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
     async def execute(
         self,
         command: str,
@@ -377,9 +432,12 @@ class LazySandbox(Sandbox):
         envs: dict[str, str] | None = None,
         as_root: bool = False,
     ) -> ExecuteResult:
-        sandbox = await self._ensure_with_retry()
+        sandbox = await self._ensure_with_retry(lease_seconds=timeout)
         try:
-            return await sandbox.execute(command, timeout=timeout, envs=envs, as_root=as_root)
+            return await self._run_with_keepalive(
+                sandbox.execute(command, timeout=timeout, envs=envs, as_root=as_root),
+                lease_seconds=timeout,
+            )
         except Exception:
             # Sandbox may have died — invalidate and retry once
             async with self._lock:
@@ -389,7 +447,10 @@ class LazySandbox(Sandbox):
             logger.warning("Lazy sandbox: execute failed, recreating sandbox")
             sandbox = await self._ensure()
             await self._ensure_skills_synced(sandbox)
-            return await sandbox.execute(command, timeout=timeout, envs=envs, as_root=as_root)
+            return await self._run_with_keepalive(
+                sandbox.execute(command, timeout=timeout, envs=envs, as_root=as_root),
+                lease_seconds=timeout,
+            )
 
     async def upload(self, files: list[tuple[str, bytes]]) -> None:
         sandbox = await self._ensure_with_retry()

--- a/backend/cubeplex/sandbox/manager.py
+++ b/backend/cubeplex/sandbox/manager.py
@@ -169,7 +169,7 @@ class SandboxManager:
         self._domain: str = config.get("sandbox.domain", "localhost:8090")
         self._image: str = config.get("sandbox.image", "ubuntu:22.04")
         self._api_key: str | None = config.get("sandbox.api_key", None)
-        self._request_timeout: int = config.get("sandbox.request_timeout", 150)
+        self._request_timeout: int = config.get("sandbox.request_timeout", 660)
         # Separate, longer budget for the synchronous create call: the server holds
         # the POST /sandboxes open until the pod is ready, so a cold image pull can
         # take minutes — far longer than the per-command request_timeout.

--- a/backend/cubeplex/sandbox/manager.py
+++ b/backend/cubeplex/sandbox/manager.py
@@ -169,7 +169,7 @@ class SandboxManager:
         self._domain: str = config.get("sandbox.domain", "localhost:8090")
         self._image: str = config.get("sandbox.image", "ubuntu:22.04")
         self._api_key: str | None = config.get("sandbox.api_key", None)
-        self._request_timeout: int = config.get("sandbox.request_timeout", 660)
+        self._request_timeout: int = config.get("sandbox.request_timeout", 1860)
         # Separate, longer budget for the synchronous create call: the server holds
         # the POST /sandboxes open until the pod is ready, so a cold image pull can
         # take minutes — far longer than the per-command request_timeout.

--- a/backend/cubeplex/sandbox/manager.py
+++ b/backend/cubeplex/sandbox/manager.py
@@ -169,7 +169,7 @@ class SandboxManager:
         self._domain: str = config.get("sandbox.domain", "localhost:8090")
         self._image: str = config.get("sandbox.image", "ubuntu:22.04")
         self._api_key: str | None = config.get("sandbox.api_key", None)
-        self._request_timeout: int = config.get("sandbox.request_timeout", 60)
+        self._request_timeout: int = config.get("sandbox.request_timeout", 150)
         # Separate, longer budget for the synchronous create call: the server holds
         # the POST /sandboxes open until the pod is ready, so a cold image pull can
         # take minutes — far longer than the per-command request_timeout.

--- a/backend/cubeplex/sandbox/opensandbox.py
+++ b/backend/cubeplex/sandbox/opensandbox.py
@@ -1,5 +1,6 @@
 """OpenSandbox implementation of the Sandbox base class."""
 
+import asyncio
 import base64
 import re
 import shlex
@@ -29,6 +30,11 @@ _TERMINAL_ENV_FILE = "/run/cubeplex/sandbox-env.sh"
 # this is the last gate before a name becomes shell code, so it re-checks
 # independently and skips anything a pre-validation row might already carry.
 _POSIX_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _is_timeout_error(exc: BaseException) -> bool:
+    text = str(exc).lower()
+    return "timeout" in text or "timed out" in text
 
 
 @contextmanager
@@ -98,25 +104,38 @@ class OpenSandbox(Sandbox):
             uid=uid,
             gid=gid,
         )
-        with _as_sandbox_error():
-            execution = await self._sandbox.commands.run(command, opts=opts)
 
-            output_lines: list[str] = []
-            for msg in execution.logs.stdout:
-                output_lines.append(msg.text)
-            for msg in execution.logs.stderr:
-                output_lines.append(msg.text)
-            output = "\n".join(output_lines) if output_lines else ""
+        async def _run() -> ExecuteResult:
+            with _as_sandbox_error():
+                execution = await self._sandbox.commands.run(command, opts=opts)
 
-            exit_code: int | None = None
-            if execution.id:
-                try:
-                    status = await self._sandbox.commands.get_command_status(execution.id)
-                    exit_code = status.exit_code
-                except Exception as e:
-                    logger.warning("Could not get exit code for command: {}", e)
+                output_lines: list[str] = []
+                for msg in execution.logs.stdout:
+                    output_lines.append(msg.text)
+                for msg in execution.logs.stderr:
+                    output_lines.append(msg.text)
+                output = "\n".join(output_lines) if output_lines else ""
 
-            return ExecuteResult(output=output, exit_code=exit_code)
+                exit_code: int | None = None
+                if execution.id:
+                    try:
+                        status = await self._sandbox.commands.get_command_status(execution.id)
+                        exit_code = status.exit_code
+                    except Exception as e:
+                        logger.warning("Could not get exit code for command: {}", e)
+
+                return ExecuteResult(output=output, exit_code=exit_code)
+
+        try:
+            if timeout is not None:
+                return await asyncio.wait_for(_run(), timeout=timeout)
+            return await _run()
+        except TimeoutError:
+            return ExecuteResult(output="[timeout]", exit_code=-1)
+        except SandboxError as exc:
+            if timeout is not None and _is_timeout_error(exc):
+                return ExecuteResult(output="[timeout]", exit_code=-1)
+            raise
 
     async def upload(self, files: list[tuple[str, bytes]]) -> None:
         """Write files then chown by numeric uid so agent can edit them.

--- a/backend/cubeplex/streams/run_events.py
+++ b/backend/cubeplex/streams/run_events.py
@@ -186,10 +186,22 @@ return 1
 # Mark a run as stale and clear the active-run lock if it still points at it.
 # KEYS[1] = meta_key, KEYS[2] = active_key
 # ARGV[1] = expected_run_id
+# ARGV[2] = observed last_event_at/started_at used for the stale decision
+#           (empty = no timestamp CAS; used by startup recovery)
 _MARK_STALE_LUA = """
-if redis.call('HGET', KEYS[1], 'status') == 'running' then
-  redis.call('HSET', KEYS[1], 'status', 'stale')
+if redis.call('HGET', KEYS[1], 'status') ~= 'running' then
+  return 0
 end
+if ARGV[2] ~= '' then
+  local current = redis.call('HGET', KEYS[1], 'last_event_at')
+  if (not current) or current == false or current == '' then
+    current = redis.call('HGET', KEYS[1], 'started_at')
+  end
+  if current ~= ARGV[2] then
+    return 0
+  end
+end
+redis.call('HSET', KEYS[1], 'status', 'stale')
 if redis.call('GET', KEYS[2]) == ARGV[1] then
   redis.call('DEL', KEYS[2])
 end
@@ -573,19 +585,26 @@ async def mark_run_stale(
     prefix: str,
     run_id: str,
     conversation_id: str,
-) -> None:
+    observed_last_event_at: str | None = None,
+) -> bool:
     """Atomically mark a run stale and release its active-run lock if held.
 
-    Idempotent: a no-op when status is already non-running and the active
-    key no longer points at this run.
+    When ``observed_last_event_at`` is set, the write is a CAS against that
+    timestamp (``last_event_at``, falling back to ``started_at``). A heartbeat
+    that refreshed the run after the caller decided it was stale makes this
+    a no-op so a live execute is not declared dead.
+
+    Returns True iff this call flipped the run to stale.
     """
-    await redis.eval(  # type: ignore[misc]
+    wrote = await redis.eval(  # type: ignore[misc]
         _MARK_STALE_LUA,
         2,
         _run_meta_key(prefix, run_id),
         _active_run_key(prefix, conversation_id),
         run_id,
+        observed_last_event_at or "",
     )
+    return int(wrote or 0) == 1
 
 
 def _last_error_key(prefix: str, conversation_id: str) -> str:

--- a/backend/cubeplex/streams/run_events.py
+++ b/backend/cubeplex/streams/run_events.py
@@ -373,6 +373,45 @@ async def update_run_meta(
     return await get_run_meta(redis, prefix=prefix, run_id=run_id)
 
 
+# KEYS[1] = meta_key, KEYS[2] = active_key
+# ARGV[1] = last_event_at, ARGV[2] = ttl_seconds, ARGV[3] = run_id
+_TOUCH_RUN_HEARTBEAT_LUA = """
+if redis.call('HGET', KEYS[1], 'status') == 'running' then
+  redis.call('HSET', KEYS[1], 'last_event_at', ARGV[1])
+  redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+end
+if redis.call('GET', KEYS[2]) == ARGV[3] then
+  redis.call('EXPIRE', KEYS[2], tonumber(ARGV[2]))
+end
+return 1
+"""
+
+
+async def touch_run_heartbeat(
+    redis: Redis,
+    *,
+    prefix: str,
+    run_id: str,
+    conversation_id: str,
+    ttl_seconds: int,
+) -> None:
+    """Refresh ``last_event_at`` without appending a user-visible event.
+
+    Long tool bodies (installs, downloads) emit nothing until they finish.
+    Without this, bootstrap stale detection treats a live worker as dead.
+    Also extends the active-run lock TTL so a long execute cannot drop it.
+    """
+    await redis.eval(  # type: ignore[misc]
+        _TOUCH_RUN_HEARTBEAT_LUA,
+        2,
+        _run_meta_key(prefix, run_id),
+        _active_run_key(prefix, conversation_id),
+        datetime.now(UTC).isoformat(),
+        str(ttl_seconds),
+        run_id,
+    )
+
+
 async def clear_active_run(
     redis: Redis,
     *,

--- a/backend/cubeplex/streams/run_manager.py
+++ b/backend/cubeplex/streams/run_manager.py
@@ -31,6 +31,7 @@ from cubeplex.streams.run_events import (
     is_stale_meta,
     mark_run_stale,
     set_conversation_last_error,
+    touch_run_heartbeat,
     update_run_meta,
 )
 from cubeplex.utils.time import utc_isoformat
@@ -125,6 +126,70 @@ def _log_tool_start(run_id: str, evt: object) -> None:
         evt.tool_call_id,
         _preview_tool_args(evt.args),
     )
+
+
+_TOOL_HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+
+class _InFlightToolHeartbeat:
+    """Bump ``last_event_at`` while any tool body is running.
+
+    Tool start/end events do not always become SSE, so a 120–600s execute
+    would otherwise look stale on refresh.
+    """
+
+    def __init__(
+        self,
+        redis: Redis,
+        *,
+        prefix: str,
+        run_id: str,
+        conversation_id: str,
+        ttl_seconds: int,
+        interval_seconds: float = _TOOL_HEARTBEAT_INTERVAL_SECONDS,
+    ) -> None:
+        self._redis = redis
+        self._prefix = prefix
+        self._run_id = run_id
+        self._conversation_id = conversation_id
+        self._ttl_seconds = ttl_seconds
+        self._interval_seconds = interval_seconds
+        self._in_flight = 0
+        self._task: asyncio.Task[None] | None = None
+
+    def observe(self, evt: object) -> None:
+        from cubepi.agent.types import ToolExecutionEndEvent, ToolExecutionStartEvent
+
+        if isinstance(evt, ToolExecutionStartEvent):
+            self._in_flight += 1
+            if self._task is None or self._task.done():
+                self._task = asyncio.create_task(self._loop())
+        elif isinstance(evt, ToolExecutionEndEvent):
+            self._in_flight = max(0, self._in_flight - 1)
+            if self._in_flight == 0:
+                self.stop()
+
+    def stop(self) -> None:
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+        self._task = None
+
+    async def _loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._interval_seconds)
+                try:
+                    await touch_run_heartbeat(
+                        self._redis,
+                        prefix=self._prefix,
+                        run_id=self._run_id,
+                        conversation_id=self._conversation_id,
+                        ttl_seconds=self._ttl_seconds,
+                    )
+                except Exception:
+                    logger.exception("run heartbeat failed for {}", self._run_id)
+        except asyncio.CancelledError:
+            return
 
 
 def _ns_to_agent_id(ns: tuple[Any, ...]) -> str | None:
@@ -1778,6 +1843,13 @@ class RunManager:
             # unwrap can stitch deltas across events; without persistent state
             # we couldn't peel the wrapper JSON as it streams.
             stream_converter = StreamConverter()
+            tool_heartbeat = _InFlightToolHeartbeat(
+                self._redis,
+                prefix=self._key_prefix,
+                run_id=run_id,
+                conversation_id=conversation_id,
+                ttl_seconds=self._run_event_ttl_seconds,
+            )
 
             def _on_event(evt: Any, _signal: Any = None) -> None:
                 # Runs on the same event loop as _run_cubepi_path, so
@@ -1787,6 +1859,7 @@ class RunManager:
                 # detach before the SSE conversion below; T6 reads
                 # `auto_detach.detached` in the terminal block.
                 _log_tool_start(run_id, evt)
+                tool_heartbeat.observe(evt)
                 auto_detach(evt, _signal)
                 nonlocal _user_msg_seen
                 if isinstance(evt, _MsgEndEvent) and isinstance(evt.message, _UserMsg):
@@ -2165,6 +2238,7 @@ class RunManager:
                 final_status = classification.status
             finally:
                 # Stop accepting steers for this run before tearing down.
+                tool_heartbeat.stop()
                 self._agents.pop(run_id, None)
                 self._hitl_channels.pop(run_id, None)
                 # Signal drainer and wait for it to flush remaining events so
@@ -2277,6 +2351,13 @@ class RunManager:
             # variant above; the deferred-call unwrap needs persistent state
             # across deltas inside a single run.
             stream_converter = StreamConverter()
+            tool_heartbeat = _InFlightToolHeartbeat(
+                self._redis,
+                prefix=self._key_prefix,
+                run_id=run_id,
+                conversation_id=conversation_id,
+                ttl_seconds=self._run_event_ttl_seconds,
+            )
 
             from cubepi.agent.types import MessageEndEvent as _MsgEndEvent
             from cubepi.providers.base import UserMessage as _UserMsg
@@ -2285,6 +2366,7 @@ class RunManager:
                 # Stop durable drains before scheduling detach so no steer can
                 # land in an Agent after its state has been persisted.
                 _log_tool_start(run_id, evt)
+                tool_heartbeat.observe(evt)
                 await auto_detach.quiesce_then_schedule(evt)
                 if isinstance(evt, _MsgEndEvent) and isinstance(evt.message, _UserMsg):
                     steer_id = evt.message.metadata.get("steer_id")
@@ -2387,6 +2469,7 @@ class RunManager:
                     claim_token=claim_token,
                     status=final_status,
                 )
+                tool_heartbeat.stop()
                 self._agents.pop(run_id, None)
                 self._hitl_channels.pop(run_id, None)
                 await sse_queue.put(None)

--- a/backend/cubeplex/streams/run_manager.py
+++ b/backend/cubeplex/streams/run_manager.py
@@ -95,6 +95,38 @@ def _message_for_run_exception(
     return english_fallback(code, params)
 
 
+_TOOL_ARGS_PREVIEW_LIMIT = 200
+
+
+def _preview_tool_args(args: object, *, limit: int = _TOOL_ARGS_PREVIEW_LIMIT) -> str:
+    """Compact tool-arg preview for debug logs (never the full payload)."""
+    if isinstance(args, str):
+        text = args
+    else:
+        try:
+            text = json.dumps(args, ensure_ascii=False, default=str)
+        except TypeError:
+            text = str(args)
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def _log_tool_start(run_id: str, evt: object) -> None:
+    """Debug-log every tool body start so a hung execute is greppable."""
+    from cubepi.agent.types import ToolExecutionStartEvent
+
+    if not isinstance(evt, ToolExecutionStartEvent):
+        return
+    logger.debug(
+        "tool start run_id={} tool={} call_id={} args={}",
+        run_id,
+        evt.tool_name,
+        evt.tool_call_id,
+        _preview_tool_args(evt.args),
+    )
+
+
 def _ns_to_agent_id(ns: tuple[Any, ...]) -> str | None:
     if not ns:
         return None
@@ -1018,7 +1050,7 @@ class RunManager:
             if existing and existing.status == "running":
                 from cubeplex.config import config as _cfg
 
-                threshold = int(_cfg.get("lifecycle.stale_run_threshold_seconds", 120))
+                threshold = int(_cfg.get("lifecycle.stale_run_threshold_seconds", 180))
                 if is_stale_meta(existing, threshold_seconds=threshold):
                     await mark_run_stale(
                         self._redis,
@@ -1754,6 +1786,7 @@ class RunManager:
                 # auto_detach must run FIRST so HitlRequestEvent triggers
                 # detach before the SSE conversion below; T6 reads
                 # `auto_detach.detached` in the terminal block.
+                _log_tool_start(run_id, evt)
                 auto_detach(evt, _signal)
                 nonlocal _user_msg_seen
                 if isinstance(evt, _MsgEndEvent) and isinstance(evt.message, _UserMsg):
@@ -2251,6 +2284,7 @@ class RunManager:
             async def _on_event(evt: Any, _signal: Any = None) -> None:
                 # Stop durable drains before scheduling detach so no steer can
                 # land in an Agent after its state has been persisted.
+                _log_tool_start(run_id, evt)
                 await auto_detach.quiesce_then_schedule(evt)
                 if isinstance(evt, _MsgEndEvent) and isinstance(evt.message, _UserMsg):
                     steer_id = evt.message.metadata.get("steer_id")

--- a/backend/cubeplex/streams/run_manager.py
+++ b/backend/cubeplex/streams/run_manager.py
@@ -1117,13 +1117,15 @@ class RunManager:
 
                 threshold = int(_cfg.get("lifecycle.stale_run_threshold_seconds", 180))
                 if is_stale_meta(existing, threshold_seconds=threshold):
-                    await mark_run_stale(
+                    marked = await mark_run_stale(
                         self._redis,
                         prefix=self._key_prefix,
                         run_id=existing.run_id,
                         conversation_id=conversation_id,
+                        observed_last_event_at=existing.last_event_at or existing.started_at,
                     )
-                    created_run = await _try_create_run()
+                    if marked:
+                        created_run = await _try_create_run()
             if created_run is None:
                 existing = await get_active_run(
                     self._redis,
@@ -2459,21 +2461,23 @@ class RunManager:
                         )
                     final_status = classification.status
             finally:
-                # CAS guard: only write the terminal status if our claim
-                # token still owns the meta row. A racing flow that took
-                # over the slot wins the row; our finalize is a no-op.
-                await finalize_run_meta_if_claim_matches(
-                    self._redis,
-                    prefix=self._key_prefix,
-                    run_id=run_id,
-                    claim_token=claim_token,
-                    status=final_status,
-                )
-                tool_heartbeat.stop()
-                self._agents.pop(run_id, None)
-                self._hitl_channels.pop(run_id, None)
-                await sse_queue.put(None)
-                await drainer
+                # Heartbeat / registration teardown must not depend on Redis
+                # finalize succeeding — a timeout there would leave the
+                # in-flight loop refreshing a dead resume.
+                try:
+                    await finalize_run_meta_if_claim_matches(
+                        self._redis,
+                        prefix=self._key_prefix,
+                        run_id=run_id,
+                        claim_token=claim_token,
+                        status=final_status,
+                    )
+                finally:
+                    tool_heartbeat.stop()
+                    self._agents.pop(run_id, None)
+                    self._hitl_channels.pop(run_id, None)
+                    await sse_queue.put(None)
+                    await drainer
 
         for agent_key in list(citation_buffers):
             await flush_citation_buffer(agent_key, agent_key)

--- a/backend/docs/deploy-k8s-graceful-restart.md
+++ b/backend/docs/deploy-k8s-graceful-restart.md
@@ -31,7 +31,7 @@ spec:
 | Key | Default | Notes |
 |---|---|---|
 | `lifecycle.graceful_drain_timeout_seconds` | 3600 | Hard cap on drain wait before forced cancel. Match `terminationGracePeriodSeconds`. |
-| `lifecycle.stale_run_threshold_seconds` | 120 | Seconds without an event before bootstrap declares a `running` run stale and clears its active-run lock. |
+| `lifecycle.stale_run_threshold_seconds` | 180 | Seconds without an event before bootstrap declares a `running` run stale and clears its active-run lock. Above the 120s execute-tool cap so a still-running command is not declared dead on refresh. |
 | `lifecycle.dev_double_signal_force_exit` | true | Second `Ctrl-C` forces immediate exit. Set false in prod if you want to require an external SIGKILL. |
 
 ## Force-killing a slow drain

--- a/backend/tests/e2e/test_sandbox_scoping.py
+++ b/backend/tests/e2e/test_sandbox_scoping.py
@@ -128,7 +128,7 @@ async def test_command_deny_blocks_and_filesystem_untouched(
     class _Sb:
         workdir = "/workspace"
 
-        async def execute(self, command: str) -> Any:  # pragma: no cover - guard
+        async def execute(self, command: str, **kwargs: object) -> Any:  # pragma: no cover - guard
             raise AssertionError("denied command must not reach the sandbox")
 
     class _ToolCall:
@@ -280,7 +280,7 @@ async def test_command_confirm_routes_through_hitl_channel(
     class _Sb:
         workdir = "/workspace"
 
-        async def execute(self, command: str) -> Any:  # pragma: no cover - unused
+        async def execute(self, command: str, **kwargs: object) -> Any:  # pragma: no cover - unused
             ran.append(command)
 
             class _R:

--- a/backend/tests/unit/test_lazy_sandbox_sync_lifecycle.py
+++ b/backend/tests/unit/test_lazy_sandbox_sync_lifecycle.py
@@ -83,6 +83,38 @@ async def test_sync_failure_does_not_set_flag_so_next_call_retries() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_keepalives_touch_and_lease_while_command_runs() -> None:
+    """A long execute must refresh last_activity and the in-use lease."""
+    catalog = MagicMock()
+    catalog.list_enabled_for_workspace = AsyncMock(return_value=[])
+    sandbox = _make_sandbox()
+
+    async def slow_execute(
+        command: str,
+        *,
+        timeout: int | None = None,
+        envs: object = None,
+        as_root: bool = False,
+    ) -> object:
+        del command, timeout, envs, as_root
+        await asyncio.sleep(0.12)
+        return MagicMock(output="", exit_code=0)
+
+    sandbox.id = "sbx-keep"
+    sandbox.execute = slow_execute
+    lazy = _make_lazy(catalog, sandbox)
+    lazy._keepalive_interval_seconds = 0.04
+
+    await lazy.execute("pip install foo", timeout=300)
+
+    # start (_ensure_with_retry) + at least one mid-command beat
+    assert lazy._manager.touch.await_count >= 2
+    assert lazy._manager.renew_lease.await_count >= 2
+    lease_kwargs = lazy._manager.renew_lease.await_args_list[-1].kwargs
+    assert lease_kwargs["lease_seconds"] == 300
+
+
+@pytest.mark.asyncio
 async def test_concurrent_first_calls_only_sync_once() -> None:
     catalog = MagicMock()
     catalog.list_enabled_for_workspace = AsyncMock(return_value=[])

--- a/backend/tests/unit/test_lazy_sandbox_sync_lifecycle.py
+++ b/backend/tests/unit/test_lazy_sandbox_sync_lifecycle.py
@@ -110,8 +110,10 @@ async def test_execute_keepalives_touch_and_lease_while_command_runs() -> None:
     # start (_ensure_with_retry) + at least one mid-command beat
     assert lazy._manager.touch.await_count >= 2
     assert lazy._manager.renew_lease.await_count >= 2
-    lease_kwargs = lazy._manager.renew_lease.await_args_list[-1].kwargs
-    assert lease_kwargs["lease_seconds"] == 300
+    # Lease window stays the construction default (None → manager 300s),
+    # not the command timeout.
+    for call in lazy._manager.renew_lease.await_args_list:
+        assert call.kwargs["lease_seconds"] is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_opensandbox_execute_env.py
+++ b/backend/tests/unit/test_opensandbox_execute_env.py
@@ -76,6 +76,34 @@ async def test_set_run_env_forwarded_to_commands_run() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_forwards_timeout_to_run_opts() -> None:
+    backend, _ = _make_backend()
+
+    await backend.execute("sleep 9", timeout=120)
+
+    _, opts = backend._test_run_calls[0]  # type: ignore[attr-defined]
+    assert opts is not None
+    assert opts.timeout is not None
+    assert opts.timeout.total_seconds() == 120
+
+
+@pytest.mark.asyncio
+async def test_execute_timeout_error_returns_marker() -> None:
+    backend, raw = _make_backend()
+
+    async def boom(command: str, *, opts: RunCommandOpts | None = None, **_: object) -> MagicMock:
+        del command, opts
+        from opensandbox.exceptions import SandboxException
+
+        raise SandboxException("command timed out after 120s")
+
+    raw.commands.run = boom
+    result = await backend.execute("sleep 999", timeout=120)
+    assert result.output == "[timeout]"
+    assert result.exit_code == -1
+
+
+@pytest.mark.asyncio
 async def test_per_call_envs_merge_and_win_over_run_env() -> None:
     """Per-call envs override run-level env; both are present in opts.envs."""
     backend, _ = _make_backend()

--- a/backend/tests/unit/test_run_heartbeat.py
+++ b/backend/tests/unit/test_run_heartbeat.py
@@ -1,0 +1,102 @@
+"""Unit tests: silent last_event_at heartbeat during long tool bodies."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import fakeredis.aioredis
+import pytest
+
+from cubeplex.streams.run_events import (
+    create_run,
+    get_run_meta,
+    iter_run_events,
+    touch_run_heartbeat,
+)
+
+
+@pytest.fixture
+def redis():
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+@pytest.mark.asyncio
+async def test_touch_run_heartbeat_updates_last_event_at_without_events(redis) -> None:
+    prefix = "test_run_hb"
+    run_id = "r-hb"
+    conv_id = "c-hb"
+    created = await create_run(
+        redis,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=datetime.now(UTC).isoformat(),
+        ttl_seconds=60,
+    )
+    assert created is not None
+    old = (datetime.now(UTC) - timedelta(seconds=400)).isoformat()
+    await redis.hset(f"{prefix}:run_meta:v2:{run_id}", "last_event_at", old)
+
+    await touch_run_heartbeat(
+        redis,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        ttl_seconds=60,
+    )
+
+    meta = await get_run_meta(redis, prefix=prefix, run_id=run_id)
+    assert meta is not None
+    assert meta.status == "running"
+    assert meta.last_event_at is not None
+    assert meta.last_event_at != old
+    assert await iter_run_events(redis, prefix=prefix, run_id=run_id) == []
+
+
+@pytest.mark.asyncio
+async def test_in_flight_tool_heartbeat_starts_and_stops() -> None:
+    import asyncio
+
+    from cubepi.agent.types import ToolExecutionEndEvent, ToolExecutionStartEvent
+
+    from cubeplex.streams.run_manager import _InFlightToolHeartbeat
+
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    prefix = "test_ifhb"
+    run_id = "r1"
+    conv_id = "c1"
+    await create_run(
+        redis,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=datetime.now(UTC).isoformat(),
+        ttl_seconds=60,
+    )
+    old = (datetime.now(UTC) - timedelta(seconds=400)).isoformat()
+    await redis.hset(f"{prefix}:run_meta:v2:{run_id}", "last_event_at", old)
+
+    hb = _InFlightToolHeartbeat(
+        redis,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        ttl_seconds=60,
+        interval_seconds=0.05,
+    )
+    hb.observe(
+        ToolExecutionStartEvent(
+            tool_call_id="c1",
+            tool_name="execute",
+            args={"command": "pip install foo"},
+        )
+    )
+    await asyncio.sleep(0.12)
+    meta = await get_run_meta(redis, prefix=prefix, run_id=run_id)
+    assert meta is not None
+    assert meta.last_event_at != old
+    hb.observe(ToolExecutionEndEvent(tool_call_id="c1", tool_name="execute", is_error=False))
+    assert hb._task is None or hb._task.done()
+    hb.stop()

--- a/backend/tests/unit/test_run_heartbeat.py
+++ b/backend/tests/unit/test_run_heartbeat.py
@@ -9,8 +9,10 @@ import pytest
 
 from cubeplex.streams.run_events import (
     create_run,
+    get_active_run,
     get_run_meta,
     iter_run_events,
+    mark_run_stale,
     touch_run_heartbeat,
 )
 
@@ -100,3 +102,78 @@ async def test_in_flight_tool_heartbeat_starts_and_stops() -> None:
     hb.observe(ToolExecutionEndEvent(tool_call_id="c1", tool_name="execute", is_error=False))
     assert hb._task is None or hb._task.done()
     hb.stop()
+
+
+@pytest.mark.asyncio
+async def test_mark_run_stale_cas_rejects_refreshed_heartbeat(redis) -> None:
+    prefix = "test_stale_cas"
+    run_id = "r-cas-hb"
+    conv_id = "c-cas-hb"
+    started = datetime.now(UTC).isoformat()
+    created = await create_run(
+        redis,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=started,
+        ttl_seconds=60,
+    )
+    assert created is not None
+    stale_at = (datetime.now(UTC) - timedelta(seconds=400)).isoformat()
+    await redis.hset(f"{prefix}:run_meta:v2:{run_id}", "last_event_at", stale_at)
+
+    await touch_run_heartbeat(
+        redis,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        ttl_seconds=60,
+    )
+
+    marked = await mark_run_stale(
+        redis,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        observed_last_event_at=stale_at,
+    )
+    assert marked is False
+    meta = await get_run_meta(redis, prefix=prefix, run_id=run_id)
+    assert meta is not None
+    assert meta.status == "running"
+    active = await get_active_run(redis, prefix=prefix, conversation_id=conv_id)
+    assert active is not None
+    assert active.run_id == run_id
+
+
+@pytest.mark.asyncio
+async def test_mark_run_stale_cas_accepts_matching_timestamp(redis) -> None:
+    prefix = "test_stale_ok"
+    run_id = "r-stale-ok"
+    conv_id = "c-stale-ok"
+    created = await create_run(
+        redis,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        status="running",
+        started_at=datetime.now(UTC).isoformat(),
+        ttl_seconds=60,
+    )
+    assert created is not None
+    stale_at = (datetime.now(UTC) - timedelta(seconds=400)).isoformat()
+    await redis.hset(f"{prefix}:run_meta:v2:{run_id}", "last_event_at", stale_at)
+
+    marked = await mark_run_stale(
+        redis,
+        prefix=prefix,
+        run_id=run_id,
+        conversation_id=conv_id,
+        observed_last_event_at=stale_at,
+    )
+    assert marked is True
+    meta = await get_run_meta(redis, prefix=prefix, run_id=run_id)
+    assert meta is not None
+    assert meta.status == "stale"
+    assert await get_active_run(redis, prefix=prefix, conversation_id=conv_id) is None

--- a/backend/tests/unit/test_run_manager_cubepi_tools.py
+++ b/backend/tests/unit/test_run_manager_cubepi_tools.py
@@ -15,6 +15,34 @@ def test_run_manager_imports_with_cubepi_tools() -> None:
     assert RunManager is not None
 
 
+def test_preview_tool_args_truncates() -> None:
+    from cubeplex.streams.run_manager import _preview_tool_args
+
+    long = {"command": "x" * 500}
+    preview = _preview_tool_args(long)
+    assert len(preview) <= 200
+    assert preview.endswith("…")
+
+
+def test_log_tool_start_ignores_other_events() -> None:
+    from cubeplex.streams.run_manager import _log_tool_start
+
+    _log_tool_start("run-1", object())
+
+
+def test_log_tool_start_accepts_start_event() -> None:
+    from cubepi.agent.types import ToolExecutionStartEvent
+
+    from cubeplex.streams.run_manager import _log_tool_start
+
+    evt = ToolExecutionStartEvent(
+        tool_call_id="call_1",
+        tool_name="execute",
+        args={"command": "gh issue list"},
+    )
+    _log_tool_start("run-1", evt)
+
+
 def test_run_cubepi_path_method_exists() -> None:
     """The cubepi dispatch method is still on RunManager."""
     from cubeplex.streams.run_manager import RunManager

--- a/backend/tests/unit/test_sandbox.py
+++ b/backend/tests/unit/test_sandbox.py
@@ -175,7 +175,7 @@ async def test_execute_tool_delegates_to_sandbox() -> None:
     args = _ExecuteArgs(command="echo hello world")
     result = await tool.execute("tc-1", args, signal=None, on_update=None)
 
-    sandbox.execute.assert_called_once_with("echo hello world")
+    sandbox.execute.assert_called_once_with("echo hello world", timeout=120)
     assert isinstance(result, AgentToolResult)
     assert "hello world" in _text(result)
 
@@ -210,6 +210,40 @@ async def test_execute_tool_no_exit_code_suffix_on_success() -> None:
     result = await tool.execute("tc-3", args)
 
     assert "[exit code:" not in _text(result)
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_timeout_returns_error_result() -> None:
+    """A timed-out command is a tool result the model can retry from, not a run crash."""
+    sandbox = _make_sandbox()
+    exec_result = MagicMock()
+    exec_result.output = "[timeout]"
+    exec_result.exit_code = -1
+    sandbox.execute = AsyncMock(return_value=exec_result)
+
+    tool = _make_execute_tool(sandbox)
+    args = _ExecuteArgs(command="sleep 999")
+    result = await tool.execute("tc-timeout", args)
+
+    sandbox.execute.assert_called_once_with("sleep 999", timeout=120)
+    text = _text(result)
+    assert text.startswith("[timeout]")
+    assert "120s" in text
+    assert result.is_error is True
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_maps_timeout_exception_to_result() -> None:
+    sandbox = _make_sandbox()
+    sandbox.execute = AsyncMock(side_effect=TimeoutError("timed out"))
+
+    tool = _make_execute_tool(sandbox)
+    result = await tool.execute("tc-to", _ExecuteArgs(command="gh issue list"))
+
+    text = _text(result)
+    assert text.startswith("[timeout]")
+    assert "120s" in text
+    assert result.is_error is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_sandbox.py
+++ b/backend/tests/unit/test_sandbox.py
@@ -251,12 +251,12 @@ def test_execute_args_rejects_timeout_above_max() -> None:
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
-        _ExecuteArgs(command="sleep 1", timeout_seconds=3600)
+        _ExecuteArgs(command="sleep 1", timeout_seconds=1801)
 
 
 def test_execute_args_accepts_timeout_at_max() -> None:
-    args = _ExecuteArgs(command="pip install foo", timeout_seconds=600)
-    assert args.timeout_seconds == 600
+    args = _ExecuteArgs(command="pip install foo", timeout_seconds=1800)
+    assert args.timeout_seconds == 1800
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_sandbox.py
+++ b/backend/tests/unit/test_sandbox.py
@@ -233,6 +233,33 @@ async def test_execute_tool_timeout_returns_error_result() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_tool_forwards_custom_timeout() -> None:
+    sandbox = _make_sandbox()
+    exec_result = MagicMock()
+    exec_result.output = "ok"
+    exec_result.exit_code = 0
+    sandbox.execute = AsyncMock(return_value=exec_result)
+
+    tool = _make_execute_tool(sandbox)
+    args = _ExecuteArgs(command="pip install foo", timeout_seconds=300)
+    await tool.execute("tc-custom", args)
+
+    sandbox.execute.assert_called_once_with("pip install foo", timeout=300)
+
+
+def test_execute_args_rejects_timeout_above_max() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        _ExecuteArgs(command="sleep 1", timeout_seconds=3600)
+
+
+def test_execute_args_accepts_timeout_at_max() -> None:
+    args = _ExecuteArgs(command="pip install foo", timeout_seconds=600)
+    assert args.timeout_seconds == 600
+
+
+@pytest.mark.asyncio
 async def test_execute_tool_maps_timeout_exception_to_result() -> None:
     sandbox = _make_sandbox()
     sandbox.execute = AsyncMock(side_effect=TimeoutError("timed out"))

--- a/backend/tests/unit/test_sandbox_local.py
+++ b/backend/tests/unit/test_sandbox_local.py
@@ -19,6 +19,14 @@ async def test_execute_exit_code():
 
 
 @pytest.mark.asyncio
+async def test_execute_timeout_kills_and_returns_marker():
+    sandbox = LocalSandbox()
+    result = await sandbox.execute("sleep 30", timeout=1)
+    assert result.output == "[timeout]"
+    assert result.exit_code == -1
+
+
+@pytest.mark.asyncio
 async def test_execute_combines_stderr():
     sandbox = LocalSandbox()
     result = await sandbox.execute("echo out && echo err >&2")

--- a/backend/tests/unit/test_sandbox_manager.py
+++ b/backend/tests/unit/test_sandbox_manager.py
@@ -29,8 +29,9 @@ def test_create_timeout_overrides_request_timeout_for_create_only(mock_encryptio
     default = manager._build_connection_config()
     create = manager._build_connection_config(request_timeout=manager._create_timeout)
 
-    # Ordinary commands keep the short per-command budget; the create call gets the
-    # longer budget so a cold image pull doesn't time out before the pod is ready.
+    # Ordinary commands use request_timeout (must cover max execute 600s).
+    # Create still passes create_timeout so a cold image pull has its own budget.
     assert default.request_timeout.total_seconds() == manager._request_timeout
     assert create.request_timeout.total_seconds() == manager._create_timeout
-    assert manager._create_timeout > manager._request_timeout
+    assert manager._request_timeout >= 600
+    assert manager._create_timeout != manager._request_timeout

--- a/backend/tests/unit/test_sandbox_manager.py
+++ b/backend/tests/unit/test_sandbox_manager.py
@@ -29,9 +29,9 @@ def test_create_timeout_overrides_request_timeout_for_create_only(mock_encryptio
     default = manager._build_connection_config()
     create = manager._build_connection_config(request_timeout=manager._create_timeout)
 
-    # Ordinary commands use request_timeout (must cover max execute 600s).
+    # Ordinary commands use request_timeout (must cover max execute 1800s).
     # Create still passes create_timeout so a cold image pull has its own budget.
     assert default.request_timeout.total_seconds() == manager._request_timeout
     assert create.request_timeout.total_seconds() == manager._create_timeout
-    assert manager._request_timeout >= 600
+    assert manager._request_timeout >= 1800
     assert manager._create_timeout != manager._request_timeout

--- a/docs/site/docs/deployment/backend-config.md
+++ b/docs/site/docs/deployment/backend-config.md
@@ -417,7 +417,7 @@ logger names to `verbose_modules` to selectively re-enable DEBUG.
 ```yaml
 lifecycle:
   graceful_drain_timeout_seconds: 3600   # max wait for in-flight runs on shutdown
-  stale_run_threshold_seconds: 120
+  stale_run_threshold_seconds: 180
 ```
 
 `graceful_drain_timeout_seconds` bounds how long the backend waits for active

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/backend-config.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/backend-config.md
@@ -397,7 +397,7 @@ logging:
 ```yaml
 lifecycle:
   graceful_drain_timeout_seconds: 3600   # 关机时等待进行中 run 的最大时间
-  stale_run_threshold_seconds: 120
+  stale_run_threshold_seconds: 180
 ```
 
 `graceful_drain_timeout_seconds` 限定后端关机前等待活动 agent run 完成的时长——


### PR DESCRIPTION
## Summary

A hung sandbox `execute` (for example `gh` waiting on GitHub) could stall an agent run for many minutes with no tool result. Refresh then marked the still-running worker stale even though the backend process was alive. Long installs had the same stale/lease problem once they outlived the idle windows.

- Default `execute` timeout is **120s**, returned as `[timeout]` (`is_error=True`) so the model can retry.
- Agents can pass **`timeout_seconds` (max 1800)** for installs, downloads, or builds.
- The 120s default and the optional longer timeout are visible in the tool description and sandbox system prompt.
- While any tool body is running, refresh **`last_event_at`** every 30s (no user-visible SSE) so a long install is not declared stale on refresh.
- During `execute`, also **touch** sandbox `last_activity` and **renew the in-use lease** on the default 300s sliding window so the idle reaper cannot pause/kill a live command.
- Raise `lifecycle.stale_run_threshold_seconds` 120 → **180**.
- Raise sandbox HTTP `request_timeout` to **1860s** so the HTTP client does not fire before an 1800s command timeout.

## Test plan

- [x] Unit: execute timeout / custom timeout / pydantic max, local kill, OpenSandbox timeout marker, lazy keepalive, run heartbeat
- [x] pre-push `check-ci`