### PR TITLE
fix(title): respect user language fallback

### DIFF
--- a/backend/cubeplex/api/routes/v1/conversations.py
+++ b/backend/cubeplex/api/routes/v1/conversations.py
@@ -962,6 +962,7 @@ async def generate_title(
         )
 
     backend = getattr(raw_request.app.state, "encryption_backend", None)
+    ui_language = {"en": "English", "zh": "Chinese"}.get(ctx.user.language, "English")
     conversation = await generate_and_apply_title(
         repo=repo,
         session=session,
@@ -969,6 +970,8 @@ async def generate_title(
         encryption_backend=backend,
         conversation=conversation,
         content=body.content,
+        ui_language=ui_language,
+        tracer=getattr(raw_request.app.state, "tracer", None),
     )
     return _serialize_conversation(conversation)
 

--- a/backend/cubeplex/prompts/title.py
+++ b/backend/cubeplex/prompts/title.py
@@ -19,14 +19,15 @@ Design notes for future editors — change carefully:
       in the user's input language;
   (2) source text plus a trailing instruction — title must reflect the
       **intent** (and its language), not the body.
-- The literal sentinel ``<<<USER_MESSAGE>>>`` is substituted by the
-  service with the user's first message (already trimmed to
-  ``MAX_SNIPPET_CHARS``). We use a sentinel + ``str.replace`` rather than
-  ``str.format`` so curly braces inside the user's content can't blow up
-  templating.
+- The literal sentinels ``<<<USER_MESSAGE>>>`` and ``<<<UI_LANGUAGE>>>`` are
+  substituted by the service with the user's first message (already trimmed
+  to ``MAX_SNIPPET_CHARS``) and interface language. We use sentinels +
+  ``str.replace`` rather than ``str.format`` so curly braces inside the
+  user's content can't blow up templating.
 """
 
 TITLE_PROMPT_PLACEHOLDER: str = "<<<USER_MESSAGE>>>"
+UI_LANGUAGE_PLACEHOLDER: str = "<<<UI_LANGUAGE>>>"
 
 TITLE_GENERATION_PROMPT: str = """\
 You name conversations for a sidebar list. Read the user's first message
@@ -34,8 +35,12 @@ below and produce a SHORT TITLE describing the conversation's intent.
 
 Rules:
 - Length: 4-6 English words OR 6-10 Chinese characters. Hard cap.
-- Language: match the language of the user's PRIMARY INTENT (which may
-  be the trailing instruction, not the pasted source material).
+- Language: write the title in the language used by the user's message.
+- If the language is difficult to determine, such as for "hi", "OK", or
+  another very short message, use the user's interface language: <<<UI_LANGUAGE>>>.
+- Do not infer the title language from the examples below.
+- The primary intent may be the trailing instruction, not the pasted source
+  material.
 - Form: a noun phrase. Never start with a verb like "Use", "Asks",
   "How to", "Translate", "Help with", "帮我", "询问".
 - Front-load the topic: the first 2-3 words / 4-6 Chinese characters
@@ -49,9 +54,9 @@ Examples:
 
 Input:
 ```
-帮我写一个 React 的虚拟滚动列表组件,需要支持动态高度。
+Help me build a React virtualized list component with dynamic row heights.
 ```
-Title: React 虚拟滚动列表
+Title: React Virtualized List
 
 Input:
 ```

--- a/backend/cubeplex/services/conversation_title.py
+++ b/backend/cubeplex/services/conversation_title.py
@@ -15,13 +15,14 @@ with the first user message. This service:
   manual rename is never clobbered.
 - Swallows LLM/provider errors and returns the conversation unchanged.
 
-The LLM call is dispatched via ``cubepi.Provider.stream`` directly — title
-generation is a single-turn request, so no agent loop is needed.
+The LLM call is dispatched as a single-turn request. When tracing is enabled,
+``Tracer.oneshot`` records the provider call without introducing an agent loop;
+the untraced path uses ``cubepi.Provider.stream`` directly.
 """
 
 import logging
 import re
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -30,7 +31,11 @@ from cubeplex.llm.builder import build_chain_model
 from cubeplex.llm.resolver import resolve_task_preset
 from cubeplex.llm.snapshot import load_llm_snapshot
 from cubeplex.models import Conversation
-from cubeplex.prompts.title import TITLE_GENERATION_PROMPT, TITLE_PROMPT_PLACEHOLDER
+from cubeplex.prompts.title import (
+    TITLE_GENERATION_PROMPT,
+    TITLE_PROMPT_PLACEHOLDER,
+    UI_LANGUAGE_PLACEHOLDER,
+)
 from cubeplex.repositories import ConversationRepository
 
 logger = logging.getLogger(__name__)
@@ -125,8 +130,9 @@ def _looks_like_echo(title: str, snippet: str) -> bool:
     return norm_s.startswith(norm_t[:prefix_len])
 
 
-def _build_prompt(snippet: str) -> str:
-    return TITLE_GENERATION_PROMPT.replace(TITLE_PROMPT_PLACEHOLDER, snippet)
+def _build_prompt(snippet: str, ui_language: str) -> str:
+    prompt = TITLE_GENERATION_PROMPT.replace(TITLE_PROMPT_PLACEHOLDER, snippet)
+    return prompt.replace(UI_LANGUAGE_PLACEHOLDER, ui_language)
 
 
 async def _generate_title(
@@ -134,6 +140,8 @@ async def _generate_title(
     org_id: str,
     encryption_backend: EncryptionBackend,
     full_prompt: str,
+    tracer: Any | None = None,
+    trace_metadata: dict[str, str] | None = None,
 ) -> str:
     """One-shot title generation via cubepi.Provider direct call.
 
@@ -154,32 +162,50 @@ async def _generate_title(
     provider_slug = bound.spec.provider_id
     model_id = bound.spec.id
 
-    try:
-        stream = await bound.provider.stream(
-            model=bound.spec,
-            messages=[UserMessage(content=[TextContent(text=full_prompt)])],
-            system_prompt="",  # title-gen prompt is fully in the user message
-            # Force reasoning off: title-gen is latency-sensitive and a
-            # reasoning model here can stall (the 30s timeout incident).
-            options=StreamOptions(reasoning=ReasoningControl(mode="off")),
-        )
+    messages = [UserMessage(content=[TextContent(text=full_prompt)])]
 
-        parts: list[str] = []
-        async for evt in stream:
-            if evt.type == "text_delta":
-                if evt.delta:
-                    parts.append(evt.delta)
-            elif evt.type == "error":
-                raise RuntimeError(evt.error_message or "title generation failed")
-            elif evt.type == "done":
-                break
+    try:
+        if tracer is not None:
+            async with tracer.oneshot(
+                model=bound,
+                operation="conversation_title",
+                metadata=trace_metadata,
+            ) as title_session:
+                raw_text = cast(
+                    str,
+                    await title_session.generate(
+                        system="",
+                        messages=messages,
+                        max_output_tokens=LLM_MAX_TOKENS,
+                    ),
+                )
+        else:
+            stream = await bound.provider.stream(
+                model=bound.spec,
+                messages=messages,
+                system_prompt="",  # title-gen prompt is fully in the user message
+                # Force reasoning off: title-gen is latency-sensitive and a
+                # reasoning model here can stall (the 30s timeout incident).
+                options=StreamOptions(reasoning=ReasoningControl(mode="off")),
+            )
+
+            parts: list[str] = []
+            async for evt in stream:
+                if evt.type == "text_delta":
+                    if evt.delta:
+                        parts.append(evt.delta)
+                elif evt.type == "error":
+                    raise RuntimeError(evt.error_message or "title generation failed")
+                elif evt.type == "done":
+                    break
+            raw_text = "".join(parts)
     except BaseException as _exc:
         # Out-of-band, best-effort runtime status writeback (spec §4.4a).
         _schedule_writeback(org_id=org_id, provider_slug=provider_slug, model_id=model_id, exc=_exc)
         raise
     else:
         _schedule_writeback(org_id=org_id, provider_slug=provider_slug, model_id=model_id, exc=None)
-    return "".join(parts)
+    return raw_text
 
 
 async def generate_and_apply_title(
@@ -190,6 +216,8 @@ async def generate_and_apply_title(
     encryption_backend: EncryptionBackend | None,
     conversation: Conversation,
     content: str,
+    ui_language: str,
+    tracer: Any | None = None,
 ) -> Conversation:
     """Generate and persist an auto-title for ``conversation``.
 
@@ -214,10 +242,17 @@ async def generate_and_apply_title(
         logger.warning("Auto-title skipped: no encryption backend on app state")
         return conversation
 
-    full_prompt = _build_prompt(snippet)
+    full_prompt = _build_prompt(snippet, ui_language)
 
     try:
-        raw_title = await _generate_title(session, org_id, encryption_backend, full_prompt)
+        raw_title = await _generate_title(
+            session,
+            org_id,
+            encryption_backend,
+            full_prompt,
+            tracer=tracer,
+            trace_metadata={"conversation_id": conversation.id, "org_id": org_id},
+        )
     except Exception:
         logger.warning("Auto-title skipped: LLM call failed", exc_info=True)
         return conversation

--- a/backend/tests/unit/test_conversation_title.py
+++ b/backend/tests/unit/test_conversation_title.py
@@ -7,11 +7,20 @@ break and hard to spot in a manual smoke test.
 """
 
 from cubeplex.services.conversation_title import (
+    _build_prompt,
     _clean_title,
     _extract_text,
     _looks_like_echo,
     _normalise_whitespace,
 )
+
+
+def test_build_prompt_uses_ui_language_for_ambiguous_input() -> None:
+    prompt = _build_prompt("hi", "zh")
+
+    assert "user's interface language: zh" in prompt
+    assert "Help me build a React virtualized list" in prompt
+    assert "帮我写一个 React" not in prompt
 
 
 class TestExtractText:


### PR DESCRIPTION
## Summary

- Use the user's message language for automatic conversation titles.
- Fall back to the persisted UI language for ambiguous short messages.
- Replace the first title few-shot example with an English example.
- Record title generation as a traceable `conversation_title` one-shot.

## Verification

- `ruff check` passed
- `mypy` passed for changed backend modules
- 24 conversation title unit tests passed
- pre-push backend and frontend `check-ci` passed
