### PR TITLE
Close stale right panel on workspace and chat switch

### DIFF
--- a/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
+++ b/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
@@ -37,6 +37,7 @@ const messages = {
       expand: 'Expand preview',
       exitExpand: 'Exit expand',
       expandedPlaceholder: 'Expanded in preview',
+      unavailable: 'Preview unavailable',
       unknownType: 'Unknown type',
       justNow: 'just now',
       minutesAgo: '{n}m ago',
@@ -114,6 +115,23 @@ describe('ArtifactPanel expand theater', () => {
       deletedIds: {},
     })
     seedArtifact()
+  })
+
+  it('keeps a close control when the selected artifact is missing', () => {
+    useArtifactStore.setState({
+      artifacts: {},
+      versions: {},
+      selectedVersion: {},
+      loading: {},
+      deletedIds: {},
+    })
+    usePanelStore.getState().openArtifact('conv-1', 'art-missing')
+
+    renderPanel()
+
+    expect(screen.getByTestId('artifact-panel-empty')).toBeInTheDocument()
+    fireEvent.click(screen.getByTitle('Close'))
+    expect(usePanelStore.getState().view).toEqual({ type: 'closed' })
   })
 
   it('opens in-app expand and unmounts rail preview (single host)', () => {

--- a/frontend/packages/web/__tests__/components/WorkspaceHomePage.test.tsx
+++ b/frontend/packages/web/__tests__/components/WorkspaceHomePage.test.tsx
@@ -18,6 +18,7 @@ const storeMocks = vi.hoisted(() => ({
   hydrate: vi.fn(),
   attachedIds: vi.fn(),
   setWorkspaceId: vi.fn(),
+  closePanel: vi.fn(),
 }))
 
 vi.mock('next/navigation', () => ({
@@ -62,18 +63,21 @@ vi.mock('@cubeplex/core', () => {
       },
       { setState: storeMocks.setConversationState },
     ),
-    usePanelStore: (
-      selector: (state: {
-        view: { type: string }
-        openSandbox: () => void
-        close: () => void
-      }) => unknown,
-    ) =>
-      selector({
-        view: { type: 'closed' },
-        openSandbox: vi.fn(),
-        close: vi.fn(),
-      }),
+    usePanelStore: Object.assign(
+      (
+        selector: (state: {
+          view: { type: string }
+          openSandbox: () => void
+          close: () => void
+        }) => unknown,
+      ) =>
+        selector({
+          view: { type: 'closed' },
+          openSandbox: vi.fn(),
+          close: storeMocks.closePanel,
+        }),
+      { getState: () => ({ close: storeMocks.closePanel }) },
+    ),
     useMessageStore: (
       selector: (state: {
         send: typeof storeMocks.send
@@ -143,6 +147,15 @@ describe('WorkspaceHomePage', () => {
         dispatchEvent: vi.fn(),
       })),
     })
+  })
+
+  it('closes a leftover panel from the previous conversation on mount', async () => {
+    await act(async () => {
+      renderWithIntl(<WorkspaceHomePage params={Promise.resolve({ wsId: 'ws-1' })} />)
+      await Promise.resolve()
+    })
+
+    expect(storeMocks.closePanel).toHaveBeenCalled()
   })
 
   it('eagerly creates a draft conversation on file pick and uploads to it', async () => {

--- a/frontend/packages/web/app/(app)/w/[wsId]/conversations/[id]/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/conversations/[id]/page.tsx
@@ -110,6 +110,9 @@ export default function ChatPage({ params }: { params: Promise<{ wsId: string; i
     })()
     return () => {
       cancelled = true
+      // Leaving this conversation (new chat, another chat, or another
+      // workspace page) must not leave the previous chat's rail open.
+      usePanelStore.getState().close()
       // Leaving the chat page must not leave activeId stuck on this
       // conversation — otherwise stream terminalization thinks the user is
       // still "present" on settings / home / another panel.

--- a/frontend/packages/web/app/(app)/w/[wsId]/layout.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/layout.tsx
@@ -3,13 +3,12 @@
 import { use, useEffect, useMemo } from 'react'
 import {
   createApiClient,
-  useArtifactStore,
   useConversationStore,
   useMcpToolRegistryStore,
   useTopicStore,
-  useWorkspaceSettingsStore,
 } from '@cubeplex/core'
 import { WorkspaceContext } from '@/hooks/useWorkspaceContext'
+import { resetWorkspaceScopedClientState } from '@/lib/resetWorkspaceScopedState'
 
 export default function WorkspaceLayout({
   params,
@@ -22,21 +21,11 @@ export default function WorkspaceLayout({
   const value = useMemo(() => ({ workspaceId: wsId }), [wsId])
 
   useEffect(() => {
-    // Reset cross-workspace state when the wsId changes so stale conversations
-    // and artifacts from the previous workspace don't bleed through, then load
-    // the new workspace's conversation list so the sidebar is populated on
-    // every page within the workspace (including the home page).
-    useConversationStore.setState({ conversations: [], activeId: null })
-    useTopicStore.setState({ topics: [], topicParticipants: {} })
-    useArtifactStore.setState({ artifacts: {} })
-    useWorkspaceSettingsStore.setState({
-      agentConfig: null,
-      skills: null,
-      mcpEffectiveConnectors: null,
-      loading: false,
-      error: null,
-    })
-    useMcpToolRegistryStore.setState({ byWorkspace: {}, loading: {} })
+    // Reset cross-workspace state when the wsId changes so stale conversations,
+    // artifacts, and the right-hand panel from the previous workspace don't
+    // bleed through, then load the new workspace's conversation list so the
+    // sidebar is populated on every page within the workspace.
+    resetWorkspaceScopedClientState()
     const client = createApiClient('')
     client.setWorkspaceId(wsId)
     useConversationStore.getState().fetchList(client)

--- a/frontend/packages/web/app/(app)/w/[wsId]/page.tsx
+++ b/frontend/packages/web/app/(app)/w/[wsId]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { use, useState, useCallback } from 'react'
+import { use, useState, useCallback, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import {
@@ -8,6 +8,7 @@ import {
   useAttachmentStore,
   useConversationStore,
   useMessageStore,
+  usePanelStore,
 } from '@cubeplex/core'
 import { AppShell } from '@/components/layout/AppShell'
 import { InputBar } from '@/components/layout/InputBar'
@@ -31,6 +32,13 @@ export default function WorkspaceHomePage({
   const { create: createConversation, rename: renameConversation } = useConversationStore()
   const send = useMessageStore((s) => s.send)
   const [draftConvId, setDraftConvId] = useState<string | null>(null)
+
+  // New chat (sidebar / composer) lands here. Conversation pages close the
+  // rail on mount; this route must too, or a tool/artifact/sandbox panel from
+  // the previous chat stays open.
+  useEffect(() => {
+    usePanelStore.getState().close()
+  }, [])
 
   const ensureConversation = useCallback(async (): Promise<string> => {
     if (draftConvId) return draftConvId

--- a/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
+++ b/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
@@ -268,7 +268,21 @@ export function ArtifactPanel() {
     loadVersions(client, conversationId, artifactId)
   }, [artifact, conversationId, artifactId, loadVersions, workspaceId])
 
-  if (view.type !== 'artifact' || !artifact || !workspaceId || !identityKey) return null
+  if (view.type !== 'artifact') return null
+
+  // Artifacts can be missing while the list is still loading, or after a
+  // workspace reset cleared the store. Keep chrome + Close so the rail is
+  // never an empty, undismissable column.
+  if (!artifact || !workspaceId || !identityKey) {
+    return (
+      <div className="flex h-full flex-col bg-background" data-testid="artifact-panel-empty">
+        <PanelHeader
+          source={{ kind: 'plain', icon: <span />, title: t('unavailable') }}
+          onClose={close}
+        />
+      </div>
+    )
+  }
 
   const artifactVersions = versions[artifact.id] ?? []
   const currentSelectedVersion = selectedVersion[artifact.id] ?? null

--- a/frontend/packages/web/components/panel/sandbox/SandboxPanel.tsx
+++ b/frontend/packages/web/components/panel/sandbox/SandboxPanel.tsx
@@ -28,8 +28,8 @@ const TABS: {
 ]
 
 /** Last workspace/conversation the sandbox panel rendered for. Module-level so
- *  remounts (route changes) can detect a scope change even when conversation
- *  pages close the panel and home does not. */
+ *  remounts (route changes) can detect a scope change if a path leaves the
+ *  panel open. */
 let lastSandboxScopeKey: string | null = null
 
 function sandboxScopeKey(workspaceId: string | null, conversationId?: string | null): string {
@@ -50,10 +50,9 @@ export function SandboxPanel({ workspaceId, conversationId }: SandboxPanelProps)
   const terminalRefreshRef = useRef<(() => Promise<unknown>) | null>(null)
   const scopeKey = sandboxScopeKey(workspaceId, conversationId)
 
-  // If the user navigates while the global sandbox panel stays open (e.g.
-  // conversation → home, or a path that does not call panelStore.close), drop
-  // any file path targeted for the previous conversation so we don't fetch it
-  // under the wrong sandbox scope.
+  // If the user navigates while the global sandbox panel stays open (a path
+  // that does not call panelStore.close), drop any file path targeted for the
+  // previous conversation so we don't fetch it under the wrong sandbox scope.
   useEffect(() => {
     const prev = lastSandboxScopeKey
     lastSandboxScopeKey = scopeKey

--- a/frontend/packages/web/lib/resetWorkspaceScopedState.test.ts
+++ b/frontend/packages/web/lib/resetWorkspaceScopedState.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useArtifactStore, usePanelStore } from '@cubeplex/core'
+
+import { resetWorkspaceScopedClientState } from './resetWorkspaceScopedState'
+
+describe('resetWorkspaceScopedClientState', () => {
+  beforeEach(() => {
+    usePanelStore.setState({ view: { type: 'closed' } })
+    useArtifactStore.setState({ artifacts: {} })
+  })
+
+  it('closes an open panel so a workspace switch cannot leave an empty rail', () => {
+    usePanelStore.getState().openArtifact('conv-1', 'art-1')
+    expect(usePanelStore.getState().view.type).toBe('artifact')
+
+    resetWorkspaceScopedClientState()
+
+    expect(usePanelStore.getState().view).toEqual({ type: 'closed' })
+  })
+
+  it('closes a sandbox panel as well as artifact/tool views', () => {
+    usePanelStore.getState().openSandbox()
+    resetWorkspaceScopedClientState()
+    expect(usePanelStore.getState().view).toEqual({ type: 'closed' })
+  })
+})

--- a/frontend/packages/web/lib/resetWorkspaceScopedState.ts
+++ b/frontend/packages/web/lib/resetWorkspaceScopedState.ts
@@ -1,0 +1,27 @@
+import {
+  useArtifactStore,
+  useConversationStore,
+  useMcpToolRegistryStore,
+  usePanelStore,
+  useTopicStore,
+  useWorkspaceSettingsStore,
+} from '@cubeplex/core'
+
+/** Drop client state that must not bleed across workspaces. */
+export function resetWorkspaceScopedClientState(): void {
+  useConversationStore.setState({ conversations: [], activeId: null })
+  useTopicStore.setState({ topics: [], topicParticipants: {} })
+  useArtifactStore.setState({ artifacts: {} })
+  useWorkspaceSettingsStore.setState({
+    agentConfig: null,
+    skills: null,
+    mcpEffectiveConnectors: null,
+    loading: false,
+    error: null,
+  })
+  useMcpToolRegistryStore.setState({ byWorkspace: {}, loading: {} })
+  // Panel content is conversation/workspace scoped. Leaving it open after
+  // a switch renders an empty rail with no close control (ArtifactPanel
+  // returns null once artifacts were cleared above).
+  usePanelStore.getState().close()
+}

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -1646,6 +1646,7 @@
       "expand": "Expand preview",
       "exitExpand": "Exit expand",
       "expandedPlaceholder": "Expanded in preview",
+      "unavailable": "Preview unavailable",
       "unknownType": "Unknown type",
       "justNow": "just now",
       "minutesAgo": "{n}m ago",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -1646,6 +1646,7 @@
       "expand": "展开预览",
       "exitExpand": "退出展开",
       "expandedPlaceholder": "已在大图预览中展开",
+      "unavailable": "预览不可用",
       "unknownType": "未知类型",
       "justNow": "刚刚",
       "minutesAgo": "{n} 分钟前",


### PR DESCRIPTION
## Summary

The right-hand panel store is global. Switching workspace or landing on new chat cleared conversation/artifact state, but left the rail open. Artifact chrome then returned `null` (no close control), so the user got an empty, undismissable column.

- Reset workspace-scoped client state now also closes the panel.
- Conversation pages close the rail on unmount; the workspace home / new-chat route closes it on mount.
- If the selected artifact is already gone, ArtifactPanel still renders a header with Close.

## Test plan

- [ ] Open an artifact (or sandbox) rail, switch workspace — rail closes; no empty column.
- [ ] Open a rail, click New chat — rail closes on the home composer.
- [ ] Open a rail, switch to another conversation — previous chat's rail does not stay open.
- [ ] If the selected artifact is missing, the empty rail still has a working Close control.