### PR TITLE
fix(admin): require organization invite acceptance

### DIFF
--- a/backend/cubeplex/api/routes/v1/admin_members.py
+++ b/backend/cubeplex/api/routes/v1/admin_members.py
@@ -18,11 +18,6 @@ router = APIRouter(prefix="/admin/members", tags=["admin-members"])
 ASSIGNABLE_ROLES = {"admin", "member"}
 
 
-class AddOrgMemberRequest(BaseModel):
-    email: str
-    role: str
-
-
 class ChangeOrgRoleRequest(BaseModel):
     role: str
 
@@ -33,13 +28,6 @@ class OrgMemberOut(BaseModel):
     display_name: str | None = None
     role: str
     created_at: str
-
-
-class AddOrgMemberResponse(BaseModel):
-    user_id: str
-    email: str
-    display_name: str | None = None
-    role: str
 
 
 class ChangeOrgRoleResponse(BaseModel):
@@ -72,33 +60,6 @@ async def list_org_members(
         )
         for m in members
     ]
-
-
-@router.post("", response_model=AddOrgMemberResponse, status_code=status.HTTP_201_CREATED)
-async def add_org_member(
-    body: AddOrgMemberRequest,
-    user: Annotated[User, Depends(require_org_admin)],
-    session: Annotated[AsyncSession, Depends(get_session)],
-) -> AddOrgMemberResponse:
-    if body.role not in ASSIGNABLE_ROLES:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="role must be admin or member")
-    org_id = await resolve_current_org_id(user, session)
-
-    target = (
-        await session.execute(select(User).where(User.email == body.email))  # type: ignore[arg-type]
-    ).scalar_one_or_none()
-    if target is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="No user with this email")
-
-    om_repo = OrganizationMembershipRepository(session)
-    existing = await om_repo.get_role(user_id=target.id, org_id=org_id)
-    if existing is not None:
-        raise HTTPException(status.HTTP_409_CONFLICT, detail="Already a member")
-
-    await om_repo.grant(user_id=target.id, org_id=org_id, role=OrgRole(body.role))
-    return AddOrgMemberResponse(
-        user_id=target.id, email=target.email, display_name=target.display_name, role=body.role
-    )
 
 
 @router.patch("/{user_id}/role", response_model=ChangeOrgRoleResponse)

--- a/backend/tests/e2e/test_admin_members.py
+++ b/backend/tests/e2e/test_admin_members.py
@@ -1,24 +1,8 @@
 """E2E tests for org member management routes (/admin/members)."""
 
-import secrets
-
 import pytest
-from fastapi_users.db import SQLAlchemyUserDatabase
-from fastapi_users.schemas import BaseUserCreate
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from cubeplex.auth.users import UserManager
-from cubeplex.models import User
 
 pytestmark = pytest.mark.e2e
-
-
-async def _create_standalone_user(session: AsyncSession) -> User:
-    """Create a user not in any org (for add-member tests)."""
-    email = f"standalone-{secrets.token_hex(4)}@example.com"
-    user_db = SQLAlchemyUserDatabase(session, User)
-    manager = UserManager(user_db)
-    return await manager.create(BaseUserCreate(email=email, password="test12345"), safe=False)
 
 
 async def test_list_org_members(admin_client, session_factory):
@@ -35,70 +19,13 @@ async def test_list_org_members(admin_client, session_factory):
     assert "created_at" in first
 
 
-async def test_add_org_member(admin_client, session_factory):
-    client, _ws = admin_client
-    async with session_factory() as session:
-        new_user = await _create_standalone_user(session)
-
-    resp = await client.post(
-        "/api/v1/admin/members",
-        json={"email": new_user.email, "role": "member"},
-    )
-    assert resp.status_code == 201, resp.text
-    data = resp.json()
-    assert data["email"] == new_user.email
-    assert data["role"] == "member"
-
-    list_resp = await client.get("/api/v1/admin/members")
-    emails = [m["email"] for m in list_resp.json()]
-    assert new_user.email in emails
-
-
-async def test_add_duplicate_member_returns_409(admin_client, session_factory):
-    client, _ws = admin_client
-    async with session_factory() as session:
-        new_user = await _create_standalone_user(session)
-
-    await client.post("/api/v1/admin/members", json={"email": new_user.email, "role": "member"})
-    resp = await client.post(
-        "/api/v1/admin/members",
-        json={"email": new_user.email, "role": "member"},
-    )
-    assert resp.status_code == 409
-
-
-async def test_add_nonexistent_email_returns_404(admin_client):
+async def test_add_org_member_route_is_not_available(admin_client):
     client, _ws = admin_client
     resp = await client.post(
         "/api/v1/admin/members",
-        json={"email": "nobody-exists@example.com", "role": "member"},
+        json={"email": "person@example.com", "role": "member"},
     )
-    assert resp.status_code == 404
-
-
-async def test_add_invalid_role_returns_400(admin_client, session_factory):
-    client, _ws = admin_client
-    async with session_factory() as session:
-        new_user = await _create_standalone_user(session)
-    resp = await client.post(
-        "/api/v1/admin/members",
-        json={"email": new_user.email, "role": "owner"},
-    )
-    assert resp.status_code == 400
-
-
-async def test_change_member_role(admin_client, session_factory):
-    client, _ws = admin_client
-    async with session_factory() as session:
-        new_user = await _create_standalone_user(session)
-
-    await client.post("/api/v1/admin/members", json={"email": new_user.email, "role": "member"})
-    resp = await client.patch(
-        f"/api/v1/admin/members/{new_user.id}/role",
-        json={"role": "admin"},
-    )
-    assert resp.status_code == 200, resp.text
-    assert resp.json()["role"] == "admin"
+    assert resp.status_code == 405, resp.text
 
 
 async def test_change_owner_role_returns_409(admin_client):
@@ -110,20 +37,6 @@ async def test_change_owner_role_returns_409(admin_client):
         json={"role": "member"},
     )
     assert resp.status_code == 409
-
-
-async def test_remove_member(admin_client, session_factory):
-    client, _ws = admin_client
-    async with session_factory() as session:
-        new_user = await _create_standalone_user(session)
-
-    await client.post("/api/v1/admin/members", json={"email": new_user.email, "role": "member"})
-    resp = await client.delete(f"/api/v1/admin/members/{new_user.id}")
-    assert resp.status_code == 204
-
-    list_resp = await client.get("/api/v1/admin/members")
-    emails = [m["email"] for m in list_resp.json()]
-    assert new_user.email not in emails
 
 
 async def test_remove_self_returns_400(admin_client):
@@ -138,23 +51,3 @@ async def test_member_user_cannot_manage_org_members(member_client):
     client, _ws = member_client
     resp = await client.get("/api/v1/admin/members")
     assert resp.status_code == 403
-
-
-async def test_remove_cascades_workspace_memberships(admin_client, session_factory):
-    client, ws_id = admin_client
-    async with session_factory() as session:
-        new_user = await _create_standalone_user(session)
-
-    await client.post("/api/v1/admin/members", json={"email": new_user.email, "role": "member"})
-    await client.post(
-        f"/api/v1/ws/{ws_id}/members",
-        json={"user_id": new_user.id, "role": "member"},
-    )
-
-    ws_resp = await client.get(f"/api/v1/ws/{ws_id}/members")
-    assert new_user.id in [m["user_id"] for m in ws_resp.json()]
-
-    await client.delete(f"/api/v1/admin/members/{new_user.id}")
-
-    ws_resp2 = await client.get(f"/api/v1/ws/{ws_id}/members")
-    assert new_user.id not in [m["user_id"] for m in ws_resp2.json()]


### PR DESCRIPTION
Closes #559

Removes the legacy direct member-grant endpoint. Organization membership is now created only when an invite token is accepted.

Verified:
- `uv run pytest tests/e2e/test_admin_members.py --no-cov`
- `uv run pytest tests/e2e/test_invite_onboarding.py::test_org_invite_reuse_rejected --no-cov`