### PR TITLE
fix(backend): bound forced run cancellation during shutdown

### DIFF
--- a/backend/cubeplex/api/app.py
+++ b/backend/cubeplex/api/app.py
@@ -444,7 +444,13 @@ async def lifespan(_app: FastAPI):  # type: ignore
         await _im_runtime_shutdown.stop(_app)
         _app.state.drain_state.enter_draining()
         drain_timeout = _lifecycle_config.get("lifecycle.graceful_drain_timeout_seconds", 3600)
+        logger.info(
+            "Starting run drain (timeout={}s, active_runs={})",
+            drain_timeout,
+            len(run_manager._tasks),
+        )
         await run_manager.drain(timeout_seconds=float(drain_timeout))
+        logger.info("Run drain completed")
         # Stop control listeners AFTER draining so in-flight runs can still be
         # cancelled/steered during graceful shutdown.
         await run_manager.stop_control_listeners()

--- a/backend/cubeplex/streams/run_manager.py
+++ b/backend/cubeplex/streams/run_manager.py
@@ -8,7 +8,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from cubepi.providers.base import ReasoningControl
 from cubepi.providers.fallback import FallbackBoundModel
@@ -1041,6 +1041,8 @@ def _extract_tool_summaries(
 class RunManager:
     """Owns background run execution and Redis persistence."""
 
+    _FORCED_CANCEL_WAIT_SECONDS: ClassVar[float] = 5.0
+
     def __init__(
         self,
         *,
@@ -1221,9 +1223,23 @@ class RunManager:
         tasks = list(self._tasks.values())
         for task in tasks:
             task.cancel()
-        for task in tasks:
-            with suppress(asyncio.CancelledError):
-                await task
+        if not tasks:
+            return
+
+        # A run can be stuck in a third-party await or accidentally swallow
+        # CancelledError. Awaiting each task directly here would make the
+        # graceful-shutdown timeout ineffective and keep the process alive
+        # forever. Give cancellation a bounded window, then let the event loop
+        # finish tearing down the remaining tasks.
+        _, pending = await asyncio.wait(
+            tasks,
+            timeout=self._FORCED_CANCEL_WAIT_SECONDS,
+        )
+        if pending:
+            logger.error(
+                "Forced run cancellation timed out; {} task(s) still pending",
+                len(pending),
+            )
 
     async def cancel_run(self, run_id: str) -> bool:
         """Cancel a single in-flight run and wait for cleanup to finish.

--- a/backend/tests/e2e/test_graceful_restart.py
+++ b/backend/tests/e2e/test_graceful_restart.py
@@ -665,3 +665,37 @@ async def test_drain_timeout_force_cancels(memory_client: httpx.AsyncClient) -> 
     await rm.drain(timeout_seconds=0.2)
     assert cancelled_seen.is_set()
     assert "integration-long" not in rm._tasks
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_does_not_wait_forever_for_stubborn_task(
+    memory_client: httpx.AsyncClient,
+) -> None:
+    """Forced shutdown must return when a run suppresses cancellation."""
+    app = memory_client._transport.app  # type: ignore[attr-defined]
+    rm = app.state.run_manager
+    release = asyncio.Event()
+    started = asyncio.Event()
+
+    async def stubborn_run() -> None:
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            await release.wait()
+
+    task = asyncio.create_task(stubborn_run(), name="run:integration-stubborn")
+    rm._tasks["integration-stubborn"] = task
+    rm._tasks_empty.clear()
+    task.add_done_callback(lambda _: rm._on_task_done("integration-stubborn"))
+    await started.wait()
+
+    start = time.monotonic()
+    await rm.cancel_all()
+    elapsed = time.monotonic() - start
+
+    assert elapsed < rm._FORCED_CANCEL_WAIT_SECONDS + 1.0
+    assert not task.done()
+
+    release.set()
+    await task


### PR DESCRIPTION
## Summary

- bound forced cancellation of in-flight runs during graceful shutdown
- log drain start/completion and active run count
- add regression coverage for tasks that suppress cancellation

## Verification

- `uv run pytest tests/e2e/test_graceful_restart.py --no-cov -q` — 23 passed
- pre-push `backend-check-ci` — passed
- pre-push `frontend-check-ci` — passed
