### PR TITLE
fix(chat): polish MCP tool call display

### DIFF
--- a/frontend/packages/core/__tests__/lib/toolName.test.ts
+++ b/frontend/packages/core/__tests__/lib/toolName.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { bareToolName } from '../../src/lib/toolName'
+import { bareToolName, humanizeToolName, splitToolName } from '../../src/lib/toolName'
 
 describe('bareToolName', () => {
   it('strips the server namespace prefix', () => {
@@ -19,5 +19,18 @@ describe('bareToolName', () => {
 
   it('handles disambiguated namespaced names (server slug with suffix)', () => {
     expect(bareToolName('WebTools_aaaa__web_search')).toBe('web_search')
+  })
+
+  it('splits a namespaced tool for display', () => {
+    expect(splitToolName('Jina_AI__search_web')).toEqual({
+      server: 'Jina_AI',
+      tool: 'search_web',
+    })
+    expect(splitToolName('execute')).toEqual({ server: null, tool: 'execute' })
+  })
+
+  it('humanizes tool identifiers without changing their meaning', () => {
+    expect(humanizeToolName('search_web')).toBe('Search web')
+    expect(humanizeToolName('Jina_AI')).toBe('Jina AI')
   })
 })

--- a/frontend/packages/core/src/index.ts
+++ b/frontend/packages/core/src/index.ts
@@ -1,7 +1,8 @@
 export * from './types'
 export * from './api'
 export * from './stores'
-export { bareToolName } from './lib/toolName'
+export { bareToolName, humanizeToolName, splitToolName } from './lib/toolName'
+export type { ToolNameParts } from './lib/toolName'
 export { formatSkillLabel } from './lib/formatSkillLabel'
 export type { SkillLabelParts } from './lib/formatSkillLabel'
 export {

--- a/frontend/packages/core/src/lib/toolName.ts
+++ b/frontend/packages/core/src/lib/toolName.ts
@@ -11,3 +11,23 @@ export function bareToolName(toolName: string): string {
   const idx = toolName.indexOf('__')
   return idx < 0 ? toolName : toolName.slice(idx + 2)
 }
+
+export interface ToolNameParts {
+  server: string | null
+  tool: string
+}
+
+/** Split the namespaced name used on the wire into its UI-friendly parts. */
+export function splitToolName(toolName: string): ToolNameParts {
+  const idx = toolName.indexOf('__')
+  return {
+    server: idx < 0 ? null : toolName.slice(0, idx),
+    tool: bareToolName(toolName),
+  }
+}
+
+/** Turn snake_case / kebab-case tool identifiers into compact UI labels. */
+export function humanizeToolName(toolName: string): string {
+  const label = toolName.replace(/[_-]+/g, ' ').trim()
+  return label ? label.charAt(0).toUpperCase() + label.slice(1) : toolName
+}

--- a/frontend/packages/web/components/chat/ToolCallItem.tsx
+++ b/frontend/packages/web/components/chat/ToolCallItem.tsx
@@ -112,6 +112,8 @@ export const ToolCallItem = memo(function ToolCallItem({
   const toolIdentifier = mcpEntry?.bare_name ?? nameParts.tool
   const FallbackIcon = getToolIcon(toolIdentifier)
   const summary = summaryOverride ?? getParamSummary(toolIdentifier, args)
+  const visibleMcpIconSrc = mcpIconSrc && !mcpIconFailed ? mcpIconSrc : null
+  const hasMcpLogo = visibleMcpIconSrc !== null
   const canOpen = Boolean(toolResult) || allowOpenWhenPending
   const labelTooltip = mcpEntry
     ? `${mcpEntry.server_name} · ${mcpEntry.bare_name}`
@@ -146,10 +148,10 @@ export const ToolCallItem = memo(function ToolCallItem({
             : 'cursor-default text-muted-foreground',
         )}
       >
-        {mcpIconSrc && !mcpIconFailed ? (
+        {visibleMcpIconSrc ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img
-            src={mcpIconSrc}
+            src={visibleMcpIconSrc}
             alt=""
             className="size-4 shrink-0 rounded-[4px] object-contain opacity-90"
             onError={() => setMcpIconFailed(true)}
@@ -161,7 +163,7 @@ export const ToolCallItem = memo(function ToolCallItem({
         )}
 
         <span className="min-w-0 flex-1 truncate">
-          {isMcpTool && serverName && (
+          {isMcpTool && serverName && !hasMcpLogo && (
             <span className="mr-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground/60">
               {serverName}
             </span>

--- a/frontend/packages/web/components/chat/ToolCallItem.tsx
+++ b/frontend/packages/web/components/chat/ToolCallItem.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, memo } from 'react'
 import type { MCPToolIcon, PendingConfirm, ToolCallRef } from '@cubeplex/core'
+import { humanizeToolName, splitToolName } from '@cubeplex/core'
 import { Check, Loader2, Plug } from 'lucide-react'
 import { getToolIcon, getParamSummary } from '@/lib/toolIcons'
 import { useMcpToolRegistryStore, useToolDetailStore } from '@cubeplex/core'
@@ -98,20 +99,27 @@ export const ToolCallItem = memo(function ToolCallItem({
     : elapsed
 
   const mcpEntry = useMcpToolRegistryStore((s) => s.lookup(name))
-  const displayName = mcpEntry?.bare_name ?? name
+  const nameParts = splitToolName(name)
+  const isMcpTool = Boolean(mcpEntry) || nameParts.server !== null
+  const displayName = humanizeToolName(mcpEntry?.bare_name ?? nameParts.tool)
+  const serverName =
+    mcpEntry?.server_name ?? (nameParts.server ? humanizeToolName(nameParts.server) : null)
   const mcpIconSrc = mcpEntry ? pickIconSrc(mcpEntry.tool_icons, mcpEntry.server_icons) : null
   const [mcpIconFailed, setMcpIconFailed] = useState(false)
   useEffect(() => {
     setMcpIconFailed(false)
   }, [mcpIconSrc])
-  const FallbackIcon = getToolIcon(displayName)
-  const summary = summaryOverride ?? getParamSummary(displayName, args)
+  const toolIdentifier = mcpEntry?.bare_name ?? nameParts.tool
+  const FallbackIcon = getToolIcon(toolIdentifier)
+  const summary = summaryOverride ?? getParamSummary(toolIdentifier, args)
   const canOpen = Boolean(toolResult) || allowOpenWhenPending
   const labelTooltip = mcpEntry
     ? `${mcpEntry.server_name} · ${mcpEntry.bare_name}`
-    : summary
-      ? `${displayName} — ${summary}`
-      : displayName
+    : serverName
+      ? `${serverName} · ${displayName}${summary ? ` — ${summary}` : ''}`
+      : summary
+        ? `${displayName} — ${summary}`
+        : displayName
 
   const handleViewInPanel = () => {
     openPanel(
@@ -131,10 +139,10 @@ export const ToolCallItem = memo(function ToolCallItem({
         disabled={!canOpen}
         title={labelTooltip}
         className={cn(
-          'group flex w-full max-w-full items-center gap-1.5 rounded-md px-1.5 py-0.5',
-          'text-left text-[12.5px] leading-5 transition-colors',
+          'group flex w-full max-w-full items-center gap-2 rounded-lg border border-transparent px-2 py-1',
+          'text-left text-[12px] leading-5 transition-colors',
           canOpen
-            ? 'cursor-pointer text-muted-foreground hover:bg-muted/70 hover:text-foreground'
+            ? 'cursor-pointer text-muted-foreground hover:border-border/60 hover:bg-muted/55 hover:text-foreground'
             : 'cursor-default text-muted-foreground',
         )}
       >
@@ -143,29 +151,26 @@ export const ToolCallItem = memo(function ToolCallItem({
           <img
             src={mcpIconSrc}
             alt=""
-            className="size-3 shrink-0 rounded-[2px] object-contain opacity-80"
+            className="size-4 shrink-0 rounded-[4px] object-contain opacity-90"
             onError={() => setMcpIconFailed(true)}
           />
         ) : mcpEntry ? (
-          <Plug className="size-3 shrink-0 opacity-70" />
+          <Plug className="size-3.5 shrink-0 opacity-70" />
         ) : (
-          <FallbackIcon className="size-3 shrink-0 opacity-70" />
+          <FallbackIcon className="size-3.5 shrink-0 opacity-70" />
         )}
 
-        <span
-          className={cn(
-            'shrink-0 font-medium',
-            isPending ? 'text-foreground' : 'text-foreground/90',
+        <span className="min-w-0 flex-1 truncate">
+          {isMcpTool && serverName && (
+            <span className="mr-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground/60">
+              {serverName}
+            </span>
           )}
-        >
-          {displayName}
+          <span className={cn('font-medium', isPending ? 'text-foreground' : 'text-foreground/90')}>
+            {displayName}
+          </span>
+          {summary && <span className="ml-2 text-muted-foreground/70">{summary}</span>}
         </span>
-
-        {summary ? (
-          <span className="min-w-0 flex-1 truncate text-muted-foreground/80">{summary}</span>
-        ) : (
-          <span className="min-w-0 flex-1" />
-        )}
 
         <span className="ml-auto flex shrink-0 items-center gap-1 tabular-nums text-[11px] text-muted-foreground/70">
           {pendingConfirm ? null : isPending ? (

--- a/frontend/packages/web/components/panel/PanelHeader.tsx
+++ b/frontend/packages/web/components/panel/PanelHeader.tsx
@@ -5,6 +5,7 @@ import { X, Copy, Check, Plug, Maximize2, Minimize2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
 import { getToolIcon, getParamSummary } from '@/lib/toolIcons'
+import { humanizeToolName, splitToolName } from '@cubeplex/core'
 import { cn } from '@/lib/utils'
 import { useMcpToolRegistryStore } from '@cubeplex/core'
 
@@ -62,7 +63,8 @@ export function PanelHeader({
   let copyText: string | undefined
 
   if (source.kind === 'tool') {
-    const displayName = mcpEntry?.bare_name ?? source.toolName
+    const nameParts = splitToolName(source.toolName)
+    const displayName = humanizeToolName(mcpEntry?.bare_name ?? nameParts.tool)
     const pickSrc = (icons: { src: string; cached_src?: string | null }[]) => {
       for (const i of icons) {
         if (i.cached_src) return i.cached_src
@@ -74,7 +76,7 @@ export function PanelHeader({
     const mcpIconSrc = mcpEntry
       ? (pickSrc(mcpEntry.tool_icons) ?? pickSrc(mcpEntry.server_icons))
       : null
-    const FallbackIcon = getToolIcon(displayName)
+    const FallbackIcon = getToolIcon(mcpEntry?.bare_name ?? nameParts.tool)
     icon = mcpIconSrc ? (
       // eslint-disable-next-line @next/next/no-img-element
       <img src={mcpIconSrc} alt="" className="size-3.5 rounded-xs shrink-0 object-contain" />
@@ -85,7 +87,8 @@ export function PanelHeader({
       <FallbackIcon className="size-3.5 text-muted-foreground shrink-0" />
     )
     title = displayName
-    subtitle = getParamSummary(displayName, source.toolArgs, 40) || undefined
+    subtitle =
+      getParamSummary(mcpEntry?.bare_name ?? nameParts.tool, source.toolArgs, 40) || undefined
     copyText = source.toolResult ?? JSON.stringify(source.toolArgs, null, 2)
   } else {
     icon = source.icon

--- a/frontend/packages/web/lib/toolIcons.ts
+++ b/frontend/packages/web/lib/toolIcons.ts
@@ -18,9 +18,11 @@ const iconMap: Record<string, LucideIcon> = {
   edit: Code,
   read: Code,
   web_search: Search,
+  search_web: Search,
   search: Search,
   web_fetch: Globe,
   fetch: Globe,
+  read_url: Globe,
   code_execute: Code,
   python: Code,
   subagent: Bot,
@@ -55,7 +57,7 @@ export function getParamSummary(
     value = String(args.command ?? args.cmd ?? '')
   } else if (bare === 'write' || bare === 'edit' || bare === 'read') {
     value = String(args.file_path ?? args.file_name ?? args.path ?? '')
-  } else if (bare === 'web_search' || bare === 'search') {
+  } else if (bare === 'web_search' || bare === 'search_web' || bare === 'search') {
     value = String(args.query ?? args.q ?? '')
   } else if (bare === 'web_fetch' || bare === 'fetch') {
     value = String(args.url ?? '')


### PR DESCRIPTION
## Summary
- humanize namespaced MCP tool calls such as `Jina_AI__search_web`
- improve tool-call row hierarchy, icon sizing, spacing, and hover state
- keep the detail panel title and fallback tool icons consistent

## Verification
- core tests: 306 passed
- core build passed
- web type-check passed
- web lint: 0 errors (existing warnings only)
- pre-push frontend check-ci passed