### PR TITLE
Point sandbox clients at the MITM CA bundle

### DIFF
--- a/deploy/kubernetes/egress-bundle/README.md
+++ b/deploy/kubernetes/egress-bundle/README.md
@@ -5,8 +5,9 @@ Kubernetes manifests and supporting code for CubePlex's secret-injecting MITM eg
 OpenSandbox server and egress image stay **100% stock**.  This bundle adds:
 
 - A **mutating admission webhook** (Python/FastAPI) that patches each sandbox pod to enable
-  transparent MITM, mount a per-sandbox mTLS client identity and the fixed CA, and load
-  the `inject.py` addon.
+  transparent MITM, mount a per-sandbox mTLS client identity and the fixed CA, load
+  the `inject.py` addon, and set `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` /
+  `NODE_EXTRA_CA_CERTS` on app containers so uv / requests / npm trust the MITM CA.
 - The **`inject.py` mitmproxy addon** that scans outbound headers for `cbxref_` placeholders,
   calls the CubePlex exchange endpoint over mTLS, and substitutes the real secret.
 - Kubernetes manifests wiring the above together.

--- a/deploy/kubernetes/egress-bundle/webhook/patch.py
+++ b/deploy/kubernetes/egress-bundle/webhook/patch.py
@@ -17,6 +17,17 @@ _ADDON_PATH = "/etc/egress-inject/inject.py"
 # launch-chrome.sh, which imports it into Chromium's NSS store — keep the two in sync.
 _SHARED_CA_PATH = "/etc/ssl/certs/cubeplex-egress-ca.pem"
 
+# Rebuilt by egress-ca-trust's update-ca-certificates onto the shared ca-trust
+# volume. uv, pip-requests, and Node/npm ship their own Mozilla roots and
+# ignore /etc/ssl/certs unless pointed here. The three names are not
+# interchangeable: requests ignores SSL_CERT_FILE; Node ignores both.
+_SYSTEM_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+_APP_TRUST_ENV = (
+    {"name": "SSL_CERT_FILE", "value": _SYSTEM_CA_BUNDLE},
+    {"name": "REQUESTS_CA_BUNDLE", "value": _SYSTEM_CA_BUNDLE},
+    {"name": "NODE_EXTRA_CA_CERTS", "value": _SYSTEM_CA_BUNDLE},
+)
+
 # OpenSandbox owns sandbox pods via a BatchSandbox CR (the per-sandbox path also
 # uses Sandbox); both live under the sandbox.opensandbox.io API group.
 _SANDBOX_OWNER_KINDS = frozenset({"BatchSandbox", "Sandbox"})
@@ -60,6 +71,18 @@ def _egress_index(pod: dict[str, Any]) -> int:
 def _app_indices(pod: dict[str, Any]) -> list[int]:
     """Return indices of all non-egress containers (may be empty)."""
     return [i for i, c in enumerate(pod["spec"]["containers"]) if c.get("name") != "egress"]
+
+
+def _merge_app_trust_env(existing: list[dict[str, Any]]) -> list[dict[str, Any]] | None:
+    """Append MITM client-trust env vars; None if every name is already set.
+
+    Existing values win so an operator-set SSL_CERT_FILE is not overwritten.
+    """
+    names = {e.get("name") for e in existing}
+    extra = [item for item in _APP_TRUST_ENV if item["name"] not in names]
+    if not extra:
+        return None
+    return list(existing) + extra
 
 
 def build_pod_patch(
@@ -134,19 +157,25 @@ def build_pod_patch(
     ops.append({"op": "add", "path": "/spec/initContainers", "value": init})
 
     # 4) ALL non-egress containers mount the shared trust dir (so the updated
-    # bundle is visible in each app container). Pods with no app containers are
-    # handled gracefully: this loop simply emits no ops.
+    # bundle is visible in each app container) and get client-trust env so
+    # uv / requests / npm actually read that bundle. Pods with no app
+    # containers are handled gracefully: this loop simply emits no ops.
     #
     # Skip any container that already mounts /etc/ssl/certs: Kubernetes rejects a
     # pod with duplicate volumeMounts.mountPath, so re-adding it would make
-    # admission succeed but pod creation fail (Codex P2).
+    # admission succeed but pod creation fail (Codex P2). The client-trust env
+    # is independent of that skip — those processes still need the pointers.
     for aidx in _app_indices(pod):
         app_c = pod["spec"]["containers"][aidx]
         existing = app_c.get("volumeMounts", [])
-        if any(m.get("mountPath") == "/etc/ssl/certs" for m in existing):
-            continue
-        app_mounts = existing + [{"name": "ca-trust", "mountPath": "/etc/ssl/certs"}]
-        ops.append({"op": "add", "path": f"/spec/containers/{aidx}/volumeMounts", "value": app_mounts})
+        if not any(m.get("mountPath") == "/etc/ssl/certs" for m in existing):
+            app_mounts = existing + [{"name": "ca-trust", "mountPath": "/etc/ssl/certs"}]
+            ops.append(
+                {"op": "add", "path": f"/spec/containers/{aidx}/volumeMounts", "value": app_mounts}
+            )
+        merged_env = _merge_app_trust_env(app_c.get("env") or [])
+        if merged_env is not None:
+            ops.append({"op": "add", "path": f"/spec/containers/{aidx}/env", "value": merged_env})
 
     # 5) pod-level volumes
     volumes = pod["spec"].get("volumes", []) + [

--- a/deploy/kubernetes/egress-bundle/webhook/tests/test_patch.py
+++ b/deploy/kubernetes/egress-bundle/webhook/tests/test_patch.py
@@ -205,3 +205,132 @@ def test_patch_egress_only_pod_no_app_container_mounts():
         and any(m.get("name") == "ca-trust" for m in op.get("value", []))
     ]
     assert ca_trust_app_mounts == []
+
+
+_SYSTEM_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+_APP_TRUST_ENV_NAMES = ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "NODE_EXTRA_CA_CERTS")
+
+
+def _env_op(ops: list[dict], container_index: int) -> dict | None:
+    path = f"/spec/containers/{container_index}/env"
+    return next((op for op in ops if op["path"] == path), None)
+
+
+def _env_map(ops: list[dict], container_index: int) -> dict[str, str]:
+    op = _env_op(ops, container_index)
+    if op is None:
+        return {}
+    return {e["name"]: e.get("value", "") for e in op["value"]}
+
+
+def test_patch_sets_app_client_trust_env():
+    """uv / requests / npm ignore the system store; the webhook must point
+    them at the rebuilt bundle (same file update-ca-certificates writes)."""
+    ops = build_pod_patch(
+        POD, sandbox_id="sbx-1", egress_image=EGRESS_IMAGE,
+        exchange_url="https://egress-exchange.internal/api/v1/internal/egress/exchange",
+    )
+    # App container is index 0; egress is index 1.
+    app_env = _env_map(ops, 0)
+    for name in _APP_TRUST_ENV_NAMES:
+        assert app_env[name] == _SYSTEM_CA_BUNDLE
+    egress_env = _env_map(ops, 1)
+    for name in _APP_TRUST_ENV_NAMES:
+        assert name not in egress_env
+
+
+def test_patch_sets_client_trust_env_on_all_app_containers():
+    ops = build_pod_patch(
+        MULTI_APP_POD, sandbox_id="sbx-2", egress_image=EGRESS_IMAGE,
+        exchange_url="https://egress-exchange.internal/api/v1/internal/egress/exchange",
+    )
+    for idx in (0, 1):
+        env = _env_map(ops, idx)
+        for name in _APP_TRUST_ENV_NAMES:
+            assert env[name] == _SYSTEM_CA_BUNDLE
+    egress_env = _env_map(ops, 2)
+    for name in _APP_TRUST_ENV_NAMES:
+        assert name not in egress_env
+
+
+def test_patch_sets_client_trust_env_even_when_ssl_certs_already_mounted():
+    """Skipping the duplicate ca-trust mount must not skip the client env.
+    Those containers still need uv/requests/npm pointed at the bundle."""
+    pod = {
+        "metadata": {
+            "ownerReferences": [
+                {
+                    "apiVersion": "sandbox.opensandbox.io/v1alpha1",
+                    "kind": "Sandbox",
+                    "name": "sbx-4",
+                }
+            ],
+            "labels": {},
+        },
+        "spec": {
+            "containers": [
+                {
+                    "name": "sandbox",
+                    "image": "py:3.13",
+                    "volumeMounts": [{"name": "existing-certs", "mountPath": "/etc/ssl/certs"}],
+                },
+                {"name": "egress", "image": EGRESS_IMAGE},
+            ],
+            "volumes": [],
+        },
+    }
+    ops = build_pod_patch(
+        pod, sandbox_id="sbx-4", egress_image=EGRESS_IMAGE,
+        exchange_url="https://egress-exchange.internal/api/v1/internal/egress/exchange",
+    )
+    assert not any(op["path"] == "/spec/containers/0/volumeMounts" for op in ops)
+    env = _env_map(ops, 0)
+    for name in _APP_TRUST_ENV_NAMES:
+        assert env[name] == _SYSTEM_CA_BUNDLE
+
+
+def test_patch_preserves_existing_app_trust_env():
+    """An operator-set SSL_CERT_FILE must not be overwritten."""
+    pod = {
+        "metadata": {
+            "ownerReferences": [
+                {
+                    "apiVersion": "sandbox.opensandbox.io/v1alpha1",
+                    "kind": "Sandbox",
+                    "name": "sbx-5",
+                }
+            ],
+            "labels": {},
+        },
+        "spec": {
+            "containers": [
+                {
+                    "name": "sandbox",
+                    "image": "py:3.13",
+                    "env": [{"name": "SSL_CERT_FILE", "value": "/custom/ca.pem"}],
+                },
+                {"name": "egress", "image": EGRESS_IMAGE},
+            ],
+            "volumes": [],
+        },
+    }
+    ops = build_pod_patch(
+        pod, sandbox_id="sbx-5", egress_image=EGRESS_IMAGE,
+        exchange_url="https://egress-exchange.internal/api/v1/internal/egress/exchange",
+    )
+    env = _env_map(ops, 0)
+    assert env["SSL_CERT_FILE"] == "/custom/ca.pem"
+    assert env["REQUESTS_CA_BUNDLE"] == _SYSTEM_CA_BUNDLE
+    assert env["NODE_EXTRA_CA_CERTS"] == _SYSTEM_CA_BUNDLE
+
+
+def test_patch_egress_only_pod_no_app_client_trust_env():
+    ops = build_pod_patch(
+        EGRESS_ONLY_POD, sandbox_id="sbx-3", egress_image=EGRESS_IMAGE,
+        exchange_url="https://egress-exchange.internal/api/v1/internal/egress/exchange",
+    )
+    # Only egress (index 0). Its env op is the MITM sidecar env, not client trust.
+    egress_env = _env_map(ops, 0)
+    for name in _APP_TRUST_ENV_NAMES:
+        assert name not in egress_env
+    assert _env_op(ops, 1) is None

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -489,6 +489,12 @@ Moving pieces the chart wires up:
 | Backend mTLS server cert + mTLS listener on `:8443` | cubeplex ns |
 | Updated backend Service exposing `:8443` | cubeplex ns |
 
+The webhook also sets `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, and
+`NODE_EXTRA_CA_CERTS` on every sandbox app container so clients that ignore
+the system trust store (uv, Python `requests`, Node/npm) trust the MITM CA.
+Existing values of those names are left alone. Recreate running sandboxes
+after upgrading the webhook — admission only runs on new pods.
+
 The `cubeplex-egress-webhook` image ships with each GHCR release, so no extra
 build is needed. Turn the feature on in `values.local.yaml`:
 

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/kubernetes.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/kubernetes.md
@@ -466,6 +466,12 @@ chart 会自动配置以下组件：
 | backend mTLS server 证书 + `:8443` 上的 mTLS listener | cubeplex 命名空间 |
 | 暴露 `:8443` 的 backend Service | cubeplex 命名空间 |
 
+webhook 还会给每个 sandbox 应用容器设置 `SSL_CERT_FILE`、
+`REQUESTS_CA_BUNDLE` 和 `NODE_EXTRA_CA_CERTS`，让不走系统信任库的客户端
+（uv、Python `requests`、Node/npm）也能信任 MITM CA。这三个名字如果容器里
+已经有值，不会覆盖。升级 webhook 之后要重建正在跑的 sandbox——admission
+只在新建 pod 时执行。
+
 `cubeplex-egress-webhook` 镜像随每个 GHCR release 一起发布，无需额外构建。
 在 `values.local.yaml` 中打开：
 


### PR DESCRIPTION
## Summary

The egress webhook already rebuilds `/etc/ssl/certs` with the MITM CA, but `uv`, pip-installed `requests`, and Node/npm ship their own Mozilla roots and never look there. Live-checked on running sandbox `2bea5d07-a5bb-4aac-a9c1-706eb30760d1-0` (pypi.org / registry.npmjs.org issued by `cubebox-egress-mitm-ca`):

| Client | no env | `SSL_CERT_FILE` | `REQUESTS_CA_BUNDLE` | `NODE_EXTRA_CA_CERTS` |
|---|---|---|---|---|
| uv 0.12.4 | `UnknownIssuer` | works | — | — |
| requests | `CERTIFICATE_VERIFY_FAILED` | still fails | works | — |
| httpx | `CERTIFICATE_VERIFY_FAILED` | works | still fails | — |
| npm / Node | timeout / `UNABLE_TO_VERIFY_LEAF_SIGNATURE` | still fails | — | works |

This injects all three on every **app** container (not the egress sidecar), pointing at the rebuilt `/etc/ssl/certs/ca-certificates.crt`. Existing values of those names are left alone. Volume-mount skip for `/etc/ssl/certs` is unchanged and no longer also skips the env.

## After merge

Rebuild and roll the `cubeplex-egress-webhook` image, then **recreate** running sandboxes. Admission only runs on new pods.

## Test plan

- [x] `pytest deploy/kubernetes/egress-bundle/webhook/tests` — 20 passed
- [x] Live MITM sandbox matrix above
- [ ] After webhook image rollout: new sandbox has the three env vars; `uv pip compile`, `requests.get`, and `npm view` succeed through MITM