### PR TITLE
Deliver present_file as a native IM image or file

### DIFF
--- a/backend/cubeplex/agents/schemas.py
+++ b/backend/cubeplex/agents/schemas.py
@@ -103,6 +103,17 @@ class ArtifactEvent(AgentEvent):
     )
 
 
+class PresentedFileEvent(AgentEvent):
+    """Presented-file event.
+
+    Emitted when the agent shows a sandbox file via present_file. IM outbound
+    consumes this; the web UI still renders from the tool_result.
+    """
+
+    type: Literal["presented_file"] = "presented_file"
+    data: dict[str, Any] = Field(description="presented_file object (id, filename, kind, …)")
+
+
 class ErrorEvent(AgentEvent):
     """Event emitted when an error occurs"""
 

--- a/backend/cubeplex/agents/stream.py
+++ b/backend/cubeplex/agents/stream.py
@@ -18,7 +18,7 @@ Two layers:
 
 cubeplex SSE event types (consumed by frontend):
     text_delta, reasoning, tool_call, tool_call_delta, tool_result,
-    usage, error, done, artifact, injected_message,
+    usage, error, done, artifact, presented_file, injected_message,
     sandbox_confirm_request, sandbox_confirm_resolved,
     ask_user_request, ask_user_resolved.
 """
@@ -112,6 +112,39 @@ def _artifact_event_from_tool_result(
         "type": "artifact",
         "action": parsed.get("action", "created"),
         "artifact": artifact,
+    }
+
+
+def _presented_file_event_from_tool_result(
+    tool_name: str, is_error: bool, result_text: str
+) -> dict[str, Any] | None:
+    """Build a presented_file SSE dict from a successful present_file result."""
+    if tool_name != "present_file" or is_error:
+        return None
+    try:
+        parsed = json.loads(result_text)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    presented = parsed.get("presented_file")
+    if not isinstance(presented, dict) or not presented.get("id"):
+        return None
+    size_raw = presented.get("size_bytes") or 0
+    try:
+        size_bytes = int(size_raw)
+    except (TypeError, ValueError):
+        size_bytes = 0
+    return {
+        "type": "presented_file",
+        "presented_file": {
+            "id": str(presented["id"]),
+            "filename": str(presented.get("filename") or "file"),
+            "mime_type": str(presented.get("mime_type") or "application/octet-stream"),
+            "kind": str(presented.get("kind") or "other"),
+            "size_bytes": size_bytes,
+            "caption": presented.get("caption"),
+        },
     }
 
 
@@ -503,6 +536,9 @@ def _convert_terminal_agent_event(evt: AgentEvent) -> list[dict[str, Any]]:
         artifact_event = _artifact_event_from_tool_result(evt.tool_name, evt.is_error, text)
         if artifact_event is not None:
             out.append(artifact_event)
+        presented_event = _presented_file_event_from_tool_result(evt.tool_name, evt.is_error, text)
+        if presented_event is not None:
+            out.append(presented_event)
         return out
 
     if isinstance(evt, MessageEndEvent) and isinstance(evt.message, AssistantMessage):

--- a/backend/cubeplex/im/artifacts.py
+++ b/backend/cubeplex/im/artifacts.py
@@ -1,14 +1,17 @@
-"""IM-side artifact dispatcher.
+"""IM-side artifact + presented-file dispatcher.
 
 Two responsibilities:
 
 - During the run, fold each artifact event into ``card_state.artifacts`` —
   inline image (where supported) or share-link, never a standalone message.
 - At run terminal, deliver file-kind artifacts as **native file messages**
-  (``deliver_terminal_files``), falling back to a share-link message on
-  oversize / upload failure.
+  (``deliver_terminal_files``) and ``present_file`` blobs as native image /
+  file messages (``deliver_terminal_presented``). Artifact oversize / upload
+  failure falls back to a share-link; presented files have no share URL and
+  fall back to a short text notice.
 
-See docs/dev/specs/2026-06-24-im-file-transfer-design.md.
+See docs/dev/specs/2026-06-24-im-file-transfer-design.md and
+docs/dev/specs/2026-08-17-im-present-file-design.md.
 """
 
 from __future__ import annotations
@@ -30,6 +33,7 @@ from cubeplex.im.types import OutboundConnector
 from cubeplex.objectstore import get_objectstore_client
 from cubeplex.objectstore.artifact_paths import artifact_file_key_candidates
 from cubeplex.services.artifact_share import mint_share_token as _default_mint
+from cubeplex.services.presented_files import presented_object_key
 
 MintShareToken = Callable[..., Awaitable[str]]
 
@@ -84,6 +88,49 @@ async def download_artifact_to_tempfile(artifact: dict[str, Any]) -> Path | None
         return Path(tmp.name)
 
 
+async def download_presented_to_tempfile(
+    presented: dict[str, Any],
+    *,
+    org_id: str,
+    workspace_id: str,
+    conversation_id: str,
+) -> Path | None:
+    """Download a presented file from ObjectStore to a temp Path (caller unlinks)."""
+    file_id = str(presented.get("id") or "")
+    filename = str(presented.get("filename") or "")
+    if not file_id or not filename:
+        logger.warning("[IM presented] missing id/filename; cannot build key")
+        return None
+    conv = str(presented.get("conversation_id") or conversation_id)
+    key = presented_object_key(
+        org_id=org_id,
+        workspace_id=workspace_id,
+        conversation_id=conv,
+        file_id=file_id,
+        filename=filename,
+    )
+    store = get_objectstore_client()
+    try:
+        data, _ctype = await store.download_file(key)
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code", "") in ("NoSuchKey", "404"):
+            logger.warning("[IM presented] objectstore file missing for {}", file_id)
+            return None
+        logger.opt(exception=True).warning(
+            "[IM presented] objectstore download failed for {}", file_id
+        )
+        return None
+    except (BotoCoreError, OSError, ValueError):
+        logger.opt(exception=True).warning(
+            "[IM presented] objectstore download failed for {}", file_id
+        )
+        return None
+    suffix = Path(filename).suffix
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(data)
+        return Path(tmp.name)
+
+
 @dataclass(slots=True)
 class IMArtifactDispatcher:
     """Bound to one run's card_state + share-link minting + native-file context."""
@@ -105,6 +152,8 @@ class IMArtifactDispatcher:
     # Raw artifact payloads captured at handle() time for terminal native-file
     # delivery (ArtifactItem on card_state lacks version/entry_file).
     _file_artifacts: dict[str, dict[str, Any]] = field(default_factory=dict)
+    # present_file payloads captured for terminal native image/file send.
+    _presented_files: dict[str, dict[str, Any]] = field(default_factory=dict)
 
     async def handle(self, artifact: dict[str, Any]) -> None:
         artifact = {
@@ -173,6 +222,16 @@ class IMArtifactDispatcher:
         if url:
             item.share_url = url
 
+    async def handle_presented(self, presented: dict[str, Any]) -> None:
+        """Capture a presented_file event for terminal native delivery."""
+        file_id = str(presented.get("id") or "")
+        if not file_id:
+            return
+        self._presented_files[file_id] = {
+            **presented,
+            "conversation_id": presented.get("conversation_id") or self.conversation_id,
+        }
+
     async def deliver_terminal_files(self) -> None:
         """Send captured file-kind artifacts as native messages, concurrently.
 
@@ -184,6 +243,15 @@ class IMArtifactDispatcher:
             return
         await asyncio.gather(
             *(self._deliver_one(aid, art) for aid, art in self._file_artifacts.items()),
+            return_exceptions=True,
+        )
+
+    async def deliver_terminal_presented(self) -> None:
+        """Send captured present_file blobs as native image/file messages."""
+        if not self._presented_files:
+            return
+        await asyncio.gather(
+            *(self._deliver_presented_one(fid, pf) for fid, pf in self._presented_files.items()),
             return_exceptions=True,
         )
 
@@ -268,6 +336,90 @@ class IMArtifactDispatcher:
 
     def _claim_key(self, artifact_id: str) -> str:
         return f"{self.redis_key_prefix}:im:artifact_sent:{self.run_id}:{artifact_id}"
+
+    async def _deliver_presented_one(self, file_id: str, presented: dict[str, Any]) -> None:
+        try:
+            claimed = await self._claim_presented(file_id)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "[IM presented] send-claim check failed for {}", file_id
+            )
+            return
+        if not claimed:
+            return
+        delivered = False
+        try:
+            delivered = await self._try_deliver_presented(presented)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "[IM presented] terminal delivery raised for {}", file_id
+            )
+        if not delivered:
+            await self._release_presented_claim(file_id)
+
+    async def _try_deliver_presented(self, presented: dict[str, Any]) -> bool:
+        tmp_path = await download_presented_to_tempfile(
+            presented,
+            org_id=self.org_id,
+            workspace_id=self.workspace_id,
+            conversation_id=self.conversation_id,
+        )
+        if tmp_path is None:
+            return await self._presented_fallback(presented)
+        ok = False
+        filename = str(presented.get("filename") or "file")
+        mime = str(presented.get("mime_type") or "") or None
+        kind = str(presented.get("kind") or "")
+        try:
+            if tmp_path.stat().st_size <= outbound_size_cap(self.platform):
+                if kind == "image" and self.supports_inline_image:
+                    send = self.connector.send_image(local_path=str(tmp_path), filename=filename)
+                else:
+                    send = self.connector.send_file(
+                        local_path=str(tmp_path), filename=filename, mime=mime
+                    )
+                ok = bool(await asyncio.wait_for(send, timeout=_SEND_TIMEOUT))
+        except Exception:
+            logger.opt(exception=True).warning(
+                "[IM presented] native send failed for {}", presented.get("id")
+            )
+            ok = False
+        finally:
+            tmp_path.unlink(missing_ok=True)
+        if ok:
+            return True
+        return await self._presented_fallback(presented)
+
+    async def _claim_presented(self, file_id: str) -> bool:
+        if self.redis is None or not self.run_id:
+            return True
+        ttl = int(config.get("streaming.run_event_ttl_seconds", 43200))
+        return bool(await self.redis.set(self._presented_claim_key(file_id), "1", nx=True, ex=ttl))
+
+    async def _release_presented_claim(self, file_id: str) -> None:
+        if self.redis is None or not self.run_id:
+            return
+        try:
+            await self.redis.delete(self._presented_claim_key(file_id))
+        except Exception:
+            logger.opt(exception=True).warning("[IM presented] claim release failed")
+
+    def _presented_claim_key(self, file_id: str) -> str:
+        return f"{self.redis_key_prefix}:im:presented_sent:{self.run_id}:{file_id}"
+
+    async def _presented_fallback(self, presented: dict[str, Any]) -> bool:
+        """Text notice when native send is impossible. No presented share-link."""
+        name = str(presented.get("filename") or "file")
+        caption = presented.get("caption")
+        text = f"📎 {name}"
+        if isinstance(caption, str) and caption.strip():
+            text = f"📎 {name} — {caption.strip()}"
+        try:
+            sent = await self.connector.send_to_chat(self.chat_id, self.reply_to_id, text)
+            return sent is not None
+        except Exception:
+            logger.opt(exception=True).warning("[IM presented] fallback send_to_chat failed")
+            return False
 
     async def _fallback_link(self, item: ArtifactItem, artifact: dict[str, Any]) -> bool:
         """Send the artifact's share-link as a standalone message. Returns True

--- a/backend/cubeplex/im/artifacts.py
+++ b/backend/cubeplex/im/artifacts.py
@@ -278,6 +278,10 @@ class IMArtifactDispatcher:
             logger.opt(exception=True).warning(
                 "[IM artifacts] terminal delivery raised for {}", artifact_id
             )
+        except BaseException:
+            # CancelledError is BaseException — must not leave a burned NX claim.
+            await self._release_claim(artifact_id)
+            raise
         if not delivered:
             # Nothing reached the user. Release the claim so a replay (tailer
             # restart) can retry rather than skipping at the claim check.
@@ -354,6 +358,10 @@ class IMArtifactDispatcher:
             logger.opt(exception=True).warning(
                 "[IM presented] terminal delivery raised for {}", file_id
             )
+        except BaseException:
+            # CancelledError is BaseException — must not leave a burned NX claim.
+            await self._release_presented_claim(file_id)
+            raise
         if not delivered:
             await self._release_presented_claim(file_id)
 

--- a/backend/cubeplex/im/dingtalk/_platform.py
+++ b/backend/cubeplex/im/dingtalk/_platform.py
@@ -88,6 +88,26 @@ class DingtalkPlatform:
             open_conversation_id=queue_item.channel_id,
         )
 
+        from cubeplex.config import config
+        from cubeplex.im.artifacts import IMArtifactDispatcher
+
+        public_base = str(config.get("api.public_url", "") or "")
+        artifact_disp = IMArtifactDispatcher(
+            connector=connector,
+            redis=app.state.redis,
+            redis_key_prefix=app.state.redis_key_prefix,
+            public_base_url=public_base,
+            org_id=account.org_id,
+            workspace_id=account.workspace_id,
+            conversation_id=queue_item.conversation_id,
+            card_state=state.card_state,
+            run_id=run_id,
+            platform="dingtalk",
+            chat_id=queue_item.channel_id,
+            reply_to_id=queue_item.reply_to_id,
+            supports_inline_image=False,
+        )
+
         shared_mode = False
         _sm = kwargs.get("session_maker")
         if _sm is not None:
@@ -107,6 +127,7 @@ class DingtalkPlatform:
             connector=connector,
             state=state,
             dispatcher=op_dispatcher,
+            artifact_dispatcher=artifact_disp,
             responder_open_id=queue_item.sender_open_id,
             shared_mode=shared_mode,
         )

--- a/backend/cubeplex/im/dingtalk/connector.py
+++ b/backend/cubeplex/im/dingtalk/connector.py
@@ -484,6 +484,11 @@ class DingtalkConnector:
         del local_path, filename
         return False
 
+    async def upload_image(self, local_path: str) -> str | None:
+        """No inline-image key; image artifacts fall back to a share-link."""
+        del local_path
+        return None
+
     async def send_to_chat(self, chat_id: str, reply_to_id: str | None, text: str) -> str | None:
         """Send a rejection notice to the conversation."""
         return await self.reply_markdown(

--- a/backend/cubeplex/im/dingtalk/connector.py
+++ b/backend/cubeplex/im/dingtalk/connector.py
@@ -480,6 +480,10 @@ class DingtalkConnector:
         del local_path, filename, mime
         return False
 
+    async def send_image(self, *, local_path: str, filename: str) -> bool:
+        del local_path, filename
+        return False
+
     async def send_to_chat(self, chat_id: str, reply_to_id: str | None, text: str) -> str | None:
         """Send a rejection notice to the conversation."""
         return await self.reply_markdown(

--- a/backend/cubeplex/im/discord/connector.py
+++ b/backend/cubeplex/im/discord/connector.py
@@ -236,6 +236,10 @@ class DiscordConnector:
         del local_path
         return None
 
+    async def send_image(self, *, local_path: str, filename: str) -> bool:
+        """Discord has no distinct image message; attach via ``send_file``."""
+        return await self.send_file(local_path=local_path, filename=filename, mime=None)
+
     async def send_file(self, *, local_path: str, filename: str, mime: str | None) -> bool:
         """Send a native file attachment to the bound channel."""
         del mime  # Discord infers type from the file.

--- a/backend/cubeplex/im/feishu/connector.py
+++ b/backend/cubeplex/im/feishu/connector.py
@@ -871,6 +871,61 @@ class FeishuConnector:
             )
         return ok
 
+    async def send_image(self, *, local_path: str, filename: str) -> bool:
+        """Upload and send a native ``image`` message to the bound chat."""
+        del filename  # Feishu image messages use image_key only.
+        if self._client is None or not self._channel_id:
+            return False
+        image_key = await self.upload_image(local_path)
+        if not image_key:
+            return False
+        payload = json.dumps({"image_key": image_key}, ensure_ascii=False)
+        from lark_oapi.api.im.v1 import (
+            CreateMessageRequest,
+            CreateMessageRequestBody,
+            ReplyMessageRequest,
+            ReplyMessageRequestBody,
+        )
+
+        if self._reply_to_id:
+            rbody = (
+                ReplyMessageRequestBody.builder()
+                .content(payload)
+                .msg_type("image")
+                .reply_in_thread(False)
+                .build()
+            )
+            rreq = (
+                ReplyMessageRequest.builder()
+                .message_id(self._reply_to_id)
+                .request_body(rbody)
+                .build()
+            )
+            resp = await asyncio.to_thread(self._client.im.v1.message.reply, rreq)
+        else:
+            cbody = (
+                CreateMessageRequestBody.builder()
+                .receive_id(self._channel_id)
+                .msg_type("image")
+                .content(payload)
+                .build()
+            )
+            creq = (
+                CreateMessageRequest.builder()
+                .receive_id_type("chat_id")
+                .request_body(cbody)
+                .build()
+            )
+            resp = await asyncio.to_thread(self._client.im.v1.message.create, creq)
+        ok = bool(getattr(resp, "success", lambda: False)())
+        if not ok:
+            logger.warning(
+                "[Feishu] send_image message failed: code={} msg={}",
+                getattr(resp, "code", None),
+                getattr(resp, "msg", None),
+            )
+        return ok
+
     # ------------------------------------------------------------------
     # Reactions (Task 10)
     # ------------------------------------------------------------------

--- a/backend/cubeplex/im/outbound.py
+++ b/backend/cubeplex/im/outbound.py
@@ -695,6 +695,20 @@ class OutboundRunTailer:
                                 logger.opt(exception=True).warning(
                                     "[outbound] deliver_terminal_presented raised"
                                 )
+                    elif (
+                        ev.payload.get("type") == "done"
+                        and bool((ev.payload.get("data") or {}).get("paused"))
+                        and self._artifact_dispatcher is not None
+                    ):
+                        # HITL pause is not a terminal finalize. present_file
+                        # is "show this now" — flush before the user answers
+                        # (QR / screenshot needed to continue).
+                        try:
+                            await self._artifact_dispatcher.deliver_terminal_presented()
+                        except Exception:
+                            logger.opt(exception=True).warning(
+                                "[outbound] paused-HITL presented flush raised"
+                            )
                 if pending_stream is not None and not done:
                     await self._flush_pending_stream(pending_stream)
                 if done:

--- a/backend/cubeplex/im/outbound.py
+++ b/backend/cubeplex/im/outbound.py
@@ -637,6 +637,17 @@ class OutboundRunTailer:
                             await self._artifact_dispatcher.handle(artifact_payload)
                         except Exception:
                             logger.opt(exception=True).warning("artifact dispatch failed")
+                    if (
+                        ev.payload.get("type") == "presented_file"
+                        and self._artifact_dispatcher is not None
+                    ):
+                        presented_payload = (ev.payload.get("data") or {}).get(
+                            "presented_file"
+                        ) or {}
+                        try:
+                            await self._artifact_dispatcher.handle_presented(presented_payload)
+                        except Exception:
+                            logger.opt(exception=True).warning("presented_file dispatch failed")
                     if op is None:
                         # Debounced text_deltas return None but still mutate
                         # card_state; refresh any pending stream so Feishu
@@ -677,6 +688,12 @@ class OutboundRunTailer:
                             except Exception:
                                 logger.opt(exception=True).warning(
                                     "[outbound] deliver_terminal_files raised"
+                                )
+                            try:
+                                await self._artifact_dispatcher.deliver_terminal_presented()
+                            except Exception:
+                                logger.opt(exception=True).warning(
+                                    "[outbound] deliver_terminal_presented raised"
                                 )
                 if pending_stream is not None and not done:
                     await self._flush_pending_stream(pending_stream)

--- a/backend/cubeplex/im/slack/connector.py
+++ b/backend/cubeplex/im/slack/connector.py
@@ -297,6 +297,10 @@ class SlackConnector:
         del local_path
         return None
 
+    async def send_image(self, *, local_path: str, filename: str) -> bool:
+        """Slack has no distinct image message; attach via ``send_file``."""
+        return await self.send_file(local_path=local_path, filename=filename, mime=None)
+
     async def send_file(self, *, local_path: str, filename: str, mime: str | None) -> bool:
         """Upload + send a native file to the bound channel via files_upload_v2."""
         del mime  # Slack infers type from the filename/bytes.

--- a/backend/cubeplex/im/teams/_platform.py
+++ b/backend/cubeplex/im/teams/_platform.py
@@ -82,6 +82,26 @@ class TeamsPlatform:
 
         dispatcher = TeamsOpDispatcher(connector=connector, state=state)
 
+        from cubeplex.config import config
+        from cubeplex.im.artifacts import IMArtifactDispatcher
+
+        public_base = str(config.get("api.public_url", "") or "")
+        artifact_disp = IMArtifactDispatcher(
+            connector=connector,
+            redis=redis,
+            redis_key_prefix=key_prefix,
+            public_base_url=public_base,
+            org_id=account.org_id,
+            workspace_id=account.workspace_id,
+            conversation_id=queue_item.conversation_id,
+            card_state=state.card_state,
+            run_id=run_id,
+            platform="teams",
+            chat_id=channel_id,
+            reply_to_id=reply_to_id,
+            supports_inline_image=False,
+        )
+
         sender_open_id = queue_item.sender_open_id or queue_item.sender_im_user_id
         tailer = OutboundRunTailer(
             redis=redis,
@@ -90,6 +110,7 @@ class TeamsPlatform:
             connector=connector,
             state=state,
             dispatcher=dispatcher,
+            artifact_dispatcher=artifact_disp,
             responder_open_id=sender_open_id,
         )
         asyncio.create_task(tailer.run(), name=f"im-tailer:{run_id}")

--- a/backend/cubeplex/im/teams/connector.py
+++ b/backend/cubeplex/im/teams/connector.py
@@ -371,6 +371,11 @@ class TeamsConnector:
         del local_path, filename
         return False
 
+    async def upload_image(self, local_path: str) -> str | None:
+        """No inline-image key; image artifacts fall back to a share-link."""
+        del local_path
+        return None
+
     async def send_to_chat(self, chat_id: str, reply_to_id: str | None, text: str) -> str | None:
         if self._app is None:
             return None

--- a/backend/cubeplex/im/teams/connector.py
+++ b/backend/cubeplex/im/teams/connector.py
@@ -367,6 +367,10 @@ class TeamsConnector:
         del local_path, filename, mime
         return False
 
+    async def send_image(self, *, local_path: str, filename: str) -> bool:
+        del local_path, filename
+        return False
+
     async def send_to_chat(self, chat_id: str, reply_to_id: str | None, text: str) -> str | None:
         if self._app is None:
             return None

--- a/backend/cubeplex/im/types.py
+++ b/backend/cubeplex/im/types.py
@@ -22,14 +22,16 @@ class OutboundConnector(Protocol):
 
     Distinct from the stateless ``registry.PlatformConnector``: these methods
     run against a connector instance already bound to a chat (channel + reply
-    target). ``send_file`` is the explicit member that makes a missing
-    implementation a type error at the dispatcher rather than a runtime
-    ``AttributeError``. ``upload_image`` is included because the image path
-    calls it; connectors without an inline-image API return ``None`` so the
-    dispatcher falls back to a share-link.
+    target). ``send_file`` / ``send_image`` are explicit members so a
+    missing implementation is a type error at the dispatcher rather than a
+    runtime ``AttributeError``. ``upload_image`` is included because the
+    artifact image path calls it; connectors without an inline-image API
+    return ``None`` so the dispatcher falls back to a share-link.
     """
 
     async def send_file(self, *, local_path: str, filename: str, mime: str | None) -> bool: ...
+
+    async def send_image(self, *, local_path: str, filename: str) -> bool: ...
 
     async def upload_image(self, local_path: str) -> str | None: ...
 

--- a/backend/cubeplex/middleware/artifacts.py
+++ b/backend/cubeplex/middleware/artifacts.py
@@ -154,6 +154,7 @@ def _make_present_file_tool(
     conversation_id: str,
     org_id: str,
     workspace_id: str,
+    run_id: str | None = None,
 ) -> AgentTool[_PresentFileArgs]:
     """Build the present_file cubepi.AgentTool."""
 
@@ -178,6 +179,7 @@ def _make_present_file_tool(
                     conversation_id=conversation_id,
                     path=args.path,
                     caption=args.caption,
+                    run_id=run_id,
                 )
         except PresentedFilePathError as exc:
             return AgentToolResult(
@@ -261,17 +263,19 @@ class ArtifactMiddleware(Middleware):
         conversation_id: str,
         org_id: str,
         workspace_id: str,
+        run_id: str | None = None,
     ) -> None:
         self.sandbox = sandbox
         self.conversation_id = conversation_id
         self.org_id = org_id
         self.workspace_id = workspace_id
+        self.run_id = run_id
 
         self._save_artifact_tool: AgentTool[Any] = _make_save_artifact_tool(
             sandbox, conversation_id, org_id, workspace_id
         )
         self._present_file_tool: AgentTool[Any] = _make_present_file_tool(
-            sandbox, conversation_id, org_id, workspace_id
+            sandbox, conversation_id, org_id, workspace_id, run_id
         )
 
     @property

--- a/backend/cubeplex/services/presented_files.py
+++ b/backend/cubeplex/services/presented_files.py
@@ -59,10 +59,23 @@ def normalize_sandbox_path(path: str) -> str:
     return normalized
 
 
+def presented_object_key(
+    *, org_id: str, workspace_id: str, conversation_id: str, file_id: str, filename: str
+) -> str:
+    """ObjectStore key for a presented file's original bytes."""
+    return f"presented/{org_id}/{workspace_id}/{conversation_id}/{file_id}/original/{filename}"
+
+
 def _build_object_key(
     *, org_id: str, workspace_id: str, conversation_id: str, file_id: str, filename: str
 ) -> str:
-    return f"presented/{org_id}/{workspace_id}/{conversation_id}/{file_id}/original/{filename}"
+    return presented_object_key(
+        org_id=org_id,
+        workspace_id=workspace_id,
+        conversation_id=conversation_id,
+        file_id=file_id,
+        filename=filename,
+    )
 
 
 def _build_thumbnail_key(

--- a/backend/cubeplex/streams/run_manager.py
+++ b/backend/cubeplex/streams/run_manager.py
@@ -322,6 +322,7 @@ def _dicts_to_sse_events(
     from cubeplex.agents.schemas import (
         ArtifactEvent,
         CitationEvent,
+        PresentedFileEvent,
         ReasoningEvent,
         TextDeltaEvent,
         ToolCallDeltaEvent,
@@ -383,6 +384,15 @@ def _dicts_to_sse_events(
         elif evt_type == "artifact":
             events.append(
                 ArtifactEvent(
+                    timestamp=evt_dict["timestamp"],
+                    data=evt_dict["data"],
+                    agent_id=evt_dict.get("agent_id"),
+                    agent_name=evt_dict.get("agent_name"),
+                )
+            )
+        elif evt_type == "presented_file":
+            events.append(
+                PresentedFileEvent(
                     timestamp=evt_dict["timestamp"],
                     data=evt_dict["data"],
                     agent_id=evt_dict.get("agent_id"),
@@ -496,6 +506,7 @@ def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent 
         AskUserResolvedEvent,
         ErrorEvent,
         InjectedMessageEvent,
+        PresentedFileEvent,
         ReasoningEvent,
         SandboxConfirmRequestEvent,
         SandboxConfirmResolvedEvent,
@@ -569,6 +580,14 @@ def cubepi_dict_to_agent_event(d: dict[str, Any], timestamp: str) -> AgentEvent 
                 "action": d.get("action", "created"),
                 "artifact": d.get("artifact", {}),
             },
+        )
+    if t == "presented_file":
+        presented = d.get("presented_file") or {}
+        if not isinstance(presented, dict) or not presented.get("id"):
+            return None
+        return PresentedFileEvent(
+            timestamp=timestamp,
+            data={"presented_file": presented},
         )
     if t == "sandbox_confirm_request":
         args = d.get("args") or {}
@@ -3125,6 +3144,7 @@ class RunManager:
                     conversation_id=conversation_id,
                     org_id=ctx.org_id,
                     workspace_id=ctx.workspace_id,
+                    run_id=run_id,
                 )
                 cubepi_middleware.append(artifact_mw)
                 # Middleware tools (save_artifact) collected for ordered merge below

--- a/backend/docs/im-feishu-setup.md
+++ b/backend/docs/im-feishu-setup.md
@@ -103,6 +103,9 @@ HTTP boundary.
       is removed when the run completes.
 - [ ] DM the bot `draw me a chart` (or any prompt that emits an `image`
       artifact) → image appears inline as a Feishu image message.
+- [ ] DM the bot something that triggers `present_file` on a PNG (e.g. a
+      QR / screenshot) → a native Feishu **image** message arrives after
+      the card finalizes (not only a web-chat card).
 - [ ] DM the bot `build a tiny website` (or any non-image artifact) →
       "📎 view →" link appears in the thread; clicking it opens the share
       preview page; the preview disappears after the 7-day TTL.

--- a/backend/tests/integration/test_im_outbound_files.py
+++ b/backend/tests/integration/test_im_outbound_files.py
@@ -59,6 +59,10 @@ class _FakeConnector:
         self.send_file_calls.append({"filename": filename})
         return self.send_ok
 
+    async def send_image(self, *, local_path: str, filename: str) -> bool:
+        self.send_file_calls.append({"filename": filename})
+        return self.send_ok
+
     async def upload_image(self, local_path: str) -> str | None:
         return None
 

--- a/backend/tests/integration/test_im_outbound_files.py
+++ b/backend/tests/integration/test_im_outbound_files.py
@@ -243,6 +243,25 @@ async def test_exception_during_delivery_releases_claim(
     assert len(conn.send_file_calls) == 1
 
 
+async def test_artifact_cancelled_error_releases_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CancelledError must not leave a burned artifact_sent claim."""
+    import asyncio
+
+    async def _boom(_a: dict[str, Any]) -> Path:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(artifacts_mod, "download_artifact_to_tempfile", _boom)
+    conn = _FakeConnector(send_ok=True)
+    redis = _FakeRedis()
+    disp = _dispatcher(conn, redis)
+    await disp.handle(_artifact("document"))
+
+    await disp.deliver_terminal_files()
+    assert "t:im:artifact_sent:run-1:art-1" not in redis.store
+
+
 async def test_website_artifact_stays_share_link_never_native(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/tests/integration/test_im_outbound_presented.py
+++ b/backend/tests/integration/test_im_outbound_presented.py
@@ -3,6 +3,7 @@
 Guards the gap where present_file succeeded on the web but IM never sent.
 """
 
+import asyncio
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -188,6 +189,26 @@ async def test_presented_total_failure_releases_claim(
     await disp.deliver_terminal_presented()
     assert len(conn.send_file_calls) == 2
     assert claim_key in redis.store
+
+
+async def test_presented_cancelled_error_releases_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CancelledError is BaseException; a burned NX claim would skip replay."""
+
+    async def _boom(_p: dict[str, Any], **_kwargs: Any) -> Path:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(artifacts_mod, "download_presented_to_tempfile", _boom)
+    conn = _FakeConnector(send_ok=True)
+    redis = _FakeRedis()
+    disp = _dispatcher(conn, redis)
+    await disp.handle_presented(_presented())
+
+    claim_key = "t:im:presented_sent:run-1:pfile-1"
+    await disp.deliver_terminal_presented()
+    assert claim_key not in redis.store
+    assert conn.send_file_calls == []
 
 
 async def test_artifact_document_still_uses_send_file(

--- a/backend/tests/integration/test_im_outbound_presented.py
+++ b/backend/tests/integration/test_im_outbound_presented.py
@@ -1,0 +1,217 @@
+"""Outbound native delivery of present_file blobs via IMArtifactDispatcher.
+
+Guards the gap where present_file succeeded on the web but IM never sent.
+"""
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cubeplex.im import artifacts as artifacts_mod
+from cubeplex.im.artifacts import IMArtifactDispatcher
+from cubeplex.im.card_model import CardState
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def set(
+        self, key: str, value: str, *, nx: bool = False, ex: int | None = None
+    ) -> bool | None:
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+    async def delete(self, key: str) -> int:
+        return 1 if self.store.pop(key, None) is not None else 0
+
+
+class _FakeConnector:
+    def __init__(self, *, send_ok: bool = True, chat_ok: bool = True) -> None:
+        self.send_ok = send_ok
+        self.chat_ok = chat_ok
+        self.send_file_calls: list[dict[str, Any]] = []
+        self.send_image_calls: list[dict[str, Any]] = []
+        self.chat_calls: list[str] = []
+
+    async def send_file(self, *, local_path: str, filename: str, mime: str | None) -> bool:
+        self.send_file_calls.append({"filename": filename, "mime": mime})
+        return self.send_ok
+
+    async def send_image(self, *, local_path: str, filename: str) -> bool:
+        self.send_image_calls.append({"filename": filename})
+        return self.send_ok
+
+    async def upload_image(self, local_path: str) -> str | None:
+        return None
+
+    async def send_to_chat(self, chat_id: str, reply_to_id: str | None, text: str) -> str | None:
+        self.chat_calls.append(text)
+        return "msg-1" if self.chat_ok else None
+
+
+async def _make_temp(_presented: dict[str, Any], *, size: int = 100, **_kwargs: Any) -> Path:
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tmp:
+        tmp.write(b"x" * size)
+        return Path(tmp.name)
+
+
+def _dispatcher(connector: _FakeConnector, redis: _FakeRedis) -> IMArtifactDispatcher:
+    return IMArtifactDispatcher(
+        connector=connector,
+        redis=redis,
+        redis_key_prefix="t",
+        public_base_url="https://example.test",
+        org_id="org-1",
+        workspace_id="ws-1",
+        conversation_id="conv-1",
+        card_state=CardState(bot_name="CubePlex", run_id="run-1"),
+        run_id="run-1",
+        platform="feishu",
+        chat_id="oc_chat",
+        reply_to_id=None,
+        supports_inline_image=True,
+    )
+
+
+def _presented(*, kind: str = "document", file_id: str = "pfile-1") -> dict[str, Any]:
+    return {
+        "id": file_id,
+        "filename": "report.xlsx" if kind != "image" else "qr.png",
+        "mime_type": "application/vnd.ms-excel" if kind != "image" else "image/png",
+        "kind": kind,
+        "size_bytes": 100,
+        "caption": "Login QR" if kind == "image" else None,
+        "conversation_id": "conv-1",
+    }
+
+
+async def test_presented_document_sent_as_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-image present_file is send_file'd at terminal, not mid-run.
+
+    Bug guarded: if the tailer never calls deliver_terminal_presented, IM
+    users get silence after a successful present_file.
+    """
+    monkeypatch.setattr(artifacts_mod, "download_presented_to_tempfile", _make_temp)
+    conn = _FakeConnector(send_ok=True)
+    disp = _dispatcher(conn, _FakeRedis())
+
+    await disp.handle_presented(_presented(kind="document"))
+    assert len(conn.send_file_calls) == 0
+
+    await disp.deliver_terminal_presented()
+    assert len(conn.send_file_calls) == 1
+    assert conn.send_file_calls[0]["filename"] == "report.xlsx"
+    assert conn.send_image_calls == []
+    assert conn.chat_calls == []
+
+
+async def test_presented_image_on_feishu_uses_send_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Feishu QR / screenshot must be a native image, not a file bubble."""
+    monkeypatch.setattr(artifacts_mod, "download_presented_to_tempfile", _make_temp)
+    conn = _FakeConnector(send_ok=True)
+    disp = _dispatcher(conn, _FakeRedis())
+
+    await disp.handle_presented(_presented(kind="image"))
+    await disp.deliver_terminal_presented()
+    assert len(conn.send_image_calls) == 1
+    assert conn.send_file_calls == []
+
+
+async def test_presented_image_without_inline_uses_send_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slack/Discord have no send_image path at the dispatcher (flag off)."""
+    monkeypatch.setattr(artifacts_mod, "download_presented_to_tempfile", _make_temp)
+    conn = _FakeConnector(send_ok=True)
+    disp = _dispatcher(conn, _FakeRedis())
+    disp.supports_inline_image = False
+
+    await disp.handle_presented(_presented(kind="image"))
+    await disp.deliver_terminal_presented()
+    assert len(conn.send_file_calls) == 1
+    assert conn.send_image_calls == []
+
+
+async def test_presented_delivery_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tailer replay must not double-send a presented file."""
+    monkeypatch.setattr(artifacts_mod, "download_presented_to_tempfile", _make_temp)
+    conn = _FakeConnector(send_ok=True)
+    redis = _FakeRedis()
+    disp = _dispatcher(conn, redis)
+    await disp.handle_presented(_presented())
+
+    await disp.deliver_terminal_presented()
+    await disp.deliver_terminal_presented()
+    assert len(conn.send_file_calls) == 1
+
+
+async def test_presented_oversize_falls_back_to_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _big(_p: dict[str, Any], **_kwargs: Any) -> Path:
+        return await _make_temp(_p, size=40 * 1024 * 1024)
+
+    monkeypatch.setattr(artifacts_mod, "download_presented_to_tempfile", _big)
+    conn = _FakeConnector(send_ok=True)
+    disp = _dispatcher(conn, _FakeRedis())
+    await disp.handle_presented(_presented())
+
+    await disp.deliver_terminal_presented()
+    assert conn.send_file_calls == []
+    assert len(conn.chat_calls) == 1
+    assert "report.xlsx" in conn.chat_calls[0]
+    assert "/api/v1/public/artifacts/share/" not in conn.chat_calls[0]
+
+
+async def test_presented_total_failure_releases_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Native + text both fail → claim released so replay retries."""
+    monkeypatch.setattr(artifacts_mod, "download_presented_to_tempfile", _make_temp)
+    conn = _FakeConnector(send_ok=False, chat_ok=False)
+    redis = _FakeRedis()
+    disp = _dispatcher(conn, redis)
+    await disp.handle_presented(_presented())
+
+    claim_key = "t:im:presented_sent:run-1:pfile-1"
+    await disp.deliver_terminal_presented()
+    assert claim_key not in redis.store
+
+    conn.send_ok = True
+    await disp.deliver_terminal_presented()
+    assert len(conn.send_file_calls) == 2
+    assert claim_key in redis.store
+
+
+async def test_artifact_document_still_uses_send_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """save_artifact outbound must not be swallowed by the present_file path."""
+
+    async def _art_temp(_a: dict[str, Any], *, size: int = 100) -> Path:
+        return await _make_temp(_a, size=size)
+
+    monkeypatch.setattr(artifacts_mod, "download_artifact_to_tempfile", _art_temp)
+    conn = _FakeConnector(send_ok=True)
+    disp = _dispatcher(conn, _FakeRedis())
+    await disp.handle(
+        {
+            "id": "art-1",
+            "artifact_type": "document",
+            "name": "out.xlsx",
+            "version": 1,
+            "entry_file": "out.xlsx",
+            "conversation_id": "conv-1",
+        }
+    )
+    await disp.deliver_terminal_files()
+    await disp.deliver_terminal_presented()
+    assert len(conn.send_file_calls) == 1
+    assert conn.send_image_calls == []

--- a/backend/tests/unit/im/test_tailer_stream_coalesce.py
+++ b/backend/tests/unit/im/test_tailer_stream_coalesce.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from contextlib import suppress
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -201,3 +203,74 @@ async def test_tailer_drains_multi_segment_stream_before_wait() -> None:
     assert stream_count == 3
     assert dispatcher.sent_char_offset == 12
     assert dispatcher.ops[-1].kind == "finalize"
+
+
+@pytest.mark.asyncio
+async def test_tailer_flushes_presented_on_paused_hitl() -> None:
+    """present_file must go out at HITL pause, not wait for the user to answer.
+
+    Bug guarded: a login QR presented before ask_user would stay unsent
+    until resume (or forever if the user never answers).
+    """
+    state = RenderState(bot_name="bot", run_id="run-pf", stream_interval=0.0)
+    state.card_id = "card-1"
+    dispatcher = _RecordingDispatcher()
+    connector = _FakeConnector()
+    flushes = {"presented": 0, "artifacts": 0}
+
+    class _ArtDisp:
+        async def handle(self, _artifact: Any) -> None:
+            return None
+
+        async def handle_presented(self, _presented: Any) -> None:
+            return None
+
+        async def deliver_terminal_files(self) -> None:
+            flushes["artifacts"] += 1
+
+        async def deliver_terminal_presented(self) -> None:
+            flushes["presented"] += 1
+
+    tailer = OutboundRunTailer(
+        redis=AsyncMock(),
+        key_prefix="cb-",
+        run_id="run-pf",
+        connector=connector,
+        state=state,
+        dispatcher=dispatcher,
+        artifact_dispatcher=_ArtDisp(),
+        block_ms=1,
+    )
+
+    events: list[_FakeEvent] = [
+        _FakeEvent(
+            "1",
+            {"type": "presented_file", "data": {"presented_file": {"id": "pfile-1"}}},
+        ),
+        _FakeEvent("2", {"type": "done", "data": {"paused": True}}),
+    ]
+
+    async def _read(*_a: Any, **_k: Any) -> list[_FakeEvent]:
+        nonlocal events
+        batch, events = events, []
+        if not batch:
+            await asyncio.Event().wait()
+        return batch
+
+    import cubeplex.im.outbound as outbound_mod
+
+    original = outbound_mod.read_run_events_after
+    outbound_mod.read_run_events_after = _read  # type: ignore[assignment]
+    task = asyncio.create_task(tailer.run())
+    try:
+        for _ in range(100):
+            if flushes["presented"] == 1:
+                break
+            await asyncio.sleep(0.01)
+        assert flushes["presented"] == 1
+        assert flushes["artifacts"] == 0
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+        outbound_mod.read_run_events_after = original  # type: ignore[assignment]

--- a/backend/tests/unit/test_presented_files.py
+++ b/backend/tests/unit/test_presented_files.py
@@ -10,6 +10,7 @@ from cubeplex.middleware.artifacts import ArtifactMiddleware
 from cubeplex.services.presented_files import (
     PresentedFilePathError,
     normalize_sandbox_path,
+    presented_object_key,
 )
 
 
@@ -41,6 +42,19 @@ def test_normalize_sandbox_path_ok(raw: str, expected: str) -> None:
 def test_normalize_sandbox_path_rejects(raw: str) -> None:
     with pytest.raises(PresentedFilePathError):
         normalize_sandbox_path(raw)
+
+
+def test_presented_object_key_layout() -> None:
+    assert (
+        presented_object_key(
+            org_id="org-1",
+            workspace_id="ws-1",
+            conversation_id="conv-1",
+            file_id="pfile-1",
+            filename="qr.png",
+        )
+        == "presented/org-1/ws-1/conv-1/pfile-1/original/qr.png"
+    )
 
 
 def test_artifact_middleware_exposes_present_file() -> None:

--- a/backend/tests/unit/test_run_manager_cubepi_dict_to_event.py
+++ b/backend/tests/unit/test_run_manager_cubepi_dict_to_event.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from cubeplex.agents.schemas import (
     ArtifactEvent,
     ErrorEvent,
+    PresentedFileEvent,
     ReasoningEvent,
     TextDeltaEvent,
     ToolCallDeltaEvent,
@@ -36,6 +37,19 @@ def test_artifact_dict_maps_to_artifact_event() -> None:
     )
     assert isinstance(evt, ArtifactEvent)
     assert evt.data == {"action": "created", "artifact": artifact}
+
+
+def test_presented_file_dict_maps_to_event() -> None:
+    """Live presented_file dict must persist; unknown types are dropped."""
+    presented = {"id": "pfile_1", "filename": "qr.png", "kind": "image"}
+    evt = cubepi_dict_to_agent_event({"type": "presented_file", "presented_file": presented}, TS)
+    assert isinstance(evt, PresentedFileEvent)
+    assert evt.data == {"presented_file": presented}
+
+
+def test_presented_file_dict_without_id_is_dropped() -> None:
+    evt = cubepi_dict_to_agent_event({"type": "presented_file", "presented_file": {}}, TS)
+    assert evt is None
 
 
 def test_text_delta_dict_maps_to_text_delta_event() -> None:

--- a/backend/tests/unit/test_stream.py
+++ b/backend/tests/unit/test_stream.py
@@ -234,6 +234,37 @@ def test_save_artifact_emits_artifact_event_after_tool_result() -> None:
     assert art_evt["artifact"] == artifact
 
 
+def test_present_file_emits_presented_file_event_after_tool_result() -> None:
+    """present_file success → tool_result + presented_file. IM outbound needs
+    the sibling; without it the tailer never sees the blob.
+    """
+    presented = {
+        "id": "pfile_1",
+        "filename": "qr.png",
+        "mime_type": "image/png",
+        "kind": "image",
+        "size_bytes": 12,
+        "caption": "Login QR",
+    }
+    payload = AgentToolResult(
+        content=[TextContent(text=json.dumps({"action": "presented", "presented_file": presented}))]
+    )
+    evt = ToolExecutionEndEvent(tool_call_id="tc-pf", tool_name="present_file", result=payload)
+    out = convert_agent_event_to_sse(evt)
+    assert [d["type"] for d in out] == ["tool_result", "presented_file"]
+    assert out[1]["presented_file"]["id"] == "pfile_1"
+    assert out[1]["presented_file"]["kind"] == "image"
+
+
+def test_present_file_error_does_not_emit_presented_file_event() -> None:
+    payload = AgentToolResult(content=[TextContent(text='{"error": "Path not found"}')])
+    evt = ToolExecutionEndEvent(
+        tool_call_id="tc-pf-err", tool_name="present_file", result=payload, is_error=True
+    )
+    out = convert_agent_event_to_sse(evt)
+    assert [d["type"] for d in out] == ["tool_result"]
+
+
 def test_save_artifact_error_does_not_emit_artifact_event() -> None:
     """An errored save_artifact result must not produce an artifact event."""
     payload = AgentToolResult(content=[TextContent(text='{"error": "Path not found"}')])

--- a/docs/dev/plans/2026-08-17-im-present-file.md
+++ b/docs/dev/plans/2026-08-17-im-present-file.md
@@ -1,0 +1,174 @@
+# IM outbound for present_file — implementation plan
+
+**Goal**: A successful `present_file` during an IM run delivers the file to
+the chat at terminal, without changing `save_artifact` outbound or the
+tool prompt.
+
+**Architecture**: Mirror artifact outbound. The stream converter emits a
+sibling `presented_file` event; `cubepi_dict_to_agent_event` persists it;
+the IM tailer captures it on `IMArtifactDispatcher` and sends at
+terminal (image message on Feishu, `send_file` elsewhere). ObjectStore
+key is reconstructed; Redis `SET NX` is the idempotency gate.
+
+**Stack**: FastAPI / cubepi SSE, Redis run stream, existing IM
+`OutboundConnector` + `IMArtifactDispatcher`.
+
+---
+
+## Unit 1 — SSE event
+
+**Files**
+
+- `backend/cubeplex/agents/stream.py` — emit sibling event from a
+  successful `present_file` tool result
+- `backend/cubeplex/agents/schemas.py` — `PresentedFileEvent`
+- `backend/cubeplex/streams/run_manager.py` — map the dict in
+  `cubepi_dict_to_agent_event` and `_dicts_to_sse_events`
+- `frontend/packages/core/src/types/events.ts` — add `'presented_file'`
+  to `AgentEventType`
+- `frontend/packages/core/src/stores/messageStore.ts` — treat like
+  `artifact` / `citation` (no-op, cursor still advances)
+
+**Interfaces**
+
+```text
+SSE dict:
+  type: "presented_file"
+  presented_file: {id, filename, mime_type, kind, size_bytes, caption?}
+
+PresentedFileEvent.data = { presented_file: <that object> }
+```
+
+Error / non-JSON / missing `presented_file` → no sibling event.
+
+**Tests** (`backend/tests/unit/`)
+
+- `test_stream.py`: success → `tool_result` + `presented_file`; error →
+  `tool_result` only
+- `test_run_manager_cubepi_dict_to_event.py`: dict maps to
+  `PresentedFileEvent`; unknown types still drop
+
+Invariant: if the sibling is omitted from `cubepi_dict_to_agent_event`,
+IM never sees the file.
+
+---
+
+## Unit 2 — Object key helper + run_id
+
+**Files**
+
+- `backend/cubeplex/services/presented_files.py` — export
+  `presented_object_key(...)` (today's private builder)
+- `backend/cubeplex/middleware/artifacts.py` — optional `run_id` on
+  middleware / tool factory, passed into `present_from_sandbox`
+- `backend/cubeplex/streams/run_manager.py` — pass the run's `run_id`
+  into `ArtifactMiddleware`
+
+**Interfaces**
+
+```python
+def presented_object_key(
+    *, org_id: str, workspace_id: str, conversation_id: str,
+    file_id: str, filename: str,
+) -> str
+```
+
+Key layout unchanged:
+`presented/{org}/{ws}/{conv}/{file_id}/original/{filename}`.
+
+**Tests**: existing middleware ctor tests still construct without
+`run_id`. Add a unit assertion that the exported key matches the
+layout.
+
+---
+
+## Unit 3 — Connector `send_image`
+
+**Files**
+
+- `backend/cubeplex/im/types.py` — add to `OutboundConnector`
+- `backend/cubeplex/im/feishu/connector.py` — upload + `msg_type=image`
+- `backend/cubeplex/im/slack/connector.py` — delegate to `send_file`
+- `backend/cubeplex/im/discord/connector.py` — delegate to `send_file`
+- `backend/cubeplex/im/dingtalk/connector.py` — return `False`
+- `backend/cubeplex/im/teams/connector.py` — return `False`
+
+**Interfaces**
+
+```python
+async def send_image(self, *, local_path: str, filename: str) -> bool
+```
+
+Feishu uses the bound chat / reply target, same as `send_file`.
+
+**Tests**: Feishu unit tests if a send-file test already mocks
+`im.v1.message.create` — extend or add a parallel send_image case.
+Otherwise the dispatcher tests (Unit 4) cover the call.
+
+---
+
+## Unit 4 — Dispatcher + tailer
+
+**Files**
+
+- `backend/cubeplex/im/artifacts.py` — `handle_presented`,
+  `deliver_terminal_presented` (or fold into the existing terminal
+  gather), download helper, claim key
+  `{prefix}:im:presented_sent:{run_id}:{pfile_id}`
+- `backend/cubeplex/im/outbound.py` — on `type == "presented_file"`
+  call `handle_presented`; after artifact terminal delivery, deliver
+  presented files
+
+**Core logic**
+
+1. Capture payload by `id` at handle time (overwrite same id is
+   impossible — each present is a new id).
+2. At terminal, concurrently deliver each captured file.
+3. Image + `supports_inline_image` → `send_image`; else `send_file`.
+4. Size above `outbound_size_cap` → skip native send, text fallback.
+5. Native send False / exception → text fallback
+   (`📎 {filename}` + caption if present).
+6. Text send also fails → release claim.
+
+Do not mint artifact share-links for presented files.
+
+**Tests** (`backend/tests/integration/test_im_outbound_files.py` or a
+sibling `test_im_outbound_presented.py`)
+
+- presented document → `send_file` once at terminal
+- presented image + inline → `send_image`, not `send_file`
+- replay → once (NX claim)
+- failed send + failed text → claim released, replay retries
+- oversize → no native send, one text notice
+- `save_artifact` document path still hits `send_file` (no regression)
+
+---
+
+## Unit 5 — Docs
+
+**Files**
+
+- `docs/site/docs/guides/conversations/artifacts.md` — mention
+  `present_file` (show-now, not gallery) and that IM delivers both
+- `docs/site/docs/guides/im/overview.md` — agent-shown files arrive as
+  native messages
+- `backend/docs/im-feishu-setup.md` — smoke: present a PNG → image
+  message
+
+No prompt change.
+
+---
+
+## Spec coverage
+
+| Spec requirement | Unit |
+|---|---|
+| Sibling SSE + persist | 1 |
+| `run_id` on row | 2 |
+| Feishu image message | 3 + 4 |
+| Native file on Slack/Discord | 4 |
+| Idempotency / retry | 4 |
+| Artifact outbound unchanged | 4 regression |
+| Text fallback, no share-link | 4 |
+| Prompt unchanged | 5 (explicit non-change) |
+| User-facing docs | 5 |

--- a/docs/dev/specs/2026-08-17-im-present-file-design.md
+++ b/docs/dev/specs/2026-08-17-im-present-file-design.md
@@ -1,0 +1,149 @@
+# IM outbound for present_file
+
+**Status**: Design
+**Date**: 2026-08-17
+**Branch**: `feat/2026-08-17-im-present-file`
+**Parent**: [present_file design](./2026-08-12-present-file-design.md) §9 (IM was
+explicitly phase 2)
+
+## Goal
+
+When an agent calls `present_file` during an IM run, the user receives that
+file in the chat (inline image on Feishu, native file elsewhere). Today the
+tool succeeds and the web UI renders the card, but IM never sees the blob.
+
+## Context
+
+Two agent → user file channels already exist:
+
+| Tool | Intent | Storage | IM today |
+|---|---|---|---|
+| `save_artifact` | keepable deliverable (gallery, versions) | `artifacts` + SSE `artifact` | `IMArtifactDispatcher` sends native file / inline image / share-link |
+| `present_file` | show this file now (QR, screenshot, temp export) | `presented_files` + `tool_result` only | **nothing** |
+
+The artifact prompt tells the model to use `present_file` for anything the
+user needs to see immediately. After that change, IM users lose files the
+web still shows.
+
+`present_file` does not emit a sibling run event. `cubepi_dict_to_agent_event`
+drops unknown types, so a raw SSE dict that is not mapped never reaches the
+Redis run stream the IM tailer reads.
+
+`PresentedFile.run_id` exists but the tool factory does not pass it.
+
+This is **not** a replacement for artifact outbound. Both stay.
+
+## Approaches considered
+
+| | Approach | Verdict |
+|---|---|---|
+| A | Tell the model (prompt only) to use `save_artifact` on IM | Rejected. Model does not know the channel; forking the system prompt by channel breaks prompt cache. Intent ≠ transport. |
+| B | Parse `tool_result` named `present_file` in the IM tailer | Works (the result is already in Redis) but IM would scrape tool JSON, the opposite of the artifact event pattern. |
+| **C** | Sibling SSE `presented_file` + tailer consumption (mirror artifact) | **Adopt.** First-class event, replay-safe, IM does not parse tool JSON. |
+
+## Design
+
+### 1. Event
+
+On a successful `present_file` tool result,
+`convert_agent_event_to_sse` emits `tool_result` then a sibling:
+
+```json
+{
+  "type": "presented_file",
+  "presented_file": {
+    "id": "pfile-…",
+    "filename": "lark-auth-qr.png",
+    "mime_type": "image/png",
+    "kind": "image",
+    "size_bytes": 1234,
+    "caption": "Login QR"
+  }
+}
+```
+
+Error results emit only `tool_result`. No `object_key` (internal) and no
+sandbox path on this event.
+
+`cubepi_dict_to_agent_event` maps the dict to a typed
+`PresentedFileEvent` so `_append_event` persists it. Drain/replay
+(`_dicts_to_sse_events`) maps the same type.
+
+Web already renders from `tool_result`. It treats the new event as a
+no-op (same as `artifact` / `citation` in `applyStreamEvent`) so the
+applied-event cursor still advances.
+
+### 2. IM delivery
+
+`OutboundRunTailer` already hands `type == "artifact"` to
+`IMArtifactDispatcher`. It does the same for `type == "presented_file"`.
+
+The dispatcher **captures** presented payloads during the run and
+**sends at terminal** (after the card finalize), same timing as file
+artifacts — no mid-stream file bubbles interleaved with card patches.
+
+Routing (per presented `kind`):
+
+| kind | Platform | How it reaches the user |
+|---|---|---|
+| `image` | Feishu (`supports_inline_image`) | Native **image** message (`upload_image` + `msg_type=image`) so a QR is visible without opening a file |
+| `image` | Slack / Discord | Native file (their `send_file` already attaches images) |
+| other | Feishu / Slack / Discord | `send_file` |
+| any | DingTalk / Teams | `send_file` is unimplemented → text notice (no presented share-link exists) |
+
+Oversize (existing `outbound_size_cap`) or upload failure → a short
+standalone text message (`📎 {filename}` plus caption if any). There is
+no public presented-file share URL; we do not invent one.
+
+Idempotency: Redis `SET NX`
+`{prefix}:im:presented_sent:{run_id}:{pfile_id}` with the run-event TTL.
+Same claim/release rules as artifacts: success keeps the claim; any
+failure releases so a tailer replay retries.
+
+Bytes come from ObjectStore using the existing key layout
+`presented/{org}/{ws}/{conv}/{pfile_id}/original/{filename}` (exported
+helper, not a DB lookup in the tailer).
+
+Subagent `present_file` still binds to the main conversation. The tailer
+consumes the event regardless of `agent_id`.
+
+### 3. `run_id` on the row
+
+`ArtifactMiddleware` / the `present_file` tool receive the run's
+`run_id` from `RunManager` and pass it into `present_from_sandbox`.
+Audit only — delivery is event-driven, not a `WHERE run_id = ?` query.
+
+### 4. Connector surface
+
+`OutboundConnector` gains `send_image(*, local_path, filename) -> bool`:
+
+- Feishu: upload + `msg_type="image"` to the bound chat
+- Slack / Discord: delegate to `send_file`
+- DingTalk / Teams: return `False`
+
+### 5. Prompt
+
+No change. The existing present vs `save_artifact` split is by **intent**,
+not channel. The platform delivers both.
+
+## Out of scope
+
+- Replacing artifact IM delivery
+- Public share-links / HTML preview for presented files
+- Changing when the model calls which tool
+- Directory / multi-file present
+- DingTalk / Teams native media upload
+- Presenting files from markdown `/workspace` paths
+
+## Success criteria
+
+1. `present_file` success → Redis run stream contains a `presented_file`
+   event after the `tool_result`.
+2. Feishu IM run: presented PNG arrives as an image message at terminal.
+3. Feishu / Slack / Discord: presented non-image file arrives via
+   `send_file`.
+4. Tailer restart / replay sends each presented file **once**.
+5. Failed send releases the claim; a later replay retries.
+6. `save_artifact` IM behavior is unchanged.
+7. Oversize / DingTalk / Teams: user gets a text notice, not silence.
+8. Error `present_file` produces no outbound send.

--- a/docs/site/docs/guides/conversations/artifacts.md
+++ b/docs/site/docs/guides/conversations/artifacts.md
@@ -14,6 +14,8 @@ You do not create artifacts directly. The agent creates them by calling one of t
 - **`save_artifact`** — registers a file or set of files the agent wrote (a website, document, code project, data file, or skill bundle) as an artifact.
 - **`generate_image`** — produces an image artifact directly from a prompt.
 
+When the agent only needs you to **see a file right now** (a login QR code, a screenshot, a one-off export) it uses **`present_file`** instead. That file appears inline in the chat and is **not** added to the artifact gallery. On Feishu, Slack, or Discord the same file is delivered as a native image or file message when the reply finishes.
+
 This happens naturally when you ask the agent to build something concrete:
 
 - "Build me a landing page"

--- a/docs/site/docs/guides/im/overview.md
+++ b/docs/site/docs/guides/im/overview.md
@@ -14,7 +14,7 @@ Every platform follows the same four-step flow:
 1. **Bind a bot.** A workspace member registers the bot's credentials (app ID, secrets, tokens) against the workspace. CubePlex stores them encrypted and creates an **IM connector account**.
 2. **Inbound message arrives.** The platform delivers each message to CubePlex — either by pushing it to a webhook URL you configure in the platform's console, or over a persistent socket CubePlex opens to the platform (see [Delivery modes](#delivery-modes)).
 3. **Identity gate + agent run.** CubePlex figures out *which CubePlex user* the sender is (see [Identity linking](#identity-linking)), confirms they belong to the workspace, then starts an agent run on their behalf.
-4. **Reply.** The agent's response streams back into the chat. On Feishu it renders as a live-updating interactive card; on other platforms it posts as a message (and edits in place where the platform allows).
+4. **Reply.** The agent's response streams back into the chat. On Feishu it renders as a live-updating interactive card; on other platforms it posts as a message (and edits in place where the platform allows). Files the agent shows you (`present_file`) or saves as downloadable deliverables (`save_artifact`) are sent as native image or file messages on Feishu, Slack, and Discord when the run finishes. Interactive websites still arrive as a share link.
 
 The bot runs each message as a real CubePlex user, so permissions, model access, and tool access are exactly what that user would have in the web app. If a sender can't be matched to a workspace member, the bot replies that it can't help and the run never starts.
 

--- a/frontend/packages/core/src/stores/messageStore.ts
+++ b/frontend/packages/core/src/stores/messageStore.ts
@@ -903,7 +903,7 @@ function applyStreamEvent(state: MessageStore, event: AgentEvent): Partial<Messa
     }
   }
 
-  if (event.type === 'artifact' || event.type === 'citation') {
+  if (event.type === 'artifact' || event.type === 'presented_file' || event.type === 'citation') {
     return base
   }
 

--- a/frontend/packages/core/src/types/events.ts
+++ b/frontend/packages/core/src/types/events.ts
@@ -56,6 +56,7 @@ export type AgentEventType =
   | 'tool_call_delta'
   | 'tool_result'
   | 'artifact'
+  | 'presented_file'
   | 'error'
   | 'done'
   | 'citation'


### PR DESCRIPTION
## Summary

`present_file` succeeded in web chat but IM never sent the file. The tool wrote `presented_files` + a `tool_result`; the IM tailer only listened to `artifact` events from `save_artifact`.

This wires the missing outbound path without replacing artifact delivery:

- Successful `present_file` emits a sibling SSE `presented_file` event (persisted like `artifact`).
- The IM tailer captures it and, at run terminal, sends a native **image** message on Feishu or `send_file` elsewhere.
- Oversize / failed send falls back to a short text notice (no presented share-link exists).
- Redis `SET NX` `im:presented_sent:{run_id}:{pfile_id}` prevents double-send on tailer replay.
- `save_artifact` outbound is unchanged. Prompt is unchanged (intent, not channel).

## Test plan

- [x] `uv run pytest` on stream converter, event mapping, presented-file unit, IM outbound presented + existing artifact outbound (85 passed)
- [x] pre-push `check-ci` (backend + frontend)
- [ ] Feishu smoke: DM a prompt that calls `present_file` on a PNG → native image message after the card finalizes
- [ ] Feishu/Slack: `present_file` on a non-image → native file message
- [ ] Confirm `save_artifact` document still sends as a file; website still share-links