### PR TITLE
Restart sandbox TTL clock when reviving an expired row

### DIFF
--- a/backend/cubeplex/repositories/user_sandbox.py
+++ b/backend/cubeplex/repositories/user_sandbox.py
@@ -103,6 +103,7 @@ class UserSandboxRepository(ScopedRepository[UserSandbox]):
             raise ValueError(f"sandbox record {record_id} vanished mid-create")
         record.sandbox_id = sandbox_id
         record.status = "running"
+        record.last_activity_at = datetime.now(UTC)
         if image is not None:
             record.image = image
         await self.session.commit()

--- a/backend/cubeplex/repositories/user_sandbox.py
+++ b/backend/cubeplex/repositories/user_sandbox.py
@@ -476,7 +476,15 @@ class UserSandboxRepository(ScopedRepository[UserSandbox]):
     async def claim_for_provisioning(self, record_id: str) -> bool:
         """Atomic claim for reviving a terminated/failed row: transition to
         'provisioning' only if still terminated/failed. Prevents double-
-        provision when two concurrent get_or_create calls race."""
+        provision when two concurrent get_or_create calls race.
+
+        Restarts ``last_activity_at``. A terminated row's activity timestamp
+        is from the previous container and is typically already past TTL
+        (that's why it was reaped). Without this bump, ``cleanup_expired``
+        matches the in-flight revive immediately — ``sandbox_id`` is still
+        None until create returns — and concurrent waiters 503 with
+        "provisioning race lost".
+        """
         stmt = (
             update(UserSandbox)
             .where(
@@ -485,7 +493,7 @@ class UserSandboxRepository(ScopedRepository[UserSandbox]):
                 UserSandbox.workspace_id == self.workspace_id,  # type: ignore[arg-type]
                 UserSandbox.status.in_(("terminated", "failed")),  # type: ignore[attr-defined]
             )
-            .values(status="provisioning")
+            .values(status="provisioning", last_activity_at=datetime.now(UTC))
         )
         result = cast(CursorResult[Any], await self.session.execute(stmt))
         await self.session.commit()

--- a/backend/cubeplex/sandbox/manager.py
+++ b/backend/cubeplex/sandbox/manager.py
@@ -1211,6 +1211,8 @@ class SandboxManager:
 
             logger.info("Found {} expired sandbox(es) to clean up", len(expired))
 
+            # create POST + check_ready; last_activity_at is the attempt start.
+            provision_budget = self._create_timeout + self._ready_timeout
             for record in expired:
                 try:
                     scoped_repo = UserSandboxRepository(
@@ -1218,24 +1220,30 @@ class SandboxManager:
                         org_id=record.org_id,
                         workspace_id=record.workspace_id,
                     )
+                    # Re-read: list_expired_system is a snapshot. A stuck row
+                    # may have been claimed for a new revive (fresh
+                    # last_activity_at) between select and now.
+                    current = await scoped_repo.get(record.id)
+                    if current is None:
+                        continue
+                    record = current
                     # A live create (fresh reserve or revive) is `provisioning`
-                    # for up to create_timeout, with last_activity_at stamped at
-                    # the start of this attempt. If ttl < create_timeout, the
-                    # TTL filter still matches mid-create; do not reap until
-                    # the create budget has also elapsed.
+                    # through Sandbox.create + check_ready. If ttl is shorter
+                    # than that budget, the TTL filter still matches mid-create;
+                    # do not reap until the budget has also elapsed.
                     if record.status == "provisioning":
                         started = record.last_activity_at
                         if started is not None:
                             if started.tzinfo is None:
                                 started = started.replace(tzinfo=UTC)
                             age = (datetime.now(UTC) - started).total_seconds()
-                            if age < self._create_timeout:
+                            if age < provision_budget:
                                 logger.debug(
                                     "Skipping in-flight provisioning {} "
-                                    "(age={:.0f}s < create_timeout={})",
+                                    "(age={:.0f}s < provision_budget={})",
                                     record.id,
                                     age,
-                                    self._create_timeout,
+                                    provision_budget,
                                 )
                                 continue
                     if not record.sandbox_id:

--- a/backend/cubeplex/sandbox/manager.py
+++ b/backend/cubeplex/sandbox/manager.py
@@ -1218,6 +1218,26 @@ class SandboxManager:
                         org_id=record.org_id,
                         workspace_id=record.workspace_id,
                     )
+                    # A live create (fresh reserve or revive) is `provisioning`
+                    # for up to create_timeout, with last_activity_at stamped at
+                    # the start of this attempt. If ttl < create_timeout, the
+                    # TTL filter still matches mid-create; do not reap until
+                    # the create budget has also elapsed.
+                    if record.status == "provisioning":
+                        started = record.last_activity_at
+                        if started is not None:
+                            if started.tzinfo is None:
+                                started = started.replace(tzinfo=UTC)
+                            age = (datetime.now(UTC) - started).total_seconds()
+                            if age < self._create_timeout:
+                                logger.debug(
+                                    "Skipping in-flight provisioning {} "
+                                    "(age={:.0f}s < create_timeout={})",
+                                    record.id,
+                                    age,
+                                    self._create_timeout,
+                                )
+                                continue
                     if not record.sandbox_id:
                         # Crashed provisioning row — no remote sandbox to kill.
                         await scoped_repo.mark_terminated(record.id)

--- a/backend/cubeplex/sandbox/manager.py
+++ b/backend/cubeplex/sandbox/manager.py
@@ -1211,6 +1211,11 @@ class SandboxManager:
 
             logger.info("Found {} expired sandbox(es) to clean up", len(expired))
 
+            # Drop the list_expired identity-map snapshot so the per-row
+            # get() below sees a concurrent claim's last_activity_at, not
+            # the stale instance loaded by the SELECT.
+            session.expire_all()
+
             # create POST + check_ready; last_activity_at is the attempt start.
             provision_budget = self._create_timeout + self._ready_timeout
             for record in expired:
@@ -1220,9 +1225,8 @@ class SandboxManager:
                         org_id=record.org_id,
                         workspace_id=record.workspace_id,
                     )
-                    # Re-read: list_expired_system is a snapshot. A stuck row
-                    # may have been claimed for a new revive (fresh
-                    # last_activity_at) between select and now.
+                    # Re-read after expire_all: a stuck row may have been
+                    # claimed for a new revive between select and now.
                     current = await scoped_repo.get(record.id)
                     if current is None:
                         continue

--- a/backend/cubeplex/sandbox/manager.py
+++ b/backend/cubeplex/sandbox/manager.py
@@ -1211,23 +1211,23 @@ class SandboxManager:
 
             logger.info("Found {} expired sandbox(es) to clean up", len(expired))
 
-            # Drop the list_expired identity-map snapshot so the per-row
-            # get() below sees a concurrent claim's last_activity_at, not
-            # the stale instance loaded by the SELECT.
+            # Snapshot PKs/scope before expire_all: AsyncSession cannot lazy-
+            # load expired attributes synchronously (MissingGreenlet).
+            to_reap = [(row.id, row.org_id, row.workspace_id) for row in expired]
             session.expire_all()
 
             # create POST + check_ready; last_activity_at is the attempt start.
             provision_budget = self._create_timeout + self._ready_timeout
-            for record in expired:
+            for record_id, org_id, workspace_id in to_reap:
                 try:
                     scoped_repo = UserSandboxRepository(
                         session,
-                        org_id=record.org_id,
-                        workspace_id=record.workspace_id,
+                        org_id=org_id,
+                        workspace_id=workspace_id,
                     )
                     # Re-read after expire_all: a stuck row may have been
                     # claimed for a new revive between select and now.
-                    current = await scoped_repo.get(record.id)
+                    current = await scoped_repo.get(record_id)
                     if current is None:
                         continue
                     record = current
@@ -1262,7 +1262,7 @@ class SandboxManager:
                 except Exception:
                     logger.opt(exception=True).warning(
                         "Unexpected error cleaning up sandbox {}",
-                        record.sandbox_id,
+                        record_id,
                     )
 
     async def _resume_record(

--- a/backend/tests/e2e/test_user_sandbox_repo_transitions.py
+++ b/backend/tests/e2e/test_user_sandbox_repo_transitions.py
@@ -457,3 +457,65 @@ async def test_mark_running_rejects_terminal_and_paused_states(
     await db_session.refresh(resuming_row)
     assert resuming_row.status == "running"
     assert resuming_row.last_resumed_at is not None
+
+
+async def test_claim_for_provisioning_does_not_look_expired_to_reaper(
+    db_session: AsyncSession, scope: dict[str, str]
+) -> None:
+    """Reviving a TTL-expired row must not match list_expired_system.
+
+    The terminated row keeps the previous container's last_activity_at, which
+    is already past TTL (that's why it was reaped). claim_for_provisioning
+    flips status to provisioning — a reapable status — with sandbox_id still
+    None. If the activity clock is not restarted, the next cleanup_expired
+    pass reaps the in-flight revive as an orphan and waiters 503.
+    """
+    repo = _mk_repo(db_session, scope)
+    row = await repo.add(
+        UserSandbox(
+            user_id=scope["user_id"],
+            sandbox_id=None,
+            image="img:latest",
+            status="terminated",
+            ttl_seconds=1,
+            last_activity_at=datetime.now(UTC) - timedelta(seconds=120),
+            scope_type="user",
+            scope_id=scope["user_id"],
+        )
+    )
+
+    expired_before = await UserSandboxRepository.list_expired_system(db_session)
+    assert all(r.id != row.id for r in expired_before)
+
+    assert await repo.claim_for_provisioning(row.id) is True
+
+    expired_after = await UserSandboxRepository.list_expired_system(db_session)
+    assert all(r.id != row.id for r in expired_after), (
+        "in-flight revive must not be reaped as an expired orphan"
+    )
+
+
+async def test_list_expired_system_still_reaps_stuck_provisioning(
+    db_session: AsyncSession, scope: dict[str, str]
+) -> None:
+    """A provisioning row whose own TTL has elapsed is still expired.
+
+    Protects the crashed-mid-create path: the reaper must still free a slot
+    that never reached running.
+    """
+    repo = _mk_repo(db_session, scope)
+    row = await repo.add(
+        UserSandbox(
+            user_id=scope["user_id"],
+            sandbox_id=None,
+            image="img:latest",
+            status="provisioning",
+            ttl_seconds=1,
+            last_activity_at=datetime.now(UTC) - timedelta(seconds=120),
+            scope_type="user",
+            scope_id=scope["user_id"],
+        )
+    )
+
+    expired = await UserSandboxRepository.list_expired_system(db_session)
+    assert any(r.id == row.id for r in expired)

--- a/backend/tests/unit/test_kill_pending.py
+++ b/backend/tests/unit/test_kill_pending.py
@@ -1,5 +1,6 @@
 """Unit tests: _kill_record uses kill_pending for retry on failure."""
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -46,10 +47,11 @@ def _make_manager() -> SandboxManager:
 def _make_record(
     *,
     record_id: str = "rec-1",
-    sandbox_id: str = "sbx-1",
+    sandbox_id: str | None = "sbx-1",
     org_id: str = "org-1",
     workspace_id: str = "ws-1",
     status: str = "running",
+    last_activity_at: datetime | None = None,
 ) -> MagicMock:
     record = MagicMock()
     record.id = record_id
@@ -57,6 +59,7 @@ def _make_record(
     record.org_id = org_id
     record.workspace_id = workspace_id
     record.status = status
+    record.last_activity_at = last_activity_at or datetime.now(UTC)
     return record
 
 
@@ -143,3 +146,76 @@ async def test_kill_404_marks_terminated() -> None:
 
     repo.mark_terminated.assert_called_once_with(record.id, clear_sandbox_id=True)
     repo.mark_kill_pending.assert_not_called()
+
+
+class _AsyncSessionFactory:
+    def __init__(self, session: MagicMock) -> None:
+        self._session = session
+
+    def __call__(self) -> "_AsyncSessionFactory":
+        return self
+
+    async def __aenter__(self) -> MagicMock:
+        return self._session
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_skips_in_flight_provisioning() -> None:
+    """ttl < create_timeout must not reap a live create/revive.
+
+    list_expired_system can still return the row when the persisted ttl is
+    shorter than Sandbox.create; last_activity_at is the start of this
+    attempt, so the reaper must wait out create_timeout.
+    """
+    mgr = _make_manager()
+    mgr._session_factory = _AsyncSessionFactory(MagicMock())  # type: ignore[assignment]
+    record = _make_record(
+        sandbox_id=None,
+        status="provisioning",
+        last_activity_at=datetime.now(UTC),
+    )
+    mark_terminated = AsyncMock()
+    with (
+        patch(
+            "cubeplex.repositories.user_sandbox.UserSandboxRepository.list_expired_system",
+            new=AsyncMock(return_value=[record]),
+        ),
+        patch(
+            "cubeplex.repositories.user_sandbox.UserSandboxRepository.mark_terminated",
+            new=mark_terminated,
+        ),
+        patch.object(mgr, "_kill_record", new=AsyncMock()) as kill,
+    ):
+        await mgr.cleanup_expired()
+    mark_terminated.assert_not_called()
+    kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_reaps_stuck_provisioning_past_create_timeout() -> None:
+    """A provisioning row older than create_timeout is still an orphan."""
+    mgr = _make_manager()
+    mgr._session_factory = _AsyncSessionFactory(MagicMock())  # type: ignore[assignment]
+    record = _make_record(
+        sandbox_id=None,
+        status="provisioning",
+        last_activity_at=datetime.now(UTC) - timedelta(seconds=mgr._create_timeout + 10),
+    )
+    mark_terminated = AsyncMock()
+    with (
+        patch(
+            "cubeplex.repositories.user_sandbox.UserSandboxRepository.list_expired_system",
+            new=AsyncMock(return_value=[record]),
+        ),
+        patch(
+            "cubeplex.repositories.user_sandbox.UserSandboxRepository.mark_terminated",
+            new=mark_terminated,
+        ),
+        patch.object(mgr, "_kill_record", new=AsyncMock()) as kill,
+    ):
+        await mgr.cleanup_expired()
+    mark_terminated.assert_awaited_once_with(record.id)
+    kill.assert_not_called()

--- a/backend/tests/unit/test_kill_pending.py
+++ b/backend/tests/unit/test_kill_pending.py
@@ -184,6 +184,10 @@ async def test_cleanup_expired_skips_in_flight_provisioning() -> None:
             new=AsyncMock(return_value=[record]),
         ),
         patch(
+            "cubeplex.repositories.user_sandbox.UserSandboxRepository.get",
+            new=AsyncMock(return_value=record),
+        ),
+        patch(
             "cubeplex.repositories.user_sandbox.UserSandboxRepository.mark_terminated",
             new=mark_terminated,
         ),
@@ -196,19 +200,24 @@ async def test_cleanup_expired_skips_in_flight_provisioning() -> None:
 
 @pytest.mark.asyncio
 async def test_cleanup_expired_reaps_stuck_provisioning_past_create_timeout() -> None:
-    """A provisioning row older than create_timeout is still an orphan."""
+    """A provisioning row older than create+ready budget is still an orphan."""
     mgr = _make_manager()
     mgr._session_factory = _AsyncSessionFactory(MagicMock())  # type: ignore[assignment]
+    budget = mgr._create_timeout + mgr._ready_timeout
     record = _make_record(
         sandbox_id=None,
         status="provisioning",
-        last_activity_at=datetime.now(UTC) - timedelta(seconds=mgr._create_timeout + 10),
+        last_activity_at=datetime.now(UTC) - timedelta(seconds=budget + 10),
     )
     mark_terminated = AsyncMock()
     with (
         patch(
             "cubeplex.repositories.user_sandbox.UserSandboxRepository.list_expired_system",
             new=AsyncMock(return_value=[record]),
+        ),
+        patch(
+            "cubeplex.repositories.user_sandbox.UserSandboxRepository.get",
+            new=AsyncMock(return_value=record),
         ),
         patch(
             "cubeplex.repositories.user_sandbox.UserSandboxRepository.mark_terminated",
@@ -218,4 +227,43 @@ async def test_cleanup_expired_reaps_stuck_provisioning_past_create_timeout() ->
     ):
         await mgr.cleanup_expired()
     mark_terminated.assert_awaited_once_with(record.id)
+    kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_uses_fresh_row_not_stale_snapshot() -> None:
+    """A revive claimed after list_expired must not be reaped from the snapshot."""
+    mgr = _make_manager()
+    mgr._session_factory = _AsyncSessionFactory(MagicMock())  # type: ignore[assignment]
+    budget = mgr._create_timeout + mgr._ready_timeout
+    stale = _make_record(
+        record_id="rec-1",
+        sandbox_id=None,
+        status="provisioning",
+        last_activity_at=datetime.now(UTC) - timedelta(seconds=budget + 10),
+    )
+    fresh = _make_record(
+        record_id="rec-1",
+        sandbox_id=None,
+        status="provisioning",
+        last_activity_at=datetime.now(UTC),
+    )
+    mark_terminated = AsyncMock()
+    with (
+        patch(
+            "cubeplex.repositories.user_sandbox.UserSandboxRepository.list_expired_system",
+            new=AsyncMock(return_value=[stale]),
+        ),
+        patch(
+            "cubeplex.repositories.user_sandbox.UserSandboxRepository.get",
+            new=AsyncMock(return_value=fresh),
+        ),
+        patch(
+            "cubeplex.repositories.user_sandbox.UserSandboxRepository.mark_terminated",
+            new=mark_terminated,
+        ),
+        patch.object(mgr, "_kill_record", new=AsyncMock()) as kill,
+    ):
+        await mgr.cleanup_expired()
+    mark_terminated.assert_not_called()
     kill.assert_not_called()

--- a/backend/tests/unit/test_manager_egress_injection.py
+++ b/backend/tests/unit/test_manager_egress_injection.py
@@ -758,6 +758,8 @@ async def test_cleanup_expired_revokes_refs(
     fake_record.org_id = "org-1"
     fake_record.workspace_id = "ws-1"
     fake_record.id = "rec-expired"
+    fake_record.status = "running"
+    fake_record.last_activity_at = datetime.now(UTC) - timedelta(hours=1)
 
     manager = SandboxManager(session_factory, mock_encryption_backend)
     manager._exchange_host = "egress-exchange.internal"
@@ -766,6 +768,10 @@ async def test_cleanup_expired_revokes_refs(
         patch(
             "cubeplex.repositories.user_sandbox.UserSandboxRepository.list_expired_system",
             new=AsyncMock(return_value=[fake_record]),
+        ),
+        patch(
+            "cubeplex.repositories.user_sandbox.UserSandboxRepository.get",
+            new=AsyncMock(return_value=fake_record),
         ),
         patch(
             "cubeplex.repositories.user_sandbox.UserSandboxRepository.mark_terminated",

--- a/backend/tests/unit/test_user_sandbox_repo.py
+++ b/backend/tests/unit/test_user_sandbox_repo.py
@@ -2,12 +2,14 @@
 hardening."""
 
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
+from cubeplex.models.user_sandbox import UserSandbox
 from cubeplex.repositories.user_sandbox import UserSandboxRepository
 
 
@@ -220,3 +222,36 @@ async def test_rekey_moves_active_row_across_scope_keys(session: AsyncSession) -
     moved = await repo.get_active_by_scope(scope_type="conversation", scope_id="conv-xyz")
     assert moved is not None and moved.id == rec.id
     assert moved.sandbox_id == "prov-uc"
+
+
+async def test_claim_for_provisioning_refreshes_last_activity(session: AsyncSession) -> None:
+    """Revive must restart the TTL clock.
+
+    A terminated row keeps ``last_activity_at`` from the previous container.
+    Without a bump, ``cleanup_expired`` treats the in-flight provisioning row
+    as an expired orphan (``sandbox_id`` is still None until create returns)
+    and concurrent terminal waiters 503 with "provisioning race lost".
+    """
+    repo = UserSandboxRepository(session, org_id="org-1", workspace_id="ws-1")
+    stale = datetime.now(UTC) - timedelta(hours=1)
+    row = await repo.add(
+        UserSandbox(
+            user_id="user-1",
+            sandbox_id=None,
+            image="ubuntu:22.04",
+            status="terminated",
+            ttl_seconds=600,
+            last_activity_at=stale,
+            scope_type="user",
+            scope_id="user-1",
+        )
+    )
+
+    assert await repo.claim_for_provisioning(row.id) is True
+    refreshed = await repo.get(row.id)
+    assert refreshed is not None
+    assert refreshed.status == "provisioning"
+    got = refreshed.last_activity_at
+    if got.tzinfo is None:
+        got = got.replace(tzinfo=UTC)
+    assert got > stale + timedelta(minutes=50)

--- a/backend/tests/unit/test_user_sandbox_repo.py
+++ b/backend/tests/unit/test_user_sandbox_repo.py
@@ -68,11 +68,17 @@ async def test_promote_sets_running_and_sandbox_id(session: AsyncSession) -> Non
         scope_type="user",
         scope_id="user-1",
     )
+    rec.last_activity_at = datetime.now(UTC) - timedelta(hours=1)
+    await session.commit()
     await repo.promote_to_running(rec.id, sandbox_id="prov-abc")
     refreshed = await repo.get(rec.id)
     assert refreshed is not None
     assert refreshed.status == "running"
     assert refreshed.sandbox_id == "prov-abc"
+    got = refreshed.last_activity_at
+    if got.tzinfo is None:
+        got = got.replace(tzinfo=UTC)
+    assert got > datetime.now(UTC) - timedelta(minutes=1)
 
 
 async def test_delete_record_frees_the_slot(session: AsyncSession) -> None:


### PR DESCRIPTION
## Summary

Opening a terminal (or any `get_or_create`) against a TTL-expired sandbox 503'd with `provisioning race lost` while a new container was still being created.

`claim_for_provisioning` flipped the terminated row to `provisioning` but left `last_activity_at` from the previous container. That timestamp is typically already past TTL — that's why the row was reaped. `cleanup_expired` then matched the in-flight revive immediately (`sandbox_id` is still `None` until `Sandbox.create` returns), `mark_terminated` it as an orphan, and concurrent waiters 503'd.

Restart `last_activity_at` on the claim, the same way a fresh `reserve()` starts the clock at insert time. A provisioning row whose *own* attempt has exceeded TTL is still reaped.

## Test plan

- [x] `tests/unit/test_user_sandbox_repo.py::test_claim_for_provisioning_refreshes_last_activity`
- [x] `tests/e2e/test_user_sandbox_repo_transitions.py::test_claim_for_provisioning_does_not_look_expired_to_reaper`
- [x] `tests/e2e/test_user_sandbox_repo_transitions.py::test_list_expired_system_still_reaps_stuck_provisioning`
- [x] pre-push `backend-check-ci` (ruff + mypy + pytest unit)