### PR TITLE
Add contributor license agreement workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,150 @@
+name: Contributor License Agreement
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  checks: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  cla:
+    name: CLA
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check contributor agreements
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const signingPhrase =
+              'I have read and agree to the CubePlex Contributor License Agreement';
+            const marker = '<!-- cubeplex-cla -->';
+            const event = context.eventName;
+
+            if (event === 'issue_comment') {
+              if (!context.payload.issue.pull_request) {
+                core.info('Issue comment is not on a pull request.');
+                return;
+              }
+              if (context.payload.comment.body.trim() !== signingPhrase) {
+                core.info('Comment is not a CLA acceptance comment.');
+                return;
+              }
+            }
+
+            const pullRequestNumber =
+              context.payload.pull_request?.number ?? context.payload.issue.number;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequestNumber,
+            });
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequestNumber,
+                per_page: 100,
+              },
+            );
+            const commits = await github.paginate(
+              github.rest.pulls.listCommits,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullRequestNumber,
+                per_page: 100,
+              },
+            );
+
+            const authors = new Map();
+            for (const commit of commits) {
+              const login = commit.author?.login ?? commit.committer?.login;
+              const isBot = login?.endsWith('[bot]') || login === 'github-actions';
+              if (login && !isBot) {
+                authors.set(login, login);
+              }
+            }
+            if (authors.size === 0) {
+              authors.set(pullRequest.user.login, pullRequest.user.login);
+            }
+
+            const signedBy = new Set(
+              comments
+                .filter((comment) => comment.body.trim() === signingPhrase)
+                .map((comment) => comment.user.login),
+            );
+            const unsigned = [...authors.keys()].filter((login) => !signedBy.has(login));
+            const botLogin = 'github-actions[bot]';
+            const existing = comments.find(
+              (comment) => comment.user.login === botLogin && comment.body.includes(marker),
+            );
+
+            const publishCheck = async (conclusion, summary) => {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'CLA',
+                head_sha: pullRequest.head.sha,
+                status: 'completed',
+                conclusion,
+                details_url: pullRequest.html_url,
+                output: {
+                  title: summary,
+                  summary,
+                },
+              });
+            };
+
+            let body;
+            if (unsigned.length > 0) {
+              body = `${marker}\nThank you for contributing to CubePlex. The following commit author(s) must read [CLA.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${pullRequest.base.ref}/CLA.md) and post this exact comment on the pull request:\n\n\`\`\`text\n${signingPhrase}\n\`\`\`\n\nStill needed: ${unsigned.map((login) => `@${login}`).join(', ')}`;
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullRequestNumber,
+                  body,
+                });
+              }
+              await publishCheck(
+                'failure',
+                'Not all human commit authors have signed the CLA.',
+              );
+              core.setFailed('Not all human commit authors have signed the CLA.');
+              return;
+            }
+
+            body = `${marker}\n✅ All human commit authors have signed the CubePlex Contributor License Agreement.`;
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequestNumber,
+                body,
+              });
+            }
+            await publishCheck(
+              'success',
+              'All human commit authors have signed the CubePlex Contributor License Agreement.',
+            );

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,74 @@
+# CubePlex Individual Contributor License Agreement
+
+Version 1.0
+
+This Individual Contributor License Agreement (the "Agreement") is between
+you (the "Contributor") and CubePlex (the "Project Owner"). It applies to
+all Contributions that you submit to the CubePlex project, including source
+code, documentation, tests, configuration, designs, and other copyrightable
+works.
+
+By posting the exact acceptance comment requested by the Project's CLA check
+on a pull request, you agree to this Agreement for your past and future
+Contributions to CubePlex.
+
+## 1. Copyright license
+
+You grant the Project Owner and recipients of software distributed by the
+Project a perpetual, worldwide, non-exclusive, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute your Contributions and derivative
+works.
+
+This license includes the right to distribute a Contribution under the
+license applicable to the part of the Project where it is incorporated. This
+includes the CubePlex Community License for community components and the
+CubePlex Enterprise license or another commercial license for code in
+`backend/ee/`, subject to the terms of those licenses.
+
+You retain ownership of your Contributions and may use them elsewhere, subject
+to any rights of third parties and any obligations you have to your employer.
+
+## 2. Patent license
+
+You grant the Project Owner and recipients of software distributed by the
+Project a perpetual, worldwide, non-exclusive, royalty-free, irrevocable
+(except as stated below) patent license to make, have made, use, offer to
+sell, sell, import, and otherwise transfer your Contributions, alone or in
+combination with the Project.
+
+If you or an entity you control initiates patent litigation alleging that the
+Project or a Contribution infringes a patent, the patent licenses granted by
+you under this Agreement terminate as of the date that litigation is filed.
+
+## 3. Your representations
+
+You represent that:
+
+1. You are legally entitled to grant the licenses in this Agreement.
+2. Each Contribution is your original work, or you have sufficient permission
+   to submit it under this Agreement.
+3. If your employer or another entity owns rights in a Contribution, you have
+   obtained its permission to submit that Contribution and to enter into this
+   Agreement on its behalf.
+4. You have identified any third-party material and preserved its applicable
+   copyright and license notices.
+
+You agree to notify the Project Owner if you later learn that any of these
+representations is inaccurate.
+
+## 4. No obligation and no warranty
+
+You are not required to provide support for a Contribution. Contributions are
+provided "AS IS", without warranties or conditions of any kind, unless
+required by applicable law or agreed in writing.
+
+## 5. Corporate contributions
+
+If you are submitting Contributions on behalf of an employer or another legal
+entity, do not sign this individual agreement unless you have authority to bind
+that entity. Contact the Project maintainers to arrange a Corporate CLA before
+the Contribution is merged.
+
+If a provision of this Agreement is held unenforceable, the remaining
+provisions remain in effect.

--- a/CLA.md
+++ b/CLA.md
@@ -24,7 +24,9 @@ This license includes the right to distribute a Contribution under the
 license applicable to the part of the Project where it is incorporated. This
 includes the CubePlex Community License for community components and the
 CubePlex Enterprise license or another commercial license for code in
-`backend/ee/`, subject to the terms of those licenses.
+any directory named exactly `ee`, subject to the terms of the applicable
+license. Copies, modifications, and compiled forms of those Enterprise
+components remain covered even if they are moved outside an `ee` directory.
 
 You retain ownership of your Contributions and may use them elsewhere, subject
 to any rights of third parties and any obligations you have to your employer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,27 @@
 
 Thanks for your interest! This doc covers how to set up your local environment so commits and pushes pass CI on the first try.
 
+## Contributor License Agreement
+
+Before a pull request can be merged, every human author of a commit in the
+pull request must accept the [CubePlex Individual Contributor License
+Agreement](CLA.md). The CLA check will explain which authors still need to
+sign. To sign, post this exact comment on the pull request:
+
+```text
+I have read and agree to the CubePlex Contributor License Agreement
+```
+
+The check runs again when the comment is posted. Contributions made on behalf
+of an employer or another legal entity require a Corporate CLA; contact the
+maintainers before submitting that contribution. Bots and automated commits
+are allowlisted by the check.
+
+The agreement keeps copyright ownership with the contributor while granting
+CubePlex the rights needed to distribute community code under the CubePlex
+Community License and code under the applicable Enterprise terms in
+`backend/ee/`.
+
 ## Prerequisites
 
 - Python 3.12+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,9 @@ are allowlisted by the check.
 The agreement keeps copyright ownership with the contributor while granting
 CubePlex the rights needed to distribute community code under the CubePlex
 Community License and code under the applicable Enterprise terms in
-`backend/ee/`.
+any directory named exactly `ee`. Copies, modifications, and compiled forms of
+those Enterprise components remain covered even if they are moved outside an
+`ee` directory.
 
 ## Prerequisites
 

--- a/backend/ee/LICENSE
+++ b/backend/ee/LICENSE
@@ -1,5 +1,5 @@
 The CubePlex Enterprise license (the "Enterprise License")
-Copyright (c) 2026 CubePlex
+Copyright (c) 2026 CubePlex Inc.
 
 With regard to the CubePlex software located in this "ee/" directory and any
 software that this directory's build artifacts are distributed as part of:


### PR DESCRIPTION
## Summary

- add a CubePlex Individual Contributor License Agreement covering copyright, patents, employer authorization, and third-party materials
- document the exact PR comment contributors use to accept the CLA
- add a GitHub Actions check that verifies every identifiable human commit author has signed before merge

## Design

This follows the comment-based acceptance model used by mature projects such as OpenAI Codex and the Contributor Assistant ecosystem, while keeping signature acceptance in the pull request itself. The agreement preserves contributor ownership and grants CubePlex Inc. the rights needed to distribute community components under the CubePlex Community License and Enterprise components under the applicable `ee/LICENSE`.

Corporate contributions are explicitly routed to a Corporate CLA instead of allowing an individual to bind an employer without authority.

## Verification

- `git diff --check`
- Prettier check for `CLA.md` and `.github/workflows/cla.yml`
- Ruby YAML parse
- JavaScript syntax check for the embedded Actions script
- pre-commit hooks passed
- pre-push hooks passed; backend/frontend checks correctly skipped because no code changed

## Activation note

This bootstrap PR adds the `pull_request_target` workflow. GitHub evaluates that event using the target branch's workflow, so the CLA check becomes active for subsequent PRs after this PR is merged.

The repository should require the `CLA` status check in the `main` branch protection/ruleset after merging.

## Legal review

`CLA.md` is an implementation draft based on public contributor agreements from mature projects. CubePlex Inc. should obtain legal review before treating it as the final corporate agreement, especially the patent, corporate-contributor, and jurisdiction terms.
