### PR TITLE
fix(pdf): normalize table col_widths so tables never render blank

### DIFF
--- a/backend/skills/preinstalled/pdf/SKILL.md
+++ b/backend/skills/preinstalled/pdf/SKILL.md
@@ -142,7 +142,9 @@ You have creative authority over the accent color. Pick it from the document's s
 
 **Rule:** choose a color that a thoughtful designer would select for this specific document — not the type's default. Muted, desaturated tones work best; avoid vivid primaries. When in doubt, go darker and more neutral.
 
-**content.json block types:**
+**content.json format:** a top-level JSON **array** of block objects, one entry
+per element in the document, e.g. `[{...}, {...}]`. A `{"blocks": [...]}`
+wrapper object is also accepted. The table below lists the block types.
 
 | Block | Usage | Key fields |
 |---|---|---|
@@ -165,6 +167,14 @@ You have creative authority over the accent color. Pick it from the document's s
 | `caption` | Small muted label | `text` |
 | `pagebreak` | Force a new page | — |
 | `spacer` | Vertical whitespace | `pt` (default 12) |
+
+**table `col_widths`:** optional list of per-column widths, one value per
+column. **Fractions summing to 1.0** (e.g. `[0.2, 0.5, 0.3]`) are the
+documented format; absolute widths in points/pixels (e.g. `[90, 210, 210]`)
+are also accepted and normalized automatically so the table fits the page.
+If omitted, columns are equal width. Never write values larger than the
+usable page width — the renderer normalizes them, but extreme values
+previously made the whole table disappear.
 
 **chart / flowchart schemas:**
 ```json

--- a/backend/skills/preinstalled/pdf/scripts/render_body.py
+++ b/backend/skills/preinstalled/pdf/scripts/render_body.py
@@ -700,6 +700,39 @@ def _add_callout(story: list, item: dict, ctx: dict):
     story.append(Spacer(1, 8))
 
 
+def _resolve_col_widths(
+    col_widths, n_cols: int, usable_w: float
+) -> list[float]:
+    """Map a table's col_widths to absolute column widths in points.
+
+    Accepts either fractions summing to ~1.0 (the documented format) or
+    absolute widths in points/pixels. Values are normalized so the table
+    always fits within usable_w. Invalid, non-numeric, or length-mismatched
+    input falls back to equal column widths.
+
+    Without this guard, pixel-style values such as [90, 210, 210] were
+    multiplied by usable_w (~432pt), producing absurd column widths
+    (tens of thousands of points) that made ReportLab silently drop the
+    entire table from the output PDF.
+    """
+    if not isinstance(col_widths, list) or len(col_widths) != n_cols:
+        return [usable_w / n_cols] * n_cols
+    try:
+        vals = [float(w) for w in col_widths]
+    except (TypeError, ValueError):
+        return [usable_w / n_cols] * n_cols
+    if not vals or any(w <= 0 for w in vals):
+        return [usable_w / n_cols] * n_cols
+    total = sum(vals)
+    if 0.9 <= total <= 1.1:
+        # Documented format: fractions summing to ~1.0.
+        fracs = vals
+    else:
+        # Absolute widths (pt/px): normalize to fractions of the total.
+        fracs = [w / total for w in vals]
+    return [usable_w * f for f in fracs]
+
+
 def _add_table(story: list, item: dict, ctx: dict):
     t        = ctx["tokens"]
     styles   = ctx["styles"]
@@ -714,11 +747,7 @@ def _add_table(story: list, item: dict, ctx: dict):
     ]
     n_cols = len(item["headers"])
 
-    # Optional col_widths as fractions summing to 1.0
-    if "col_widths" in item and len(item["col_widths"]) == n_cols:
-        col_w = [usable_w * f for f in item["col_widths"]]
-    else:
-        col_w = [usable_w / n_cols] * n_cols
+    col_w = _resolve_col_widths(item.get("col_widths"), n_cols, usable_w)
 
     tbl = Table([headers] + rows, colWidths=col_w)
     tbl.setStyle(TableStyle([
@@ -991,6 +1020,25 @@ _RESETS_NUMBERED = frozenset({
 })
 
 
+def normalize_content(content) -> list:
+    """Accept a list of blocks or a {"blocks": [...]} wrapper; reject anything else loudly.
+
+    Agents have produced content.json with a top-level {"blocks": [...]} object
+    (the shape used by other document pipelines). Iterating that dict directly
+    yields string keys and crashes with a confusing ``'str' object has no
+    attribute 'get'`` inside build_story. Unwrap it here and fail loudly on
+    truly invalid shapes instead of failing somewhere opaque.
+    """
+    if isinstance(content, dict) and isinstance(content.get("blocks"), list):
+        content = content["blocks"]
+    if not isinstance(content, list) or any(not isinstance(b, dict) for b in content):
+        raise ValueError(
+            "content.json must be a list of block objects (or "
+            f'{{"blocks": [...]}}); got {type(content).__name__}'
+        )
+    return content
+
+
 def build_story(content: list, tokens: dict, styles: dict) -> list:
     usable_w = A4[0] - tokens["margin_left"] - tokens["margin_right"]
 
@@ -1042,7 +1090,8 @@ def build_story(content: list, tokens: dict, styles: dict) -> list:
 # Main build
 # ══════════════════════════════════════════════════════════════════════════════
 
-def build(tokens: dict, content: list, out_path: str) -> dict:
+def build(tokens: dict, content, out_path: str) -> dict:
+    content = normalize_content(content)
     registered = register_fonts(tokens)
 
     # If the requested body font wasn't registered (e.g. not installed), fall back to built-ins.

--- a/backend/tests/unit/test_pdf_render_body.py
+++ b/backend/tests/unit/test_pdf_render_body.py
@@ -1,0 +1,84 @@
+"""Unit tests for pdf skill render_body.py table-width and content normalization.
+
+These tests import render_body from the skill scripts directory. If reportlab
+is not installed the whole module skips (render_body would otherwise try to
+auto-install dependencies via pip).
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+if importlib.util.find_spec("reportlab") is None:
+    pytest.skip("reportlab not installed", allow_module_level=True)
+
+# Block render_body's module-level ensure_deps from pip-installing deps.
+subprocess.check_call = lambda *a, **k: (_ for _ in ()).throw(  # noqa: ARG005
+    AssertionError("render_body must not pip-install in unit tests")
+)
+
+_SCRIPTS = Path(__file__).parent.parent.parent / "skills/preinstalled/pdf/scripts"
+sys.path.insert(0, str(_SCRIPTS))
+import render_body  # noqa: E402
+
+
+# ── _resolve_col_widths ────
+
+
+def test_col_widths_fractions_kept():
+    col_w = render_body._resolve_col_widths([0.2, 0.5, 0.3], 3, 400.0)
+    assert col_w == pytest.approx([80.0, 200.0, 120.0])
+
+
+def test_col_widths_absolute_normalized():
+    # Pixel-style absolute widths (the #509 case) must be normalized, not
+    # multiplied by usable_w (which produced ~38k/90k/90k pt and made
+    # ReportLab silently drop the table).
+    col_w = render_body._resolve_col_widths([90, 210, 210], 3, 432.0)
+    assert col_w == pytest.approx([432 * 90 / 510, 432 * 210 / 510, 432 * 210 / 510])
+    assert sum(col_w) == pytest.approx(432.0)
+
+
+def test_col_widths_missing_falls_back_equal():
+    col_w = render_body._resolve_col_widths(None, 3, 300.0)
+    assert col_w == pytest.approx([100.0, 100.0, 100.0])
+
+
+def test_col_widths_mismatch_falls_back_equal():
+    col_w = render_body._resolve_col_widths([0.5, 0.5], 3, 300.0)
+    assert col_w == pytest.approx([100.0, 100.0, 100.0])
+
+
+def test_col_widths_non_numeric_falls_back_equal():
+    col_w = render_body._resolve_col_widths(["a", "b", "c"], 3, 300.0)
+    assert col_w == pytest.approx([100.0, 100.0, 100.0])
+
+
+def test_col_widths_non_positive_falls_back_equal():
+    col_w = render_body._resolve_col_widths([0.5, -1.0, 0.5], 3, 300.0)
+    assert col_w == pytest.approx([100.0, 100.0, 100.0])
+
+
+# ── normalize_content ──────────
+
+def test_normalize_list_passthrough():
+    blocks = [{"type": "body", "text": "hi"}]
+    assert render_body.normalize_content(blocks) is blocks
+
+
+def test_normalize_blocks_wrapper_unwrapped():
+    blocks = [{"type": "body", "text": "hi"}]
+    assert render_body.normalize_content({"blocks": blocks}) == blocks
+
+
+def test_normalize_rejects_plain_dict():
+    with pytest.raises(ValueError, match="list of block objects"):
+        render_body.normalize_content({"type": "body"})
+
+
+def test_normalize_rejects_embedded_string():
+    with pytest.raises(ValueError, match="list of block objects"):
+        render_body.normalize_content([{"type": "body"}, "oops"])

--- a/backend/tests/unit/test_pdf_render_body.py
+++ b/backend/tests/unit/test_pdf_render_body.py
@@ -24,7 +24,6 @@ _SCRIPTS = Path(__file__).parent.parent.parent / "skills/preinstalled/pdf/script
 sys.path.insert(0, str(_SCRIPTS))
 import render_body  # noqa: E402
 
-
 # ── _resolve_col_widths ────
 
 
@@ -63,6 +62,7 @@ def test_col_widths_non_positive_falls_back_equal():
 
 
 # ── normalize_content ──────────
+
 
 def test_normalize_list_passthrough():
     blocks = [{"type": "body", "text": "hi"}]


### PR DESCRIPTION
## Problem

Closes #509 — in agent-generated PDFs, `table` blocks could render with **completely blank cell content** (headers + rows), even though the surrounding text, captions, and body were fine. The table content was missing from the PDF text layer entirely.

Root cause found by replaying the real failing artifact (`conv-1pKcEsLKiTcVMq`, "红筹架构拆除后 A/H 股上市项目研究"):

1. **`col_widths` unit mismatch** (the primary bug). `_add_table()` treated `col_widths` as fractions and multiplied each value by `usable_w` (~432pt). Agents naturally write pixel-style values like `[90, 210, 210]`, which produced column widths of ~38k / 90k / 90k points. ReportLab then silently dropped the entire table from the output — no error, `make.sh` reported "No issues detected".
2. **content.json shape.** Agents emitted `{"blocks": [...]}` (the shape used by other doc pipelines). `build_story()` iterates the top-level value, so it walked the dict's string keys and failed with a confusing `'str' object has no attribute 'get'`. The sandbox skill version that produced the artifact happened to unwrap it, but the repo skill errors.

## Fix

- `render_body.py`:
  - `_resolve_col_widths()` — accepts fractions (sum ≈ 1.0, documented format) **or** absolute widths (pt/px) and normalizes them so the table always fits the page. Invalid/mismatched/non-positive input falls back to equal columns instead of blanking the table.
  - `normalize_content()` — unwraps `{"blocks": [...]}` and rejects truly invalid content loudly (clear `ValueError` instead of an opaque `AttributeError` deep in rendering).
- `SKILL.md` — documents the content.json top-level shape and the `col_widths` units (fractions vs absolute, auto-normalized).
- New unit tests in `backend/tests/unit/test_pdf_render_body.py` covering both normalizers and the fallback paths.

## Verification

- `backend/tests/unit/test_pdf_render_body.py` + `test_pdf_font_catalog.py`: **24 passed**.
- E2E replay in a real cubeplex sandbox (`cubeplex-sandbox:0.3.0-260802`): the exact failing `content.json` (blocks wrapper + `col_widths: [90, 210, 210]`, unchanged) now produces the matrix table with all headers and rows visible — text layer verified via `pdftotext`, visuals verified via `pdftoppm`.