### PR TITLE
ci(e2e): isolate real-LLM frontend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,10 @@ jobs:
       CUBEPLEX_E2E_LLM_BASE_URL: ${{ secrets.CUBEPLEX_E2E_LLM_BASE_URL || 'http://127.0.0.1:9' }}
       CUBEPLEX_E2E_LLM_API_KEY: ${{ secrets.CUBEPLEX_E2E_LLM_API_KEY || 'ci-placeholder' }}
       CUBEPLEX_E2E_LLM_MODEL_ID: ${{ secrets.CUBEPLEX_E2E_LLM_MODEL_ID || 'ci-placeholder' }}
-      CUBEPLEX_E2E_REAL_LLM: ${{ secrets.CUBEPLEX_E2E_LLM_BASE_URL != '' && secrets.CUBEPLEX_E2E_LLM_API_KEY != '' && secrets.CUBEPLEX_E2E_LLM_MODEL_ID != '' }}
+      # Never opt Playwright into the live LLM on the PR path. Tests tagged
+      # @real-llm are grepped out by `make frontend-test-e2e-ci` and run in
+      # nightly-real-llm.yml instead.
+      CUBEPLEX_E2E_REAL_LLM: 'false'
       CUBEPLEX_SANDBOX__DOMAIN: ${{ secrets.CUBEPLEX_SANDBOX__DOMAIN || '127.0.0.1:9' }}
       CUBEPLEX_SANDBOX__IMAGE: ${{ secrets.CUBEPLEX_SANDBOX__IMAGE || 'ci-placeholder' }}
       CUBEPLEX_SANDBOX__API_KEY: ${{ secrets.CUBEPLEX_SANDBOX__API_KEY || 'ci-placeholder' }}

--- a/.github/workflows/nightly-real-llm.yml
+++ b/.github/workflows/nightly-real-llm.yml
@@ -1,11 +1,15 @@
 name: Nightly real-LLM E2E
 
-# Runs tests marked `@pytest.mark.real_llm` against the live LLM
-# gateway. These are intentionally deselected from the PR-trigger backend-e2e
-# lane (`make backend-test-e2e` -> `pytest -m "not real_llm"`) because they
-# burn vendor tokens and take ~5-10× longer than mock-path tests. They still
-# need to run somewhere — prompt-cache discipline, journey middleware, and
-# the streaming send-message path all depend on the real LLM contract.
+# Runs tests that need a live LLM:
+#   - backend: `@pytest.mark.real_llm` (`make test-real-llm`)
+#   - frontend: Playwright tests tagged `@real-llm` (`make frontend-test-e2e-real-llm`)
+#
+# These are deselected from PR CI (`pytest -m "not real_llm"` and
+# `playwright --grep-invert @real-llm`) because they burn vendor tokens
+# and take ~5-10× longer than mock-path tests. They still need to run
+# somewhere — prompt-cache discipline, journey middleware, streaming
+# send-message, attachments, and memory reflection all depend on the
+# real LLM contract.
 #
 # Triggers:
 #   - 04:30 UTC daily cron (off-peak for vendor APIs)
@@ -110,3 +114,142 @@ jobs:
       - name: Cleanup leftover test sandboxes
         if: always()
         run: make backend-cleanup-sandboxes
+
+  frontend-real-llm:
+    name: real_llm playwright
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      ENV_FOR_DYNACONF: test
+      CUBEPLEX_E2E_LLM_BASE_URL: ${{ secrets.CUBEPLEX_E2E_LLM_BASE_URL }}
+      CUBEPLEX_E2E_LLM_API_KEY: ${{ secrets.CUBEPLEX_E2E_LLM_API_KEY }}
+      CUBEPLEX_E2E_LLM_MODEL_ID: ${{ secrets.CUBEPLEX_E2E_LLM_MODEL_ID }}
+      CUBEPLEX_E2E_REAL_LLM: 'true'
+      CUBEPLEX_SANDBOX__DOMAIN: ${{ secrets.CUBEPLEX_SANDBOX__DOMAIN }}
+      CUBEPLEX_SANDBOX__IMAGE: ${{ secrets.CUBEPLEX_SANDBOX__IMAGE }}
+      CUBEPLEX_SANDBOX__API_KEY: ${{ secrets.CUBEPLEX_SANDBOX__API_KEY }}
+      CUBEPLEX_AUTH__VAULT_KEY: 1EwVRAtWccVJhdXX_2iepp7OlPfadfHpWNwVFpRzLBI=
+      CUBEPLEX_API_URL: http://127.0.0.1:8001
+    services:
+      postgres:
+        image: cubeplex/postgresql-pgroonga-pgvector:18.2-pgroonga4.0.6-pgvector0.8.2
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: testpass
+          POSTGRES_DB: cubeplex_test
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+      redis:
+        image: redis:7-alpine
+        ports: ['6379:6379']
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          prune-cache: false
+      - uses: pnpm/action-setup@v6.0.10
+        with:
+          package_json_file: frontend/package.json
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Require live LLM secrets
+        run: |
+          if [ -z "$CUBEPLEX_E2E_LLM_BASE_URL" ] || [ -z "$CUBEPLEX_E2E_LLM_API_KEY" ] || [ -z "$CUBEPLEX_E2E_LLM_MODEL_ID" ]; then
+            echo "CUBEPLEX_E2E_LLM_* secrets are required for nightly real-LLM frontend e2e"
+            exit 1
+          fi
+
+      - name: Install backend
+        run: make backend-install
+
+      - name: Install frontend
+        run: make frontend-install
+
+      - name: Build @cubeplex/core
+        run: make frontend-build-core
+
+      - name: Prepare RustFS data dirs
+        run: |
+          mkdir -p /tmp/rustfs/data /tmp/rustfs/logs
+          sudo chown -R 10001:10001 /tmp/rustfs
+
+      - name: Start RustFS
+        run: |
+          docker run -d --name rustfs \
+            -p 9000:9000 -p 9001:9001 \
+            -v /tmp/rustfs/data:/data \
+            -v /tmp/rustfs/logs:/logs \
+            rustfs/rustfs:1.0.0-alpha.97
+          for i in {1..30}; do
+            if curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:9000/ | grep -qE '^(2|3|4)'; then
+              echo "RustFS ready"
+              break
+            fi
+            sleep 2
+          done
+
+      - name: Create RustFS test bucket
+        env:
+          AWS_ACCESS_KEY_ID: rustfsadmin
+          AWS_SECRET_ACCESS_KEY: rustfsadmin
+        run: |
+          aws --endpoint-url http://127.0.0.1:9000 \
+            s3 mb s3://cubeplex-test --region us-east-1
+
+      - name: Alembic migrate
+        run: make backend-migrate
+
+      - name: Start backend in background
+        run: |
+          nohup make backend-start > /tmp/backend-console.log 2>&1 &
+
+      - name: Wait for backend ready
+        run: |
+          timeout 60 bash -c '
+            until curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8001/docs | grep -qE "^(2|3|4)"; do
+              sleep 2
+            done
+          '
+
+      - name: Install playwright browsers
+        run: make frontend-install-browsers
+
+      - name: Playwright real-LLM e2e
+        run: make frontend-test-e2e-real-llm
+
+      - name: Cleanup leftover test sandboxes
+        if: always()
+        run: make backend-cleanup-sandboxes
+
+      - name: Upload backend logs on failure
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-frontend-backend-log
+          path: |
+            /tmp/backend.log
+            /tmp/backend-console.log
+
+      - name: Upload playwright traces on failure
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-frontend-playwright-traces
+          path: |
+            frontend/test-results/
+            frontend/playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,8 @@ Full rules: **[docs/testing.md](docs/testing.md)**. TDD judgment:
   - **If it opens `AsyncSession`, runs alembic, or hits the app → e2e.**
     Misplacement breaks `make check-ci`.
 - Real services at internal boundaries; mock only the outermost external the
-  test isn't about. Real-LLM: `@pytest.mark.real_llm`.
+  test isn't about. Real-LLM: `@pytest.mark.real_llm` (backend) or
+  Playwright `@real-llm` (frontend). Both run only in nightly-real-llm.yml.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install skills-restore backend-install frontend-install backend-check-ci frontend-check-ci check-ci backend-migrate backend-test-e2e backend-test-e2e-ci backend-start backend-cleanup-sandboxes frontend-build-core frontend-install-browsers frontend-test-e2e frontend-test-e2e-ci test-ui-unit test-ui-e2e test-ui test-all clean
+.PHONY: help install skills-restore backend-install frontend-install backend-check-ci frontend-check-ci check-ci backend-migrate backend-test-e2e backend-test-e2e-ci backend-start backend-cleanup-sandboxes frontend-build-core frontend-install-browsers frontend-test-e2e frontend-test-e2e-ci frontend-test-e2e-real-llm test-ui-unit test-ui-e2e test-ui test-all clean
 
 help:
 	@echo "Available commands:"
@@ -17,7 +17,8 @@ help:
 	@echo "  make frontend-build-core        - Build @cubeplex/core"
 	@echo "  make frontend-install-browsers  - Install Playwright Chromium browser"
 	@echo "  make frontend-test-e2e          - Run frontend Playwright tests"
-	@echo "  make frontend-test-e2e-ci       - Run frontend Playwright tests with CI output"
+	@echo "  make frontend-test-e2e-ci       - Run frontend Playwright tests with CI output (excludes @real-llm)"
+	@echo "  make frontend-test-e2e-real-llm - Run frontend Playwright tests tagged @real-llm"
 	@echo "  make test-ui-unit               - Run frontend unit tests"
 	@echo "  make test-ui-e2e                - Run frontend Playwright tests"
 	@echo "  make test-ui                    - Run all frontend tests"
@@ -76,6 +77,9 @@ frontend-test-e2e:
 
 frontend-test-e2e-ci:
 	$(MAKE) -C frontend test-e2e-ci
+
+frontend-test-e2e-real-llm:
+	$(MAKE) -C frontend test-e2e-real-llm
 
 test-ui-unit:
 	$(MAKE) -C frontend test-unit

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,7 +38,13 @@ A presence check is fine *as a step inside a real flow* (you click X, expect a c
 - **Real services, not mocks, at internal boundaries.** Postgres, Redis, rustfs, the running FastAPI app are all real. Mock only at the OUTERMOST external boundary the test isn't about — opensandbox SDK, lark_oapi token endpoint, Tempo HTTP client, cubepi LLM provider when not testing the LLM path itself.
 - **No fake-server E2E.** If the system genuinely can't be simulated (third-party SaaS, no test mode), drop down to a **unit test of the seam**, don't build a fake server.
 - **Skip honestly.** When external infra (e.g. opensandbox lacking pause API on a given backend) can't satisfy the test, `pytest.skip(reason="...")` with a *named* reason — never `xfail`, never silent. See `tests/e2e/test_sandbox_pause_resume.py` "G11" pattern.
-- **Real-LLM tests are tagged.** `@pytest.mark.real_llm`. CI fast lane runs `-m "not real_llm"`; the real-LLM suite runs separately. Don't drop real LLM calls into a test that doesn't need to assert about model behavior.
+- **Real-LLM tests are tagged and stay off the PR path.**
+  - Backend: `@pytest.mark.real_llm`. Fast lane is `-m "not real_llm"`;
+    nightly is `make test-real-llm` in `.github/workflows/nightly-real-llm.yml`.
+  - Frontend: Playwright `{ tag: '@real-llm' }` plus `skipWithoutRealLlm()`.
+    PR CI is `make frontend-test-e2e-ci` (`--grep-invert @real-llm`).
+    Nightly is `make frontend-test-e2e-real-llm` (`--grep @real-llm`).
+  Don't drop a live LLM call into a test that does not carry the marker.
 - **No fire-and-forget sleeps.** Replace `await asyncio.sleep(0.5)` with a bounded poll loop waiting on the observable state — `test_steer_endpoint.py:46` is the model.
 - **Cleanup per test.** Shared `DEFAULT_ORG/WS` is fine for read-only checks; tests that create rows must delete them (or use a per-test fresh workspace). Aggregate queries (`select count(*)`) across runs are a flake-bomb.
 

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install build-core build lint type-check format format-check test-unit test-e2e test-e2e-ci install-browsers check-i18n check-ci
+.PHONY: help install build-core build lint type-check format format-check test-unit test-e2e test-e2e-ci test-e2e-real-llm install-browsers check-i18n check-ci
 
 help:
 	@echo "Available commands:"
@@ -11,7 +11,8 @@ help:
 	@echo "  make format-check      - Check frontend formatting"
 	@echo "  make test-unit         - Run frontend unit tests"
 	@echo "  make test-e2e          - Run Playwright E2E tests"
-	@echo "  make test-e2e-ci       - Run Playwright E2E tests with CI output"
+	@echo "  make test-e2e-ci       - Run Playwright E2E tests with CI output (excludes @real-llm)"
+	@echo "  make test-e2e-real-llm - Run Playwright tests tagged @real-llm"
 	@echo "  make install-browsers  - Install Playwright Chromium browser"
 	@echo "  make check-i18n        - Check i18n locale parity + dynamic t() calls"
 	@echo "  make check-ci          - Run frontend CI checks"
@@ -44,7 +45,10 @@ test-e2e:
 	pnpm test:e2e
 
 test-e2e-ci:
-	PLAYWRIGHT_FORCE_TTY=1 pnpm test:e2e
+	PLAYWRIGHT_FORCE_TTY=1 pnpm test:e2e -- --grep-invert @real-llm
+
+test-e2e-real-llm:
+	PLAYWRIGHT_FORCE_TTY=1 pnpm test:e2e -- --grep @real-llm
 
 install-browsers:
 	pnpm exec playwright install --with-deps chromium

--- a/frontend/packages/web/__tests__/e2e/_helpers/auth.ts
+++ b/frontend/packages/web/__tests__/e2e/_helpers/auth.ts
@@ -6,6 +6,16 @@ export function uniqueEmail(prefix = 'u'): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}@example.com`
 }
 
+/** Playwright tag for tests that call a live LLM. PR CI greps this out. */
+export const REAL_LLM_TAG = '@real-llm'
+
+/**
+ * Skip unless `CUBEPLEX_E2E_REAL_LLM=true`.
+ *
+ * Also tag the test `{ tag: REAL_LLM_TAG }` so PR CI
+ * (`pnpm test:e2e -- --grep-invert @real-llm`) excludes it. Nightly
+ * (`--grep @real-llm` in nightly-real-llm.yml) is the only CI that runs it.
+ */
 export function skipWithoutRealLlm(): void {
   test.skip(process.env.CUBEPLEX_E2E_REAL_LLM !== 'true', 'requires external LLM credentials')
 }

--- a/frontend/packages/web/__tests__/e2e/attachments.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/attachments.spec.ts
@@ -1,14 +1,14 @@
 import { test, expect } from '@playwright/test'
 import path from 'node:path'
 import fs from 'node:fs'
-import { registerAndLand, skipWithoutRealLlm } from './_helpers/auth'
+import { REAL_LLM_TAG, registerAndLand, skipWithoutRealLlm } from './_helpers/auth'
 
 test.describe('M7 attachments happy path', () => {
   // This test exercises the full attachment upload + send cycle including LLM response.
   // Allow up to 3 minutes to accommodate slow LLM endpoints.
   test.setTimeout(180_000)
 
-  test('upload image, send, see attachment in history', async ({ page }) => {
+  test('upload image, send, see attachment in history', { tag: REAL_LLM_TAG }, async ({ page }) => {
     skipWithoutRealLlm()
     await registerAndLand(page)
 
@@ -119,64 +119,70 @@ test.describe('M7 attachments — home page eager-create flow', () => {
     }
   })
 
-  test('uploads on the home page and sends with attachment above the bubble', async ({ page }) => {
-    skipWithoutRealLlm()
-    await registerAndLand(page)
+  test(
+    'uploads on the home page and sends with attachment above the bubble',
+    {
+      tag: REAL_LLM_TAG,
+    },
+    async ({ page }) => {
+      skipWithoutRealLlm()
+      await registerAndLand(page)
 
-    // Write a tiny valid PNG inline (re-use the same trick as the existing test).
-    const tmp = path.join(__dirname, '__tmp_homeflow.png')
-    fs.writeFileSync(
-      tmp,
-      Buffer.from(
-        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
-        'base64',
-      ),
-    )
+      // Write a tiny valid PNG inline (re-use the same trick as the existing test).
+      const tmp = path.join(__dirname, '__tmp_homeflow.png')
+      fs.writeFileSync(
+        tmp,
+        Buffer.from(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+          'base64',
+        ),
+      )
 
-    try {
-      await page.getByTestId('composer-add-menu').click()
-      const fileChooserPromise = page.waitForEvent('filechooser')
-      await page.getByTestId('composer-add-upload').click()
-      const fc = await fileChooserPromise
-      await fc.setFiles(tmp)
-
-      // Wait for upload completion: the upload-progress spinner inside the chip
-      // disappears when the upload resolves.
-      await expect(page.locator('.animate-spin').first()).toBeHidden({ timeout: 15_000 })
-
-      // Send a short prompt.
-      await page.locator('textarea').fill('Reply with the single word OK')
-      await page.getByTestId('send-button').click()
-
-      // Navigation should land on the conversation page.
-      await expect(page).toHaveURL(/\/w\/[^/]+\/conversations\//, { timeout: 10_000 })
-
-      // Wait for the LLM round to finish.
-      await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 90_000 })
-      await page.reload()
-
-      // After reload, the user message + attachments are in history. Wait
-      // for the message text first — that's the most reliable signal that
-      // the conversation history has loaded — then check attachments. Doing
-      // it the other way around races the history fetch on a cold backend.
-      const userMsg = page.getByText('Reply with the single word OK').first()
-      await expect(userMsg).toBeVisible({ timeout: 15_000 })
-
-      const attach = page.getByTestId('message-attachments').first()
-      await expect(attach).toBeVisible({ timeout: 5_000 })
-
-      // Attachments block is positioned ABOVE the user message in DOM/visual order.
-      const userBox = await userMsg.boundingBox()
-      const attachBox = await attach.boundingBox()
-      expect(userBox).not.toBeNull()
-      expect(attachBox).not.toBeNull()
-      expect(userBox!.y).toBeGreaterThan(attachBox!.y)
-    } finally {
       try {
-        fs.unlinkSync(tmp)
-      } catch {
-        // ignore
+        await page.getByTestId('composer-add-menu').click()
+        const fileChooserPromise = page.waitForEvent('filechooser')
+        await page.getByTestId('composer-add-upload').click()
+        const fc = await fileChooserPromise
+        await fc.setFiles(tmp)
+
+        // Wait for upload completion: the upload-progress spinner inside the chip
+        // disappears when the upload resolves.
+        await expect(page.locator('.animate-spin').first()).toBeHidden({ timeout: 15_000 })
+
+        // Send a short prompt.
+        await page.locator('textarea').fill('Reply with the single word OK')
+        await page.getByTestId('send-button').click()
+
+        // Navigation should land on the conversation page.
+        await expect(page).toHaveURL(/\/w\/[^/]+\/conversations\//, { timeout: 10_000 })
+
+        // Wait for the LLM round to finish.
+        await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 90_000 })
+        await page.reload()
+
+        // After reload, the user message + attachments are in history. Wait
+        // for the message text first — that's the most reliable signal that
+        // the conversation history has loaded — then check attachments. Doing
+        // it the other way around races the history fetch on a cold backend.
+        const userMsg = page.getByText('Reply with the single word OK').first()
+        await expect(userMsg).toBeVisible({ timeout: 15_000 })
+
+        const attach = page.getByTestId('message-attachments').first()
+        await expect(attach).toBeVisible({ timeout: 5_000 })
+
+        // Attachments block is positioned ABOVE the user message in DOM/visual order.
+        const userBox = await userMsg.boundingBox()
+        const attachBox = await attach.boundingBox()
+        expect(userBox).not.toBeNull()
+        expect(attachBox).not.toBeNull()
+        expect(userBox!.y).toBeGreaterThan(attachBox!.y)
+      } finally {
+        try {
+          fs.unlinkSync(tmp)
+        } catch {
+          // ignore
+        }
       }
-    }
-  })
+    },
+  )
 })

--- a/frontend/packages/web/__tests__/e2e/chat-flow.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/chat-flow.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
-import { registerAndLand, skipWithoutRealLlm } from './_helpers/auth'
+import { REAL_LLM_TAG, registerAndLand, skipWithoutRealLlm } from './_helpers/auth'
 
-test('can send a message and see a response', async ({ page }) => {
+test('can send a message and see a response', { tag: REAL_LLM_TAG }, async ({ page }) => {
   skipWithoutRealLlm()
   await registerAndLand(page)
 
@@ -24,7 +24,7 @@ test('can send a message and see a response', async ({ page }) => {
   expect(text!.trim().length).toBeGreaterThan(0)
 })
 
-test('conversation history persists after page reload', async ({ page }) => {
+test('conversation history persists after page reload', { tag: REAL_LLM_TAG }, async ({ page }) => {
   skipWithoutRealLlm()
   await registerAndLand(page)
 

--- a/frontend/packages/web/__tests__/e2e/memory-reflection.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/memory-reflection.spec.ts
@@ -1,27 +1,33 @@
 import { test, expect } from '@playwright/test'
-import { registerAndLand, skipWithoutRealLlm } from './_helpers/auth'
+import { REAL_LLM_TAG, registerAndLand, skipWithoutRealLlm } from './_helpers/auth'
 
-test('preference message triggers reflection and surfaces memory chip', async ({ page }) => {
-  skipWithoutRealLlm()
-  // Headroom: cold sandbox (~80s on first run) + main agent reply + detached
-  // reflection LLM call (~5–15s after main run completes).
-  test.setTimeout(180_000)
-  await registerAndLand(page)
+test(
+  'preference message triggers reflection and surfaces memory chip',
+  {
+    tag: REAL_LLM_TAG,
+  },
+  async ({ page }) => {
+    skipWithoutRealLlm()
+    // Headroom: cold sandbox (~80s on first run) + main agent reply + detached
+    // reflection LLM call (~5–15s after main run completes).
+    test.setTimeout(180_000)
+    await registerAndLand(page)
 
-  const input = page.getByPlaceholder('Tell CubePlex what you want to get done…')
-  await input.fill('Please remember that I prefer concise, direct answers in our conversations.')
-  await input.press('Enter')
+    const input = page.getByPlaceholder('Tell CubePlex what you want to get done…')
+    await input.fill('Please remember that I prefer concise, direct answers in our conversations.')
+    await input.press('Enter')
 
-  await expect(page).toHaveURL(/\/w\/[^/]+\/conversations\//)
+    await expect(page).toHaveURL(/\/w\/[^/]+\/conversations\//)
 
-  // Wait for the main run to fully complete (loading indicator hidden).
-  await expect(page.getByTestId('loading-indicator')).toBeVisible({ timeout: 15_000 })
-  await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 120_000 })
+    // Wait for the main run to fully complete (loading indicator hidden).
+    await expect(page.getByTestId('loading-indicator')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 120_000 })
 
-  // MemoryUpdateChip is a permanent per-conversation count ("1 memories" /
-  // "1 条记忆"). The main agent may save via tools, or the detached
-  // ReflectionRunner publishes a UserEvent that refetches the count.
-  await expect(page.getByRole('button', { name: /\d+\s+(memories|条记忆)/ })).toBeVisible({
-    timeout: 45_000,
-  })
-})
+    // MemoryUpdateChip is a permanent per-conversation count ("1 memories" /
+    // "1 条记忆"). The main agent may save via tools, or the detached
+    // ReflectionRunner publishes a UserEvent that refetches the count.
+    await expect(page.getByRole('button', { name: /\d+\s+(memories|条记忆)/ })).toBeVisible({
+      timeout: 45_000,
+    })
+  },
+)

--- a/frontend/packages/web/__tests__/e2e/steering.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/steering.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
-import { registerAndLand, skipWithoutRealLlm } from './_helpers/auth'
+import { REAL_LLM_TAG, registerAndLand, skipWithoutRealLlm } from './_helpers/auth'
 
 async function startRun(page: Page, prompt: string): Promise<void> {
   const input = page.getByPlaceholder('Tell CubePlex what you want to get done…')
@@ -16,67 +16,77 @@ const STREAMY_PROMPT =
   'Tell me a slow, gentle bedtime story about a small robot exploring a ' +
   'quiet forest. At least 400 words. Do not use any tools — just write prose.'
 
-test('steer shows a pending chip, then commits into the transcript at a stable position', async ({
-  page,
-}) => {
-  skipWithoutRealLlm()
-  test.setTimeout(240_000)
-  await registerAndLand(page)
-  await startRun(page, STREAMY_PROMPT)
+test(
+  'steer shows a pending chip, then commits into the transcript at a stable position',
+  {
+    tag: REAL_LLM_TAG,
+  },
+  async ({ page }) => {
+    skipWithoutRealLlm()
+    test.setTimeout(240_000)
+    await registerAndLand(page)
+    await startRun(page, STREAMY_PROMPT)
 
-  // Type a steer while the run is streaming.
-  const input = page.getByPlaceholder('Tell CubePlex what you want to get done…')
-  await input.fill('Actually, also say hello at the end.')
-  await input.press('Enter')
+    // Type a steer while the run is streaming.
+    const input = page.getByPlaceholder('Tell CubePlex what you want to get done…')
+    await input.fill('Actually, also say hello at the end.')
+    await input.press('Enter')
 
-  // Pending chip appears above the input (not yet in the transcript).
-  const chip = page.getByTestId('pending-steer')
-  await expect(chip).toBeVisible({ timeout: 5_000 })
-  await expect(chip).toContainText('Actually, also say hello at the end.')
+    // Pending chip appears above the input (not yet in the transcript).
+    const chip = page.getByTestId('pending-steer')
+    await expect(chip).toBeVisible({ timeout: 5_000 })
+    await expect(chip).toContainText('Actually, also say hello at the end.')
 
-  // Once cubepi drains the steer, the chip disappears and the steer becomes a
-  // real user message in the transcript.
-  await expect(chip).toBeHidden({ timeout: 150_000 })
-  const steerInTranscript = page
-    .locator('[data-role="user"]')
-    .filter({ hasText: 'Actually, also say hello at the end.' })
-  await expect(steerInTranscript).toBeVisible()
+    // Once cubepi drains the steer, the chip disappears and the steer becomes a
+    // real user message in the transcript.
+    await expect(chip).toBeHidden({ timeout: 150_000 })
+    const steerInTranscript = page
+      .locator('[data-role="user"]')
+      .filter({ hasText: 'Actually, also say hello at the end.' })
+    await expect(steerInTranscript).toBeVisible()
 
-  // Capture the ordered role sequence, then reload and assert it is unchanged
-  // (the committed steer must not jump position on refresh).
-  await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 150_000 })
-  const rolesBefore = await page
-    .locator('[data-role]')
-    .evaluateAll((els) => els.map((e) => e.getAttribute('data-role')))
+    // Capture the ordered role sequence, then reload and assert it is unchanged
+    // (the committed steer must not jump position on refresh).
+    await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 150_000 })
+    const rolesBefore = await page
+      .locator('[data-role]')
+      .evaluateAll((els) => els.map((e) => e.getAttribute('data-role')))
 
-  await page.reload()
-  await expect(page.locator('[data-role="user"]').first()).toBeVisible({ timeout: 10_000 })
-  const rolesAfter = await page
-    .locator('[data-role]')
-    .evaluateAll((els) => els.map((e) => e.getAttribute('data-role')))
-  expect(rolesAfter).toEqual(rolesBefore)
-})
+    await page.reload()
+    await expect(page.locator('[data-role="user"]').first()).toBeVisible({ timeout: 10_000 })
+    const rolesAfter = await page
+      .locator('[data-role]')
+      .evaluateAll((els) => els.map((e) => e.getAttribute('data-role')))
+    expect(rolesAfter).toEqual(rolesBefore)
+  },
+)
 
-test('cancelling a pending steer removes the chip before it is injected', async ({ page }) => {
-  skipWithoutRealLlm()
-  test.setTimeout(240_000)
-  await registerAndLand(page)
-  await startRun(page, STREAMY_PROMPT)
+test(
+  'cancelling a pending steer removes the chip before it is injected',
+  {
+    tag: REAL_LLM_TAG,
+  },
+  async ({ page }) => {
+    skipWithoutRealLlm()
+    test.setTimeout(240_000)
+    await registerAndLand(page)
+    await startRun(page, STREAMY_PROMPT)
 
-  const input = page.getByPlaceholder('Tell CubePlex what you want to get done…')
-  await input.fill('Never mind this instruction.')
-  await input.press('Enter')
+    const input = page.getByPlaceholder('Tell CubePlex what you want to get done…')
+    await input.fill('Never mind this instruction.')
+    await input.press('Enter')
 
-  const chip = page.getByTestId('pending-steer')
-  await expect(chip).toBeVisible({ timeout: 5_000 })
+    const chip = page.getByTestId('pending-steer')
+    await expect(chip).toBeVisible({ timeout: 5_000 })
 
-  // Cancel before the agent drains it.
-  await chip.getByRole('button', { name: /cancel/i }).click()
-  await expect(chip).toBeHidden({ timeout: 5_000 })
+    // Cancel before the agent drains it.
+    await chip.getByRole('button', { name: /cancel/i }).click()
+    await expect(chip).toBeHidden({ timeout: 5_000 })
 
-  // It must never appear as a committed user message in the transcript.
-  await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 150_000 })
-  await expect(
-    page.locator('[data-role="user"]').filter({ hasText: 'Never mind this instruction.' }),
-  ).toHaveCount(0)
-})
+    // It must never appear as a committed user message in the transcript.
+    await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 150_000 })
+    await expect(
+      page.locator('[data-role="user"]').filter({ hasText: 'Never mind this instruction.' }),
+    ).toHaveCount(0)
+  },
+)

--- a/frontend/packages/web/__tests__/e2e/streaming.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/streaming.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
-import { registerAndLand, skipWithoutRealLlm } from './_helpers/auth'
+import { REAL_LLM_TAG, registerAndLand, skipWithoutRealLlm } from './_helpers/auth'
 
-test('loading animation appears while streaming', async ({ page }) => {
+test('loading animation appears while streaming', { tag: REAL_LLM_TAG }, async ({ page }) => {
   skipWithoutRealLlm()
   // Cold sandbox provisioning for a fresh user can take ~80s in CI; raise the
   // per-test cap above the default 90s so the run can finish before timeout.
@@ -24,25 +24,31 @@ test('loading animation appears while streaming', async ({ page }) => {
   expect(text!.length).toBeGreaterThan(20)
 })
 
-test('input stays editable while streaming (so the user can steer)', async ({ page }) => {
-  skipWithoutRealLlm()
-  // Same cold-sandbox headroom as above (fresh user → ~80s provisioning).
-  test.setTimeout(150_000)
-  await registerAndLand(page)
+test(
+  'input stays editable while streaming (so the user can steer)',
+  {
+    tag: REAL_LLM_TAG,
+  },
+  async ({ page }) => {
+    skipWithoutRealLlm()
+    // Same cold-sandbox headroom as above (fresh user → ~80s provisioning).
+    test.setTimeout(150_000)
+    await registerAndLand(page)
 
-  const input = page.getByPlaceholder('Tell CubePlex what you want to get done…')
-  await input.fill('Write a short poem.')
-  await input.press('Enter')
+    const input = page.getByPlaceholder('Tell CubePlex what you want to get done…')
+    await input.fill('Write a short poem.')
+    await input.press('Enter')
 
-  await expect(page).toHaveURL(/\/w\/[^/]+\/conversations\//)
+    await expect(page).toHaveURL(/\/w\/[^/]+\/conversations\//)
 
-  // While the run streams, the composer must remain enabled — steering needs
-  // the user to type mid-run. (Previously the box was locked during streaming.)
-  await expect(page.getByTestId('loading-indicator')).toBeVisible({ timeout: 10_000 })
-  await expect(page.getByPlaceholder('Tell CubePlex what you want to get done…')).toBeEnabled()
+    // While the run streams, the composer must remain enabled — steering needs
+    // the user to type mid-run. (Previously the box was locked during streaming.)
+    await expect(page.getByTestId('loading-indicator')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByPlaceholder('Tell CubePlex what you want to get done…')).toBeEnabled()
 
-  // Same cold-sandbox headroom as the test above (fresh user → ~80s provisioning).
-  await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 120_000 })
+    // Same cold-sandbox headroom as the test above (fresh user → ~80s provisioning).
+    await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 120_000 })
 
-  await expect(page.getByPlaceholder('Tell CubePlex what you want to get done…')).toBeEnabled()
-})
+    await expect(page.getByPlaceholder('Tell CubePlex what you want to get done…')).toBeEnabled()
+  },
+)


### PR DESCRIPTION
## Summary
- tag frontend E2E flows that require a live LLM with `@real-llm`
- exclude those tests from PR CI and run them in the nightly real-LLM workflow
- document the frontend real-LLM test contract and add Make targets

## Validation
- frontend Prettier check
- frontend TypeScript type-check
- pre-commit hooks: YAML, ESLint, Prettier, i18n parity
- pre-push fast lane: backend check-ci and frontend check-ci

Base: `main` (rebased before push)