### PR TITLE
Improve research task orchestration

### DIFF
--- a/backend/cubeplex/prompts/subagents.py
+++ b/backend/cubeplex/prompts/subagents.py
@@ -1,42 +1,36 @@
 """Subagent delegation prompt — injected when subagents are configured."""
 
-SUBAGENT_PROMPT = """## Delegating Tasks to Subagents
+SUBAGENT_PROMPT = """## Delegating to Subagents
 
-You can delegate work to specialized subagents using the `subagent` tool. Each subagent runs independently and returns a result.
+Use the `subagent` tool for substantial, self-contained work that benefits from
+specialized attention or parallel execution. Do simple tasks yourself.
 
-**When to use subagents:**
-- Tasks that can be parallelized (e.g., researching multiple topics at once)
-- Tasks requiring specialized expertise beyond your current tools
-- Long-running tasks you can delegate while continuing other work
+### Execution semantics
 
-**When NOT to use subagents:**
-- Simple, fast tasks — just do them yourself
-- Tasks requiring your current conversation context
+Each subagent runs independently and has no access to the conversation or other
+subagents. Multiple `subagent` calls in the same assistant response run concurrently.
+Dispatch tasks together only when each can complete correctly using information
+available before the batch starts.
 
-**Task Decomposition:**
-Break complex tasks into **atomic, self-contained units** — each subagent task should be focused and independent:
-```
-Good: "Search for Tesla 2024 revenue by region"
-Good: "Find BYD battery technology specifications"
-Bad: "Research Tesla and BYD" (too broad — split into angles first)
-```
+If task B needs task A's result, dispatch A first, inspect its result, then dispatch B
+in a later turn.
 
-**Iteration Patterns:**
-- **Sequential Refinement**: Task A's result reveals a gap → dispatch Task B to fill that specific gap → Task C for deeper follow-up
-- **Parallel Fan-Out**: Dispatch multiple independent tasks simultaneously, then merge results
-- **Verification Chain**: Task A finds something → dispatch Task B to verify or find counter-evidence
-- **Recursive Decomposition**: If a subagent returns "incomplete" or "needs more specificity," break the task further and redispatch
+### Before dispatching
 
-**Field Guidelines:**
-- `name`: A professional, personified name that matches the role. The name should feel credible and fit the expertise domain — avoid mismatches like casual names for serious roles.
-  - Economics/Finance roles: "Dr. Chen", "Prof. Li", "Dr. Kim"
-  - Research/Search roles: "Scout", "Atlas", "Recon"
-  - Data/Analysis roles: "Aria", "Nova", "Sage"
-  - Engineering/Code roles: "Forge", "Bolt", "Coder"
-- `role`: A concise professional title (2-5 words) describing what this agent specializes in. Examples: "经济分析师", "信息检索专家", "数据可视化工程师", "Financial Analyst"
-- `task`: A one-line summary of the specific task being delegated (shown in UI). Examples: "分析特斯拉2024年各区域营收", "Search for BYD battery specs"
-- `prompt`: The full prompt crafted for this subagent — write it as a professional brief tailored to the agent's role and goal. The subagent has no access to your conversation history. Include relevant context, constraints, and expected deliverables. Think of it as briefing a specialist: frame the request in their domain language.
-  - Good: "As a financial analyst, evaluate Tesla's 2024 Q1-Q4 revenue performance across North America, Europe, and Asia-Pacific regions. Focus on YoY growth rates, identify the strongest-performing region, and flag any anomalies. Present findings in a structured comparison table."
-  - Bad: "Search for Tesla 2024 revenue by region" (too generic — doesn't leverage the agent's expertise)
-- The subagent returns a single result when complete
-- You can dispatch multiple subagents in parallel by calling `subagent` multiple times"""
+- Decide shared definitions, method, sources, and output schema once.
+- Split work into exact, non-overlapping ownership boundaries.
+- Do not make several workers independently discover the same source or invent the
+  same method.
+- Prefer fewer well-defined tasks over broad or overlapping fan-out.
+
+### Writing the brief
+
+Each `prompt` must include the goal, relevant context, exact scope, required inputs,
+sources, constraints, expected output, exclusions, and stopping conditions. The brief
+must stand alone because the subagent cannot see conversation history.
+
+Use `name` for a concise professional identifier, `role` for the specialty, and `task`
+for a one-line UI summary.
+
+After results return, validate and merge them yourself. Treat a subagent result as
+evidence to inspect, not an automatically verified final answer."""

--- a/backend/skills/preinstalled/deep-research/SKILL.md
+++ b/backend/skills/preinstalled/deep-research/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deep-research
 description: Use when a question needs current multi-source research, multi-angle investigation, or iterative verification before producing a report or detailed answer
-version: 3.2.0
+version: 3.3.0
 keywords:
   - research
   - multi-agent
@@ -13,549 +13,183 @@ keywords:
 
 # Deep Research
 
-## Overview
+Use a supervisor-subagent loop when one question needs current evidence from
+multiple sources, competing explanations, or iterative verification. The main
+agent owns the question, verification map, dependencies, review, and synthesis.
+Subagents answer narrow questions; they do not manage the plan or write the final
+report.
 
-Use a **supervisor-subagent loop** for serious research.
-The main agent first grounds the request, then owns planning, todo state, review, and final synthesis.
-Subagents do not manage the plan. They only execute narrowly scoped research tasks and return facts.
+Use direct search for a quick fact with one clear source. Use `wide-research`
+when breadth is the hard part and the primary output is a comprehensive list or
+dataset.
 
-**Core principle:** never write the final answer from general knowledge when the task requires real research. Research coverage determines answer quality.
+## Non-negotiable invariants
 
-## Architecture
+1. Ground the question before planning or fan-out.
+2. Build a verification map and identify dependencies before dispatch.
+3. Run only independent tasks in the same wave.
+4. Review and consolidate one wave before designing the next.
+5. Preserve claim-level evidence, counter-evidence, gaps, and conflicts.
+6. Synthesize only from the reviewed evidence set; mark inference and uncertainty.
 
-```text
-User Query
-    │
-    ▼
-┌──────────────────────────────────────────────────────────────┐
-│ MAIN AGENT (Supervisor)                                     │
-│ • Do lightweight reconnaissance first                       │
-│ • Clarify the request if needed                             │
-│ • Classify the task                                         │
-│ • Decompose into verification points                        │
-│ • Create/update workflow-stage todos via `write_todos`      │
-└──────────────────────────────────────────────────────────────┘
-    │
-    │ one active todo = one active research phase
-    ▼
-┌──────────────────────────────────────────────────────────────┐
-│ ACTIVE TODO / RESEARCH PHASE                                │
-│ Example: "Run current research round across required angles"│
-└──────────────────────────────────────────────────────────────┘
-    │
-    │ supervisor chooses the angle decomposition for this phase
-    │ and fan-outs parallel `subagent` calls inside this one todo
-    ▼
-┌─────────────┐  ┌─────────────┐  ┌─────────────┐
-│ Subagent A  │  │ Subagent B  │  │ Subagent C  │
-│ facts       │  │ facts       │  │ facts       │
-│ gaps        │  │ gaps        │  │ conflicts   │
-└─────────────┘  └─────────────┘  └─────────────┘
-    │
-    ▼
-┌──────────────────────────────────────────────────────────────┐
-│ MAIN AGENT REVIEW                                            │
-│ • Are findings specific and source-backed?                   │
-│ • Are there gaps or conflicts?                               │
-│ • Is another round needed?                                   │
-└──────────────────────────────────────────────────────────────┘
-    │                              │
-    │ more research needed         │ research sufficient
-    ▼                              ▼
-update current todo / add new      mark research todos complete
-todos / dispatch more subagents    move report todo to in_progress
-    │                              │
-    └─────────────── loop ─────────┘
-                   ▼
-            Final synthesis/report
-```
+## 1. Ground the question
 
-## Core Model
+Use the smallest useful reconnaissance action to understand the topic, source
+landscape, and ambiguity. If the request is time-sensitive, anchor the current
+date and relevant period before research, then include that context in later
+subagent briefs. Do not call the date tool for timeless conceptual questions.
 
-Treat the workflow as two separate layers:
+Clarify only a missing choice that materially changes the research question,
+comparison, time range, evidence standard, or deliverable. Otherwise state a
+reasonable assumption and proceed.
 
-- **Todo layer**: the main agent's deep-research workflow stages
-- **Subagent layer**: angle decomposition and parallel execution inside the active stage
+Classify the task:
 
-The key rule is:
+- **verification:** test one claim and seek counter-evidence
+- **comparison:** evaluate shared criteria across named subjects
+- **explanation:** establish mechanisms, chronology, and competing accounts
+- **comprehensive investigation:** combine several dependent verification points
 
-> A single `in_progress` todo represents one active **research phase**, not one research angle and not one subagent. That phase may dispatch multiple subagents in parallel.
+## 2. Build the verification and dependency map
 
-Do **not** create one todo per subagent or one todo per angle if that would leave multiple simultaneous active todos or force the model into artificial serial execution.
-
-## Main Agent Responsibilities
-
-The main agent must:
-
-1. Run a lightweight grounding step before planning.
-2. Clarify the user request when scope, time frame, or success criteria are ambiguous.
-3. Classify the research task.
-4. Decompose the topic into atomic verification points.
-5. Use `write_todos` to create and maintain the workflow-stage plan.
-6. Dispatch parallel `subagent` calls for the current phase.
-7. Review subagent results for gaps, conflicts, and follow-ups.
-8. Update the todo list after each review round.
-9. Generate the final report only after research todos are complete.
-
-## Subagent Responsibilities
-
-Subagents must:
-
-- work on one narrow, self-contained question
-- search, extract, and return concrete facts
-- report gaps, conflicts, and missing data explicitly
-- avoid writing the final report
-- avoid planning or updating todos
-
-Subagents are **fact extractors**, not project managers.
-
-## When to Use
-
-Use this skill when:
-
-- the user asks to research, investigate, verify, compare, or explain something in depth
-- the answer needs current information from multiple sources
-- one search is unlikely to be enough
-- the task requires follow-up rounds after initial findings
-- the output needs evidence-backed analysis or a report
-
-Do not use this full workflow for:
-
-- a single quick fact with one clear authoritative source
-- purely conversational questions
-- tasks that do not require external evidence
-
-## Phase 0: Ground the Request Before Planning
-
-**This phase is mandatory. Do NOT skip it. Do NOT call `write_todos` or `subagent` until Phase 0 is complete.**
-
-Before writing todos or dispatching subagents, do a **lightweight reconnaissance pass** to understand what the user is actually asking.
-
-### Step 0a: Temporal Grounding (check FIRST)
-
-Scan the user's request for **any** time reference — explicit or implied:
-
-- Explicit: dates, years, quarters, "2024", "Q1", "last month", "recent"
-- Implicit: "current status", "latest", "now", "market share" (implies recency), "trend", "forecast", news events, pricing, rankings, competitive landscape
-
-**If the request contains ANY time signal (explicit or implicit):**
-
-1. Call the `datetime` tool immediately — before any other action.
-2. Use the result to anchor all subsequent planning: determine the correct year, quarter, and date range.
-3. Include the anchored time context in every subagent prompt you later dispatch (e.g., "Today is 2026-04-14. Research data from 2025-2026.").
-
-**If the request is purely conceptual** (e.g., "explain how transformers work", "compare REST vs GraphQL architectures") — no temporal grounding is needed.
-
-When in doubt, call `datetime`. The cost is one lightweight tool call; the cost of getting the time wrong propagates to every subagent and corrupts the entire research.
-
-### Step 0b: Topic Reconnaissance
-
-Use the smallest useful tool action to understand the research landscape:
-
-- a simple web search to identify the topic, likely source landscape, or whether the question is temporal
-- a quick direct tool lookup when the request names a specific entity, event, metric, or date range
-
-The goal of this pass is not to complete the research. The goal is to reduce ambiguity before planning.
-
-### Step 0c: Scope Assessment
-
-During this pass, determine:
-
-- what the actual research object is
-- whether the request is time-sensitive (if you haven't called `datetime` yet, reconsider)
-- whether the user is asking for explanation, verification, comparison, or report generation
-- what obvious ambiguities or missing constraints exist
-
-### Clarification Rule
-
-If the user's request is still ambiguous after lightweight reconnaissance, ask a clarifying question before creating todos or spawning subagents.
-
-Examples:
-
-- unclear scope
-- unclear time range
-- unclear comparison target
-- unclear output format
-- unclear standard for success
-
-Do **not** jump straight from the raw user message into `write_todos` if you do not yet understand the request well enough to plan intelligently.
-
-## Phase 1: Classify and Decompose
-
-Before researching, classify the request:
-
-| Type | Characteristics | Approach |
-|------|----------------|----------|
-| **Quick Fact** | One specific answer | Search directly, skip heavy orchestration |
-| **Verification** | A claim needs confirmation or challenge | Search for evidence and counter-evidence |
-| **Comprehensive** | Multi-dimensional topic | Full supervisor + todo + subagent loop |
-| **Temporal** | News, prices, events, recent changes | Prefer official and up-to-date sources |
-
-Then break the topic into **atomic verification points**.
-Each point should represent one dimension that can be researched independently.
-
-Good decomposition:
+Before substantial fan-out, record:
 
 ```text
-Topic: Tesla vs BYD competitive position
-- Market share, 2024-2026
-- Battery technology differences
-- Financial performance
-- Production capacity
-- Regulatory environment
+Question and intended deliverable:
+As-of date or time range:
+Definitions and comparison criteria:
+Verification points or claims:
+Preferred source types and evidence threshold:
+Known inputs and evidence already available:
+Dependencies between verification points:
+Stopping rule and budget:
 ```
 
-Bad decomposition:
+For each proposed task, identify what inputs it needs, whether those inputs exist
+now, what evidence it should produce, and which later tasks consume that output.
 
-- "Research Tesla and BYD"
-- "Compare everything"
+Different angles are not automatically independent. Tasks may run in the same
+wave only when none consumes another task's future output and each can complete
+correctly from inputs available before the wave starts.
 
-## Phase 2: Create the Todo Plan
+Common dependency chains include:
 
-Before dispatching substantial research, the main agent should call `write_todos`.
+- source identification → source-specific extraction
+- candidate discovery → candidate verification
+- evidence collection → conflict resolution
+- findings → synthesis
 
-Use todos to track **workflow stages** — they describe what phase of the research process you are in, not what topics you are researching. The angle decomposition happens inside the active todo when you dispatch subagents; it does not appear in the todo list itself.
+Do not write later-wave prompts before their required inputs exist. Later tasks
+should be shaped by the reviewed findings, gaps, and conflicts from earlier
+waves, not guessed in advance.
 
-**The litmus test:** if a todo item reads like a research question or topic heading, it belongs in a subagent prompt, not in the todo list. Todos should answer "what step of the process am I on?" not "what do I need to find out?"
+Use workflow-stage todos for substantial research, with one active phase:
+ground and map, collect evidence, review and verify gaps, then synthesize. Todos
+track phases, not research angles or individual subagents.
 
-Good todo list:
+## 3. Run dependency-ordered waves
 
-```json
-{
-  "todos": [
-    {"content": "Ground the request: clarify scope, time range, and success criteria", "status": "completed"},
-    {"content": "Round 1: broad research across all identified angles", "status": "in_progress"},
-    {"content": "Review round 1, resolve conflicts and fill critical gaps", "status": "pending"},
-    {"content": "Write and save final report as artifact", "status": "pending"}
-  ]
-}
+Deep research normally follows this shape:
+
+```text
+Wave 1: independent reconnaissance or evidence discovery
+Review: consolidate evidence, gaps, conflicts, and dependencies
+Wave 2: targeted verification using reviewed Wave 1 outputs
+Review: resolve material uncertainty and update confidence
+Synthesis: answer only from the reviewed evidence set
 ```
 
-Bad todo list (DO NOT do this — these are research topics disguised as todos):
+This is a model, not a mandatory number of rounds. A simple verification may need
+one collection wave; a difficult conflict may need several narrower waves.
 
-```json
-{
-  "todos": [
-    {"content": "Research Tesla market share data", "status": "in_progress"},
-    {"content": "Research BYD market share data", "status": "in_progress"},
-    {"content": "Compare battery technology", "status": "pending"},
-    {"content": "Analyze financial performance", "status": "pending"},
-    {"content": "Check regulatory environment", "status": "pending"}
-  ]
-}
+Within a wave, assign exact, non-overlapping verification points or intentionally
+orthogonal evidence lanes. Parallel workers may independently test the same
+material claim only when independent corroboration or counter-evidence is the
+purpose. Do not use duplicate vague prompts as a substitute for coverage.
+
+Bad same-wave design:
+
+```text
+A: discover the relevant companies
+B: verify whether each relevant company qualifies
 ```
 
-Why this is wrong:
-- Each item is a research angle, not a workflow stage
-- Multiple items would need to be `in_progress` simultaneously
-- It forces serial execution of things that should run in parallel as subagents
-- The todo list becomes a table of contents for the report, not a process tracker
+Task B lacks its candidate input. Run discovery, consolidate the candidate set,
+then dispatch qualification in the next wave.
 
-### Todo Rules
+## 4. Brief research subagents
 
-- The main agent owns all `write_todos` calls.
-- Unless everything is done, there must be exactly one `in_progress` todo.
-- A todo may be revised, split, expanded, or replaced after review.
-- If new gaps appear, add or rewrite future todos.
-- The todo list should describe the deep-research flow, not the full internal decomposition of angles.
-- The supervisor should decide angle decomposition separately from todo writing.
-- If the current phase narrows after one round, keep it `in_progress` and rewrite it more specifically.
-- Final report generation should usually be its own todo.
+The generic subagent instructions already define self-contained prompts and
+parallel execution semantics. Add the research contract needed for this slice:
 
-## Phase 3: Fan Out Subagents Inside the Active Todo
+- the exact verification point and why it matters
+- date anchor, definitions, and existing inputs
+- preferred primary sources and useful independent sources
+- what would support, weaken, or falsify the claim
+- explicit exclusions and non-overlap with sibling tasks
+- the required evidence structure and stopping boundary
 
-Once one research phase is `in_progress`, the main agent may dispatch multiple subagents inside that phase.
+Require a compact structured result:
 
-**Time context in subagent prompts:** If Phase 0 established a temporal anchor, you MUST include it at the start of every subagent prompt. Subagents have no conversation context — if you don't tell them the date, they will guess from training data and return stale results. Format: `"Today is YYYY-MM-DD. [rest of prompt]"`
-
-### Subagent Prompt Template
-
-Every subagent prompt must include **all five sections** below. A vague one-liner prompt produces vague output. The prompt is the only contract between the supervisor and the subagent — everything you need from the subagent must be spelled out in it.
-
-```
-1. CONTEXT    — date anchor, background the subagent needs, why this matters
-2. TASK       — the specific, narrow research question (one question per subagent)
-3. METHOD     — what to search for, what sources to prefer, what to avoid
-4. OUTPUT     — required structure for the response (see below)
-5. BOUNDARIES — what NOT to do (no report writing, no speculation, no planning)
+```text
+Findings:
+- claim, value or event, time, and source URL or citation marker
+Counter-evidence:
+Gaps:
+Conflicts:
+Limitations:
+Confidence: high | medium | low, with reason
 ```
 
-### Required Output Structure
-
-Instruct every subagent to return findings in this exact structure:
-
-```
-## Facts
-- [Subject] [Time] [Metric]: [Value] (Source: [name/url])
-- ...
-
-## Gaps
-- What could not be confirmed and why
-
-## Conflicts
-- Where sources disagree and what the disagreement is
-
-## Limitations
-- Source quality issues, paywalled data, methodology concerns
-```
-
-Every fact must include a **source name or URL**. Subagent results carry citation metadata — the source information you include in the prompt output requirements is what enables citations in the final report.
-
-### Full Example
-
-```python
-subagent(
-    name="Dr. Chen",
-    role="Auto Market Analyst",
-    task="Find global EV market share data for 2024-2026",
-    prompt="""Today is 2026-04-14.
-
-CONTEXT:
-We are researching the competitive position of Tesla vs BYD in the global EV market.
-Your focus is global market share data. Other subagents are covering China-specific data
-and battery technology separately — do not duplicate their scope.
-
-TASK:
-Find global BEV (battery electric vehicle) market share figures for Tesla and BYD
-for calendar years 2024 and 2025, plus any available 2026 partial-year data.
-
-METHOD:
-- Search for industry reports from CleanTechnica, EV-Volumes, Counterpoint, SNE Research
-- Prefer quarterly or annual share percentages over unit sales alone
-- Cross-reference at least two independent sources per data point
-- If a figure appears in only one source, flag it in Limitations
-
-OUTPUT:
-Return your findings in this structure:
-
-## Facts
-- [Company] [Period] [Metric]: [Value] (Source: [name/url])
-  Example: Tesla Q3 2025 global BEV share: 14.2% (Source: Counterpoint Research)
-
-## Gaps
-- List what you could not find (e.g., "2026 Q1 data not yet published by any source")
-
-## Conflicts
-- Where two sources give different numbers for the same metric
-
-## Limitations
-- Source quality or methodology issues
-
-BOUNDARIES:
-- Do NOT write a summary, analysis, or report
-- Do NOT speculate on reasons behind the numbers
-- Do NOT plan further research steps
-- Say "not found" explicitly when evidence is missing — do not fill gaps with general knowledge
-"""
-)
-subagent(
-    name="Atlas",
-    role="China Market Researcher",
-    task="Find China-specific EV market share for Tesla and BYD",
-    prompt="""Today is 2026-04-14.
-
-CONTEXT:
-We are comparing Tesla vs BYD competitive position. Your scope is China domestic market only.
-Another subagent covers global data — focus exclusively on China registrations and market share.
-
-TASK:
-Find China domestic BEV/PHEV market share and unit sales for Tesla and BYD for 2024-2025,
-plus any 2026 partial data. Include both BEV-only and total NEV (BEV+PHEV) if available,
-since BYD's PHEV share significantly affects the comparison.
-
-METHOD:
-- Search CPCA (China Passenger Car Association) monthly reports
-- Check CAAM (China Association of Automobile Manufacturers) data
-- Cross-reference with local media (CnEVPost, Gasgoo, 36kr)
-- Distinguish between wholesale and retail figures
-
-OUTPUT:
-## Facts
-- [Company] [Period] [Market: China] [Metric]: [Value] (Source: [name/url])
-
-## Gaps
-- What could not be confirmed
-
-## Conflicts
-- Where sources disagree (e.g., wholesale vs retail discrepancies)
-
-## Limitations
-- Methodology notes (BEV-only vs NEV, wholesale vs retail)
-
-BOUNDARIES:
-- Do NOT write analysis or draw conclusions
-- Do NOT cover markets outside China
-- Say "not found" when evidence is missing
-"""
-)
-```
-
-All subagents dispatched in one round belong to the same active todo (e.g., `Round 1: broad research across all identified angles`). This is the core coordination rule:
-
-> One active todo can contain many parallel subagent runs. The todo tracks the research phase. The subagents are the execution units inside it.
-
-## Phase 4: Subagent Output Review and Citation Integrity
-
-When subagent results come back, the main agent must check both **content quality** and **citation integrity** before proceeding.
-
-### Content quality check
-
-For each subagent result, verify:
-
-1. **Specificity**: are there concrete facts with numbers/dates, or vague summaries?
-2. **Source attribution**: does every fact include a source name or URL?
-3. **Coverage**: did the subagent answer the assigned question?
-4. **Gaps**: what remains unanswered?
-5. **Conflicts**: do results disagree across subagents?
-
-### Citation integrity
-
-Subagent results carry citation metadata (URLs, titles) from their search and browsing tools. When the main agent synthesizes the final report:
-
-- **Preserve source URLs** from subagent findings — do not strip or summarize away the source references
-- **Cite inline** in the report body: link facts to their sources so the reader can verify
-- **Do not fabricate sources** — if a subagent reported a fact without a source, mark it as unverified rather than inventing a citation
-
-Bad:
-
-- "Tesla performed well." (no specifics, no source)
-- "According to industry reports, BYD leads in China." (which reports?)
-
-Good:
-
-- "Tesla global BEV share in 2024 was 17.1% (Source: Counterpoint Research Q4 2024 report)."
-
-## Phase 5: Supervisor Review Loop
-
-After subagents return, the main agent must review before continuing.
-
-Review each result for:
-
-1. **Specificity**: are there concrete facts or vague summaries?
-2. **Coverage**: did the subagent answer the assigned question?
-3. **Gaps**: what remains unanswered?
-4. **Conflicts**: do results disagree?
-5. **Follow-ups**: what new questions emerged?
-
-### Review Outcomes
-
-| Situation | Main agent action |
-|-----------|-------------------|
-| Results are strong and complete | Mark current todo `completed`, move next todo to `in_progress` |
-| Current phase needs another pass | Keep current todo `in_progress`, rewrite it more narrowly |
-| New gaps appear | Add new pending todos |
-| Sources conflict | Update todos first, usually by moving `Resolve conflicts and fill critical gaps` to `in_progress`, then dispatch verifier subagents |
-| The final report is now justified | Move report todo to `in_progress` |
-
-### Required Todo Update After Review
-
-After a meaningful review round, the main agent should update the todo list to reflect the new state.
-
-Typical update patterns:
-
-- current todo becomes `completed`, next todo becomes `in_progress`
-- current todo stays `in_progress` but is rewritten to a narrower question
-- one or more new pending todos are added for gaps or conflict resolution
-
-If review reveals **material conflicts** or **missing evidence that blocks synthesis**, update `write_todos` before dispatching the next round.
-In most cases this means:
-
-- mark the current research-round todo `completed` or narrow it explicitly
-- set `Resolve conflicts and fill critical gaps` to `in_progress`
-- keep `Synthesize findings into final report` as `pending`
-
-Do not continue into another subagent round for conflict resolution while the todo list still implies you are in the previous phase.
-
-Do not leave the todo list stale while continuing research rounds.
-
-## Loop Discipline
-
-- Cap the deep research loop at **3 rounds** unless the task clearly justifies more.
-- Each round should become narrower and more targeted.
-- If data is genuinely unavailable after repeated attempts, mark that as a limitation and move on.
-- Avoid redispatching the same vague prompt.
-
-## Phase 6: Synthesis and Report
-
-Only synthesize after the research plan is complete enough.
-Usually this means:
-
-- core research todos are `completed`
-- open conflicts are resolved or explicitly documented
-- known gaps are clearly marked
-- the final report todo is the only active step
-
-### Output Format
-
-**Default behavior: save the report as an artifact file** using the `save_artifact` tool (or write to a file if `save_artifact` is unavailable). Only output the report directly in the chat if the user explicitly asks for inline output.
-
-When saving as artifact:
-- Use a descriptive filename (e.g., `tesla-vs-byd-competitive-analysis.md`)
-- After saving, reply to the user with a brief summary (3-5 sentences) of the key conclusions and mention that the full report has been saved
-
-### Report Structure
-
-The report should include:
-
-1. **Executive summary** — key conclusions in 3-5 sentences
-2. **Key findings** — the most important facts, each with inline source citations
-3. **Analysis by research angle** — detailed findings organized by the angles researched, with source links
-4. **Conflicts and uncertainty** — where sources disagreed and how conflicts were resolved (or not)
-5. **Confidence and limitations** — what could not be verified, source quality issues
-
-### Citation Requirements in the Report
-
-Every factual claim in the report must trace back to a source from the subagent research. Use inline citations:
-
-- Link to source URLs where available: `[Counterpoint Research](url)`
-- Name the source when URL is unavailable: `(Source: CPCA monthly report, March 2026)`
-- Mark unverified claims explicitly: `(unverified — single source only)`
-
-Do NOT strip source information during synthesis. The reader should be able to answer both:
-
-- "What did you conclude?"
-- "What evidence supports that, and where can I verify it?"
-
-## Quality Checklist
-
-Before finalizing:
-
-- [ ] Did I cover the key research angles?
-- [ ] Do I have specific numbers, dates, or source-backed facts where appropriate?
-- [ ] Did I review subagent findings instead of accepting them blindly?
-- [ ] Did I update the todo plan as the research evolved?
-- [ ] Did I handle conflicts or explicitly document them?
-- [ ] Did I mark what could not be verified?
-- [ ] Did I avoid writing the final report before research completion?
-- [ ] Does every fact in the report include an inline source citation?
-- [ ] Did I save the report as an artifact (not just output inline)?
-- [ ] Are my todos tracking workflow stages, not research topics?
-
-If any answer is no, continue the loop or mark the limitation explicitly.
-
-## Common Mistakes
-
-- **Skipping Phase 0 temporal grounding** — dispatching subagents without calling `datetime` first on time-sensitive topics, causing all subagents to operate with wrong time assumptions
-- **Omitting date context from subagent prompts** — even if you called `datetime`, subagents have no memory of it; you must include "Today is YYYY-MM-DD" in each prompt
-- **Writing research topics as todos** — todos like "Research market share" or "Analyze battery tech" are research angles, not workflow stages; they belong in subagent prompts, not in the todo list
-- **One-liner subagent prompts** — a prompt like "Find Tesla market share data" is too vague; subagent prompts must include all five sections (Context, Task, Method, Output, Boundaries)
-- **Stripping citations during synthesis** — subagent results carry source URLs and names; the final report must preserve them as inline citations, not summarize them away
-- **Outputting report inline instead of saving** — unless the user asks for inline output, always save the report as an artifact file
-- Treating each subagent as its own active todo
-- Letting multiple todos appear active at once
-- Never calling `write_todos` after the research plan changes
-- Accepting vague subagent output without source attribution
-- Dispatching dependent tasks in parallel
-- Starting synthesis after one shallow round
-- Hiding unresolved conflicts
-- Using outdated information on temporal questions
-
-## Output Standard
-
-A successful deep research run should produce:
-
-1. Coverage of the main verification points
-2. Concrete facts gathered by specialized subagents
-3. Explicit gaps and limitations
-4. Conflict handling or conflict disclosure
-5. A final synthesis produced only after the research work packages are complete
+A source must support the exact claim attached to it. A homepage or generic
+article link is not evidence for unrelated fields. Missing evidence remains a
+gap; subagents must not fill it from general knowledge.
+
+## 5. Maintain and review the evidence map
+
+For long or multi-wave work, persist the verification map and reviewed evidence
+in a workspace file so context compaction does not become the source of truth.
+The main agent owns this evidence map. Record each verification point as
+`supported`, `contested`, `unknown`, or `failed`, with source provenance
+and unresolved questions.
+
+After every wave, the main agent must review:
+
+1. Did each worker answer its assigned verification point?
+2. Does every material fact have direct evidence?
+3. Are sources primary enough, current enough, and methodologically comparable?
+4. What evidence conflicts, and is the disagreement definitional or factual?
+5. Which gaps block the requested conclusion?
+6. Which next tasks now have all required inputs?
+
+Merge duplicated findings without losing independent provenance. Update the
+verification map, confidence, and todo phase before another wave. The next wave
+must target named gaps, conflicts, weak sources, or counter-evidence and should
+usually be narrower than the previous one.
+
+Do not treat a subagent result as verified merely because it is detailed. Do not
+dispatch synthesis while material verification points still depend on unfinished
+research.
+
+## 6. Stop and synthesize
+
+Stop when the core verification points have reviewed evidence, material conflicts
+are resolved or disclosed, remaining gaps are unlikely to change the answer
+within the budget, and another wave has a clear lower expected value than
+synthesis. Repeated failure is a limitation, not permission to infer an answer.
+
+The final response or report should:
+
+- lead with the supported answer to the user's question
+- distinguish sourced findings from the main agent's inference
+- preserve inline citations or source URLs for factual claims
+- explain material conflicts and how they affect confidence
+- state unresolved gaps, source limitations, and the as-of date
+- avoid stronger certainty than the evidence supports
+
+Save a substantial reusable report as an artifact when useful or requested;
+otherwise answer directly in the format the user asked for.
+
+Before finalizing, confirm that every key conclusion traces to reviewed evidence,
+no dependent work was mistaken for independent fan-out, counter-evidence was not
+silently dropped, and limitations are visible.

--- a/backend/skills/preinstalled/wide-research/SKILL.md
+++ b/backend/skills/preinstalled/wide-research/SKILL.md
@@ -7,7 +7,7 @@ description: >
   all or many matching entities, map a market or literature set, enrich a known
   list, or apply the same research contract across many inputs; use
   deep-research instead for one topic that needs multi-step investigation.
-version: 1.0.0
+version: 1.1.0
 keywords:
   - research
   - wide-research
@@ -21,323 +21,171 @@ keywords:
 
 # Wide Research
 
-Build a verifiable set of research rows, not a pile of mini-reports. The main
-agent owns the research contract, partition plan, shared ledger, validation,
-coverage assessment, and final deliverable. Subagents independently discover or
-verify bounded slices and return structured evidence.
+Build a verifiable set of rows, not a collection of mini-reports. The main agent
+owns the universe definition, source strategy, row contract, partition manifest,
+canonical ledger, validation, coverage assessment, and final dataset. Subagents
+only execute bounded, independent slices using that shared design.
 
-## Choose the right research mode
-
-Use this workflow when breadth is the hard part:
-
-- enumerate all or many entities satisfying shared constraints
-- research the same fields for a known list of inputs
-- build a market map, catalog, landscape, bibliography, or comparison matrix
-- search multiple independent regions, categories, registries, or source types
-- produce a structured dataset whose missing and uncertain rows must remain visible
-
-Use `deep-research` instead when the task centers on one subject, depends on a
-chain of discoveries, or mainly needs causal analysis and narrative synthesis.
-Use direct search for one quick fact. For mixed tasks, run wide discovery first,
-then investigate only ambiguous or high-value rows in depth.
+Use this workflow when breadth is the hard part: enumerating many entities,
+enriching a known list, traversing a registry, or building a market map. Use
+`deep-research` when one subject needs a chain of discoveries or causal analysis.
+Use direct search for one quick fact.
 
 ## Non-negotiable invariants
 
-1. Define the set and row schema before large-scale dispatch.
-2. Partition by independent objects or orthogonal discovery lanes. Do not give
-   multiple subagents the same vague topic.
-3. Every accepted field must trace to evidence. Missing means `unknown`, never a guess.
-4. Preserve excluded, uncertain, failed, and unprocessed items; never silently drop them.
-5. Separate discovery from qualification when the candidate universe is unknown.
-6. Use deterministic code for mechanical normalization, schema validation, set
-   operations, and exact deduplication when tools permit. Reserve model judgment
-   for semantic aliases, conflicting evidence, and qualification decisions.
-7. Never claim an open-web result is exhaustive unless the universe is bounded by
-   an authoritative source that was fully traversed.
+1. Define the universe, row schema, and evidence threshold before large fan-out.
+2. Select and test shared sources before splitting collection work.
+3. Give every input or partition one owner and preserve every terminal state.
+4. Separate discovery from qualification when the candidate universe is unknown.
+5. Store non-trivial research in a durable ledger; conversation context is not
+   the source of truth.
+6. Use deterministic code for parsing, normalization, schema checks, exact
+   deduplication, joins, and counts. Use model judgment for semantic conflicts.
+7. Never claim an open-web result is exhaustive. Claim completeness for a
+   bounded universe only after its declared source boundaries were traversed.
 
-## Workflow
+## 1. Define the research contract
 
-### 1. Ground the request
-
-Before creating a large plan or dispatching subagents, determine:
-
-- **research object** — company, product, paper, policy, repository, person, etc.
-- **universe** — known input list, bounded registry/catalog, or unknown open web
-- **inclusion and exclusion rules** — conditions a row must satisfy
-- **required fields** — the shared output columns
-- **time boundary** — as-of date, publication window, or event period
-- **evidence threshold** — preferred source types and any cross-check requirement
-- **deliverable** — table, JSON/CSV, report, files, or a combination
-- **budget** — useful limits on waves, tool calls, cost, or wall time
-
-If the request is time-sensitive, call the available datetime tool first and
-carry that date into every subagent brief. If a missing choice would materially
-change membership in the set, ask one concise clarification. Otherwise state a
-reasonable assumption and proceed.
-
-### 2. Write the research contract
-
-Record a compact contract before fan-out. At minimum it must contain:
+Resolve choices that change membership in the set; ask one concise clarification
+only when a safe assumption would materially change the result. Record:
 
 ```text
-Goal:
-Universe:
-As-of date / time range:
-Include when:
-Exclude when:
-Required fields:
-Evidence standard:
+Goal and research object:
+Universe: known list | bounded source | open web
+As-of date or time range:
+Include when / exclude when:
+Required fields and field semantics:
+Evidence threshold:
 Output format:
-Stopping rule:
+Stopping rule and budget:
 ```
 
-Define field semantics precisely enough that independent workers make compatible
-decisions. For example, distinguish native support from integrations, current
-CEO from founder, announced availability from generally available, and calendar
-year from fiscal year.
+Each row needs a stable identifier, normalized fields, qualification status,
+claim-level evidence, gaps, conflicts, and confidence. Missing values remain
+`unknown`; they are never inferred during synthesis.
 
-Use a row contract shaped like this unless the task needs another schema:
+For substantial work, use workflow-stage todos such as contract and pilot,
+collection, validation, gap filling, and delivery. Keep partition and item state
+in the ledger, not in hundreds of todo entries.
 
-```json
-{
-  "canonical_name": "...",
-  "aliases": [],
-  "status": "verified|excluded|uncertain|failed",
-  "qualification": {
-    "decision": "include|exclude|unknown",
-    "reason": "..."
-  },
-  "fields": {},
-  "evidence": [
-    {
-      "claim": "...",
-      "source_title": "...",
-      "source_url": "https://...",
-      "source_date": "YYYY-MM-DD|unknown",
-      "evidence_summary": "..."
-    }
-  ],
-  "gaps": [],
-  "conflicts": [],
-  "confidence": "high|medium|low"
-}
-```
+## 2. Map and pilot the sources
 
-Keep claim-level evidence: one homepage URL attached to an entire row is not
-sufficient when different fields come from different sources.
+Do not dispatch collection workers until the main agent has determined:
 
-### 3. Create workflow-stage todos
+- whether the universe is known, bounded by authoritative sources, or open-web
+- the preferred source for each part of the universe and allowed fallbacks
+- whether one source covers the full time range or where source boundaries change
+- how pagination, date limits, categories, and official totals prove coverage
+- which populated fields need primary evidence or an independent cross-check
+- the shared extraction, normalization, and deduplication method
 
-For a substantial run, use `write_todos` to track phases, not individual
-entities or subagents. Keep exactly one phase active. A typical plan is:
+If several workers would rediscover the same source or method, resolve it once
+centrally before fan-out. Different source segments are acceptable only when the
+source map records their coverage boundary, overlapping range, normalization
+rule, and reconciliation method.
 
-```text
-1. Define and sample-check the research contract
-2. Run broad discovery or known-list collection
-3. Validate candidates and resolve conflicts
-4. Measure coverage and fill material gaps
-5. Produce the dataset and research summary
-```
+Pilot the complete method on a small, varied sample before scaling. Include an
+ordinary row, an exclusion or missing value, and an ambiguous or conflicting
+case when available. Confirm that the source is traversable, the schema fits,
+evidence supports individual fields, and expected cost is acceptable. Revise the
+contract or source strategy before launching a large batch.
 
-The partition manifest and item statuses belong in the research ledger, not in
-hundreds of todo entries.
+## 3. Create the durable ledger
 
-### 4. Pilot before scaling
+A durable ledger is required when the work has multiple partitions or waves,
+may be compacted or truncated, or needs validation, retries, deduplication, or
+conflict tracking.
 
-Run the full contract against a small, varied sample before wide dispatch. Choose
-examples likely to expose ambiguity, not merely the easiest rows. Check whether:
+Choose the internal format for the state shape:
 
-- workers interpret inclusion rules consistently
-- every required field can be represented by the schema
-- evidence supports individual claims
-- `unknown`, exclusion, and source conflict cases are expressible
-- one row's typical cost and runtime fit the budget
-
-Revise the contract once if the pilot exposes a structural problem. Do not launch
-dozens of workers with a broken schema.
-
-### 5. Partition the work
-
-Choose the partition strategy from the universe type.
-
-#### Known input list
-
-Split by entity or by balanced batches of entities. Each input must have one
-owner in the manifest. Use smaller batches for hard or heterogeneous inputs and
-larger batches for uniform lookups.
-
-#### Bounded registry or catalog
-
-Partition by non-overlapping page range, category, date interval, or registry
-segment. Record the traversal boundaries so coverage can be proven later.
-
-#### Unknown open-web universe
-
-Use multiple orthogonal discovery lanes, such as:
-
-- geography or language
-- product/category taxonomy
-- source type: official registries, industry directories, papers, repositories
-- query family and domain terminology
-- time window
-
-Overlap between lanes is useful evidence of saturation, but the lanes must not
-all be paraphrases of the same search. Discovery workers return candidates;
-separate validation workers decide whether they qualify.
-
-Run independent partitions in parallel up to the available concurrency. If the
-input count exceeds practical concurrency, process it through bounded waves.
-Do not dispatch dependent validation before its candidates exist.
-
-### 6. Brief subagents with a complete contract
-
-Each `subagent` call must be self-contained because subagents do not see the
-conversation. Include:
-
-```text
-CONTEXT
-- Current date and research goal
-- Shared definitions needed for this slice
-
-SLICE
-- Exact inputs or discovery boundary owned by this worker
-- Explicit non-overlap with other workers
-
-METHOD
-- Sources and tools to prefer
-- Inclusion/exclusion checks
-- Cross-check requirement
-
-OUTPUT
-- The shared row schema, one record per candidate/input
-- Source URL or preserved citation marker for every factual claim
-
-BOUNDARIES
-- Do not write the final report
-- Do not expand beyond the assigned slice
-- Do not infer missing values
-- Return excluded, unknown, and failed rows explicitly
-```
-
-For discovery workers, require a stable candidate identifier, aliases, discovery
-source, and the reason the candidate may qualify. For validation workers, provide
-the candidate record and require a fresh qualification decision rather than a
-rubber stamp.
-
-### 7. Maintain a durable ledger
-
-After every wave, merge results into one ledger. For small work, an in-context
-table is enough. For larger work, persist JSONL, CSV, or a small database under a
-writable workspace path so context compaction cannot erase the set.
+- **CSV** for flat rows with a fixed schema
+- **JSONL** for aliases, multiple evidence records, conflicts, and attempt history
+- **SQLite** for large datasets or frequent querying and updates
+- **Excel** as a user-facing export, not the internal source of truth
 
 Track at least:
 
-- partition ID and assigned boundary
-- candidate or input ID
-- processing status and attempt count
-- normalized row
-- claim-level evidence
-- unresolved gaps and conflicts
-- exclusion reason
+```text
+partition_id and owned boundary
+canonical item ID
+processing status and attempt count
+qualification decision and reason
+normalized fields
+claim-level evidence and provenance
+gaps, conflicts, and exclusion reason
+last completed research phase
+```
 
-Validate every returned record against the schema before merging it. Retry a
-malformed or transiently failed slice only within the stated budget; otherwise
-keep it as `failed` with the reason.
+Use explicit states such as `pending`, `processing`, `verified`, `excluded`,
+`uncertain`, and `failed`. Absence of a row never means completion.
 
-### 8. Normalize, deduplicate, and validate
+Subagents must not concurrently edit the same ledger file. Each worker returns
+structured records or writes a partition-specific file. The main agent validates
+and merges results into the canonical ledger after each wave. Generate the final
+dataset and optional Excel workbook deterministically from that ledger; do not
+use the user-facing export as mutable research state.
 
-Apply deterministic normalization first: whitespace, case, URLs, dates, units,
-and exact identifiers. Then review likely semantic duplicates such as aliases,
-renamed products, parent/subsidiary relationships, or the same paper in multiple
-indexes. Preserve merge provenance so evidence is not lost.
+## 4. Partition into independent waves
 
-Validation should answer separately:
+Choose boundaries from the universe and source strategy:
 
-1. Does the candidate satisfy every required inclusion rule?
-2. Does each populated field have evidence that supports that exact value?
-3. Are sources current enough for the contract's time boundary?
-4. Do sources conflict, and if so can the difference be explained?
-5. Is the row `verified`, `excluded`, `uncertain`, or `failed`?
+- **Known list:** assign each input once, individually or in balanced batches.
+- **Bounded source:** split non-overlapping page ranges, registry segments,
+  categories, or date intervals from the already selected source.
+- **Open web:** use orthogonal discovery lanes such as geography, terminology,
+  source type, or category; later validate the merged candidate set separately.
 
-Prefer first-party or primary sources for qualification. Use independent
-secondary sources for discovery or cross-checking. If evidence is weak or
-conflicting, keep the row uncertain and launch a narrowly scoped verifier only
-when resolving it matters to the requested result.
+Time is a valid partition only after the shared source, filters, schema, and
+validation method are fixed. Do not mechanically assign different years to
+workers who must each rediscover the same data source and invent a method.
 
-### 9. Measure coverage and run gap-filling waves
+Before a wave, record a partition manifest containing the partition ID, exact
+owned boundary, explicit non-overlap, input artifact, expected output path or
+schema, and terminal status. Tasks in one wave must be independently completable
+from inputs that already exist. Do not dispatch qualification, enrichment, or
+synthesis tasks before their candidate or collection artifacts exist.
 
-Review coverage after each meaningful wave.
+Every subagent brief must carry the shared contract plus its exact slice, source
+policy, validation checks, output schema, and boundaries. Workers must return
+excluded, uncertain, failed, and unprocessed items explicitly and must not write
+the final report.
 
-For a known list, report:
+## 5. Merge, validate, and fill gaps
 
-- total inputs, processed inputs, verified, excluded, uncertain, and failed
-- completeness of each required field
-- any unprocessed IDs
+After each wave, the main agent must:
 
-For a bounded source, also report partitions/pages traversed versus expected.
+1. validate every partition output against the shared schema
+2. merge it into the canonical ledger without losing provenance
+3. normalize exact identifiers, dates, units, names, and URLs deterministically
+4. inspect semantic duplicates, aliases, renamed entities, and source conflicts
+5. reconcile row counts against known inputs, traversed boundaries, or official totals
+6. mark each partition and item with an explicit state
+7. launch another wave only for a named gap, conflict, or failed partition
 
-For an unknown universe, absolute recall is unknowable. Assess method coverage:
+Discovery evidence makes an item a candidate, not automatically `verified`.
+Qualification should prefer primary sources and check every inclusion rule and
+populated field. Keep weak or conflicting records `uncertain` unless a targeted
+verifier resolves them.
 
-- which geographies, categories, languages, source types, and query families ran
-- how many new qualified candidates each lane and wave contributed
-- how much independent-lane overlap occurred
-- which material segments remain weak
+Measure coverage by universe type:
 
-Launch another wave only for a named gap, conflict, failed partition, or newly
-productive lead. Each wave should be narrower than the last.
+- known list: every input has a terminal state and field-completeness metrics
+- bounded source: every declared boundary was traversed and counts reconciled
+- open web: report lanes attempted, overlap, new candidates by wave, and weak areas
 
-Default stopping rules:
+Stop when all known inputs or bounded partitions have terminal states, or when
+the declared open-web lanes and gap-filling budget are exhausted. Budget
+exhaustion is a limitation, not evidence of completeness.
 
-- known list: every input has a terminal status
-- bounded source: every declared partition was traversed
-- open web: required lanes ran and two consecutive gap-filling waves produced no
-  material new qualified items, or the agreed budget was reached
+## 6. Deliver honestly
 
-Budget exhaustion is a limitation, not evidence of completeness.
+Deliver the normalized dataset before the narrative. The summary should state
+the contract and as-of date, headline counts, artifact location, status counts,
+unresolved gaps and conflicts, coverage method, stopping condition, and limits
+on completeness. Preserve source URLs or citation markers with the claims they
+support.
 
-### 10. Deliver the dataset before the narrative
-
-The primary deliverable is the normalized dataset. For non-trivial results, save
-it as an artifact in the user's requested format; CSV or JSON is preferable for
-reuse, with a Markdown summary for humans. Do not squeeze a large result set into
-chat and silently truncate it.
-
-The summary should state:
-
-1. research contract and as-of date
-2. headline counts and strongest findings
-3. link to or location of the complete dataset
-4. exclusions, uncertain rows, failures, and unresolved conflicts
-5. coverage method and stopping condition
-6. limitations on any completeness claim
-
-Preserve inline citations or source URLs in both the dataset and summary. The
-reader must be able to trace each accepted claim back to its supporting source.
-
-## Quality gate
-
-Before finalizing, verify:
-
-- every partition has a recorded terminal status
-- every input or discovered candidate remains accounted for
-- accepted fields have claim-level evidence
-- duplicates were merged without losing provenance
-- uncertain, excluded, and failed rows are visible
-- coverage metrics match the universe type
-- the stopping rule was actually met or its failure is disclosed
-- “all”, “complete”, and “exhaustive” are used only when justified
-- the structured dataset is available without chat truncation
-
-If any item fails, run a targeted correction wave or disclose the limitation.
-
-## Common failure modes
-
-- **Many agents, one vague prompt** — creates duplicate searches rather than breadth.
-- **Discovery equals verification** — candidates are presented as qualified results.
-- **Free-form mini-reports** — aggregation becomes lossy and inconsistent.
-- **One source per row** — individual field claims cannot be audited.
-- **Silent tail loss** — timeouts, empty results, and malformed rows disappear.
-- **Context-only ledger** — a long run loses state after compaction.
-- **Writer fills blanks** — synthesis converts unknowns into hallucinated facts.
-- **Search saturation equals completeness** — open-web recall is overstated.
-- **Unbounded fan-out** — cost rises without improving independent coverage.
+Before finalizing, verify that every partition is accounted for, accepted fields
+have evidence, duplicates retain provenance, uncertain and failed records remain
+visible, and the completeness language matches the measured coverage. If not,
+run a targeted correction wave or disclose the limitation.

--- a/backend/tests/unit/test_deep_research_skill.py
+++ b/backend/tests/unit/test_deep_research_skill.py
@@ -1,0 +1,43 @@
+"""Contract tests for the preinstalled deep-research skill."""
+
+from pathlib import Path
+
+from cubeplex.skills.frontmatter import parse_skill_md
+
+_PREINSTALLED = (
+    Path(__file__).resolve().parents[2] / "skills" / "preinstalled" / "deep-research" / "SKILL.md"
+)
+
+
+def test_preinstalled_deep_research_skill_exists_and_parses() -> None:
+    assert _PREINSTALLED.is_file()
+
+    frontmatter = parse_skill_md(_PREINSTALLED.read_text(encoding="utf-8"))
+
+    assert frontmatter.name == "deep-research"
+    assert frontmatter.version == "3.3.0"
+    assert "multi-source" in frontmatter.description.lower()
+
+
+def test_deep_research_orders_dependent_work_into_waves() -> None:
+    normalized = " ".join(_PREINSTALLED.read_text(encoding="utf-8").split())
+
+    assert "Different angles are not automatically independent" in normalized
+    assert "Tasks may run in the same wave only when" in normalized
+    assert "Do not write later-wave prompts before their required inputs exist" in normalized
+    assert "candidate discovery → candidate verification" in normalized
+
+
+def test_deep_research_requires_review_between_waves() -> None:
+    normalized = " ".join(_PREINSTALLED.read_text(encoding="utf-8").split())
+
+    assert "Wave 1: independent reconnaissance or evidence discovery" in normalized
+    assert "Review: consolidate evidence, gaps, conflicts, and dependencies" in normalized
+    assert "Wave 2: targeted verification using reviewed Wave 1 outputs" in normalized
+    assert "Synthesis: answer only from the reviewed evidence set" in normalized
+
+
+def test_deep_research_skill_stays_focused() -> None:
+    body = _PREINSTALLED.read_text(encoding="utf-8")
+
+    assert len(body.split()) <= 1600

--- a/backend/tests/unit/test_prompts.py
+++ b/backend/tests/unit/test_prompts.py
@@ -49,6 +49,18 @@ def test_system_prompt_mentions_tools():
     assert "tool" in BASE_SYSTEM_PROMPT.lower()
 
 
+def test_subagent_prompt_explains_parallel_independence_and_dependency_order():
+    normalized = " ".join(SUBAGENT_PROMPT.split())
+
+    assert "same assistant response run concurrently" in normalized
+    assert "If task B needs task A's result" in normalized
+    assert "Do not make several workers independently discover the same source" in normalized
+
+
+def test_subagent_prompt_stays_concise():
+    assert len(SUBAGENT_PROMPT.split()) <= 250
+
+
 def test_sandbox_prompt_mentions_execute():
     rendered = SANDBOX_PROMPT_TEMPLATE.format(workdir="/root")
     assert "execute" in rendered.lower()

--- a/backend/tests/unit/test_wide_research_skill.py
+++ b/backend/tests/unit/test_wide_research_skill.py
@@ -16,6 +16,29 @@ def test_preinstalled_wide_research_skill_exists_and_parses() -> None:
     frontmatter = parse_skill_md(_PREINSTALLED.read_text(encoding="utf-8"))
 
     assert frontmatter.name == "wide-research"
-    assert frontmatter.version == "1.0.0"
+    assert frontmatter.version == "1.1.0"
     assert "comprehensive" in frontmatter.description.lower()
     assert "parallel" in frontmatter.description.lower()
+
+
+def test_wide_research_requires_source_strategy_before_fanout() -> None:
+    normalized = " ".join(_PREINSTALLED.read_text(encoding="utf-8").split())
+
+    assert "Do not dispatch collection workers until" in normalized
+    assert "If several workers would rediscover the same source or method" in normalized
+    assert "Time is a valid partition only after" in normalized
+
+
+def test_wide_research_uses_a_single_writer_durable_ledger() -> None:
+    normalized = " ".join(_PREINSTALLED.read_text(encoding="utf-8").split())
+
+    assert "Subagents must not concurrently edit the same ledger file" in normalized
+    assert "canonical ledger" in normalized
+    assert "final dataset" in normalized
+    assert all(file_type in normalized for file_type in ["CSV", "JSONL", "SQLite", "Excel"])
+
+
+def test_wide_research_skill_stays_focused() -> None:
+    body = _PREINSTALLED.read_text(encoding="utf-8")
+
+    assert len(body.split()) <= 1500


### PR DESCRIPTION
## Summary

- clarify that same-turn subagent calls run concurrently and must be independent
- make wide research source-first with bounded partitions and a single-writer durable ledger
- make deep research dependency-aware through reviewed discovery, verification, and synthesis waves
- add prompt and preinstalled-skill contract tests

## Testing

- pre-push backend `make check-ci`
- `uv run pytest tests/unit/test_*skill*.py --no-cov` (101 passed)
- targeted prompt and research-skill tests (18 passed)