### PR TITLE
Keep artifact preview mounted on expand

### DIFF
--- a/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
+++ b/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
@@ -134,9 +134,10 @@ describe('ArtifactPanel expand theater', () => {
     expect(usePanelStore.getState().view).toEqual({ type: 'closed' })
   })
 
-  it('opens in-app expand and unmounts rail preview (single host)', () => {
+  it('opens in-app expand and reparents the same preview host', () => {
     renderPanel()
     expect(screen.getByTestId('artifact-rail-preview')).toBeInTheDocument()
+    const previewBefore = screen.getByTestId('preview-host')
     expect(screen.getAllByTestId('preview-host')).toHaveLength(1)
 
     fireEvent.click(screen.getByTitle('Expand preview'))
@@ -144,11 +145,29 @@ describe('ArtifactPanel expand theater', () => {
     expect(screen.getByTestId('artifact-rail-placeholder')).toBeInTheDocument()
     expect(screen.queryByTestId('artifact-rail-preview')).not.toBeInTheDocument()
     expect(screen.getByTestId('artifact-expand-preview')).toBeInTheDocument()
-    // Only the theater hosts the preview while expanded.
+    // Same single preview — Office/HTML iframes must not remount.
     expect(screen.getAllByTestId('preview-host')).toHaveLength(1)
-    expect(
-      within(screen.getByTestId('artifact-expand-preview')).getByTestId('preview-host'),
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('preview-host')).toBe(previewBefore)
+    expect(within(screen.getByTestId('artifact-expand-preview')).getByTestId('preview-host')).toBe(
+      previewBefore,
+    )
+  })
+
+  it('exit expand reparents the same preview host back to the rail', () => {
+    renderPanel()
+    const previewBefore = screen.getByTestId('preview-host')
+    fireEvent.click(screen.getByTitle('Expand preview'))
+    expect(screen.getByTestId('artifact-expand-preview')).toBeInTheDocument()
+    expect(screen.getByTestId('preview-host')).toBe(previewBefore)
+
+    fireEvent.click(screen.getAllByTitle('Exit expand')[0]!)
+
+    expect(screen.queryByTestId('artifact-expand-preview')).not.toBeInTheDocument()
+    expect(screen.getByTestId('artifact-rail-preview')).toBeInTheDocument()
+    expect(screen.getByTestId('preview-host')).toBe(previewBefore)
+    expect(within(screen.getByTestId('artifact-rail-preview')).getByTestId('preview-host')).toBe(
+      previewBefore,
+    )
   })
 
   it.each([

--- a/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
+++ b/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
@@ -1,6 +1,16 @@
 'use client'
 
-import { useState, useEffect, useRef, type Ref } from 'react'
+import {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useCallback,
+  useSyncExternalStore,
+  type Ref,
+} from 'react'
+import { createPortal } from 'react-dom'
 import dynamic from 'next/dynamic'
 import { useArtifactStore, usePanelStore, createApiClient } from '@cubeplex/core'
 import type { Artifact, ArtifactVersion } from '@cubeplex/core'
@@ -218,6 +228,43 @@ export function PreviewContent({
   }
 }
 
+const subscribeNoop = (): (() => void) => () => {}
+
+/** True only after client hydration (SSR snapshot is false). */
+function useIsClient(): boolean {
+  return useSyncExternalStore(
+    subscribeNoop,
+    () => true,
+    () => false,
+  )
+}
+
+/**
+ * Imperative portal host for PreviewContent. React portals into this element;
+ * we reparent it between rail and theater so heavy previews (Office iframe,
+ * PDF worker, HTML) are not destroyed on expand/exit.
+ *
+ * Created once on the client (not during SSR). Cleanup removes the node on unmount.
+ */
+function usePreviewHost(): HTMLDivElement | null {
+  const isClient = useIsClient()
+  const host = useMemo(() => {
+    if (!isClient) return null
+    const el = document.createElement('div')
+    el.dataset.artifactPreviewHost = 'true'
+    el.className = 'h-full w-full min-h-0'
+    return el
+  }, [isClient])
+
+  useEffect(() => {
+    return () => {
+      host?.remove()
+    }
+  }, [host])
+
+  return host
+}
+
 export function ArtifactPanel() {
   const view = usePanelStore((s) => s.view)
   const close = usePanelStore((s) => s.close)
@@ -240,12 +287,52 @@ export function ArtifactPanel() {
   const [expandedKey, setExpandedKey] = useState<string | null>(null)
   const expanded = expandedKey !== null && expandedKey === identityKey
 
+  const host = usePreviewHost()
+  const railSlotRef = useRef<HTMLDivElement | null>(null)
+  const theaterSlotRef = useRef<HTMLDivElement | null>(null)
+
+  const attachHost = useCallback(
+    (slot: HTMLDivElement | null) => {
+      if (!host || !slot || host.parentElement === slot) return
+      slot.appendChild(host)
+    },
+    [host],
+  )
+
+  // Default: keep host in the rail. Theater attach happens via theater slot
+  // callback ref (dialog content mounts in a portal, so a plain layout effect
+  // can race and see a null theaterSlotRef).
+  useLayoutEffect(() => {
+    if (!expanded) attachHost(railSlotRef.current)
+  }, [expanded, host, attachHost])
+
+  const setRailSlot = useCallback(
+    (el: HTMLDivElement | null) => {
+      railSlotRef.current = el
+      if (!expanded) attachHost(el)
+    },
+    [expanded, attachHost],
+  )
+
+  const setTheaterSlot = useCallback(
+    (el: HTMLDivElement | null) => {
+      theaterSlotRef.current = el
+      if (expanded) attachHost(el)
+    },
+    [expanded, attachHost],
+  )
+
   const openExpand = (): void => {
     if (identityKey) setExpandedKey(identityKey)
   }
-  const closeExpand = (): void => {
+  const closeExpand = useCallback((): void => {
+    // Move host out of the dialog tree before React unmounts the dialog.
+    const rail = railSlotRef.current
+    if (host && rail && host.parentElement !== rail) {
+      rail.appendChild(host)
+    }
     setExpandedKey(null)
-  }
+  }, [host])
 
   const [railPortalEl, setRailPortalEl] = useState<HTMLElement | null>(null)
   const [theaterPortalEl, setTheaterPortalEl] = useState<HTMLElement | null>(null)
@@ -258,8 +345,13 @@ export function ArtifactPanel() {
   const isDesktop = useMediaQuery('(min-width: 768px)', true)
 
   useEffect(() => {
-    if (!isDesktop) setExpandedKey(null)
-  }, [isDesktop])
+    if (!isDesktop) {
+      // Reparent before the theater unmounts so the iframe stays attached.
+      // Deriving `expanded` from isDesktop would detach it with the dialog.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      closeExpand()
+    }
+  }, [isDesktop, closeExpand])
 
   useEffect(() => {
     if (!artifact || artifact.version <= 1 || !conversationId || !artifactId) return
@@ -304,6 +396,17 @@ export function ArtifactPanel() {
     workspaceId,
   }
 
+  const previewPortal =
+    host &&
+    createPortal(
+      <PreviewContent
+        artifact={artifact}
+        version={currentSelectedVersion}
+        workspaceId={workspaceId}
+      />,
+      host,
+    )
+
   return (
     <div ref={setRailPortalEl} className="flex flex-col h-full bg-background">
       <ArtifactPanelHeader
@@ -316,30 +419,29 @@ export function ArtifactPanel() {
         expandButtonRef={expandButtonRef}
         portalContainer={railPortalEl}
       />
-      <div className="flex-1 overflow-hidden">
-        {expanded ? (
+      {/* h-full min-h-0: keep the height chain so Office iframes / image
+          carousel (h-full + absolute top-1/2 arrows) fill the rail body.
+          Without this, percentage heights collapse to content (~150px iframe). */}
+      <div className="relative flex-1 min-h-0 overflow-hidden">
+        <div
+          ref={setRailSlot}
+          className="h-full w-full min-h-0"
+          data-testid={expanded ? 'artifact-rail-placeholder' : 'artifact-rail-preview'}
+        />
+        {expanded && (
           <div
-            className="flex h-full items-center justify-center text-sm text-muted-foreground px-4
-              text-center"
-            data-testid="artifact-rail-placeholder"
+            className="pointer-events-none absolute inset-0 flex items-center justify-center
+              px-4 text-center text-sm text-muted-foreground"
           >
             {t('expandedPlaceholder')}
-          </div>
-        ) : (
-          // h-full min-h-0: keep the height chain so Office iframes / image
-          // carousel (h-full + absolute top-1/2 arrows) fill the rail body.
-          // Without this, percentage heights collapse to content (~150px iframe).
-          <div data-testid="artifact-rail-preview" className="h-full min-h-0">
-            <PreviewContent
-              artifact={artifact}
-              version={currentSelectedVersion}
-              workspaceId={workspaceId}
-            />
           </div>
         )}
       </div>
 
-      {/* Mount theater only while expanded so PreviewContent has a single host.
+      {previewPortal}
+
+      {/* Theater chrome only while expanded. PreviewContent lives in `host`
+          and is reparented into the dialog slot so iframes are not remounted.
           Modal backdrop makes the rail inert — exit expand, then rail Close. */}
       {expanded && (
         <ArtifactExpandDialog
@@ -363,11 +465,7 @@ export function ArtifactPanel() {
             </div>
           }
         >
-          <PreviewContent
-            artifact={artifact}
-            version={currentSelectedVersion}
-            workspaceId={workspaceId}
-          />
+          <div ref={setTheaterSlot} className="h-full w-full min-h-0" />
         </ArtifactExpandDialog>
       )}
     </div>


### PR DESCRIPTION
## Summary

Expanding (or closing) the artifact theater was remounting `PreviewContent`. For Excel/Office that means a new preview token plus a full Office Online iframe reload, which is slow.

This reparents a single preview host between the rail and the theater — the same pattern `BrowserView` already uses for the Neko iframe — so Office/HTML iframes and PDF workers stay mounted.

## Test plan

- [x] `ArtifactPanelExpand` unit tests: expand/exit keep the same preview DOM node (12 passing)
- [ ] Open an `.xlsx` artifact, click expand — spreadsheet should stay rendered, no Office loading spinner
- [ ] Close the theater — rail preview should still be the same document, no reload
- [ ] Expand HTML / PDF artifacts and confirm they also keep state (scroll position / page)
- [ ] Esc / backdrop / theater X still close expand only; rail X still closes the panel