### PR TITLE
fix(im): deliver artifacts/presented files with real filename extension

### DIFF
--- a/backend/cubeplex/im/artifacts.py
+++ b/backend/cubeplex/im/artifacts.py
@@ -17,6 +17,7 @@ docs/dev/specs/2026-08-17-im-present-file-design.md.
 from __future__ import annotations
 
 import asyncio
+import mimetypes
 import tempfile
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -301,13 +302,23 @@ class IMArtifactDispatcher:
         tmp_path = await download_artifact_to_tempfile(artifact)
         if tmp_path is None:
             return await self._fallback_link(item, artifact)
+        # Feishu (and every other send_file connector) derives the delivered
+        # file's identity + inline preview from the file_name we send. The
+        # artifact display ``name`` is often a human title with no extension
+        # ("Quarterly Report"), so prefer the real file basename from
+        # ``entry_file`` / ``path`` and only fall back to ``item.name`` when
+        # that basename carries no extension. See issue #511.
+        real = (str(artifact.get("entry_file") or "") or str(artifact.get("path") or "")).rsplit(
+            "/", 1
+        )[-1]
+        filename = real if Path(real).suffix else item.name
         ok = False
         try:
             if tmp_path.stat().st_size <= outbound_size_cap(self.platform):
                 ok = bool(
                     await asyncio.wait_for(
                         self.connector.send_file(
-                            local_path=str(tmp_path), filename=item.name, mime=None
+                            local_path=str(tmp_path), filename=filename, mime=None
                         ),
                         timeout=_SEND_TIMEOUT,
                     )
@@ -378,6 +389,13 @@ class IMArtifactDispatcher:
         filename = str(presented.get("filename") or "file")
         mime = str(presented.get("mime_type") or "") or None
         kind = str(presented.get("kind") or "")
+        # A missing extension on the upstream filename makes the delivered file
+        # un-openable in Feishu; derive one from the mime type when absent. See
+        # issue #511.
+        if not Path(filename).suffix and mime:
+            ext = mimetypes.guess_extension(mime)
+            if ext:
+                filename = f"{filename}{ext}"
         try:
             if tmp_path.stat().st_size <= outbound_size_cap(self.platform):
                 if kind == "image" and self.supports_inline_image:

--- a/backend/tests/integration/test_im_outbound_files.py
+++ b/backend/tests/integration/test_im_outbound_files.py
@@ -290,3 +290,49 @@ async def test_image_on_no_inline_platform_falls_back_to_share_link(
     await disp.handle(_artifact("image"))
     assert disp.card_state.artifacts[0].share_url is not None
     assert disp.card_state.artifacts[0].image_key is None
+
+
+async def test_file_artifact_uses_entry_file_basename_not_display_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The delivered file name must be the real file basename, not the artifact
+    display name. Regression guard for #511 (Feishu received 'Quarterly Report'
+    with no .xlsx and couldn't preview)."""
+    monkeypatch.setattr(artifacts_mod, "download_artifact_to_tempfile", _make_temp)
+    conn = _FakeConnector(send_ok=True)
+    disp = _dispatcher(conn, _FakeRedis())
+    await disp.handle(
+        {
+            "id": "art-1",
+            "artifact_type": "document",
+            "name": "Quarterly Report",
+            "version": 1,
+            "entry_file": "out.xlsx",
+            "conversation_id": "conv-1",
+        }
+    )
+    await disp.deliver_terminal_files()
+    assert len(conn.send_file_calls) == 1
+    assert conn.send_file_calls[0]["filename"] == "out.xlsx"
+
+
+async def test_file_artifact_entry_file_wins_over_named_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both the display name and entry_file carry extensions, the real file
+    (entry_file) basename is authoritative — it's what we actually download."""
+    monkeypatch.setattr(artifacts_mod, "download_artifact_to_tempfile", _make_temp)
+    conn = _FakeConnector(send_ok=True)
+    disp = _dispatcher(conn, _FakeRedis())
+    await disp.handle(
+        {
+            "id": "art-1",
+            "artifact_type": "document",
+            "name": "report.pdf",
+            "version": 1,
+            "entry_file": "out.xlsx",
+            "conversation_id": "conv-1",
+        }
+    )
+    await disp.deliver_terminal_files()
+    assert conn.send_file_calls[0]["filename"] == "out.xlsx"

--- a/backend/tests/integration/test_im_outbound_presented.py
+++ b/backend/tests/integration/test_im_outbound_presented.py
@@ -236,3 +236,39 @@ async def test_artifact_document_still_uses_send_file(
     await disp.deliver_terminal_presented()
     assert len(conn.send_file_calls) == 1
     assert conn.send_image_calls == []
+
+
+async def test_presented_filename_missing_extension_derived_from_mime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A presented filename without an extension must get one from mime_type so
+    Feishu can open it. Regression guard for #511."""
+    monkeypatch.setattr(artifacts_mod, "download_presented_to_tempfile", _make_temp)
+    conn = _FakeConnector(send_ok=True)
+    disp = _dispatcher(conn, _FakeRedis())
+    await disp.handle_presented(
+        {
+            "id": "pfile-1",
+            "filename": "report",
+            "mime_type": "application/pdf",
+            "kind": "document",
+            "size_bytes": 100,
+            "conversation_id": "conv-1",
+        }
+    )
+    await disp.deliver_terminal_presented()
+    assert len(conn.send_file_calls) == 1
+    assert conn.send_file_calls[0]["filename"].endswith(".pdf")
+
+
+async def test_presented_filename_extension_preserved_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the upstream filename already has an extension, it must NOT be
+    double-appended."""
+    monkeypatch.setattr(artifacts_mod, "download_presented_to_tempfile", _make_temp)
+    conn = _FakeConnector(send_ok=True)
+    disp = _dispatcher(conn, _FakeRedis())
+    await disp.handle_presented(_presented(kind="document"))
+    await disp.deliver_terminal_presented()
+    assert conn.send_file_calls[0]["filename"] == "report.xlsx"


### PR DESCRIPTION
## Summary

Fixes #511. Feishu (and every `send_file` connector) derives the delivered file's identity and inline preview from the `file_name` we send. The artifact display name is often a human title with no extension, so it was sent as e.g. `Quarterly Report` and Feishu could not open the preview.

- `save_artifact` (`_try_deliver`): prefer the real file basename from `entry_file`/`path`; fall back to the display name only when that basename has no extension.
- `present_file` (`_try_deliver_presented`): derive a missing extension from `mime_type` via `mimetypes.guess_extension`.

The broken `filename` was set in the platform-agnostic `IMArtifactDispatcher`, so this also hardens Slack/Discord/Teams/DingTalk.

## Test plan

- Added regression tests in `test_im_outbound_files.py` and `test_im_outbound_presented.py`:
  - display name without extension → uses `entry_file` filename
  - `entry_file` takes priority over a display name that already has an extension
  - `present_file` with extensionless `filename` → extension filled from `mime_type`
  - already-extended `filename` → not double-appended
- `uv run pytest tests/integration/test_im_outbound_files.py tests/integration/test_im_outbound_presented.py` → 22 passed
- `ruff check` + `ruff format --check` clean on changed files