### PR TITLE
Show execute command intent in chat

### DIFF
--- a/backend/cubeplex/middleware/sandbox.py
+++ b/backend/cubeplex/middleware/sandbox.py
@@ -115,6 +115,12 @@ MAX_EXECUTE_TIMEOUT_SECONDS = 1800
 
 class _ExecuteArgs(BaseModel):
     command: str
+    description: str = Field(
+        description=(
+            "Short, user-facing summary of what this command does (5-10 words). "
+            "Shown in the chat UI instead of the raw command."
+        ),
+    )
     timeout_seconds: int | None = Field(
         default=None,
         ge=1,

--- a/backend/cubeplex/middleware/sandbox.py
+++ b/backend/cubeplex/middleware/sandbox.py
@@ -114,13 +114,14 @@ MAX_EXECUTE_TIMEOUT_SECONDS = 1800
 
 
 class _ExecuteArgs(BaseModel):
-    command: str
     description: str = Field(
         description=(
             "Short, user-facing summary of what this command does (5-10 words). "
-            "Shown in the chat UI instead of the raw command."
+            "Emit this FIRST, before command, so the chat UI can show it while "
+            "the command text is still streaming."
         ),
     )
+    command: str
     timeout_seconds: int | None = Field(
         default=None,
         ge=1,
@@ -283,6 +284,8 @@ def _make_execute_tool(
         name="execute",
         description=(
             "Execute a shell command in the sandbox environment. "
+            "Always set description first (a 5-10 word user-facing summary) "
+            "so the chat UI can show it while the command is still streaming. "
             "Default timeout is 120 seconds. For installs, downloads, or "
             "builds, pass timeout_seconds (max 1800). If you hit the limit, "
             "raise timeout_seconds or split the work and retry."

--- a/backend/tests/e2e/test_sandbox_scoping.py
+++ b/backend/tests/e2e/test_sandbox_scoping.py
@@ -137,7 +137,10 @@ async def test_command_deny_blocks_and_filesystem_untouched(
 
     class _Ctx:
         tool_call = _ToolCall()
-        args = sandbox_mw._ExecuteArgs(command="rm -rf /workspace")
+        args = sandbox_mw._ExecuteArgs(
+            command="rm -rf /workspace",
+            description="Delete workspace",
+        )
 
     class _StubChannel:
         async def approve(self, **kwargs: Any) -> Any:  # pragma: no cover - guard
@@ -295,7 +298,10 @@ async def test_command_confirm_routes_through_hitl_channel(
 
     class _Ctx:
         tool_call = _ToolCall()
-        args = sandbox_mw._ExecuteArgs(command="git push origin main")
+        args = sandbox_mw._ExecuteArgs(
+            command="git push origin main",
+            description="Push to origin",
+        )
 
     from cubepi.hitl import ApproveAnswer, HitlCancelled, HitlTimedOut
 

--- a/backend/tests/unit/test_sandbox.py
+++ b/backend/tests/unit/test_sandbox.py
@@ -271,6 +271,11 @@ def test_execute_args_schema_tells_model_description_is_shown_in_chat() -> None:
     assert "description" in schema["required"]
     field_doc = props["description"]["description"].lower()
     assert "chat" in field_doc
+    # Property order is what models follow when streaming tool-call JSON.
+    # description first means the chat chip can render before a long command.
+    assert list(props)[0] == "description"
+    assert schema["required"][0] == "description"
+    assert "first" in field_doc
 
 
 def test_execute_args_rejects_timeout_above_max() -> None:

--- a/backend/tests/unit/test_sandbox.py
+++ b/backend/tests/unit/test_sandbox.py
@@ -174,7 +174,7 @@ async def test_execute_tool_delegates_to_sandbox() -> None:
     sandbox.execute = AsyncMock(return_value=exec_result)
 
     tool = _make_execute_tool(sandbox)
-    args = _ExecuteArgs(command="echo hello world")
+    args = _ExecuteArgs(command="echo hello world", description="Echo a greeting")
     result = await tool.execute("tc-1", args, signal=None, on_update=None)
 
     sandbox.execute.assert_called_once_with("echo hello world", timeout=120)
@@ -191,7 +191,7 @@ async def test_execute_tool_appends_exit_code_on_failure() -> None:
     sandbox.execute = AsyncMock(return_value=exec_result)
 
     tool = _make_execute_tool(sandbox)
-    args = _ExecuteArgs(command="nonexistent")
+    args = _ExecuteArgs(command="nonexistent", description="Run a missing command")
     result = await tool.execute("tc-2", args)
 
     text = _text(result)
@@ -208,7 +208,7 @@ async def test_execute_tool_no_exit_code_suffix_on_success() -> None:
     sandbox.execute = AsyncMock(return_value=exec_result)
 
     tool = _make_execute_tool(sandbox)
-    args = _ExecuteArgs(command="true")
+    args = _ExecuteArgs(command="true", description="Succeed immediately")
     result = await tool.execute("tc-3", args)
 
     assert "[exit code:" not in _text(result)
@@ -224,7 +224,7 @@ async def test_execute_tool_timeout_returns_error_result() -> None:
     sandbox.execute = AsyncMock(return_value=exec_result)
 
     tool = _make_execute_tool(sandbox)
-    args = _ExecuteArgs(command="sleep 999")
+    args = _ExecuteArgs(command="sleep 999", description="Sleep past timeout")
     result = await tool.execute("tc-timeout", args)
 
     sandbox.execute.assert_called_once_with("sleep 999", timeout=120)
@@ -243,21 +243,49 @@ async def test_execute_tool_forwards_custom_timeout() -> None:
     sandbox.execute = AsyncMock(return_value=exec_result)
 
     tool = _make_execute_tool(sandbox)
-    args = _ExecuteArgs(command="pip install foo", timeout_seconds=300)
+    args = _ExecuteArgs(
+        command="pip install foo",
+        description="Install a package",
+        timeout_seconds=300,
+    )
     await tool.execute("tc-custom", args)
 
     sandbox.execute.assert_called_once_with("pip install foo", timeout=300)
+
+
+def test_execute_args_requires_description() -> None:
+    """description is required so the chat UI can show intent instead of the raw command."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        _ExecuteArgs(command="ls")
+
+    args = _ExecuteArgs(command="ls", description="List files")
+    assert args.description == "List files"
+
+
+def test_execute_args_schema_tells_model_description_is_shown_in_chat() -> None:
+    schema = _ExecuteArgs.model_json_schema()
+    props = schema["properties"]
+    assert "description" in props
+    assert "description" in schema["required"]
+    field_doc = props["description"]["description"].lower()
+    assert "chat" in field_doc
 
 
 def test_execute_args_rejects_timeout_above_max() -> None:
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
-        _ExecuteArgs(command="sleep 1", timeout_seconds=1801)
+        _ExecuteArgs(command="sleep 1", description="Sleep briefly", timeout_seconds=1801)
 
 
 def test_execute_args_accepts_timeout_at_max() -> None:
-    args = _ExecuteArgs(command="pip install foo", timeout_seconds=1800)
+    args = _ExecuteArgs(
+        command="pip install foo",
+        description="Install a package",
+        timeout_seconds=1800,
+    )
     assert args.timeout_seconds == 1800
 
 
@@ -267,7 +295,10 @@ async def test_execute_tool_maps_timeout_exception_to_result() -> None:
     sandbox.execute = AsyncMock(side_effect=TimeoutError("timed out"))
 
     tool = _make_execute_tool(sandbox)
-    result = await tool.execute("tc-to", _ExecuteArgs(command="gh issue list"))
+    result = await tool.execute(
+        "tc-to",
+        _ExecuteArgs(command="gh issue list", description="List GitHub issues"),
+    )
 
     text = _text(result)
     assert text.startswith("[timeout]")

--- a/frontend/packages/web/components/chat/AssistantMessage.tsx
+++ b/frontend/packages/web/components/chat/AssistantMessage.tsx
@@ -36,6 +36,7 @@ import { deriveRunChipStatus } from '@/lib/runChipStatus'
 import { TokenUsageBar } from './TokenUsageBar'
 import { MemoryUpdateChip } from './MemoryUpdateChip'
 import { getWriteFileSummary } from '@/lib/writeFilePreview'
+import { getStreamingParamSummary } from '@/lib/toolIcons'
 import { extractWidgetCode, extractJsonStringPrefix } from '@/lib/partialJson'
 import { WidgetView } from '@/components/chat/widget/WidgetView'
 import { MarkdownWithCitations } from '@/components/shared/MarkdownWithCitations'
@@ -596,7 +597,7 @@ function ContentBlockRenderer({
           summaryOverride={
             supportsPreview && block.name === 'write'
               ? getWriteFileSummary({}, block.args_text)
-              : block.args_text.trim() || undefined
+              : getStreamingParamSummary(block.name || 'tool', block.args_text) || undefined
           }
           contentTypeOverride={supportsPreview ? block.name : undefined}
           toolRef={

--- a/frontend/packages/web/components/chat/SubAgentCard.tsx
+++ b/frontend/packages/web/components/chat/SubAgentCard.tsx
@@ -15,6 +15,7 @@ import { AgentAvatar } from './AgentAvatar'
 import { useNowSeconds } from '@/hooks/useNowSeconds'
 import { proseClasses } from '@/lib/utils'
 import { getWriteFileSummary } from '@/lib/writeFilePreview'
+import { getStreamingParamSummary } from '@/lib/toolIcons'
 
 interface Props {
   name: string
@@ -116,7 +117,7 @@ export const SubAgentCard = memo(function SubAgentCard({
           summaryOverride={
             supportsPreview && block.name === 'write'
               ? getWriteFileSummary({}, block.args_text)
-              : block.args_text.trim() || undefined
+              : getStreamingParamSummary(block.name || 'tool', block.args_text) || undefined
           }
           contentTypeOverride={supportsPreview ? block.name : undefined}
           toolRef={

--- a/frontend/packages/web/lib/__tests__/toolIcons.test.ts
+++ b/frontend/packages/web/lib/__tests__/toolIcons.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getParamSummary } from '@/lib/toolIcons'
+import { getParamSummary, getStreamingParamSummary } from '@/lib/toolIcons'
 
 describe('getParamSummary', () => {
   it('prefers model-supplied description over command', () => {
@@ -33,6 +33,31 @@ describe('getParamSummary', () => {
   it('collapses whitespace in description', () => {
     expect(getParamSummary('task', { description: 'Find  auth\nmiddleware' })).toBe(
       'Find auth middleware',
+    )
+  })
+})
+
+describe('getStreamingParamSummary', () => {
+  it('reads description from incomplete execute JSON', () => {
+    expect(
+      getStreamingParamSummary(
+        'execute',
+        '{"description": "Install packages", "command": "npm install ',
+      ),
+    ).toBe('Install packages')
+  })
+
+  it('shows the description prefix while it is still streaming', () => {
+    expect(getStreamingParamSummary('execute', '{"description": "Install pac')).toBe('Install pac')
+  })
+
+  it('does not dump raw command JSON while waiting for description', () => {
+    expect(getStreamingParamSummary('execute', '{"command": "npm install a-very-long')).toBe('')
+  })
+
+  it('falls back to args text for tools without a description field', () => {
+    expect(getStreamingParamSummary('web_search', '{"query": "cubeplex')).toBe(
+      '{"query": "cubeplex',
     )
   })
 })

--- a/frontend/packages/web/lib/toolIcons.ts
+++ b/frontend/packages/web/lib/toolIcons.ts
@@ -10,6 +10,7 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 import { bareToolName } from '@cubeplex/core'
+import { extractJsonStringPrefix } from '@/lib/partialJson'
 
 const iconMap: Record<string, LucideIcon> = {
   execute: Terminal,
@@ -71,4 +72,19 @@ export function getParamSummary(
     return value.slice(0, maxLen) + '...'
   }
   return value
+}
+
+/**
+ * Summary for a still-streaming tool call, whose args are incomplete JSON.
+ * Prefer a completed-or-partial `description` so execute can render intent
+ * before a long `command` finishes. Execute does not fall back to raw JSON
+ * — that would dump the command as it streams.
+ */
+export function getStreamingParamSummary(toolName: string, argsText: string, maxLen = 60): string {
+  const desc = extractJsonStringPrefix(argsText, 'description')
+  if (desc.trim()) {
+    return getParamSummary(toolName, { description: desc }, maxLen)
+  }
+  if (bareToolName(toolName) === 'execute') return ''
+  return argsText.trim()
 }


### PR DESCRIPTION
## Summary

- Add a required `description` argument to the sandbox `execute` tool so the model supplies a short, user-facing summary of the command.
- The chat tool chip and side-panel subtitle already prefer `args.description` over the raw command, so no frontend change is needed.
- Existing tool calls without `description` still fall back to the command text.

## Test plan

- [x] `uv run pytest tests/unit/test_sandbox.py --no-cov`
- [x] `pnpm exec vitest run lib/__tests__/toolIcons.test.ts` (existing display contract)
- [x] pre-push backend `make check-ci`