### PR TITLE
Show enabled status for workspace-private skills

### DIFF
--- a/docs/site/docs/guides/skills/managing-skills.md
+++ b/docs/site/docs/guides/skills/managing-skills.md
@@ -14,7 +14,7 @@ Open the **Skills** page from the workspace sidebar to see every skill available
 - **Name** and short description. Uploaded skills are stored as `org-slug:skill-slug` for uniqueness, but the card shows only the short skill slug. Hover the name or open the detail panel to see the full canonical name (which is what agents pass to `load_skill`).
 - **Source** — whether the skill is built-in (preinstalled) or uploaded.
 - **Version** — the currently installed version.
-- **State** — whether the skill is enabled, disabled, or available but not yet installed.
+- **State** — whether the skill is enabled, disabled, or available but not yet installed. Workspace-private skills show both **Private** and **Enabled** because they are always enabled.
 
 You can filter the list by source (preinstalled / uploaded), by state (enabled / disabled / available), or by a text search.
 

--- a/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillCard.tsx
+++ b/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillCard.tsx
@@ -23,7 +23,7 @@ interface WorkspaceSkillCardProps {
   onClick: () => void
 }
 
-function StateBadge({ state }: { state: WorkspaceSkillState }) {
+function StateBadges({ state }: { state: WorkspaceSkillState }) {
   const t = useTranslations('wsSettings.skillCard')
   if (state === 'org-enabled') {
     return (
@@ -43,10 +43,16 @@ function StateBadge({ state }: { state: WorkspaceSkillState }) {
   }
   if (state === 'workspace-private') {
     return (
-      <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
-        <Lock className="size-3" />
-        {t('private')}
-      </span>
+      <>
+        <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+          <Lock className="size-3" />
+          {t('private')}
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full bg-success-solid/10 px-1.5 py-0.5 text-[10px] font-medium text-success-fg">
+          <CheckCircle2 className="size-3" />
+          {t('enabled')}
+        </span>
+      </>
     )
   }
   return (
@@ -87,7 +93,7 @@ export function WorkspaceSkillCard({ skill, active, onClick }: WorkspaceSkillCar
         >
           {label.primary}
         </span>
-        <StateBadge state={skill.workspaceState} />
+        <StateBadges state={skill.workspaceState} />
         {upgradable && (
           <span className="inline-flex items-center gap-1 rounded-full bg-warning-solid/10 px-1.5 py-0.5 text-[10px] font-medium text-warning-fg">
             <ArrowUpCircle className="size-3" />

--- a/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillDetail.tsx
+++ b/frontend/packages/web/components/workspace-settings/skills/WorkspaceSkillDetail.tsx
@@ -583,6 +583,11 @@ export function WorkspaceSkillDetail({ wsId, skill, onActionDone }: WorkspaceSki
           >
             {t(STATE_KEY[skill.workspaceState])}
           </Badge>
+          {skill.workspaceState === 'workspace-private' && (
+            <Badge variant="outline" className={cn(STATE_BADGE_VARIANT['org-enabled'].className)}>
+              {t(STATE_KEY['org-enabled'])}
+            </Badge>
+          )}
           {skill.install_state === 'update_available' && (
             <Badge variant="outline" className="border-warning-border text-warning-fg">
               {t('stateUpgradable')}


### PR DESCRIPTION
## Summary

- show both Private and Enabled badges for workspace-private skills
- keep the card and detail panel status labels consistent
- document that workspace-private skills are always enabled

## Verification

- frontend pre-push check-ci
- TypeScript type-check
- ESLint and Prettier