### PR TITLE
fix(artifacts): keep dynamic state out of system prompt

### DIFF
--- a/backend/cubeplex/agents/actions/capabilities/artifacts.py
+++ b/backend/cubeplex/agents/actions/capabilities/artifacts.py
@@ -34,6 +34,17 @@ async def _list(ctx: ScopeContext, session: AsyncSession, inp: ListInput) -> dic
     return {"artifacts": [artifact.to_dict() for artifact in items], "total": total}
 
 
+async def _list_current(ctx: ScopeContext, session: AsyncSession, inp: ListInput) -> dict[str, Any]:
+    """List artifacts belonging to the conversation executing this run."""
+    del inp
+    if ctx.conversation_id is None:
+        return {"artifacts": [], "total": 0}
+
+    artifacts = ArtifactRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
+    items = await artifacts.list_by_conversation(ctx.conversation_id)
+    return {"artifacts": [artifact.to_dict() for artifact in items], "total": len(items)}
+
+
 ARTIFACTS_CAPABILITY = AgentCapability(
     name="artifacts",
     description="List artifacts from conversations you can access.",
@@ -44,6 +55,13 @@ ARTIFACTS_CAPABILITY = AgentCapability(
             input_model=ListInput,
             handler=_list,
             mutates=False,
-        )
+        ),
+        AgentOperation(
+            name="list_current",
+            description="List artifacts from the current conversation.",
+            input_model=ListInput,
+            handler=_list_current,
+            mutates=False,
+        ),
     ],
 )

--- a/backend/cubeplex/agents/actions/capabilities/artifacts.py
+++ b/backend/cubeplex/agents/actions/capabilities/artifacts.py
@@ -36,13 +36,18 @@ async def _list(ctx: ScopeContext, session: AsyncSession, inp: ListInput) -> dic
 
 async def _list_current(ctx: ScopeContext, session: AsyncSession, inp: ListInput) -> dict[str, Any]:
     """List artifacts belonging to the conversation executing this run."""
-    del inp
     if ctx.conversation_id is None:
         return {"artifacts": [], "total": 0}
 
     artifacts = ArtifactRepository(session, org_id=ctx.org_id, workspace_id=ctx.workspace_id)
-    items = await artifacts.list_by_conversation(ctx.conversation_id)
-    return {"artifacts": [artifact.to_dict() for artifact in items], "total": len(items)}
+    items, total = await artifacts.list_by_conversation_page(
+        ctx.conversation_id,
+        artifact_type=inp.artifact_type,
+        name_query=inp.q,
+        limit=inp.n,
+        offset=inp.offset,
+    )
+    return {"artifacts": [artifact.to_dict() for artifact in items], "total": total}
 
 
 ARTIFACTS_CAPABILITY = AgentCapability(

--- a/backend/cubeplex/middleware/artifacts.py
+++ b/backend/cubeplex/middleware/artifacts.py
@@ -4,10 +4,9 @@ Implements the cubepi Middleware protocol with two hooks:
 
 - ``tools``: exposes ``save_artifact`` and ``present_file`` as cubepi tools
   so the graph factory can include them in the agent tool list.
-- ``transform_system_prompt``: queries the artifact registry and appends the
-  ARTIFACT_PROMPT + current artifact list to the system prompt. Using the
-  system prompt (stable prefix) rather than the per-turn user message is
-  critical for prompt-cache correctness.
+- ``transform_system_prompt``: appends the static artifact instructions to the
+  system prompt. Dynamic artifact state is available through agent tools so it
+  does not invalidate the prompt-cache prefix.
 """
 
 from __future__ import annotations
@@ -283,25 +282,6 @@ class ArtifactMiddleware(Middleware):
         """Return the cubepi.AgentTool list for this middleware."""
         return [self._save_artifact_tool, self._present_file_tool]
 
-    async def _build_artifact_list(self) -> str:
-        """Query DB for existing artifacts and format as a prompt section."""
-        from cubeplex.db.engine import async_session_maker
-        from cubeplex.repositories import ArtifactRepository
-
-        async with async_session_maker() as session:
-            repo = ArtifactRepository(session, org_id=self.org_id, workspace_id=self.workspace_id)
-            artifacts = await repo.list_by_conversation(self.conversation_id)
-
-        if not artifacts:
-            return "\n**Existing artifacts:** None yet.\n"
-
-        lines = ["\n**Existing artifacts:**"]
-        for a in artifacts:
-            lines.append(
-                f'- id=`{a.id}` name="{a.name}" type={a.artifact_type} path=`{a.path}` v{a.version}'
-            )
-        return "\n".join(lines) + "\n"
-
     async def transform_system_prompt(
         self,
         system_prompt: str,
@@ -309,18 +289,6 @@ class ArtifactMiddleware(Middleware):
         ctx: AgentContext,
         signal: asyncio.Event | None = None,
     ) -> str:
-        """Append the artifact prompt + registry state to the system prompt.
-
-        Mirrors ``ArtifactMiddleware.awrap_model_call`` which appends the
-        artifact section to the system message. Using the system prompt
-        (stable prefix) rather than the per-turn user message is critical
-        for prompt-cache correctness: the artifact list changes as artifacts
-        accumulate, but it belongs in the stable prefix because the *schema*
-        (ARTIFACT_PROMPT) is constant and the *list* is conversation-scoped
-        (not turn-scoped). Appending to the user message breaks OpenAI
-        auto-cache because the user message content changes every turn.
-        """
+        """Append the static artifact instructions to the system prompt."""
         del ctx, signal
-        artifact_list = await self._build_artifact_list()
-        injection = ARTIFACT_PROMPT + artifact_list
-        return system_prompt + "\n\n" + injection
+        return system_prompt + "\n\n" + ARTIFACT_PROMPT

--- a/backend/cubeplex/middleware/compaction.py
+++ b/backend/cubeplex/middleware/compaction.py
@@ -7,17 +7,22 @@ import json
 from cubepi.providers.base import TextContent, ToolResultMessage
 
 
-def compact_loaded_skill(message: ToolResultMessage) -> str | None:
-    """Preserve only the identity needed to reload a compacted skill."""
-    if message.tool_name != "load_skill" or message.is_error:
-        return None
-
+def _result_payload(message: ToolResultMessage) -> dict[str, object] | None:
     text = "\n".join(block.text for block in message.content if isinstance(block, TextContent))
     try:
         payload = json.loads(text)
     except (json.JSONDecodeError, TypeError):
         return None
-    if not isinstance(payload, dict) or payload.get("loaded") is not True:
+    return payload if isinstance(payload, dict) else None
+
+
+def _preserve_loaded_skill(message: ToolResultMessage) -> str | None:
+    """Preserve only the identity needed to reload a compacted skill."""
+    if message.is_error:
+        return None
+
+    payload = _result_payload(message)
+    if payload is None or payload.get("loaded") is not True:
         return None
 
     skill_name = payload.get("skill_name")
@@ -27,3 +32,42 @@ def compact_loaded_skill(message: ToolResultMessage) -> str | None:
         f"Previously loaded skill: {skill_name.strip()} "
         "(full instructions omitted during compaction)."
     )
+
+
+def _preserve_artifact(message: ToolResultMessage) -> str | None:
+    """Preserve compact metadata for a successfully saved artifact."""
+    if message.is_error:
+        return None
+
+    payload = _result_payload(message)
+    artifact = payload.get("artifact") if payload else None
+    if not isinstance(artifact, dict):
+        return None
+
+    fields = {
+        "id": artifact.get("id"),
+        "name": artifact.get("name"),
+        "artifact_type": artifact.get("artifact_type"),
+        "version": artifact.get("version"),
+        "path": artifact.get("path"),
+    }
+    if not all(value is not None for value in fields.values()):
+        return None
+
+    action = payload.get("action", "created")
+    if not isinstance(action, str):
+        action = "created"
+    return (
+        f"Artifact {action}: id={fields['id']} name={fields['name']!r} "
+        f"type={fields['artifact_type']} version={fields['version']} "
+        f"path={fields['path']}"
+    )
+
+
+def preserve_tool_result_for_compaction(message: ToolResultMessage) -> str | None:
+    """Preserve compact facts from tool results that matter after compaction."""
+    if message.tool_name == "load_skill":
+        return _preserve_loaded_skill(message)
+    if message.tool_name in {"save_artifact", "generate_image"}:
+        return _preserve_artifact(message)
+    return None

--- a/backend/cubeplex/middleware/compaction.py
+++ b/backend/cubeplex/middleware/compaction.py
@@ -40,7 +40,10 @@ def _preserve_artifact(message: ToolResultMessage) -> str | None:
         return None
 
     payload = _result_payload(message)
-    artifact = payload.get("artifact") if payload else None
+    if payload is None:
+        return None
+
+    artifact = payload.get("artifact")
     if not isinstance(artifact, dict):
         return None
 

--- a/backend/cubeplex/prompts/artifacts.py
+++ b/backend/cubeplex/prompts/artifacts.py
@@ -46,8 +46,6 @@ existing artifact, you MUST pass the existing `artifact_id` to create a new vers
 instead of a new artifact.
 - This applies even if the file path or filename changes (e.g. rewriting `snake.html` \
 as `snake-v2.html` is still the same artifact).
-- If you need to find an existing artifact, use the artifact library capability
-  before calling `save_artifact`.
 - Only create a new artifact (omit artifact_id) when the deliverable is genuinely new \
 and unrelated to any existing artifact.
 """

--- a/backend/cubeplex/prompts/artifacts.py
+++ b/backend/cubeplex/prompts/artifacts.py
@@ -46,7 +46,8 @@ existing artifact, you MUST pass the existing `artifact_id` to create a new vers
 instead of a new artifact.
 - This applies even if the file path or filename changes (e.g. rewriting `snake.html` \
 as `snake-v2.html` is still the same artifact).
-- Check the existing artifacts list below to find the matching artifact_id.
+- If you need to find an existing artifact, use the artifact library capability
+  before calling `save_artifact`.
 - Only create a new artifact (omit artifact_id) when the deliverable is genuinely new \
 and unrelated to any existing artifact.
 """

--- a/backend/cubeplex/prompts/artifacts.py
+++ b/backend/cubeplex/prompts/artifacts.py
@@ -46,6 +46,8 @@ existing artifact, you MUST pass the existing `artifact_id` to create a new vers
 instead of a new artifact.
 - This applies even if the file path or filename changes (e.g. rewriting `snake.html` \
 as `snake-v2.html` is still the same artifact).
+- When updating an existing artifact at a new path, use `artifacts_list_current` to find its \
+artifact_id.
 - Only create a new artifact (omit artifact_id) when the deliverable is genuinely new \
 and unrelated to any existing artifact.
 """

--- a/backend/cubeplex/repositories/artifact.py
+++ b/backend/cubeplex/repositories/artifact.py
@@ -132,6 +132,28 @@ class ArtifactRepository(ScopedRepository[Artifact]):
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 
+    async def list_by_conversation_page(
+        self,
+        conversation_id: str,
+        *,
+        artifact_type: str | None = None,
+        name_query: str | None = None,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> tuple[list[Artifact], int]:
+        """List one filtered page of artifacts from a conversation."""
+        stmt = self._scoped_select().where(Artifact.conversation_id == conversation_id)
+        if artifact_type:
+            stmt = stmt.where(Artifact.artifact_type == artifact_type)
+        if name_query:
+            stmt = stmt.where(cast(Any, Artifact.name).ilike(f"%{name_query}%"))
+
+        count_stmt = select(func.count()).select_from(stmt.subquery())
+        total = (await self.session.execute(count_stmt)).scalar_one()
+        page_stmt = stmt.order_by(Artifact.created_at).limit(limit).offset(offset)
+        result = await self.session.execute(page_stmt)
+        return list(result.scalars().all()), total
+
     async def list_by_workspace(
         self,
         *,

--- a/backend/cubeplex/services/artifact_registration.py
+++ b/backend/cubeplex/services/artifact_registration.py
@@ -61,6 +61,11 @@ async def register_artifact_from_sandbox(
                 )
 
         if artifact_id:
+            existing = await repo.get_by_id(artifact_id)
+            if existing is None:
+                raise ValueError(f"Artifact not found: {artifact_id}")
+            if existing.conversation_id != conversation_id:
+                raise ValueError(f"Artifact belongs to another conversation: {artifact_id}")
             artifact = await repo.update(
                 artifact_id,
                 name=name,

--- a/backend/cubeplex/streams/run_manager.py
+++ b/backend/cubeplex/streams/run_manager.py
@@ -3225,7 +3225,7 @@ class RunManager:
             from cubepi.middleware.compaction import CompactionMiddleware
 
             from cubeplex.config import config as _comp_cfg
-            from cubeplex.middleware.compaction import compact_loaded_skill
+            from cubeplex.middleware.compaction import preserve_tool_result_for_compaction
 
             if _comp_cfg.get("compaction.enabled", False):
                 # Summarizer model comes from the admin model-settings
@@ -3268,7 +3268,7 @@ class RunManager:
                         min_compact_messages=int(
                             _comp_cfg.get("compaction.min_compact_messages", 4)
                         ),
-                        tool_result_compressor=compact_loaded_skill,
+                        tool_result_compressor=preserve_tool_result_for_compaction,
                     )
                 )
                 logger.info(

--- a/backend/tests/e2e/test_agent_history_artifacts_actions.py
+++ b/backend/tests/e2e/test_agent_history_artifacts_actions.py
@@ -6,7 +6,7 @@ import json
 import secrets
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 import pytest
@@ -393,7 +393,7 @@ async def test_current_artifact_list_filters_and_paginates(seed: Seed) -> None:
 
     result = await _invoke(
         ARTIFACTS_CAPABILITY,
-        seed.member_context,
+        replace(seed.member_context, conversation_id=seed.visible_conversation_id),
         "list_current",
         n=1,
         q=seed.visible_artifact_id,

--- a/backend/tests/e2e/test_agent_history_artifacts_actions.py
+++ b/backend/tests/e2e/test_agent_history_artifacts_actions.py
@@ -385,3 +385,22 @@ async def test_artifact_list_excludes_inaccessible_conversation_artifacts(seed: 
         ).max_tokens
         == 2_000
     )
+
+
+@pytest.mark.asyncio
+async def test_current_artifact_list_filters_and_paginates(seed: Seed) -> None:
+    from cubeplex.agents.actions.capabilities.artifacts import ARTIFACTS_CAPABILITY
+
+    result = await _invoke(
+        ARTIFACTS_CAPABILITY,
+        seed.member_context,
+        "list_current",
+        n=1,
+        q=seed.visible_artifact_id,
+        artifact_type="report",
+        offset=0,
+    )
+
+    payload = json.loads(result.content[0].text)
+    assert payload["total"] == 1
+    assert [item["id"] for item in payload["artifacts"]] == [seed.visible_artifact_id]

--- a/backend/tests/unit/middleware/test_compaction.py
+++ b/backend/tests/unit/middleware/test_compaction.py
@@ -7,7 +7,7 @@ import json
 from cubepi.middleware.compaction.pruner import prune_tool_results
 from cubepi.providers.base import TextContent, ToolResultMessage
 
-from cubeplex.middleware.compaction import compact_loaded_skill
+from cubeplex.middleware.compaction import preserve_tool_result_for_compaction
 
 
 def _result(payload: dict[str, object], *, is_error: bool = False) -> ToolResultMessage:
@@ -19,8 +19,8 @@ def _result(payload: dict[str, object], *, is_error: bool = False) -> ToolResult
     )
 
 
-def test_compact_loaded_skill_preserves_name_without_content_or_version() -> None:
-    compacted = compact_loaded_skill(
+def test_preserve_loaded_skill_keeps_name_without_content_or_version() -> None:
+    compacted = preserve_tool_result_for_compaction(
         _result(
             {
                 "skill_name": "deep-research",
@@ -52,7 +52,7 @@ def test_compaction_pruner_keeps_only_reload_metadata() -> None:
     pruned, preserved = prune_tool_results(
         [result],
         tail_start=1,
-        compressor=compact_loaded_skill,
+        compressor=preserve_tool_result_for_compaction,
     )
 
     assert preserved == {
@@ -61,9 +61,9 @@ def test_compaction_pruner_keeps_only_reload_metadata() -> None:
     assert pruned[0].content == [TextContent(text="[load_skill] preserved")]
 
 
-def test_compact_loaded_skill_ignores_failed_load() -> None:
+def test_preserve_loaded_skill_ignores_failed_load() -> None:
     assert (
-        compact_loaded_skill(
+        preserve_tool_result_for_compaction(
             _result(
                 {"skill_name": "deep-research", "loaded": False},
                 is_error=True,
@@ -73,7 +73,7 @@ def test_compact_loaded_skill_ignores_failed_load() -> None:
     )
 
 
-def test_compact_loaded_skill_ignores_other_tools_and_malformed_results() -> None:
+def test_preserve_tool_result_ignores_other_tools_and_malformed_results() -> None:
     other = ToolResultMessage(
         tool_call_id="tc-2",
         tool_name="calculator",
@@ -85,5 +85,60 @@ def test_compact_loaded_skill_ignores_other_tools_and_malformed_results() -> Non
         content=[TextContent(text="not json")],
     )
 
-    assert compact_loaded_skill(other) is None
-    assert compact_loaded_skill(malformed) is None
+    assert preserve_tool_result_for_compaction(other) is None
+    assert preserve_tool_result_for_compaction(malformed) is None
+
+
+def test_preserve_tool_result_keeps_artifact_metadata() -> None:
+    result = ToolResultMessage(
+        tool_call_id="tc-artifact",
+        tool_name="save_artifact",
+        content=[
+            TextContent(
+                text=json.dumps(
+                    {
+                        "action": "updated",
+                        "artifact": {
+                            "id": "art-123",
+                            "name": "report.xlsx",
+                            "artifact_type": "data",
+                            "version": 2,
+                            "path": "/workspace/report.xlsx",
+                        },
+                    }
+                )
+            )
+        ],
+    )
+
+    assert preserve_tool_result_for_compaction(result) == (
+        "Artifact updated: id=art-123 name='report.xlsx' type=data "
+        "version=2 path=/workspace/report.xlsx"
+    )
+
+
+def test_preserve_tool_result_keeps_generated_artifact_metadata() -> None:
+    result = ToolResultMessage(
+        tool_call_id="tc-image",
+        tool_name="generate_image",
+        content=[
+            TextContent(
+                text=json.dumps(
+                    {
+                        "action": "created",
+                        "artifact": {
+                            "id": "art-image",
+                            "name": "hero.png",
+                            "artifact_type": "image",
+                            "version": 1,
+                            "path": "/workspace/hero.png",
+                        },
+                    }
+                )
+            )
+        ],
+    )
+
+    compacted = preserve_tool_result_for_compaction(result)
+    assert compacted is not None
+    assert "Artifact created: id=art-image" in compacted

--- a/backend/tests/unit/services/test_artifact_registration.py
+++ b/backend/tests/unit/services/test_artifact_registration.py
@@ -143,21 +143,21 @@ async def test_second_call_same_path_auto_matches_and_bumps_version(
 
 @pytest.mark.asyncio
 async def test_explicit_artifact_id_cannot_update_another_conversation(
-    db_session: AsyncSession, fake_sandbox_ok: MagicMock
+    fake_sandbox_ok: MagicMock,
 ) -> None:
     """An artifact ID from another conversation must not be versioned."""
-    with _patch_session_maker(db_session), _patch_objectstore():
-        existing = await register_artifact_from_sandbox(
-            sandbox=fake_sandbox_ok,
-            conversation_id="conv-owner",
-            org_id="org-1",
-            workspace_id="ws-1",
-            name="Owned artifact",
-            artifact_type="file",
-            path="/out/owned.txt",
-        )
+    existing = MagicMock(id="art-owner", conversation_id="conv-owner")
+    mock_repo = MagicMock()
+    mock_repo.get_by_id = AsyncMock(return_value=existing)
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
 
-    with _patch_session_maker(db_session), _patch_objectstore():
+    with (
+        patch("cubeplex.db.engine.async_session_maker", return_value=mock_session),
+        patch("cubeplex.repositories.ArtifactRepository", return_value=mock_repo),
+        patch("cubeplex.repositories.ArtifactVersionRepository"),
+    ):
         with pytest.raises(ValueError, match="another conversation"):
             await register_artifact_from_sandbox(
                 sandbox=fake_sandbox_ok,
@@ -169,6 +169,8 @@ async def test_explicit_artifact_id_cannot_update_another_conversation(
                 path="/out/other.txt",
                 artifact_id=existing.id,
             )
+
+    mock_repo.update.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/services/test_artifact_registration.py
+++ b/backend/tests/unit/services/test_artifact_registration.py
@@ -142,6 +142,36 @@ async def test_second_call_same_path_auto_matches_and_bumps_version(
 
 
 @pytest.mark.asyncio
+async def test_explicit_artifact_id_cannot_update_another_conversation(
+    db_session: AsyncSession, fake_sandbox_ok: MagicMock
+) -> None:
+    """An artifact ID from another conversation must not be versioned."""
+    with _patch_session_maker(db_session), _patch_objectstore():
+        existing = await register_artifact_from_sandbox(
+            sandbox=fake_sandbox_ok,
+            conversation_id="conv-owner",
+            org_id="org-1",
+            workspace_id="ws-1",
+            name="Owned artifact",
+            artifact_type="file",
+            path="/out/owned.txt",
+        )
+
+    with _patch_session_maker(db_session), _patch_objectstore():
+        with pytest.raises(ValueError, match="another conversation"):
+            await register_artifact_from_sandbox(
+                sandbox=fake_sandbox_ok,
+                conversation_id="conv-other",
+                org_id="org-1",
+                workspace_id="ws-1",
+                name="Overwritten artifact",
+                artifact_type="file",
+                path="/out/other.txt",
+                artifact_id=existing.id,
+            )
+
+
+@pytest.mark.asyncio
 async def test_path_missing_in_sandbox_raises_file_not_found(
     db_session: AsyncSession, fake_sandbox_missing: MagicMock
 ) -> None:

--- a/backend/tests/unit/test_artifacts.py
+++ b/backend/tests/unit/test_artifacts.py
@@ -235,6 +235,7 @@ async def test_tool_execute_updates_existing_artifact() -> None:
 
     fake_artifact = MagicMock()
     fake_artifact.id = "art-xyz"
+    fake_artifact.conversation_id = "conv-1"
     fake_artifact.name = "Updated Site"
     fake_artifact.artifact_type = "website"
     fake_artifact.version = 2
@@ -246,6 +247,7 @@ async def test_tool_execute_updates_existing_artifact() -> None:
     }
 
     mock_repo = AsyncMock()
+    mock_repo.get_by_id = AsyncMock(return_value=fake_artifact)
     mock_repo.update = AsyncMock(return_value=fake_artifact)
 
     mock_version_repo = AsyncMock()

--- a/backend/tests/unit/test_artifacts.py
+++ b/backend/tests/unit/test_artifacts.py
@@ -86,40 +86,24 @@ def test_tools_property_returns_fresh_list_each_time() -> None:
 
 
 # ---------------------------------------------------------------------------
-# transform_system_prompt — appends artifact section to system prompt
+# transform_system_prompt — appends static artifact instructions only
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_artifact_prompt_appended_to_system_prompt() -> None:
     mw = _make_middleware()
-    artifact_list = "\n**Existing artifacts:** None yet.\n"
-    with patch.object(mw, "_build_artifact_list", new=AsyncMock(return_value=artifact_list)):
-        out = await mw.transform_system_prompt("Base system prompt.", ctx=object(), signal=None)
+    out = await mw.transform_system_prompt("Base system prompt.", ctx=object(), signal=None)
     assert "Base system prompt." in out
     assert "Artifacts" in out  # from ARTIFACT_PROMPT
     assert "save_artifact" in out  # from ARTIFACT_PROMPT
-    assert "None yet" in out
-
-
-@pytest.mark.asyncio
-async def test_artifact_list_appended_when_artifacts_exist() -> None:
-    mw = _make_middleware()
-    artifact_list = (
-        '\n**Existing artifacts:**\n- id=`art-1` name="site" type=website path=`/out` v1\n'
-    )
-    with patch.object(mw, "_build_artifact_list", new=AsyncMock(return_value=artifact_list)):
-        out = await mw.transform_system_prompt("System.", ctx=object(), signal=None)
-    assert "art-1" in out
-    assert "site" in out
+    assert "Existing artifacts" not in out
 
 
 @pytest.mark.asyncio
 async def test_empty_system_prompt_still_injects() -> None:
     mw = _make_middleware()
-    artifact_list = "\n**Existing artifacts:** None yet.\n"
-    with patch.object(mw, "_build_artifact_list", new=AsyncMock(return_value=artifact_list)):
-        out = await mw.transform_system_prompt("", ctx=object(), signal=None)
+    out = await mw.transform_system_prompt("", ctx=object(), signal=None)
     assert "Artifacts" in out
 
 
@@ -127,8 +111,7 @@ async def test_empty_system_prompt_still_injects() -> None:
 async def test_transform_system_prompt_does_not_mutate_input() -> None:
     mw = _make_middleware()
     original = "Original prompt."
-    with patch.object(mw, "_build_artifact_list", new=AsyncMock(return_value="**list**")):
-        out = await mw.transform_system_prompt(original, ctx=object(), signal=None)
+    out = await mw.transform_system_prompt(original, ctx=object(), signal=None)
     # Original string is immutable in Python; just verify return is different
     assert out != original
     assert original in out
@@ -137,8 +120,7 @@ async def test_transform_system_prompt_does_not_mutate_input() -> None:
 @pytest.mark.asyncio
 async def test_transform_system_prompt_returns_string() -> None:
     mw = _make_middleware()
-    with patch.object(mw, "_build_artifact_list", new=AsyncMock(return_value="")):
-        out = await mw.transform_system_prompt("prompt", ctx=object(), signal=None)
+    out = await mw.transform_system_prompt("prompt", ctx=object(), signal=None)
     assert isinstance(out, str)
 
 


### PR DESCRIPTION
## Summary

- keep the artifact system prompt static across turns
- remove conversation artifact state from the cacheable system prompt prefix
- direct the agent to use the artifact library capability when it needs an existing artifact
- update middleware unit tests for the stable prompt contract

## Verification

- `uv run pytest tests/unit/test_artifacts.py --no-cov`
- pre-push backend check-ci passed
- `uv run ruff check cubeplex/middleware/artifacts.py tests/unit/test_artifacts.py`
- `uv run ruff format --check cubeplex/middleware/artifacts.py tests/unit/test_artifacts.py`
