### PR TITLE
fix(auth): enforce CSRF for cookie sessions

### DIFF
--- a/backend/cubeplex/api/middleware/csrf.py
+++ b/backend/cubeplex/api/middleware/csrf.py
@@ -37,12 +37,7 @@ class CSRFMiddleware:
         cookies = _parse_cookies(scope["headers"])
         has_auth = self.auth_cookie in cookies
         csrf_cookie = cookies.get(self.csrf_cookie)
-        # Bearer-authed requests (API keys) bypass CSRF: there is no cookie to
-        # replay so the attack the double-submit cookie defends against does
-        # not apply. The Bearer token is the authentication.
-        has_bearer = _has_bearer_auth(scope["headers"])
-
-        if method not in SAFE_METHODS and has_auth and not has_bearer:
+        if method not in SAFE_METHODS and has_auth:
             csrf_header = _get_header(scope["headers"], CSRF_HEADER.encode())
             if not csrf_cookie or not csrf_header or csrf_cookie != csrf_header:
                 await _send_403(send, "CSRF token missing or mismatched")
@@ -87,14 +82,6 @@ def _get_header(headers: list[tuple[bytes, bytes]], name: bytes) -> str | None:
         if k == name:
             return v.decode("latin-1")
     return None
-
-
-def _has_bearer_auth(headers: list[tuple[bytes, bytes]]) -> bool:
-    raw = _get_header(headers, b"authorization")
-    if not raw:
-        return False
-    scheme, _, token = raw.partition(" ")
-    return scheme.lower() == "bearer" and bool(token.strip())
 
 
 async def _send_403(send: Send, message: str) -> None:

--- a/backend/tests/unit/test_csrf_middleware.py
+++ b/backend/tests/unit/test_csrf_middleware.py
@@ -1,0 +1,30 @@
+"""CSRF middleware security contracts."""
+
+import httpx
+import pytest
+from starlette.responses import Response
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from cubeplex.api.middleware.csrf import CSRFMiddleware
+from cubeplex.config import config
+
+
+async def _ok_app(scope: Scope, receive: Receive, send: Send) -> None:
+    await Response(status_code=204)(scope, receive, send)
+
+
+@pytest.mark.asyncio
+async def test_invalid_bearer_cannot_bypass_cookie_csrf() -> None:
+    app: ASGIApp = CSRFMiddleware(_ok_app)
+    transport = httpx.ASGITransport(app=app)
+    auth_cookie = str(config.get("auth.cookie_name", "cubeplex_auth"))
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/mutating-route",
+            cookies={auth_cookie: "valid-cookie-session"},
+            headers={"Authorization": "Bearer not-a-real-key"},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["error_code"] == "CSRF_FORBIDDEN"


### PR DESCRIPTION
Closes #557

A syntactically valid Bearer header can no longer disable CSRF when a browser auth cookie is present. Pure API-key clients continue to bypass CSRF because they do not send a session cookie.

Verified:
- `uv run pytest tests/unit/test_csrf_middleware.py --no-cov`
- `uv run pytest tests/e2e/test_api_keys.py --no-cov`