### PR TITLE
fix(frontend): load jest-dom matchers for Vitest

### DIFF
--- a/frontend/packages/web/vitest.setup.ts
+++ b/frontend/packages/web/vitest.setup.ts
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom/vitest'
 import { vi } from 'vitest'
 
 // @lobehub/icons transitively imports @emoji-mart/data JSON that Vitest cannot


### PR DESCRIPTION
Vitest 5 no longer picks up the Jest matcher type augmentation from the default jest-dom entrypoint.

Use the documented Vitest entrypoint so web type-check and unit tests retain the jest-dom matchers.

Validation:
- pnpm --filter web type-check
- make check-ci (frontend)
- core: 252 tests passed
- web: 456 passed, 1 skipped