### PR TITLE
fix(auth): reject unsafe signing secrets

### DIFF
--- a/backend/cubeplex/api/app.py
+++ b/backend/cubeplex/api/app.py
@@ -20,6 +20,36 @@ from redis.asyncio import Redis
 from cubeplex.credentials.encryption import FernetBackend
 from cubeplex.utils import log
 
+_MIN_AUTH_SECRET_LENGTH = 32
+_AUTH_SECRET_PLACEHOLDERS = {"replace_me", "use env"}
+
+
+def validate_auth_secrets() -> None:
+    """Reject unsafe signing secrets before the application accepts requests."""
+    if os.getenv("ENV_FOR_DYNACONF", "development").lower() in {"test", "testing"}:
+        return
+
+    from cubeplex.config import config
+
+    for setting, env_var in (
+        ("auth.jwt_secret", "CUBEPLEX_AUTH__JWT_SECRET"),
+        ("auth.csrf_secret", "CUBEPLEX_AUTH__CSRF_SECRET"),
+    ):
+        raw_secret = config.get(setting)
+        secret = str(raw_secret).strip() if raw_secret is not None else ""
+        normalized_secret = secret.lower()
+        if not secret:
+            raise RuntimeError(f"{env_var} is required")
+        if (
+            normalized_secret.startswith("change_me")
+            or normalized_secret in _AUTH_SECRET_PLACEHOLDERS
+        ):
+            raise RuntimeError(f"{env_var} must not use a placeholder value")
+        if len(secret) < _MIN_AUTH_SECRET_LENGTH:
+            raise RuntimeError(
+                f"{env_var} must be at least {_MIN_AUTH_SECRET_LENGTH} characters long"
+            )
+
 
 def _build_encryption_backend() -> FernetBackend:
     """Build the process-wide credential vault encryption backend."""
@@ -54,6 +84,7 @@ async def lifespan(_app: FastAPI):  # type: ignore
     # ==================== Startup ====================
     log.init()
     logger.info("Application starting up")
+    validate_auth_secrets()
     _app.state.encryption_backend = _build_encryption_backend()
     _app.state.mcp_user_token_signer = _build_mcp_user_token_signer()
 

--- a/backend/tests/unit/test_vault_key_loading.py
+++ b/backend/tests/unit/test_vault_key_loading.py
@@ -4,6 +4,73 @@ import pytest
 from cryptography.fernet import Fernet
 
 
+@pytest.mark.parametrize(
+    ("setting", "value", "message"),
+    [
+        ("auth.jwt_secret", "REPLACE_ME", "placeholder"),
+        ("auth.jwt_secret", "CHANGE_ME_IN_PRODUCTION_NOT_SECURE", "placeholder"),
+        ("auth.csrf_secret", "USE ENV", "placeholder"),
+        ("auth.jwt_secret", "too-short", "at least 32 characters"),
+        ("auth.csrf_secret", "", "is required"),
+    ],
+)
+def test_validate_auth_secrets_rejects_unsafe_production_values(
+    monkeypatch: pytest.MonkeyPatch,
+    setting: str,
+    value: str,
+    message: str,
+) -> None:
+    monkeypatch.setenv("ENV_FOR_DYNACONF", "production")
+    from cubeplex.config import config
+
+    original_value = config.get(setting)
+    original_jwt_secret = config.get("auth.jwt_secret")
+    original_csrf_secret = config.get("auth.csrf_secret")
+    config.set("auth.jwt_secret", "a" * 32)
+    config.set("auth.csrf_secret", "b" * 32)
+    config.set(setting, value)
+
+    from cubeplex.api.app import validate_auth_secrets
+
+    try:
+        with pytest.raises(RuntimeError, match=message):
+            validate_auth_secrets()
+    finally:
+        config.set(setting, original_value)
+        config.set("auth.jwt_secret", original_jwt_secret)
+        config.set("auth.csrf_secret", original_csrf_secret)
+
+
+def test_validate_auth_secrets_allows_test_profile_placeholders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENV_FOR_DYNACONF", "test")
+
+    from cubeplex.api.app import validate_auth_secrets
+
+    validate_auth_secrets()
+
+
+def test_validate_auth_secrets_accepts_strong_production_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENV_FOR_DYNACONF", "production")
+    from cubeplex.config import config
+
+    original_jwt_secret = config.get("auth.jwt_secret")
+    original_csrf_secret = config.get("auth.csrf_secret")
+    config.set("auth.jwt_secret", "a" * 32)
+    config.set("auth.csrf_secret", "b" * 32)
+
+    from cubeplex.api.app import validate_auth_secrets
+
+    try:
+        validate_auth_secrets()
+    finally:
+        config.set("auth.jwt_secret", original_jwt_secret)
+        config.set("auth.csrf_secret", original_csrf_secret)
+
+
 def test_build_encryption_backend_requires_vault_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CUBEPLEX_AUTH__VAULT_KEY", raising=False)
     from cubeplex.config import config

--- a/deploy/docker-compose/config/config.production.secrets.yaml.example
+++ b/deploy/docker-compose/config/config.production.secrets.yaml.example
@@ -10,7 +10,8 @@
 dynaconf_merge: true
 production:
   auth:
-    # openssl rand -hex 32
+    # Replace both values with `openssl rand -hex 32`; startup refuses
+    # placeholders or values under 32 characters.
     jwt_secret: "REPLACE_ME"
     csrf_secret: "REPLACE_ME"
     # python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"

--- a/deploy/kubernetes/charts/cubeplex/templates/backend-secret.yaml
+++ b/deploy/kubernetes/charts/cubeplex/templates/backend-secret.yaml
@@ -1,6 +1,12 @@
 {{- $jwt := required "backend.secrets.auth.jwt_secret must be set in values.local.yaml" .Values.backend.secrets.auth.jwt_secret -}}
 {{- $csrf := required "backend.secrets.auth.csrf_secret must be set in values.local.yaml" .Values.backend.secrets.auth.csrf_secret -}}
 {{- $vault := required "backend.secrets.auth.vault_key must be set in values.local.yaml (Fernet key)" .Values.backend.secrets.auth.vault_key -}}
+{{- range $name, $secret := dict "jwt_secret" $jwt "csrf_secret" $csrf "vault_key" $vault }}
+{{- $normalized := lower (trim $secret) -}}
+{{- if or (hasPrefix "change_me" $normalized) (eq $normalized "replace_me") (eq $normalized "use env") }}
+{{- fail (printf "backend.secrets.auth.%s must be a generated secret, not a placeholder" $name) }}
+{{- end }}
+{{- end }}
 {{- $pgPass := required "postgres.auth.password must be set in values.local.yaml" .Values.postgres.auth.password -}}
 {{- $redisPass := required "redis.auth.password must be set in values.local.yaml" .Values.redis.auth.password -}}
 {{- $rustfsAccessKey := .Values.rustfs.auth.accessKey -}}

--- a/docs/site/docs/deployment/backend-config.md
+++ b/docs/site/docs/deployment/backend-config.md
@@ -73,12 +73,13 @@ rather not write to disk.
 
 ## Required in production
 
-The install fails fast if these are empty — set them before first boot:
+The install fails fast if these are empty. The backend also refuses to boot when
+an auth signing secret is a known placeholder or has fewer than 32 characters:
 
 | Key | Purpose |
 |---|---|
-| `auth.jwt_secret` | Signs session JWTs. `openssl rand -hex 32`. |
-| `auth.csrf_secret` | CSRF double-submit cookie. `openssl rand -hex 32`. |
+| `auth.jwt_secret` | Signs session JWTs. `openssl rand -hex 32`; placeholders and values under 32 characters are rejected. |
+| `auth.csrf_secret` | CSRF double-submit cookie. `openssl rand -hex 32`; placeholders and values under 32 characters are rejected. |
 | `auth.vault_key` | Fernet key encrypting the MCP / credentials vault. |
 | `database.password` | Postgres password (match your infra). |
 | `redis.url` | Includes the Redis password. |

--- a/docs/site/docs/deployment/overview.md
+++ b/docs/site/docs/deployment/overview.md
@@ -153,7 +153,10 @@ Every deployment needs three auth secrets, regardless of mode:
 | `csrf_secret` | CSRF double-submit cookie | `openssl rand -hex 32` |
 | `vault_key` | Fernet key encrypting the MCP / credentials vault | `python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'` |
 
-All three are required — both installers fail fast if any is empty.
+All three are required. The backend refuses to start outside tests if either
+signing secret is empty, fewer than 32 characters, or a known placeholder such
+as `REPLACE_ME`, `USE ENV`, or `CHANGE_ME…`. Helm also rejects those
+placeholders during installation.
 
 ## Upgrading artifact object keys
 

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/backend-config.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/backend-config.md
@@ -67,12 +67,13 @@ production:
 
 ## 生产环境必填
 
-以下为空时安装会直接失败——首次启动前请先设置：
+以下为空时安装会直接失败。认证签名密钥若使用已知占位符或少于 32 个字符，
+后端也会拒绝启动：
 
 | Key | 用途 |
 |---|---|
-| `auth.jwt_secret` | 签发会话 JWT。`openssl rand -hex 32`。 |
-| `auth.csrf_secret` | CSRF 双提交 cookie。`openssl rand -hex 32`。 |
+| `auth.jwt_secret` | 签发会话 JWT。`openssl rand -hex 32`；占位符和少于 32 个字符的值会被拒绝。 |
+| `auth.csrf_secret` | CSRF 双提交 cookie。`openssl rand -hex 32`；占位符和少于 32 个字符的值会被拒绝。 |
 | `auth.vault_key` | 加密 MCP / 凭证 vault 的 Fernet key。 |
 | `database.password` | Postgres 密码（与你的基础设施一致）。 |
 | `redis.url` | 包含 Redis 密码。 |

--- a/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/overview.md
+++ b/docs/site/i18n/zh-Hans/docusaurus-plugin-content-docs/current/deployment/overview.md
@@ -147,7 +147,9 @@ volcengine / moonshot / zhipu / minimax / openrouter / anthropic / openai
 | `csrf_secret` | CSRF 双提交 cookie | `openssl rand -hex 32` |
 | `vault_key` | 加密 MCP / 凭证 vault 的 Fernet key | `python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'` |
 
-三者都是必填项——两种安装方式在任一项为空时都会直接安装失败。
+三者都是必填项。测试环境以外，任一签名密钥为空、少于 32 个字符，或使用
+`REPLACE_ME`、`USE ENV`、`CHANGE_ME…` 等已知占位符时，后端都会拒绝启动。
+Helm 也会在安装时拒绝这些占位符。
 
 ## 下一步
 


### PR DESCRIPTION
Closes #560.

Rejects missing, placeholder, and short JWT/CSRF signing secrets at startup outside test environments. Helm rejects shipped placeholder values before install, and deployment docs now state the requirements.