### PR TITLE
Render single $ literally instead of as inline math

### DIFF
--- a/frontend/packages/web/components/shared/MarkdownWithCitations.tsx
+++ b/frontend/packages/web/components/shared/MarkdownWithCitations.tsx
@@ -18,10 +18,13 @@ import { resolveSandboxHref } from '@/lib/sandboxLinks'
 const CITATION_RE = /【\d+-\d+】/
 
 // singleTilde:false → only ~~text~~ is strikethrough, so "28~29℃" ranges render literally.
+// singleDollarTextMath:false → only `$$…$$` (display math) is parsed as KaTeX.
+// Plain single `$…$` (e.g. currency like "$271,677.37") renders literally instead of
+// being mis-detected as an inline formula.
 const REMARK_PLUGINS: ComponentProps<typeof ReactMarkdown>['remarkPlugins'] = [
   [remarkGfm, { singleTilde: false }],
   remarkBreaks,
-  remarkMath,
+  [remarkMath, { singleDollarTextMath: false }],
 ]
 
 const REHYPE_PLUGINS: ComponentProps<typeof ReactMarkdown>['rehypePlugins'] = [

--- a/frontend/packages/web/components/shared/__tests__/MarkdownWithCitations.memo.test.tsx
+++ b/frontend/packages/web/components/shared/__tests__/MarkdownWithCitations.memo.test.tsx
@@ -29,3 +29,25 @@ describe('MarkdownWithCitations memoization', () => {
     expect(screen.getByText('beta')).toBeInTheDocument()
   })
 })
+
+describe('MarkdownWithCitations math rendering', () => {
+  it('renders currency amounts with single $ literally (no KaTeX)', () => {
+    const text =
+      'Monthly revenue increased from $271,677.37 in January to $272,748.58 in February'
+    const { container } = render(
+      <MarkdownWithCitations conversationId="conv-test">{text}</MarkdownWithCitations>,
+    )
+    // Single-$ spans must NOT be parsed as math (no katex markup injected).
+    expect(container.querySelector('.katex')).toBeNull()
+    // The dollar amounts must survive as literal text.
+    expect(container.textContent).toContain('$271,677.37')
+    expect(container.textContent).toContain('$272,748.58')
+  })
+
+  it('still renders $$…$$ display math as KaTeX', () => {
+    const { container } = render(
+      <MarkdownWithCitations conversationId="conv-test">{'E = mc^2 in $$E=mc^2$$ form'}</MarkdownWithCitations>,
+    )
+    expect(container.querySelector('.katex')).not.toBeNull()
+  })
+})

--- a/frontend/packages/web/components/shared/__tests__/MarkdownWithCitations.memo.test.tsx
+++ b/frontend/packages/web/components/shared/__tests__/MarkdownWithCitations.memo.test.tsx
@@ -32,8 +32,7 @@ describe('MarkdownWithCitations memoization', () => {
 
 describe('MarkdownWithCitations math rendering', () => {
   it('renders currency amounts with single $ literally (no KaTeX)', () => {
-    const text =
-      'Monthly revenue increased from $271,677.37 in January to $272,748.58 in February'
+    const text = 'Monthly revenue increased from $271,677.37 in January to $272,748.58 in February'
     const { container } = render(
       <MarkdownWithCitations conversationId="conv-test">{text}</MarkdownWithCitations>,
     )
@@ -46,7 +45,9 @@ describe('MarkdownWithCitations math rendering', () => {
 
   it('still renders $$…$$ display math as KaTeX', () => {
     const { container } = render(
-      <MarkdownWithCitations conversationId="conv-test">{'E = mc^2 in $$E=mc^2$$ form'}</MarkdownWithCitations>,
+      <MarkdownWithCitations conversationId="conv-test">
+        {'E = mc^2 in $$E=mc^2$$ form'}
+      </MarkdownWithCitations>,
     )
     expect(container.querySelector('.katex')).not.toBeNull()
   })


### PR DESCRIPTION
## Summary
- `remark-math` was treating a single `$…$` as inline KaTeX. Sentences with currency like _"Monthly revenue increased from $271,677.37 in January to $272,748.58 in February"_ were mis-rendered as a formula.
- Disabled single-dollar text math (`singleDollarTextMath: false`) in `MarkdownWithCitations.tsx`. Display math via `$$…$$` still renders.
- Added regression tests: currency amounts render literally (no `.katex` markup), and `$$…$$` still renders as KaTeX.

## Test plan
- [x] `pnpm --filter web test MarkdownWithCitations` → 5 passed
- [x] New test asserts no `.katex` span for `$271,677.37 … $272,748.58` and that the amounts survive as literal text
- [x] New test confirms `$$E=mc^2$$` still renders as KaTeX

🤖 Generated with WorkBuddy