### PR TITLE
Discard stale attachment hydration results

### DIFF
--- a/frontend/packages/core/__tests__/stores/attachmentStore.test.ts
+++ b/frontend/packages/core/__tests__/stores/attachmentStore.test.ts
@@ -26,7 +26,7 @@ import { uploadAttachment, deleteAttachment, listAttachments } from '../../src/a
 
 describe('attachmentStore', () => {
   beforeEach(() => {
-    useAttachmentStore.setState({ staging: {} })
+    useAttachmentStore.setState({ staging: {}, hydrateGeneration: {}, skipHydrate: {} })
     vi.clearAllMocks()
   })
 
@@ -99,6 +99,24 @@ describe('attachmentStore', () => {
     const list = useAttachmentStore.getState().staging.conv1
     expect(list?.length).toBe(1)
     expect(list?.[0].serverFile?.id).toBe('srv-1')
+  })
+
+  it('does not restore submitted attachments from an older hydrate request', async () => {
+    let resolveList!: (value: { attachments: AttachmentDto[]; total: number }) => void
+    ;(listAttachments as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((resolve) => {
+        resolveList = resolve
+      }),
+    )
+
+    const hydratePromise = useAttachmentStore.getState().hydrate({} as never, 'conv1')
+    useAttachmentStore.getState().clear('conv1')
+    useAttachmentStore.getState().markSkipHydrate('conv1')
+
+    resolveList({ attachments: [fakeServerDto], total: 1 })
+    await hydratePromise
+
+    expect(useAttachmentStore.getState().staging.conv1).toBeUndefined()
   })
 
   describe('cancel', () => {

--- a/frontend/packages/core/src/stores/attachmentStore.ts
+++ b/frontend/packages/core/src/stores/attachmentStore.ts
@@ -16,6 +16,9 @@ export interface UploadingFile {
 
 interface AttachmentStoreState {
   staging: Record<string, UploadingFile[]>
+  // Invalidates hydrate requests that started before a local clear. Without
+  // this, a slow pending-attachment response can restore files after submit.
+  hydrateGeneration: Record<string, number>
   // Convs whose next hydrate() call should be skipped. Set by clear() callers
   // (home-page submit) that navigate immediately without awaiting send(), so
   // the server's mark_attached_bulk hasn't run yet when the conversation page
@@ -38,6 +41,7 @@ const abortControllers: Record<string, AbortController> = {}
 
 export const useAttachmentStore = create<AttachmentStoreState>((set, get) => ({
   staging: {},
+  hydrateGeneration: {},
   skipHydrate: {},
 
   async upload(client, convId, files) {
@@ -143,7 +147,13 @@ export const useAttachmentStore = create<AttachmentStoreState>((set, get) => ({
     set((s) => {
       const next = { ...s.staging }
       delete next[convId]
-      return { staging: next }
+      return {
+        staging: next,
+        hydrateGeneration: {
+          ...s.hydrateGeneration,
+          [convId]: (s.hydrateGeneration[convId] ?? 0) + 1,
+        },
+      }
     })
   },
 
@@ -169,12 +179,14 @@ export const useAttachmentStore = create<AttachmentStoreState>((set, get) => ({
       })
       return
     }
+    const generation = get().hydrateGeneration[convId] ?? 0
     let list: Awaited<ReturnType<typeof listAttachments>>
     try {
       list = await listAttachments(client, convId, 'pending')
     } catch {
       return
     }
+    if ((get().hydrateGeneration[convId] ?? 0) !== generation) return
     if (!list.attachments.length) return
     set((s) => ({
       staging: {

--- a/frontend/packages/web/__tests__/e2e/attachments.spec.ts
+++ b/frontend/packages/web/__tests__/e2e/attachments.spec.ts
@@ -128,6 +128,47 @@ test.describe('M7 attachments — home page eager-create flow', () => {
       skipWithoutRealLlm()
       await registerAndLand(page)
 
+      let pendingRequestStartedResolve!: () => void
+      let allowPendingFetchResolve!: () => void
+      let pendingResponseReadyResolve!: () => void
+      let releasePendingResponseResolve!: () => void
+      let pendingResponseFulfilledResolve!: () => void
+      const pendingRequestStarted = new Promise<void>((resolve) => {
+        pendingRequestStartedResolve = resolve
+      })
+      const allowPendingFetch = new Promise<void>((resolve) => {
+        allowPendingFetchResolve = resolve
+      })
+      const pendingResponseReady = new Promise<void>((resolve) => {
+        pendingResponseReadyResolve = resolve
+      })
+      const releasePendingResponse = new Promise<void>((resolve) => {
+        releasePendingResponseResolve = resolve
+      })
+      const pendingResponseFulfilled = new Promise<void>((resolve) => {
+        pendingResponseFulfilledResolve = resolve
+      })
+      let pendingAttachmentCount = 0
+      let interceptedPendingRequest = false
+
+      await page.route(/\/attachments\?status=pending$/, async (route) => {
+        if (interceptedPendingRequest) {
+          await route.continue()
+          return
+        }
+        interceptedPendingRequest = true
+        pendingRequestStartedResolve()
+        await allowPendingFetch
+        const response = await route.fetch()
+        const body = await response.body()
+        const payload = JSON.parse(body.toString()) as { attachments: unknown[] }
+        pendingAttachmentCount = payload.attachments.length
+        pendingResponseReadyResolve()
+        await releasePendingResponse
+        await route.fulfill({ response, body })
+        pendingResponseFulfilledResolve()
+      })
+
       // Write a tiny valid PNG inline (re-use the same trick as the existing test).
       const tmp = path.join(__dirname, '__tmp_homeflow.png')
       fs.writeFileSync(
@@ -149,12 +190,30 @@ test.describe('M7 attachments — home page eager-create flow', () => {
         // disappears when the upload resolves.
         await expect(page.locator('.animate-spin').first()).toBeHidden({ timeout: 15_000 })
 
+        // The draft conversation mount starts a pending-attachment hydration.
+        // Let it read the uploaded file, but hold that stale response until
+        // after submit clears staging and navigation mounts the conversation.
+        await pendingRequestStarted
+        allowPendingFetchResolve()
+        await pendingResponseReady
+        expect(pendingAttachmentCount).toBe(1)
+
         // Send a short prompt.
         await page.locator('textarea').fill('Reply with the single word OK')
         await page.getByTestId('send-button').click()
 
         // Navigation should land on the conversation page.
         await expect(page).toHaveURL(/\/w\/[^/]+\/conversations\//, { timeout: 10_000 })
+
+        releasePendingResponseResolve()
+        await pendingResponseFulfilled
+        await page.evaluate(
+          () =>
+            new Promise<void>((resolve) => {
+              requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+            }),
+        )
+        await expect(page.getByRole('button', { name: 'Remove __tmp_homeflow.png' })).toHaveCount(0)
 
         // Wait for the LLM round to finish.
         await expect(page.getByTestId('loading-indicator')).toBeHidden({ timeout: 90_000 })
@@ -177,6 +236,8 @@ test.describe('M7 attachments — home page eager-create flow', () => {
         expect(attachBox).not.toBeNull()
         expect(userBox!.y).toBeGreaterThan(attachBox!.y)
       } finally {
+        allowPendingFetchResolve()
+        releasePendingResponseResolve()
         try {
           fs.unlinkSync(tmp)
         } catch {


### PR DESCRIPTION
## Summary

- track a per-conversation hydration generation in the frontend attachment store
- invalidate in-flight pending-attachment hydration when submitted attachments are cleared
- add a store regression test for stale hydration results
- extend the Playwright home-upload flow to hold a pending response across submit/navigation and verify the composer chip does not reappear

## Verification

- pre-push frontend check-ci (build-core, lint, format, type-check, Vitest, Next build)
- attachment store tests: 8 passed
- web type-check and targeted E2E lint: passed
- Codex re-review of 98af28d9: no major issues