### PR TITLE
pre-push 按改动跳过无关的前后端检查

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 # Two-stage hooks:
 #   pre-commit (≤10s): staged-file checks, file hygiene + ruff check + format check + eslint/prettier --check
-#   pre-push   (≤3min): CI-equivalent backend-check + frontend-check
+#   pre-push: CI-equivalent check-ci per side, skipped when the push has no
+#   matching code (docs-only, opposite side). Makefile / this file still
+#   trigger both, because they are the gate.
 #
 # Policy: ZERO auto-fix. All hooks are check-only. Developers run `make format`
 # or `pnpm format` manually before committing.
@@ -69,7 +71,9 @@ repos:
         exclude: ^frontend/(node_modules|.*/dist|.*/\.next|test-results|playwright-report)/
         pass_filenames: false
 
-  # Pre-push: 跑 CI 等价检查
+  # Pre-push: CI-equivalent checks for the side(s) that changed.
+  # files/exclude use search() against paths in the push range (not the
+  # whole tree). Markdown is documentation even under backend/ or frontend/.
   - repo: local
     hooks:
       - id: backend-check-ci
@@ -78,11 +82,13 @@ repos:
         language: system
         stages: [pre-push]
         pass_filenames: false
-        always_run: true
+        files: ^(backend/|Makefile$|\.pre-commit-config\.yaml$)
+        exclude: \.(md|mdx|rst)$
       - id: frontend-check-ci
         name: frontend check-ci (build-core + lint + format + type-check + vitest + next build)
         entry: make frontend-check-ci
         language: system
         stages: [pre-push]
         pass_filenames: false
-        always_run: true
+        files: ^(frontend/|Makefile$|\.pre-commit-config\.yaml$)
+        exclude: \.(md|mdx|rst)$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,8 @@ Full-stack agent platform.
 8. **Stay on the feature branch** during multi-task work. No auto-switch to
    main or mid-execution merges.
 9. **Verify before claiming done.** Run the command; paste evidence. Pre-push
-   already runs `make check-ci` — don't run it by hand first.
+   already runs `make check-ci` for the side(s) whose code is in the push —
+   don't run it by hand first. Docs-only pushes skip both.
 10. **Act on valid review feedback** — push the fix; don't ask permission.
 11. **Incremental tests during dev** — only the changed module; full suite at
     pre-PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,16 @@ We use pre-commit with **two stages** and a strict **no-auto-fix** policy — ho
   - Ruff `check --no-fix` and `ruff format --check` on staged Python files
   - ESLint (no `--fix`) and Prettier `--check` on staged frontend files
 
-- **pre-push** (runs on `git push`, ~3 minutes):
-  - `cd backend && make check-ci` (ruff + ruff-format + mypy + pytest unit)
-  - `pnpm -r type-check && pnpm -r lint && pnpm -r format:check && pnpm -r test`
+- **pre-push** (runs on `git push`; only the sides that changed):
+  - Backend `make check-ci` (ruff + ruff-format + mypy + pytest unit) when the
+    push includes backend code. Markdown under `backend/` does not count.
+  - Frontend `make check-ci` (core build, lint, format, type-check, vitest,
+    `next build`) when the push includes frontend code. Markdown under
+    `frontend/` does not count.
+  - Changing the root `Makefile` or `.pre-commit-config.yaml` runs both,
+    because those files are the gate.
+  - Docs-only and unrelated paths (`docs/`, `scripts/`, `deploy/`, …) skip
+    both checks. GitHub CI still runs the full suite on the PR.
 
 **If a hook fails, the hook does NOT modify your files.** Run the appropriate formatter manually and re-stage:
 

--- a/backend/tests/unit/test_pre_push_filters.py
+++ b/backend/tests/unit/test_pre_push_filters.py
@@ -1,0 +1,69 @@
+"""Contract for pre-push check-ci file filters.
+
+A docs-only or opposite-side push must not run that side's check-ci; a code
+change (or a change to the hook/Makefile gate) must.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CONFIG_PATH = _REPO_ROOT / ".pre-commit-config.yaml"
+
+
+def _load_hooks() -> dict[str, dict[str, Any]]:
+    raw = yaml.safe_load(_CONFIG_PATH.read_text())
+    found: dict[str, dict[str, Any]] = {}
+    for repo in raw["repos"]:
+        for hook in repo.get("hooks", []):
+            hook_id = hook.get("id")
+            if hook_id in {"backend-check-ci", "frontend-check-ci"}:
+                found[hook_id] = hook
+    return found
+
+
+def _matches(hook: dict[str, Any], path: str) -> bool:
+    if hook.get("always_run"):
+        return True
+    include = re.compile(hook.get("files") or "")
+    exclude = re.compile(hook.get("exclude") or "^$")
+    return bool(include.search(path) and not exclude.search(path))
+
+
+def test_pre_push_check_ci_hooks_exist() -> None:
+    hooks = _load_hooks()
+    assert set(hooks) == {"backend-check-ci", "frontend-check-ci"}
+    for hook in hooks.values():
+        assert hook.get("always_run") is not True
+        assert "pre-push" in hook.get("stages", [])
+
+
+def test_backend_check_ci_runs_for_backend_code_not_docs() -> None:
+    hook = _load_hooks()["backend-check-ci"]
+    assert _matches(hook, "backend/cubeplex/middleware/sandbox.py")
+    assert _matches(hook, "backend/pyproject.toml")
+    assert _matches(hook, "backend/Makefile")
+    assert _matches(hook, "Makefile")
+    assert _matches(hook, ".pre-commit-config.yaml")
+    assert not _matches(hook, "backend/README.md")
+    assert not _matches(hook, "backend/docs/auth.md")
+    assert not _matches(hook, "docs/testing.md")
+    assert not _matches(hook, "frontend/packages/web/app/page.tsx")
+    assert not _matches(hook, "scripts/new-worktree")
+
+
+def test_frontend_check_ci_runs_for_frontend_code_not_docs() -> None:
+    hook = _load_hooks()["frontend-check-ci"]
+    assert _matches(hook, "frontend/packages/web/app/page.tsx")
+    assert _matches(hook, "frontend/package.json")
+    assert _matches(hook, "Makefile")
+    assert _matches(hook, ".pre-commit-config.yaml")
+    assert not _matches(hook, "frontend/README.md")
+    assert not _matches(hook, "docs/testing.md")
+    assert not _matches(hook, "backend/cubeplex/middleware/sandbox.py")
+    assert not _matches(hook, "CONTRIBUTING.md")


### PR DESCRIPTION
## 变更

- 本机 `~/.ssh/config` 给 `github.com` 加了 `ServerAliveInterval 30`（不在本 PR 里，是机器配置），避免 pre-push 跑太久时 GitHub 掐空闲 SSH。
- pre-push 的 `backend-check-ci` / `frontend-check-ci` 不再 `always_run`。
- 只在 push 范围内有对应代码时才跑该侧检查；`*.md` / `*.mdx` / `*.rst` 不算代码。
- 改根目录 `Makefile` 或 `.pre-commit-config.yaml` 仍跑两侧，因为那是检查门闸本身。
- 纯文档、`scripts/`、`deploy/`、只改另一侧代码时，对应检查显示 Skipped。

GitHub CI 仍然全量跑，这只缩短本地 push 的空等。