### PR TITLE
feat: add description field to preview/install tool inputs for meaningful chip display

### DIFF
--- a/backend/cubeplex/agents/actions/capabilities/skills.py
+++ b/backend/cubeplex/agents/actions/capabilities/skills.py
@@ -93,6 +93,14 @@ class PreviewInput(BaseModel):
             "content so you can describe the skill before suggesting installation."
         ),
     )
+    description: str = Field(
+        default="",
+        description=(
+            "Human-readable name or short intent of the skill being previewed. "
+            "The UI displays this in the tool-call chip instead of the raw "
+            "candidate_id. Always pass the skill's `name` from the find result."
+        ),
+    )
 
 
 class InstallInput(BaseModel):
@@ -100,6 +108,14 @@ class InstallInput(BaseModel):
         description=(
             "The candidate_id from a find result. "
             "Only call this after the user has explicitly confirmed they want to install."
+        ),
+    )
+    description: str = Field(
+        default="",
+        description=(
+            "Human-readable name or short intent of the skill being installed. "
+            "The UI displays this in the tool-call chip instead of the raw "
+            "candidate_id. Always pass the skill's `name` from the find result."
         ),
     )
 
@@ -142,8 +158,9 @@ async def _handle_find_impl(
         "hint": (
             "To use an 'enabled' candidate now, call load_skill(canonical_name). "
             "To install an 'in_catalog' or 'available' candidate: present it to the "
-            "user with platform_skills_preview(candidate_id=...) so they can see "
-            "what it does, then call platform_skills_install(candidate_id=...) "
+            "user with platform_skills_preview(candidate_id=..., description='<name>') "
+            "so they can see what it does (pass the skill name as description for UI), "
+            "then call platform_skills_install(candidate_id=..., description='<name>') "
             "only when the user explicitly asks to install. Never install silently."
         ),
     }
@@ -312,7 +329,9 @@ def build_skills_capability(deps: SkillDeps) -> AgentCapability:
                 description=(
                     "Fetch the full SKILL.md for a candidate so you can describe it "
                     "to the user before suggesting installation. Use after find. "
-                    'Example: {"candidate_id":"<candidate_id from find>"}'
+                    "Pass the skill name from the find result as `description` so "
+                    "the UI displays a meaningful label. "
+                    'Example: {"candidate_id":"<candidate_id from find>","description":"Web Search"}'
                 ),
                 input_model=PreviewInput,
                 handler=preview_handler,
@@ -323,7 +342,9 @@ def build_skills_capability(deps: SkillDeps) -> AgentCapability:
                 description=(
                     "Install a skill candidate into the current workspace. "
                     "Only call when the user has explicitly asked to install. "
-                    'Example: {"candidate_id":"<candidate_id from find>"}'
+                    "Pass the skill name from the find result as `description` so "
+                    "the UI displays a meaningful label. "
+                    'Example: {"candidate_id":"<candidate_id from find>","description":"Web Search"}'
                 ),
                 input_model=InstallInput,
                 handler=install_handler,


### PR DESCRIPTION
## Problem

`platform_skills_preview` and `platform_skills_install` tool calls display the raw `candidate_id` (a base64 opaque token like `bG9jYWx8fHNr...`) in the frontend tool-call chip, which is completely uninformative.

## Solution

Add an optional `description` field to `PreviewInput` and `InstallInput` Pydantic models. The frontend's `getParamSummary()` already prioritizes a `description` field in tool arguments — when the agent passes the skill name as `description`, the chip will display it as a meaningful label.

**No frontend changes needed.** The existing `getParamSummary` logic handles this automatically:
```typescript
const desc = args.description
if (typeof desc === 'string' && desc.trim()) { return desc.trim() }
```

## Changes

| File | Change |
|---|---|
| `backend/cubeplex/agents/actions/capabilities/skills.py` | Add `description: str = Field(default="")` to `PreviewInput` + `InstallInput` |
| Same file | Update operation descriptions and find-hint to guide the agent to pass skill name as `description` |

## Testing

- Backend: `tests/unit/test_skills_capability.py` — 11/11 passed (optional field with default, existing instantiations still work)
- Frontend: `lib/__tests__/toolIcons.test.ts` — 10/10 passed (no change needed)

## After

When the agent follows the tool description hint and passes `description`, the chip shows:
```
Platform Skills Preview — Web Search
```
