### PR TITLE
Lock the product UI to the default theme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Wrong changes here are expensive (cache bills, auth, data corruption).
 | Agent middleware, request flow, event types | [backend/docs/agent-system-design.md](backend/docs/agent-system-design.md) |
 | MCP catalog / OAuth / connector install | [backend/docs/mcp_catalog_oauth.md](backend/docs/mcp_catalog_oauth.md) |
 | Frontend auth, CSRF, SSE proxy, deploy mode | [frontend/docs/auth-and-sse.md](frontend/docs/auth-and-sse.md) |
+| Frontend product UI, theme, tokens | [frontend/design.md](frontend/design.md) |
 | Worktree provisioning, rebase / migration drift | [docs/worktrees.md](docs/worktrees.md) |
 | Tests — writing, placing, reviewing | [docs/testing.md](docs/testing.md) |
 | Cutting a release (versions, tags, images, deploy-doc snippets) | [docs/releasing.md](docs/releasing.md) |
@@ -146,7 +147,7 @@ Load on demand when the situation matches.
 |---|---|
 | `cubepi` | Agents on CubePi — API, providers, tools, middleware, MCP, HITL |
 | `cubepi-trace` | Debug a cubepi run (spans, tool I/O, tokens, cache) |
-| `web-design-guidelines` | UI a11y / design review |
+| `web-design-guidelines` | UI a11y / design review (after [frontend/design.md](frontend/design.md)) |
 | `playwright-cli` | Playwright tests |
 
 Escape hatch: `/codex:rescue` — stuck; want a second opinion.

--- a/frontend/design.md
+++ b/frontend/design.md
@@ -1,30 +1,100 @@
-# CubePlex default theme
+---
+name: cubeplex-frontend-design
+description: >
+  Visual language and token contract for the CubePlex product UI
+  (frontend/packages/web). Load when shaping, building, restyling, or
+  reviewing user-facing pages and components: theme, color, type,
+  spacing, motion, chat, list-detail, admin vs workspace, empty /
+  loading / error states, copy that sits in the UI. Skip backend-only
+  work, telemetry, generated files, and docs with no shipped UI.
+---
 
-Living summary of the **default** product theme (the Vercel-Mono family).
+# CubePlex product UI
+
+This is the design contract for the **shipped product**, not a restyle
+brief. Keep CubePlex looking like CubePlex. The default family (Vercel-Mono
+direction: restrained grayscale, one blue accent, Geist) is already locked
+in `globals.css`; this file tells agents how to use it.
+
 Source of truth for values is
 [`packages/web/app/globals.css`](packages/web/app/globals.css). If this
-doc and that file disagree, believe the CSS.
+doc and that file disagree, believe the CSS. Frozen history lives in
+[`docs/dev/specs/2026-06-10-ui-redesign-design.md`](../docs/dev/specs/2026-06-10-ui-redesign-design.md)
+— do not back-port tuned tokens into the spec, and do not treat the spec's
+prototype numbers (e.g. a 760px chat column) as current.
 
-The app still has a second family, **Operator** (`.operator-light` /
-`.operator-dark`). It is registered with `next-themes` and its tokens stay
-in `globals.css`, but it is not user-selectable. The product writes only
-`light` / `dark` / `system` of the default family.
+[`docs/STYLE_GUIDE.md`](docs/STYLE_GUIDE.md) is a previous product. Ignore
+its palettes, fonts, and dark-first rules.
+
+## When to load
+
+Read this file before changing anything a user sees or interacts with:
+pages, layouts, components, tokens, theme wiring, empty/error/loading
+states, and UI copy.
+
+Skip it for backend-only work, API contracts with no visual effect,
+telemetry, generated files, and documentation that is not a shipped
+screen.
+
+## Priority when requirements compete
+
+1. Preserve product behavior, i18n keys, workspace-vs-admin scope
+   isolation, and existing component APIs.
+2. Use named tokens and existing primitives (`@/components/ui`,
+   `@/components/shared`). Do not invent a parallel look.
+3. Make the user's job and the primary action unmistakable.
+4. Match the **default** family (light / dark / system). Do not revive
+   Operator as a user-facing flavor.
+5. Cover every reachable state the change can enter.
+6. Refine density, motion, and alignment last, without weakening
+   hierarchy.
+
+Do not redesign the surrounding page to "match a template." Change the
+smallest coherent surface that solves the job.
+
+## Operating contract
+
+- **Start with the job, not the pixels.** Who is acting, on what object,
+  to accomplish what, and what the system will change.
+- **Reuse before restyle.** `Button`, `EmptyState`, `SectionHeader`,
+  `ListDetailLayout`, `RailCard`, and the panel shell already encode
+  decisions. Forking them recreates the divergence they were written to
+  stop.
+- **CSS is the token source.** Hex in this file is an index. New color
+  goes into `globals.css` as a token, then into a utility class — never
+  as a one-off in a component.
+- **Shipped code is evidence, not automatic precedent.** A nearby
+  `text-[11px]` or `bg-amber-500/10` is a leftover to avoid, not a
+  pattern to copy. The ESLint raw-palette guard in
+  `packages/web/eslint.config.mjs` is the mechanical check; this file is
+  the judgment.
+- **Decide before decorating.** Information architecture, component
+  choice, and states come before new color, type, or motion.
+- **Verify the rendered surface.** Source inspection is not visual
+  proof. Exercise the change the way a user would, including the other
+  screens that share the state you touched.
 
 ## Character
 
 Restrained grayscale surfaces, crisp 1px borders for layering, one blue
-accent, small radii, Geist for UI and Geist Mono for data. Calibrated
-against Vercel Geist and Linear — not pure black + pure white.
+accent, small radii, Geist for UI and Geist Mono for data. Tuned for
+long sessions — not pure black + pure white, not a marketing page.
 
 - **Light** is the `@theme` baseline.
 - **Dark** is a class override (`.dark` on `<html>`).
 - New users follow the OS via `defaultTheme="system"`.
-- Choosing light or dark in the UI leaves system mode (no third "system"
-  option).
+- Choosing light or dark in the UI leaves system mode. There is no third
+  "system" control.
 
 Accent (`#0070f3`) is for primary actions, focus rings, and active
 indicators. Status color (success / warning / danger / info) is not
 accent. Everything else stays near-neutral.
+
+The app still has a second family, **Operator** (`.operator-light` /
+`.operator-dark`). It is registered with `next-themes` and its tokens
+stay in `globals.css`, but it is not user-selectable. The product writes
+only `light` / `dark` / `system` of the default family. See the Operator
+section at the bottom — do not delete it, and do not build new UI on it.
 
 ## Architecture
 
@@ -46,7 +116,14 @@ Wiring:
   onto `light` / `dark` so users are not stuck after the flavor picker
   was removed
 - Widgets cannot inherit CSS variables into an iframe `srcdoc`; they
-  snapshot computed tokens (see `WidgetView`)
+  snapshot computed tokens (see `WidgetView`). Literal hex there is
+  structural, not a license to hardcode color in the rest of the app.
+
+Stack to preserve: Next.js App Router, React 19, Tailwind 4, shadcn
+`base-nova` in `packages/web/components/ui`, Lucide, next-intl. Add
+components with `pnpm dlx shadcn@latest add …` from `packages/web/`.
+Do not introduce a second component library, icon kit, or animation
+library.
 
 ## Color
 
@@ -54,10 +131,11 @@ Tailwind 4 maps `--color-*` to utilities (`bg-background`, `text-faint`,
 `border-border-strong`, `bg-success-surface`, …). Use those classes. Do
 not hardcode hex or `gray-*` / `blue-*` / `amber-*` in product UI.
 
-### Surfaces (elevation)
+### Surfaces
 
-Layering is mostly **border + background step**, not shadow. Four
-surfaces:
+Layering is **border + background step**, not shadow. Named surface
+tokens (several share a hex on purpose — pick by role, not by looking
+for a unique swatch):
 
 | Token        | Light     | Dark      | Typical use                                       |
 | ------------ | --------- | --------- | ------------------------------------------------- |
@@ -70,8 +148,8 @@ surfaces:
 | `muted`      | `#f5f5f5` | `#181818` | Quiet fills                                       |
 | `secondary`  | `#f5f5f5` | `#181818` | Secondary button fill                             |
 
-Dark contrast is tuned down from the original spec (`#000` / `#ededed`).
-Body text sits around 12:1 on the soft black, not 17:1.
+Dark contrast is intentionally below a pure-black / near-white pairing.
+Body text sits around 12:1 on the soft black.
 
 ### Text
 
@@ -104,7 +182,11 @@ brand blue for dark mode.
 ### Status
 
 Each status is a four-slot set: `surface` / `border` / `fg` / `solid`.
-`destructive` aliases danger for shadcn.
+`destructive` is the shadcn slot aliased onto danger (`#e5484d` fill,
+`#ffffff` text on the solid slot). The default `Button variant="destructive"`
+is a tinted surface (`bg-destructive/10 text-destructive`), not a solid
+red fill. Use the solid slot only when the action is the page's primary
+destructive control.
 
 **Light**
 
@@ -115,8 +197,8 @@ Each status is a four-slot set: `surface` / `border` / `fg` / `solid`.
 | danger  | `#fdebeb` | `#f5c2c2` | `#c22929` | `#e5484d` |
 | info    | `#e9f2fe` | `#c0dcfb` | `#0a5cc2` | `#3b82f6` |
 
-**Dark** — lower saturation, dimmer foregrounds (the earlier bright mint /
-hot red poked on a dark canvas):
+**Dark** — lower saturation, dimmer foregrounds so status does not poke
+on a dark canvas:
 
 |         | surface                   | border                    | fg        | solid     |
 | ------- | ------------------------- | ------------------------- | --------- | --------- |
@@ -125,9 +207,7 @@ hot red poked on a dark canvas):
 | danger  | `rgba(195, 75, 80, 0.1)`  | `rgba(195, 75, 80, 0.3)`  | `#d97478` | `#b54146` |
 | info    | `rgba(80, 130, 200, 0.1)` | `rgba(80, 130, 200, 0.3)` | `#7eaadf` | `#4a78b8` |
 
-`destructive` = `#e5484d` on `#ffffff` in both modes.
-
-Info covers awaiting-input, notices, and “official” badges — blues that
+Info covers awaiting-input, notices, and "official" badges — blues that
 are **not** actions. Keep `#0070f3` for actions.
 
 ## Typography
@@ -138,7 +218,8 @@ are **not** actions. Keep `#0070f3` for actions.
 | Code, data, commands, paths | Geist Mono → `ui-monospace`, `SF Mono`                                             |
 
 Loaded in `app/layout.tsx` as `--font-geist-sans` / `--font-geist-mono`.
-(Inter Tight and JetBrains Mono are loaded for the Operator family only.)
+Inter Tight and JetBrains Mono are loaded for the Operator family only —
+do not use them on default-family UI.
 
 ### Size scale
 
@@ -152,9 +233,14 @@ Loaded in `app/layout.tsx` as `--font-geist-sans` / `--font-geist-mono`.
 | xl   | 20px | 1.35               | `text-xl`                                           |
 | 2xl  | 24px | 1.25               | `text-2xl`                                          |
 
-Do not add `text-[11px]` / `text-[13px]` one-offs. Section labels: 11px
-uppercase + wider tracking (`text-2xs font-medium uppercase tracking-wider text-faint`).
-Numbers in data (tokens, cost, timestamps): `tabular-nums`.
+Do not add `text-[11px]` / `text-[13px]` one-offs. Prefer `text-2xs`
+over a leftover `text-[11px]`. Section labels: `text-2xs font-medium
+uppercase tracking-wider text-faint`. Numbers in data (tokens, cost,
+timestamps): `tabular-nums`.
+
+`text-lg` appears on a few pane titles (`SectionHeader`). Do not spread
+it. New titles: `text-base` / `text-xl` from the table, or reuse
+`SectionHeader`.
 
 ## Shape
 
@@ -163,6 +249,9 @@ Numbers in data (tokens, cost, timestamps): `tabular-nums`.
 | `radius-xs` | 4px   | Badges, chips                      |
 | `radius`    | 6px   | Buttons, inputs, cards (`rounded`) |
 | `radius-lg` | 10px  | Panels, modals (`rounded-lg`)      |
+
+`EmptyState` and `RailCard` use `rounded-xl`. Reuse that on those
+surfaces; do not invent a fourth radius for a one-off.
 
 Spacing is a 4px grid (Tailwind defaults). Prefer `p-2` / `p-4` / `gap-2`
 / `gap-4` over arbitrary values.
@@ -187,7 +276,8 @@ rules (panel width, `animate-rise-in`).
 Named animations in `globals.css`: `animate-rise-in`, `animate-scale-in`,
 thinking sparkle/shimmer, auth-cube drift. Prefer `transform` + `opacity`.
 `prefers-reduced-motion: reduce` collapses animation and transition
-duration site-wide.
+duration site-wide. Do not add auto-playing decorative motion, marquees,
+or scroll-triggered reveals.
 
 Press feedback on buttons: `active:translate-y-px active:scale-[0.98]`.
 
@@ -196,6 +286,146 @@ Press feedback on buttons: `active:translate-y-px active:scale-[0.98]`.
 Code blocks use the GitHub palette (`.hljs-*` in `globals.css`), not the
 status tokens. Container chrome is `bg-muted` / sunken; only the spans
 are colored. Light and `.dark` each have their own set.
+
+## Product surfaces
+
+These are the layouts that already exist. Fit new UI into them; do not
+invent a fourth chrome.
+
+### Chat
+
+Sidebar / main column / resizable right panel. Column width is
+`CHAT_COLUMN_CLASS` in `packages/web/lib/chatLayout.ts`
+(`max-w-[57.6rem]`, centered) — keep the composer and the message list
+on the same class so the edges line up.
+
+- User bubbles: `bg-raised`, `border-border`, `rounded-lg rounded-br-xs`,
+  right-aligned, `max-w-[88%] md:max-w-[78%]`.
+- Assistant replies: no bubble, no avatar — typography in
+  `ASSISTANT_CONTENT_MAX_CLASS`.
+- Selected conversations in the sidebar: raised fill + a 2px primary
+  left indicator, not a saturated background.
+- Tool-call groups are bordered compact mono rows; row click opens the
+  right panel. Do not restyle them into colorful cards.
+
+### Workspace list-detail
+
+Triggers, scheduled tasks, IM, skills, and similar pages use
+`ListDetailLayout` + `RailCard` + `SectionHeader` + `EmptyState` under
+`components/shared/`.
+
+- Desktop (≥768px): fixed list rail + flex detail. The rail width does
+  not change when a row is selected.
+- Mobile: list fills the pane; the detail is a full-screen overlay with
+  a back control.
+- Selected `RailCard`: `border-primary/40 bg-primary/5` plus a 2px
+  primary left bar. Do not invent a third selected style.
+- Empty states: the shared `EmptyState` (dashed border, icon, title,
+  hint, optional CTA). Pair any `max-w-*` wrapper with `w-full` so the
+  card does not shrink-wrap and the header action does not drift.
+- One primary action per `SectionHeader`, pinned to the content width
+  (`PANE_CONTENT_WIDTH` / `SETTINGS_CONTENT_WIDTH`).
+
+Workspace and org-admin stay **separate pages** even when the modules
+match. Reuse `<List>`, `<DetailPanel>`, … — never
+`mode?: 'admin' | 'workspace'` on a page component.
+
+### Panels
+
+Right-panel content goes through the shared panel shell (`PanelHeader` +
+adapters). Switching content updates the header in place. Terminal /
+code adapters stay sunken + mono. Do not hand-roll a second header.
+
+### Auth and marketing-adjacent screens
+
+Login / setup may be quieter than the app chrome. They still use the
+same tokens, Geist, and primary accent. Do not introduce a campaign
+look (centered hero, badge row, gradient mesh, three feature cards).
+
+## States
+
+Design every state the product can actually enter. Minimum set for a
+changed surface:
+
+- loading (prefer the control's own busy affordance; keep the label)
+- empty (shared `EmptyState`, with a next step when one exists)
+- populated
+- validation / recoverable error (do not wipe the user's input)
+- permission / disabled
+- destructive (verb + object; undo when the system can honestly support
+  it — the toast + delayed-delete path already exists)
+- compact vs wide (chat is the mobile-supported surface; management
+  pages must not overflow or trap the detail off-screen)
+
+Do not add a state the product cannot reach just to look complete.
+
+## Copy
+
+User-visible strings go through next-intl (`en` and `zh` together;
+`scripts/check-i18n-keys.mjs` enforces key parity). Write the sentence
+the least specialized user of that screen can act on. Name the object
+and the consequence on destructive actions. Do not ship `Confirm`, `OK`,
+or a bare verb as the primary destructive CTA.
+
+Placeholder tone: the user commands the agent ("Describe a task…"), not
+the other way around.
+
+## Accessibility
+
+shadcn/Radix covers a baseline. Still required on every change:
+
+- Icon-only buttons have `aria-label`.
+- Decorative icons are `aria-hidden`.
+- Focus is visible (`focus-visible:ring-2 focus-visible:ring-ring` or
+  the button's `ring-3 ring-ring/50`). Never `outline-none` without a
+  replacement.
+- Color is not the only state cue.
+- Hit targets stay usable on touch; input text stays `text-base` where
+  iOS zoom matters.
+
+Deeper a11y review: the `web-design-guidelines` skill.
+
+## Reject
+
+Do not ship these on product UI. They are the usual generated defaults,
+not CubePlex:
+
+- Raw hex, `rgb()`, or Tailwind palette utilities (`bg-gray-900`,
+  `text-blue-500`, `border-amber-200`, …) outside the widget iframe
+  exception.
+- A second brand blue, or status color used as the accent.
+- Decorative gradients, gradient text, glass, blobs, glows, mesh
+  backgrounds, ornamental shadows.
+- Generic centered hero + card grid, badge/pill rows for ordinary
+  metadata, nested cards to fake hierarchy.
+- New radii, type sizes, or durations invented per component.
+- Shadows as the elevation system on panels.
+- Auto-playing decorative motion, simulated typing, pulsing status
+  ornaments.
+- Operator fonts, Operator tokens, or a family picker in new UI.
+- A `mode?: 'admin' | 'workspace'` page, or one route that restyles
+  itself for both scopes.
+- Hand-rolled empty states, pane headers, or list-detail chrome when
+  the shared components already cover it.
+- Copying [`docs/STYLE_GUIDE.md`](docs/STYLE_GUIDE.md) (stale Inter /
+  HSL / dark-first palette).
+
+Restraint here means hierarchy, alignment, and one accent — not empty
+margins and thin rules for their own sake. If a screen feels unfinished,
+fix the job, the states, or the reuse; do not fill the gap with chrome.
+
+## Verify
+
+Before calling UI work done:
+
+1. The primary job and primary action are obvious on the changed screen.
+2. Light and dark both hold contrast and hierarchy.
+3. Every reachable state you touched still works, including empty and
+   error.
+4. Other routes that share the component or store still behave.
+5. Compact and wide layouts do not overflow or hide the main action.
+6. You exercised it in the browser (or the closest substitute) rather
+   than trusting a static screenshot.
 
 ## Usage
 
@@ -211,14 +441,11 @@ are colored. Light and `.dark` each have their own set.
 ```
 
 - Import UI primitives from `@/components/ui/` (shadcn `base-nova`,
-  Lucide icons).
+  Lucide). Shared chrome from `@/components/shared/`.
 - Hover: `hover:bg-accent` or `hover:bg-muted`, 120ms.
-- Focus: `focus-visible:ring-2 focus-visible:ring-ring` (or the button’s
+- Focus: `focus-visible:ring-2 focus-visible:ring-ring` (or the button's
   `ring-3 ring-ring/50`).
-- Selected list rows: raised fill + a 2px primary indicator, not a
-  saturated background.
-- Chat column max-width is 760px; user bubbles are `bg-raised`, 6px
-  radius, right-aligned, max 78% on desktop.
+- Chat column: `CHAT_COLUMN_CLASS`, not a one-off `max-w-*`.
 
 ## Operator family (kept, not shipped)
 
@@ -229,4 +456,5 @@ not brand blue), indigo reserved for the focus ring, tighter radii
 (3 / 5 / 6), no shadows, `.uppercase` auto-promoted to mono.
 
 To re-expose it as a user flavor, restore a family toggle that composes
-`{operator-}{light|dark}` and remove `DefaultThemeGuard`.
+`{operator-}{light|dark}` and remove `DefaultThemeGuard`. Until then,
+new work stays on `light` / `dark` / `system`.

--- a/frontend/design.md
+++ b/frontend/design.md
@@ -1,0 +1,232 @@
+# CubePlex default theme
+
+Living summary of the **default** product theme (the Vercel-Mono family).
+Source of truth for values is
+[`packages/web/app/globals.css`](packages/web/app/globals.css). If this
+doc and that file disagree, believe the CSS.
+
+The app still has a second family, **Operator** (`.operator-light` /
+`.operator-dark`). It is registered with `next-themes` and its tokens stay
+in `globals.css`, but it is not user-selectable. The product writes only
+`light` / `dark` / `system` of the default family.
+
+## Character
+
+Restrained grayscale surfaces, crisp 1px borders for layering, one blue
+accent, small radii, Geist for UI and Geist Mono for data. Calibrated
+against Vercel Geist and Linear — not pure black + pure white.
+
+- **Light** is the `@theme` baseline.
+- **Dark** is a class override (`.dark` on `<html>`).
+- New users follow the OS via `defaultTheme="system"`.
+- Choosing light or dark in the UI leaves system mode (no third "system"
+  option).
+
+Accent (`#0070f3`) is for primary actions, focus rings, and active
+indicators. Status color (success / warning / danger / info) is not
+accent. Everything else stays near-neutral.
+
+## Architecture
+
+Two orthogonal axes, even though only one family ships in the UI:
+
+| Axis   | Values                                          | `<html>` class                                           |
+| ------ | ----------------------------------------------- | -------------------------------------------------------- |
+| Family | default (ships) / operator (registered, hidden) | _(none)_ / `operator-*`                                  |
+| Mode   | light / dark / system                           | `light` / `dark` (or `operator-light` / `operator-dark`) |
+
+`@custom-variant dark` matches both `.dark` and `.operator-dark`, so
+`dark:` utilities work for either family.
+
+Wiring:
+
+- `next-themes` `ThemeProvider` in `packages/web/app/layout.tsx`
+- Light/dark toggle: header `ThemeToggle` and the account menu
+- `DefaultThemeGuard` remaps a leftover `operator-*` localStorage value
+  onto `light` / `dark` so users are not stuck after the flavor picker
+  was removed
+- Widgets cannot inherit CSS variables into an iframe `srcdoc`; they
+  snapshot computed tokens (see `WidgetView`)
+
+## Color
+
+Tailwind 4 maps `--color-*` to utilities (`bg-background`, `text-faint`,
+`border-border-strong`, `bg-success-surface`, …). Use those classes. Do
+not hardcode hex or `gray-*` / `blue-*` / `amber-*` in product UI.
+
+### Surfaces (elevation)
+
+Layering is mostly **border + background step**, not shadow. Four
+surfaces:
+
+| Token        | Light     | Dark      | Typical use                                       |
+| ------------ | --------- | --------- | ------------------------------------------------- |
+| `background` | `#ffffff` | `#0a0a0a` | Page canvas                                       |
+| `card`       | `#fafafa` | `#141414` | Panels, sidebar                                   |
+| `raised`     | `#f5f5f5` | `#181818` | Input bar, user bubble, hover fills               |
+| `sunken`     | `#fafafa` | `#050505` | Code blocks, terminal                             |
+| `popover`    | `#ffffff` | `#141414` | Menus, dropdowns                                  |
+| `accent`     | `#f0f0f0` | `#1c1c1c` | Hover slot (selected rows use raised + indicator) |
+| `muted`      | `#f5f5f5` | `#181818` | Quiet fills                                       |
+| `secondary`  | `#f5f5f5` | `#181818` | Secondary button fill                             |
+
+Dark contrast is tuned down from the original spec (`#000` / `#ededed`).
+Body text sits around 12:1 on the soft black, not 17:1.
+
+### Text
+
+| Token              | Light     | Dark      | Typical use                               |
+| ------------------ | --------- | --------- | ----------------------------------------- |
+| `foreground`       | `#171717` | `#d4d4d7` | Body                                      |
+| `muted-foreground` | `#666666` | `#8e8e93` | Secondary                                 |
+| `faint`            | `#999999` | `#595960` | Labels, hints, captions, section eyebrows |
+
+### Chrome
+
+| Token           | Light     | Dark      | Typical use                               |
+| --------------- | --------- | --------- | ----------------------------------------- |
+| `border`        | `#eaeaea` | `#262626` | Default 1px edge                          |
+| `border-strong` | `#d4d4d4` | `#3a3a3a` | Focused input, toast, stronger separators |
+| `input`         | `#eaeaea` | `#262626` | Input border                              |
+| `ring`          | `#0070f3` | `#0070f3` | Focus ring (same as primary)              |
+
+### Accent and brand
+
+| Token                  | Value     | Typical use                                            |
+| ---------------------- | --------- | ------------------------------------------------------ |
+| `primary`              | `#0070f3` | Solid CTA, active indicator, links that are actions    |
+| `primary-foreground`   | `#ffffff` | Text on primary                                        |
+| `--brand-mark-primary` | `#1268e8` | Logo mark stroke only (`CubePlexLogo`). Not a UI fill. |
+
+Primary is the **same hex in light and dark**. Do not invent a second
+brand blue for dark mode.
+
+### Status
+
+Each status is a four-slot set: `surface` / `border` / `fg` / `solid`.
+`destructive` aliases danger for shadcn.
+
+**Light**
+
+|         | surface   | border    | fg        | solid     |
+| ------- | --------- | --------- | --------- | --------- |
+| success | `#e6f6ee` | `#b3e6cc` | `#0f7b3f` | `#17a35a` |
+| warning | `#fff7e6` | `#ffe1a6` | `#925f00` | `#f5a623` |
+| danger  | `#fdebeb` | `#f5c2c2` | `#c22929` | `#e5484d` |
+| info    | `#e9f2fe` | `#c0dcfb` | `#0a5cc2` | `#3b82f6` |
+
+**Dark** — lower saturation, dimmer foregrounds (the earlier bright mint /
+hot red poked on a dark canvas):
+
+|         | surface                   | border                    | fg        | solid     |
+| ------- | ------------------------- | ------------------------- | --------- | --------- |
+| success | `rgba(45, 145, 90, 0.1)`  | `rgba(45, 145, 90, 0.3)`  | `#6db58a` | `#3f8c63` |
+| warning | `rgba(200, 145, 50, 0.1)` | `rgba(200, 145, 50, 0.3)` | `#d1a164` | `#b07e3a` |
+| danger  | `rgba(195, 75, 80, 0.1)`  | `rgba(195, 75, 80, 0.3)`  | `#d97478` | `#b54146` |
+| info    | `rgba(80, 130, 200, 0.1)` | `rgba(80, 130, 200, 0.3)` | `#7eaadf` | `#4a78b8` |
+
+`destructive` = `#e5484d` on `#ffffff` in both modes.
+
+Info covers awaiting-input, notices, and “official” badges — blues that
+are **not** actions. Keep `#0070f3` for actions.
+
+## Typography
+
+| Role                        | Font                                                                               |
+| --------------------------- | ---------------------------------------------------------------------------------- |
+| UI + body                   | Geist Sans → `-apple-system`, `PingFang SC`, `Microsoft YaHei`, `Noto Sans CJK SC` |
+| Code, data, commands, paths | Geist Mono → `ui-monospace`, `SF Mono`                                             |
+
+Loaded in `app/layout.tsx` as `--font-geist-sans` / `--font-geist-mono`.
+(Inter Tight and JetBrains Mono are loaded for the Operator family only.)
+
+### Size scale
+
+| Step | Size | Line height        | Utility                                             |
+| ---- | ---- | ------------------ | --------------------------------------------------- |
+| 2xs  | 11px | 1.45               | `text-2xs` — eyebrows, chips, meta                  |
+| xs   | 12px | (Tailwind default) | `text-xs`                                           |
+| sm   | 13px | 1.55               | `text-sm`                                           |
+| md   | 14px | 1.55               | `text-md` — body in chat / inputs                   |
+| base | 16px | (Tailwind default) | `text-base` — leave on inputs (iOS zoom) and titles |
+| xl   | 20px | 1.35               | `text-xl`                                           |
+| 2xl  | 24px | 1.25               | `text-2xl`                                          |
+
+Do not add `text-[11px]` / `text-[13px]` one-offs. Section labels: 11px
+uppercase + wider tracking (`text-2xs font-medium uppercase tracking-wider text-faint`).
+Numbers in data (tokens, cost, timestamps): `tabular-nums`.
+
+## Shape
+
+| Token       | Value | Typical use                        |
+| ----------- | ----- | ---------------------------------- |
+| `radius-xs` | 4px   | Badges, chips                      |
+| `radius`    | 6px   | Buttons, inputs, cards (`rounded`) |
+| `radius-lg` | 10px  | Panels, modals (`rounded-lg`)      |
+
+Spacing is a 4px grid (Tailwind defaults). Prefer `p-2` / `p-4` / `gap-2`
+/ `gap-4` over arbitrary values.
+
+Shadows are the exception, not the layering system: `shadow-sm` on the
+composer, `shadow-lg` on toasts and the account menu. Do not pile
+elevation shadows on panels — use `border` vs `border-strong`.
+
+## Motion
+
+| Token            | Value                           | Typical use                          |
+| ---------------- | ------------------------------- | ------------------------------------ |
+| `duration-fast`  | 120ms                           | Hover / press (`duration-fast`)      |
+| `duration-base`  | 200ms                           | Expand / fade (`duration-base`)      |
+| `duration-slow`  | 300ms                           | Panel open / slide (`duration-slow`) |
+| `ease-out-quart` | `cubic-bezier(0.16, 1, 0.3, 1)` | Default easing                       |
+
+`--duration-*` powers Tailwind `duration-*` utilities.
+`--transition-duration-*` is the same set for handwritten `transition:`
+rules (panel width, `animate-rise-in`).
+
+Named animations in `globals.css`: `animate-rise-in`, `animate-scale-in`,
+thinking sparkle/shimmer, auth-cube drift. Prefer `transform` + `opacity`.
+`prefers-reduced-motion: reduce` collapses animation and transition
+duration site-wide.
+
+Press feedback on buttons: `active:translate-y-px active:scale-[0.98]`.
+
+## Syntax highlighting
+
+Code blocks use the GitHub palette (`.hljs-*` in `globals.css`), not the
+status tokens. Container chrome is `bg-muted` / sunken; only the spans
+are colored. Light and `.dark` each have their own set.
+
+## Usage
+
+```tsx
+<div className="bg-background text-foreground">
+<div className="bg-card border border-border">
+<button className="bg-primary text-primary-foreground">
+<p className="text-sm text-muted-foreground">
+<span className="text-2xs text-faint uppercase tracking-wider">
+<div className="bg-raised border border-border-strong">
+<pre className="bg-sunken">
+<div className="bg-success-surface text-success-fg border border-success-border">
+```
+
+- Import UI primitives from `@/components/ui/` (shadcn `base-nova`,
+  Lucide icons).
+- Hover: `hover:bg-accent` or `hover:bg-muted`, 120ms.
+- Focus: `focus-visible:ring-2 focus-visible:ring-ring` (or the button’s
+  `ring-3 ring-ring/50`).
+- Selected list rows: raised fill + a 2px primary indicator, not a
+  saturated background.
+- Chat column max-width is 760px; user bubbles are `bg-raised`, 6px
+  radius, right-aligned, max 78% on desktop.
+
+## Operator family (kept, not shipped)
+
+Do not delete `.operator-light` / `.operator-dark` or drop those names
+from `ThemeProvider`. They are an alternate voice: Inter Tight +
+JetBrains Mono, inverse elevation, high-contrast **neutral** CTA (ink,
+not brand blue), indigo reserved for the focus ring, tighter radii
+(3 / 5 / 6), no shadows, `.uppercase` auto-promoted to mono.
+
+To re-expose it as a user flavor, restore a family toggle that composes
+`{operator-}{light|dark}` and remove `DefaultThemeGuard`.

--- a/frontend/docs/STYLE_GUIDE.md
+++ b/frontend/docs/STYLE_GUIDE.md
@@ -1,6 +1,10 @@
 # CubePlex Frontend 样式指南
 
-> 本文档基于 cubetrace/frontend 的设计系统整理而成，所有前端开发需遵循此规范。
+> **Superseded.** Product UI tokens and visual language live in
+> [`../design.md`](../design.md). Do not follow the palettes, fonts, or
+> dark-first rules below — they describe a previous product.
+>
+> 本文档基于 cubetrace/frontend 的设计系统整理而成，已不再作为实现依据。
 
 ---
 

--- a/frontend/docs/quick-reference.md
+++ b/frontend/docs/quick-reference.md
@@ -3,7 +3,8 @@
 Reference content for the CubePlex frontend monorepo. For workflow
 discipline, hard rules, and skill triggers, see the root
 [AGENTS.md](../../AGENTS.md). For auth, CSRF, SSE, and deployment-mode
-behavior, see [auth-and-sse.md](auth-and-sse.md).
+behavior, see [auth-and-sse.md](auth-and-sse.md). For product UI tokens
+and visual language, see [design.md](../design.md).
 
 ## Repository Structure
 

--- a/frontend/packages/web/__tests__/components/ThemeToggle.test.tsx
+++ b/frontend/packages/web/__tests__/components/ThemeToggle.test.tsx
@@ -1,29 +1,47 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { ThemeProvider } from 'next-themes'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ThemeProvider, useTheme } from 'next-themes'
 import { NextIntlClientProvider } from 'next-intl'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
+import { DefaultThemeGuard } from '@/components/ui/default-theme-guard'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const intl = {
+  locale: 'en' as const,
+  messages: { avatar: { lightTheme: 'Light', darkTheme: 'Dark' } },
+}
+
+function stubMatchMedia(matchesDark: boolean) {
+  vi.stubGlobal('matchMedia', (q: string) => ({
+    matches: matchesDark && q.includes('dark'),
+    media: q,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+    onchange: null,
+  }))
+}
+
+function ThemeProbe() {
+  const { theme } = useTheme()
+  return <span data-testid="theme">{theme}</span>
+}
+
+function cleanupTheme() {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+  document.documentElement.className = ''
+}
 
 // system resolves dark; first click must flip to LIGHT (uses resolvedTheme)
 describe('ThemeToggle under theme=system', () => {
-  afterEach(() => vi.unstubAllGlobals())
+  afterEach(cleanupTheme)
 
   it('first click flips against resolvedTheme, not raw theme', () => {
-    vi.stubGlobal('matchMedia', (q: string) => ({
-      matches: q.includes('dark'),
-      media: q,
-      addListener: () => {},
-      removeListener: () => {},
-      addEventListener: () => {},
-      removeEventListener: () => {},
-      dispatchEvent: () => false,
-      onchange: null,
-    }))
+    stubMatchMedia(true)
     render(
-      <NextIntlClientProvider
-        locale="en"
-        messages={{ avatar: { lightTheme: 'Light', darkTheme: 'Dark' } }}
-      >
+      <NextIntlClientProvider {...intl}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <ThemeToggle />
         </ThemeProvider>
@@ -31,5 +49,47 @@ describe('ThemeToggle under theme=system', () => {
     )
     fireEvent.click(screen.getByRole('button'))
     expect(document.documentElement.classList.contains('light')).toBe(true)
+  })
+
+  it('writes default-family names even when operator is active', async () => {
+    stubMatchMedia(false)
+    render(
+      <NextIntlClientProvider {...intl}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="operator-dark"
+          enableSystem={false}
+          themes={['light', 'dark', 'operator-light', 'operator-dark']}
+        >
+          <ThemeToggle />
+        </ThemeProvider>
+      </NextIntlClientProvider>,
+    )
+    fireEvent.click(await screen.findByRole('button'))
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+    expect(document.documentElement.classList.contains('operator-light')).toBe(false)
+    expect(document.documentElement.classList.contains('operator-dark')).toBe(false)
+  })
+})
+
+describe('DefaultThemeGuard', () => {
+  afterEach(cleanupTheme)
+
+  it('remaps a leftover operator-dark value onto dark', async () => {
+    stubMatchMedia(false)
+    render(
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="operator-dark"
+        enableSystem={false}
+        themes={['light', 'dark', 'operator-light', 'operator-dark']}
+      >
+        <DefaultThemeGuard />
+        <ThemeProbe />
+      </ThemeProvider>,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('theme').textContent).toBe('dark')
+    })
   })
 })

--- a/frontend/packages/web/app/globals.css
+++ b/frontend/packages/web/app/globals.css
@@ -182,8 +182,10 @@
 
   /* ============================================================
      OPERATOR — alt theme family inspired by cubepi docs + e2b.
-     Two variants: .operator-light and .operator-dark; user picks
-     light/dark independently from picking the Operator flavor.
+     Two variants: .operator-light and .operator-dark. The product UI
+     ships the default family; Operator stays registered as an alt
+     family (next-themes names + these classes). Light/dark is
+     independent of family.
      Shared traits:
      - Inter Tight headlines, JetBrains Mono chrome
      - Inverse elevation: page is the softer surface, panels are

--- a/frontend/packages/web/app/layout.tsx
+++ b/frontend/packages/web/app/layout.tsx
@@ -5,6 +5,7 @@ import { Inter_Tight, JetBrains_Mono } from 'next/font/google'
 import { NextIntlClientProvider } from 'next-intl'
 import { getLocale, getMessages } from 'next-intl/server'
 import { ThemeProvider } from 'next-themes'
+import { DefaultThemeGuard } from '@/components/ui/default-theme-guard'
 import { Toaster } from '@/components/ui/sonner'
 import './globals.css'
 
@@ -46,8 +47,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             attribute="class"
             defaultTheme="system"
             enableSystem
+            // Operator family stays registered so its CSS classes still resolve.
             themes={['light', 'dark', 'operator-light', 'operator-dark']}
           >
+            <DefaultThemeGuard />
             {children}
             <Toaster />
           </ThemeProvider>

--- a/frontend/packages/web/components/chat/widget/WidgetView.tsx
+++ b/frontend/packages/web/components/chat/widget/WidgetView.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Copy, Maximize2, Minimize2, RotateCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { htmlIsDark } from '@/lib/themeFlavor'
 import { WIDGET_SHELL_HTML } from './widgetShell'
 
 const READY_TIMEOUT_MS = 5000
@@ -40,7 +41,7 @@ function resolveThemeTokens(isDark: boolean): ThemeTokens {
 }
 
 function isAppDark(): boolean {
-  return typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
+  return typeof document !== 'undefined' && htmlIsDark(document.documentElement)
 }
 
 interface WidgetViewProps {
@@ -301,7 +302,7 @@ function WidgetFrame({
     const push = () => {
       const win = iframeRef.current?.contentWindow
       if (!win) return
-      const t = resolveThemeTokens(html.classList.contains('dark'))
+      const t = resolveThemeTokens(htmlIsDark(html))
       win.postMessage({ widgetId, type: 'theme', ...t }, '*')
     }
     if (ready) push()

--- a/frontend/packages/web/components/sidebar/AvatarPopover.tsx
+++ b/frontend/packages/web/components/sidebar/AvatarPopover.tsx
@@ -25,12 +25,11 @@ import {
   LogOut,
   Moon,
   Shield,
-  Sparkles,
   Sun,
-  Terminal,
   User as UserIcon,
 } from 'lucide-react'
 import { clearAllPresetSelectionStores } from '@/lib/stores/preset-selection'
+import { resolveColorMode } from '@/lib/themeFlavor'
 
 export function AvatarPopover({ collapsed }: { collapsed?: boolean }) {
   const t = useTranslations('avatar')
@@ -44,6 +43,7 @@ export function AvatarPopover({ collapsed }: { collapsed?: boolean }) {
   const [mounted, setMounted] = useState(false)
   const [langOpen, setLangOpen] = useState(false)
   const currentLocale = useLocale()
+  const currentMode = resolveColorMode(theme, resolvedTheme)
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -143,56 +143,20 @@ export function AvatarPopover({ collapsed }: { collapsed?: boolean }) {
           <span>{t('profileSettings')}</span>
         </Link>
 
-        {mounted &&
-          (() => {
-            // Two orthogonal axes: flavor (default / operator) × mode (light / dark).
-            // Compose to a concrete next-themes value: light, dark,
-            // operator-light, operator-dark. resolvedTheme handles 'system'.
-            const isOperator = theme === 'operator-light' || theme === 'operator-dark'
-            const currentMode =
-              theme === 'operator-light' || theme === 'light'
-                ? 'light'
-                : theme === 'operator-dark' || theme === 'dark'
-                  ? 'dark'
-                  : (resolvedTheme ?? 'light')
-            const toggleMode = () => {
-              const nextMode = currentMode === 'dark' ? 'light' : 'dark'
-              setTheme(isOperator ? `operator-${nextMode}` : nextMode)
-            }
-            const toggleFlavor = () => {
-              setTheme(isOperator ? currentMode : `operator-${currentMode}`)
-            }
-            return (
-              <>
-                <button
-                  type="button"
-                  onClick={toggleMode}
-                  className="w-full flex items-center gap-2 px-2 py-1.5 rounded-sm text-[12.5px] hover:bg-accent/60 transition-colors"
-                >
-                  {currentMode === 'dark' ? (
-                    <Sun className="size-3.5 text-muted-foreground" />
-                  ) : (
-                    <Moon className="size-3.5 text-muted-foreground" />
-                  )}
-                  <span>{currentMode === 'dark' ? t('lightTheme') : t('darkTheme')}</span>
-                </button>
-                <button
-                  type="button"
-                  onClick={toggleFlavor}
-                  className="w-full flex items-center gap-2 px-2 py-1.5 rounded-sm text-[12.5px] hover:bg-accent/60 transition-colors"
-                >
-                  {isOperator ? (
-                    <Sparkles className="size-3.5 text-muted-foreground" />
-                  ) : (
-                    <Terminal className="size-3.5 text-muted-foreground" />
-                  )}
-                  <span className="font-mono uppercase tracking-wider text-[11px]">
-                    {isOperator ? 'Default theme' : 'Operator theme'}
-                  </span>
-                </button>
-              </>
-            )
-          })()}
+        {mounted && (
+          <button
+            type="button"
+            onClick={() => setTheme(currentMode === 'dark' ? 'light' : 'dark')}
+            className="w-full flex items-center gap-2 px-2 py-1.5 rounded-sm text-[12.5px] hover:bg-accent/60 transition-colors"
+          >
+            {currentMode === 'dark' ? (
+              <Sun className="size-3.5 text-muted-foreground" />
+            ) : (
+              <Moon className="size-3.5 text-muted-foreground" />
+            )}
+            <span>{currentMode === 'dark' ? t('lightTheme') : t('darkTheme')}</span>
+          </button>
+        )}
 
         {(() => {
           const languages = [

--- a/frontend/packages/web/components/ui/default-theme-guard.tsx
+++ b/frontend/packages/web/components/ui/default-theme-guard.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { useEffect } from 'react'
+import { remapOperatorTheme } from '@/lib/themeFlavor'
+
+/** Remap leftover operator-* storage to the default family. */
+export function DefaultThemeGuard() {
+  const { theme, setTheme } = useTheme()
+  useEffect(() => {
+    const next = remapOperatorTheme(theme)
+    if (next) setTheme(next)
+  }, [theme, setTheme])
+  return null
+}

--- a/frontend/packages/web/components/ui/sonner.tsx
+++ b/frontend/packages/web/components/ui/sonner.tsx
@@ -2,12 +2,13 @@
 
 import { useTheme } from 'next-themes'
 import { Toaster as Sonner } from 'sonner'
+import { resolveColorMode } from '@/lib/themeFlavor'
 
 export function Toaster(props: React.ComponentProps<typeof Sonner>) {
-  const { resolvedTheme } = useTheme()
+  const { theme, resolvedTheme } = useTheme()
   return (
     <Sonner
-      theme={resolvedTheme === 'dark' ? 'dark' : 'light'}
+      theme={resolveColorMode(theme, resolvedTheme)}
       position="bottom-right"
       toastOptions={{
         classNames: {

--- a/frontend/packages/web/components/ui/theme-toggle.tsx
+++ b/frontend/packages/web/components/ui/theme-toggle.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import { Button } from './button'
 import { Moon, Sun } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { resolveColorMode } from '@/lib/themeFlavor'
 
 export function ThemeToggle() {
   const t = useTranslations('avatar')
@@ -18,18 +19,12 @@ export function ThemeToggle() {
 
   if (!mounted) return null
 
-  // Theme is two-axis: flavor (default | operator) × mode (light | dark).
-  // This button toggles mode only, preserving the active flavor.
-  const isOperator = theme === 'operator-light' || theme === 'operator-dark'
-  const currentMode =
-    theme === 'operator-light' || theme === 'light'
-      ? 'light'
-      : theme === 'operator-dark' || theme === 'dark'
-        ? 'dark'
-        : (resolvedTheme ?? 'light')
+  // Product UI writes the default family only (light | dark). Operator names
+  // still resolve so a leftover stored value shows the right icon.
+  const currentMode = resolveColorMode(theme, resolvedTheme)
   const label = currentMode === 'dark' ? t('lightTheme') : t('darkTheme')
   const next = currentMode === 'dark' ? 'light' : 'dark'
-  const onClick = () => setTheme(isOperator ? `operator-${next}` : next)
+  const onClick = () => setTheme(next)
 
   return (
     <Button variant="ghost" size="sm" aria-label={label} title={label} onClick={onClick}>

--- a/frontend/packages/web/lib/themeFlavor.test.ts
+++ b/frontend/packages/web/lib/themeFlavor.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { htmlIsDark, remapOperatorTheme, resolveColorMode } from './themeFlavor'
+
+describe('resolveColorMode', () => {
+  it('reads default-family names', () => {
+    expect(resolveColorMode('light')).toBe('light')
+    expect(resolveColorMode('dark')).toBe('dark')
+  })
+
+  it('reads operator-family names as the same color mode', () => {
+    expect(resolveColorMode('operator-light')).toBe('light')
+    expect(resolveColorMode('operator-dark')).toBe('dark')
+  })
+
+  it('falls back to resolvedTheme when theme is system', () => {
+    expect(resolveColorMode('system', 'dark')).toBe('dark')
+    expect(resolveColorMode('system', 'light')).toBe('light')
+    expect(resolveColorMode('system', 'operator-dark')).toBe('dark')
+  })
+})
+
+describe('remapOperatorTheme', () => {
+  it('maps operator names onto the default family', () => {
+    expect(remapOperatorTheme('operator-light')).toBe('light')
+    expect(remapOperatorTheme('operator-dark')).toBe('dark')
+  })
+
+  it('leaves default-family and system values alone', () => {
+    expect(remapOperatorTheme('light')).toBeNull()
+    expect(remapOperatorTheme('dark')).toBeNull()
+    expect(remapOperatorTheme('system')).toBeNull()
+    expect(remapOperatorTheme(undefined)).toBeNull()
+  })
+})
+
+describe('htmlIsDark', () => {
+  const classListOf = (...tokens: string[]) => ({
+    contains: (name: string) => tokens.includes(name),
+  })
+
+  it('treats .dark and .operator-dark as dark', () => {
+    expect(htmlIsDark({ classList: classListOf('dark') })).toBe(true)
+    expect(htmlIsDark({ classList: classListOf('operator-dark') })).toBe(true)
+  })
+
+  it('treats default and operator light as not dark', () => {
+    expect(htmlIsDark({ classList: classListOf() })).toBe(false)
+    expect(htmlIsDark({ classList: classListOf('light') })).toBe(false)
+    expect(htmlIsDark({ classList: classListOf('operator-light') })).toBe(false)
+  })
+})

--- a/frontend/packages/web/lib/themeFlavor.ts
+++ b/frontend/packages/web/lib/themeFlavor.ts
@@ -1,0 +1,30 @@
+/** Color mode independent of theme family (default vs operator). */
+
+export type ColorMode = 'light' | 'dark'
+
+export function isLightThemeName(name: string | undefined): boolean {
+  return name === 'light' || name === 'operator-light'
+}
+
+export function isDarkThemeName(name: string | undefined): boolean {
+  return name === 'dark' || name === 'operator-dark'
+}
+
+export function resolveColorMode(theme: string | undefined, resolvedTheme?: string): ColorMode {
+  if (isLightThemeName(theme)) return 'light'
+  if (isDarkThemeName(theme)) return 'dark'
+  if (isLightThemeName(resolvedTheme)) return 'light'
+  if (isDarkThemeName(resolvedTheme)) return 'dark'
+  return 'light'
+}
+
+/** Map a leftover operator-* next-themes value onto the default family. */
+export function remapOperatorTheme(theme: string | undefined): ColorMode | null {
+  if (theme === 'operator-light') return 'light'
+  if (theme === 'operator-dark') return 'dark'
+  return null
+}
+
+export function htmlIsDark(html: { classList: { contains(token: string): boolean } }): boolean {
+  return html.classList.contains('dark') || html.classList.contains('operator-dark')
+}


### PR DESCRIPTION
## Summary

- Remove the Default / Operator flavor picker from the account menu. Light/dark still toggles, but always writes the default family (`light` / `dark` / `system`).
- Remap leftover `operator-*` localStorage values onto `light` / `dark` so users are not stuck after the picker is gone.
- Keep Operator CSS and the `next-themes` names so the alt family can be re-enabled later.
- Document the current default theme in `frontend/design.md`.

## Test plan

- [x] `vitest` for `themeFlavor`, `ThemeToggle`, and `DefaultThemeGuard` (10 tests)
- [x] Pre-push frontend `check-ci` (build-core + lint + format + type-check + vitest + next build)
- [x] Browser: login page with `localStorage.theme = operator-dark` remaps to default dark (`#0a0a0a` / `#0070f3`); forcing `.operator-dark` still applies Operator tokens
- [ ] Logged-in account menu: flavor row is gone; light/dark still works