### PR TITLE
Stop skills.sh path aliases from colliding candidate ids

### DIFF
--- a/backend/cubeplex/skills/discovery.py
+++ b/backend/cubeplex/skills/discovery.py
@@ -48,6 +48,29 @@ def _dedupe_key(c: SkillCandidate) -> str:
     return c.name.split(":", 1)[-1].strip().lower()
 
 
+def _path_leaf(source_ref: str) -> str:
+    return source_ref.rstrip("/").rsplit("/", 1)[-1].lower()
+
+
+def _prefer_same_id(
+    incumbent: SkillCandidate, challenger: SkillCandidate, *, query: str
+) -> SkillCandidate:
+    """Pick one candidate when two share an install handle (candidate_id).
+
+    Prefer the display name that matches the directory leaf so a catalog
+    alias (website-to-hyperframes) does not hide the real slug (hyperframes).
+    """
+    inc_exact = _dedupe_key(incumbent) == _path_leaf(incumbent.source_ref)
+    ch_exact = _dedupe_key(challenger) == _path_leaf(challenger.source_ref)
+    if ch_exact and not inc_exact:
+        return challenger
+    if inc_exact and not ch_exact:
+        return incumbent
+    if _score(challenger, query) < _score(incumbent, query):
+        return challenger
+    return incumbent
+
+
 def _tokens(text: str) -> set[str]:
     return {t for t in re.split(r"[^a-z0-9]+", text.lower()) if t}
 
@@ -85,18 +108,30 @@ def _score(c: SkillCandidate, query: str) -> tuple[int, int, int, int]:
 def rank_candidates(
     candidates: list[SkillCandidate], *, query: str, limit: int
 ) -> list[SkillCandidate]:
-    """Dedupe by normalized display slug (local wins), then sort and truncate.
+    """Dedupe by install handle then display slug (local wins), sort, truncate.
 
     Drop candidates with no query overlap (bucket 3) only if local — remote
     API sources (skills.sh, etc.) have already filtered for relevance, so
     bucket 3 filtering should not apply to them. LocalCatalogAdapter returns
     every visible skill regardless of query, so filtering it prevents
     spurious results like discover?q=<nonsense>.
+
+    candidate_id collapse runs first: two catalog names that resolve to the
+    same source_ref are the same install target and must not both reach the
+    client (React keys on candidate_id).
     """
-    by_slug: dict[str, SkillCandidate] = {}
+    by_id: dict[str, SkillCandidate] = {}
     for c in candidates:
         if c.source_kind == "local" and _score(c, query)[0] >= 3:
             continue  # drop unrelated local skills only
+        prev = by_id.get(c.candidate_id)
+        if prev is None:
+            by_id[c.candidate_id] = c
+        else:
+            by_id[c.candidate_id] = _prefer_same_id(prev, c, query=query)
+
+    by_slug: dict[str, SkillCandidate] = {}
+    for c in by_id.values():
         key = _dedupe_key(c)
         prev = by_slug.get(key)
         if prev is None:

--- a/backend/cubeplex/skills/sources/skills_sh.py
+++ b/backend/cubeplex/skills/sources/skills_sh.py
@@ -154,18 +154,17 @@ class SkillsShAdapter:
     ) -> str:
         """Resolve the actual GitHub directory path for a skillId.
 
-        skills.sh sometimes prefixes skillIds with an owner alias
-        (e.g. "sleek-design-mobile-apps" for dir "design-mobile-apps").
-        If no exact match, progressively strip the leading dash-segment
-        until a match is found or the slug is exhausted.
+        skills.sh sometimes prefixes skillIds with a single owner-alias
+        segment (e.g. "sleek-design-mobile-apps" for dir "design-mobile-apps").
+        Only that one leading segment is stripped. Going further lets a
+        distinct catalog name (website-to-hyperframes) steal a sibling
+        directory (hyperframes) and emit a duplicate candidate_id.
         """
         if (source, slug) in skill_paths:
             return skill_paths[(source, slug)]
-        parts = slug.split("-")
-        for i in range(1, len(parts)):
-            candidate = "-".join(parts[i:])
-            if (source, candidate) in skill_paths:
-                return skill_paths[(source, candidate)]
+        _, sep, rest = slug.partition("-")
+        if sep and rest and (source, rest) in skill_paths:
+            return skill_paths[(source, rest)]
         return slug
 
     def trust_for_ref(self, source_ref: str) -> TrustTier:

--- a/backend/tests/e2e/test_skills_sync_cold_start_e2e.py
+++ b/backend/tests/e2e/test_skills_sync_cold_start_e2e.py
@@ -6,7 +6,7 @@ Two complementary assertion blocks:
   1. Direct ``_sync_skills`` call into a ``MemSandbox`` — asserts manifest +
      file content without any LazySandbox overhead (fast, readable).
   2. ``LazySandbox.execute("true")`` gate — exercises ``_ensure_skills_synced``
-     / ``_synced_for_this_run`` / ``_sync_lock`` end-to-end with a
+     / ``_synced_skills_generation`` / ``_sync_lock`` end-to-end with a
      ``_CountingCatalog`` wrapper to verify the second execute call short-circuits.
 """
 
@@ -118,7 +118,7 @@ async def test_cold_start_writes_files_and_manifest(
     # -----------------------------------------------------------------------
     # Block 2: Drive sync through the LazySandbox gate.
     #
-    # Exercises _ensure_skills_synced / _synced_for_this_run / _sync_lock —
+    # Exercises _ensure_skills_synced / generation flag / _sync_lock —
     # code paths that the direct _sync_skills call above bypasses.
     # -----------------------------------------------------------------------
     from cryptography.fernet import Fernet
@@ -147,16 +147,16 @@ async def test_cold_start_writes_files_and_manifest(
 
         # First execute: _ensure_skills_synced runs → list_enabled called once.
         await lazy2.execute("true")
-        assert lazy2._synced_for_this_run is True, (
-            "_synced_for_this_run should be True after first execute"
+        assert lazy2._synced_skills_generation == lazy2._skills_generation, (
+            "current generation should be synced after first execute"
         )
         assert counting_catalog.list_enabled_calls == 1, (
             f"expected 1 list_enabled call after first execute, got {counting_catalog.list_enabled_calls}"
         )
 
-        # Second execute: short-circuit — _synced_for_this_run already True.
+        # Second execute: short-circuit — current generation already synced.
         await lazy2.execute("true")
-        assert lazy2._synced_for_this_run is True
+        assert lazy2._synced_skills_generation == lazy2._skills_generation
         assert counting_catalog.list_enabled_calls == 1, (
             "second execute must NOT trigger another sync — "
             f"list_enabled_calls={counting_catalog.list_enabled_calls}"

--- a/backend/tests/e2e/test_skills_sync_failure_e2e.py
+++ b/backend/tests/e2e/test_skills_sync_failure_e2e.py
@@ -10,10 +10,9 @@ Two complementary blocks:
      ``_sync_skills`` itself and that the manifest is NOT written (no half-state).
      Subsequent successful sync heals the state.
   2. LazySandbox gate: drives the same failure through ``_ensure_skills_synced``
-     so we verify the outer ``except Exception`` catch (F4 invariant) —
-     ``_synced_for_this_run`` stays False on failure, then becomes True after
-     the healing retry.  Uses the same outer-boundary ``MemSandbox.execute``
-     patch as Block 1 — no internal function patching.
+     so we verify the F4 invariant — the current skills generation stays
+     unsynced on failure, then matches after a successful retry. Uses the
+     same outer-boundary ``MemSandbox.execute`` patch as Block 1.
 """
 
 from __future__ import annotations
@@ -153,16 +152,14 @@ async def test_lazy_sandbox_f4_synced_flag_stays_false_on_failure_then_heals(
     fresh_workspace_and_sandbox: SimpleNamespace,
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """F4 invariant: _ensure_skills_synced must NOT set _synced_for_this_run on failure.
+    """F4: a failed sync must not mark the current skills generation ready.
 
     Patches ``MemSandbox.execute`` at the outer boundary to raise on the
     tar-extract command (first occurrence only), which causes the real
-    ``_sync_skills`` to raise, which ``_ensure_skills_synced`` catches without
-    setting the flag.  The second ``lazy.execute`` retries the real sync path
-    and heals.
+    ``_sync_skills`` to raise. ``_sync_skills_locked`` then leaves
+    ``_synced_skills_generation`` unset so the next ``lazy.execute`` retries.
 
-    Invariant: if F4 regresses (flag set on failure), the second execute would
-    short-circuit and leave _synced_for_this_run True and skills stale.
+    If F4 regresses, the second execute short-circuits and skills stay stale.
     """
     from tests.e2e.conftest import install_skill_for_workspace, uninstall_skill_for_workspace
 
@@ -198,7 +195,7 @@ async def test_lazy_sandbox_f4_synced_flag_stays_false_on_failure_then_heals(
         # Must accept as_root: LazySandbox always forwards it. Dropping the
         # kwarg raises TypeError after the intentional tar failure; the lazy
         # retry path then wipes the injected MemSandbox, re-syncs successfully,
-        # and spuriously sets _synced_for_this_run True (F4 false-positive).
+        # and spuriously marks the current generation synced (F4 false-positive).
         if "tar -xzf" in command and not fail_once["done"]:
             fail_once["done"] = True
             raise RuntimeError("simulated extract failure")
@@ -228,16 +225,16 @@ async def test_lazy_sandbox_f4_synced_flag_stays_false_on_failure_then_heals(
             lazy._sandbox = sandbox
 
             # First execute: _ensure_skills_synced → real _sync_skills →
-            # sandbox.execute(tar cmd) raises → caught by _ensure_skills_synced
-            # → _synced_for_this_run stays False.  The execute itself must NOT raise.
+            # sandbox.execute(tar cmd) raises → generation stays unsynced.
+            # The execute itself must NOT raise.
             result = await lazy.execute("true")
             assert result.exit_code in (0, None), (
                 f"sandbox not usable after sync failure: exit={result.exit_code}"
             )
 
-            # F4: flag must remain False so the next execute retries.
-            assert lazy._synced_for_this_run is False, (
-                "_synced_for_this_run was set True despite _sync_skills failure — F4 violated"
+            # F4: current generation must stay unsynced so the next execute retries.
+            assert lazy._synced_skills_generation is None, (
+                "current generation was marked synced despite _sync_skills failure"
             )
 
             # Manifest must NOT be present (first sync failed before writing it).
@@ -256,9 +253,9 @@ async def test_lazy_sandbox_f4_synced_flag_stays_false_on_failure_then_heals(
             # Second execute: real _sync_skills runs without interference → heals.
             await lazy.execute("true")
 
-            # Flag becomes True after the successful retry.
-            assert lazy._synced_for_this_run is True, (
-                "_synced_for_this_run should be True after successful retry"
+            # Current generation is marked synced after the successful retry.
+            assert lazy._synced_skills_generation == lazy._skills_generation, (
+                "current generation should be synced after successful retry"
             )
 
             # Manifest must now be populated.

--- a/backend/tests/unit/test_skill_discovery_ranking.py
+++ b/backend/tests/unit/test_skill_discovery_ranking.py
@@ -95,6 +95,44 @@ def test_non_matching_query_drops_unrelated_candidates():
     assert rank_candidates(cands, query="quantum origami", limit=5) == []
 
 
+def test_dedupe_same_candidate_id_keeps_path_matching_name():
+    """Two catalog names that resolve to the same install target collapse to one.
+
+    Prefer the candidate whose display name matches the directory leaf, so
+    'hyperframes' wins over 'website-to-hyperframes' when they share a
+    candidate_id.
+    """
+    shared_id = "remote-hyperframes-dir"
+    shared_ref = "heygen-com/hyperframes/main/skills/hyperframes"
+    alias = SkillCandidate(
+        candidate_id=shared_id,
+        name="website-to-hyperframes",
+        canonical_name="website-to-hyperframes",
+        description="",
+        source_kind="remote",
+        source_ref=shared_ref,
+        keywords=[],
+        stars=1,
+    )
+    canonical = SkillCandidate(
+        candidate_id=shared_id,
+        name="hyperframes",
+        canonical_name="hyperframes",
+        description="",
+        source_kind="remote",
+        source_ref=shared_ref,
+        keywords=[],
+        stars=10,
+    )
+    ranked = rank_candidates([alias, canonical], query="hyperframes", limit=20)
+    assert len(ranked) == 1
+    assert ranked[0].name == "hyperframes"
+
+    ranked_reverse = rank_candidates([canonical, alias], query="hyperframes", limit=20)
+    assert len(ranked_reverse) == 1
+    assert ranked_reverse[0].name == "hyperframes"
+
+
 def test_matching_subset_survives_when_others_dont():
     target = _c("slide-deck", desc="Build presentations", keywords=["slides"], kind="local")
     noise = _c("data-pipeline", desc="ETL jobs", keywords=["etl"], kind="local")

--- a/backend/tests/unit/test_skills_sh_adapter.py
+++ b/backend/tests/unit/test_skills_sh_adapter.py
@@ -120,6 +120,44 @@ def test_index_skill_paths_root_level_skill_md():
     assert skill_paths[("jackwener/twitter-cli", "twitter-cli")] == ""
 
 
+def _adapter() -> SkillsShAdapter:
+    return SkillsShAdapter(
+        source_id="test-registry",
+        trust_tier="community",
+        source_name="skills.sh",
+        github_token=None,
+    )
+
+
+def test_resolve_keeps_owner_alias_to_real_directory():
+    """skills.sh prefixes some skillIds with a single owner-alias segment."""
+    adapter = _adapter()
+    source = "sleek/skills"
+    skill_paths = {(source, "design-mobile-apps"): "skills/design-mobile-apps"}
+    assert (
+        adapter._resolve_skill_path(source, "sleek-design-mobile-apps", skill_paths)
+        == "skills/design-mobile-apps"
+    )
+
+
+def test_resolve_does_not_steal_sibling_directory_via_suffix():
+    """website-to-hyperframes must not bind to the sibling hyperframes folder.
+
+    Progressive suffix matching used to strip 'website-to-' and land on
+    skills/hyperframes, so two catalog names shared one candidate_id.
+    """
+    adapter = _adapter()
+    source = "heygen-com/hyperframes"
+    skill_paths = {
+        (source, "hyperframes"): "skills/hyperframes",
+        (source, "hyperframes-cli"): "skills/hyperframes-cli",
+    }
+    assert adapter._resolve_skill_path(source, "hyperframes", skill_paths) == ("skills/hyperframes")
+    assert adapter._resolve_skill_path(source, "website-to-hyperframes", skill_paths) == (
+        "website-to-hyperframes"
+    )
+
+
 def test_official_source_detection():
     """Test that official status comes only from the whitelist, not registry config."""
     from cubeplex.skills.sources.base import TrustTier


### PR DESCRIPTION
## Summary

`website-to-hyperframes` and `hyperframes` were two different catalog names that resolved to the same GitHub directory (`skills/hyperframes`). They shared a `candidate_id`, so React warned about duplicate keys even though the cards had different titles.

- skills.sh path resolution now strips **one** owner-alias segment only (`sleek-design-mobile-apps` → `design-mobile-apps`), not every suffix until a sibling hits.
- Ranking also collapses leftover same-`candidate_id` rows, preferring the name that matches the directory leaf.

Reproduced from trace `e02b59c3` / `conv-1q9JW8dZxxaOYD` (`platform_skills_find` query=`hyperframes`).

## Test plan

- [x] `pytest tests/unit/test_skills_sh_adapter.py tests/unit/test_skill_discovery_ranking.py` (18 passed)
- [x] Pre-push backend `check-ci`