### PR TITLE
Fix false IM binding failure after login

### DIFF
--- a/backend/cubeplex/api/routes/v1/im_link.py
+++ b/backend/cubeplex/api/routes/v1/im_link.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -77,27 +78,23 @@ async def _upsert_identity_link(
             detail={"code": "account_not_found", "message": "IM account not found."},
         )
 
-    existing = (
+    link = IMIdentityLink(
+        org_id=account.org_id,
+        workspace_id=account.workspace_id,
+        account_id=claims.account_id,
+        im_user_id=claims.im_user_id,
+        user_id=user_id,
+    )
+    try:
+        # Confirmations can race on first login; let Postgres resolve the unique key.
         await session.execute(
-            select(IMIdentityLink).where(
-                IMIdentityLink.account_id == claims.account_id,  # type: ignore[arg-type]
-                IMIdentityLink.im_user_id == claims.im_user_id,  # type: ignore[arg-type]
+            insert(IMIdentityLink)
+            .values(**link.model_dump())
+            .on_conflict_do_update(
+                index_elements=["account_id", "im_user_id"],
+                set_={"user_id": user_id},
             )
         )
-    ).scalar_one_or_none()
-    if existing is not None:
-        existing.user_id = user_id
-        session.add(existing)
-    else:
-        link = IMIdentityLink(
-            org_id=account.org_id,
-            workspace_id=account.workspace_id,
-            account_id=claims.account_id,
-            im_user_id=claims.im_user_id,
-            user_id=user_id,
-        )
-        session.add(link)
-    try:
         await session.commit()
     except IntegrityError:
         await session.rollback()

--- a/backend/tests/e2e/test_im_link_confirm.py
+++ b/backend/tests/e2e/test_im_link_confirm.py
@@ -1,0 +1,94 @@
+"""Concurrent browser confirmations must persist one link and both succeed."""
+
+import asyncio
+import secrets
+
+import httpx
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from cubeplex.im.link import get_jwt_secret, sign_link_token
+from cubeplex.models.im_connector import IMIdentityLink
+from tests.e2e.conftest import DEFAULT_ORG_ID, DEFAULT_TEST_EMAIL, DEFAULT_WS_ID
+from tests.e2e.im_fixtures import im_cleanup, im_seed_account, im_seed_stub_credential
+
+
+@pytest.mark.asyncio
+async def test_concurrent_confirmations_and_reopen_succeed(
+    async_client: httpx.AsyncClient,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    user_id = (await async_client.get("/api/v1/auth/me")).json()["id"]
+    suffix = secrets.token_hex(5)
+    account_id = f"imac-{suffix}"
+    credential_id = f"cred-{suffix}"
+    async with session_factory() as session:
+        await im_seed_stub_credential(session, credential_id=credential_id, org_id=DEFAULT_ORG_ID)
+        await im_seed_account(
+            session,
+            account_id=account_id,
+            org_id=DEFAULT_ORG_ID,
+            ws_id=DEFAULT_WS_ID,
+            user_id=user_id,
+            credential_id=credential_id,
+            external_account_id=suffix,
+            platform="wecom",
+        )
+        await session.commit()
+
+    token = sign_link_token(
+        im_user_id="wecom-sender",
+        email=DEFAULT_TEST_EMAIL,
+        account_id=account_id,
+        workspace_id=DEFAULT_WS_ID,
+        platform="wecom",
+        secret=get_jwt_secret(),
+    )
+    try:
+        async with asyncio.timeout(15), session_factory() as blocker:
+            # Let both requests read the empty mapping before either can insert.
+            await blocker.execute(text("LOCK TABLE im_identity_links IN SHARE MODE"))
+            async with asyncio.TaskGroup() as group:
+                requests = [
+                    group.create_task(
+                        async_client.post("/api/v1/im/link/confirm", json={"token": token})
+                    )
+                    for _ in range(2)
+                ]
+                try:
+                    async with session_factory() as observer:
+                        while True:
+                            waiting = await observer.scalar(
+                                text(
+                                    "SELECT count(*) FROM pg_stat_activity "
+                                    "WHERE datname = current_database() "
+                                    "AND wait_event_type = 'Lock' "
+                                    "AND query ILIKE 'INSERT INTO im_identity_links%'"
+                                )
+                            )
+                            if waiting == 2:
+                                break
+                            await observer.rollback()
+                            await asyncio.sleep(0.01)
+                finally:
+                    await blocker.rollback()
+            responses = [task.result() for task in requests]
+        assert [r.status_code for r in responses] == [200, 200], [r.text for r in responses]
+        reopened = await async_client.post("/api/v1/im/link/confirm", json={"token": token})
+        assert reopened.status_code == 200, reopened.text
+        assert reopened.json()["ok"] is True
+        async with session_factory() as session:
+            links = (
+                await session.scalars(
+                    select(IMIdentityLink).where(
+                        IMIdentityLink.account_id == account_id,  # type: ignore[arg-type]
+                    )
+                )
+            ).all()
+            assert len(links) == 1
+            assert links[0].user_id == user_id
+    finally:
+        async with session_factory() as session:
+            await im_cleanup(session, account_ids=[account_id], credential_ids=[credential_id])
+            await session.commit()

--- a/docs/site/docs/guides/im/overview.md
+++ b/docs/site/docs/guides/im/overview.md
@@ -64,7 +64,7 @@ The sender sends the bot:
 
 (The Chinese alias `绑定 you@example.com` also works.) The bot replies with a confirmation URL of the form `https://<your-cubeplex-host>/im-link?token=...`. The link carries a short-lived signed token (valid 10 minutes) encoding the claimed email and the target workspace.
 
-The sender opens that link **while logged in to CubePlex**. CubePlex confirms that the logged-in user's email matches the claimed email and that they belong to the workspace, then permanently links the chat identity to the CubePlex account. After that, the sender's messages run as that user without re-linking.
+The sender opens that link and signs in to CubePlex if needed. After sign-in, CubePlex returns to the confirmation page, checks that the user's email matches the claimed email and that they belong to the workspace, then permanently links the chat identity to the CubePlex account. Reopening a still-valid link or submitting the same confirmation more than once succeeds without creating another binding. After that, the sender's messages run as that user without re-linking.
 
 :::tip
 The email you `/link` must be the email of an existing CubePlex account that is already a member of the bot's workspace. Linking does not create accounts or grant membership — it only connects an existing one.

--- a/frontend/packages/web/__tests__/components/ImLinkPage.test.tsx
+++ b/frontend/packages/web/__tests__/components/ImLinkPage.test.tsx
@@ -1,0 +1,74 @@
+import { StrictMode } from 'react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ImLinkPage } from '@/components/auth/ImLinkPage'
+import messages from '@/messages/en.json'
+
+const navigation = vi.hoisted(() => ({ token: 'first', replace: vi.fn() }))
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams({ token: navigation.token }),
+  useRouter: () => ({ replace: navigation.replace }),
+}))
+
+function page() {
+  return (
+    <StrictMode>
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <ImLinkPage />
+      </NextIntlClientProvider>
+    </StrictMode>
+  )
+}
+
+const success = () => Response.json({ ok: true, platform: 'wecom', account_id: 'account' })
+
+describe('IM link confirmation lifecycle', () => {
+  beforeEach(() => {
+    navigation.token = 'first'
+    navigation.replace.mockClear()
+  })
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('submits once under StrictMode and still shows the completed binding', async () => {
+    const response = Promise.withResolvers<Response>()
+    const fetch = vi.fn().mockReturnValue(response.promise)
+    vi.stubGlobal('fetch', fetch)
+    render(page())
+    expect(fetch).toHaveBeenCalledTimes(1)
+    await act(async () => response.resolve(success()))
+    expect(
+      screen.getByText(messages.im.link.success.replace('{platform}', 'wecom')),
+    ).toBeInTheDocument()
+  })
+
+  it('ignores an old failure after a different token has succeeded', async () => {
+    const oldResponse = Promise.withResolvers<Response>()
+    const fetch = vi.fn().mockReturnValue(oldResponse.promise)
+    vi.stubGlobal('fetch', fetch)
+    const view = render(page())
+    navigation.token = 'second'
+    fetch.mockResolvedValue(success())
+    view.rerender(page())
+    await screen.findByText(messages.im.link.success.replace('{platform}', 'wecom'))
+    await act(async () => oldResponse.resolve(Response.json({}, { status: 409 })))
+    expect(screen.queryByText(messages.im.link.error)).not.toBeInTheDocument()
+    expect(
+      screen.getByText(messages.im.link.success.replace('{platform}', 'wecom')),
+    ).toBeInTheDocument()
+  })
+
+  it('preserves the token when redirecting an unauthenticated user to login', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({}, { status: 401 })))
+    render(page())
+    await waitFor(() =>
+      expect(navigation.replace).toHaveBeenCalledWith(
+        `/login?next=${encodeURIComponent('/im-link?token=first')}`,
+      ),
+    )
+    expect(navigation.replace).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/packages/web/__tests__/components/ImLinkPage.test.tsx
+++ b/frontend/packages/web/__tests__/components/ImLinkPage.test.tsx
@@ -23,6 +23,14 @@ function page() {
 
 const success = () => Response.json({ ok: true, platform: 'wecom', account_id: 'account' })
 
+function pendingResponse() {
+  let resolve!: (response: Response) => void
+  const promise = new Promise<Response>((complete) => {
+    resolve = complete
+  })
+  return { promise, resolve }
+}
+
 describe('IM link confirmation lifecycle', () => {
   beforeEach(() => {
     navigation.token = 'first'
@@ -34,7 +42,7 @@ describe('IM link confirmation lifecycle', () => {
   })
 
   it('submits once under StrictMode and still shows the completed binding', async () => {
-    const response = Promise.withResolvers<Response>()
+    const response = pendingResponse()
     const fetch = vi.fn().mockReturnValue(response.promise)
     vi.stubGlobal('fetch', fetch)
     render(page())
@@ -46,7 +54,7 @@ describe('IM link confirmation lifecycle', () => {
   })
 
   it('ignores an old failure after a different token has succeeded', async () => {
-    const oldResponse = Promise.withResolvers<Response>()
+    const oldResponse = pendingResponse()
     const fetch = vi.fn().mockReturnValue(oldResponse.promise)
     vi.stubGlobal('fetch', fetch)
     const view = render(page())

--- a/frontend/packages/web/components/auth/ImLinkPage.tsx
+++ b/frontend/packages/web/components/auth/ImLinkPage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
@@ -21,6 +21,10 @@ export function ImLinkPage() {
   const router = useRouter()
   const token = searchParams.get('token')
   const client = useMemo(() => createApiClient(''), [])
+  const confirmation = useRef<{
+    token: string
+    promise: ReturnType<typeof confirmImLink>
+  } | null>(null)
 
   const [status, setStatus] = useState<Status>('verifying')
   const [errorMsg, setErrorMsg] = useState('')
@@ -33,12 +37,20 @@ export function ImLinkPage() {
       setErrorMsg(t('invalidToken'))
       return
     }
-    confirmImLink(client, token)
+    let active = true
+    // Reuse the request when StrictMode replays this effect.
+    if (confirmation.current?.token !== token) {
+      confirmation.current = { token, promise: confirmImLink(client, token) }
+    }
+    setStatus('verifying')
+    confirmation.current.promise
       .then((result) => {
+        if (!active) return
         setStatus('success')
         setPlatform(result.platform)
       })
       .catch((err: unknown) => {
+        if (!active) return
         if (err instanceof ApiError && err.status === 401) {
           const returnUrl = `/im-link?token=${encodeURIComponent(token)}`
           // LoginForm reads ``next``, not ``redirect`` — using the wrong param
@@ -51,6 +63,9 @@ export function ImLinkPage() {
         const key = err instanceof ApiError && err.code ? CODE_TO_KEY[err.code] : undefined
         setErrorMsg(key ? t(key) : t('error'))
       })
+    return () => {
+      active = false
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router/t are stable
   }, [client, token])
 


### PR DESCRIPTION
Opening a WeCom `/link` URL after login could persist the binding but display failure: duplicate confirmations raced, returning 200 followed by 409, and the later error overwrote the success state.

Use a PostgreSQL upsert for the identity mapping so concurrent confirmations both succeed. Reuse the pending confirmation during React effect replay and ignore callbacks after cleanup, preserving the login return URL. Update the IM linking guide with login and repeat-confirmation behavior.

Validation:
- Real PostgreSQL regression: force both requests into the first-insert race using a table lock. Before: 200 + 409; after: both 200, reopening succeeds, exactly one mapping persists (`1 passed`).
- Frontend lifecycle regressions: StrictMode submits once, stale errors cannot overwrite a new token's success, and 401 redirects once with the return URL (`3 passed`).
- Commit hooks and both backend/frontend pre-push check-ci gates passed, including the production Next.js build.
