### PR TITLE
fix(mcp): show catalog logos in chat tool calls

### DIFF
--- a/backend/cubeplex/api/routes/v1/ws_mcp.py
+++ b/backend/cubeplex/api/routes/v1/ws_mcp.py
@@ -635,6 +635,7 @@ async def list_workspace_active_tools(
                     bare_name=bare,
                     connector_id=spec.connector_id,
                     server_name=spec.name,
+                    icon=spec.template_icon,
                     server_icons=server_icons,
                     tool_icons=_icons_for(tool_icons_map.get(bare)),
                 )

--- a/backend/cubeplex/api/schemas/mcp.py
+++ b/backend/cubeplex/api/schemas/mcp.py
@@ -323,6 +323,8 @@ class McpActiveToolOut(BaseModel):
     bare_name: str
     connector_id: str
     server_name: str
+    # Catalog brand key, resolved by the frontend to /mcp-icons/{icon}.svg.
+    icon: str | None = None
     server_icons: list[McpIconOut] = Field(default_factory=list)
     tool_icons: list[McpIconOut] = Field(default_factory=list)
 

--- a/backend/cubeplex/mcp/effective.py
+++ b/backend/cubeplex/mcp/effective.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any, Literal, cast
 
 from cubeplex.mcp.exceptions import OAuthRefreshFailed
+from cubeplex.mcp.icons import template_icon_key
 from cubeplex.mcp.oauth.token_manager import OAuthTokenManager
 from cubeplex.models import (
     MCPConnector,
@@ -174,6 +175,7 @@ class MCPRuntimeConnectorSpec:
     timeout: float = 30.0
     sse_read_timeout: float = 300.0
     template_id: str | None = None
+    template_icon: str | None = None
     org_id: str = ""
     workspace_id: str = ""
     grant: MCPCredentialGrant | None = None
@@ -256,6 +258,9 @@ class MCPEffectiveConnectorService:
                 timeout=row.connector.timeout,
                 sse_read_timeout=row.connector.sse_read_timeout,
                 template_id=row.connector.template_id,
+                template_icon=template_icon_key(
+                    row.template.template_metadata if row.template is not None else None
+                ),
                 org_id=row.connector.org_id,
                 workspace_id=workspace_id,
                 grant=row.grant,

--- a/frontend/packages/core/src/api/mcp.ts
+++ b/frontend/packages/core/src/api/mcp.ts
@@ -441,6 +441,8 @@ export interface MCPActiveTool {
   connector_id: string
   /** Install display name (the slug source for namespacing). */
   server_name: string
+  /** Catalog brand key, rendered from the local /mcp-icons asset set. */
+  icon: string | null
   server_icons: MCPToolIcon[]
   tool_icons: MCPToolIcon[]
 }

--- a/frontend/packages/web/components/chat/ToolCallItem.tsx
+++ b/frontend/packages/web/components/chat/ToolCallItem.tsx
@@ -31,6 +31,11 @@ function pickIconSrc(toolIcons: MCPToolIcon[], serverIcons: MCPToolIcon[]): stri
   return null
 }
 
+function pickCatalogIconSrc(icon: string | null | undefined): string | null {
+  if (!icon || !/^[a-zA-Z0-9_-]{1,64}$/.test(icon)) return null
+  return `/mcp-icons/${icon}.svg`
+}
+
 interface ToolCallItemProps {
   name: string
   arguments: Record<string, unknown>
@@ -104,7 +109,9 @@ export const ToolCallItem = memo(function ToolCallItem({
   const displayName = humanizeToolName(mcpEntry?.bare_name ?? nameParts.tool)
   const serverName =
     mcpEntry?.server_name ?? (nameParts.server ? humanizeToolName(nameParts.server) : null)
-  const mcpIconSrc = mcpEntry ? pickIconSrc(mcpEntry.tool_icons, mcpEntry.server_icons) : null
+  const mcpIconSrc = mcpEntry
+    ? (pickCatalogIconSrc(mcpEntry.icon) ?? pickIconSrc(mcpEntry.tool_icons, mcpEntry.server_icons))
+    : null
   const [mcpIconFailed, setMcpIconFailed] = useState(false)
   useEffect(() => {
     setMcpIconFailed(false)


### PR DESCRIPTION
## Summary
- expose the catalog brand icon on the workspace active-tools response
- render local catalog logos such as `/mcp-icons/jina.svg` in chat tool calls
- preserve discovery-icon fallback for custom MCP servers

## Verification
- `tests/unit/test_mcp_effective_service.py`: 8 passed
- core build passed
- web type-check passed
- pre-push backend/frontend check-ci passed