### PR TITLE
fix(im): stack WeCom credential fields in the connect wizard

### DIFF
--- a/frontend/packages/web/components/im/ImConnectWizard/platforms/types.ts
+++ b/frontend/packages/web/components/im/ImConnectWizard/platforms/types.ts
@@ -12,6 +12,9 @@ export type FieldDef = {
   options?: { value: string; labelKey: string }[]
   placeholder?: string
   default?: string
+  /** Span the full wizard row instead of sharing a two-column cell. */
+  fullWidth?: boolean
+  descriptionKey?: string
 }
 
 export type PrereqItem = {

--- a/frontend/packages/web/components/im/ImConnectWizard/platforms/wecom.ts
+++ b/frontend/packages/web/components/im/ImConnectWizard/platforms/wecom.ts
@@ -29,18 +29,22 @@ export const wecomDescriptor: PlatformDescriptor = {
       labelKey: 'im.wizard.wecom.field.botId',
       type: 'text',
       required: true,
-    },
-    {
-      key: 'bot_name',
-      labelKey: 'im.wizard.wecom.field.botName',
-      type: 'text',
-      required: true,
+      fullWidth: true,
     },
     {
       key: 'secret',
       labelKey: 'im.wizard.wecom.field.secret',
       type: 'password',
       required: true,
+      fullWidth: true,
+    },
+    {
+      key: 'bot_name',
+      labelKey: 'im.wizard.wecom.field.botName',
+      type: 'text',
+      required: true,
+      fullWidth: true,
+      descriptionKey: 'im.wizard.wecom.field.botNameHint',
     },
   ],
   steps: [

--- a/frontend/packages/web/components/im/ImConnectWizard/steps/StepCredentials.tsx
+++ b/frontend/packages/web/components/im/ImConnectWizard/steps/StepCredentials.tsx
@@ -11,10 +11,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
 
 import type { WizardStepProps } from '../platforms/types'
 
 type DynamicT = (key: string, values?: Record<string, string | number>) => string
+
+function FieldHint({ text }: { text: string }): React.ReactElement {
+  return <p className="text-xs leading-snug text-muted-foreground">{text}</p>
+}
 
 export function StepCredentials({
   descriptor,
@@ -23,13 +28,17 @@ export function StepCredentials({
 }: WizardStepProps): React.ReactElement {
   const t = useTranslations() as unknown as DynamicT
   return (
-    <div className="grid grid-cols-2 gap-3">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-3">
       {descriptor.credentialFields.map((f) => {
         if (f.showIf && !f.showIf(form)) return null
+        const fieldClass = cn('min-w-0 space-y-1.5', f.fullWidth && 'sm:col-span-2')
+        const hint = f.descriptionKey ? <FieldHint text={t(f.descriptionKey)} /> : null
         if (f.type === 'select' && f.options) {
           return (
-            <div key={f.key} className="space-y-1">
-              <Label htmlFor={`cred-${f.key}`}>{t(f.labelKey)}</Label>
+            <div key={f.key} className={fieldClass}>
+              <Label htmlFor={`cred-${f.key}`} className="leading-snug">
+                {t(f.labelKey)}
+              </Label>
               <Select
                 value={form[f.key] ?? ''}
                 onValueChange={(v) => onChange({ [f.key]: v ?? '' })}
@@ -45,12 +54,15 @@ export function StepCredentials({
                   ))}
                 </SelectContent>
               </Select>
+              {hint}
             </div>
           )
         }
         return (
-          <div key={f.key} className="space-y-1">
-            <Label htmlFor={`cred-${f.key}`}>{t(f.labelKey)}</Label>
+          <div key={f.key} className={fieldClass}>
+            <Label htmlFor={`cred-${f.key}`} className="leading-snug">
+              {t(f.labelKey)}
+            </Label>
             <Input
               id={`cred-${f.key}`}
               type={f.type}
@@ -59,6 +71,7 @@ export function StepCredentials({
               value={form[f.key] ?? ''}
               onChange={(e) => onChange({ [f.key]: e.target.value })}
             />
+            {hint}
           </div>
         )
       })}

--- a/frontend/packages/web/messages/en.json
+++ b/frontend/packages/web/messages/en.json
@@ -2603,7 +2603,8 @@
         },
         "field": {
           "botId": "Bot ID",
-          "botName": "Bot name (exactly as shown in WeCom)",
+          "botName": "Bot name",
+          "botNameHint": "Must match the name shown in WeCom exactly",
           "secret": "Secret"
         }
       },

--- a/frontend/packages/web/messages/zh.json
+++ b/frontend/packages/web/messages/zh.json
@@ -2603,7 +2603,8 @@
         },
         "field": {
           "botId": "Bot ID",
-          "botName": "机器人名称（与企业微信中显示的完全一致）",
+          "botName": "机器人名称",
+          "botNameHint": "须与企业微信中显示的名称完全一致",
           "secret": "Secret"
         }
       },


### PR DESCRIPTION
## Summary

The WeCom connect-bot credentials step put Bot ID, Secret, and name in a two-column grid. The long name label wrapped inside a half-width cell, so the three fields looked packed together.

This change:

- Gives each WeCom credential field a full row
- Moves the “must match the WeCom display name” constraint into hint text under the name field
- Stacks credential fields on narrow viewports; platforms with short paired fields (Feishu, Slack, Discord) stay two-column on desktop

## Test plan

- [x] Open Workspace settings → IM → Connect → WeCom → Credentials
- [x] Confirm Bot ID, Secret, and name each occupy a full row on desktop
- [x] Confirm the same stacked layout on a ~390px viewport
- [x] Confirm Feishu credentials still render as a two-column grid on desktop
- [x] Spot-check Chinese copy: label `机器人名称`, hint `须与企业微信中显示的名称完全一致`