### PR TITLE
Sync runtime-installed skills into active sandboxes

### DIFF
--- a/backend/cubeplex/agents/actions/capabilities/skills.py
+++ b/backend/cubeplex/agents/actions/capabilities/skills.py
@@ -12,6 +12,7 @@ to the model as runtime infrastructure and stays wired in run_manager.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -74,6 +75,7 @@ class SkillDeps:
     org_id: str
     org_slug: str
     workspace_id: str | None
+    on_skills_changed: Callable[[], Awaitable[None]] | None = None
 
 
 # --- Input models per operation ---
@@ -235,6 +237,9 @@ async def _handle_install_impl(
     except SkillInstallError as exc:
         raise ActionInvalidInput(str(exc)) from exc
 
+    if deps.on_skills_changed is not None:
+        await deps.on_skills_changed()
+
     return {
         "installed": True,
         "canonical_name": result.canonical_name,
@@ -266,6 +271,9 @@ async def _handle_publish_skill_impl(
 
     skill = await _SkillRepository(session).get(sv.skill_id)
     canonical_name = skill.name if skill is not None else sv.skill_id
+
+    if deps.on_skills_changed is not None:
+        await deps.on_skills_changed()
 
     return {
         "published": True,

--- a/backend/cubeplex/sandbox/lazy.py
+++ b/backend/cubeplex/sandbox/lazy.py
@@ -286,33 +286,52 @@ class LazySandbox(Sandbox):
             # Second concurrent call may have already completed the sync.
             if self._synced_for_this_run:
                 return
-            result = await _sync_skills(
-                catalog=self._catalog,
-                workspace_id=self._workspace_id,
-                org_id=self._org_id,
-                sandbox=sandbox,
-            )
-            # Hot path: nothing changed → no event, no snapshot bump
-            if result.status == "noop":
-                self._synced_for_this_run = True
+            await self._sync_skills_locked(sandbox)
+
+    async def _sync_skills_locked(self, sandbox: Sandbox) -> None:
+        """Run one sync while the caller holds ``_sync_lock``."""
+        assert self._catalog is not None
+        result = await _sync_skills(
+            catalog=self._catalog,
+            workspace_id=self._workspace_id,
+            org_id=self._org_id,
+            sandbox=sandbox,
+        )
+        # Hot path: nothing changed → no event, no snapshot bump
+        if result.status == "noop":
+            self._synced_for_this_run = True
+            return
+        # Cold / delta / failed → emit event (best-effort)
+        if self._event_service is not None and self._user_sandbox_id is not None:
+            try:
+                await self._event_service.record(
+                    user_sandbox_id=self._user_sandbox_id,
+                    org_id=self._org_id,
+                    workspace_id=self._workspace_id,
+                    result=result,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to record sync event for ws {}; continuing",
+                    self._workspace_id,
+                )
+        if result.status == "success":
+            self._synced_for_this_run = True
+        # status == "failed" → flag stays False (F4 invariant)
+
+    async def refresh_skills(self) -> None:
+        """Refresh an existing sandbox after the enabled skill set changes.
+
+        Keep sandbox creation lazy. If this run has not used the sandbox yet,
+        its first filesystem operation will perform the normal initial sync.
+        """
+        if self._catalog is None:
+            return
+        async with self._sync_lock:
+            self._synced_for_this_run = False
+            if self._sandbox is None:
                 return
-            # Cold / delta / failed → emit event (best-effort)
-            if self._event_service is not None and self._user_sandbox_id is not None:
-                try:
-                    await self._event_service.record(
-                        user_sandbox_id=self._user_sandbox_id,
-                        org_id=self._org_id,
-                        workspace_id=self._workspace_id,
-                        result=result,
-                    )
-                except Exception:
-                    logger.exception(
-                        "Failed to record sync event for ws {}; continuing",
-                        self._workspace_id,
-                    )
-            if result.status == "success":
-                self._synced_for_this_run = True
-            # status == "failed" → flag stays False (F4 invariant)
+            await self._sync_skills_locked(self._sandbox)
 
     async def _ensure_with_retry(self) -> Sandbox:
         """Ensure sandbox, retrying once if the existing one is broken."""

--- a/backend/cubeplex/sandbox/lazy.py
+++ b/backend/cubeplex/sandbox/lazy.py
@@ -221,7 +221,8 @@ class LazySandbox(Sandbox):
         self._sandbox: Sandbox | None = None
         self._user_sandbox_id: str | None = None
         self._lock = asyncio.Lock()
-        self._synced_for_this_run = False
+        self._skills_generation = 0
+        self._synced_skills_generation: int | None = None
         self._sync_lock = asyncio.Lock()  # independent of _lock; serialises _sync_skills
 
     # ------------------------------------------------------------------
@@ -280,17 +281,20 @@ class LazySandbox(Sandbox):
         Double-check pattern: fast path avoids lock acquisition after first sync.
         Failure does NOT set the flag so the next tool call retries (F4).
         """
-        if self._catalog is None or self._synced_for_this_run:
+        generation = self._skills_generation
+        if self._catalog is None or self._synced_skills_generation == generation:
             return
         async with self._sync_lock:
+            generation = self._skills_generation
             # Second concurrent call may have already completed the sync.
-            if self._synced_for_this_run:
+            if self._synced_skills_generation == generation:
                 return
-            await self._sync_skills_locked(sandbox)
+            await self._sync_skills_locked(sandbox, generation)
 
-    async def _sync_skills_locked(self, sandbox: Sandbox) -> None:
+    async def _sync_skills_locked(self, sandbox: Sandbox, generation: int) -> None:
         """Run one sync while the caller holds ``_sync_lock``."""
         assert self._catalog is not None
+        user_sandbox_id = self._user_sandbox_id
         result = await _sync_skills(
             catalog=self._catalog,
             workspace_id=self._workspace_id,
@@ -299,13 +303,14 @@ class LazySandbox(Sandbox):
         )
         # Hot path: nothing changed → no event, no snapshot bump
         if result.status == "noop":
-            self._synced_for_this_run = True
+            if self._skills_generation == generation:
+                self._synced_skills_generation = generation
             return
         # Cold / delta / failed → emit event (best-effort)
-        if self._event_service is not None and self._user_sandbox_id is not None:
+        if self._event_service is not None and user_sandbox_id is not None:
             try:
                 await self._event_service.record(
-                    user_sandbox_id=self._user_sandbox_id,
+                    user_sandbox_id=user_sandbox_id,
                     org_id=self._org_id,
                     workspace_id=self._workspace_id,
                     result=result,
@@ -315,9 +320,15 @@ class LazySandbox(Sandbox):
                     "Failed to record sync event for ws {}; continuing",
                     self._workspace_id,
                 )
-        if result.status == "success":
-            self._synced_for_this_run = True
-        # status == "failed" → flag stays False (F4 invariant)
+        if result.status == "success" and self._skills_generation == generation:
+            self._synced_skills_generation = generation
+        # Failed or superseded syncs leave the current generation unsynced.
+
+    def _invalidate_skills_sync(self) -> int:
+        """Advance the generation so an older sync cannot mark current state ready."""
+        self._skills_generation += 1
+        self._synced_skills_generation = None
+        return self._skills_generation
 
     async def refresh_skills(self) -> None:
         """Refresh an existing sandbox after the enabled skill set changes.
@@ -328,10 +339,10 @@ class LazySandbox(Sandbox):
         if self._catalog is None:
             return
         async with self._sync_lock:
-            self._synced_for_this_run = False
+            generation = self._invalidate_skills_sync()
             if self._sandbox is None:
                 return
-            await self._sync_skills_locked(self._sandbox)
+            await self._sync_skills_locked(self._sandbox, generation)
 
     async def _ensure_with_retry(self) -> Sandbox:
         """Ensure sandbox, retrying once if the existing one is broken."""
@@ -341,7 +352,7 @@ class LazySandbox(Sandbox):
             # First attempt failed — reset and try creating a fresh one
             async with self._lock:
                 self._sandbox = None
-                self._synced_for_this_run = False  # new sandbox must re-sync (F5)
+                self._invalidate_skills_sync()
                 self._user_sandbox_id = None
             logger.warning(
                 "Lazy sandbox: first attempt failed for scope {}/{}, retrying",
@@ -451,7 +462,7 @@ class LazySandbox(Sandbox):
             # Sandbox may have died — invalidate and retry once
             async with self._lock:
                 self._sandbox = None
-                self._synced_for_this_run = False  # new sandbox must re-sync (F5)
+                self._invalidate_skills_sync()
                 self._user_sandbox_id = None
             logger.warning("Lazy sandbox: execute failed, recreating sandbox")
             sandbox = await self._ensure()
@@ -467,7 +478,7 @@ class LazySandbox(Sandbox):
         except Exception:
             async with self._lock:
                 self._sandbox = None
-                self._synced_for_this_run = False  # new sandbox must re-sync (F5)
+                self._invalidate_skills_sync()
                 self._user_sandbox_id = None
             logger.warning("Lazy sandbox: upload failed, recreating sandbox")
             sandbox = await self._ensure()

--- a/backend/cubeplex/streams/run_manager.py
+++ b/backend/cubeplex/streams/run_manager.py
@@ -3097,6 +3097,7 @@ class RunManager:
                                 org_id=ctx.org_id,
                                 org_slug=_org.slug,
                                 workspace_id=ctx.workspace_id,
+                                on_skills_changed=getattr(sandbox, "refresh_skills", None),
                             )
                     except Exception as _skill_exc:  # noqa: BLE001
                         logger.warning(

--- a/backend/tests/unit/test_lazy_sandbox_sync_lifecycle.py
+++ b/backend/tests/unit/test_lazy_sandbox_sync_lifecycle.py
@@ -114,6 +114,17 @@ async def test_refresh_skills_keeps_an_uninitialized_sandbox_lazy() -> None:
 
 
 @pytest.mark.asyncio
+async def test_refresh_skills_without_a_catalog_is_a_noop() -> None:
+    sandbox = _make_sandbox()
+    lazy = _make_lazy(None, sandbox)
+
+    await lazy.refresh_skills()
+
+    assert lazy.initialized is False
+    lazy._manager.get_or_create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_refresh_does_not_mark_a_replacement_sandbox_synced() -> None:
     """An old-sandbox refresh must not suppress sync on a concurrent replacement."""
     refresh_download_started = asyncio.Event()

--- a/backend/tests/unit/test_lazy_sandbox_sync_lifecycle.py
+++ b/backend/tests/unit/test_lazy_sandbox_sync_lifecycle.py
@@ -5,8 +5,8 @@ If F3/F4/F5 regress, these tests catch it.
 F3: two concurrent execute calls must not both run _sync_skills → independent
     _sync_lock serialises them; double-check pattern lets the second skip.
 F4: a sync failure must NOT set the flag; the next execute must retry.
-F5: sandbox recreate (execute / upload failure path) must reset
-    _synced_for_this_run so the new sandbox gets synced.
+F5: sandbox recreate (execute / upload failure path) must advance the sync
+    generation so the new sandbox gets synced.
 """
 
 from __future__ import annotations
@@ -111,6 +111,70 @@ async def test_refresh_skills_keeps_an_uninitialized_sandbox_lazy() -> None:
     assert lazy.initialized is False
     lazy._manager.get_or_create.assert_not_awaited()
     catalog.list_enabled_for_workspace.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_mark_a_replacement_sandbox_synced() -> None:
+    """An old-sandbox refresh must not suppress sync on a concurrent replacement."""
+    refresh_download_started = asyncio.Event()
+    allow_refresh_download = asyncio.Event()
+    command_started = asyncio.Event()
+    allow_command_failure = asyncio.Event()
+
+    old_sandbox = _make_sandbox()
+    old_download_count = 0
+
+    async def old_download(_paths: list[str]) -> list[tuple[str, bytes]]:
+        nonlocal old_download_count
+        old_download_count += 1
+        if old_download_count == 2:
+            refresh_download_started.set()
+            await allow_refresh_download.wait()
+        return []
+
+    old_execute_count = 0
+
+    async def old_execute(*_args: object, **_kwargs: object) -> MagicMock:
+        nonlocal old_execute_count
+        old_execute_count += 1
+        if old_execute_count == 2:
+            command_started.set()
+            await allow_command_failure.wait()
+            raise RuntimeError("old sandbox died")
+        return MagicMock(output="", exit_code=0)
+
+    old_sandbox.download = AsyncMock(side_effect=old_download)
+    old_sandbox.execute = AsyncMock(side_effect=old_execute)
+    new_sandbox = _make_sandbox()
+
+    catalog = MagicMock()
+    catalog.list_enabled_for_workspace = AsyncMock(return_value=[])
+    lazy = _make_lazy(catalog, old_sandbox)
+    lazy._manager.get_or_create = AsyncMock(
+        side_effect=[
+            SandboxAttachment(sandbox=old_sandbox, user_sandbox_id="uss-old"),
+            SandboxAttachment(sandbox=new_sandbox, user_sandbox_id="uss-new"),
+        ]
+    )
+
+    await lazy.execute("initial")
+    command_task = asyncio.create_task(lazy.execute("fails"))
+    await command_started.wait()
+
+    refresh_task = asyncio.create_task(lazy.refresh_skills())
+    await refresh_download_started.wait()
+    allow_command_failure.set()
+    for _ in range(100):
+        if lazy._manager.get_or_create.await_count == 2:
+            break
+        await asyncio.sleep(0)
+    assert lazy._manager.get_or_create.await_count == 2
+
+    allow_refresh_download.set()
+    await asyncio.gather(command_task, refresh_task)
+
+    assert catalog.list_enabled_for_workspace.await_count == 3
+    new_sandbox.download.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_lazy_sandbox_sync_lifecycle.py
+++ b/backend/tests/unit/test_lazy_sandbox_sync_lifecycle.py
@@ -65,6 +65,55 @@ async def test_sync_runs_once_per_run() -> None:
 
 
 @pytest.mark.asyncio
+async def test_refresh_skills_resyncs_an_initialized_sandbox() -> None:
+    """A skill installed mid-run must reach a sandbox already synced this run."""
+    installed_skill = SimpleNamespace(
+        name="org:slides",
+        version="1.0.0",
+        skill_version_id="skv-slides",
+        content_hash="sha256:slides",
+        storage_prefix="skills/slides/1.0.0/",
+    )
+    catalog = MagicMock()
+    catalog.list_enabled_for_workspace = AsyncMock(
+        side_effect=[[], [installed_skill]],
+    )
+    catalog.list_files_for_sandbox_sync = AsyncMock(
+        return_value=[("SKILL.md", b"# Slides")],
+    )
+    sandbox = _make_sandbox()
+    lazy = _make_lazy(catalog, sandbox)
+
+    await lazy.execute("true")
+    refresh_skills = getattr(lazy, "refresh_skills", None)
+
+    assert refresh_skills is not None, "LazySandbox must expose a mid-run skill refresh"
+    await refresh_skills()
+
+    assert catalog.list_enabled_for_workspace.await_count == 2
+    catalog.list_files_for_sandbox_sync.assert_awaited_once_with(
+        "skv-slides",
+        storage_prefix="skills/slides/1.0.0/",
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_skills_keeps_an_uninitialized_sandbox_lazy() -> None:
+    catalog = MagicMock()
+    catalog.list_enabled_for_workspace = AsyncMock(return_value=[])
+    sandbox = _make_sandbox()
+    lazy = _make_lazy(catalog, sandbox)
+    refresh_skills = getattr(lazy, "refresh_skills", None)
+
+    assert refresh_skills is not None, "LazySandbox must expose a mid-run skill refresh"
+    await refresh_skills()
+
+    assert lazy.initialized is False
+    lazy._manager.get_or_create.assert_not_awaited()
+    catalog.list_enabled_for_workspace.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_sync_failure_does_not_set_flag_so_next_call_retries() -> None:
     catalog = MagicMock()
     catalog.list_enabled_for_workspace = AsyncMock(

--- a/backend/tests/unit/test_skills_capability.py
+++ b/backend/tests/unit/test_skills_capability.py
@@ -23,6 +23,7 @@ def _make_deps(
     registry: Any | None = None,
     catalog: Any | None = None,
     catalog_session: Any | None = None,
+    on_skills_changed: Any | None = None,
 ) -> SkillDeps:
     return SkillDeps(
         catalog=catalog or MagicMock(),
@@ -31,6 +32,7 @@ def _make_deps(
         org_id="org-test",
         org_slug="org-slug",
         workspace_id="ws-test",
+        on_skills_changed=on_skills_changed,
     )
 
 
@@ -226,7 +228,8 @@ async def test_install_success_returns_payload(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(_skills_mod, "_SkillInstallService", lambda **_kw: fake_svc)
     monkeypatch.setattr(_skills_mod, "_SkillPublishService", lambda **_kw: MagicMock())
 
-    deps = _make_deps()
+    on_skills_changed = AsyncMock()
+    deps = _make_deps(on_skills_changed=on_skills_changed)
     cid = encode_candidate_id("remote", "owner/repo/main/skill", source_id="src-1")
     fake_session = MagicMock()
 
@@ -242,6 +245,7 @@ async def test_install_success_returns_payload(monkeypatch: pytest.MonkeyPatch) 
         "version": "1.0.0",
     }
     fake_svc.install.assert_awaited_once_with(cid)
+    on_skills_changed.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
@@ -253,7 +257,8 @@ async def test_install_error_raises_invalid_input(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(_skills_mod, "_SkillInstallService", lambda **_kw: fake_svc)
     monkeypatch.setattr(_skills_mod, "_SkillPublishService", lambda **_kw: MagicMock())
 
-    deps = _make_deps()
+    on_skills_changed = AsyncMock()
+    deps = _make_deps(on_skills_changed=on_skills_changed)
     cid = encode_candidate_id("remote", "owner/repo/main/skill", source_id="src-1")
 
     with pytest.raises(ActionInvalidInput, match="trust tier too low"):
@@ -263,6 +268,7 @@ async def test_install_error_raises_invalid_input(monkeypatch: pytest.MonkeyPatc
             MagicMock(),
             InstallInput(candidate_id=cid),
         )
+    on_skills_changed.assert_not_awaited()
 
 
 # --- mutation gate ---
@@ -335,7 +341,8 @@ async def test_publish_skill_success(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_skill_repo.get = AsyncMock(return_value=fake_skill)
     monkeypatch.setattr(_skills_mod, "_SkillRepository", lambda _s: fake_skill_repo)
 
-    deps = _make_deps()
+    on_skills_changed = AsyncMock()
+    deps = _make_deps(on_skills_changed=on_skills_changed)
     fake_session = MagicMock()
 
     result = await _handle_publish_skill_impl(
@@ -354,6 +361,7 @@ async def test_publish_skill_success(monkeypatch: pytest.MonkeyPatch) -> None:
         artifact_id="art-abc",
         workspace_id="ws-test",
     )
+    on_skills_changed.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- refresh an already-initialized sandbox when the enabled skill set changes
- keep sandbox creation lazy when no filesystem tool has run yet
- trigger refresh after in-chat skill installs and publishes

## Tests

- `uv run pytest tests/unit/test_lazy_sandbox_sync_lifecycle.py tests/unit/test_skills_capability.py tests/unit/test_load_skill.py -q --no-cov`
- `uv run ruff check ...` and `uv run ruff format --check ...`
- `uv run mypy cubeplex/sandbox/lazy.py cubeplex/agents/actions/capabilities/skills.py cubeplex/streams/run_manager.py`
- pre-push `backend check-ci`