### PR TITLE
fix(admin): reject ambiguous organization selection

### DIFF
--- a/backend/cubeplex/auth/dependencies.py
+++ b/backend/cubeplex/auth/dependencies.py
@@ -188,10 +188,10 @@ async def require_org_admin(
     user: Annotated[User, Depends(current_active_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> User:
-    """User has org-level admin or owner role in their current org."""
+    """Require one unambiguous org-level admin or owner membership."""
     from cubeplex.repositories import OrganizationMembershipRepository
 
-    org_id = await resolve_current_org_id(user, session)
+    org_id = await resolve_unambiguous_admin_org_id(user, session)
     is_admin = await OrganizationMembershipRepository(session).is_admin(
         user_id=user.id, org_id=org_id
     )

--- a/backend/tests/e2e/test_admin_me.py
+++ b/backend/tests/e2e/test_admin_me.py
@@ -147,3 +147,30 @@ async def test_admin_me_uses_org_membership_not_workspace_admin(member_client, s
     resp = await client.get("/api/v1/admin/me")
     assert resp.status_code == 200, resp.text
     assert resp.json()["is_admin"] is False
+
+
+async def test_admin_provider_route_rejects_ambiguous_org(admin_client, session_factory):
+    """An admin in two orgs must select one before an admin route can run."""
+    import secrets
+
+    from sqlalchemy import select
+
+    from cubeplex.models import User
+    from cubeplex.models.organization_membership import OrgRole
+    from cubeplex.repositories import OrganizationMembershipRepository, OrganizationRepository
+
+    client, _workspace_id = admin_client
+    me = (await client.get("/api/v1/auth/me")).json()
+    async with session_factory() as session:
+        user = (await session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+        org = await OrganizationRepository(session).create(
+            name="Second admin org", slug=f"second-admin-{secrets.token_hex(4)}"
+        )
+        await OrganizationMembershipRepository(session).grant(
+            user_id=user.id, org_id=org.id, role=OrgRole.ADMIN
+        )
+
+    response = await client.get("/api/v1/admin/providers")
+
+    assert response.status_code == 400, response.text
+    assert response.json()["error_code"] == "ambiguous_org"


### PR DESCRIPTION
Closes #558

Admin dependencies now reject requests from users who administer multiple organizations instead of silently choosing one.

Verified: `uv run pytest tests/e2e/test_admin_me.py --no-cov`