### PR TITLE
Allow admins to delete uploaded catalog skills

### DIFF
--- a/backend/cubeplex/api/routes/v1/admin_skills.py
+++ b/backend/cubeplex/api/routes/v1/admin_skills.py
@@ -558,6 +558,31 @@ async def uninstall_skill(
     await session.commit()
 
 
+@router.delete("/{skill_id}", status_code=204)
+async def delete_catalog_skill(
+    skill_id: str,
+    *,
+    user: Annotated[User, Depends(require_org_admin)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> None:
+    """Remove an uploaded skill from the org catalog.
+
+    Preinstalled skills cannot be deleted (uninstall + tombstone instead).
+    Cascades org-wide and workspace-private installs plus version rows.
+    """
+    org_id = await resolve_current_org_id(user, session)
+    skill = await SkillRepository(session).get(skill_id)
+    if skill is None or not _visible(skill, org_id):
+        raise HTTPException(status_code=404, detail="SKILL_NOT_FOUND")
+    if skill.source != "uploaded":
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "CANNOT_DELETE_PREINSTALLED"},
+        )
+    publisher = SkillPublishService(session=session, cache=_cache())
+    await publisher.delete_uploaded(org_id=org_id, skill=skill)
+
+
 @router.post("/upload", status_code=201)
 async def upload_skill(
     file: Annotated[UploadFile, File(...)],

--- a/backend/cubeplex/skills/cache.py
+++ b/backend/cubeplex/skills/cache.py
@@ -7,6 +7,7 @@ Concurrent calls for the same skill_version_id deduplicate via per-key asyncio l
 from __future__ import annotations
 
 import asyncio
+import shutil
 from pathlib import Path
 
 from loguru import logger
@@ -27,9 +28,7 @@ class SkillCache:
     def _lock_for(self, skill_version_id: str) -> asyncio.Lock:
         return self._locks.setdefault(skill_version_id, asyncio.Lock())
 
-    async def ensure_extracted(
-        self, skill_version_id: str, *, storage_prefix: str
-    ) -> Path:
+    async def ensure_extracted(self, skill_version_id: str, *, storage_prefix: str) -> Path:
         """Returns local cache dir for this version. Fetches on miss."""
         target = self.cache_dir(skill_version_id)
         sentinel = target / ".extracted"
@@ -54,7 +53,7 @@ class SkillCache:
             keys = await store.list_objects(storage_prefix)
             written = 0
             for key in keys:
-                rel = key[len(storage_prefix):]
+                rel = key[len(storage_prefix) :]
                 if not rel:
                     continue
                 data, _ = await store.download_file(key)
@@ -72,18 +71,20 @@ class SkillCache:
                 )
                 return target
             sentinel.write_bytes(b"")
-            logger.debug(
-                "Skill cache: extracted {} files for {}", written, skill_version_id
-            )
+            logger.debug("Skill cache: extracted {} files for {}", written, skill_version_id)
         return target
+
+    def purge(self, skill_version_id: str) -> None:
+        """Drop the on-disk cache dir for a version. Best-effort."""
+        target = self.cache_dir(skill_version_id)
+        shutil.rmtree(target, ignore_errors=True)
+        self._locks.pop(skill_version_id, None)
 
     async def list_files(
         self, skill_version_id: str, *, storage_prefix: str
     ) -> list[tuple[str, bytes]]:
         """Returns [(rel_path, bytes), ...]. Fetches via cache (extracts if missing)."""
-        cache_dir = await self.ensure_extracted(
-            skill_version_id, storage_prefix=storage_prefix
-        )
+        cache_dir = await self.ensure_extracted(skill_version_id, storage_prefix=storage_prefix)
         out: list[tuple[str, bytes]] = []
         for path in cache_dir.rglob("*"):
             if not path.is_file() or path.name == ".extracted":

--- a/backend/cubeplex/skills/service.py
+++ b/backend/cubeplex/skills/service.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 
 from loguru import logger
-from sqlalchemy import exists, or_, select
+from sqlalchemy import delete, exists, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cubeplex.models import (
@@ -457,6 +457,70 @@ class SkillPublishService:
                 installed_by_user_id=actor_user_id,
             )
         return sv
+
+    async def delete_uploaded(self, *, org_id: str, skill: Skill) -> None:
+        """Remove an org-owned uploaded skill from the catalog.
+
+        Cascades workspace bindings, org-wide and workspace-private installs,
+        versions, and best-effort object-store / local-cache files. Caller must
+        have already checked visibility and ``source == "uploaded"``.
+        """
+        versions = await SkillVersionRepository(self.session).list_for_skill(skill.id)
+        prefixes = [v.storage_prefix for v in versions]
+        version_ids = [v.id for v in versions]
+
+        install_rows = list(
+            (
+                await self.session.execute(
+                    select(OrgSkillInstall).where(
+                        OrgSkillInstall.org_id == org_id,  # type: ignore[arg-type]
+                        OrgSkillInstall.skill_id == skill.id,  # type: ignore[arg-type]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        install_ids = [row.id for row in install_rows]
+        if install_ids:
+            await self.session.execute(
+                delete(WorkspaceSkillBinding).where(
+                    WorkspaceSkillBinding.org_skill_install_id.in_(install_ids)  # type: ignore[attr-defined]
+                )
+            )
+            await self.session.flush()
+            await self.session.execute(
+                delete(OrgSkillInstall).where(
+                    OrgSkillInstall.id.in_(install_ids)  # type: ignore[attr-defined]
+                )
+            )
+
+        await self.session.execute(
+            delete(OrgPreinstalledTombstone).where(
+                OrgPreinstalledTombstone.org_id == org_id,  # type: ignore[arg-type]
+                OrgPreinstalledTombstone.skill_id == skill.id,  # type: ignore[arg-type]
+            )
+        )
+        await self.session.execute(
+            delete(SkillVersion).where(SkillVersion.skill_id == skill.id)  # type: ignore[arg-type]
+        )
+        await self.session.execute(delete(Skill).where(Skill.id == skill.id))  # type: ignore[arg-type]
+        await self.session.commit()
+
+        store = get_objectstore_client()
+        for prefix in prefixes:
+            try:
+                keys = await store.list_objects(prefix)
+            except Exception:
+                logger.exception("Failed listing skill objects for prefix {}", prefix)
+                continue
+            for key in keys:
+                try:
+                    await store.delete_file(key)
+                except Exception:
+                    logger.exception("Failed deleting skill object {}", key)
+        for version_id in version_ids:
+            self.cache.purge(version_id)
 
 
 def _extract_zip(zip_bytes: bytes) -> dict[str, bytes]:

--- a/backend/tests/e2e/test_skill_catalog_delete.py
+++ b/backend/tests/e2e/test_skill_catalog_delete.py
@@ -1,0 +1,132 @@
+"""Admin can remove an uploaded skill from the org catalog.
+
+Workspace upload / install registers the Skill row on the org catalog even
+when the install itself is workspace-private. Uninstall only drops the
+org-wide install pin; without a catalog delete the leftover row is stuck.
+"""
+
+from __future__ import annotations
+
+import io
+import secrets
+import zipfile
+
+import httpx
+import pytest
+
+
+def _zip_skill(name: str, version: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr(
+            "SKILL.md",
+            f"---\nname: {name}\ndescription: d\nversion: {version}\n---\n# {name}\n",
+        )
+    return buf.getvalue()
+
+
+async def _workspace_upload(
+    client: httpx.AsyncClient, ws_id: str, name: str, version: str = "1.0.0"
+) -> str:
+    resp = await client.post(
+        f"/api/v1/ws/{ws_id}/settings/skills/upload",
+        files={"file": ("a.zip", _zip_skill(name, version), "application/zip")},
+    )
+    assert resp.status_code == 201, resp.text
+    skill_id = resp.json()["skill_id"]
+    assert isinstance(skill_id, str)
+    return skill_id
+
+
+def _catalog_row(rows: list[dict[str, object]], skill_id: str) -> dict[str, object] | None:
+    for row in rows:
+        if row["id"] == skill_id:
+            return row
+    return None
+
+
+@pytest.mark.asyncio
+async def test_admin_deletes_workspace_uploaded_skill_from_catalog(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    """Workspace upload lands on the org catalog as uninstalled; delete removes it."""
+    client, ws_id = admin_client
+    skill_id = await _workspace_upload(client, ws_id, f"ws-up-{secrets.token_hex(4)}")
+
+    listed = await client.get("/api/v1/admin/skills")
+    assert listed.status_code == 200
+    row = _catalog_row(listed.json(), skill_id)
+    assert row is not None
+    assert row["install_state"] == "uninstalled"
+    assert row["source"] == "uploaded"
+
+    deleted = await client.delete(f"/api/v1/admin/skills/{skill_id}")
+    assert deleted.status_code == 204, deleted.text
+
+    listed2 = await client.get("/api/v1/admin/skills")
+    assert _catalog_row(listed2.json(), skill_id) is None
+
+    detail = await client.get(f"/api/v1/admin/skills/{skill_id}")
+    assert detail.status_code == 404
+
+    settings = await client.get(f"/api/v1/ws/{ws_id}/settings/skills")
+    assert settings.status_code == 200
+    body = settings.json()
+    assert all(s["skill_id"] != skill_id for s in body["workspace_skills"])
+    assert all(s["skill_id"] != skill_id for s in body["org_skills"])
+
+
+@pytest.mark.asyncio
+async def test_admin_delete_cascades_org_wide_install(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    client, _ws_id = admin_client
+    name = f"org-up-{secrets.token_hex(4)}"
+    up = await client.post(
+        "/api/v1/admin/skills/upload",
+        files={"file": ("a.zip", _zip_skill(name, "1.0.0"), "application/zip")},
+    )
+    assert up.status_code == 201, up.text
+    skill_id = up.json()["skill_id"]
+
+    detail = await client.get(f"/api/v1/admin/skills/{skill_id}")
+    assert detail.json()["install_state"] == "installed"
+
+    deleted = await client.delete(f"/api/v1/admin/skills/{skill_id}")
+    assert deleted.status_code == 204, deleted.text
+
+    listed = await client.get("/api/v1/admin/skills")
+    assert _catalog_row(listed.json(), skill_id) is None
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_delete_preinstalled_skill(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    client, _ = admin_client
+    listed = await client.get("/api/v1/admin/skills?source=preinstalled")
+    skill = next(r for r in listed.json() if r["name"] == "deep-research")
+
+    resp = await client.delete(f"/api/v1/admin/skills/{skill['id']}")
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "CANNOT_DELETE_PREINSTALLED"
+
+    listed2 = await client.get("/api/v1/admin/skills?source=preinstalled")
+    assert any(r["id"] == skill["id"] for r in listed2.json())
+
+
+@pytest.mark.asyncio
+async def test_delete_unknown_skill_returns_404(
+    admin_client: tuple[httpx.AsyncClient, str],
+) -> None:
+    client, _ = admin_client
+    resp = await client.delete("/api/v1/admin/skills/skl_does_not_exist")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_delete_catalog_skill(
+    non_admin_client: httpx.AsyncClient,
+) -> None:
+    resp = await non_admin_client.delete("/api/v1/admin/skills/skl_does_not_exist")
+    assert resp.status_code == 403

--- a/backend/tests/unit/test_skill_catalog_delete.py
+++ b/backend/tests/unit/test_skill_catalog_delete.py
@@ -1,0 +1,218 @@
+"""Unit coverage for org-catalog skill delete (route + cascade + cache purge).
+
+E2E owns the DB/API contract; these tests pin the in-process branches Codecov's
+unit upload sees first: 404/422 at the route, install cascade, and object-store
+failures that must not roll back a completed catalog delete.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from cubeplex.api.routes.v1 import admin_skills as admin_skills_mod
+from cubeplex.api.routes.v1.admin_skills import delete_catalog_skill
+from cubeplex.skills.cache import SkillCache
+from cubeplex.skills.service import SkillPublishService
+
+
+def _execute_result(rows: list[object]) -> MagicMock:
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = rows
+    return result
+
+
+@pytest.mark.asyncio
+async def test_delete_catalog_skill_404_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(admin_skills_mod, "resolve_current_org_id", AsyncMock(return_value="org-1"))
+    repo = SimpleNamespace(get=AsyncMock(return_value=None))
+    monkeypatch.setattr(admin_skills_mod, "SkillRepository", lambda _session: repo)
+
+    with pytest.raises(HTTPException) as raised:
+        await delete_catalog_skill("skl_missing", user=MagicMock(), session=MagicMock())
+    assert raised.value.status_code == 404
+    assert raised.value.detail == "SKILL_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_delete_catalog_skill_404_when_other_org(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(admin_skills_mod, "resolve_current_org_id", AsyncMock(return_value="org-1"))
+    skill = SimpleNamespace(id="skl-1", source="uploaded", owner_org_id="org-other")
+    repo = SimpleNamespace(get=AsyncMock(return_value=skill))
+    monkeypatch.setattr(admin_skills_mod, "SkillRepository", lambda _session: repo)
+
+    with pytest.raises(HTTPException) as raised:
+        await delete_catalog_skill("skl-1", user=MagicMock(), session=MagicMock())
+    assert raised.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_catalog_skill_rejects_preinstalled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(admin_skills_mod, "resolve_current_org_id", AsyncMock(return_value="org-1"))
+    skill = SimpleNamespace(id="skl-1", source="preinstalled", owner_org_id=None)
+    repo = SimpleNamespace(get=AsyncMock(return_value=skill))
+    monkeypatch.setattr(admin_skills_mod, "SkillRepository", lambda _session: repo)
+
+    with pytest.raises(HTTPException) as raised:
+        await delete_catalog_skill("skl-1", user=MagicMock(), session=MagicMock())
+    assert raised.value.status_code == 422
+    assert raised.value.detail == {"code": "CANNOT_DELETE_PREINSTALLED"}
+
+
+@pytest.mark.asyncio
+async def test_delete_catalog_skill_calls_publisher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(admin_skills_mod, "resolve_current_org_id", AsyncMock(return_value="org-1"))
+    skill = SimpleNamespace(id="skl-1", source="uploaded", owner_org_id="org-1")
+    repo = SimpleNamespace(get=AsyncMock(return_value=skill))
+    monkeypatch.setattr(admin_skills_mod, "SkillRepository", lambda _session: repo)
+    publisher = SimpleNamespace(delete_uploaded=AsyncMock())
+    monkeypatch.setattr(admin_skills_mod, "SkillPublishService", lambda **_kw: publisher)
+    monkeypatch.setattr(admin_skills_mod, "_cache", lambda: MagicMock())
+
+    await delete_catalog_skill("skl-1", user=MagicMock(), session=MagicMock())
+    publisher.delete_uploaded.assert_awaited_once_with(org_id="org-1", skill=skill)
+
+
+def _publisher(
+    session: MagicMock,
+    cache: MagicMock,
+    *,
+    versions: list[object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> SkillPublishService:
+    monkeypatch.setattr(
+        "cubeplex.skills.service.SkillVersionRepository",
+        lambda _session: SimpleNamespace(list_for_skill=AsyncMock(return_value=versions)),
+    )
+    return SkillPublishService(session=session, cache=cache)
+
+
+@pytest.mark.asyncio
+async def test_delete_uploaded_cascades_installs_and_objects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.execute = AsyncMock(return_value=_execute_result([SimpleNamespace(id="osi-1")]))
+
+    version = SimpleNamespace(id="sklv-1", storage_prefix="skills/org/foo/1.0.0/")
+    cache = MagicMock()
+    store = MagicMock()
+    store.list_objects = AsyncMock(return_value=["skills/org/foo/1.0.0/SKILL.md"])
+    store.delete_file = AsyncMock()
+    monkeypatch.setattr("cubeplex.skills.service.get_objectstore_client", lambda: store)
+
+    skill = SimpleNamespace(id="skl-1")
+    await _publisher(session, cache, versions=[version], monkeypatch=monkeypatch).delete_uploaded(
+        org_id="org-1", skill=skill
+    )
+
+    assert session.flush.await_count == 1
+    session.commit.assert_awaited_once()
+    store.delete_file.assert_awaited_once_with("skills/org/foo/1.0.0/SKILL.md")
+    cache.purge.assert_called_once_with("sklv-1")
+
+
+@pytest.mark.asyncio
+async def test_delete_uploaded_skips_binding_delete_when_no_installs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.execute = AsyncMock(return_value=_execute_result([]))
+
+    cache = MagicMock()
+    store = MagicMock()
+    store.list_objects = AsyncMock(return_value=[])
+    monkeypatch.setattr("cubeplex.skills.service.get_objectstore_client", lambda: store)
+
+    skill = SimpleNamespace(id="skl-1")
+    await _publisher(session, cache, versions=[], monkeypatch=monkeypatch).delete_uploaded(
+        org_id="org-1", skill=skill
+    )
+
+    session.flush.assert_not_awaited()
+    session.commit.assert_awaited_once()
+    cache.purge.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_uploaded_survives_objectstore_list_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.execute = AsyncMock(return_value=_execute_result([]))
+
+    version = SimpleNamespace(id="sklv-1", storage_prefix="skills/org/foo/1.0.0/")
+    cache = MagicMock()
+    store = MagicMock()
+    store.list_objects = AsyncMock(side_effect=RuntimeError("s3 down"))
+    store.delete_file = AsyncMock()
+    monkeypatch.setattr("cubeplex.skills.service.get_objectstore_client", lambda: store)
+
+    await _publisher(session, cache, versions=[version], monkeypatch=monkeypatch).delete_uploaded(
+        org_id="org-1", skill=SimpleNamespace(id="skl-1")
+    )
+
+    store.delete_file.assert_not_awaited()
+    cache.purge.assert_called_once_with("sklv-1")
+
+
+@pytest.mark.asyncio
+async def test_delete_uploaded_survives_objectstore_delete_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.execute = AsyncMock(return_value=_execute_result([]))
+
+    version = SimpleNamespace(id="sklv-1", storage_prefix="skills/org/foo/1.0.0/")
+    cache = MagicMock()
+    store = MagicMock()
+    store.list_objects = AsyncMock(return_value=["skills/org/foo/1.0.0/SKILL.md"])
+    store.delete_file = AsyncMock(side_effect=RuntimeError("delete failed"))
+    monkeypatch.setattr("cubeplex.skills.service.get_objectstore_client", lambda: store)
+
+    await _publisher(session, cache, versions=[version], monkeypatch=monkeypatch).delete_uploaded(
+        org_id="org-1", skill=SimpleNamespace(id="skl-1")
+    )
+
+    cache.purge.assert_called_once_with("sklv-1")
+
+
+def test_skill_cache_purge_removes_dir_and_lock(tmp_path: Path) -> None:
+    cache = SkillCache(cache_root=tmp_path)
+    version_id = "sklv-1"
+    target = cache.cache_dir(version_id)
+    target.mkdir()
+    (target / "SKILL.md").write_text("x")
+    cache._lock_for(version_id)
+    assert version_id in cache._locks
+
+    cache.purge(version_id)
+
+    assert not target.exists()
+    assert version_id not in cache._locks
+
+
+def test_skill_cache_purge_missing_dir_is_noop(tmp_path: Path) -> None:
+    cache = SkillCache(cache_root=tmp_path)
+    cache.purge("sklv-absent")
+    assert not cache.cache_dir("sklv-absent").exists()

--- a/docs/site/docs/admin/skills-management.md
+++ b/docs/site/docs/admin/skills-management.md
@@ -57,7 +57,8 @@ Once a registry is connected (and enabled), its skills surface in the discovery 
 From **Admin > Skills** you control which skills exist in your organization and how they reach workspaces:
 
 - **Install** a skill org-wide so it becomes available to every workspace. Each org-wide install carries an **auto-bind** setting: when on, the skill is automatically enabled in workspaces; when off, a workspace owner must turn it on per workspace. Preinstalled skills default to auto-bind on; uploaded skills default to off.
-- **Uninstall** a skill to remove it from the org. This also removes its per-workspace bindings. Uninstalling a *preinstalled* skill records a tombstone so CubePlex does not restore it on the next system update.
+- **Uninstall** a skill to remove the org-wide install pin. This also removes its per-workspace bindings. The catalog row stays, so a workspace can still install it privately. Uninstalling a *preinstalled* skill records a tombstone so CubePlex does not restore it on the next system update.
+- **Delete from catalog** (uploaded skills only) permanently removes the skill, its versions, and any org-wide or workspace-private installs. Use this for skills that were uploaded or installed from a workspace and should no longer appear in the org catalog. Preinstalled skills cannot be deleted; uninstall them instead.
 
 Whether a specific workspace can use an org-installed skill is then a per-workspace toggle (managed by the workspace owner from the workspace **Skills** page, or by an admin from the skill's workspace-bindings view). Disabling a skill for a workspace hides it from the agent there; historical conversation output is unaffected.
 

--- a/docs/site/docs/guides/skills/managing-skills.md
+++ b/docs/site/docs/guides/skills/managing-skills.md
@@ -69,6 +69,8 @@ The agent keeps using the installed version until an upgrade completes; later co
 
 To remove a skill from your workspace, open its detail panel and use the uninstall action. This removes the workspace binding but does not delete the skill from the org catalog — other workspaces that use the same skill are unaffected.
 
+A skill uploaded or installed in a workspace is also registered on the org catalog. Removing the workspace install leaves that catalog row behind. An org admin can delete it from **Admin > Skills** with **Delete from catalog**.
+
 For org-wide skills, only an admin can fully uninstall them. See [Administration > Skills Management](../../admin/skills-management.md) for details.
 
 **Built-in skills** have special handling: if an admin uninstalls a preinstalled skill for the org, CubePlex records that decision so the skill is not automatically restored on the next system update.

--- a/frontend/packages/web/app/admin/skills/page.tsx
+++ b/frontend/packages/web/app/admin/skills/page.tsx
@@ -88,6 +88,10 @@ export default function SkillsPage() {
             <SkillDetailPanel
               skillId={selection?.kind === 'skill' ? selection.id : null}
               onActionDone={() => void refresh()}
+              onDeleted={() => {
+                setSelection(null)
+                void refresh()
+              }}
             />
           )
         }

--- a/frontend/packages/web/components/admin/skills/OrgInstallActions.tsx
+++ b/frontend/packages/web/components/admin/skills/OrgInstallActions.tsx
@@ -10,21 +10,24 @@ import { jsonHeaders, csrfHeaders, readApiError } from '@/lib/csrf'
 interface OrgInstallActionsProps {
   skill: SkillDetail
   onActionDone: () => void
+  onDeleted?: () => void
 }
 
-type Action = 'install' | 'upgrade' | 'uninstall' | 'refresh' | null
+type Action = 'install' | 'upgrade' | 'uninstall' | 'refresh' | 'delete' | null
 
-export function OrgInstallActions({ skill, onActionDone }: OrgInstallActionsProps) {
+export function OrgInstallActions({ skill, onActionDone, onDeleted }: OrgInstallActionsProps) {
   const t = useTranslations('adminSkills')
   const [busy, setBusy] = useState<Action>(null)
   const [error, setError] = useState<string | null>(null)
   const [refreshNote, setRefreshNote] = useState<string | null>(null)
   const [confirmUninstall, setConfirmUninstall] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
 
   // Reset confirm dialog whenever install_state changes (e.g. after upgrade or version switch)
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setConfirmUninstall(false)
+    setConfirmDelete(false)
   }, [skill.install_state])
 
   async function install(version: string): Promise<void> {
@@ -39,6 +42,15 @@ export function OrgInstallActions({ skill, onActionDone }: OrgInstallActionsProp
 
   async function uninstall(): Promise<void> {
     const res = await fetch(`/api/v1/admin/skills/${skill.id}/install`, {
+      method: 'DELETE',
+      credentials: 'include',
+      headers: csrfHeaders(),
+    })
+    if (!res.ok && res.status !== 204) throw new Error(await readApiError(res))
+  }
+
+  async function deleteFromCatalog(): Promise<void> {
+    const res = await fetch(`/api/v1/admin/skills/${skill.id}`, {
       method: 'DELETE',
       credentials: 'include',
       headers: csrfHeaders(),
@@ -67,13 +79,18 @@ export function OrgInstallActions({ skill, onActionDone }: OrgInstallActionsProp
     }
   }
 
-  async function run(action: Exclude<Action, null>, fn: () => Promise<void>): Promise<void> {
+  async function run(
+    action: Exclude<Action, null>,
+    fn: () => Promise<void>,
+    after?: () => void,
+  ): Promise<void> {
     setBusy(action)
     setError(null)
     setRefreshNote(null)
     try {
       await fn()
-      onActionDone()
+      if (after) after()
+      else onActionDone()
     } catch (err) {
       setError((err as Error).message)
     } finally {
@@ -84,6 +101,7 @@ export function OrgInstallActions({ skill, onActionDone }: OrgInstallActionsProp
   const installed =
     skill.install_state === 'installed' || skill.install_state === 'update_available'
   const canRefresh = Boolean(skill.imported_from_registry_id)
+  const canDelete = skill.source === 'uploaded'
 
   return (
     <div className="flex flex-col items-end gap-1.5">
@@ -135,7 +153,10 @@ export function OrgInstallActions({ skill, onActionDone }: OrgInstallActionsProp
             variant="ghost"
             className="cursor-pointer text-destructive hover:bg-destructive/10 hover:text-destructive"
             disabled={busy !== null}
-            onClick={() => setConfirmUninstall(true)}
+            onClick={() => {
+              setConfirmDelete(false)
+              setConfirmUninstall(true)
+            }}
             data-testid="skill-uninstall-button"
           >
             <Trash2 className="size-3.5" />
@@ -158,6 +179,44 @@ export function OrgInstallActions({ skill, onActionDone }: OrgInstallActionsProp
               type="button"
               className="cursor-pointer rounded p-0.5 text-muted-foreground hover:bg-muted"
               onClick={() => setConfirmUninstall(false)}
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
+        )}
+
+        {canDelete && !confirmDelete && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="cursor-pointer text-destructive hover:bg-destructive/10 hover:text-destructive"
+            disabled={busy !== null}
+            onClick={() => {
+              setConfirmUninstall(false)
+              setConfirmDelete(true)
+            }}
+            data-testid="skill-delete-button"
+          >
+            <Trash2 className="size-3.5" />
+            {t('deleteFromCatalog')}
+          </Button>
+        )}
+
+        {canDelete && confirmDelete && (
+          <div className="flex items-center gap-1.5 rounded-md border border-destructive/30 bg-destructive/5 px-2.5 py-1.5">
+            <span className="text-xs text-destructive">{t('confirmDelete')}</span>
+            <button
+              type="button"
+              className="cursor-pointer rounded p-0.5 text-destructive hover:bg-destructive/20"
+              disabled={busy !== null}
+              onClick={() => void run('delete', deleteFromCatalog, onDeleted ?? onActionDone)}
+            >
+              <Check className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              className="cursor-pointer rounded p-0.5 text-muted-foreground hover:bg-muted"
+              onClick={() => setConfirmDelete(false)}
             >
               <X className="size-3.5" />
             </button>

--- a/frontend/packages/web/components/admin/skills/SkillDetailPanel.tsx
+++ b/frontend/packages/web/components/admin/skills/SkillDetailPanel.tsx
@@ -24,6 +24,7 @@ const ReactDiffViewer = dynamic(() => import('react-diff-viewer-continued'), { s
 interface SkillDetailPanelProps {
   skillId: string | null
   onActionDone: () => void
+  onDeleted?: () => void
 }
 
 const contentFetcher = async (url: string): Promise<SkillContent> => {
@@ -421,7 +422,7 @@ function CompareTab({ skillId, versions }: { skillId: string; versions: SkillVer
 
 // ─── Main Panel ──────────────────────────────────────────────────────────────
 
-export function SkillDetailPanel({ skillId, onActionDone }: SkillDetailPanelProps) {
+export function SkillDetailPanel({ skillId, onActionDone, onDeleted }: SkillDetailPanelProps) {
   const t = useTranslations('adminSkills')
   const tExtra = useTranslations('adminSkillsExtra')
   const { skill, loading, error, refresh } = useAdminSkill(skillId)
@@ -497,7 +498,12 @@ export function SkillDetailPanel({ skillId, onActionDone }: SkillDetailPanelProp
             </Badge>
           )}
           <div className="ml-auto">
-            <OrgInstallActions key={skill.id} skill={skill} onActionDone={handleActionDone} />
+            <OrgInstallActions
+              key={skill.id}
+              skill={skill}
+              onActionDone={handleActionDone}
+              onDeleted={onDeleted}
+            />
           </div>
         </div>
         <SkillCanonicalNameRow

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -728,6 +728,8 @@
     "viaRegistry": "via",
     "uninstall": "Uninstall",
     "confirmUninstall": "Confirm uninstall?",
+    "deleteFromCatalog": "Delete from catalog",
+    "confirmDelete": "Delete this skill and all workspace installs?",
     "defaultLinkAll": "Link all workspaces by default",
     "defaultLinkAllEnabled": "All workspaces enable this skill by default (can be individually disabled)",
     "defaultLinkAllDisabled": "Each workspace must manually enable this skill",

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -728,6 +728,8 @@
     "viaRegistry": "来自",
     "uninstall": "卸载",
     "confirmUninstall": "确认卸载？",
+    "deleteFromCatalog": "从目录删除",
+    "confirmDelete": "删除该 skill 及其所有 workspace 安装？",
     "defaultLinkAll": "默认关联所有 Workspace",
     "defaultLinkAllEnabled": "所有 Workspace 默认启用此 skill（可在各 Workspace 单独关闭）",
     "defaultLinkAllDisabled": "各 Workspace 需手动启用此 skill",


### PR DESCRIPTION
## Summary

Workspace installs/uploads register a `Skill` row on the org catalog, but Admin > Skills only had **Uninstall**, which drops the org-wide pin and leaves the catalog row. Workspace-private installs showed as uninstalled, so there was no way to remove them from the org at all.

- Add `DELETE /api/v1/admin/skills/{skill_id}` for uploaded skills (preinstalled still 422).
- Cascade org-wide and workspace-private installs, versions, bindings, and best-effort object-store/cache cleanup.
- Show **Delete from catalog** on the admin skill detail panel.
- Document the distinction between uninstall and catalog delete.

## Test plan

- [x] `uv run pytest tests/e2e/test_skill_catalog_delete.py --no-cov`
- [x] Uninstall regression: `test_admin_uninstall_preinstalled_creates_tombstone`, `test_admin_uninstall_with_workspace_binding_succeeds`
- [ ] In Admin > Skills, open a workspace-uploaded skill and confirm **Delete from catalog** removes it from the list and from workspace settings
- [ ] Confirm preinstalled skills still only show Uninstall (no catalog delete)