### PR TITLE
fix(auth): rate-limit proxied clients correctly

### DIFF
--- a/backend/config.test.yaml
+++ b/backend/config.test.yaml
@@ -98,6 +98,9 @@ test:
   # Auth: relax rate limits so playwright e2e (multiple registrations from 127.0.0.1) don't hit 429
   auth:
     rate_limit:
+      # Unit tests must not depend on a live Redis server. Production defaults
+      # to redis.url so rate-limit windows are shared across backend replicas.
+      storage_uri: "memory://"
       login_per_minute: 1000
       register_per_minute: 1000
     # Low policy + verification=auto (False, since email.backend=log) keep the

--- a/backend/cubeplex/api/middleware/rate_limit.py
+++ b/backend/cubeplex/api/middleware/rate_limit.py
@@ -2,10 +2,26 @@
 
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+from starlette.requests import Request
 
 from cubeplex.config import config
 
-limiter = Limiter(key_func=get_remote_address)
+
+def get_rate_limit_client(request: Request) -> str:
+    """Return the original client address carried through the frontend proxy."""
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        client_address = forwarded_for.split(",", maxsplit=1)[0].strip()
+        if client_address:
+            return client_address
+    return get_remote_address(request)
+
+
+limiter = Limiter(
+    key_func=get_rate_limit_client,
+    storage_uri=str(config.get("redis.url", "redis://localhost:6379/0")),
+    key_prefix=f"{config.get('redis.key_prefix', 'cubeplex')}:rate-limit",
+)
 
 LOGIN_LIMIT = f"{config.get('auth.rate_limit.login_per_minute', 5)}/minute"
 REGISTER_LIMIT = f"{config.get('auth.rate_limit.register_per_minute', 3)}/minute"

--- a/backend/cubeplex/api/middleware/rate_limit.py
+++ b/backend/cubeplex/api/middleware/rate_limit.py
@@ -19,7 +19,12 @@ def get_rate_limit_client(request: Request) -> str:
 
 limiter = Limiter(
     key_func=get_rate_limit_client,
-    storage_uri=str(config.get("redis.url", "redis://localhost:6379/0")),
+    storage_uri=str(
+        config.get(
+            "auth.rate_limit.storage_uri",
+            config.get("redis.url", "redis://localhost:6379/0"),
+        )
+    ),
     key_prefix=f"{config.get('redis.key_prefix', 'cubeplex')}:rate-limit",
 )
 

--- a/backend/docs/auth.md
+++ b/backend/docs/auth.md
@@ -14,7 +14,9 @@ via `OrgScopedMixin`.
 
 - **fastapi-users** with JWT cookie strategy.
 - Auth cookie: `cubeplex_auth`.
-- Register / login endpoints are rate-limited via slowapi.
+- Register / login endpoints are rate-limited via slowapi, using Redis so the
+  limit is shared by backend replicas. Requests forwarded by the frontend are
+  keyed by the original address in `X-Forwarded-For`.
 
 ### CSRF
 

--- a/backend/tests/unit/test_rate_limit.py
+++ b/backend/tests/unit/test_rate_limit.py
@@ -1,8 +1,13 @@
 """Tests for HTTP rate-limit client identification."""
 
+from limits.storage import MemoryStorage
 from starlette.requests import Request
 
 from cubeplex.api.middleware.rate_limit import limiter
+
+
+def test_rate_limiter_uses_in_memory_storage_in_tests() -> None:
+    assert isinstance(limiter._storage, MemoryStorage)
 
 
 def test_rate_limit_client_uses_original_forwarded_address() -> None:

--- a/backend/tests/unit/test_rate_limit.py
+++ b/backend/tests/unit/test_rate_limit.py
@@ -1,0 +1,33 @@
+"""Tests for HTTP rate-limit client identification."""
+
+from starlette.requests import Request
+
+from cubeplex.api.middleware.rate_limit import limiter
+
+
+def test_rate_limit_client_uses_original_forwarded_address() -> None:
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/v1/auth/login",
+            "headers": [(b"x-forwarded-for", b"198.51.100.10, 10.0.0.5")],
+            "client": ("10.0.0.5", 12345),
+        }
+    )
+
+    assert limiter._key_func(request) == "198.51.100.10"
+
+
+def test_rate_limit_client_uses_peer_address_without_forwarded_header() -> None:
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/v1/auth/login",
+            "headers": [],
+            "client": ("198.51.100.11", 12345),
+        }
+    )
+
+    assert limiter._key_func(request) == "198.51.100.11"


### PR DESCRIPTION
Closes #556

- use the original client address forwarded by the frontend
- store slowapi counters in Redis so backend replicas share a limit
- cover forwarded and direct request address selection

Verified:
- `uv run pytest tests/unit/test_rate_limit.py --no-cov`
- `uv run pytest tests/e2e/test_auth.py --no-cov`