### PR TITLE
Keep Office preview connected during expand

### DIFF
--- a/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
+++ b/frontend/packages/web/__tests__/components/ArtifactPanelExpand.test.tsx
@@ -134,10 +134,14 @@ describe('ArtifactPanel expand theater', () => {
     expect(usePanelStore.getState().view).toEqual({ type: 'closed' })
   })
 
-  it('opens in-app expand and reparents the same preview host', () => {
+  it('opens in-app expand without reparenting the preview host', () => {
     renderPanel()
     expect(screen.getByTestId('artifact-rail-preview')).toBeInTheDocument()
     const previewBefore = screen.getByTestId('preview-host')
+    const hostBefore = previewBefore.closest('[data-artifact-preview-host]')
+    const parentBefore = hostBefore?.parentElement
+    expect(hostBefore).toBeTruthy()
+    expect(parentBefore).toBeTruthy()
     expect(screen.getAllByTestId('preview-host')).toHaveLength(1)
 
     fireEvent.click(screen.getByTitle('Expand preview'))
@@ -148,23 +152,31 @@ describe('ArtifactPanel expand theater', () => {
     // Same single preview — Office/HTML iframes must not remount.
     expect(screen.getAllByTestId('preview-host')).toHaveLength(1)
     expect(screen.getByTestId('preview-host')).toBe(previewBefore)
+    expect(screen.getByTestId('preview-host').closest('[data-artifact-preview-host]')).toBe(
+      hostBefore,
+    )
+    expect(hostBefore?.parentElement).toBe(parentBefore)
     expect(within(screen.getByTestId('artifact-expand-preview')).getByTestId('preview-host')).toBe(
       previewBefore,
     )
   })
 
-  it('exit expand reparents the same preview host back to the rail', () => {
+  it('exit expand keeps the preview host under the same parent', () => {
     renderPanel()
     const previewBefore = screen.getByTestId('preview-host')
+    const hostBefore = previewBefore.closest('[data-artifact-preview-host]')
+    const parentBefore = hostBefore?.parentElement
     fireEvent.click(screen.getByTitle('Expand preview'))
     expect(screen.getByTestId('artifact-expand-preview')).toBeInTheDocument()
     expect(screen.getByTestId('preview-host')).toBe(previewBefore)
+    expect(hostBefore?.parentElement).toBe(parentBefore)
 
     fireEvent.click(screen.getAllByTitle('Exit expand')[0]!)
 
     expect(screen.queryByTestId('artifact-expand-preview')).not.toBeInTheDocument()
     expect(screen.getByTestId('artifact-rail-preview')).toBeInTheDocument()
     expect(screen.getByTestId('preview-host')).toBe(previewBefore)
+    expect(hostBefore?.parentElement).toBe(parentBefore)
     expect(within(screen.getByTestId('artifact-rail-preview')).getByTestId('preview-host')).toBe(
       previewBefore,
     )

--- a/frontend/packages/web/components/panel/artifact/ArtifactExpandDialog.tsx
+++ b/frontend/packages/web/components/panel/artifact/ArtifactExpandDialog.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode, RefObject } from 'react'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
 
 interface ArtifactExpandDialogProps {
   open: boolean
@@ -10,6 +11,8 @@ interface ArtifactExpandDialogProps {
   title: string
   /** Stable identity so React remounts if selection swaps while open */
   identityKey: string
+  /** Optional stable rail slot that permanently owns the preview dialog portal. */
+  portalContainer?: HTMLElement
   header: ReactNode
   children: ReactNode
   /**
@@ -34,6 +37,7 @@ export function ArtifactExpandDialog({
   onOpenChange,
   title,
   identityKey,
+  portalContainer,
   header,
   children,
   initialFocusRef,
@@ -44,15 +48,30 @@ export function ArtifactExpandDialog({
       <DialogContent
         key={identityKey}
         showCloseButton={false}
-        className="flex h-[90vh] w-[min(90vw,1400px)] max-w-none flex-col gap-0 overflow-hidden
-          p-0 sm:max-w-none"
+        portalContainer={portalContainer}
+        portalClassName={portalContainer ? 'contents' : undefined}
+        keepMounted={Boolean(portalContainer)}
+        forceVisible={Boolean(portalContainer)}
+        className={cn(
+          'flex max-w-none flex-col gap-0 overflow-hidden p-0 sm:max-w-none',
+          open
+            ? 'fixed h-[90vh] w-[min(90vw,1400px)]'
+            : cn(
+                'absolute inset-0 z-0 h-full w-full translate-x-0 translate-y-0 rounded-none',
+                'bg-background ring-0 duration-0 data-closed:animate-none',
+              ),
+        )}
+        role={open ? 'dialog' : 'presentation'}
         aria-describedby={undefined}
         initialFocus={initialFocusRef}
         finalFocus={finalFocusRef}
       >
-        <DialogTitle className="sr-only">{title}</DialogTitle>
-        {header}
-        <div className="min-h-0 flex-1 overflow-hidden" data-testid="artifact-expand-preview">
+        {open && <DialogTitle className="sr-only">{title}</DialogTitle>}
+        {open && header}
+        <div
+          className="min-h-0 flex-1 overflow-hidden"
+          data-testid={open ? 'artifact-expand-preview' : 'artifact-rail-preview'}
+        >
           {children}
         </div>
       </DialogContent>

--- a/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
+++ b/frontend/packages/web/components/panel/artifact/ArtifactPanel.tsx
@@ -1,16 +1,6 @@
 'use client'
 
-import {
-  useState,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useCallback,
-  useSyncExternalStore,
-  type Ref,
-} from 'react'
-import { createPortal } from 'react-dom'
+import { useState, useEffect, useRef, useCallback, type Ref } from 'react'
 import dynamic from 'next/dynamic'
 import { useArtifactStore, usePanelStore, createApiClient } from '@cubeplex/core'
 import type { Artifact, ArtifactVersion } from '@cubeplex/core'
@@ -228,43 +218,6 @@ export function PreviewContent({
   }
 }
 
-const subscribeNoop = (): (() => void) => () => {}
-
-/** True only after client hydration (SSR snapshot is false). */
-function useIsClient(): boolean {
-  return useSyncExternalStore(
-    subscribeNoop,
-    () => true,
-    () => false,
-  )
-}
-
-/**
- * Imperative portal host for PreviewContent. React portals into this element;
- * we reparent it between rail and theater so heavy previews (Office iframe,
- * PDF worker, HTML) are not destroyed on expand/exit.
- *
- * Created once on the client (not during SSR). Cleanup removes the node on unmount.
- */
-function usePreviewHost(): HTMLDivElement | null {
-  const isClient = useIsClient()
-  const host = useMemo(() => {
-    if (!isClient) return null
-    const el = document.createElement('div')
-    el.dataset.artifactPreviewHost = 'true'
-    el.className = 'h-full w-full min-h-0'
-    return el
-  }, [isClient])
-
-  useEffect(() => {
-    return () => {
-      host?.remove()
-    }
-  }, [host])
-
-  return host
-}
-
 export function ArtifactPanel() {
   const view = usePanelStore((s) => s.view)
   const close = usePanelStore((s) => s.close)
@@ -287,52 +240,14 @@ export function ArtifactPanel() {
   const [expandedKey, setExpandedKey] = useState<string | null>(null)
   const expanded = expandedKey !== null && expandedKey === identityKey
 
-  const host = usePreviewHost()
-  const railSlotRef = useRef<HTMLDivElement | null>(null)
-  const theaterSlotRef = useRef<HTMLDivElement | null>(null)
-
-  const attachHost = useCallback(
-    (slot: HTMLDivElement | null) => {
-      if (!host || !slot || host.parentElement === slot) return
-      slot.appendChild(host)
-    },
-    [host],
-  )
-
-  // Default: keep host in the rail. Theater attach happens via theater slot
-  // callback ref (dialog content mounts in a portal, so a plain layout effect
-  // can race and see a null theaterSlotRef).
-  useLayoutEffect(() => {
-    if (!expanded) attachHost(railSlotRef.current)
-  }, [expanded, host, attachHost])
-
-  const setRailSlot = useCallback(
-    (el: HTMLDivElement | null) => {
-      railSlotRef.current = el
-      if (!expanded) attachHost(el)
-    },
-    [expanded, attachHost],
-  )
-
-  const setTheaterSlot = useCallback(
-    (el: HTMLDivElement | null) => {
-      theaterSlotRef.current = el
-      if (expanded) attachHost(el)
-    },
-    [expanded, attachHost],
-  )
+  const [railSlotEl, setRailSlotEl] = useState<HTMLDivElement | null>(null)
 
   const openExpand = (): void => {
     if (identityKey) setExpandedKey(identityKey)
   }
   const closeExpand = useCallback((): void => {
-    // Move host out of the dialog tree before React unmounts the dialog.
-    const rail = railSlotRef.current
-    if (host && rail && host.parentElement !== rail) {
-      rail.appendChild(host)
-    }
     setExpandedKey(null)
-  }, [host])
+  }, [])
 
   const [railPortalEl, setRailPortalEl] = useState<HTMLElement | null>(null)
   const [theaterPortalEl, setTheaterPortalEl] = useState<HTMLElement | null>(null)
@@ -346,8 +261,6 @@ export function ArtifactPanel() {
 
   useEffect(() => {
     if (!isDesktop) {
-      // Reparent before the theater unmounts so the iframe stays attached.
-      // Deriving `expanded` from isDesktop would detach it with the dialog.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       closeExpand()
     }
@@ -396,17 +309,6 @@ export function ArtifactPanel() {
     workspaceId,
   }
 
-  const previewPortal =
-    host &&
-    createPortal(
-      <PreviewContent
-        artifact={artifact}
-        version={currentSelectedVersion}
-        workspaceId={workspaceId}
-      />,
-      host,
-    )
-
   return (
     <div ref={setRailPortalEl} className="flex flex-col h-full bg-background">
       <ArtifactPanelHeader
@@ -424,33 +326,32 @@ export function ArtifactPanel() {
           Without this, percentage heights collapse to content (~150px iframe). */}
       <div className="relative flex-1 min-h-0 overflow-hidden">
         <div
-          ref={setRailSlot}
-          className="h-full w-full min-h-0"
-          data-testid={expanded ? 'artifact-rail-placeholder' : 'artifact-rail-preview'}
+          ref={setRailSlotEl}
+          className="relative h-full w-full min-h-0"
+          data-testid="artifact-preview-slot"
         />
         {expanded && (
           <div
             className="pointer-events-none absolute inset-0 flex items-center justify-center
               px-4 text-center text-sm text-muted-foreground"
+            data-testid="artifact-rail-placeholder"
           >
             {t('expandedPlaceholder')}
           </div>
         )}
       </div>
 
-      {previewPortal}
-
-      {/* Theater chrome only while expanded. PreviewContent lives in `host`
-          and is reparented into the dialog slot so iframes are not remounted.
-          Modal backdrop makes the rail inert — exit expand, then rail Close. */}
-      {expanded && (
+      {/* Keep the dialog portal rooted in the rail slot. Expanding changes only
+          popup layout, so iframe browsing contexts are never reparented. */}
+      {railSlotEl && (
         <ArtifactExpandDialog
-          open
+          open={expanded}
           onOpenChange={(open) => {
             if (!open) closeExpand()
           }}
           title={artifact.name}
           identityKey={identityKey}
+          portalContainer={railSlotEl}
           initialFocusRef={exitExpandButtonRef}
           finalFocusRef={expandButtonRef}
           header={
@@ -465,7 +366,13 @@ export function ArtifactPanel() {
             </div>
           }
         >
-          <div ref={setTheaterSlot} className="h-full w-full min-h-0" />
+          <div data-artifact-preview-host className="h-full w-full min-h-0">
+            <PreviewContent
+              artifact={artifact}
+              version={currentSelectedVersion}
+              workspaceId={workspaceId}
+            />
+          </div>
         </ArtifactExpandDialog>
       )}
     </div>

--- a/frontend/packages/web/components/ui/dialog.tsx
+++ b/frontend/packages/web/components/ui/dialog.tsx
@@ -40,12 +40,20 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  portalContainer,
+  portalClassName,
+  keepMounted = false,
+  forceVisible = false,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  portalContainer?: DialogPrimitive.Portal.Props['container']
+  portalClassName?: string
+  keepMounted?: boolean
+  forceVisible?: boolean
 }) {
   return (
-    <DialogPortal>
+    <DialogPortal container={portalContainer} className={portalClassName} keepMounted={keepMounted}>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
@@ -53,6 +61,7 @@ function DialogContent({
           'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
           className,
         )}
+        {...(forceVisible ? { hidden: false } : {})}
         {...props}
       >
         {children}


### PR DESCRIPTION
## Summary

- keep the artifact preview popup mounted in a stable rail-owned portal
- switch between rail and theater with layout only, without reparenting iframe ancestors
- cover the DOM ancestry invariant that prevents Office iframe browsing-context reloads

## Test plan

- [x] `pnpm --filter web exec vitest run __tests__/components/ArtifactPanelExpand.test.tsx __tests__/components/BrowserViewExpand.test.tsx`
- [x] frontend pre-push `check-ci`