### PR TITLE
fix(im): drop subagent stream text from main IM card

### DIFF
--- a/backend/cubeplex/im/outbound.py
+++ b/backend/cubeplex/im/outbound.py
@@ -83,6 +83,14 @@ def fold_event(event: dict[str, Any], state: RenderState, *, now: float) -> Outb
     data = event.get("data") or {}
 
     if etype == "text_delta":
+        # Sub-agent text streams must NOT land in the main card's content.
+        # When subagents run in parallel their deltas interleave with the
+        # main agent's own text and garble the card. Sub-agent activity is
+        # already surfaced via the SubAgentRow tool counts (see the
+        # ``tool_call`` handler), so we drop the deltas here — mirroring the
+        # ``tool_result`` no-op. Fixes #508.
+        if event.get("agent_id"):
+            return None
         delta = str(data.get("content", ""))
         if state.card_state.hitl_resolved:
             state.card_state.post_hitl_content += delta
@@ -424,6 +432,13 @@ def fold_event(event: dict[str, Any], state: RenderState, *, now: float) -> Outb
         return OutboundOp(kind="patch_card") if state.card_id else OutboundOp(kind="card_create")
 
     if etype == "done":
+        # A sub-agent terminal event must never finalize the PARENT card.
+        # cubepi_dict_to_agent_event drops a sub-agent ``done`` at translation
+        # time, so this guard is defensive against a stray sub-agent terminal
+        # that would otherwise mark the main card finalized and exit the
+        # tailer early. Fixes #508.
+        if event.get("agent_id"):
+            return None
         # RunManager stamps ``data.paused=true`` on the DoneEvent when the
         # final_status is ``paused_hitl`` (cubeplex/streams/run_manager.py).
         # That's a soft pause, not a terminal end — resume_run_with_answer
@@ -443,6 +458,13 @@ def fold_event(event: dict[str, Any], state: RenderState, *, now: float) -> Outb
         return OutboundOp(kind="finalize", final=True)
 
     if etype == "error":
+        # A sub-agent's own error must not finalize / fail the MAIN card.
+        # The parent agent surfaces the sub-agent failure through its own
+        # tool_result and keeps running; suppressing the terminal op here
+        # prevents a sub-agent error from ending the run prematurely. Fixes
+        # #508.
+        if event.get("agent_id"):
+            return None
         state.card_state.finalized = True
         state.card_state.error = str(data.get("message") or "the run failed")
         return OutboundOp(kind="finalize", final=True)

--- a/backend/tests/im/test_fold_event_terminal.py
+++ b/backend/tests/im/test_fold_event_terminal.py
@@ -410,3 +410,38 @@ def test_first_event_stamps_run_start_monotonic() -> None:
     # Second event does not overwrite.
     fold_event({"type": "text_delta", "data": {"content": "."}}, state, now=99.0)
     assert state.card_state.run_start_monotonic == 42.0
+
+
+def test_subagent_done_does_not_finalize_main_card() -> None:
+    """Regression for #508: a sub-agent's terminal ``done`` must not mark the
+    parent card finalized (which would exit the tailer early and strand the
+    run). The guard is defensive — sub-agent ``done`` is dropped at
+    translation time, but a stray one must never finalize the main card."""
+    state = _state_with_card()
+    op = fold_event(
+        {"type": "done", "data": {}, "agent_id": "subagent:tc-1"},
+        state,
+        now=0.0,
+    )
+    assert op is None
+    assert state.card_state.finalized is False
+
+
+def test_subagent_error_does_not_finalize_main_card() -> None:
+    """Regression for #508: a sub-agent's own error must not finalize / fail
+    the MAIN card. The parent agent surfaces the sub-agent failure through
+    its own tool_result and keeps running; suppressing the terminal op here
+    prevents a sub-agent error from ending the run prematurely."""
+    state = _state_with_card()
+    op = fold_event(
+        {
+            "type": "error",
+            "agent_id": "subagent:tc-1",
+            "data": {"error_code": "run_error", "message": "sub boom", "details": "..."},
+        },
+        state,
+        now=0.0,
+    )
+    assert op is None
+    assert state.card_state.finalized is False
+    assert state.card_state.error != "sub boom"

--- a/backend/tests/im/test_fold_event_text.py
+++ b/backend/tests/im/test_fold_event_text.py
@@ -59,3 +59,32 @@ def test_throttled_delta_returns_none() -> None:
     op = fold_event({"type": "text_delta", "data": {"content": "b"}}, state, now=1.05)
     assert op is None
     assert state.card_state.streaming_content == "ab"
+
+
+def test_subagent_text_delta_does_not_pollute_main_card() -> None:
+    """Regression for #508: a sub-agent's text_delta must not pollute the
+    main card's streaming_content (nor emit a card_create). When subagents
+    run in parallel their deltas would otherwise interleave with the main
+    agent's text and garble the card. Sub-agent activity is surfaced
+    separately via SubAgentRow tool counts."""
+    state = _state()
+    op = fold_event(
+        {
+            "type": "text_delta",
+            "data": {"content": "subagent says hi"},
+            "agent_id": "subagent:tc-1",
+        },
+        state,
+        now=0.0,
+    )
+    assert op is None
+    assert state.card_state.streaming_content == ""
+    # The main agent's own stream is unaffected and still drives the card.
+    main_op = fold_event(
+        {"type": "text_delta", "data": {"content": "main says hello"}},
+        state,
+        now=0.1,
+    )
+    assert isinstance(main_op, OutboundOp)
+    assert main_op.kind == "card_create"
+    assert state.card_state.streaming_content == "main says hello"


### PR DESCRIPTION
## Summary

Fixes #508 — when subagents run in parallel, their streamed text leaked into the main run's IM card, interleaving N+1 streams into garbled output.

Root cause: in `backend/cubeplex/im/outbound.py`, `fold_event` routes subagent events into the shared run-event stream that feeds the IM card state machine. `tool_call`/`tool_result` already guard on `agent_id`, but `text_delta` never did, so subagent text deltas were appended to the card's `streaming_content` alongside the main agent's.

## Changes

- `text_delta` → return `None` when `event["agent_id"]` is set (mirrors the existing `tool_result` no-op). Subagent activity is already surfaced via `SubAgentRow` tool counts.
- `done` / `error` → same guard, so a subagent's terminal event cannot prematurely finalize or fail the parent card.
- Left intentionally unguarded: `artifact` (legitimate run output), `citation` (no-op index), `ask_user_request` / `sandbox_confirm_*` (not initiated by subagents in this design).

## Test plan

- Added regression tests: `test_subagent_text_delta_does_not_pollute_main_card`, `test_subagent_done_does_not_finalize_main_card`, `test_subagent_error_does_not_finalize_main_card`.
- `ruff format --check` + `ruff check` clean on changed files.
- `tests/im/test_fold_event_text.py` + `tests/im/test_fold_event_terminal.py` → 22 passed; broader IM + subagent-event suites → 32 passed.